### PR TITLE
ensure zenoh-util keeps exporting its previous symbols by default

### DIFF
--- a/commons/zenoh-util/Cargo.toml
+++ b/commons/zenoh-util/Cargo.toml
@@ -27,6 +27,14 @@ categories = ["network-programming"]
 description = "Internal crate for zenoh."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+compat = [
+    "zenoh-cfg-properties",
+    "zenoh-crypto",
+    "zenoh-sync",
+    "zenoh-collections",
+]
+default = ["compat"]
 [badges]
 maintenance = { status = "actively-developed" }
 

--- a/commons/zenoh-util/src/lib.rs
+++ b/commons/zenoh-util/src/lib.rs
@@ -16,22 +16,22 @@
 extern crate lazy_static;
 use std::path::{Path, PathBuf};
 #[cfg(features = "zenoh-collections")]
-#[deprecated = "This module is now a separate crate. Use the crate directly for shorter compile-times"]
+#[deprecated = "This module is now a separate crate. Use the `zenoh_collections` crate directly for shorter compile-times. You may disable this re-export by disabling `zenoh-util`'s default features."]
 pub use zenoh_collections as collections;
-#[deprecated = "This module is now a separate crate. Use the crate directly for shorter compile-times"]
+#[deprecated = "This module is now a separate crate. Use the `zenoh_core` crate directly for shorter compile-times. You may disable this re-export by disabling `zenoh-util`'s default features."]
 pub use zenoh_core as core;
 #[cfg(features = "zenoh-crypto")]
-#[deprecated = "This module is now a separate crate. Use the crate directly for shorter compile-times"]
+#[deprecated = "This module is now a separate crate. Use the `zenoh_crypto` crate directly for shorter compile-times. You may disable this re-export by disabling `zenoh-util`'s default features."]
 pub use zenoh_crypto as crypto;
 pub mod ffi;
 mod lib_loader;
 pub mod net;
 pub use lib_loader::*;
 #[cfg(features = "zenoh-cfg-properties")]
-#[deprecated = "This module is now a separate crate. Use the crate directly for shorter compile-times"]
+#[deprecated = "This module is now a separate crate. Use the `zenoh_cfg_properties` crate directly for shorter compile-times. You may disable this re-export by disabling `zenoh-util`'s default features."]
 pub use zenoh_cfg_properties as properties;
 #[cfg(features = "zenoh-sync")]
-#[deprecated = "This module is now a separate crate. Use the crate directly for shorter compile-times"]
+#[deprecated = "This module is now a separate crate. Use the `zenoh_sync` crate directly for shorter compile-times. You may disable this re-export by disabling `zenoh-util`'s default features."]
 pub use zenoh_sync as sync;
 
 /// the "ZENOH_HOME" environement variable name


### PR DESCRIPTION
Detected this in zenoh-flow, zenoh-util reexports were feature gated the wrong way, breaking backwards compatibility.