### PR TITLE
Remove transport_multilink feature. Fix #180.

### DIFF
--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -40,7 +40,6 @@ auth_usrpwd = []
 complete_n = []
 shared-memory = ["bincode", "shared_memory"]
 stats = []
-transport_multilink = ["auth_pubkey"]
 transport_quic = ["quinn", "rcgen", "webpki", "async-std/tokio1"]
 transport_tcp = []
 transport_tls = ["async-rustls"]
@@ -50,7 +49,6 @@ default = [
     "auth_pubkey",
     "auth_usrpwd",
     "shared-memory",
-    "transport_multilink",
     "transport_quic",
     "transport_tcp",
     "transport_tls",

--- a/zenoh/src/net/transport/manager.rs
+++ b/zenoh/src/net/transport/manager.rs
@@ -75,9 +75,8 @@ use zenoh_util::zparse;
 ///         .lease(Duration::from_secs(1))
 ///         .keep_alive(Duration::from_millis(100))
 ///         .open_timeout(Duration::from_secs(1))
-///         .open_pending(10)   // Set to 10 the number of simultanous pending incoming transports
-///         // #[cfg(feature = "transport_multilink")]
-///         // .max_links(2)    // Allow max 2 links per transport
+///         .open_pending(10)   // Set to 10 the number of simultanous pending incoming transports        
+///         .max_links(1)    // Allow max 1 inbound link per transport
 ///         .max_sessions(5);   // Allow max 5 transports open
 /// let manager = TransportManager::builder()
 ///         .pid(PeerId::rand())

--- a/zenoh/src/net/transport/unicast/manager.rs
+++ b/zenoh/src/net/transport/unicast/manager.rs
@@ -36,7 +36,6 @@ pub struct TransportManagerConfigUnicast {
     pub open_timeout: Duration,
     pub open_pending: usize,
     pub max_sessions: usize,
-    #[cfg(feature = "transport_multilink")]
     pub max_links: usize,
     pub is_qos: bool,
     #[cfg(feature = "shared-memory")]
@@ -72,7 +71,6 @@ pub struct TransportManagerBuilderUnicast {
     pub(super) open_timeout: Duration,
     pub(super) open_pending: usize,
     pub(super) max_sessions: usize,
-    #[cfg(feature = "transport_multilink")]
     pub(super) max_links: usize,
     pub(super) is_qos: bool,
     #[cfg(feature = "shared-memory")]
@@ -107,7 +105,6 @@ impl TransportManagerBuilderUnicast {
         self
     }
 
-    #[cfg(feature = "transport_multilink")]
     pub fn max_links(mut self, max_links: usize) -> Self {
         self.max_links = max_links;
         self
@@ -153,7 +150,6 @@ impl TransportManagerBuilderUnicast {
         if let Some(v) = properties.transport().unicast().max_sessions() {
             self = self.max_sessions(*v);
         }
-        #[cfg(feature = "transport_multilink")]
         if let Some(v) = properties.transport().unicast().max_links() {
             self = self.max_links(*v);
         }
@@ -180,13 +176,13 @@ impl TransportManagerBuilderUnicast {
             open_timeout: self.open_timeout,
             open_pending: self.open_pending,
             max_sessions: self.max_sessions,
-            #[cfg(feature = "transport_multilink")]
             max_links: self.max_links,
             is_qos: self.is_qos,
             #[cfg(feature = "shared-memory")]
             is_shm: self.is_shm,
         };
 
+        // Enable pubkey authentication by default to avoid PeerId spoofing
         #[cfg(feature = "auth_pubkey")]
         if !self
             .peer_authenticator
@@ -230,7 +226,6 @@ impl Default for TransportManagerBuilderUnicast {
             open_timeout: Duration::from_millis(zparse!(ZN_OPEN_TIMEOUT_DEFAULT).unwrap()),
             open_pending: zparse!(ZN_OPEN_INCOMING_PENDING_DEFAULT).unwrap(),
             max_sessions: zparse!(ZN_MAX_SESSIONS_UNICAST_DEFAULT).unwrap(),
-            #[cfg(feature = "transport_multilink")]
             max_links: zparse!(ZN_MAX_LINKS_DEFAULT).unwrap(),
             is_qos: zparse!(ZN_QOS_DEFAULT).unwrap(),
             #[cfg(feature = "shared-memory")]

--- a/zenoh/src/net/transport/unicast/transport.rs
+++ b/zenoh/src/net/transport/unicast/transport.rs
@@ -230,6 +230,7 @@ impl TransportUnicastInner {
         if let LinkUnicastDirection::Inbound = direction {
             let count = guard.iter().filter(|l| l.direction == direction).count();
             let limit = self.config.manager.config.unicast.max_links;
+
             if count >= limit {
                 let e = zerror!(
                     "Can not add Link {} with peer {}: max num of links reached {}/{}",

--- a/zenoh/tests/unicast_authenticator.rs
+++ b/zenoh/tests/unicast_authenticator.rs
@@ -117,7 +117,7 @@ impl TransportEventHandler for SHClientAuthenticator {
     }
 }
 
-#[cfg(feature = "transport_multilink")]
+#[cfg(feature = "auth_pubkey")]
 async fn authenticator_multilink(endpoint: &EndPoint) {
     // Create the router transport manager
     let router_id = PeerId::new(1, [0u8; PeerId::MAX_SIZE]);
@@ -742,7 +742,7 @@ async fn authenticator_shared_memory(endpoint: &EndPoint) {
 }
 
 async fn run(endpoint: &EndPoint) {
-    #[cfg(feature = "transport_multilink")]
+    #[cfg(feature = "auth_pubkey")]
     authenticator_multilink(endpoint).await;
     #[cfg(feature = "auth_usrpwd")]
     authenticator_user_password(endpoint).await;

--- a/zenoh/tests/unicast_concurrent.rs
+++ b/zenoh/tests/unicast_concurrent.rs
@@ -11,387 +11,384 @@
 // Contributors:
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
-#[cfg(feature = "transport_multilink")]
-mod tests {
-    use async_std::prelude::*;
-    use async_std::sync::{Arc, Barrier};
-    use async_std::task;
-    use std::any::Any;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::time::Duration;
-    use zenoh::net::link::{EndPoint, Link};
-    use zenoh::net::protocol::core::{
-        Channel, CongestionControl, PeerId, Priority, Reliability, WhatAmI,
-    };
-    use zenoh::net::protocol::io::ZBuf;
-    use zenoh::net::protocol::proto::ZenohMessage;
-    use zenoh::net::transport::{
-        TransportEventHandler, TransportManager, TransportMulticast,
-        TransportMulticastEventHandler, TransportPeer, TransportPeerEventHandler, TransportUnicast,
-    };
-    use zenoh_util::core::Result as ZResult;
-    use zenoh_util::zasync_executor_init;
+use async_std::prelude::*;
+use async_std::sync::{Arc, Barrier};
+use async_std::task;
+use std::any::Any;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+use zenoh::net::link::{EndPoint, Link};
+use zenoh::net::protocol::core::{
+    Channel, CongestionControl, PeerId, Priority, Reliability, WhatAmI,
+};
+use zenoh::net::protocol::io::ZBuf;
+use zenoh::net::protocol::proto::ZenohMessage;
+use zenoh::net::transport::{
+    TransportEventHandler, TransportManager, TransportMulticast, TransportMulticastEventHandler,
+    TransportPeer, TransportPeerEventHandler, TransportUnicast,
+};
+use zenoh_util::core::Result as ZResult;
+use zenoh_util::zasync_executor_init;
 
-    const MSG_COUNT: usize = 1_000;
-    const MSG_SIZE: usize = 1_024;
-    const TIMEOUT: Duration = Duration::from_secs(60);
-    const SLEEP: Duration = Duration::from_millis(100);
+const MSG_COUNT: usize = 1_000;
+const MSG_SIZE: usize = 1_024;
+const TIMEOUT: Duration = Duration::from_secs(60);
+const SLEEP: Duration = Duration::from_millis(100);
 
-    macro_rules! ztimeout {
-        ($f:expr) => {
-            $f.timeout(TIMEOUT).await.unwrap()
+macro_rules! ztimeout {
+    ($f:expr) => {
+        $f.timeout(TIMEOUT).await.unwrap()
+    };
+}
+
+// Transport Handler for the router
+struct SHPeer {
+    count: Arc<AtomicUsize>,
+}
+
+impl SHPeer {
+    fn new() -> Self {
+        Self {
+            count: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn get_count(&self) -> usize {
+        self.count.load(Ordering::SeqCst)
+    }
+}
+
+impl TransportEventHandler for SHPeer {
+    fn new_unicast(
+        &self,
+        _peer: TransportPeer,
+        _transport: TransportUnicast,
+    ) -> ZResult<Arc<dyn TransportPeerEventHandler>> {
+        let mh = Arc::new(MHPeer::new(self.count.clone()));
+        Ok(mh)
+    }
+
+    fn new_multicast(
+        &self,
+        _transport: TransportMulticast,
+    ) -> ZResult<Arc<dyn TransportMulticastEventHandler>> {
+        panic!();
+    }
+}
+
+struct MHPeer {
+    count: Arc<AtomicUsize>,
+}
+
+impl MHPeer {
+    fn new(count: Arc<AtomicUsize>) -> Self {
+        Self { count }
+    }
+}
+
+impl TransportPeerEventHandler for MHPeer {
+    fn handle_message(&self, _msg: ZenohMessage) -> ZResult<()> {
+        self.count.fetch_add(1, Ordering::AcqRel);
+        Ok(())
+    }
+
+    fn new_link(&self, _link: Link) {}
+    fn del_link(&self, _link: Link) {}
+    fn closing(&self) {}
+    fn closed(&self) {}
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+async fn transport_concurrent(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPoint>) {
+    /* [Peers] */
+    let peer_id01 = PeerId::new(1, [1_u8; PeerId::MAX_SIZE]);
+    let peer_id02 = PeerId::new(1, [2_u8; PeerId::MAX_SIZE]);
+
+    // Create the peer01 transport manager
+    let peer_sh01 = Arc::new(SHPeer::new());
+    let unicast01 = TransportManager::config_unicast().max_links(endpoint02.len());
+    let peer01_manager = TransportManager::builder()
+        .whatami(WhatAmI::Peer)
+        .pid(peer_id01)
+        .unicast(unicast01)
+        .build(peer_sh01.clone())
+        .unwrap();
+
+    // Create the peer01 transport manager
+    let peer_sh02 = Arc::new(SHPeer::new());
+    let unicast02 = TransportManager::config_unicast().max_links(endpoint01.len());
+    let peer02_manager = TransportManager::builder()
+        .whatami(WhatAmI::Peer)
+        .pid(peer_id02)
+        .unicast(unicast02)
+        .build(peer_sh02.clone())
+        .unwrap();
+
+    // Barrier to synchronize the two tasks
+    let barrier_peer = Arc::new(Barrier::new(2));
+    let barrier_open_wait = Arc::new(Barrier::new(endpoint01.len() + endpoint02.len()));
+    let barrier_open_done = Arc::new(Barrier::new(endpoint01.len() + endpoint02.len() + 2));
+
+    // Peer01
+    let c_barp = barrier_peer.clone();
+    let c_barow = barrier_open_wait.clone();
+    let c_barod = barrier_open_done.clone();
+    let c_pid02 = peer_id02;
+    let c_end01 = endpoint01.clone();
+    let c_end02 = endpoint02.clone();
+    let peer01_task = task::spawn(async move {
+        // Add the endpoints on the first peer
+        for e in c_end01.iter() {
+            let res = ztimeout!(peer01_manager.add_listener(e.clone()));
+            println!("[Transport Peer 01a] => Adding endpoint {:?}: {:?}", e, res);
+            assert!(res.is_ok());
+        }
+        let locs = peer01_manager.get_listeners();
+        println!(
+            "[Transport Peer 01b] => Getting endpoints: {:?} {:?}",
+            c_end01, locs
+        );
+        assert_eq!(c_end01.len(), locs.len());
+
+        // Open the transport with the second peer
+        for e in c_end02.iter() {
+            let cc_barow = c_barow.clone();
+            let cc_barod = c_barod.clone();
+            let c_p01m = peer01_manager.clone();
+            let c_end = e.clone();
+            task::spawn(async move {
+                println!("[Transport Peer 01c] => Waiting for opening transport");
+                // Syncrhonize before opening the transports
+                ztimeout!(cc_barow.wait());
+                let res = ztimeout!(c_p01m.open_transport(c_end.clone()));
+                println!(
+                    "[Transport Peer 01d] => Opening transport with {:?}: {:?}",
+                    c_end, res
+                );
+                assert!(res.is_ok());
+
+                // Syncrhonize after opening the transports
+                ztimeout!(cc_barod.wait());
+            });
+        }
+
+        // Syncrhonize after opening the transports
+        ztimeout!(c_barod.wait());
+        println!("[Transport Peer 01e] => Waiting... OK");
+
+        // Verify that the transport has been correctly open
+        assert_eq!(peer01_manager.get_transports().len(), 1);
+        let s02 = peer01_manager.get_transport(&c_pid02).unwrap();
+        assert_eq!(
+            s02.get_links().unwrap().len(),
+            c_end01.len() + c_end02.len()
+        );
+
+        // Create the message to send
+        let key = "/test02".into();
+        let payload = ZBuf::from(vec![0_u8; MSG_SIZE]);
+        let channel = Channel {
+            priority: Priority::default(),
+            reliability: Reliability::Reliable,
         };
-    }
+        let congestion_control = CongestionControl::Block;
+        let data_info = None;
+        let routing_context = None;
+        let reply_context = None;
+        let attachment = None;
 
-    // Transport Handler for the router
-    struct SHPeer {
-        count: Arc<AtomicUsize>,
-    }
+        let message = ZenohMessage::make_data(
+            key,
+            payload,
+            channel,
+            congestion_control,
+            data_info,
+            routing_context,
+            reply_context,
+            attachment,
+        );
 
-    impl SHPeer {
-        fn new() -> Self {
-            Self {
-                count: Arc::new(AtomicUsize::new(0)),
+        // Synchronize wit the peer
+        ztimeout!(c_barp.wait());
+        println!("[Transport Peer 01f] => Waiting... OK");
+
+        for i in 0..MSG_COUNT {
+            println!("[Transport Peer 01g] Scheduling message {}", i);
+            s02.schedule(message.clone()).unwrap();
+        }
+        println!("[Transport Peer 01g] => Scheduling OK");
+
+        // Wait for the messages to arrive to the other side
+        ztimeout!(async {
+            while peer_sh02.get_count() != MSG_COUNT {
+                task::sleep(SLEEP).await;
             }
-        }
+        });
 
-        fn get_count(&self) -> usize {
-            self.count.load(Ordering::SeqCst)
-        }
-    }
+        // Synchronize wit the peer
+        ztimeout!(c_barp.wait());
 
-    impl TransportEventHandler for SHPeer {
-        fn new_unicast(
-            &self,
-            _peer: TransportPeer,
-            _transport: TransportUnicast,
-        ) -> ZResult<Arc<dyn TransportPeerEventHandler>> {
-            let mh = Arc::new(MHPeer::new(self.count.clone()));
-            Ok(mh)
-        }
+        println!("[Transport Peer 01h] => Closing {:?}...", s02);
+        let res = ztimeout!(s02.close());
+        println!("[Transport Peer 01l] => Closing {:?}: {:?}", s02, res);
+        assert!(res.is_ok());
 
-        fn new_multicast(
-            &self,
-            _transport: TransportMulticast,
-        ) -> ZResult<Arc<dyn TransportMulticastEventHandler>> {
-            panic!();
-        }
-    }
+        // Close the transport
+        ztimeout!(peer01_manager.close());
+    });
 
-    struct MHPeer {
-        count: Arc<AtomicUsize>,
-    }
-
-    impl MHPeer {
-        fn new(count: Arc<AtomicUsize>) -> Self {
-            Self { count }
-        }
-    }
-
-    impl TransportPeerEventHandler for MHPeer {
-        fn handle_message(&self, _msg: ZenohMessage) -> ZResult<()> {
-            self.count.fetch_add(1, Ordering::AcqRel);
-            Ok(())
-        }
-
-        fn new_link(&self, _link: Link) {}
-        fn del_link(&self, _link: Link) {}
-        fn closing(&self) {}
-        fn closed(&self) {}
-
-        fn as_any(&self) -> &dyn Any {
-            self
-        }
-    }
-
-    async fn transport_concurrent(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPoint>) {
-        /* [Peers] */
-        let peer_id01 = PeerId::new(1, [1_u8; PeerId::MAX_SIZE]);
-        let peer_id02 = PeerId::new(1, [2_u8; PeerId::MAX_SIZE]);
-
-        // Create the peer01 transport manager
-        let peer_sh01 = Arc::new(SHPeer::new());
-        let unicast01 = TransportManager::config_unicast().max_links(endpoint02.len());
-        let peer01_manager = TransportManager::builder()
-            .whatami(WhatAmI::Peer)
-            .pid(peer_id01)
-            .unicast(unicast01)
-            .build(peer_sh01.clone())
-            .unwrap();
-
-        // Create the peer01 transport manager
-        let peer_sh02 = Arc::new(SHPeer::new());
-        let unicast02 = TransportManager::config_unicast().max_links(endpoint01.len());
-        let peer02_manager = TransportManager::builder()
-            .whatami(WhatAmI::Peer)
-            .pid(peer_id02)
-            .unicast(unicast02)
-            .build(peer_sh02.clone())
-            .unwrap();
-
-        // Barrier to synchronize the two tasks
-        let barrier_peer = Arc::new(Barrier::new(2));
-        let barrier_open_wait = Arc::new(Barrier::new(endpoint01.len() + endpoint02.len()));
-        let barrier_open_done = Arc::new(Barrier::new(endpoint01.len() + endpoint02.len() + 2));
-
-        // Peer01
-        let c_barp = barrier_peer.clone();
-        let c_barow = barrier_open_wait.clone();
-        let c_barod = barrier_open_done.clone();
-        let c_pid02 = peer_id02;
-        let c_end01 = endpoint01.clone();
-        let c_end02 = endpoint02.clone();
-        let peer01_task = task::spawn(async move {
-            // Add the endpoints on the first peer
-            for e in c_end01.iter() {
-                let res = ztimeout!(peer01_manager.add_listener(e.clone()));
-                println!("[Transport Peer 01a] => Adding endpoint {:?}: {:?}", e, res);
-                assert!(res.is_ok());
-            }
-            let locs = peer01_manager.get_listeners();
-            println!(
-                "[Transport Peer 01b] => Getting endpoints: {:?} {:?}",
-                c_end01, locs
-            );
-            assert_eq!(c_end01.len(), locs.len());
-
-            // Open the transport with the second peer
-            for e in c_end02.iter() {
-                let cc_barow = c_barow.clone();
-                let cc_barod = c_barod.clone();
-                let c_p01m = peer01_manager.clone();
-                let c_end = e.clone();
-                task::spawn(async move {
-                    println!("[Transport Peer 01c] => Waiting for opening transport");
-                    // Syncrhonize before opening the transports
-                    ztimeout!(cc_barow.wait());
-                    let res = ztimeout!(c_p01m.open_transport(c_end.clone()));
-                    println!(
-                        "[Transport Peer 01d] => Opening transport with {:?}: {:?}",
-                        c_end, res
-                    );
-                    assert!(res.is_ok());
-
-                    // Syncrhonize after opening the transports
-                    ztimeout!(cc_barod.wait());
-                });
-            }
-
-            // Syncrhonize after opening the transports
-            ztimeout!(c_barod.wait());
-            println!("[Transport Peer 01e] => Waiting... OK");
-
-            // Verify that the transport has been correctly open
-            assert_eq!(peer01_manager.get_transports().len(), 1);
-            let s02 = peer01_manager.get_transport(&c_pid02).unwrap();
-            assert_eq!(
-                s02.get_links().unwrap().len(),
-                c_end01.len() + c_end02.len()
-            );
-
-            // Create the message to send
-            let key = "/test02".into();
-            let payload = ZBuf::from(vec![0_u8; MSG_SIZE]);
-            let channel = Channel {
-                priority: Priority::default(),
-                reliability: Reliability::Reliable,
-            };
-            let congestion_control = CongestionControl::Block;
-            let data_info = None;
-            let routing_context = None;
-            let reply_context = None;
-            let attachment = None;
-
-            let message = ZenohMessage::make_data(
-                key,
-                payload,
-                channel,
-                congestion_control,
-                data_info,
-                routing_context,
-                reply_context,
-                attachment,
-            );
-
-            // Synchronize wit the peer
-            ztimeout!(c_barp.wait());
-            println!("[Transport Peer 01f] => Waiting... OK");
-
-            for i in 0..MSG_COUNT {
-                println!("[Transport Peer 01g] Scheduling message {}", i);
-                s02.schedule(message.clone()).unwrap();
-            }
-            println!("[Transport Peer 01g] => Scheduling OK");
-
-            // Wait for the messages to arrive to the other side
-            ztimeout!(async {
-                while peer_sh02.get_count() != MSG_COUNT {
-                    task::sleep(SLEEP).await;
-                }
-            });
-
-            // Synchronize wit the peer
-            ztimeout!(c_barp.wait());
-
-            println!("[Transport Peer 01h] => Closing {:?}...", s02);
-            let res = ztimeout!(s02.close());
-            println!("[Transport Peer 01l] => Closing {:?}: {:?}", s02, res);
+    // Peer02
+    let c_barp = barrier_peer;
+    let c_barow = barrier_open_wait.clone();
+    let c_barod = barrier_open_done.clone();
+    let c_pid01 = peer_id01;
+    let c_end01 = endpoint01.clone();
+    let c_end02 = endpoint02.clone();
+    let peer02_task = task::spawn(async move {
+        // Add the endpoints on the first peer
+        for e in c_end02.iter() {
+            let res = ztimeout!(peer02_manager.add_listener(e.clone()));
+            println!("[Transport Peer 02a] => Adding endpoint {:?}: {:?}", e, res);
             assert!(res.is_ok());
+        }
+        let locs = peer02_manager.get_listeners();
+        println!(
+            "[Transport Peer 02b] => Getting endpoints: {:?} {:?}",
+            c_end02, locs
+        );
+        assert_eq!(c_end02.len(), locs.len());
 
-            // Close the transport
-            ztimeout!(peer01_manager.close());
-        });
+        // Open the transport with the first peer
+        for e in c_end01.iter() {
+            let cc_barow = c_barow.clone();
+            let cc_barod = c_barod.clone();
+            let c_p02m = peer02_manager.clone();
+            let c_end = e.clone();
+            task::spawn(async move {
+                println!("[Transport Peer 02c] => Waiting for opening transport");
+                // Syncrhonize before opening the transports
+                ztimeout!(cc_barow.wait());
 
-        // Peer02
-        let c_barp = barrier_peer;
-        let c_barow = barrier_open_wait.clone();
-        let c_barod = barrier_open_done.clone();
-        let c_pid01 = peer_id01;
-        let c_end01 = endpoint01.clone();
-        let c_end02 = endpoint02.clone();
-        let peer02_task = task::spawn(async move {
-            // Add the endpoints on the first peer
-            for e in c_end02.iter() {
-                let res = ztimeout!(peer02_manager.add_listener(e.clone()));
-                println!("[Transport Peer 02a] => Adding endpoint {:?}: {:?}", e, res);
+                let res = ztimeout!(c_p02m.open_transport(c_end.clone()));
+                println!(
+                    "[Transport Peer 02d] => Opening transport with {:?}: {:?}",
+                    c_end, res
+                );
                 assert!(res.is_ok());
-            }
-            let locs = peer02_manager.get_listeners();
-            println!(
-                "[Transport Peer 02b] => Getting endpoints: {:?} {:?}",
-                c_end02, locs
-            );
-            assert_eq!(c_end02.len(), locs.len());
 
-            // Open the transport with the first peer
-            for e in c_end01.iter() {
-                let cc_barow = c_barow.clone();
-                let cc_barod = c_barod.clone();
-                let c_p02m = peer02_manager.clone();
-                let c_end = e.clone();
-                task::spawn(async move {
-                    println!("[Transport Peer 02c] => Waiting for opening transport");
-                    // Syncrhonize before opening the transports
-                    ztimeout!(cc_barow.wait());
-
-                    let res = ztimeout!(c_p02m.open_transport(c_end.clone()));
-                    println!(
-                        "[Transport Peer 02d] => Opening transport with {:?}: {:?}",
-                        c_end, res
-                    );
-                    assert!(res.is_ok());
-
-                    // Syncrhonize after opening the transports
-                    ztimeout!(cc_barod.wait());
-                });
-            }
-
-            // Syncrhonize after opening the transports
-            ztimeout!(c_barod.wait());
-
-            // Verify that the transport has been correctly open
-            println!(
-                "[Transport Peer 02e] => Transports: {:?}",
-                peer02_manager.get_transports()
-            );
-            assert_eq!(peer02_manager.get_transports().len(), 1);
-            let s01 = peer02_manager.get_transport(&c_pid01).unwrap();
-            assert_eq!(
-                s01.get_links().unwrap().len(),
-                c_end01.len() + c_end02.len()
-            );
-
-            // Create the message to send
-            let key = "/test02".into();
-            let payload = ZBuf::from(vec![0_u8; MSG_SIZE]);
-            let channel = Channel {
-                priority: Priority::default(),
-                reliability: Reliability::Reliable,
-            };
-            let congestion_control = CongestionControl::Block;
-            let data_info = None;
-            let routing_context = None;
-            let reply_context = None;
-            let attachment = None;
-
-            let message = ZenohMessage::make_data(
-                key,
-                payload,
-                channel,
-                congestion_control,
-                data_info,
-                routing_context,
-                reply_context,
-                attachment,
-            );
-
-            // Synchronize wit the peer
-            ztimeout!(c_barp.wait());
-            println!("[Transport Peer 02f] => Waiting... OK");
-
-            for i in 0..MSG_COUNT {
-                println!("[Transport Peer 02g] Scheduling message {}", i);
-                s01.schedule(message.clone()).unwrap();
-            }
-            println!("[Transport Peer 02g] => Scheduling OK");
-
-            // Wait for the messages to arrive to the other side
-            ztimeout!(async {
-                while peer_sh01.get_count() != MSG_COUNT {
-                    task::sleep(SLEEP).await;
-                }
+                // Syncrhonize after opening the transports
+                ztimeout!(cc_barod.wait());
             });
+        }
 
-            // Synchronize wit the peer
-            ztimeout!(c_barp.wait());
+        // Syncrhonize after opening the transports
+        ztimeout!(c_barod.wait());
 
-            println!("[Transport Peer 02h] => Closing {:?}...", s01);
-            let res = ztimeout!(s01.close());
-            println!("[Transport Peer 02l] => Closing {:?}: {:?}", s01, res);
-            assert!(res.is_ok());
+        // Verify that the transport has been correctly open
+        println!(
+            "[Transport Peer 02e] => Transports: {:?}",
+            peer02_manager.get_transports()
+        );
+        assert_eq!(peer02_manager.get_transports().len(), 1);
+        let s01 = peer02_manager.get_transport(&c_pid01).unwrap();
+        assert_eq!(
+            s01.get_links().unwrap().len(),
+            c_end01.len() + c_end02.len()
+        );
 
-            // Close the transport
-            ztimeout!(peer02_manager.close());
+        // Create the message to send
+        let key = "/test02".into();
+        let payload = ZBuf::from(vec![0_u8; MSG_SIZE]);
+        let channel = Channel {
+            priority: Priority::default(),
+            reliability: Reliability::Reliable,
+        };
+        let congestion_control = CongestionControl::Block;
+        let data_info = None;
+        let routing_context = None;
+        let reply_context = None;
+        let attachment = None;
+
+        let message = ZenohMessage::make_data(
+            key,
+            payload,
+            channel,
+            congestion_control,
+            data_info,
+            routing_context,
+            reply_context,
+            attachment,
+        );
+
+        // Synchronize wit the peer
+        ztimeout!(c_barp.wait());
+        println!("[Transport Peer 02f] => Waiting... OK");
+
+        for i in 0..MSG_COUNT {
+            println!("[Transport Peer 02g] Scheduling message {}", i);
+            s01.schedule(message.clone()).unwrap();
+        }
+        println!("[Transport Peer 02g] => Scheduling OK");
+
+        // Wait for the messages to arrive to the other side
+        ztimeout!(async {
+            while peer_sh01.get_count() != MSG_COUNT {
+                task::sleep(SLEEP).await;
+            }
         });
 
-        println!("[Transport Current 01] => Starting...");
-        peer01_task.join(peer02_task).await;
-        println!("[Transport Current 02] => ...Stopped");
+        // Synchronize wit the peer
+        ztimeout!(c_barp.wait());
 
-        // Wait a little bit
-        task::sleep(SLEEP).await;
-    }
+        println!("[Transport Peer 02h] => Closing {:?}...", s01);
+        let res = ztimeout!(s01.close());
+        println!("[Transport Peer 02l] => Closing {:?}: {:?}", s01, res);
+        assert!(res.is_ok());
 
-    #[cfg(feature = "transport_tcp")]
-    #[test]
-    fn transport_tcp_concurrent() {
-        task::block_on(async {
-            zasync_executor_init!();
-        });
+        // Close the transport
+        ztimeout!(peer02_manager.close());
+    });
 
-        let endpoint01: Vec<EndPoint> = vec![
-            "tcp/127.0.0.1:7447".parse().unwrap(),
-            "tcp/127.0.0.1:7448".parse().unwrap(),
-            "tcp/127.0.0.1:7449".parse().unwrap(),
-            "tcp/127.0.0.1:7450".parse().unwrap(),
-            "tcp/127.0.0.1:7451".parse().unwrap(),
-            "tcp/127.0.0.1:7452".parse().unwrap(),
-            "tcp/127.0.0.1:7453".parse().unwrap(),
-            "tcp/127.0.0.1:7454".parse().unwrap(),
-        ];
-        let endpoint02: Vec<EndPoint> = vec![
-            "tcp/127.0.0.1:7455".parse().unwrap(),
-            "tcp/127.0.0.1:7456".parse().unwrap(),
-            "tcp/127.0.0.1:7457".parse().unwrap(),
-            "tcp/127.0.0.1:7458".parse().unwrap(),
-            "tcp/127.0.0.1:7459".parse().unwrap(),
-            "tcp/127.0.0.1:7460".parse().unwrap(),
-            "tcp/127.0.0.1:7461".parse().unwrap(),
-            "tcp/127.0.0.1:7462".parse().unwrap(),
-        ];
+    println!("[Transport Current 01] => Starting...");
+    peer01_task.join(peer02_task).await;
+    println!("[Transport Current 02] => ...Stopped");
 
-        task::block_on(async {
-            transport_concurrent(endpoint01, endpoint02).await;
-        });
-    }
+    // Wait a little bit
+    task::sleep(SLEEP).await;
+}
+
+#[cfg(feature = "transport_tcp")]
+#[test]
+fn transport_tcp_concurrent() {
+    task::block_on(async {
+        zasync_executor_init!();
+    });
+
+    let endpoint01: Vec<EndPoint> = vec![
+        "tcp/127.0.0.1:7447".parse().unwrap(),
+        "tcp/127.0.0.1:7448".parse().unwrap(),
+        "tcp/127.0.0.1:7449".parse().unwrap(),
+        "tcp/127.0.0.1:7450".parse().unwrap(),
+        "tcp/127.0.0.1:7451".parse().unwrap(),
+        "tcp/127.0.0.1:7452".parse().unwrap(),
+        "tcp/127.0.0.1:7453".parse().unwrap(),
+        "tcp/127.0.0.1:7454".parse().unwrap(),
+    ];
+    let endpoint02: Vec<EndPoint> = vec![
+        "tcp/127.0.0.1:7455".parse().unwrap(),
+        "tcp/127.0.0.1:7456".parse().unwrap(),
+        "tcp/127.0.0.1:7457".parse().unwrap(),
+        "tcp/127.0.0.1:7458".parse().unwrap(),
+        "tcp/127.0.0.1:7459".parse().unwrap(),
+        "tcp/127.0.0.1:7460".parse().unwrap(),
+        "tcp/127.0.0.1:7461".parse().unwrap(),
+        "tcp/127.0.0.1:7462".parse().unwrap(),
+    ];
+
+    task::block_on(async {
+        transport_concurrent(endpoint01, endpoint02).await;
+    });
 }

--- a/zenoh/tests/unicast_intermittent.rs
+++ b/zenoh/tests/unicast_intermittent.rs
@@ -146,12 +146,9 @@ async fn transport_intermittent(endpoint: &EndPoint) {
 
     let router_handler = Arc::new(SHRouterIntermittent::default());
     // Create the router transport manager
-    #[allow(unused_mut)]
-    let mut unicast = TransportManager::config_unicast().max_sessions(3);
-    #[cfg(feature = "transport_multilink")]
-    {
-        unicast = unicast.max_links(1);
-    }
+    let unicast = TransportManager::config_unicast()
+        .max_links(1)
+        .max_sessions(3);
     let router_manager = TransportManager::builder()
         .whatami(WhatAmI::Router)
         .pid(router_id)
@@ -166,12 +163,9 @@ async fn transport_intermittent(endpoint: &EndPoint) {
 
     // Create the transport transport manager for the first client
     let counter = Arc::new(AtomicUsize::new(0));
-    #[allow(unused_mut)]
-    let mut unicast = TransportManager::config_unicast().max_sessions(3);
-    #[cfg(feature = "transport_multilink")]
-    {
-        unicast = unicast.max_links(1);
-    }
+    let unicast = TransportManager::config_unicast()
+        .max_links(1)
+        .max_sessions(3);
     let client01_manager = TransportManager::builder()
         .whatami(WhatAmI::Client)
         .pid(client01_id)
@@ -180,12 +174,9 @@ async fn transport_intermittent(endpoint: &EndPoint) {
         .unwrap();
 
     // Create the transport transport manager for the second client
-    #[allow(unused_mut)]
-    let mut unicast = TransportManager::config_unicast().max_sessions(1);
-    #[cfg(feature = "transport_multilink")]
-    {
-        unicast = unicast.max_links(1);
-    }
+    let unicast = TransportManager::config_unicast()
+        .max_links(1)
+        .max_sessions(1);
     let client02_manager = TransportManager::builder()
         .whatami(WhatAmI::Client)
         .pid(client02_id)
@@ -194,12 +185,9 @@ async fn transport_intermittent(endpoint: &EndPoint) {
         .unwrap();
 
     // Create the transport transport manager for the third client
-    #[allow(unused_mut)]
-    let mut unicast = TransportManager::config_unicast().max_sessions(1);
-    #[cfg(feature = "transport_multilink")]
-    {
-        unicast = unicast.max_links(1);
-    }
+    let unicast = TransportManager::config_unicast()
+        .max_links(1)
+        .max_sessions(1);
     let client03_manager = TransportManager::builder()
         .whatami(WhatAmI::Client)
         .pid(client03_id)

--- a/zenoh/tests/unicast_openclose.rs
+++ b/zenoh/tests/unicast_openclose.rs
@@ -87,12 +87,9 @@ async fn openclose_transport(endpoint: &EndPoint) {
 
     let router_handler = Arc::new(SHRouterOpenClose::default());
     // Create the router transport manager
-    #[allow(unused_mut)]
-    let mut unicast = TransportManager::config_unicast().max_sessions(1);
-    #[cfg(feature = "transport_multilink")]
-    {
-        unicast = unicast.max_links(2);
-    }
+    let unicast = TransportManager::config_unicast()
+        .max_links(2)
+        .max_sessions(1);
     let router_manager = TransportManager::builder()
         .whatami(WhatAmI::Router)
         .pid(router_id)
@@ -105,12 +102,9 @@ async fn openclose_transport(endpoint: &EndPoint) {
     let client02_id = PeerId::new(1, [2_u8; PeerId::MAX_SIZE]);
 
     // Create the transport transport manager for the first client
-    #[allow(unused_mut)]
-    let mut unicast = TransportManager::config_unicast().max_sessions(1);
-    #[cfg(feature = "transport_multilink")]
-    {
-        unicast = unicast.max_links(2);
-    }
+    let unicast = TransportManager::config_unicast()
+        .max_links(2)
+        .max_sessions(1);
     let client01_manager = TransportManager::builder()
         .whatami(WhatAmI::Client)
         .pid(client01_id)
@@ -119,12 +113,9 @@ async fn openclose_transport(endpoint: &EndPoint) {
         .unwrap();
 
     // Create the transport transport manager for the second client
-    #[allow(unused_mut)]
-    let mut unicast = TransportManager::config_unicast().max_sessions(1);
-    #[cfg(feature = "transport_multilink")]
-    {
-        unicast = unicast.max_links(1);
-    }
+    let unicast = TransportManager::config_unicast()
+        .max_links(1)
+        .max_sessions(1);
     let client02_manager = TransportManager::builder()
         .whatami(WhatAmI::Client)
         .pid(client02_id)
@@ -186,26 +177,23 @@ async fn openclose_transport(endpoint: &EndPoint) {
     /* [2] */
     // Open a second transport from the client to the router
     // -> This should be accepted
-    #[cfg(feature = "transport_multilink")]
-    {
-        links_num = 2;
+    links_num = 2;
 
-        println!("\nTransport Open Close [2a1]");
-        let res = ztimeout!(client01_manager.open_transport(endpoint.clone()));
-        println!("Transport Open Close [2a2]: {:?}", res);
-        assert!(res.is_ok());
-        let c_ses2 = res.unwrap();
-        println!("Transport Open Close [2b1]");
-        let transports = client01_manager.get_transports();
-        println!("Transport Open Close [2b2]: {:?}", transports);
-        assert_eq!(transports.len(), 1);
-        assert_eq!(c_ses2.get_pid().unwrap(), router_id);
-        println!("Transport Open Close [2c1]");
-        let links = c_ses2.get_links().unwrap();
-        println!("Transport Open Close [2c2]: {:?}", links);
-        assert_eq!(links.len(), links_num);
-        assert_eq!(c_ses2, c_ses1);
-    }
+    println!("\nTransport Open Close [2a1]");
+    let res = ztimeout!(client01_manager.open_transport(endpoint.clone()));
+    println!("Transport Open Close [2a2]: {:?}", res);
+    assert!(res.is_ok());
+    let c_ses2 = res.unwrap();
+    println!("Transport Open Close [2b1]");
+    let transports = client01_manager.get_transports();
+    println!("Transport Open Close [2b2]: {:?}", transports);
+    assert_eq!(transports.len(), 1);
+    assert_eq!(c_ses2.get_pid().unwrap(), router_id);
+    println!("Transport Open Close [2c1]");
+    let links = c_ses2.get_links().unwrap();
+    println!("Transport Open Close [2c2]: {:?}", links);
+    assert_eq!(links.len(), links_num);
+    assert_eq!(c_ses2, c_ses1);
 
     // Verify that the transport has been open on the router
     println!("Transport Open Close [2d1]");

--- a/zenoh/tests/unicast_simultaneous.rs
+++ b/zenoh/tests/unicast_simultaneous.rs
@@ -11,327 +11,324 @@
 // Contributors:
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
-#[cfg(feature = "transport_multilink")]
-mod tests {
-    use async_std::prelude::*;
-    use async_std::sync::Arc;
-    use async_std::task;
-    use std::any::Any;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::time::Duration;
-    use zenoh::net::link::{EndPoint, Link};
-    use zenoh::net::protocol::core::{
-        Channel, CongestionControl, PeerId, Priority, Reliability, WhatAmI,
+use async_std::prelude::*;
+use async_std::sync::Arc;
+use async_std::task;
+use std::any::Any;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+use zenoh::net::link::{EndPoint, Link};
+use zenoh::net::protocol::core::{
+    Channel, CongestionControl, PeerId, Priority, Reliability, WhatAmI,
+};
+use zenoh::net::protocol::io::ZBuf;
+use zenoh::net::protocol::proto::ZenohMessage;
+use zenoh::net::transport::{
+    TransportEventHandler, TransportManager, TransportMulticast, TransportMulticastEventHandler,
+    TransportPeer, TransportPeerEventHandler, TransportUnicast,
+};
+use zenoh_util::core::Result as ZResult;
+use zenoh_util::zasync_executor_init;
+
+const TIMEOUT: Duration = Duration::from_secs(60);
+const SLEEP: Duration = Duration::from_millis(500);
+
+const MSG_COUNT: usize = 16;
+const MSG_SIZE: usize = 1_024;
+
+macro_rules! ztimeout {
+    ($f:expr) => {
+        $f.timeout(TIMEOUT).await.unwrap()
     };
-    use zenoh::net::protocol::io::ZBuf;
-    use zenoh::net::protocol::proto::ZenohMessage;
-    use zenoh::net::transport::{
-        TransportEventHandler, TransportManager, TransportMulticast,
-        TransportMulticastEventHandler, TransportPeer, TransportPeerEventHandler, TransportUnicast,
-    };
-    use zenoh_util::core::Result as ZResult;
-    use zenoh_util::zasync_executor_init;
+}
 
-    const TIMEOUT: Duration = Duration::from_secs(60);
-    const SLEEP: Duration = Duration::from_millis(500);
+// Transport Handler for the router
+struct SHPeer {
+    pid: PeerId,
+    count: Arc<AtomicUsize>,
+}
 
-    const MSG_COUNT: usize = 16;
-    const MSG_SIZE: usize = 1_024;
+impl SHPeer {
+    fn new(pid: PeerId) -> Self {
+        Self {
+            pid,
+            count: Arc::new(AtomicUsize::new(0)),
+        }
+    }
 
-    macro_rules! ztimeout {
-        ($f:expr) => {
-            $f.timeout(TIMEOUT).await.unwrap()
+    fn get_count(&self) -> usize {
+        self.count.load(Ordering::SeqCst)
+    }
+}
+
+impl TransportEventHandler for SHPeer {
+    fn new_unicast(
+        &self,
+        _peer: TransportPeer,
+        transport: TransportUnicast,
+    ) -> ZResult<Arc<dyn TransportPeerEventHandler>> {
+        // Create the message to send
+        let key = "/test".into();
+        let payload = ZBuf::from(vec![0_u8; MSG_SIZE]);
+        let channel = Channel {
+            priority: Priority::Control,
+            reliability: Reliability::Reliable,
         };
-    }
+        let congestion_control = CongestionControl::Block;
+        let data_info = None;
+        let routing_context = None;
+        let reply_context = None;
+        let attachment = None;
 
-    // Transport Handler for the router
-    struct SHPeer {
-        pid: PeerId,
-        count: Arc<AtomicUsize>,
-    }
-
-    impl SHPeer {
-        fn new(pid: PeerId) -> Self {
-            Self {
-                pid,
-                count: Arc::new(AtomicUsize::new(0)),
-            }
-        }
-
-        fn get_count(&self) -> usize {
-            self.count.load(Ordering::SeqCst)
-        }
-    }
-
-    impl TransportEventHandler for SHPeer {
-        fn new_unicast(
-            &self,
-            _peer: TransportPeer,
-            transport: TransportUnicast,
-        ) -> ZResult<Arc<dyn TransportPeerEventHandler>> {
-            // Create the message to send
-            let key = "/test".into();
-            let payload = ZBuf::from(vec![0_u8; MSG_SIZE]);
-            let channel = Channel {
-                priority: Priority::Control,
-                reliability: Reliability::Reliable,
-            };
-            let congestion_control = CongestionControl::Block;
-            let data_info = None;
-            let routing_context = None;
-            let reply_context = None;
-            let attachment = None;
-
-            let message = ZenohMessage::make_data(
-                key,
-                payload,
-                channel,
-                congestion_control,
-                data_info,
-                routing_context,
-                reply_context,
-                attachment,
-            );
-
-            println!("[Simultaneous {}] Sending {}...", self.pid, MSG_COUNT);
-            for _ in 0..MSG_COUNT {
-                transport.handle_message(message.clone()).unwrap();
-            }
-            println!("[Simultaneous {}] ... sent {}", self.pid, MSG_COUNT);
-
-            let mh = Arc::new(MHPeer::new(self.count.clone()));
-            Ok(mh)
-        }
-
-        fn new_multicast(
-            &self,
-            _transport: TransportMulticast,
-        ) -> ZResult<Arc<dyn TransportMulticastEventHandler>> {
-            panic!();
-        }
-    }
-
-    struct MHPeer {
-        count: Arc<AtomicUsize>,
-    }
-
-    impl MHPeer {
-        fn new(count: Arc<AtomicUsize>) -> Self {
-            Self { count }
-        }
-    }
-
-    impl TransportPeerEventHandler for MHPeer {
-        fn handle_message(&self, _msg: ZenohMessage) -> ZResult<()> {
-            self.count.fetch_add(1, Ordering::AcqRel);
-            Ok(())
-        }
-
-        fn new_link(&self, _link: Link) {}
-        fn del_link(&self, _link: Link) {}
-        fn closing(&self) {}
-        fn closed(&self) {}
-
-        fn as_any(&self) -> &dyn Any {
-            self
-        }
-    }
-
-    async fn transport_simultaneous(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPoint>) {
-        /* [Peers] */
-        let peer_id01 = PeerId::new(1, [1_u8; PeerId::MAX_SIZE]);
-        let peer_id02 = PeerId::new(1, [2_u8; PeerId::MAX_SIZE]);
-
-        // Create the peer01 transport manager
-        let peer_sh01 = Arc::new(SHPeer::new(peer_id01));
-        let unicast = TransportManager::config_unicast().max_links(endpoint01.len());
-        let peer01_manager = TransportManager::builder()
-            .whatami(WhatAmI::Peer)
-            .pid(peer_id01)
-            .unicast(unicast)
-            .build(peer_sh01.clone())
-            .unwrap();
-
-        // Create the peer02 transport manager
-        let peer_sh02 = Arc::new(SHPeer::new(peer_id02));
-        let unicast = TransportManager::config_unicast().max_links(endpoint02.len());
-        let peer02_manager = TransportManager::builder()
-            .whatami(WhatAmI::Peer)
-            .pid(peer_id02)
-            .unicast(unicast)
-            .build(peer_sh02.clone())
-            .unwrap();
-
-        // Add the endpoints on the peer01
-        for e in endpoint01.iter() {
-            let res = ztimeout!(peer01_manager.add_listener(e.clone()));
-            println!("[Simultaneous 01a] => Adding endpoint {:?}: {:?}", e, res);
-            assert!(res.is_ok());
-        }
-        let locs = peer01_manager.get_listeners();
-        println!(
-            "[Simultaneous 01b] => Getting endpoints: {:?} {:?}",
-            endpoint01, locs
+        let message = ZenohMessage::make_data(
+            key,
+            payload,
+            channel,
+            congestion_control,
+            data_info,
+            routing_context,
+            reply_context,
+            attachment,
         );
-        assert_eq!(endpoint01.len(), locs.len());
 
-        // Add the endpoints on peer02
-        for e in endpoint02.iter() {
-            let res = ztimeout!(peer02_manager.add_listener(e.clone()));
-            println!("[Simultaneous 02a] => Adding endpoint {:?}: {:?}", e, res);
-            assert!(res.is_ok());
+        println!("[Simultaneous {}] Sending {}...", self.pid, MSG_COUNT);
+        for _ in 0..MSG_COUNT {
+            transport.handle_message(message.clone()).unwrap();
         }
-        let locs = peer02_manager.get_listeners();
-        println!(
-            "[Simultaneous 02b] => Getting endpoints: {:?} {:?}",
-            endpoint02, locs
-        );
-        assert_eq!(endpoint02.len(), locs.len());
+        println!("[Simultaneous {}] ... sent {}", self.pid, MSG_COUNT);
 
-        // Endpoints
-        let c_ep01 = endpoint01.clone();
-        let c_ep02 = endpoint02.clone();
+        let mh = Arc::new(MHPeer::new(self.count.clone()));
+        Ok(mh)
+    }
 
-        // Peer01
-        let c_p01m = peer01_manager.clone();
-        let peer01_task = task::spawn(async move {
-            // Open the transport with the second peer
-            // These open should succeed
-            for e in c_ep02.iter() {
-                println!("[Simultaneous 01c] => Opening transport with {:?}...", e);
-                let _ = ztimeout!(c_p01m.open_transport(e.clone())).unwrap();
-            }
+    fn new_multicast(
+        &self,
+        _transport: TransportMulticast,
+    ) -> ZResult<Arc<dyn TransportMulticastEventHandler>> {
+        panic!();
+    }
+}
 
-            // These open should fails
-            for e in c_ep02.iter() {
-                println!("[Simultaneous 01d] => Exceeding transport with {:?}...", e);
-                let res = ztimeout!(c_p01m.open_transport(e.clone()));
-                assert!(res.is_err());
-            }
+struct MHPeer {
+    count: Arc<AtomicUsize>,
+}
 
-            task::sleep(SLEEP).await;
+impl MHPeer {
+    fn new(count: Arc<AtomicUsize>) -> Self {
+        Self { count }
+    }
+}
 
-            let tp02 = ztimeout!(async {
-                let mut tp02 = None;
-                while tp02.is_none() {
-                    task::sleep(SLEEP).await;
-                    println!(
-                        "[Simultaneous 01e] => Transports: {:?}",
-                        peer01_manager.get_transports()
-                    );
-                    tp02 = peer01_manager.get_transport(&peer_id02);
-                }
+impl TransportPeerEventHandler for MHPeer {
+    fn handle_message(&self, _msg: ZenohMessage) -> ZResult<()> {
+        self.count.fetch_add(1, Ordering::AcqRel);
+        Ok(())
+    }
 
-                tp02.unwrap()
-            });
+    fn new_link(&self, _link: Link) {}
+    fn del_link(&self, _link: Link) {}
+    fn closing(&self) {}
+    fn closed(&self) {}
 
-            // Wait for the links to be properly established
-            ztimeout!(async {
-                let expected = endpoint01.len() + c_ep02.len();
-                let mut tl02 = vec![];
-                while tl02.len() != expected {
-                    task::sleep(SLEEP).await;
-                    tl02 = tp02.get_links().unwrap();
-                    println!("[Simultaneous 01f] => Links {}/{}", tl02.len(), expected);
-                }
-            });
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
 
-            // Wait for the messages to arrive to peer 01
-            ztimeout!(async {
-                let mut check = 0;
-                while check != MSG_COUNT {
-                    task::sleep(SLEEP).await;
-                    check = peer_sh01.get_count();
-                    println!("[Simultaneous 01g] => Received {:?}/{:?}", check, MSG_COUNT);
-                }
-            });
-        });
+async fn transport_simultaneous(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPoint>) {
+    /* [Peers] */
+    let peer_id01 = PeerId::new(1, [1_u8; PeerId::MAX_SIZE]);
+    let peer_id02 = PeerId::new(1, [2_u8; PeerId::MAX_SIZE]);
 
-        // Peer02
-        let c_p02m = peer02_manager.clone();
-        let peer02_task = task::spawn(async move {
-            // Open the transport with the first peer
-            // These open should succeed
-            for e in c_ep01.iter() {
-                println!("[Simultaneous 02c] => Opening transport with {:?}...", e);
-                let _ = ztimeout!(c_p02m.open_transport(e.clone())).unwrap();
-            }
+    // Create the peer01 transport manager
+    let peer_sh01 = Arc::new(SHPeer::new(peer_id01));
+    let unicast = TransportManager::config_unicast().max_links(endpoint01.len());
+    let peer01_manager = TransportManager::builder()
+        .whatami(WhatAmI::Peer)
+        .pid(peer_id01)
+        .unicast(unicast)
+        .build(peer_sh01.clone())
+        .unwrap();
 
-            // These open should fails
-            for e in c_ep01.iter() {
-                println!("[Simultaneous 02d] => Exceeding transport with {:?}...", e);
-                let res = ztimeout!(c_p02m.open_transport(e.clone()));
-                assert!(res.is_err());
-            }
+    // Create the peer02 transport manager
+    let peer_sh02 = Arc::new(SHPeer::new(peer_id02));
+    let unicast = TransportManager::config_unicast().max_links(endpoint02.len());
+    let peer02_manager = TransportManager::builder()
+        .whatami(WhatAmI::Peer)
+        .pid(peer_id02)
+        .unicast(unicast)
+        .build(peer_sh02.clone())
+        .unwrap();
 
-            task::sleep(SLEEP).await;
+    // Add the endpoints on the peer01
+    for e in endpoint01.iter() {
+        let res = ztimeout!(peer01_manager.add_listener(e.clone()));
+        println!("[Simultaneous 01a] => Adding endpoint {:?}: {:?}", e, res);
+        assert!(res.is_ok());
+    }
+    let locs = peer01_manager.get_listeners();
+    println!(
+        "[Simultaneous 01b] => Getting endpoints: {:?} {:?}",
+        endpoint01, locs
+    );
+    assert_eq!(endpoint01.len(), locs.len());
 
-            let tp01 = ztimeout!(async {
-                let mut tp01 = None;
-                while tp01.is_none() {
-                    task::sleep(SLEEP).await;
-                    println!(
-                        "[Simultaneous 02e] => Transports: {:?}",
-                        peer02_manager.get_transports()
-                    );
-                    tp01 = peer02_manager.get_transport(&peer_id01);
-                }
-                tp01.unwrap()
-            });
+    // Add the endpoints on peer02
+    for e in endpoint02.iter() {
+        let res = ztimeout!(peer02_manager.add_listener(e.clone()));
+        println!("[Simultaneous 02a] => Adding endpoint {:?}: {:?}", e, res);
+        assert!(res.is_ok());
+    }
+    let locs = peer02_manager.get_listeners();
+    println!(
+        "[Simultaneous 02b] => Getting endpoints: {:?} {:?}",
+        endpoint02, locs
+    );
+    assert_eq!(endpoint02.len(), locs.len());
 
-            // Wait for the links to be properly established
-            ztimeout!(async {
-                let expected = c_ep01.len() + endpoint02.len();
-                let mut tl01 = vec![];
-                while tl01.len() != expected {
-                    task::sleep(SLEEP).await;
-                    tl01 = tp01.get_links().unwrap();
-                    println!("[Simultaneous 02f] => Links {}/{}", tl01.len(), expected);
-                }
-            });
+    // Endpoints
+    let c_ep01 = endpoint01.clone();
+    let c_ep02 = endpoint02.clone();
 
-            // Wait for the messages to arrive to peer 02
-            ztimeout!(async {
-                let mut check = 0;
-                while check != MSG_COUNT {
-                    task::sleep(SLEEP).await;
-                    check = peer_sh02.get_count();
-                    println!("[Simultaneous 02g] => Received {:?}/{:?}", check, MSG_COUNT);
-                }
-            });
-        });
+    // Peer01
+    let c_p01m = peer01_manager.clone();
+    let peer01_task = task::spawn(async move {
+        // Open the transport with the second peer
+        // These open should succeed
+        for e in c_ep02.iter() {
+            println!("[Simultaneous 01c] => Opening transport with {:?}...", e);
+            let _ = ztimeout!(c_p01m.open_transport(e.clone())).unwrap();
+        }
 
-        println!("[Simultaneous] => Waiting for peer01 and peer02 tasks...");
-        peer01_task.join(peer02_task).await;
-        println!("[Simultaneous] => Waiting for peer01 and peer02 tasks... DONE\n");
+        // These open should fails
+        for e in c_ep02.iter() {
+            println!("[Simultaneous 01d] => Exceeding transport with {:?}...", e);
+            let res = ztimeout!(c_p01m.open_transport(e.clone()));
+            assert!(res.is_err());
+        }
 
         task::sleep(SLEEP).await;
-    }
 
-    #[cfg(feature = "transport_tcp")]
-    #[test]
-    fn transport_tcp_simultaneous() {
-        task::block_on(async {
-            zasync_executor_init!();
+        let tp02 = ztimeout!(async {
+            let mut tp02 = None;
+            while tp02.is_none() {
+                task::sleep(SLEEP).await;
+                println!(
+                    "[Simultaneous 01e] => Transports: {:?}",
+                    peer01_manager.get_transports()
+                );
+                tp02 = peer01_manager.get_transport(&peer_id02);
+            }
+
+            tp02.unwrap()
         });
 
-        let endpoint01: Vec<EndPoint> = vec![
-            "tcp/127.0.0.1:15447".parse().unwrap(),
-            "tcp/127.0.0.1:15448".parse().unwrap(),
-            "tcp/127.0.0.1:15449".parse().unwrap(),
-            "tcp/127.0.0.1:15450".parse().unwrap(),
-            "tcp/127.0.0.1:15451".parse().unwrap(),
-            "tcp/127.0.0.1:15452".parse().unwrap(),
-            "tcp/127.0.0.1:15453".parse().unwrap(),
-        ];
-        let endpoint02: Vec<EndPoint> = vec![
-            "tcp/127.0.0.1:15454".parse().unwrap(),
-            "tcp/127.0.0.1:15455".parse().unwrap(),
-            "tcp/127.0.0.1:15456".parse().unwrap(),
-        ];
-
-        task::block_on(async {
-            transport_simultaneous(endpoint01, endpoint02).await;
+        // Wait for the links to be properly established
+        ztimeout!(async {
+            let expected = endpoint01.len() + c_ep02.len();
+            let mut tl02 = vec![];
+            while tl02.len() != expected {
+                task::sleep(SLEEP).await;
+                tl02 = tp02.get_links().unwrap();
+                println!("[Simultaneous 01f] => Links {}/{}", tl02.len(), expected);
+            }
         });
-    }
+
+        // Wait for the messages to arrive to peer 01
+        ztimeout!(async {
+            let mut check = 0;
+            while check != MSG_COUNT {
+                task::sleep(SLEEP).await;
+                check = peer_sh01.get_count();
+                println!("[Simultaneous 01g] => Received {:?}/{:?}", check, MSG_COUNT);
+            }
+        });
+    });
+
+    // Peer02
+    let c_p02m = peer02_manager.clone();
+    let peer02_task = task::spawn(async move {
+        // Open the transport with the first peer
+        // These open should succeed
+        for e in c_ep01.iter() {
+            println!("[Simultaneous 02c] => Opening transport with {:?}...", e);
+            let _ = ztimeout!(c_p02m.open_transport(e.clone())).unwrap();
+        }
+
+        // These open should fails
+        for e in c_ep01.iter() {
+            println!("[Simultaneous 02d] => Exceeding transport with {:?}...", e);
+            let res = ztimeout!(c_p02m.open_transport(e.clone()));
+            assert!(res.is_err());
+        }
+
+        task::sleep(SLEEP).await;
+
+        let tp01 = ztimeout!(async {
+            let mut tp01 = None;
+            while tp01.is_none() {
+                task::sleep(SLEEP).await;
+                println!(
+                    "[Simultaneous 02e] => Transports: {:?}",
+                    peer02_manager.get_transports()
+                );
+                tp01 = peer02_manager.get_transport(&peer_id01);
+            }
+            tp01.unwrap()
+        });
+
+        // Wait for the links to be properly established
+        ztimeout!(async {
+            let expected = c_ep01.len() + endpoint02.len();
+            let mut tl01 = vec![];
+            while tl01.len() != expected {
+                task::sleep(SLEEP).await;
+                tl01 = tp01.get_links().unwrap();
+                println!("[Simultaneous 02f] => Links {}/{}", tl01.len(), expected);
+            }
+        });
+
+        // Wait for the messages to arrive to peer 02
+        ztimeout!(async {
+            let mut check = 0;
+            while check != MSG_COUNT {
+                task::sleep(SLEEP).await;
+                check = peer_sh02.get_count();
+                println!("[Simultaneous 02g] => Received {:?}/{:?}", check, MSG_COUNT);
+            }
+        });
+    });
+
+    println!("[Simultaneous] => Waiting for peer01 and peer02 tasks...");
+    peer01_task.join(peer02_task).await;
+    println!("[Simultaneous] => Waiting for peer01 and peer02 tasks... DONE\n");
+
+    task::sleep(SLEEP).await;
+}
+
+#[cfg(feature = "transport_tcp")]
+#[test]
+fn transport_tcp_simultaneous() {
+    task::block_on(async {
+        zasync_executor_init!();
+    });
+
+    let endpoint01: Vec<EndPoint> = vec![
+        "tcp/127.0.0.1:15447".parse().unwrap(),
+        "tcp/127.0.0.1:15448".parse().unwrap(),
+        "tcp/127.0.0.1:15449".parse().unwrap(),
+        "tcp/127.0.0.1:15450".parse().unwrap(),
+        "tcp/127.0.0.1:15451".parse().unwrap(),
+        "tcp/127.0.0.1:15452".parse().unwrap(),
+        "tcp/127.0.0.1:15453".parse().unwrap(),
+    ];
+    let endpoint02: Vec<EndPoint> = vec![
+        "tcp/127.0.0.1:15454".parse().unwrap(),
+        "tcp/127.0.0.1:15455".parse().unwrap(),
+        "tcp/127.0.0.1:15456".parse().unwrap(),
+    ];
+
+    task::block_on(async {
+        transport_simultaneous(endpoint01, endpoint02).await;
+    });
 }

--- a/zenoh/tests/unicast_transport.rs
+++ b/zenoh/tests/unicast_transport.rs
@@ -163,12 +163,8 @@ async fn open_transport(
 
     // Create the router transport manager
     let router_handler = Arc::new(SHRouter::default());
-    #[allow(unused_mut)] // transport_multilink-memory feature requires mut
-    let mut unicast = TransportManager::config_unicast();
-    #[cfg(feature = "transport_multilink")]
-    {
-        unicast = unicast.max_links(endpoints.len());
-    }
+    let unicast = TransportManager::config_unicast().max_links(endpoints.len());
+
     let router_manager = TransportManager::builder()
         .pid(router_id)
         .whatami(WhatAmI::Router)
@@ -177,12 +173,7 @@ async fn open_transport(
         .unwrap();
 
     // Create the client transport manager
-    #[allow(unused_mut)] // transport_multilink-memory feature requires mut
-    let mut unicast = TransportManager::config_unicast();
-    #[cfg(feature = "transport_multilink")]
-    {
-        unicast = unicast.max_links(endpoints.len());
-    }
+    let unicast = TransportManager::config_unicast().max_links(endpoints.len());
     let client_manager = TransportManager::builder()
         .whatami(WhatAmI::Client)
         .pid(client_id)
@@ -329,18 +320,9 @@ async fn run_single(endpoints: &[EndPoint], channel: Channel, msg_size: usize) {
 }
 
 async fn run(endpoints: &[EndPoint], channel: &[Channel], msg_size: &[usize]) {
-    #[cfg(feature = "transport_multilink")]
     for ch in channel.iter() {
         for ms in msg_size.iter() {
             run_single(endpoints, *ch, *ms).await;
-        }
-    }
-    #[cfg(not(feature = "transport_multilink"))]
-    for ch in channel.iter() {
-        for ms in msg_size.iter() {
-            for i in 0..endpoints.len() {
-                run_single(&endpoints[i..i + 1], *ch, *ms).await;
-            }
         }
     }
 }
@@ -436,11 +418,7 @@ fn transport_unicast_unix_only() {
     let _ = std::fs::remove_file("zenoh-test-unix-socket-5.sock.lock");
 }
 
-#[cfg(all(
-    feature = "transport_multilink",
-    feature = "transport_tcp",
-    feature = "transport_udp"
-))]
+#[cfg(all(feature = "transport_tcp", feature = "transport_udp"))]
 #[test]
 fn transport_unicast_tcp_udp() {
     task::block_on(async {
@@ -470,7 +448,6 @@ fn transport_unicast_tcp_udp() {
 }
 
 #[cfg(all(
-    feature = "transport_multilink",
     feature = "transport_tcp",
     feature = "transport_unixsock-stream",
     target_family = "unix"
@@ -508,7 +485,6 @@ fn transport_unicast_tcp_unix() {
 }
 
 #[cfg(all(
-    feature = "transport_multilink",
     feature = "transport_udp",
     feature = "transport_unixsock-stream",
     target_family = "unix"
@@ -546,7 +522,6 @@ fn transport_unicast_udp_unix() {
 }
 
 #[cfg(all(
-    feature = "transport_multilink",
     feature = "transport_tcp",
     feature = "transport_udp",
     feature = "transport_unixsock-stream",


### PR DESCRIPTION
This PR removes the `transport_multilink` feature since is no longer required.
This is due to recent changes to support simultaneous session initialisation between peers, which de facto requires the `transport_multilink` feature to be always enabled.