### PR TITLE
Fix examples' --listener option that was ignored

### DIFF
--- a/zenoh/examples/z_delete.rs
+++ b/zenoh/examples/z_delete.rs
@@ -74,7 +74,7 @@ fn parse_args() -> (Config, String) {
     if let Some(values) = args.values_of("peer") {
         config.peers.extend(values.map(|v| v.parse().unwrap()))
     }
-    if let Some(values) = args.values_of("listeners") {
+    if let Some(values) = args.values_of("listener") {
         config.listeners.extend(values.map(|v| v.parse().unwrap()))
     }
     if args.is_present("no-multicast-scouting") {

--- a/zenoh/examples/z_eval.rs
+++ b/zenoh/examples/z_eval.rs
@@ -100,7 +100,7 @@ fn parse_args() -> (Config, String, String) {
     if let Some(values) = args.values_of("peer") {
         config.peers.extend(values.map(|v| v.parse().unwrap()))
     }
-    if let Some(values) = args.values_of("listeners") {
+    if let Some(values) = args.values_of("listener") {
         config.listeners.extend(values.map(|v| v.parse().unwrap()))
     }
     if args.is_present("no-multicast-scouting") {

--- a/zenoh/examples/z_get.rs
+++ b/zenoh/examples/z_get.rs
@@ -87,7 +87,7 @@ fn parse_args() -> (Config, String, QueryTarget) {
     if let Some(values) = args.values_of("peer") {
         config.peers.extend(values.map(|v| v.parse().unwrap()))
     }
-    if let Some(values) = args.values_of("listeners") {
+    if let Some(values) = args.values_of("listener") {
         config.listeners.extend(values.map(|v| v.parse().unwrap()))
     }
     if args.is_present("no-multicast-scouting") {

--- a/zenoh/examples/z_info.rs
+++ b/zenoh/examples/z_info.rs
@@ -65,7 +65,7 @@ fn parse_args() -> Config {
     if let Some(values) = args.values_of("peer") {
         config.peers.extend(values.map(|v| v.parse().unwrap()))
     }
-    if let Some(values) = args.values_of("listeners") {
+    if let Some(values) = args.values_of("listener") {
         config.listeners.extend(values.map(|v| v.parse().unwrap()))
     }
     if args.is_present("no-multicast-scouting") {

--- a/zenoh/examples/z_ping.rs
+++ b/zenoh/examples/z_ping.rs
@@ -116,7 +116,7 @@ fn parse_args() -> (Config, usize, usize) {
     if let Some(values) = args.values_of("peer") {
         config.peers.extend(values.map(|v| v.parse().unwrap()))
     }
-    if let Some(values) = args.values_of("listeners") {
+    if let Some(values) = args.values_of("listener") {
         config.listeners.extend(values.map(|v| v.parse().unwrap()))
     }
     if args.is_present("no-multicast-scouting") {

--- a/zenoh/examples/z_pong.rs
+++ b/zenoh/examples/z_pong.rs
@@ -77,7 +77,7 @@ fn parse_args() -> Config {
     if let Some(values) = args.values_of("peer") {
         config.peers.extend(values.map(|v| v.parse().unwrap()))
     }
-    if let Some(values) = args.values_of("listeners") {
+    if let Some(values) = args.values_of("listener") {
         config.listeners.extend(values.map(|v| v.parse().unwrap()))
     }
     if args.is_present("no-multicast-scouting") {

--- a/zenoh/examples/z_pub.rs
+++ b/zenoh/examples/z_pub.rs
@@ -84,7 +84,7 @@ fn parse_args() -> (Config, String, String) {
     if let Some(values) = args.values_of("peer") {
         config.peers.extend(values.map(|v| v.parse().unwrap()))
     }
-    if let Some(values) = args.values_of("listeners") {
+    if let Some(values) = args.values_of("listener") {
         config.listeners.extend(values.map(|v| v.parse().unwrap()))
     }
     if args.is_present("no-multicast-scouting") {

--- a/zenoh/examples/z_pub_shm.rs
+++ b/zenoh/examples/z_pub_shm.rs
@@ -140,7 +140,7 @@ fn parse_args() -> (Config, String, String) {
     if let Some(values) = args.values_of("peer") {
         config.peers.extend(values.map(|v| v.parse().unwrap()))
     }
-    if let Some(values) = args.values_of("listeners") {
+    if let Some(values) = args.values_of("listener") {
         config.listeners.extend(values.map(|v| v.parse().unwrap()))
     }
     if args.is_present("no-multicast-scouting") {

--- a/zenoh/examples/z_pub_thr.rs
+++ b/zenoh/examples/z_pub_thr.rs
@@ -78,7 +78,7 @@ fn parse_args() -> (Config, usize) {
     if let Some(values) = args.values_of("peer") {
         config.peers.extend(values.map(|v| v.parse().unwrap()))
     }
-    if let Some(values) = args.values_of("listeners") {
+    if let Some(values) = args.values_of("listener") {
         config.listeners.extend(values.map(|v| v.parse().unwrap()))
     }
     if args.is_present("no-multicast-scouting") {

--- a/zenoh/examples/z_pull.rs
+++ b/zenoh/examples/z_pull.rs
@@ -99,7 +99,7 @@ fn parse_args() -> (Config, String) {
     if let Some(values) = args.values_of("peer") {
         config.peers.extend(values.map(|v| v.parse().unwrap()))
     }
-    if let Some(values) = args.values_of("listeners") {
+    if let Some(values) = args.values_of("listener") {
         config.listeners.extend(values.map(|v| v.parse().unwrap()))
     }
     if args.is_present("no-multicast-scouting") {

--- a/zenoh/examples/z_put.rs
+++ b/zenoh/examples/z_put.rs
@@ -71,7 +71,7 @@ fn parse_args() -> (Config, String, String) {
     if let Some(values) = args.values_of("peer") {
         config.peers.extend(values.map(|v| v.parse().unwrap()))
     }
-    if let Some(values) = args.values_of("listeners") {
+    if let Some(values) = args.values_of("listener") {
         config.listeners.extend(values.map(|v| v.parse().unwrap()))
     }
     if args.is_present("no-multicast-scouting") {

--- a/zenoh/examples/z_put_float.rs
+++ b/zenoh/examples/z_put_float.rs
@@ -81,7 +81,7 @@ fn parse_args() -> (Config, String, f64) {
     if let Some(values) = args.values_of("peer") {
         config.peers.extend(values.map(|v| v.parse().unwrap()))
     }
-    if let Some(values) = args.values_of("listeners") {
+    if let Some(values) = args.values_of("listener") {
         config.listeners.extend(values.map(|v| v.parse().unwrap()))
     }
     if args.is_present("no-multicast-scouting") {

--- a/zenoh/examples/z_storage.rs
+++ b/zenoh/examples/z_storage.rs
@@ -121,7 +121,7 @@ fn parse_args() -> (Config, String) {
     if let Some(values) = args.values_of("peer") {
         config.peers.extend(values.map(|v| v.parse().unwrap()))
     }
-    if let Some(values) = args.values_of("listeners") {
+    if let Some(values) = args.values_of("listener") {
         config.listeners.extend(values.map(|v| v.parse().unwrap()))
     }
     if args.is_present("no-multicast-scouting") {

--- a/zenoh/examples/z_sub.rs
+++ b/zenoh/examples/z_sub.rs
@@ -93,7 +93,7 @@ fn parse_args() -> (Config, String) {
     if let Some(values) = args.values_of("peer") {
         config.peers.extend(values.map(|v| v.parse().unwrap()))
     }
-    if let Some(values) = args.values_of("listeners") {
+    if let Some(values) = args.values_of("listener") {
         config.listeners.extend(values.map(|v| v.parse().unwrap()))
     }
     if args.is_present("no-multicast-scouting") {

--- a/zenoh/examples/z_sub_thr.rs
+++ b/zenoh/examples/z_sub_thr.rs
@@ -105,7 +105,7 @@ fn parse_args() -> (Config, u32, u128) {
     if let Some(values) = args.values_of("peer") {
         config.peers.extend(values.map(|v| v.parse().unwrap()))
     }
-    if let Some(values) = args.values_of("listeners") {
+    if let Some(values) = args.values_of("listener") {
         config.listeners.extend(values.map(|v| v.parse().unwrap()))
     }
     if args.is_present("no-multicast-scouting") {


### PR DESCRIPTION
Cause: mismatch between `--listener` option declaration and `args.values_of("listeners")` to retrieve the values.
It should be `args.values_of("listener")`.