### PR TITLE
Activate timestamping in zenohd by default

### DIFF
--- a/plugins/example-plugin/src/lib.rs
+++ b/plugins/example-plugin/src/lib.rs
@@ -41,7 +41,7 @@ async fn run(runtime: Runtime, args: &'static ArgMatches<'_>) {
 
     let session = Session::init(runtime).await;
 
-    let mut stored: HashMap<String, (RBuf, Option<RBuf>)> = HashMap::new();
+    let mut stored: HashMap<String, (RBuf, Option<DataInfo>)> = HashMap::new();
 
     let sub_info = SubInfo {
         reliability: Reliability::Reliable,

--- a/plugins/zplugin_storages/src/memory_backend/mod.rs
+++ b/plugins/zplugin_storages/src/memory_backend/mod.rs
@@ -240,6 +240,10 @@ impl Timed for TimedCleanup {
 // generate a reception timestamp with id=0x00
 fn new_reception_timestamp() -> Timestamp {
     use std::time::{SystemTime, UNIX_EPOCH};
+    use zenoh::TimestampID;
     let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-    Timestamp::new(now.into(), vec![0x00])
+    Timestamp::new(
+        now.into(),
+        TimestampID::new(1, [0u8; TimestampID::MAX_SIZE]),
+    )
 }

--- a/plugins/zplugin_storages/src/memory_backend/mod.rs
+++ b/plugins/zplugin_storages/src/memory_backend/mod.rs
@@ -118,7 +118,17 @@ impl Storage for MemoryStorage {
 
     async fn on_sample(&mut self, sample: Sample) -> ZResult<()> {
         trace!("on_sample for {}", sample.res_name);
-        let (kind, _, timestamp) = utils::decode_data_info(sample.data_info.clone());
+        let (kind, timestamp) = if let Some(ref info) = sample.data_info {
+            (
+                info.kind.map_or(ChangeKind::PUT, ChangeKind::from),
+                match &info.timestamp {
+                    Some(ts) => ts.clone(),
+                    None => new_reception_timestamp(),
+                },
+            )
+        } else {
+            (ChangeKind::PUT, new_reception_timestamp())
+        };
         match kind {
             ChangeKind::PUT => match self.map.write().await.entry(sample.res_name.clone()) {
                 Entry::Vacant(v) => {
@@ -225,4 +235,11 @@ impl Timed for TimedCleanup {
     async fn run(&mut self) {
         self.map.write().await.remove(&self.path);
     }
+}
+
+// generate a reception timestamp with id=0x00
+fn new_reception_timestamp() -> Timestamp {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+    Timestamp::new(now.into(), vec![0x00])
 }

--- a/zenoh-ffi/src/lib.rs
+++ b/zenoh-ffi/src/lib.rs
@@ -280,7 +280,7 @@ pub unsafe extern "C" fn zn_scout_whatami(si: *mut ZNScout, idx: c_uint) -> c_ui
 #[no_mangle]
 pub unsafe extern "C" fn zn_scout_peerid(si: *mut ZNScout, idx: c_uint) -> *const c_uchar {
     match &(*si).0[idx as usize].pid {
-        Some(v) => v.id.as_ptr() as *const c_uchar,
+        Some(v) => v.as_slice().as_ptr() as *const c_uchar,
         None => std::ptr::null(),
     }
 }
@@ -673,8 +673,8 @@ pub unsafe extern "C" fn zn_query(
 
             while let Some(reply) = q.next().await {
                 source_info.kind = reply.source_kind as c_uint;
-                source_info.id.val = reply.replier_id.id.as_ptr() as *const c_uchar;
-                source_info.id.len = reply.replier_id.id.len() as c_uint;
+                source_info.id.val = reply.replier_id.as_slice().as_ptr() as *const c_uchar;
+                source_info.id.len = reply.replier_id.as_slice().len() as c_uint;
                 sample.key.val = reply.data.res_name.as_ptr() as *const c_char;
                 sample.key.len = reply.data.res_name.len() as c_uint;
                 let data = reply.data.payload.to_vec();

--- a/zenoh-protocol/Cargo.toml
+++ b/zenoh-protocol/Cargo.toml
@@ -36,7 +36,7 @@ log = "0.4.11"
 rand = "0.7.3"
 http-types = "2.4.0"
 uuid = { version = "0.8.1", features = ["v4"] }
-uhlc = "0.1"
+uhlc = "0.2"
 zenoh-util =  { version = "0.5.0", path = "../zenoh-util" }
 
 [dependencies.async-std]

--- a/zenoh-protocol/benches/data_creation.rs
+++ b/zenoh-protocol/benches/data_creation.rs
@@ -17,9 +17,9 @@ extern crate criterion;
 use async_std::sync::Arc;
 use criterion::Criterion;
 
-use zenoh_protocol::core::ResKey;
+use zenoh_protocol::core::{PeerId, ResKey};
 use zenoh_protocol::io::RBuf;
-use zenoh_protocol::proto::ZenohMessage;
+use zenoh_protocol::proto::{DataInfo, ZenohMessage};
 
 fn consume_message(msg: ZenohMessage) {
     drop(msg);
@@ -37,7 +37,15 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     for n in &iters {
         let res_key = ResKey::RIdWithSuffix(18, String::from("/com/acme/sensors/temp"));
-        let info = Some(RBuf::from(vec![0; 1024]));
+        let info = Some(DataInfo {
+            source_id: Some(PeerId { id: vec![0; 16] }),
+            source_sn: Some(12345),
+            first_broker_id: Some(PeerId { id: vec![0; 16] }),
+            first_broker_sn: Some(12345),
+            timestamp: Some(uhlc::Timestamp::new(Default::default(), vec![0; 16])),
+            kind: Some(0),
+            encoding: Some(0),
+        });
         let payload = RBuf::from(vec![0; 1024]);
 
         c.bench_function(format!("{} msg_creation", n).as_str(), |b| {
@@ -58,7 +66,15 @@ fn criterion_benchmark(c: &mut Criterion) {
     }
 
     let res_key = ResKey::RIdWithSuffix(18, String::from("/com/acme/sensors/temp"));
-    let info = Some(RBuf::from(vec![0; 1024]));
+    let info = Some(DataInfo {
+        source_id: Some(PeerId { id: vec![0; 16] }),
+        source_sn: Some(12345),
+        first_broker_id: Some(PeerId { id: vec![0; 16] }),
+        first_broker_sn: Some(12345),
+        timestamp: Some(uhlc::Timestamp::new(Default::default(), vec![0; 16])),
+        kind: Some(0),
+        encoding: Some(0),
+    });
     let payload = RBuf::from(vec![0; 1024]);
     let msg = Arc::new(ZenohMessage::make_data(
         reliable,

--- a/zenoh-protocol/benches/data_creation.rs
+++ b/zenoh-protocol/benches/data_creation.rs
@@ -38,11 +38,14 @@ fn criterion_benchmark(c: &mut Criterion) {
     for n in &iters {
         let res_key = ResKey::RIdWithSuffix(18, String::from("/com/acme/sensors/temp"));
         let info = Some(DataInfo {
-            source_id: Some(PeerId { id: vec![0; 16] }),
+            source_id: Some(PeerId::new(16, [0u8; PeerId::MAX_SIZE])),
             source_sn: Some(12345),
-            first_broker_id: Some(PeerId { id: vec![0; 16] }),
+            first_broker_id: Some(PeerId::new(16, [0u8; PeerId::MAX_SIZE])),
             first_broker_sn: Some(12345),
-            timestamp: Some(uhlc::Timestamp::new(Default::default(), vec![0; 16])),
+            timestamp: Some(uhlc::Timestamp::new(
+                Default::default(),
+                uhlc::ID::new(16, [1u8; uhlc::ID::MAX_SIZE]),
+            )),
             kind: Some(0),
             encoding: Some(0),
         });
@@ -67,11 +70,14 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     let res_key = ResKey::RIdWithSuffix(18, String::from("/com/acme/sensors/temp"));
     let info = Some(DataInfo {
-        source_id: Some(PeerId { id: vec![0; 16] }),
+        source_id: Some(PeerId::new(16, [0u8; PeerId::MAX_SIZE])),
         source_sn: Some(12345),
-        first_broker_id: Some(PeerId { id: vec![0; 16] }),
+        first_broker_id: Some(PeerId::new(16, [0u8; PeerId::MAX_SIZE])),
         first_broker_sn: Some(12345),
-        timestamp: Some(uhlc::Timestamp::new(Default::default(), vec![0; 16])),
+        timestamp: Some(uhlc::Timestamp::new(
+            Default::default(),
+            uhlc::ID::new(16, [0u8; uhlc::ID::MAX_SIZE]),
+        )),
         kind: Some(0),
         encoding: Some(0),
     });

--- a/zenoh-protocol/src/proto/demux.rs
+++ b/zenoh-protocol/src/proto/demux.rs
@@ -71,9 +71,7 @@ impl<P: Primitives + Send + Sync> SessionEventHandler for DeMux<P> {
                 key, info, payload, ..
             }) => match msg.reply_context {
                 None => {
-                    self.primitives
-                        .data(&key, reliability, &info, payload)
-                        .await;
+                    self.primitives.data(&key, reliability, info, payload).await;
                 }
                 Some(rep) => match rep.replier_id {
                     Some(replier_id) => {

--- a/zenoh-protocol/src/proto/msg.rs
+++ b/zenoh-protocol/src/proto/msg.rs
@@ -295,6 +295,7 @@ pub struct Query {
 }
 
 // Zenoh messages at zenoh level
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum ZenohBody {
     Declare(Declare),

--- a/zenoh-protocol/src/proto/msg.rs
+++ b/zenoh-protocol/src/proto/msg.rs
@@ -201,7 +201,7 @@ pub mod zmsg {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct DataInfo {
     pub source_id: Option<PeerId>,
     pub source_sn: Option<ZInt>,
@@ -239,7 +239,7 @@ pub struct Declare {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Data {
     pub key: ResKey,
-    pub info: Option<RBuf>,
+    pub info: Option<DataInfo>,
     pub payload: RBuf,
 }
 
@@ -349,7 +349,7 @@ impl ZenohMessage {
     pub fn make_data(
         channel: Channel,
         key: ResKey,
-        info: Option<RBuf>,
+        info: Option<DataInfo>,
         payload: RBuf,
         reply_context: Option<ReplyContext>,
         attachment: Option<Attachment>,

--- a/zenoh-protocol/src/proto/msg_reader.rs
+++ b/zenoh-protocol/src/proto/msg_reader.rs
@@ -288,7 +288,7 @@ impl RBuf {
                     let channel = zmsg::has_flag(header, zmsg::flag::R);
                     let key = self.read_reskey(zmsg::has_flag(header, zmsg::flag::K))?;
                     let info = if zmsg::has_flag(header, zmsg::flag::I) {
-                        Some(RBuf::from(self.read_bytes_array()?))
+                        Some(self.read_datainfo()?)
                     } else {
                         None
                     };

--- a/zenoh-protocol/src/proto/msg_reader.rs
+++ b/zenoh-protocol/src/proto/msg_reader.rs
@@ -632,13 +632,28 @@ impl RBuf {
 
     pub fn read_timestamp(&mut self) -> ZResult<Timestamp> {
         let time = self.read_zint_as_u64()?;
-        let mut bytes = [0u8; 16];
-        self.read_bytes(&mut bytes[..])?;
-        Ok(Timestamp::new(uhlc::NTP64(time), bytes.into()))
+        let zint = self.read_zint()?;
+        if zint > (uhlc::ID::MAX_SIZE as ZInt) {
+            panic!(
+                "Reading a Timestamp's ID size that exceed {} bytes: {}",
+                uhlc::ID::MAX_SIZE,
+                zint
+            ); //@TODO: return error
+        }
+        let size = zint as usize;
+        let mut id = [0u8; PeerId::MAX_SIZE];
+        self.read_bytes(&mut id[..size])?;
+        Ok(Timestamp::new(uhlc::NTP64(time), uhlc::ID::new(size, id)))
     }
 
     fn read_peerid(&mut self) -> ZResult<PeerId> {
-        let id = self.read_bytes_array()?;
-        Ok(PeerId { id })
+        let zint = self.read_zint()?;
+        if zint > (PeerId::MAX_SIZE as ZInt) {
+            panic!("Reading a PeerId size that exceed 16 bytes: {}", zint); //@TODO: return error
+        }
+        let size = zint as usize;
+        let mut id = [0u8; PeerId::MAX_SIZE];
+        self.read_bytes(&mut id[..size])?;
+        Ok(PeerId::new(size, id))
     }
 }

--- a/zenoh-protocol/src/proto/msg_writer.rs
+++ b/zenoh-protocol/src/proto/msg_writer.rs
@@ -214,8 +214,8 @@ impl WBuf {
 
             ZenohBody::Data(Data { key, info, payload }) => {
                 check!(self.write_reskey(&key));
-                if let Some(rbuf) = info {
-                    check!(self.write_rbuf(&rbuf));
+                if let Some(data_info) = info {
+                    check!(self.write_datainfo(&data_info));
                 }
                 check!(self.write_rbuf(&payload));
             }

--- a/zenoh-protocol/src/proto/mux.rs
+++ b/zenoh-protocol/src/proto/mux.rs
@@ -14,7 +14,7 @@
 use crate::core::{PeerId, ResKey, ZInt};
 use crate::core::{QueryConsolidation, QueryTarget, SubInfo};
 use crate::io::RBuf;
-use crate::proto::{channel, Declaration, Primitives, ReplyContext, ZenohMessage};
+use crate::proto::{channel, DataInfo, Declaration, Primitives, ReplyContext, ZenohMessage};
 use crate::session::SessionEventHandler;
 use async_std::sync::Arc;
 use async_trait::async_trait;
@@ -112,7 +112,13 @@ impl<T: SessionEventHandler + Send + Sync + ?Sized> Primitives for Mux<T> {
             .await;
     }
 
-    async fn data(&self, reskey: &ResKey, reliability: bool, info: &Option<RBuf>, payload: RBuf) {
+    async fn data(
+        &self,
+        reskey: &ResKey,
+        reliability: bool,
+        info: Option<DataInfo>,
+        payload: RBuf,
+    ) {
         self.handler
             .handle_message(ZenohMessage::make_data(
                 reliability,
@@ -156,7 +162,7 @@ impl<T: SessionEventHandler + Send + Sync + ?Sized> Primitives for Mux<T> {
         source_kind: ZInt,
         replier_id: PeerId,
         reskey: ResKey,
-        info: Option<RBuf>,
+        info: Option<DataInfo>,
         payload: RBuf,
     ) {
         self.handler

--- a/zenoh-protocol/src/proto/primitives.rs
+++ b/zenoh-protocol/src/proto/primitives.rs
@@ -13,6 +13,7 @@
 //
 use crate::core::{PeerId, QueryConsolidation, QueryTarget, ResKey, SubInfo, ZInt};
 use crate::io::RBuf;
+use crate::proto::DataInfo;
 use async_trait::async_trait;
 
 #[async_trait]
@@ -29,7 +30,7 @@ pub trait Primitives {
     async fn queryable(&self, reskey: &ResKey);
     async fn forget_queryable(&self, reskey: &ResKey);
 
-    async fn data(&self, reskey: &ResKey, reliable: bool, info: &Option<RBuf>, payload: RBuf);
+    async fn data(&self, reskey: &ResKey, reliable: bool, info: Option<DataInfo>, payload: RBuf);
     async fn query(
         &self,
         reskey: &ResKey,
@@ -44,7 +45,7 @@ pub trait Primitives {
         source_kind: ZInt,
         replier_id: PeerId,
         reskey: ResKey,
-        info: Option<RBuf>,
+        info: Option<DataInfo>,
         payload: RBuf,
     );
     async fn reply_final(&self, qid: ZInt);

--- a/zenoh-protocol/src/session/manager.rs
+++ b/zenoh-protocol/src/session/manager.rs
@@ -63,7 +63,7 @@ use zenoh_util::{zasyncread, zasyncwrite, zerror};
 /// let config = SessionManagerConfig {
 ///     version: 0,
 ///     whatami: whatami::PEER,
-///     id: PeerId{id: vec![1, 2]},
+///     id: PeerId::from(uuid::Uuid::new_v4()),
 ///     handler: Arc::new(MySH::new())
 /// };
 /// let manager = SessionManager::new(config, None);
@@ -72,7 +72,7 @@ use zenoh_util::{zasyncread, zasyncwrite, zerror};
 /// let config = SessionManagerConfig {
 ///     version: 0,
 ///     whatami: whatami::PEER,
-///     id: PeerId{id: vec![3, 4]},
+///     id: PeerId::from(uuid::Uuid::new_v4()),
 ///     handler: Arc::new(MySH::new())
 /// };
 /// // Setting a value to None means to use the default value

--- a/zenoh-protocol/tests/channel.rs
+++ b/zenoh-protocol/tests/channel.rs
@@ -126,8 +126,8 @@ impl SessionEventHandler for SCClient {
 
 async fn channel_reliable(locators: Vec<Locator>) {
     // Define client and router IDs
-    let client_id = PeerId { id: vec![0u8] };
-    let router_id = PeerId { id: vec![1u8] };
+    let client_id = PeerId::new(1, [0u8; PeerId::MAX_SIZE]);
+    let router_id = PeerId::new(1, [1u8; PeerId::MAX_SIZE]);
 
     // Create the router session manager
     let router_handler = Arc::new(SHRouter::new());
@@ -200,8 +200,8 @@ async fn channel_reliable(locators: Vec<Locator>) {
 
 async fn channel_best_effort(locators: Vec<Locator>) {
     // Define client and router IDs
-    let client_id = PeerId { id: vec![0u8] };
-    let router_id = PeerId { id: vec![1u8] };
+    let client_id = PeerId::new(1, [0u8; PeerId::MAX_SIZE]);
+    let router_id = PeerId::new(1, [1u8; PeerId::MAX_SIZE]);
 
     // Create the router session manager
     let router_handler = Arc::new(SHRouter::new());

--- a/zenoh-protocol/tests/msg_codec.rs
+++ b/zenoh-protocol/tests/msg_codec.rs
@@ -19,7 +19,6 @@ use zenoh_protocol::proto::*;
 
 const NUM_ITER: usize = 100;
 const PROPS_LENGTH: usize = 3;
-const PID_MAX_SIZE: usize = 16;
 const PROP_MAX_SIZE: usize = 64;
 const MAX_PAYLOAD_SIZE: usize = 256;
 
@@ -48,9 +47,7 @@ fn gen_buffer(max_size: usize) -> Vec<u8> {
 }
 
 fn gen_pid() -> PeerId {
-    PeerId {
-        id: gen_buffer(PID_MAX_SIZE),
-    }
+    PeerId::from(uuid::Uuid::new_v4())
 }
 
 fn gen_props(len: usize, max_size: usize) -> Vec<Property> {
@@ -167,11 +164,7 @@ fn gen_consolidation() -> QueryConsolidation {
 }
 
 fn gen_timestamp() -> Timestamp {
-    // Timestamp::new(uhlc::NTP64(gen!(u64)), gen_buffer(PID_MAX_SIZE))
-    let mut buf: Vec<u8> = Vec::with_capacity(PID_MAX_SIZE);
-    buf.resize(PID_MAX_SIZE, 0);
-    thread_rng().fill(buf.as_mut_slice());
-    Timestamp::new(uhlc::NTP64(gen!(u64)), buf)
+    Timestamp::new(uhlc::NTP64(gen!(u64)), uhlc::ID::from(uuid::Uuid::new_v4()))
 }
 
 fn gen_data_info() -> DataInfo {

--- a/zenoh-protocol/tests/session.rs
+++ b/zenoh-protocol/tests/session.rs
@@ -155,7 +155,7 @@ async fn session_lease(locator: Locator) {
     let lease: ZInt = 1_000;
 
     /* [ROUTER] */
-    let router_id = PeerId { id: vec![0u8] };
+    let router_id = PeerId::new(1, [0u8; PeerId::MAX_SIZE]);
 
     // Create the barrier to detect when a new session is open
     let router_new_barrier = Arc::new(Barrier::new(2));
@@ -181,7 +181,7 @@ async fn session_lease(locator: Locator) {
     let router_manager = SessionManager::new(config, Some(opt_config));
 
     /* [CLIENT] */
-    let client01_id = PeerId { id: vec![1u8] };
+    let client01_id = PeerId::new(1, [1u8; PeerId::MAX_SIZE]);
     let client01_handler = Arc::new(SHClientLease::new());
 
     // Create the transport session manager for the first client
@@ -390,7 +390,7 @@ async fn session_open_close(locator: Locator) {
     let attachment = None;
 
     /* [ROUTER] */
-    let router_id = PeerId { id: vec![0u8] };
+    let router_id = PeerId::new(1, [0u8; PeerId::MAX_SIZE]);
 
     // Create the barrier to detect when a new session is open
     let router_new_barrier = Arc::new(Barrier::new(2));
@@ -416,8 +416,8 @@ async fn session_open_close(locator: Locator) {
     let router_manager = SessionManager::new(config, Some(opt_config));
 
     /* [CLIENT] */
-    let client01_id = PeerId { id: vec![1u8] };
-    let client02_id = PeerId { id: vec![2u8] };
+    let client01_id = PeerId::new(1, [1u8; PeerId::MAX_SIZE]);
+    let client02_id = PeerId::new(1, [2u8; PeerId::MAX_SIZE]);
 
     // Create the transport session manager for the first client
     let config = SessionManagerConfig {

--- a/zenoh-router/Cargo.toml
+++ b/zenoh-router/Cargo.toml
@@ -44,7 +44,6 @@ criterion = "0.3.3"
 
 [features]
 default = []
-no_timestamp = []
 
 [[bench]]
 name = "tables_bench"

--- a/zenoh-router/Cargo.toml
+++ b/zenoh-router/Cargo.toml
@@ -44,7 +44,7 @@ criterion = "0.3.3"
 
 [features]
 default = []
-add_timestamp = []
+no_timestamp = []
 
 [[bench]]
 name = "tables_bench"

--- a/zenoh-router/Cargo.toml
+++ b/zenoh-router/Cargo.toml
@@ -30,7 +30,7 @@ env_logger = "0.7.1"
 clap = "2"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 socket2 = "0.3.12"
-uhlc = "0.1"
+uhlc = "0.2"
 zenoh-protocol =  { version = "0.5.0", path = "../zenoh-protocol" }
 zenoh-util =  { version = "0.5.0", path = "../zenoh-util" }
 hex = "0.4"

--- a/zenoh-router/benches/tables_bench.rs
+++ b/zenoh-router/benches/tables_bench.rs
@@ -17,7 +17,6 @@ extern crate zenoh_router;
 use async_std::sync::Arc;
 use async_std::task;
 use criterion::{BenchmarkId, Criterion};
-use uhlc::HLC;
 use zenoh_protocol::core::{whatami, Reliability, SubInfo, SubMode};
 use zenoh_protocol::io::RBuf;
 use zenoh_protocol::proto::Mux;
@@ -28,7 +27,7 @@ use zenoh_router::routing::resource::*;
 
 fn tables_bench(c: &mut Criterion) {
     task::block_on(async {
-        let tables = Tables::new(HLC::default());
+        let tables = Tables::new(None);
         let primitives = Arc::new(Mux::new(Arc::new(DummyHandler::new())));
 
         let face0 = Tables::open_face(&tables, whatami::CLIENT, primitives.clone()).await;

--- a/zenoh-router/src/bin/zenohd.rs
+++ b/zenoh-router/src/bin/zenohd.rs
@@ -65,6 +65,11 @@ fn main() {
                 "--plugin-nolookup \
              'When set, zenohd will not look for plugins nor try to load any plugin except the \
              ones explicitely configured with -P or --plugin.'",
+            ))
+            .arg(Arg::from_usage(
+                "--no-timestamp \
+             'By default zenohd adds a HLC-generated Timestamp to each routed Data if there isn't already one. \
+             This option desactivates this feature.'",
             ));
 
         let mut plugins_mgr = PluginsMgr::new();
@@ -88,6 +93,7 @@ fn main() {
             .map(|v| v.map(|l| l.parse().unwrap()).collect())
             .or_else(|| Some(vec![]))
             .unwrap();
+        let add_timestamp = !std::env::args().any(|arg| arg == "--no-timestamp");
 
         let config = Config {
             whatami: whatami::BROKER,
@@ -95,6 +101,7 @@ fn main() {
             listeners,
             multicast_interface: "auto".to_string(),
             scouting_delay: std::time::Duration::new(0, 200_000_000),
+            add_timestamp,
         };
 
         let runtime = match Runtime::new(0, config, args.value_of("id")).await {

--- a/zenoh-router/src/routing/broker.rs
+++ b/zenoh-router/src/routing/broker.rs
@@ -60,7 +60,7 @@ pub use crate::routing::resource::*;
 ///     let primitives = broker.new_primitives(dummy_primitives).await;
 ///
 ///     // Use primitives
-///     primitives.data(&"/demo".to_string().into(), true, &None, RBuf::from(vec![1, 2])).await;
+///     primitives.data(&"/demo".to_string().into(), true, None, RBuf::from(vec![1, 2])).await;
 ///
 ///     // Close primitives
 ///     primitives.close().await;

--- a/zenoh-router/src/routing/broker.rs
+++ b/zenoh-router/src/routing/broker.rs
@@ -44,14 +44,17 @@ pub use crate::routing::resource::*;
 ///     use zenoh_protocol::session::DummyHandler;
 ///     let dummy_primitives = Arc::new(Mux::new(Arc::new(DummyHandler::new())));
 ///
+///     // UUID used for HLC and PeerId
+///     let id = uuid::Uuid::new_v4();
+///
 ///     // Instanciate broker
-///     let broker = Arc::new(Broker::new(HLC::default()));
+///     let broker = Arc::new(Broker::new(Some(HLC::with_system_time(id.into()))));
 ///
 ///     // Instanciate SessionManager and plug it to the broker
 ///     let config = SessionManagerConfig {
 ///         version: 0,
 ///         whatami: PEER,
-///         id: PeerId{id: vec![1, 2]},
+///         id: PeerId::from(id),
 ///         handler: broker.clone()
 ///     };
 ///     let manager = SessionManager::new(config, None);
@@ -72,7 +75,7 @@ pub struct Broker {
 }
 
 impl Broker {
-    pub fn new(hlc: HLC) -> Broker {
+    pub fn new(hlc: Option<HLC>) -> Broker {
         Broker {
             tables: Tables::new(hlc),
         }
@@ -114,11 +117,11 @@ pub struct Tables {
     face_counter: usize,
     pub(crate) root_res: Arc<Resource>,
     pub(crate) faces: HashMap<usize, Arc<FaceState>>,
-    pub(crate) hlc: HLC,
+    pub(crate) hlc: Option<HLC>,
 }
 
 impl Tables {
-    pub fn new(hlc: HLC) -> Arc<RwLock<Tables>> {
+    pub fn new(hlc: Option<HLC>) -> Arc<RwLock<Tables>> {
         Arc::new(RwLock::new(Tables {
             face_counter: 0,
             root_res: Resource::root(),

--- a/zenoh-router/src/routing/face.rs
+++ b/zenoh-router/src/routing/face.rs
@@ -20,7 +20,7 @@ use zenoh_protocol::core::{
     PeerId, QueryConsolidation, QueryTarget, ResKey, SubInfo, WhatAmI, ZInt,
 };
 use zenoh_protocol::io::RBuf;
-use zenoh_protocol::proto::Primitives;
+use zenoh_protocol::proto::{DataInfo, Primitives};
 
 pub struct FaceState {
     pub(super) id: usize,
@@ -126,7 +126,7 @@ impl Primitives for Face {
         undeclare_queryable(&mut tables, &mut self.state.clone(), prefixid, suffix).await;
     }
 
-    async fn data(&self, reskey: &ResKey, reliable: bool, info: &Option<RBuf>, payload: RBuf) {
+    async fn data(&self, reskey: &ResKey, reliable: bool, info: Option<DataInfo>, payload: RBuf) {
         let (prefixid, suffix) = reskey.into();
         let mut tables = self.tables.write().await;
         route_data(
@@ -170,7 +170,7 @@ impl Primitives for Face {
         source_kind: ZInt,
         replier_id: PeerId,
         reskey: ResKey,
-        info: Option<RBuf>,
+        info: Option<DataInfo>,
         payload: RBuf,
     ) {
         let mut tables = self.tables.write().await;

--- a/zenoh-router/src/routing/pubsub.rs
+++ b/zenoh-router/src/routing/pubsub.rs
@@ -251,10 +251,7 @@ pub async fn route_data_to_map(
 
 lazy_static! {
     static ref UNIQUE_TS: uhlc::Timestamp = {
-        let id: Vec<u8> = vec![
-            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
-            0x0f, 0x10,
-        ];
+        let id = uhlc::ID::from(uuid::Uuid::new_v4());
         uhlc::Timestamp::new(Default::default(), id)
     };
 }

--- a/zenoh-router/src/routing/queries.rs
+++ b/zenoh-router/src/routing/queries.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 
 use zenoh_protocol::core::{whatami, PeerId, QueryConsolidation, QueryTarget, ResKey, ZInt};
 use zenoh_protocol::io::RBuf;
+use zenoh_protocol::proto::DataInfo;
 
 use crate::routing::broker::Tables;
 use crate::routing::face::FaceState;
@@ -279,7 +280,7 @@ pub(crate) async fn route_reply_data(
     source_kind: ZInt,
     replier_id: PeerId,
     reskey: ResKey,
-    info: Option<RBuf>,
+    info: Option<DataInfo>,
     payload: RBuf,
 ) {
     match face.pending_queries.get(&qid) {

--- a/zenoh-router/src/routing/resource.rs
+++ b/zenoh-router/src/routing/resource.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 use zenoh_protocol::core::rname::intersect;
 use zenoh_protocol::core::{SubInfo, ZInt};
 use zenoh_protocol::io::RBuf;
+use zenoh_protocol::proto::DataInfo;
 
 pub(super) struct Context {
     pub(super) face: Arc<FaceState>,
@@ -26,7 +27,7 @@ pub(super) struct Context {
     pub(super) subs: Option<SubInfo>,
     #[allow(dead_code)]
     pub(super) qabl: bool,
-    pub(super) last_values: HashMap<String, (Option<RBuf>, RBuf)>,
+    pub(super) last_values: HashMap<String, (Option<DataInfo>, RBuf)>,
 }
 
 pub struct Resource {

--- a/zenoh-router/src/runtime/mod.rs
+++ b/zenoh-router/src/runtime/mod.rs
@@ -62,7 +62,11 @@ impl Runtime {
 
         log::debug!("Using PID: {}", pid);
 
-        let hlc = HLC::with_system_time(uhlc::ID::from(&pid));
+        let hlc = if config.add_timestamp {
+            Some(HLC::with_system_time(uhlc::ID::from(&pid)))
+        } else {
+            None
+        };
         let broker = Arc::new(Broker::new(hlc));
 
         let sm_config = SessionManagerConfig {
@@ -135,6 +139,7 @@ pub struct Config {
     pub listeners: Vec<Locator>,
     pub multicast_interface: String,
     pub scouting_delay: Duration,
+    pub add_timestamp: bool,
 }
 
 impl Config {
@@ -145,6 +150,7 @@ impl Config {
             listeners: vec![],
             multicast_interface: "auto".to_string(),
             scouting_delay: Duration::new(0, 250_000_000),
+            add_timestamp: false,
         }
     }
 
@@ -201,6 +207,11 @@ impl Config {
             "broker" => Ok(whatami::BROKER),
             _ => Err(()),
         }
+    }
+
+    pub fn add_timestamp(mut self) -> Self {
+        self.add_timestamp = true;
+        self
     }
 }
 

--- a/zenoh-router/tests/tables.rs
+++ b/zenoh-router/tests/tables.rs
@@ -28,7 +28,7 @@ use zenoh_router::routing::broker::*;
 #[test]
 fn base_test() {
     task::block_on(async {
-        let tables = Tables::new(HLC::default());
+        let tables = Tables::new(Some(HLC::default()));
         let primitives = Arc::new(Mux::new(Arc::new(DummyHandler::new())));
         let face = Tables::open_face(&tables, whatami::CLIENT, primitives.clone()).await;
         declare_resource(
@@ -124,7 +124,7 @@ fn match_test() {
             "/x/*e",
         ];
 
-        let tables = Tables::new(HLC::default());
+        let tables = Tables::new(Some(HLC::default()));
         let primitives = Arc::new(Mux::new(Arc::new(DummyHandler::new())));
         let face = Tables::open_face(&tables, whatami::CLIENT, primitives.clone()).await;
         for (i, rname) in rnames.iter().enumerate() {
@@ -158,7 +158,7 @@ fn match_test() {
 #[test]
 fn clean_test() {
     task::block_on(async {
-        let tables = Tables::new(HLC::default());
+        let tables = Tables::new(Some(HLC::default()));
 
         let primitives = Arc::new(Mux::new(Arc::new(DummyHandler::new())));
         let face0 = Tables::open_face(&tables, whatami::CLIENT, primitives.clone()).await;
@@ -505,7 +505,7 @@ impl Primitives for ClientPrimitives {
 #[test]
 fn client_test() {
     task::block_on(async {
-        let tables = Tables::new(HLC::default());
+        let tables = Tables::new(Some(HLC::default()));
         let sub_info = SubInfo {
             reliability: Reliability::Reliable,
             mode: SubMode::Push,

--- a/zenoh-router/tests/tables.rs
+++ b/zenoh-router/tests/tables.rs
@@ -21,7 +21,7 @@ use zenoh_protocol::core::{
     whatami, PeerId, QueryConsolidation, QueryTarget, Reliability, ResKey, SubInfo, SubMode, ZInt,
 };
 use zenoh_protocol::io::RBuf;
-use zenoh_protocol::proto::{Mux, Primitives};
+use zenoh_protocol::proto::{DataInfo, Mux, Primitives};
 use zenoh_protocol::session::DummyHandler;
 use zenoh_router::routing::broker::*;
 
@@ -461,7 +461,13 @@ impl Primitives for ClientPrimitives {
     async fn queryable(&self, _reskey: &ResKey) {}
     async fn forget_queryable(&self, _reskey: &ResKey) {}
 
-    async fn data(&self, reskey: &ResKey, _reliable: bool, _info: &Option<RBuf>, _payload: RBuf) {
+    async fn data(
+        &self,
+        reskey: &ResKey,
+        _reliable: bool,
+        _info: Option<DataInfo>,
+        _payload: RBuf,
+    ) {
         *self.data.lock().unwrap() = Some(reskey.clone());
     }
     async fn query(
@@ -479,7 +485,7 @@ impl Primitives for ClientPrimitives {
         _source_kind: ZInt,
         _replier_id: PeerId,
         _reskey: ResKey,
-        _info: Option<RBuf>,
+        _info: Option<DataInfo>,
         _payload: RBuf,
     ) {
     }
@@ -603,7 +609,7 @@ fn client_test() {
             0,
             "/test/client/z1_wr1",
             true,
-            &None,
+            None,
             RBuf::new(),
         )
         .await;
@@ -629,7 +635,7 @@ fn client_test() {
             11,
             "/z1_wr2",
             true,
-            &None,
+            None,
             RBuf::new(),
         )
         .await;
@@ -655,7 +661,7 @@ fn client_test() {
             0,
             "/test/client/**",
             true,
-            &None,
+            None,
             RBuf::new(),
         )
         .await;
@@ -681,7 +687,7 @@ fn client_test() {
             12,
             "",
             true,
-            &None,
+            None,
             RBuf::new(),
         )
         .await;
@@ -707,7 +713,7 @@ fn client_test() {
             22,
             "",
             true,
-            &None,
+            None,
             RBuf::new(),
         )
         .await;

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -92,7 +92,7 @@ path = "examples/zenoh-net/zn_write.rs"
 name = "zn_pub"
 path = "examples/zenoh-net/zn_pub.rs"
 
-[[example]] 
+[[example]]
 name = "zn_sub"
 path = "examples/zenoh-net/zn_sub.rs"
 

--- a/zenoh/examples/zenoh-net/zn_pull.rs
+++ b/zenoh/examples/zenoh-net/zn_pull.rs
@@ -48,9 +48,6 @@ async fn main() {
                 let sample = sample.unwrap();
                 println!(">> [Subscription listener] Received ('{}': '{}')",
                     sample.res_name, String::from_utf8_lossy(&sample.payload.to_vec()));
-                if let Some(mut info) = sample.data_info {
-                    let _info = info.read_datainfo();
-                }
             },
 
             _ = stdin.read_exact(&mut input).fuse() => {

--- a/zenoh/examples/zenoh-net/zn_storage.rs
+++ b/zenoh/examples/zenoh-net/zn_storage.rs
@@ -28,7 +28,7 @@ async fn main() {
 
     let (config, selector) = parse_args();
 
-    let mut stored: HashMap<String, (RBuf, Option<RBuf>)> = HashMap::new();
+    let mut stored: HashMap<String, (RBuf, Option<DataInfo>)> = HashMap::new();
 
     println!("Opening session...");
     let session = open(config, None).await.unwrap();

--- a/zenoh/examples/zenoh-net/zn_sub.rs
+++ b/zenoh/examples/zenoh-net/zn_sub.rs
@@ -47,9 +47,6 @@ async fn main() {
                 let sample = sample.unwrap();
                 println!(">> [Subscription listener] Received ('{}': '{}')",
                     sample.res_name, String::from_utf8_lossy(&sample.payload.to_vec()));
-                if let Some(mut info) = sample.data_info {
-                    let _info = info.read_datainfo();
-                }
             },
 
             _ = stdin.read_exact(&mut input).fuse() => {

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -92,7 +92,7 @@ pub use values::*;
 
 pub mod utils;
 
-pub use zenoh_protocol::core::Timestamp;
+pub use zenoh_protocol::core::{Timestamp, TimestampID};
 
 type Config = net::Config;
 

--- a/zenoh/src/net/session.rs
+++ b/zenoh/src/net/session.rs
@@ -211,24 +211,24 @@ impl Session {
         trace!("info()");
         let mut info = Properties::new();
         let runtime = self.runtime.read().await;
-        info.push((ZN_INFO_PID_KEY, runtime.pid.id.clone()));
+        info.push((ZN_INFO_PID_KEY, runtime.pid.as_slice().to_vec()));
         for session in runtime.orchestrator.manager.get_sessions().await {
             if let Ok(what) = session.get_whatami() {
                 if what & whatami::PEER != 0 {
                     if let Ok(peer) = session.get_pid() {
-                        info.push((ZN_INFO_PEER_PID_KEY, peer.id));
+                        info.push((ZN_INFO_PEER_PID_KEY, peer.as_slice().to_vec()));
                     }
                 }
             }
         }
         if runtime.orchestrator.whatami & whatami::BROKER != 0 {
-            info.push((ZN_INFO_ROUTER_PID_KEY, runtime.pid.id.clone()));
+            info.push((ZN_INFO_ROUTER_PID_KEY, runtime.pid.as_slice().to_vec()));
         }
         for session in runtime.orchestrator.manager.get_sessions().await {
             if let Ok(what) = session.get_whatami() {
                 if what & whatami::BROKER != 0 {
                     if let Ok(peer) = session.get_pid() {
-                        info.push((ZN_INFO_ROUTER_PID_KEY, peer.id));
+                        info.push((ZN_INFO_ROUTER_PID_KEY, peer.as_slice().to_vec()));
                     }
                 }
             }

--- a/zenoh/src/net/types.rs
+++ b/zenoh/src/net/types.rs
@@ -68,8 +68,11 @@ pub use zenoh_protocol::proto::Hello;
 /// # use zenoh_protocol::io::RBuf;
 /// # use zenoh_protocol::proto::DataInfo;
 /// # let sample = zenoh::net::Sample { res_name: "".to_string(), payload: RBuf::new(), data_info: None };
-/// if let Some(mut info) = sample.data_info {
-///     let info: DataInfo = info.read_datainfo().unwrap();
+/// if let Some(info) = sample.data_info {
+///     match info.timestamp {
+///         Some(ts) => println!("Sample's timestamp: {}", ts),
+///         None => println!("Sample has no timestamp"),
+///     }
 /// }
 /// ```
 pub use zenoh_protocol::proto::DataInfo;
@@ -116,7 +119,7 @@ impl Stream for HelloStream {
 pub struct Sample {
     pub res_name: String,
     pub payload: RBuf,
-    pub data_info: Option<RBuf>,
+    pub data_info: Option<DataInfo>,
 }
 
 /// The callback that will be called on each data for a [CallbackSubscriber](CallbackSubscriber).

--- a/zenoh/src/workspace.rs
+++ b/zenoh/src/workspace.rs
@@ -24,6 +24,7 @@ use async_std::task::{Context, Poll};
 use log::{debug, warn};
 use pin_project_lite::pin_project;
 use std::convert::TryInto;
+use zenoh_protocol::core::TimestampID;
 use zenoh_util::zerror;
 
 pub struct Workspace {
@@ -428,6 +429,10 @@ impl Stream for GetRequestStream {
 // generate a reception timestamp with id=0x00
 fn new_reception_timestamp() -> Timestamp {
     use std::time::{SystemTime, UNIX_EPOCH};
+
     let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-    Timestamp::new(now.into(), vec![0x00])
+    Timestamp::new(
+        now.into(),
+        TimestampID::new(1, [0u8; TimestampID::MAX_SIZE]),
+    )
 }

--- a/zenoh/src/workspace.rs
+++ b/zenoh/src/workspace.rs
@@ -14,10 +14,9 @@
 use crate::net::queryable::EVAL;
 use crate::net::{
     data_kind, encoding, DataInfo, Query, QueryConsolidation, QueryTarget, Queryable, RBuf,
-    Reliability, RepliesSender, Reply, ResKey, Sample, Session, SubInfo, SubMode, Subscriber, WBuf,
-    ZInt,
+    Reliability, RepliesSender, Reply, ResKey, Sample, Session, SubInfo, SubMode, Subscriber, ZInt,
 };
-use crate::{utils, Path, PathExpr, Selector, Timestamp, Value, ZError, ZErrorKind, ZResult};
+use crate::{Path, PathExpr, Selector, Timestamp, Value, ZError, ZErrorKind, ZResult};
 use async_std::pin::Pin;
 use async_std::stream::Stream;
 use async_std::sync::Receiver;
@@ -208,7 +207,14 @@ pub struct Data {
 
 fn reply_to_data(reply: Reply, decode_value: bool) -> ZResult<Data> {
     let path: Path = reply.data.res_name.try_into().unwrap();
-    let (_, encoding, timestamp) = utils::decode_data_info(reply.data.data_info);
+    let (encoding, timestamp) = if let Some(info) = reply.data.data_info {
+        (
+            info.encoding.unwrap_or(encoding::APP_OCTET_STREAM),
+            info.timestamp.unwrap_or_else(new_reception_timestamp),
+        )
+    } else {
+        (encoding::APP_OCTET_STREAM, new_reception_timestamp())
+    };
     let value = if decode_value {
         Value::decode(encoding, reply.data.payload)?
     } else {
@@ -286,11 +292,23 @@ impl Change {
     fn new(
         res_name: &str,
         payload: RBuf,
-        data_info: Option<RBuf>,
+        data_info: Option<DataInfo>,
         decode_value: bool,
     ) -> ZResult<Change> {
         let path = res_name.try_into()?;
-        let (kind, encoding, timestamp) = utils::decode_data_info(data_info);
+        let (kind, encoding, timestamp) = if let Some(info) = data_info {
+            (
+                info.kind.map_or(ChangeKind::PUT, ChangeKind::from),
+                info.encoding.unwrap_or(encoding::APP_OCTET_STREAM),
+                info.timestamp.unwrap_or_else(new_reception_timestamp),
+            )
+        } else {
+            (
+                ChangeKind::PUT,
+                encoding::APP_OCTET_STREAM,
+                new_reception_timestamp(),
+            )
+        };
         let value = if kind == ChangeKind::DELETE {
             None
         } else if decode_value {
@@ -354,12 +372,10 @@ fn path_value_to_sample(path: Path, value: Value) -> Sample {
         kind: None,
         encoding: Some(encoding),
     };
-    let mut infobuf = WBuf::new(16, false);
-    infobuf.write_datainfo(&info);
     Sample {
         res_name: path.to_string(),
         payload,
-        data_info: Some(infobuf.into()),
+        data_info: Some(info),
     }
 }
 
@@ -407,4 +423,11 @@ impl Stream for GetRequestStream {
             Poll::Pending => Poll::Pending,
         }
     }
+}
+
+// generate a reception timestamp with id=0x00
+fn new_reception_timestamp() -> Timestamp {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+    Timestamp::new(now.into(), vec![0x00])
 }


### PR DESCRIPTION
This pull requests brings the following changes:

- Addition of a **Config::add_timestamp** boolean in zenoh-net API (set to false by default)
- Addition of a "**--no-timestamp**" option in zenohd (set to false by default). I.e.: by default zenohd will check the DataInfo of the Data messages it routes. If it contains no timestamp, zenohd will add one, generated by it's HLC. If it contains one, zenohd will update its HLC with the incoming time.
- Changes in internal APIs to always **deserialize a received DataInfo**. This causes an improvement of throughput perfs in case DataInfo is checked for timestamp (but causes a loss if not).
- Changes in internal representation of PeerIds and Timestamps to use an **u8 fixed-size array** instead of a Vec<u8>. This causes an improvement of throughput perfs, since the PeerIds can be allocated on the stack.