### PR TITLE
Remove unnecessary internal Arc references and remove Clone impls

### DIFF
--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -333,6 +333,7 @@ where
             .filter_map(|iface| Runtime::bind_ucast_port(iface).ok())
             .collect();
         if !sockets.is_empty() {
+            // TODO: join this task
             async_std::task::spawn(async move {
                 let hello_sender = &hello_sender;
                 let mut stop_receiver = stop_receiver.stream();

--- a/zenoh/src/net/link/manager.rs
+++ b/zenoh/src/net/link/manager.rs
@@ -45,7 +45,7 @@ pub(crate) struct LinkManagerBuilderUnicast;
 
 impl LinkManagerBuilderUnicast {
     pub(crate) fn make(
-        manager: TransportManager,
+        manager: Arc<TransportManager>,
         protocol: &LocatorProtocol,
     ) -> ZResult<LinkManagerUnicast> {
         match protocol {

--- a/zenoh/src/net/link/udp/unicast.rs
+++ b/zenoh/src/net/link/udp/unicast.rs
@@ -256,12 +256,12 @@ impl ListenerUnicastUdp {
 }
 
 pub struct LinkManagerUnicastUdp {
-    manager: TransportManager,
+    manager: Arc<TransportManager>,
     listeners: Arc<RwLock<HashMap<SocketAddr, ListenerUnicastUdp>>>,
 }
 
 impl LinkManagerUnicastUdp {
-    pub(crate) fn new(manager: TransportManager) -> Self {
+    pub(crate) fn new(manager: Arc<TransportManager>) -> Self {
         Self {
             manager,
             listeners: Arc::new(RwLock::new(HashMap::new())),
@@ -442,7 +442,7 @@ async fn accept_read_task(
     socket: UdpSocket,
     active: Arc<AtomicBool>,
     signal: Signal,
-    manager: TransportManager,
+    manager: Arc<TransportManager>,
 ) -> ZResult<()> {
     let socket = Arc::new(socket);
     let links: LinkHashMap = Arc::new(Mutex::new(HashMap::new()));
@@ -534,7 +534,10 @@ async fn accept_read_task(
                         LinkUnicastUdpVariant::Unconnected(unconnected),
                     ));
                     // Add the new link to the set of connected peers
-                    manager.handle_new_link_unicast(LinkUnicast(link)).await;
+                    manager
+                        .clone()
+                        .handle_new_link_unicast(LinkUnicast(link))
+                        .await;
                 }
             }
         };

--- a/zenoh/src/net/link/unixsock_stream/unicast.rs
+++ b/zenoh/src/net/link/unixsock_stream/unicast.rs
@@ -182,12 +182,12 @@ impl ListenerUnixSocketStream {
 }
 
 pub struct LinkManagerUnicastUnixSocketStream {
-    manager: TransportManager,
+    manager: Arc<TransportManager>,
     listeners: Arc<RwLock<HashMap<String, ListenerUnixSocketStream>>>,
 }
 
 impl LinkManagerUnicastUnixSocketStream {
-    pub(crate) fn new(manager: TransportManager) -> Self {
+    pub(crate) fn new(manager: Arc<TransportManager>) -> Self {
         Self {
             manager,
             listeners: Arc::new(RwLock::new(HashMap::new())),
@@ -449,7 +449,7 @@ async fn accept_task(
     socket: UnixListener,
     active: Arc<AtomicBool>,
     signal: Signal,
-    manager: TransportManager,
+    manager: Arc<TransportManager>,
 ) -> ZResult<()> {
     enum Action {
         Accept(UnixStream),
@@ -530,7 +530,10 @@ async fn accept_task(
         ));
 
         // Communicate the new link to the initial transport manager
-        manager.handle_new_link_unicast(LinkUnicast(link)).await;
+        manager
+            .clone()
+            .handle_new_link_unicast(LinkUnicast(link))
+            .await;
     }
 
     Ok(())

--- a/zenoh/src/net/routing/network.rs
+++ b/zenoh/src/net/routing/network.rs
@@ -474,6 +474,7 @@ impl Network {
                         let runtime = self.runtime.clone();
                         let pid = node.pid;
                         let locators = locators.clone();
+                        // TODO: join this task
                         async_std::task::spawn(async move {
                             // random backoff
                             async_std::task::sleep(std::time::Duration::from_millis(

--- a/zenoh/src/net/routing/router.rs
+++ b/zenoh/src/net/routing/router.rs
@@ -460,6 +460,7 @@ impl TransportPeerEventHandler for LinkStateInterceptor {
         let tables_ref = self.tables.clone();
         let pid = self.transport.get_pid().unwrap();
         let whatami = self.transport.get_whatami();
+        // TODO: join this task
         async_std::task::spawn(async move {
             async_std::task::sleep(std::time::Duration::from_millis(*LINK_CLOSURE_DELAY)).await;
             let mut tables = zwrite!(tables_ref);

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -105,6 +105,7 @@ impl AdminSpace {
         });
 
         let cfg_rx = admin.context.runtime.config.subscribe();
+        // TODO: join this task
         task::spawn({
             let admin = admin.clone();
             async move {
@@ -384,6 +385,7 @@ impl Primitives for AdminSpace {
         let value_selector = value_selector.to_string();
 
         // router is not re-entrant
+        // TODO: join this task
         task::spawn(async move {
             let handler_tasks = futures::future::join_all(matching_handlers.into_iter().map(
                 |(key, handler)| async {

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -479,7 +479,7 @@ pub async fn router_data(
     _key: &KeyExpr<'_>,
     #[allow(unused_variables)] selector: &str,
 ) -> (ZBuf, Encoding) {
-    let transport_mgr = context.runtime.manager().clone();
+    let transport_mgr = context.runtime.manager();
 
     // plugins info
     let plugins: Vec<serde_json::Value> = {

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -143,6 +143,7 @@ impl Runtime {
         }
 
         let receiver = config.subscribe();
+        // TODO: join this task
         async_std::task::spawn({
             let runtime = runtime.clone();
             async move {

--- a/zenoh/src/net/runtime/orchestrator.rs
+++ b/zenoh/src/net/runtime/orchestrator.rs
@@ -154,6 +154,7 @@ impl Runtime {
 
         for peer in peers {
             let this = self.clone();
+            // TODO: join this task
             async_std::task::spawn(async move { this.peer_connector(peer).await });
         }
 
@@ -167,6 +168,7 @@ impl Runtime {
                     .collect();
                 if !sockets.is_empty() {
                     let this = self.clone();
+                    // TODO: join this task
                     async_std::task::spawn(async move {
                         async_std::prelude::FutureExt::race(
                             this.responder(&mcast_socket, &sockets),
@@ -227,6 +229,7 @@ impl Runtime {
 
         for peer in peers {
             let this = self.clone();
+            // TODO: join this task
             async_std::task::spawn(async move { this.peer_connector(peer).await });
         }
 
@@ -241,6 +244,7 @@ impl Runtime {
                 if !sockets.is_empty() {
                     let this = self.clone();
                     if routers_autoconnect_multicast {
+                        // TODO: join this task
                         async_std::task::spawn(async move {
                             async_std::prelude::FutureExt::race(
                                 this.responder(&mcast_socket, &sockets),
@@ -249,6 +253,7 @@ impl Runtime {
                             .await;
                         });
                     } else {
+                        // TODO: join this task
                         async_std::task::spawn(async move {
                             this.responder(&mcast_socket, &sockets).await;
                         });
@@ -302,6 +307,7 @@ impl Runtime {
                     false
                 }) {
                     let this = self.clone();
+                    // TODO: join this task
                     async_std::task::spawn(async move { this.peer_connector(peer).await });
                 }
             }
@@ -758,6 +764,7 @@ impl Runtime {
         match session.runtime.whatami {
             WhatAmI::Client => {
                 let runtime = session.runtime.clone();
+                // TODO: join this task
                 async_std::task::spawn(async move {
                     let mut delay = CONNECTION_RETRY_INITIAL_PERIOD;
                     while runtime.start_client().await.is_err() {
@@ -775,6 +782,7 @@ impl Runtime {
                     if peers.contains(locator) {
                         let locator = locator.clone();
                         let runtime = session.runtime.clone();
+                        // TODO: join this task
                         async_std::task::spawn(
                             async move { runtime.peer_connector(locator).await },
                         );

--- a/zenoh/src/net/transport/common/conduit.rs
+++ b/zenoh/src/net/transport/common/conduit.rs
@@ -14,7 +14,7 @@
 use super::defragmentation::DefragBuffer;
 use super::protocol::core::{ConduitSn, Priority, Reliability, ZInt};
 use super::seq_num::{SeqNum, SeqNumGenerator};
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 use zenoh_util::core::zresult::ZResult;
 use zenoh_util::zlock;
 
@@ -67,11 +67,11 @@ impl TransportChannelRx {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(crate) struct TransportConduitTx {
     pub(crate) priority: Priority,
-    pub(crate) reliable: Arc<Mutex<TransportChannelTx>>,
-    pub(crate) best_effort: Arc<Mutex<TransportChannelTx>>,
+    pub(crate) reliable: Mutex<TransportChannelTx>,
+    pub(crate) best_effort: Mutex<TransportChannelTx>,
 }
 
 impl TransportConduitTx {
@@ -80,8 +80,8 @@ impl TransportConduitTx {
         let bch = TransportChannelTx::make(sn_resolution)?;
         let ctx = TransportConduitTx {
             priority,
-            reliable: Arc::new(Mutex::new(rch)),
-            best_effort: Arc::new(Mutex::new(bch)),
+            reliable: Mutex::new(rch),
+            best_effort: Mutex::new(bch),
         };
         Ok(ctx)
     }
@@ -92,11 +92,11 @@ impl TransportConduitTx {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(crate) struct TransportConduitRx {
     pub(crate) priority: Priority,
-    pub(crate) reliable: Arc<Mutex<TransportChannelRx>>,
-    pub(crate) best_effort: Arc<Mutex<TransportChannelRx>>,
+    pub(crate) reliable: Mutex<TransportChannelRx>,
+    pub(crate) best_effort: Mutex<TransportChannelRx>,
 }
 
 impl TransportConduitRx {
@@ -110,8 +110,8 @@ impl TransportConduitRx {
             TransportChannelRx::make(Reliability::BestEffort, sn_resolution, defrag_buff_size)?;
         let ctr = TransportConduitRx {
             priority,
-            reliable: Arc::new(Mutex::new(rch)),
-            best_effort: Arc::new(Mutex::new(bch)),
+            reliable: Mutex::new(rch),
+            best_effort: Mutex::new(bch),
         };
         Ok(ctr)
     }

--- a/zenoh/src/net/transport/common/pipeline.rs
+++ b/zenoh/src/net/transport/common/pipeline.rs
@@ -997,6 +997,7 @@ mod tests {
 
         let c_pipeline = pipeline.clone();
         let c_size = size.clone();
+        // TODO: join this task
         task::spawn(async move {
             loop {
                 let payload_sizes: [usize; 16] = [
@@ -1041,6 +1042,7 @@ mod tests {
 
         let c_pipeline = pipeline;
         let c_count = count.clone();
+        // TODO: join this task
         task::spawn(async move {
             loop {
                 let (batch, priority) = c_pipeline.pull().await.unwrap();
@@ -1050,6 +1052,7 @@ mod tests {
             }
         });
 
+        // TODO: join this task
         task::block_on(async {
             let mut prev_size: usize = usize::MAX;
             loop {

--- a/zenoh/src/net/transport/manager.rs
+++ b/zenoh/src/net/transport/manager.rs
@@ -260,7 +260,7 @@ impl Default for TransportManagerBuilder {
     }
 }
 
-#[derive(Clone)]
+// #[derive(Clone)]
 pub struct TransportManager {
     pub config: Arc<TransportManagerConfig>,
     pub(crate) state: Arc<TransportManagerState>,
@@ -305,7 +305,7 @@ impl TransportManager {
     /*************************************/
     /*              LISTENER             */
     /*************************************/
-    pub async fn add_listener(&self, endpoint: EndPoint) -> ZResult<Locator> {
+    pub async fn add_listener(self: Arc<Self>, endpoint: EndPoint) -> ZResult<Locator> {
         if endpoint.locator.address.is_multicast() {
             // @TODO: multicast
             unimplemented!();
@@ -346,7 +346,7 @@ impl TransportManager {
         // @TODO: multicast
     }
 
-    pub async fn open_transport(&self, endpoint: EndPoint) -> ZResult<TransportUnicast> {
+    pub async fn open_transport(self: Arc<Self>, endpoint: EndPoint) -> ZResult<TransportUnicast> {
         if endpoint.locator.address.is_multicast() {
             // @TODO: multicast
             unimplemented!();

--- a/zenoh/src/net/transport/multicast/establishment.rs
+++ b/zenoh/src/net/transport/multicast/establishment.rs
@@ -21,7 +21,7 @@ use zenoh_util::core::Result as ZResult;
 use zenoh_util::zasynclock;
 
 pub(crate) async fn open_link(
-    manager: &TransportManager,
+    manager: Arc<TransportManager>,
     link: LinkMulticast,
 ) -> ZResult<TransportMulticast> {
     // Create and configure the multicast transport
@@ -51,7 +51,7 @@ pub(crate) async fn open_link(
         initial_sns,
         link: link.clone(),
     };
-    let ti = Arc::new(TransportMulticastInner::make(config)?);
+    let ti = TransportMulticastInner::make(config)?;
 
     // Store the active transport
     let transport: TransportMulticast = (&ti).into();

--- a/zenoh/src/net/transport/multicast/link.rs
+++ b/zenoh/src/net/transport/multicast/link.rs
@@ -125,6 +125,7 @@ impl TransportLinkMulticast {
                     log::debug!("{}", e);
                     // Spawn a task to avoid a deadlock waiting for this same task
                     // to finish in the close() joining its handle
+                    // TODO: join this task
                     task::spawn(async move { c_transport.delete().await });
                 }
             });
@@ -163,6 +164,7 @@ impl TransportLinkMulticast {
                     log::debug!("{}", e);
                     // Spawn a task to avoid a deadlock waiting for this same task
                     // to finish in the close() joining its handle
+                    // TODO: join this task
                     task::spawn(async move { c_transport.delete().await });
                 }
             });

--- a/zenoh/src/net/transport/multicast/link.rs
+++ b/zenoh/src/net/transport/multicast/link.rs
@@ -24,7 +24,6 @@ use async_std::prelude::*;
 use async_std::task;
 use async_std::task::JoinHandle;
 use std::convert::TryInto;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use zenoh_util::collections::RecyclingObjectPool;
@@ -52,7 +51,6 @@ pub(super) struct TransportLinkMulticast {
     pipeline: Option<Arc<TransmissionPipeline>>,
     // The signals to stop TX/RX tasks
     handle_tx: Option<JoinHandle<()>>,
-    active_rx: Arc<AtomicBool>,
     signal_rx: Signal,
     handle_rx: Option<JoinHandle<()>>,
 }
@@ -67,7 +65,6 @@ impl TransportLinkMulticast {
             inner: link,
             pipeline: None,
             handle_tx: None,
-            active_rx: Arc::new(AtomicBool::new(false)),
             signal_rx: Signal::new(),
             handle_rx: None,
         }
@@ -141,12 +138,10 @@ impl TransportLinkMulticast {
 
     pub(super) fn start_rx(&mut self) {
         if self.handle_rx.is_none() {
-            self.active_rx.store(true, Ordering::Release);
             // Spawn the RX task
             let c_link = self.inner.clone();
             let c_transport = self.transport.clone();
             let c_signal = self.signal_rx.clone();
-            let c_active = self.active_rx.clone();
             let c_rx_buff_size = self.transport.manager.config.link_rx_buff_size;
 
             let handle = task::spawn(async move {
@@ -155,11 +150,12 @@ impl TransportLinkMulticast {
                     c_link.clone(),
                     c_transport.clone(),
                     c_signal.clone(),
-                    c_active.clone(),
                     c_rx_buff_size,
                 )
                 .await;
-                c_active.store(false, Ordering::Release);
+
+                c_signal.trigger();
+
                 if let Err(e) = res {
                     log::debug!("{}", e);
                     // Spawn a task to avoid a deadlock waiting for this same task
@@ -173,7 +169,6 @@ impl TransportLinkMulticast {
     }
 
     pub(super) fn stop_rx(&mut self) {
-        self.active_rx.store(false, Ordering::Release);
         self.signal_rx.trigger();
     }
 
@@ -326,7 +321,6 @@ async fn rx_task(
     link: LinkMulticast,
     transport: Arc<TransportMulticastInner>,
     signal: Signal,
-    active: Arc<AtomicBool>,
     rx_buff_size: usize,
 ) -> ZResult<()> {
     enum Action {
@@ -350,7 +344,7 @@ async fn rx_task(
     let mtu = link.get_mtu() as usize;
     let n = 1 + (rx_buff_size / mtu);
     let pool = RecyclingObjectPool::new(n, || vec![0_u8; mtu].into_boxed_slice());
-    while active.load(Ordering::Acquire) {
+    while !signal.is_triggered() {
         // Clear the zbuf
         zbuf.clear();
         // Retrieve one buffer

--- a/zenoh/src/net/transport/multicast/manager.rs
+++ b/zenoh/src/net/transport/multicast/manager.rs
@@ -41,9 +41,9 @@ pub struct TransportManagerBuilderMulticast {
 
 pub struct TransportManagerStateMulticast {
     // Established listeners
-    pub(super) protocols: Arc<Mutex<HashMap<LocatorProtocol, LinkManagerMulticast>>>,
+    pub(super) protocols: Mutex<HashMap<LocatorProtocol, LinkManagerMulticast>>,
     // Established transports
-    pub(super) transports: Arc<Mutex<HashMap<Locator, Arc<TransportMulticastInner>>>>,
+    pub(super) transports: Mutex<HashMap<Locator, Arc<TransportMulticastInner>>>,
 }
 
 pub struct TransportManagerParamsMulticast {
@@ -110,8 +110,8 @@ impl TransportManagerBuilderMulticast {
         };
 
         let state = TransportManagerStateMulticast {
-            protocols: Arc::new(Mutex::new(HashMap::new())),
-            transports: Arc::new(Mutex::new(HashMap::new())),
+            protocols: Mutex::new(HashMap::new()),
+            transports: Mutex::new(HashMap::new()),
         };
 
         let params = TransportManagerParamsMulticast { config, state };
@@ -183,7 +183,7 @@ impl TransportManager {
     /*             TRANSPORT             */
     /*************************************/
     pub async fn open_transport_multicast(
-        &self,
+        self: Arc<Self>,
         mut endpoint: EndPoint,
     ) -> ZResult<TransportMulticast> {
         if !endpoint.locator.address.is_multicast() {

--- a/zenoh/src/net/transport/multicast/rx.rs
+++ b/zenoh/src/net/transport/multicast/rx.rs
@@ -20,6 +20,7 @@ use super::protocol::proto::{
 };
 use super::transport::{TransportMulticastInner, TransportMulticastPeer};
 use crate::net::link::Locator;
+use std::sync::Arc;
 use std::sync::MutexGuard;
 use zenoh_util::core::Result as ZResult;
 use zenoh_util::zerror;
@@ -145,7 +146,11 @@ impl TransportMulticastInner {
         Ok(())
     }
 
-    pub(super) fn handle_join_from_unknown(&self, join: Join, locator: &Locator) -> ZResult<()> {
+    pub(super) fn handle_join_from_unknown(
+        self: Arc<Self>,
+        join: Join,
+        locator: &Locator,
+    ) -> ZResult<()> {
         if zread!(self.peers).len() >= self.manager.config.multicast.max_sessions {
             log::debug!(
                 "Ingoring Join on {} from peer: {}. Max sessions reached: {}.",
@@ -192,7 +197,11 @@ impl TransportMulticastInner {
         Ok(())
     }
 
-    pub(super) fn receive_message(&self, msg: TransportMessage, locator: &Locator) -> ZResult<()> {
+    pub(super) fn receive_message(
+        self: Arc<Self>,
+        msg: TransportMessage,
+        locator: &Locator,
+    ) -> ZResult<()> {
         // Process the received message
         let r_guard = zread!(self.peers);
         match r_guard.get(locator) {

--- a/zenoh/src/net/transport/unicast/establishment/mod.rs
+++ b/zenoh/src/net/transport/unicast/establishment/mod.rs
@@ -24,6 +24,7 @@ use crate::net::link::{Link, LinkUnicast};
 use authenticator::AuthenticatedPeerLink;
 use rand::Rng;
 use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
 use std::time::Duration;
 use zenoh_util::core::Result as ZResult;
 use zenoh_util::crypto::{BlockCipher, PseudoRng};
@@ -205,7 +206,7 @@ pub(super) struct InputInit {
     pub(super) is_qos: bool,
 }
 async fn transport_init(
-    manager: &TransportManager,
+    manager: Arc<TransportManager>,
     input: self::InputInit,
 ) -> ZResult<TransportUnicast> {
     // Initialize the transport if it is new

--- a/zenoh/src/net/transport/unicast/link.rs
+++ b/zenoh/src/net/transport/unicast/link.rs
@@ -22,7 +22,6 @@ use crate::net::link::{LinkUnicast, LinkUnicastDirection};
 use async_std::prelude::*;
 use async_std::task;
 use async_std::task::JoinHandle;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use zenoh_util::collections::RecyclingObjectPool;
@@ -41,8 +40,7 @@ pub(super) struct TransportLinkUnicast {
     transport: Arc<TransportUnicastInner>,
     // The signals to stop TX/RX tasks
     handle_tx: Option<JoinHandle<()>>,
-    active_rx: Arc<AtomicBool>,
-    signal_rx: Signal,
+    signal: Signal,
     handle_rx: Option<JoinHandle<()>>,
 }
 
@@ -58,8 +56,7 @@ impl TransportLinkUnicast {
             link,
             pipeline: None,
             handle_tx: None,
-            active_rx: Arc::new(AtomicBool::new(false)),
-            signal_rx: Signal::new(),
+            signal: Signal::new(),
             handle_rx: None,
         }
     }
@@ -114,12 +111,10 @@ impl TransportLinkUnicast {
 
     pub(super) fn start_rx(&mut self, lease: Duration) {
         if self.handle_rx.is_none() {
-            self.active_rx.store(true, Ordering::Release);
             // Spawn the RX task
             let c_link = self.link.clone();
             let c_transport = self.transport.clone();
-            let c_signal = self.signal_rx.clone();
-            let c_active = self.active_rx.clone();
+            let c_signal = self.signal.clone();
             let c_rx_buff_size = self.transport.config.manager.config.link_rx_buff_size;
 
             let handle = task::spawn(async move {
@@ -129,11 +124,11 @@ impl TransportLinkUnicast {
                     c_transport.clone(),
                     lease,
                     c_signal.clone(),
-                    c_active.clone(),
                     c_rx_buff_size,
                 )
                 .await;
-                c_active.store(false, Ordering::Release);
+                c_signal.trigger();
+
                 if let Err(e) = res {
                     log::debug!("{}", e);
 
@@ -148,8 +143,7 @@ impl TransportLinkUnicast {
     }
 
     pub(super) fn stop_rx(&mut self) {
-        self.active_rx.store(false, Ordering::Release);
-        self.signal_rx.trigger();
+        self.signal.trigger();
     }
 
     pub(super) async fn close(mut self) -> ZResult<()> {
@@ -231,7 +225,6 @@ async fn rx_task_stream(
     transport: Arc<TransportUnicastInner>,
     lease: Duration,
     signal: Signal,
-    active: Arc<AtomicBool>,
     rx_buff_size: usize,
 ) -> ZResult<()> {
     enum Action {
@@ -259,7 +252,7 @@ async fn rx_task_stream(
     let mtu = link.get_mtu() as usize;
     let n = 1 + (rx_buff_size / mtu);
     let pool = RecyclingObjectPool::new(n, || vec![0_u8; mtu].into_boxed_slice());
-    while active.load(Ordering::Acquire) {
+    while !signal.is_triggered() {
         // Clear the ZBuf
         zbuf.clear();
 
@@ -306,7 +299,6 @@ async fn rx_task_dgram(
     transport: Arc<TransportUnicastInner>,
     lease: Duration,
     signal: Signal,
-    active: Arc<AtomicBool>,
     rx_buff_size: usize,
 ) -> ZResult<()> {
     enum Action {
@@ -330,7 +322,7 @@ async fn rx_task_dgram(
     let mtu = link.get_mtu() as usize;
     let n = 1 + (rx_buff_size / mtu);
     let pool = RecyclingObjectPool::new(n, || vec![0_u8; mtu].into_boxed_slice());
-    while active.load(Ordering::Acquire) {
+    while !signal.is_triggered() {
         // Clear the zbuf
         zbuf.clear();
         // Retrieve one buffer
@@ -383,12 +375,11 @@ async fn rx_task(
     transport: Arc<TransportUnicastInner>,
     lease: Duration,
     signal: Signal,
-    active: Arc<AtomicBool>,
     rx_buff_size: usize,
 ) -> ZResult<()> {
     if link.is_streamed() {
-        rx_task_stream(link, transport, lease, signal, active, rx_buff_size).await
+        rx_task_stream(link, transport, lease, signal, rx_buff_size).await
     } else {
-        rx_task_dgram(link, transport, lease, signal, active, rx_buff_size).await
+        rx_task_dgram(link, transport, lease, signal, rx_buff_size).await
     }
 }

--- a/zenoh/src/net/transport/unicast/link.rs
+++ b/zenoh/src/net/transport/unicast/link.rs
@@ -98,6 +98,7 @@ impl TransportLinkUnicast {
                     log::debug!("{}", e);
                     // Spawn a task to avoid a deadlock waiting for this same task
                     // to finish in the close() joining its handle
+                    // TODO: join this task
                     task::spawn(async move { c_transport.del_link(&c_link).await });
                 }
             });
@@ -135,8 +136,10 @@ impl TransportLinkUnicast {
                 c_active.store(false, Ordering::Release);
                 if let Err(e) = res {
                     log::debug!("{}", e);
+
                     // Spawn a task to avoid a deadlock waiting for this same task
                     // to finish in the close() joining its handle
+                    // TODO: join this task
                     task::spawn(async move { c_transport.del_link(&c_link).await });
                 }
             });

--- a/zenoh/src/net/transport/unicast/manager.rs
+++ b/zenoh/src/net/transport/unicast/manager.rs
@@ -601,6 +601,7 @@ impl TransportManager {
         let c_manager = self.clone();
         let incoming = incoming.clone();
 
+        // TODO: join this task
         task::spawn(async move {
             let mut auth_link = AuthenticatedPeerLink {
                 src: link.get_src(),

--- a/zenoh/src/net/transport/unicast/rx.rs
+++ b/zenoh/src/net/transport/unicast/rx.rs
@@ -106,6 +106,7 @@ impl TransportUnicastInner {
         let c_link = link.clone();
         // Spawn a task to avoid a deadlock waiting for this same task
         // to finish in the link close() joining the rx handle
+        // TODO: join this task
         task::spawn(async move {
             if link_only {
                 let _ = c_transport.del_link(&c_link).await;

--- a/zenoh/src/net/transport/unicast/tx.rs
+++ b/zenoh/src/net/transport/unicast/tx.rs
@@ -15,7 +15,6 @@
 use super::protocol::proto::ZenohBody;
 use super::protocol::proto::ZenohMessage;
 use super::transport::TransportUnicastInner;
-use zenoh_util::zread;
 
 impl TransportUnicastInner {
     #[inline(always)]

--- a/zenoh/src/session.rs
+++ b/zenoh/src/session.rs
@@ -1221,6 +1221,7 @@ impl Session {
 
         if local {
             let this = self.clone();
+            // TODO: join this task
             task::spawn(async move {
                 while let Some((replier_kind, sample)) = rep_receiver.stream().next().await {
                     let (key_expr, payload, data_info) = sample.split();
@@ -1236,6 +1237,7 @@ impl Session {
                 this.send_reply_final(qid);
             });
         } else {
+            // TODO: join this task
             task::spawn(async move {
                 while let Some((replier_kind, sample)) = rep_receiver.stream().next().await {
                     let (key_expr, payload, data_info) = sample.split();

--- a/zenoh/tests/endpoints.rs
+++ b/zenoh/tests/endpoints.rs
@@ -80,17 +80,19 @@ impl TransportPeerEventHandler for SC {
 
 async fn run(endpoints: &[EndPoint]) {
     // Create the transport manager
-    let sm = TransportManager::builder()
-        .whatami(WhatAmI::Peer)
-        .pid(PeerId::new(1, [0_u8; PeerId::MAX_SIZE]))
-        .build(Arc::new(SH::default()))
-        .unwrap();
+    let sm = Arc::new(
+        TransportManager::builder()
+            .whatami(WhatAmI::Peer)
+            .pid(PeerId::new(1, [0_u8; PeerId::MAX_SIZE]))
+            .build(Arc::new(SH::default()))
+            .unwrap(),
+    );
 
     for _ in 0..RUNS {
         // Create the listeners
         for e in endpoints.iter() {
             println!("Add {}", e);
-            let res = ztimeout!(sm.add_listener(e.clone()));
+            let res = ztimeout!(sm.clone().add_listener(e.clone()));
             println!("Res: {:?}", res);
             assert!(res.is_ok());
         }

--- a/zenoh/tests/unicast_concurrent.rs
+++ b/zenoh/tests/unicast_concurrent.rs
@@ -112,22 +112,26 @@ mod tests {
         // Create the peer01 transport manager
         let peer_sh01 = Arc::new(SHPeer::new());
         let unicast01 = TransportManager::config_unicast().max_links(endpoint02.len());
-        let peer01_manager = TransportManager::builder()
-            .whatami(WhatAmI::Peer)
-            .pid(peer_id01)
-            .unicast(unicast01)
-            .build(peer_sh01.clone())
-            .unwrap();
+        let peer01_manager = Arc::new(
+            TransportManager::builder()
+                .whatami(WhatAmI::Peer)
+                .pid(peer_id01)
+                .unicast(unicast01)
+                .build(peer_sh01.clone())
+                .unwrap(),
+        );
 
         // Create the peer01 transport manager
         let peer_sh02 = Arc::new(SHPeer::new());
         let unicast02 = TransportManager::config_unicast().max_links(endpoint01.len());
-        let peer02_manager = TransportManager::builder()
-            .whatami(WhatAmI::Peer)
-            .pid(peer_id02)
-            .unicast(unicast02)
-            .build(peer_sh02.clone())
-            .unwrap();
+        let peer02_manager = Arc::new(
+            TransportManager::builder()
+                .whatami(WhatAmI::Peer)
+                .pid(peer_id02)
+                .unicast(unicast02)
+                .build(peer_sh02.clone())
+                .unwrap(),
+        );
 
         // Barrier to synchronize the two tasks
         let barrier_peer = Arc::new(Barrier::new(2));
@@ -144,7 +148,7 @@ mod tests {
         let peer01_task = task::spawn(async move {
             // Add the endpoints on the first peer
             for e in c_end01.iter() {
-                let res = ztimeout!(peer01_manager.add_listener(e.clone()));
+                let res = ztimeout!(peer01_manager.clone().add_listener(e.clone()));
                 println!("[Transport Peer 01a] => Adding endpoint {:?}: {:?}", e, res);
                 assert!(res.is_ok());
             }
@@ -165,7 +169,7 @@ mod tests {
                     println!("[Transport Peer 01c] => Waiting for opening transport");
                     // Syncrhonize before opening the transports
                     ztimeout!(cc_barow.wait());
-                    let res = ztimeout!(c_p01m.open_transport(c_end.clone()));
+                    let res = ztimeout!(c_p01m.clone().open_transport(c_end.clone()));
                     println!(
                         "[Transport Peer 01d] => Opening transport with {:?}: {:?}",
                         c_end, res
@@ -252,7 +256,7 @@ mod tests {
         let peer02_task = task::spawn(async move {
             // Add the endpoints on the first peer
             for e in c_end02.iter() {
-                let res = ztimeout!(peer02_manager.add_listener(e.clone()));
+                let res = ztimeout!(peer02_manager.clone().add_listener(e.clone()));
                 println!("[Transport Peer 02a] => Adding endpoint {:?}: {:?}", e, res);
                 assert!(res.is_ok());
             }
@@ -274,7 +278,7 @@ mod tests {
                     // Syncrhonize before opening the transports
                     ztimeout!(cc_barow.wait());
 
-                    let res = ztimeout!(c_p02m.open_transport(c_end.clone()));
+                    let res = ztimeout!(c_p02m.clone().open_transport(c_end.clone()));
                     println!(
                         "[Transport Peer 02d] => Opening transport with {:?}: {:?}",
                         c_end, res

--- a/zenoh/tests/unicast_defragmentation.rs
+++ b/zenoh/tests/unicast_defragmentation.rs
@@ -42,29 +42,33 @@ async fn run(endpoint: &EndPoint, channel: Channel, msg_size: usize) {
     let router_id = PeerId::new(1, [1_u8; PeerId::MAX_SIZE]);
 
     // Create the router transport manager
-    let router_manager = TransportManager::builder()
-        .pid(router_id)
-        .whatami(WhatAmI::Router)
-        .defrag_buff_size(MSG_DEFRAG_BUF)
-        .build(Arc::new(DummyTransportEventHandler::default()))
-        .unwrap();
+    let router_manager = Arc::new(
+        TransportManager::builder()
+            .pid(router_id)
+            .whatami(WhatAmI::Router)
+            .defrag_buff_size(MSG_DEFRAG_BUF)
+            .build(Arc::new(DummyTransportEventHandler::default()))
+            .unwrap(),
+    );
 
     // Create the client transport manager
-    let client_manager = TransportManager::builder()
-        .whatami(WhatAmI::Client)
-        .pid(client_id)
-        .defrag_buff_size(MSG_DEFRAG_BUF)
-        .build(Arc::new(DummyTransportEventHandler::default()))
-        .unwrap();
+    let client_manager = Arc::new(
+        TransportManager::builder()
+            .whatami(WhatAmI::Client)
+            .pid(client_id)
+            .defrag_buff_size(MSG_DEFRAG_BUF)
+            .build(Arc::new(DummyTransportEventHandler::default()))
+            .unwrap(),
+    );
 
     // Create the listener on the router
     println!("Add locator: {}", endpoint);
-    let _ = ztimeout!(router_manager.add_listener(endpoint.clone())).unwrap();
+    let _ = ztimeout!(router_manager.clone().add_listener(endpoint.clone())).unwrap();
 
     // Create an empty transport with the client
     // Open transport -> This should be accepted
     println!("Opening transport with {}", endpoint);
-    let _ = ztimeout!(client_manager.open_transport(endpoint.clone())).unwrap();
+    let _ = ztimeout!(client_manager.clone().open_transport(endpoint.clone())).unwrap();
 
     let client_transport = client_manager.get_transport(&router_id).unwrap();
 

--- a/zenoh/tests/unicast_intermittent.rs
+++ b/zenoh/tests/unicast_intermittent.rs
@@ -152,12 +152,14 @@ async fn transport_intermittent(endpoint: &EndPoint) {
     {
         unicast = unicast.max_links(1);
     }
-    let router_manager = TransportManager::builder()
-        .whatami(WhatAmI::Router)
-        .pid(router_id)
-        .unicast(unicast)
-        .build(router_handler.clone())
-        .unwrap();
+    let router_manager = Arc::new(
+        TransportManager::builder()
+            .whatami(WhatAmI::Router)
+            .pid(router_id)
+            .unicast(unicast)
+            .build(router_handler.clone())
+            .unwrap(),
+    );
 
     /* [CLIENT] */
     let client01_id = PeerId::new(1, [1_u8; PeerId::MAX_SIZE]);
@@ -172,12 +174,14 @@ async fn transport_intermittent(endpoint: &EndPoint) {
     {
         unicast = unicast.max_links(1);
     }
-    let client01_manager = TransportManager::builder()
-        .whatami(WhatAmI::Client)
-        .pid(client01_id)
-        .unicast(unicast)
-        .build(Arc::new(SHClientStable::new(counter.clone())))
-        .unwrap();
+    let client01_manager = Arc::new(
+        TransportManager::builder()
+            .whatami(WhatAmI::Client)
+            .pid(client01_id)
+            .unicast(unicast)
+            .build(Arc::new(SHClientStable::new(counter.clone())))
+            .unwrap(),
+    );
 
     // Create the transport transport manager for the second client
     #[allow(unused_mut)]
@@ -186,12 +190,14 @@ async fn transport_intermittent(endpoint: &EndPoint) {
     {
         unicast = unicast.max_links(1);
     }
-    let client02_manager = TransportManager::builder()
-        .whatami(WhatAmI::Client)
-        .pid(client02_id)
-        .unicast(unicast)
-        .build(Arc::new(SHClientIntermittent::default()))
-        .unwrap();
+    let client02_manager = Arc::new(
+        TransportManager::builder()
+            .whatami(WhatAmI::Client)
+            .pid(client02_id)
+            .unicast(unicast)
+            .build(Arc::new(SHClientIntermittent::default()))
+            .unwrap(),
+    );
 
     // Create the transport transport manager for the third client
     #[allow(unused_mut)]
@@ -200,24 +206,26 @@ async fn transport_intermittent(endpoint: &EndPoint) {
     {
         unicast = unicast.max_links(1);
     }
-    let client03_manager = TransportManager::builder()
-        .whatami(WhatAmI::Client)
-        .pid(client03_id)
-        .unicast(unicast)
-        .build(Arc::new(SHClientIntermittent::default()))
-        .unwrap();
+    let client03_manager = Arc::new(
+        TransportManager::builder()
+            .whatami(WhatAmI::Client)
+            .pid(client03_id)
+            .unicast(unicast)
+            .build(Arc::new(SHClientIntermittent::default()))
+            .unwrap(),
+    );
 
     /* [1] */
     // Add a listener to the router
     println!("\nTransport Intermittent [1a1]");
-    let _ = ztimeout!(router_manager.add_listener(endpoint.clone())).unwrap();
+    let _ = ztimeout!(router_manager.clone().add_listener(endpoint.clone())).unwrap();
     let locators = router_manager.get_listeners();
     println!("Transport Intermittent [1a2]: {:?}", locators);
     assert_eq!(locators.len(), 1);
 
     /* [2] */
     // Open a transport from client01 to the router
-    let c_ses1 = ztimeout!(client01_manager.open_transport(endpoint.clone())).unwrap();
+    let c_ses1 = ztimeout!(client01_manager.clone().open_transport(endpoint.clone())).unwrap();
     assert_eq!(c_ses1.get_links().unwrap().len(), 1);
     assert_eq!(client01_manager.get_transports().len(), 1);
     assert_eq!(c_ses1.get_pid().unwrap(), router_id);
@@ -232,7 +240,10 @@ async fn transport_intermittent(endpoint: &EndPoint) {
             print!("+");
             std::io::stdout().flush().unwrap();
 
-            let c_ses2 = ztimeout!(c_client02_manager.open_transport(c_endpoint.clone())).unwrap();
+            let c_ses2 = ztimeout!(c_client02_manager
+                .clone()
+                .open_transport(c_endpoint.clone()))
+            .unwrap();
             assert_eq!(c_ses2.get_links().unwrap().len(), 1);
             assert_eq!(c_client02_manager.get_transports().len(), 1);
             assert_eq!(c_ses2.get_pid().unwrap(), c_router_id);
@@ -256,7 +267,10 @@ async fn transport_intermittent(endpoint: &EndPoint) {
             print!("*");
             std::io::stdout().flush().unwrap();
 
-            let c_ses3 = ztimeout!(c_client03_manager.open_transport(c_endpoint.clone())).unwrap();
+            let c_ses3 = ztimeout!(c_client03_manager
+                .clone()
+                .open_transport(c_endpoint.clone()))
+            .unwrap();
             assert_eq!(c_ses3.get_links().unwrap().len(), 1);
             assert_eq!(c_client03_manager.get_transports().len(), 1);
             assert_eq!(c_ses3.get_pid().unwrap(), c_router_id);

--- a/zenoh/tests/unicast_openclose.rs
+++ b/zenoh/tests/unicast_openclose.rs
@@ -93,12 +93,14 @@ async fn openclose_transport(endpoint: &EndPoint) {
     {
         unicast = unicast.max_links(2);
     }
-    let router_manager = TransportManager::builder()
-        .whatami(WhatAmI::Router)
-        .pid(router_id)
-        .unicast(unicast)
-        .build(router_handler.clone())
-        .unwrap();
+    let router_manager = Arc::new(
+        TransportManager::builder()
+            .whatami(WhatAmI::Router)
+            .pid(router_id)
+            .unicast(unicast)
+            .build(router_handler.clone())
+            .unwrap(),
+    );
 
     /* [CLIENT] */
     let client01_id = PeerId::new(1, [1_u8; PeerId::MAX_SIZE]);
@@ -111,12 +113,14 @@ async fn openclose_transport(endpoint: &EndPoint) {
     {
         unicast = unicast.max_links(2);
     }
-    let client01_manager = TransportManager::builder()
-        .whatami(WhatAmI::Client)
-        .pid(client01_id)
-        .unicast(unicast)
-        .build(Arc::new(SHClientOpenClose::new()))
-        .unwrap();
+    let client01_manager = Arc::new(
+        TransportManager::builder()
+            .whatami(WhatAmI::Client)
+            .pid(client01_id)
+            .unicast(unicast)
+            .build(Arc::new(SHClientOpenClose::new()))
+            .unwrap(),
+    );
 
     // Create the transport transport manager for the second client
     #[allow(unused_mut)]
@@ -125,17 +129,19 @@ async fn openclose_transport(endpoint: &EndPoint) {
     {
         unicast = unicast.max_links(1);
     }
-    let client02_manager = TransportManager::builder()
-        .whatami(WhatAmI::Client)
-        .pid(client02_id)
-        .unicast(unicast)
-        .build(Arc::new(SHClientOpenClose::new()))
-        .unwrap();
+    let client02_manager = Arc::new(
+        TransportManager::builder()
+            .whatami(WhatAmI::Client)
+            .pid(client02_id)
+            .unicast(unicast)
+            .build(Arc::new(SHClientOpenClose::new()))
+            .unwrap(),
+    );
 
     /* [1] */
     println!("\nTransport Open Close [1a1]");
     // Add the locator on the router
-    let res = ztimeout!(router_manager.add_listener(endpoint.clone()));
+    let res = ztimeout!(router_manager.clone().add_listener(endpoint.clone()));
     println!("Transport Open Close [1a1]: {:?}", res);
     assert!(res.is_ok());
     println!("Transport Open Close [1a2]");
@@ -148,7 +154,7 @@ async fn openclose_transport(endpoint: &EndPoint) {
     let mut links_num = 1;
 
     println!("Transport Open Close [1c1]");
-    let res = ztimeout!(client01_manager.open_transport(endpoint.clone()));
+    let res = ztimeout!(client01_manager.clone().open_transport(endpoint.clone()));
     println!("Transport Open Close [1c2]: {:?}", res);
     assert!(res.is_ok());
     let c_ses1 = res.unwrap();
@@ -191,7 +197,7 @@ async fn openclose_transport(endpoint: &EndPoint) {
         links_num = 2;
 
         println!("\nTransport Open Close [2a1]");
-        let res = ztimeout!(client01_manager.open_transport(endpoint.clone()));
+        let res = ztimeout!(client01_manager.clone().open_transport(endpoint.clone()));
         println!("Transport Open Close [2a2]: {:?}", res);
         assert!(res.is_ok());
         let c_ses2 = res.unwrap();
@@ -230,7 +236,7 @@ async fn openclose_transport(endpoint: &EndPoint) {
     // Open transport -> This should be rejected because
     // of the maximum limit of links per transport
     println!("\nTransport Open Close [3a1]");
-    let res = ztimeout!(client01_manager.open_transport(endpoint.clone()));
+    let res = ztimeout!(client01_manager.clone().open_transport(endpoint.clone()));
     println!("Transport Open Close [3a2]: {:?}", res);
     assert!(res.is_err());
     println!("Transport Open Close [3b1]");
@@ -291,7 +297,7 @@ async fn openclose_transport(endpoint: &EndPoint) {
     links_num = 1;
 
     println!("\nTransport Open Close [5a1]");
-    let res = ztimeout!(client01_manager.open_transport(endpoint.clone()));
+    let res = ztimeout!(client01_manager.clone().open_transport(endpoint.clone()));
     println!("Transport Open Close [5a2]: {:?}", res);
     assert!(res.is_ok());
     let c_ses3 = res.unwrap();
@@ -324,7 +330,7 @@ async fn openclose_transport(endpoint: &EndPoint) {
     // Open transport -> This should be rejected because
     // of the maximum limit of transports
     println!("\nTransport Open Close [6a1]");
-    let res = ztimeout!(client02_manager.open_transport(endpoint.clone()));
+    let res = ztimeout!(client02_manager.clone().open_transport(endpoint.clone()));
     println!("Transport Open Close [6a2]: {:?}", res);
     assert!(res.is_err());
     println!("Transport Open Close [6b1]");
@@ -377,7 +383,7 @@ async fn openclose_transport(endpoint: &EndPoint) {
     links_num = 1;
 
     println!("\nTransport Open Close [8a1]");
-    let res = ztimeout!(client02_manager.open_transport(endpoint.clone()));
+    let res = ztimeout!(client02_manager.clone().open_transport(endpoint.clone()));
     println!("Transport Open Close [8a2]: {:?}", res);
     assert!(res.is_ok());
     let c_ses4 = res.unwrap();

--- a/zenoh/tests/unicast_shm.rs
+++ b/zenoh/tests/unicast_shm.rs
@@ -144,12 +144,14 @@ mod tests {
             TransportManager::config_unicast().peer_authenticator(HashSet::from_iter(vec![
                 SharedMemoryAuthenticator::make().unwrap().into(),
             ]));
-        let peer_shm01_manager = TransportManager::builder()
-            .whatami(WhatAmI::Peer)
-            .pid(peer_shm01)
-            .unicast(unicast)
-            .build(peer_shm01_handler.clone())
-            .unwrap();
+        let peer_shm01_manager = Arc::new(
+            TransportManager::builder()
+                .whatami(WhatAmI::Peer)
+                .pid(peer_shm01)
+                .unicast(unicast)
+                .build(peer_shm01_handler.clone())
+                .unwrap(),
+        );
 
         // Create a peer manager with shared-memory authenticator enabled
         let peer_shm02_handler = Arc::new(SHPeer::new(true));
@@ -157,35 +159,40 @@ mod tests {
             TransportManager::config_unicast().peer_authenticator(HashSet::from_iter(vec![
                 SharedMemoryAuthenticator::make().unwrap().into(),
             ]));
-        let peer_shm02_manager = TransportManager::builder()
-            .whatami(WhatAmI::Peer)
-            .pid(peer_shm02)
-            .unicast(unicast)
-            .build(peer_shm02_handler.clone())
-            .unwrap();
+        let peer_shm02_manager = Arc::new(
+            TransportManager::builder()
+                .whatami(WhatAmI::Peer)
+                .pid(peer_shm02)
+                .unicast(unicast)
+                .build(peer_shm02_handler.clone())
+                .unwrap(),
+        );
 
         // Create a peer manager with shared-memory authenticator disabled
         let peer_net01_handler = Arc::new(SHPeer::new(false));
-        let peer_net01_manager = TransportManager::builder()
-            .whatami(WhatAmI::Peer)
-            .pid(peer_net01)
-            .build(peer_net01_handler.clone())
-            .unwrap();
+        let peer_net01_manager = Arc::new(
+            TransportManager::builder()
+                .whatami(WhatAmI::Peer)
+                .pid(peer_net01)
+                .build(peer_net01_handler.clone())
+                .unwrap(),
+        );
 
         // Create the listener on the peer
         println!("\nTransport SHM [1a]");
         let _ = ztimeout!(peer_shm01_manager
+            .clone()
             .add_listener(endpoint.clone())
             .timeout(TIMEOUT))
         .unwrap();
 
         // Create a transport with the peer
         println!("Transport SHM [1b]");
-        let _ = ztimeout!(peer_shm02_manager.open_transport(endpoint.clone())).unwrap();
+        let _ = ztimeout!(peer_shm02_manager.clone().open_transport(endpoint.clone())).unwrap();
 
         // Create a transport with the peer
         println!("Transport SHM [1c]");
-        let _ = ztimeout!(peer_net01_manager.open_transport(endpoint.clone())).unwrap();
+        let _ = ztimeout!(peer_net01_manager.clone().open_transport(endpoint.clone())).unwrap();
 
         // Retrieve the transports
         println!("Transport SHM [2a]");

--- a/zenoh/tests/unicast_simultaneous.rs
+++ b/zenoh/tests/unicast_simultaneous.rs
@@ -145,26 +145,30 @@ mod tests {
         // Create the peer01 transport manager
         let peer_sh01 = Arc::new(SHPeer::new(peer_id01));
         let unicast = TransportManager::config_unicast().max_links(endpoint01.len());
-        let peer01_manager = TransportManager::builder()
-            .whatami(WhatAmI::Peer)
-            .pid(peer_id01)
-            .unicast(unicast)
-            .build(peer_sh01.clone())
-            .unwrap();
+        let peer01_manager = Arc::new(
+            TransportManager::builder()
+                .whatami(WhatAmI::Peer)
+                .pid(peer_id01)
+                .unicast(unicast)
+                .build(peer_sh01.clone())
+                .unwrap(),
+        );
 
         // Create the peer02 transport manager
         let peer_sh02 = Arc::new(SHPeer::new(peer_id02));
         let unicast = TransportManager::config_unicast().max_links(endpoint02.len());
-        let peer02_manager = TransportManager::builder()
-            .whatami(WhatAmI::Peer)
-            .pid(peer_id02)
-            .unicast(unicast)
-            .build(peer_sh02.clone())
-            .unwrap();
+        let peer02_manager = Arc::new(
+            TransportManager::builder()
+                .whatami(WhatAmI::Peer)
+                .pid(peer_id02)
+                .unicast(unicast)
+                .build(peer_sh02.clone())
+                .unwrap(),
+        );
 
         // Add the endpoints on the peer01
         for e in endpoint01.iter() {
-            let res = ztimeout!(peer01_manager.add_listener(e.clone()));
+            let res = ztimeout!(peer01_manager.clone().add_listener(e.clone()));
             println!("[Simultaneous 01a] => Adding endpoint {:?}: {:?}", e, res);
             assert!(res.is_ok());
         }
@@ -177,7 +181,7 @@ mod tests {
 
         // Add the endpoints on peer02
         for e in endpoint02.iter() {
-            let res = ztimeout!(peer02_manager.add_listener(e.clone()));
+            let res = ztimeout!(peer02_manager.clone().add_listener(e.clone()));
             println!("[Simultaneous 02a] => Adding endpoint {:?}: {:?}", e, res);
             assert!(res.is_ok());
         }
@@ -199,13 +203,13 @@ mod tests {
             // These open should succeed
             for e in c_ep02.iter() {
                 println!("[Simultaneous 01c] => Opening transport with {:?}...", e);
-                let _ = ztimeout!(c_p01m.open_transport(e.clone())).unwrap();
+                let _ = ztimeout!(c_p01m.clone().open_transport(e.clone())).unwrap();
             }
 
             // These open should fails
             for e in c_ep02.iter() {
                 println!("[Simultaneous 01d] => Exceeding transport with {:?}...", e);
-                let res = ztimeout!(c_p01m.open_transport(e.clone()));
+                let res = ztimeout!(c_p01m.clone().open_transport(e.clone()));
                 assert!(res.is_err());
             }
 
@@ -254,13 +258,13 @@ mod tests {
             // These open should succeed
             for e in c_ep01.iter() {
                 println!("[Simultaneous 02c] => Opening transport with {:?}...", e);
-                let _ = ztimeout!(c_p02m.open_transport(e.clone())).unwrap();
+                let _ = ztimeout!(c_p02m.clone().open_transport(e.clone())).unwrap();
             }
 
             // These open should fails
             for e in c_ep01.iter() {
                 println!("[Simultaneous 02d] => Exceeding transport with {:?}...", e);
-                let res = ztimeout!(c_p02m.open_transport(e.clone()));
+                let res = ztimeout!(c_p02m.clone().open_transport(e.clone()));
                 assert!(res.is_err());
             }
 

--- a/zenoh/tests/unicast_transport.rs
+++ b/zenoh/tests/unicast_transport.rs
@@ -152,9 +152,9 @@ impl TransportPeerEventHandler for SCClient {
 async fn open_transport(
     endpoints: &[EndPoint],
 ) -> (
-    TransportManager,
+    Arc<TransportManager>,
     Arc<SHRouter>,
-    TransportManager,
+    Arc<TransportManager>,
     TransportUnicast,
 ) {
     // Define client and router IDs
@@ -169,12 +169,14 @@ async fn open_transport(
     {
         unicast = unicast.max_links(endpoints.len());
     }
-    let router_manager = TransportManager::builder()
-        .pid(router_id)
-        .whatami(WhatAmI::Router)
-        .unicast(unicast)
-        .build(router_handler.clone())
-        .unwrap();
+    let router_manager = Arc::new(
+        TransportManager::builder()
+            .pid(router_id)
+            .whatami(WhatAmI::Router)
+            .unicast(unicast)
+            .build(router_handler.clone())
+            .unwrap(),
+    );
 
     // Create the client transport manager
     #[allow(unused_mut)] // transport_multilink-memory feature requires mut
@@ -183,24 +185,26 @@ async fn open_transport(
     {
         unicast = unicast.max_links(endpoints.len());
     }
-    let client_manager = TransportManager::builder()
-        .whatami(WhatAmI::Client)
-        .pid(client_id)
-        .unicast(unicast)
-        .build(Arc::new(SHClient::default()))
-        .unwrap();
+    let client_manager = Arc::new(
+        TransportManager::builder()
+            .whatami(WhatAmI::Client)
+            .pid(client_id)
+            .unicast(unicast)
+            .build(Arc::new(SHClient::default()))
+            .unwrap(),
+    );
 
     // Create the listener on the router
     for e in endpoints.iter() {
         println!("Add endpoint: {}", e);
-        let _ = ztimeout!(router_manager.add_listener(e.clone())).unwrap();
+        let _ = ztimeout!(router_manager.clone().add_listener(e.clone())).unwrap();
     }
 
     // Create an empty transport with the client
     // Open transport -> This should be accepted
     for e in endpoints.iter() {
         println!("Opening transport with {}", e);
-        let _ = ztimeout!(client_manager.open_transport(e.clone())).unwrap();
+        let _ = ztimeout!(client_manager.clone().open_transport(e.clone())).unwrap();
     }
 
     let client_transport = client_manager.get_transport(&router_id).unwrap();
@@ -215,8 +219,8 @@ async fn open_transport(
 }
 
 async fn close_transport(
-    router_manager: TransportManager,
-    client_manager: TransportManager,
+    router_manager: Arc<TransportManager>,
+    client_manager: Arc<TransportManager>,
     client_transport: TransportUnicast,
     endpoints: &[EndPoint],
 ) {


### PR DESCRIPTION
This PR removes unnecessary `Arc` fields. For example. this is a cloneable struct with internal `Arc` references.

```rust
#[derive(Clone)]
pub(crate) struct TransportUnicastInner {
    pub(super) config: Arc<TransportUnicastConfig>,
    pub(super) conduit_tx: Arc<[TransportConduitTx]>,
    pub(super) conduit_rx: Arc<Vec<TransportConduitRx>>,
    pub(super) links: Arc<RwLock<Vec<TransportLinkUnicast>>>,
    pub(super) callback: Arc<RwLock<Option<Arc<dyn TransportPeerEventHandler>>>>,
    pub(super) alive: AsyncArc<AsyncMutex<bool>>,
    pub(super) stats: Arc<TransportUnicastStatsAtomic>,
}

// cloning this type implies implicit shared references
let new_inner: TransportUnicastInner = orig_inner.clone();
```

It is refactored into in the way that unnecessary `Arc` wraps are removed. Only keep those that will be cloned later. `Clone` trait is removed to prevent accidental owned data copy. Cloning this type will requires wrapping an explicit reference counter `Arc` to user.

```rust
// #[derive(Clone)]
pub(crate) struct TransportUnicastInner {
    pub(super) config: TransportUnicastConfig,
    pub(super) conduit_tx: Arc<[TransportConduitTx]>,
    pub(super) conduit_rx: Vec<TransportConduitRx>,
    pub(super) links: RwLock<Vec<TransportLinkUnicast>>,
    pub(super) callback: RwLock<Option<Arc<dyn TransportPeerEventHandler>>>,
    pub(super) alive: AsyncArc<AsyncMutex<bool>>,
    pub(super) stats: Arc<TransportUnicastStatsAtomic>,
}

// Now the type is Send and Sync, but not Clone.
let new_inner: Arc<TransportUnicastInner> = orig_inner.clone();
```

Next step is to refactor `TransportManager` into separate types `UnicastManagerInit`, `UnicastManagerRunning`,  `MultucastManagerInit`, `MultucastManagerRunning`. This work needs some discussion to go.