### PR TITLE
Removed trailing whitespace

### DIFF
--- a/zenoh-ffi/test/test_query.c
+++ b/zenoh-ffi/test/test_query.c
@@ -17,10 +17,10 @@
 #include <unistd.h>
 #include <string.h>
 
-void query_callback(const zn_source_info *info, const zn_sample *sample) {    
-    printf(">> Received:\n\t (%.*s, %.*s)\n", 
-        sample->key.len, sample->key.val, 
-        sample->value.len, sample->value.val);    
+void query_callback(const zn_source_info *info, const zn_sample *sample) {
+    printf(">> Received:\n\t (%.*s, %.*s)\n",
+        sample->key.len, sample->key.val,
+        sample->value.len, sample->value.val);
 }
 
 int main(int argc, char** argv) {
@@ -28,11 +28,11 @@ int main(int argc, char** argv) {
     char *predicate = "";
     ZNSubscriber *sub = 0;
 
-    if (argc > 1) {        
-        key_expr = argv[1];        
+    if (argc > 1) {
+        key_expr = argv[1];
     }
-    if (argc > 2) {        
-        predicate = argv[2];        
+    if (argc > 2) {
+        predicate = argv[2];
     }
     printf("Query expression to %s:%s\n", key_expr, predicate);
 
@@ -41,8 +41,8 @@ int main(int argc, char** argv) {
     if (s == 0) {
         printf("Error creating session!\n");
         exit(-1);
-    } 
+    }
 
     zn_query(s, key_expr, predicate, zn_query_target_default(), zn_query_consolidation_default(), query_callback);
-    sleep(1);        
+    sleep(1);
 }

--- a/zenoh-ffi/test/test_session.c
+++ b/zenoh-ffi/test/test_session.c
@@ -22,21 +22,21 @@ int main(int argc, char** argv) {
   if (s == 0) {
     printf("Error creating session!\n");
     exit(-1);
-  }   
-  ZNProperties *ps = zn_info(s);  
+  }
+  ZNProperties *ps = zn_info(s);
   int n = zn_properties_len(ps);
   int id;
-  
+
   for (int i = 0; i < n; ++i) {
     id = zn_property_id(ps, i);
     const zn_bytes *bs = zn_property_value(ps, i);
     printf("> %d - ", id);
-    for (int j = 0; j < bs->len; j++) {      
+    for (int j = 0; j < bs->len; j++) {
       printf("%d", (int)bs->val[j]);
     }
     printf("\n");
   }
-  
+
   const char *data = "Hello from C";
   const char *key = "/demo/example/quote";
   zn_write(s, key, data, strlen(data));

--- a/zenoh-ffi/test/test_sub.c
+++ b/zenoh-ffi/test/test_sub.c
@@ -17,18 +17,18 @@
 #include <unistd.h>
 #include <string.h>
 
-void sub_callback(const zn_sample *sample) {    
-    printf(">> Received:\n\t (%.*s, %.*s)\n", 
-        sample->key.len, sample->key.val, 
-        sample->value.len, sample->value.val);    
+void sub_callback(const zn_sample *sample) {
+    printf(">> Received:\n\t (%.*s, %.*s)\n",
+        sample->key.len, sample->key.val,
+        sample->value.len, sample->value.val);
 }
 
 int main(int argc, char** argv) {
     char *key_expr = "/demo/example/**";
     ZNSubscriber *sub = 0;
 
-    if (argc > 1) {        
-        key_expr = argv[1];        
+    if (argc > 1) {
+        key_expr = argv[1];
     }
     printf("Subscription expression to %s\n", key_expr);
 
@@ -37,12 +37,12 @@ int main(int argc, char** argv) {
     if (s == 0) {
         printf("Error creating session!\n");
         exit(-1);
-    } 
-    
+    }
+
     sub = zn_declare_subscriber(s, key_expr, sub_callback);
 
     sleep(5);
 
     zn_undeclare_subscriber(sub);
-    
+
 }

--- a/zenoh-ffi/test/thrput_test.c
+++ b/zenoh-ffi/test/thrput_test.c
@@ -21,22 +21,22 @@ int main(int argc, char** argv) {
   size_t len;
   if (argc < 2) {
     printf("USAGE:\n\t thrput_test <size>\n");
-    return -1;    
+    return -1;
   }
   len = atoi(argv[1]);
-  
+
 
   ZNSession *s = zn_open(PEER_MODE, 0, 0);
   if (s == 0) {
     printf("Error creating session!\n");
     exit(-1);
-  } 
+  }
   sleep(1);
   char *data = (char*) malloc(len);
   memset(data, 1, len);
   printf("Running throughput test for %zu bytes payload.\n", len);
   const char *key = "/test/thr";
-  size_t id = zn_declare_resource(s, key);  
+  size_t id = zn_declare_resource(s, key);
   while (1) {
     zn_write_wrid(s, id, data, len);
   }

--- a/zenoh-perf/src/bin/router_thr_pub_client.rs
+++ b/zenoh-perf/src/bin/router_thr_pub_client.rs
@@ -27,7 +27,7 @@ fn print_usage(bin: String) {
     println!(
         "Usage:
     cargo run --release --bin {} <payload size in bytes> [<locator to connect to>]
-Example: 
+Example:
     cargo run --release --bin {} 8100 tcp/127.0.0.1:7447",
         bin, bin
     );

--- a/zenoh-perf/src/bin/router_thr_pub_light_client.rs
+++ b/zenoh-perf/src/bin/router_thr_pub_light_client.rs
@@ -54,7 +54,7 @@ fn print_usage(bin: String) {
     println!(
         "Usage:
     cargo run --release --bin {} <payload size in bytes> <locator to connect to>
-Example: 
+Example:
     cargo run --release --bin {} 8100 tcp/127.0.0.1:7447",
         bin, bin
     );

--- a/zenoh-perf/src/bin/router_thr_pub_peer.rs
+++ b/zenoh-perf/src/bin/router_thr_pub_peer.rs
@@ -27,7 +27,7 @@ fn print_usage(bin: String) {
     println!(
         "Usage:
     cargo run --release --bin {} <payload size in bytes> [<locator to connect to>]
-Example: 
+Example:
     cargo run --release --bin {} 8100 tcp/127.0.0.1:7447",
         bin, bin
     );

--- a/zenoh-perf/src/bin/router_thr_sub_client.rs
+++ b/zenoh-perf/src/bin/router_thr_sub_client.rs
@@ -116,7 +116,7 @@ fn print_usage(bin: String) {
     println!(
         "Usage:
     cargo run --release --bin {} [<locator to connect to>]
-Example: 
+Example:
     cargo run --release --bin {} tcp/127.0.0.1:7447",
         bin, bin
     );

--- a/zenoh-perf/src/bin/router_thr_sub_light_client.rs
+++ b/zenoh-perf/src/bin/router_thr_sub_light_client.rs
@@ -140,7 +140,7 @@ fn print_usage(bin: String) {
     println!(
         "Usage:
     cargo run --release --bin {} <locator to connect to>
-Example: 
+Example:
     cargo run --release --bin {} tcp/127.0.0.1:7447",
         bin, bin
     );

--- a/zenoh-perf/src/bin/router_thr_sub_peer.rs
+++ b/zenoh-perf/src/bin/router_thr_sub_peer.rs
@@ -117,7 +117,7 @@ fn print_usage(bin: String) {
     println!(
         "Usage:
     cargo run --release --bin {} <locator to listen on>
-Example: 
+Example:
     cargo run --release --bin {} tcp/127.0.0.1:7447",
         bin, bin
     );

--- a/zenoh-perf/src/bin/session_thr_broker.rs
+++ b/zenoh-perf/src/bin/session_thr_broker.rs
@@ -85,7 +85,7 @@ fn print_usage(bin: String) {
     println!(
         "Usage:
     cargo run --release --bin {} <locator to listen on>
-Example: 
+Example:
     cargo run --release --bin {} tcp/127.0.0.1:7447",
         bin, bin
     );

--- a/zenoh-perf/src/bin/session_thr_pub_client.rs
+++ b/zenoh-perf/src/bin/session_thr_pub_client.rs
@@ -47,7 +47,7 @@ fn print_usage(bin: String) {
     println!(
         "Usage:
     cargo run --release --bin {} <payload size in bytes> <locator to connect to>
-Example: 
+Example:
     cargo run --release --bin {} 8100 tcp/127.0.0.1:7447",
         bin, bin
     );

--- a/zenoh-perf/src/bin/session_thr_pub_peer.rs
+++ b/zenoh-perf/src/bin/session_thr_pub_peer.rs
@@ -47,7 +47,7 @@ fn print_usage(bin: String) {
     println!(
         "Usage:
     cargo run --release --bin {} <payload size in bytes> <locator to connect to>
-Example: 
+Example:
     cargo run --release --bin {} 8100 tcp/127.0.0.1:7447",
         bin, bin
     );

--- a/zenoh-perf/src/bin/session_thr_pubsub_client.rs
+++ b/zenoh-perf/src/bin/session_thr_pubsub_client.rs
@@ -88,7 +88,7 @@ fn print_usage(bin: String) {
     println!(
         "Usage:
     cargo run --release --bin {} <payload size in bytes> <locator to connect to>
-Example: 
+Example:
     cargo run --release --bin {} 8100 tcp/127.0.0.1:7447",
         bin, bin
     );

--- a/zenoh-perf/src/bin/session_thr_pubsub_peer.rs
+++ b/zenoh-perf/src/bin/session_thr_pubsub_peer.rs
@@ -88,7 +88,7 @@ fn print_usage(bin: String) {
     println!(
 "Usage:
     cargo run --release --bin {} <payload size in bytes> <locator to listen on> <locator to connect to>
-Example: 
+Example:
     cargo run --release --bin {} 8100 tcp/127.0.0.1:7447 tcp/127.0.0.1:7448",
         bin, bin
     );

--- a/zenoh-perf/src/bin/session_thr_sink_tcp.rs
+++ b/zenoh-perf/src/bin/session_thr_sink_tcp.rs
@@ -123,7 +123,7 @@ fn print_usage(bin: String) {
     println!(
         "Usage:
     cargo run --release --bin {} <TCP address to listen on> <buffer size> <has length>
-Example: 
+Example:
     cargo run --release --bin {} 127.0.0.1:7447 8192 true",
         bin, bin
     );

--- a/zenoh-perf/src/bin/session_thr_sub_client.rs
+++ b/zenoh-perf/src/bin/session_thr_sub_client.rs
@@ -90,7 +90,7 @@ fn print_usage(bin: String) {
     println!(
         "Usage:
     cargo run --release --bin {} <locator to connect to>
-Example: 
+Example:
     cargo run --release --bin {} tcp/127.0.0.1:7447",
         bin, bin
     );

--- a/zenoh-perf/src/bin/session_thr_sub_peer.rs
+++ b/zenoh-perf/src/bin/session_thr_sub_peer.rs
@@ -88,7 +88,7 @@ fn print_usage(bin: String) {
     println!(
         "Usage:
     cargo run --release --bin {} <locator to listen on>
-Example: 
+Example:
     cargo run --release --bin {} tcp/127.0.0.1:7447",
         bin, bin
     );

--- a/zenoh-protocol/src/proto/decl.rs
+++ b/zenoh-protocol/src/proto/decl.rs
@@ -41,7 +41,7 @@ pub enum Declaration {
     /// +---------------+
     /// ~    ResKey     ~ if  K==1 then only numerical id
     /// +---------------+
-    ///    
+    ///
     /// @Olivier, the idea would be to be able to declare a
     /// resource using an ID to avoid sending the prefix.
     /// If we do this however, we open the door to receiving declaration

--- a/zenoh-protocol/src/proto/msg.rs
+++ b/zenoh-protocol/src/proto/msg.rs
@@ -30,7 +30,7 @@ pub mod channel {
 ///       in bytes of the message, resulting in the maximum lenght of a message being 65_536 bytes.
 ///       This is necessary in those stream-oriented transports (e.g., TCP) that do not preserve
 ///       the boundary of the serialized messages. The length is encoded as little-endian.
-///       In any case, the lenght of a message must not exceed 65_536 bytes.    
+///       In any case, the lenght of a message must not exceed 65_536 bytes.
 ///
 /// The Attachment can decorate any message (i.e., SessionMessage and ZenohMessage) and it allows to
 /// append to the message any additional information. Since the information contained in the

--- a/zenoh-protocol/src/session/channel/batch.rs
+++ b/zenoh-protocol/src/session/channel/batch.rs
@@ -70,7 +70,7 @@ impl SerializationBatch {
     ///                   In case of `is_streamed` being true, the first 2 bytes of the serialization batch
     ///                   are used to encode the total amount of serialized bytes as 16-bits little endian.
     ///                   Writing these 2 bytes allows the receiver to detect the amount of bytes it is expected
-    ///                   to read when operating on non-boundary preserving transport protocols.  
+    ///                   to read when operating on non-boundary preserving transport protocols.
     ///
     /// * `sn_reliable` - The sequence number generator for the reliable channel.
     ///

--- a/zenoh-protocol/src/session/channel/reliability_queue.rs
+++ b/zenoh-protocol/src/session/channel/reliability_queue.rs
@@ -68,7 +68,7 @@ impl<T> ReliabilityQueue<T> {
         self.sn.get()
     }
 
-    pub(super) fn set_base(&mut self, sn: ZInt) -> ZResult<()> {        
+    pub(super) fn set_base(&mut self, sn: ZInt) -> ZResult<()> {
         let gap: usize = match self.sn.gap(sn) {
             Ok(gap) => match gap.try_into() {
                 Ok(gap) => gap,
@@ -78,9 +78,9 @@ impl<T> ReliabilityQueue<T> {
         };
 
         self.sn.set(sn)?;
-                
+
         if gap >= self.capacity() {
-            // If the gap is larger than the capacity, reset the queue            
+            // If the gap is larger than the capacity, reset the queue
             for i in 0..self.capacity() {
                 self.inner[i] = None;
             }
@@ -92,9 +92,9 @@ impl<T> ReliabilityQueue<T> {
                 if self.inner[self.index].is_some() {
                     self.len -= 1;
                     self.inner[self.index] = None;
-                }                
+                }
                 self.index = (self.index + 1) % self.capacity();
-            }           
+            }
         }
 
         Ok(())
@@ -161,7 +161,7 @@ impl<T> ReliabilityQueue<T> {
         }
     }
 
-    pub(super) fn pull(&mut self) -> Option<T> {        
+    pub(super) fn pull(&mut self) -> Option<T> {
         let t = self.inner[self.index].take();
         if t.is_some() {
             self.len -= 1;
@@ -171,14 +171,14 @@ impl<T> ReliabilityQueue<T> {
         t
     }
 
-    /// Returns a bitmask of surely missed messages. 
+    /// Returns a bitmask of surely missed messages.
     /// A bit is set to 1 iff the position in the queue is empty and
     /// there is at least one message with a higher sequence number.
     pub(super) fn get_mask(&self) -> ZInt {
         let mut mask: ZInt = 0;
         let mut count = 0;
         let mut i = 0;
-        while count < self.len() {        
+        while count < self.len() {
             let index = (self.index + i) % self.capacity();
             if self.inner[index].is_none() {
                 mask |= 1 << i;
@@ -371,7 +371,7 @@ mod tests {
         let size = 8;
         let mut queue: ReliabilityQueue<ZInt> = ReliabilityQueue::new(size, 0, 8);
 
-        let mut sn: ZInt = 0;  
+        let mut sn: ZInt = 0;
         while sn < size as ZInt {
             let res = queue.insert(sn, sn);
             assert!(res.is_ok());
@@ -383,7 +383,7 @@ mod tests {
         assert_eq!(queue.get_mask(), mask);
 
         // Insert the missing elements
-        let mut sn: ZInt = 1;  
+        let mut sn: ZInt = 1;
         while sn < size as ZInt {
             let res = queue.insert(sn, sn);
             assert!(res.is_ok());
@@ -470,7 +470,7 @@ mod tests {
         // Rebase the queue
         let res = queue.set_base(4);
         assert!(res.is_ok());
-        
+
         // Verify that the base is correct
         assert_eq!(queue.get_base(), 4);
         // Verify that the length of the queue is correct
@@ -505,7 +505,7 @@ mod tests {
         assert!(res.is_ok());
         // Verify that the base is correct
         assert_eq!(queue.get_base(), 0);
-        
+
         // Fill the queue
         for i in 0..size as ZInt {
             // Push the element on the queue is correct
@@ -561,19 +561,19 @@ mod tests {
         let res = queue.remove(1);
         assert_eq!(res.unwrap(), 1);
         assert_eq!(queue.len(), 4);
-     
+
         let res = queue.remove(0);
         assert_eq!(res.unwrap(), 0);
         assert_eq!(queue.len(), 3);
-        
+
         let res = queue.remove(2);
         assert_eq!(res.unwrap(), 2);
         assert_eq!(queue.len(), 2);
-            
+
         let res = queue.remove(4);
         assert_eq!(res.unwrap(), 4);
         assert_eq!(queue.len(), 1);
-            
+
         let res = queue.remove(6);
         assert_eq!(res.unwrap(), 6);
         assert!(queue.is_empty());

--- a/zenoh-router/src/routing/broker.rs
+++ b/zenoh-router/src/routing/broker.rs
@@ -43,7 +43,7 @@ pub use crate::routing::resource::*;
 ///     use zenoh_protocol::proto::Mux;
 ///     use zenoh_protocol::session::DummyHandler;
 ///     let dummy_primitives = Arc::new(Mux::new(Arc::new(DummyHandler::new())));
-///   
+///
 ///     // Instanciate broker
 ///     let broker = Arc::new(Broker::new(HLC::default()));
 ///
@@ -58,7 +58,7 @@ pub use crate::routing::resource::*;
 ///
 ///     // Declare new primitives
 ///     let primitives = broker.new_primitives(dummy_primitives).await;
-///     
+///
 ///     // Use primitives
 ///     primitives.data(&"/demo".to_string().into(), true, &None, RBuf::from(vec![1, 2])).await;
 ///

--- a/zenoh-util/src/collections/credit_queue.rs
+++ b/zenoh-util/src/collections/credit_queue.rs
@@ -64,7 +64,7 @@ impl<T> CreditQueue<T> {
     /// Create a new credit-based queue.
     ///
     /// # Arguments
-    /// * `queue` - A vector containing the parameters for the queues in the form of tuples: (capacity, credits)      
+    /// * `queue` - A vector containing the parameters for the queues in the form of tuples: (capacity, credits)
     ///
     /// * `concurrency_level` - The desired concurrency_level when accessing a single priority queue.
     ///


### PR DESCRIPTION
While examining the source code I found a few places where there was trailing whitespace. I don't know if that was intended, but here's a PR that cleans that up.