### PR TITLE
Implement `futures::stream::FusedStream` for receiver types

### DIFF
--- a/zenoh-util/src/sync/channel.rs
+++ b/zenoh-util/src/sync/channel.rs
@@ -91,6 +91,13 @@ macro_rules! zreceiver{
             }
         }
 
+        impl$(<$( $lt ),+>)? futures::stream::FusedStream for $struct_name$(<$( $lt ),+>)? {
+            #[inline(always)]
+            fn is_terminated(&self) -> bool {
+                self.stream.is_terminated()
+            }
+        }
+
         impl $struct_name$(<$( $lt ),+>)? {
             #[inline(always)]
             pub fn iter(&self) -> Iter<'_, $recv_type> {


### PR DESCRIPTION
Implementing the [`FusedStream`](https://docs.rs/futures/0.3.17/futures/stream/trait.FusedStream.html) trait makes it possible to use the receiver types together with the [`futures::select!`](https://docs.rs/futures/0.3.17/futures/macro.select.html) macro.
