### PR TITLE
Add github workflow for automated build. Fix eclipse-zenoh/zenoh#3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: Build on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+  
+    - name: Install required libs (Ubuntu)
+      run: sudo apt-get install libev-dev libsqlite3-dev libmariadb-dev postgresql-client
+      if: matrix.os == 'ubuntu-latest'
+    - name: Install required libs (MacOS)
+      run: |
+        brew uninstall --ignore-dependencies libpq
+        brew install libev pkg-config sqlite mariadb postgresql
+      if: matrix.os == 'macOS-latest'
+
+    - name: Setup OCaml
+      uses: avsm/setup-ocaml@v1.0
+      with:
+        ocaml-version: 4.07.1 # optional, default is 4.08.1
+    
+    - name: Setup opam dependencies
+      run: |
+        opam install conf-libev
+        opam depext -yt
+        opam install -t . --deps-only
+    
+    - name: Build
+      run: opam exec -- dune build @all
+    
+    - name: Tests
+      run: opam exec -- dune runtest
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        # Artifact name
+        name: zenoh-${{ matrix.os }}
+        # Directory containing files to upload
+        path: _build/default/install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,9 +33,10 @@ jobs:
     
     - name: Setup opam dependencies
       run: |
-        opam install conf-libev
-        opam depext -yt
-        opam install -t . --deps-only
+        OPAMJOBS=1 opam config report
+        OPAMJOBS=1 opam install conf-libev
+        OPAMJOBS=1 opam depext -yt
+        OPAMJOBS=1 opam install -t . --deps-only
     
     - name: Build
       run: opam exec -- dune build @all

--- a/zenoh-router.opam
+++ b/zenoh-router.opam
@@ -37,6 +37,9 @@ depends: [
   "ocaml" {= "4.07.1"}
   "dune" {= "2.3.0" }
   "lwt" {= "5.1.1" }
+  "atdgen" {= "2.0.0" }
+  "yojson" {= "1.7.0" }
+  "cmdliner" {= "1.0.4" }
   "apero-core" {= "0.4.7"}
   "apero-net" {= "0.4.7"}
   "zenoh-proto" {= "0.4.1"}

--- a/zenoh-storages-be-sql.opam
+++ b/zenoh-storages-be-sql.opam
@@ -37,5 +37,10 @@ install: [
 depends: [
   "ocaml" {= "4.07.1"}
   "dune" {= "2.3.0" }
+  "caqti" {= "1.2.1" }
+  "caqti-driver-sqlite3" {= "1.2.1" }
+  "caqti-driver-mariadb" {= "1.2.1" }
+  "caqti-driver-postgresql" {= "1.2.1" }
+  "caqti-lwt" {= "1.2.0" }
   "zenoh-storages-be-lib" {= "0.4.1"}
 ]

--- a/zenoh.opam
+++ b/zenoh.opam
@@ -40,6 +40,7 @@ depends: [
   "apero-net" {= "0.4.7"}
   "zenoh-proto" {= "0.4.1"}
   "zenoh-net-ocaml" {= "0.4.1"}
+  "alcotest" {with-test & = "1.0.1"}
 ]
 
 synopsis : "Zenoh -- the ZEro Network Over-Head protocol"


### PR DESCRIPTION
Notes:

This fix also required to complete opam files with missing dependencies for their installation via the "opam depext -yt" command

A weird opam behaviour caused random build failure when installing uri.2.2.1 dependency:
```
# File "lib/.wrapped_compat/Uri_re.ml-gen", line 1, characters 99-110:
# Error: Unbound module Uri__Uri_re
```
It seems to be caused by different ordering of dependencies installation, caused by the parallelism of opam when using deveral jobs (7 by default). Setting the environment variable to OPAMJOBS=1 seems to solve the issue.