### PR TITLE
Transport and listener checks in tests

### DIFF
--- a/zenoh/tests/unicast_authenticator.rs
+++ b/zenoh/tests/unicast_authenticator.rs
@@ -376,7 +376,11 @@ async fn authenticator_multilink(endpoint: &EndPoint) {
     println!("Transport Authenticator PubKey [2d2]: {:?}", res);
     assert!(res.is_ok());
 
-    task::sleep(SLEEP).await;
+    ztimeout!(async {
+        while !router_manager.get_transports().is_empty() {
+            task::sleep(SLEEP).await;
+        }
+    });
 
     /* [3a] */
     // Open a first transport from client02 to the router
@@ -413,7 +417,11 @@ async fn authenticator_multilink(endpoint: &EndPoint) {
     println!("Transport Authenticator PubKey [3d2]: {:?}", res);
     assert!(res.is_ok());
 
-    task::sleep(SLEEP).await;
+    ztimeout!(async {
+        while !router_manager.get_transports().is_empty() {
+            task::sleep(SLEEP).await;
+        }
+    });
 
     /* [4a] */
     // Open a first transport from client01_spoof to the router
@@ -450,7 +458,11 @@ async fn authenticator_multilink(endpoint: &EndPoint) {
     println!("Transport Authenticator PubKey [4d2]: {:?}", res);
     assert!(res.is_ok());
 
-    task::sleep(SLEEP).await;
+    ztimeout!(async {
+        while !router_manager.get_transports().is_empty() {
+            task::sleep(SLEEP).await;
+        }
+    });
 
     /* [5a] */
     // Open a first transport from client01 to the router
@@ -487,7 +499,11 @@ async fn authenticator_multilink(endpoint: &EndPoint) {
     println!("Transport Authenticator PubKey [5d2]: {:?}", res);
     assert!(res.is_ok());
 
-    task::sleep(SLEEP).await;
+    ztimeout!(async {
+        while !router_manager.get_transports().is_empty() {
+            task::sleep(SLEEP).await;
+        }
+    });
 
     /* [6] */
     // Perform clean up of the open locators
@@ -496,8 +512,11 @@ async fn authenticator_multilink(endpoint: &EndPoint) {
     println!("Transport Authenticator UserPassword [6a2]: {:?}", res);
     assert!(res.is_ok());
 
-    // Wait a little bit
-    task::sleep(SLEEP).await;
+    ztimeout!(async {
+        while !router_manager.get_listeners().is_empty() {
+            task::sleep(SLEEP).await;
+        }
+    });
 
     ztimeout!(router_manager.close());
     ztimeout!(client01_manager.close());
@@ -611,6 +630,12 @@ async fn authenticator_user_password(endpoint: &EndPoint) {
     println!("Transport Authenticator UserPassword [3a1]: {:?}", res);
     assert!(res.is_ok());
 
+    ztimeout!(async {
+        while !router_manager.get_transports().is_empty() {
+            task::sleep(SLEEP).await;
+        }
+    });
+
     /* [4] */
     // Open a second transport from the client to the router
     // -> This should be rejected
@@ -658,8 +683,11 @@ async fn authenticator_user_password(endpoint: &EndPoint) {
     println!("Transport Authenticator UserPassword [8a2]: {:?}", res);
     assert!(res.is_ok());
 
-    // Wait a little bit
-    task::sleep(SLEEP).await;
+    ztimeout!(async {
+        while !router_manager.get_transports().is_empty() {
+            task::sleep(SLEEP).await;
+        }
+    });
 
     /* [9] */
     // Perform clean up of the open locators
@@ -667,6 +695,12 @@ async fn authenticator_user_password(endpoint: &EndPoint) {
     let res = ztimeout!(router_manager.del_listener(endpoint));
     println!("Transport Authenticator UserPassword [9a2]: {:?}", res);
     assert!(res.is_ok());
+
+    ztimeout!(async {
+        while !router_manager.get_listeners().is_empty() {
+            task::sleep(SLEEP).await;
+        }
+    });
 
     // Wait a little bit
     task::sleep(SLEEP).await;
@@ -729,7 +763,11 @@ async fn authenticator_shared_memory(endpoint: &EndPoint) {
     println!("Transport Authenticator SharedMemory [3a1]: {:?}", res);
     assert!(res.is_ok());
 
-    task::sleep(SLEEP).await;
+    ztimeout!(async {
+        while !router_manager.get_transports().is_empty() {
+            task::sleep(SLEEP).await;
+        }
+    });
 
     /* [4] */
     // Perform clean up of the open locators
@@ -737,6 +775,12 @@ async fn authenticator_shared_memory(endpoint: &EndPoint) {
     let res = ztimeout!(router_manager.del_listener(endpoint));
     println!("Transport Authenticator SharedMemory [4a2]: {:?}", res);
     assert!(res.is_ok());
+
+    ztimeout!(async {
+        while !router_manager.get_listeners().is_empty() {
+            task::sleep(SLEEP).await;
+        }
+    });
 
     task::sleep(SLEEP).await;
 }

--- a/zenoh/tests/unicast_conduits.rs
+++ b/zenoh/tests/unicast_conduits.rs
@@ -236,8 +236,11 @@ async fn close_transport(
     println!("Closing transport with {}", ee);
     let _ = ztimeout!(client_transport.close()).unwrap();
 
-    // Wait a little bit
-    task::sleep(SLEEP).await;
+    ztimeout!(async {
+        while !router_manager.get_transports().is_empty() {
+            task::sleep(SLEEP).await;
+        }
+    });
 
     // Stop the locators on the manager
     for e in endpoints.iter() {

--- a/zenoh/tests/unicast_defragmentation.rs
+++ b/zenoh/tests/unicast_defragmentation.rs
@@ -111,6 +111,12 @@ async fn run(endpoint: &EndPoint, channel: Channel, msg_size: usize) {
     let _ = ztimeout!(router_manager.del_listener(endpoint)).unwrap();
 
     // Wait a little bit
+    ztimeout!(async {
+        while !router_manager.get_listeners().is_empty() {
+            task::sleep(SLEEP).await;
+        }
+    });
+
     task::sleep(SLEEP).await;
 
     ztimeout!(router_manager.close());

--- a/zenoh/tests/unicast_openclose.rs
+++ b/zenoh/tests/unicast_openclose.rs
@@ -429,6 +429,12 @@ async fn openclose_transport(endpoint: &EndPoint) {
     println!("Transport Open Close [10a2]: {:?}", res);
     assert!(res.is_ok());
 
+    ztimeout!(async {
+        while !router_manager.get_listeners().is_empty() {
+            task::sleep(SLEEP).await;
+        }
+    });
+
     // Wait a little bit
     task::sleep(SLEEP).await;
 

--- a/zenoh/tests/unicast_shm.rs
+++ b/zenoh/tests/unicast_shm.rs
@@ -311,14 +311,22 @@ mod tests {
         println!("Transport SHM [5b]");
         let _ = ztimeout!(peer_net01_transport.close()).unwrap();
 
-        // Wait a little bit
-        task::sleep(SLEEP).await;
+        ztimeout!(async {
+            while !peer_shm01_manager.get_transports().is_empty() {
+                task::sleep(SLEEP).await;
+            }
+        });
 
         // Delete the listener
         println!("Transport SHM [6a]");
         let _ = ztimeout!(peer_shm01_manager.del_listener(endpoint)).unwrap();
 
         // Wait a little bit
+        ztimeout!(async {
+            while !peer_shm01_manager.get_listeners().is_empty() {
+                task::sleep(SLEEP).await;
+            }
+        });
         task::sleep(SLEEP).await;
 
         ztimeout!(peer_net01_manager.close());

--- a/zenoh/tests/unicast_simultaneous.rs
+++ b/zenoh/tests/unicast_simultaneous.rs
@@ -262,6 +262,7 @@ async fn transport_simultaneous(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPo
             assert!(res.is_err());
         }
 
+        // Wait a little bit
         task::sleep(SLEEP).await;
 
         let tp01 = ztimeout!(async {
@@ -303,6 +304,7 @@ async fn transport_simultaneous(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPo
     peer01_task.join(peer02_task).await;
     println!("[Simultaneous] => Waiting for peer01 and peer02 tasks... DONE\n");
 
+    // Wait a little bit
     task::sleep(SLEEP).await;
 }
 

--- a/zenoh/tests/unicast_transport.rs
+++ b/zenoh/tests/unicast_transport.rs
@@ -219,14 +219,23 @@ async fn close_transport(
     println!("Closing transport with {}", ee);
     let _ = ztimeout!(client_transport.close()).unwrap();
 
-    // Wait a little bit
-    task::sleep(SLEEP).await;
+    ztimeout!(async {
+        while !router_manager.get_transports().is_empty() {
+            task::sleep(SLEEP).await;
+        }
+    });
 
     // Stop the locators on the manager
     for e in endpoints.iter() {
         println!("Del locator: {}", e);
         let _ = ztimeout!(router_manager.del_listener(e)).unwrap();
     }
+
+    ztimeout!(async {
+        while !router_manager.get_listeners().is_empty() {
+            task::sleep(SLEEP).await;
+        }
+    });
 
     // Wait a little bit
     task::sleep(SLEEP).await;


### PR DESCRIPTION
This PR improves unicast transport tests by explicitly checking when transports and listeners are closed.