### PR TITLE
Run rustfmt as part of CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,6 +53,4 @@ jobs:
     - name: Run tests
       run: cargo test --verbose
     - name: Run rustfmt
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt -- --check
+      run: cargo fmt -- --check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,10 +47,25 @@ jobs:
         command: check
 
     - name: Build
-      run: cargo build --verbose --all-targets
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --verbose --all-targets
+
     - name: Clippy
-      run: cargo clippy --all --examples
+      uses: actions-rs/cargo@v1
+      with:
+        command: clippy
+        args: --all --examples
+
     - name: Run tests
-      run: cargo test --verbose
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --verbose
+
     - name: Run rustfmt
-      run: cargo fmt -- --check
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: -- --check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,3 +52,7 @@ jobs:
       run: cargo clippy --all --examples
     - name: Run tests
       run: cargo test --verbose
+    - name: Run rustfmt
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt -- --check


### PR DESCRIPTION
This will enforce the Rust styleguide on every PR. This currently fails because `rust-master` does not pass the styleguide.