### PR TITLE
fix README.md path in zenoh/Cargo.toml, Fixes #71

### DIFF
--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -24,7 +24,7 @@ edition = "2018"
 license = " EPL-2.0 OR Apache-2.0"
 categories = ["network-programming"]
 description = "Zenoh: Zero Overhead Pub/sub, Store/Query and Compute."
-readme = "../README.md"
+readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This fixes #71. 

Signed-off-by: gabrik <gabriele.baldoni@gmail.com>