### PR TITLE
Bump async-std to 1.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f06685bad74e0570f5213741bea82158279a4103d988e57bfada11ad230341"
+checksum = "f8056f1455169ab86dd47b47391e4ab0cbd25410a70e9fe675544f49bafaf952"
 dependencies = [
  "async-attributes",
  "async-channel",

--- a/commons/zenoh-buffers/Cargo.toml
+++ b/commons/zenoh-buffers/Cargo.toml
@@ -36,7 +36,7 @@ shared-memory = ["shared_memory", "serde", "log", "bincode"]
 zenoh-core = { path = "../zenoh-core/" }
 zenoh-collections = { path = "../zenoh-collections/" }
 
-async-std = { version = "=1.9.0", default-features = false }
+async-std = { version = "=1.10.0", default-features = false }
 bincode = { version = "1.3.1", optional = true }
 hex = "0.4.2"
 log = { version = "0.4", optional = true }

--- a/commons/zenoh-collections/Cargo.toml
+++ b/commons/zenoh-collections/Cargo.toml
@@ -31,6 +31,6 @@ description = "Internal crate for zenoh."
 zenoh-core = { path = "../zenoh-core/" }
 zenoh-sync = { path = "../zenoh-sync/" }
 async-trait = "0.1.42"
-async-std = { version = "=1.9.0", features = ["unstable"] }
+async-std = { version = "=1.10.0", features = ["unstable"] }
 flume = "0.10.5"
 log = "0.4.14"

--- a/commons/zenoh-sync/Cargo.toml
+++ b/commons/zenoh-sync/Cargo.toml
@@ -29,7 +29,7 @@ description = "Internal crate for zenoh."
 
 [dependencies]
 zenoh-core = { path = "../zenoh-core/" }
-async-std = { version = "=1.9.0", features = ["unstable"] }
+async-std = { version = "=1.10.0", features = ["unstable"] }
 event-listener = "2.5.1"
 flume = "0.10.5"
 futures-lite = "1.11.3"

--- a/commons/zenoh-util/Cargo.toml
+++ b/commons/zenoh-util/Cargo.toml
@@ -44,7 +44,7 @@ zenoh-cfg-properties = { path = "../zenoh-cfg-properties", optional = true }
 zenoh-crypto = { path = "../zenoh-crypto/", optional = true }
 zenoh-sync = { path = "../zenoh-sync/", optional = true }
 zenoh-collections = { path = "../zenoh-collections/", optional = true }
-async-std = { version = "=1.9.0" }
+async-std = { version = "=1.10.0" }
 clap = "2.33.3"
 futures = "0.3.12"
 hex = "0.4.2"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -37,7 +37,7 @@ shared-memory = ["zenoh/shared-memory"]
 [dependencies]
 zenoh = { path = "../zenoh/" }
 
-async-std = { version = "=1.9.0", default-features = false, features = [
+async-std = { version = "=1.10.0", default-features = false, features = [
 	"attributes",
 ] }
 clap = "2.33.3"

--- a/io/zenoh-link-commons/Cargo.toml
+++ b/io/zenoh-link-commons/Cargo.toml
@@ -39,5 +39,5 @@ zenoh-protocol-core = { path = "../../commons/zenoh-protocol-core/" }
 zenoh-protocol = { path = "../../commons/zenoh-protocol/" }
 
 async-trait = "0.1.42"
-async-std = { version = "=1.9.0", default-features = false }
+async-std = { version = "=1.10.0", default-features = false }
 flume = "0.10.5"

--- a/io/zenoh-link/Cargo.toml
+++ b/io/zenoh-link/Cargo.toml
@@ -49,7 +49,7 @@ zenoh-link-tls = { path = "../zenoh-links/zenoh-link-tls/", optional = true }
 zenoh-link-udp = { path = "../zenoh-links/zenoh-link-udp/", optional = true }
 zenoh-link-unixsock_stream = { path = "../zenoh-links/zenoh-link-unixsock_stream/", optional = true }
 
-async-std = { version = "=1.9.0", default-features = false }
+async-std = { version = "=1.10.0", default-features = false }
 async-trait = "0.1.42"
 
 rcgen = { version = "0.8.9", optional = true }

--- a/io/zenoh-links/zenoh-link-quic/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-quic/Cargo.toml
@@ -40,7 +40,7 @@ zenoh-protocol-core = { path = "../../../commons/zenoh-protocol-core/" }
 
 zenoh-link-commons = { path = "../../zenoh-link-commons/" }
 
-async-std = { version = "=1.9.0", default-features = false, features = [
+async-std = { version = "=1.10.0", default-features = false, features = [
 	"unstable",
 	"tokio1",
 ] }

--- a/io/zenoh-links/zenoh-link-tcp/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-tcp/Cargo.toml
@@ -38,6 +38,6 @@ zenoh-protocol-core = { path = "../../../commons/zenoh-protocol-core/" }
 
 zenoh-link-commons = { path = "../../zenoh-link-commons/" }
 
-async-std = { version = "=1.9.0", default-features = false }
+async-std = { version = "=1.10.0", default-features = false }
 async-trait = "0.1.42"
 log = "0.4"

--- a/io/zenoh-links/zenoh-link-tls/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-tls/Cargo.toml
@@ -41,6 +41,6 @@ zenoh-protocol-core = { path = "../../../commons/zenoh-protocol-core/" }
 zenoh-link-commons = { path = "../../zenoh-link-commons/" }
 
 async-rustls = { version = "=0.2.0" }
-async-std = { version = "=1.9.0", default-features = false }
+async-std = { version = "=1.10.0", default-features = false }
 async-trait = "0.1.42"
 log = "0.4"

--- a/io/zenoh-links/zenoh-link-udp/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-udp/Cargo.toml
@@ -39,7 +39,7 @@ zenoh-protocol-core = { path = "../../../commons/zenoh-protocol-core/" }
 
 zenoh-link-commons = { path = "../../zenoh-link-commons/" }
 
-async-std = { version = "=1.9.0", default-features = false }
+async-std = { version = "=1.10.0", default-features = false }
 async-trait = "0.1.42"
 log = "0.4"
 socket2 = "0.4.0"

--- a/io/zenoh-links/zenoh-link-unixsock_stream/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-unixsock_stream/Cargo.toml
@@ -37,7 +37,7 @@ zenoh-protocol-core = { path = "../../../commons/zenoh-protocol-core/" }
 
 zenoh-link-commons = { path = "../../zenoh-link-commons/" }
 
-async-std = { version = "=1.9.0", default-features = false }
+async-std = { version = "=1.10.0", default-features = false }
 async-trait = "0.1.42"
 log = "0.4"
 nix = { version = "0.23.0" }

--- a/io/zenoh-transport/Cargo.toml
+++ b/io/zenoh-transport/Cargo.toml
@@ -60,7 +60,7 @@ zenoh-protocol = { path = "../../commons/zenoh-protocol/" }
 zenoh-link = { path = "../zenoh-link/" }
 
 async-global-executor = "2.0.2"
-async-std = { version = "=1.9.0", default-features = false }
+async-std = { version = "=1.10.0", default-features = false }
 async-trait = "0.1.42"
 flume = "0.10.5"
 log = "0.4"

--- a/plugins/example-plugin/Cargo.toml
+++ b/plugins/example-plugin/Cargo.toml
@@ -32,7 +32,7 @@ crate-type = ["cdylib"]
 
 
 [dependencies]
-async-std = "=1.9.0"
+async-std = "=1.10.0"
 clap = "2"
 env_logger = "0.9.0"
 futures = "0.3.12"

--- a/plugins/zenoh-backend-traits/Cargo.toml
+++ b/plugins/zenoh-backend-traits/Cargo.toml
@@ -31,7 +31,7 @@ description = "Zenoh: traits to be implemented by backends libraries"
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-async-std = "=1.9.0"
+async-std = "=1.10.0"
 async-trait = "0.1.51"
 derive_more = "0.99"
 serde_json = "1.0"

--- a/plugins/zenoh-plugin-rest/Cargo.toml
+++ b/plugins/zenoh-plugin-rest/Cargo.toml
@@ -39,7 +39,7 @@ crate-type = ["cdylib", "rlib"]
 
 
 [dependencies]
-async-std = "=1.9.0"
+async-std = "=1.10.0"
 base64 = "0.13.0"
 clap = "2.33.3"
 env_logger = "0.9.0"

--- a/plugins/zenoh-plugin-storages/Cargo.toml
+++ b/plugins/zenoh-plugin-storages/Cargo.toml
@@ -37,7 +37,7 @@ crate-type = ["cdylib"]
 
 
 [dependencies]
-async-std = "=1.9.0"
+async-std = "=1.10.0"
 async-trait = "0.1"
 clap = "2.33.3"
 env_logger = "0.9.0"

--- a/zenoh-ext/Cargo.toml
+++ b/zenoh-ext/Cargo.toml
@@ -26,7 +26,7 @@ description = "Zenoh: extensions to the client API."
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-async-std = { version = "=1.9.0", default-features = false, features = [
+async-std = { version = "=1.10.0", default-features = false, features = [
     "attributes",
     "unstable",
 ] }

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -78,7 +78,7 @@ zenoh-transport = { path = "../io/zenoh-transport/" }
 zenoh-plugin-trait = { path = "../plugins/zenoh-plugin-trait", default-features = false }
 
 async-global-executor = "2.0.2"
-async-std = { version = "=1.9.0", default-features = false, features = [
+async-std = { version = "=1.10.0", default-features = false, features = [
     "attributes",
 ] }
 async-trait = "0.1.42"

--- a/zenohd/Cargo.toml
+++ b/zenohd/Cargo.toml
@@ -37,7 +37,7 @@ shared-memory = ["zenoh/shared-memory"]
 [dependencies]
 zenoh = { path = "../zenoh/" }
 
-async-std = { version = "=1.9.0", default-features = false, features = [
+async-std = { version = "=1.10.0", default-features = false, features = [
 	"attributes",
 ] }
 clap = "2.33.3"


### PR DESCRIPTION
This allows in zenoh-python the usage of [pyo3-asyncio 0.15](https://github.com/awestlake87/pyo3-asyncio/) which requires it (necessary for eclipse-zenoh/zenoh-python#34).