### PR TITLE
Compile with Rust 1.47

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2018,6 +2018,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3041,6 +3047,7 @@ dependencies = [
  "pnet",
  "rand 0.8.3",
  "rand_chacha 0.3.0",
+ "rustversion",
  "sha3",
  "shellexpand",
  "winapi 0.3.9",

--- a/zenoh-util/Cargo.toml
+++ b/zenoh-util/Cargo.toml
@@ -48,6 +48,7 @@ hmac = "0.10.1"
 sha3 = "0.9.1"
 clap = "2"
 log = "0.4.14"
+rustversion = "1.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["iphlpapi"] }

--- a/zenoh/src/net/routing/network.rs
+++ b/zenoh/src/net/routing/network.rs
@@ -734,10 +734,15 @@ pub(super) fn shared_nodes(net1: &Network, net2: &Network) -> Vec<PeerId> {
     net1.graph
         .node_references()
         .filter_map(|(_, node1)| {
-            net2.graph
+            if net2
+                .graph
                 .node_references()
                 .any(|(_, node2)| node1.pid == node2.pid)
-                .then(|| node1.pid.clone())
+            {
+                Some(node1.pid.clone())
+            } else {
+                None
+            }
         })
         .collect()
 }

--- a/zenoh/src/net/routing/resource.rs
+++ b/zenoh/src/net/routing/resource.rs
@@ -148,8 +148,13 @@ impl Resource {
     #[inline(always)]
     pub fn routers_data_route(&self, context: usize) -> Option<Arc<Route>> {
         match &self.context {
-            Some(ctx) => (ctx.routers_data_routes.len() > context)
-                .then(|| ctx.routers_data_routes[context].clone()),
+            Some(ctx) => {
+                if ctx.routers_data_routes.len() > context {
+                    Some(ctx.routers_data_routes[context].clone())
+                } else {
+                    None
+                }
+            }
             None => None,
         }
     }
@@ -157,8 +162,13 @@ impl Resource {
     #[inline(always)]
     pub fn peers_data_route(&self, context: usize) -> Option<Arc<Route>> {
         match &self.context {
-            Some(ctx) => (ctx.peers_data_routes.len() > context)
-                .then(|| ctx.peers_data_routes[context].clone()),
+            Some(ctx) => {
+                if ctx.peers_data_routes.len() > context {
+                    Some(ctx.peers_data_routes[context].clone())
+                } else {
+                    None
+                }
+            }
             None => None,
         }
     }
@@ -174,8 +184,13 @@ impl Resource {
     #[inline(always)]
     pub fn routers_query_route(&self, context: usize) -> Option<Arc<Route>> {
         match &self.context {
-            Some(ctx) => (ctx.routers_query_routes.len() > context)
-                .then(|| ctx.routers_query_routes[context].clone()),
+            Some(ctx) => {
+                if ctx.routers_query_routes.len() > context {
+                    Some(ctx.routers_query_routes[context].clone())
+                } else {
+                    None
+                }
+            }
             None => None,
         }
     }
@@ -183,8 +198,13 @@ impl Resource {
     #[inline(always)]
     pub fn peers_query_route(&self, context: usize) -> Option<Arc<Route>> {
         match &self.context {
-            Some(ctx) => (ctx.peers_query_routes.len() > context)
-                .then(|| ctx.peers_query_routes[context].clone()),
+            Some(ctx) => {
+                if ctx.peers_query_routes.len() > context {
+                    Some(ctx.peers_query_routes[context].clone())
+                } else {
+                    None
+                }
+            }
             None => None,
         }
     }

--- a/zenoh/src/net/session.rs
+++ b/zenoh/src/net/session.rs
@@ -555,14 +555,22 @@ impl Session {
                 let joined_sub = state.subscribers.values().any(|s| {
                     rname::include(join_sub, &state.localkey_to_resname(&s.reskey).unwrap())
                 });
-                (!joined_sub).then(|| join_sub.clone().into())
+                if !joined_sub {
+                    Some(join_sub.clone().into())
+                } else {
+                    None
+                }
             }
             None => {
                 let twin_sub = state.subscribers.values().any(|s| {
                     state.localkey_to_resname(&s.reskey).unwrap()
                         == state.localkey_to_resname(&sub_state.reskey).unwrap()
                 });
-                (!twin_sub).then(|| sub_state.reskey.clone())
+                if !twin_sub {
+                    Some(sub_state.reskey.clone())
+                } else {
+                    None
+                }
             }
         };
 


### PR DESCRIPTION
Before submitting the zenoh bridge to the ROS index, I tested if it could be built by the version of the Rust compiler that Ubuntu ships with (1.47). I'm avoiding rustup so that the ROS buildfarm can build packages cleanly without dependencies that can't be installed via APT.