### PR TITLE
[minor edit] Add Signal.is_triggered() to replace extra "active" atomic boolean

### DIFF
--- a/commons/zenoh-sync/src/signal.rs
+++ b/commons/zenoh-sync/src/signal.rs
@@ -13,25 +13,44 @@
 //
 use async_std::sync::Arc;
 use event_listener::Event;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering::*;
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Signal {
-    event: Arc<Event>,
+    shared: Arc<Inner>,
+}
+
+#[derive(Debug)]
+struct Inner {
+    event: Event,
+    triggered: AtomicBool,
 }
 
 impl Signal {
     pub fn new() -> Self {
-        let event = Arc::new(Event::new());
-        Signal { event }
+        Signal {
+            shared: Arc::new(Inner {
+                event: Event::new(),
+                triggered: AtomicBool::new(false),
+            }),
+        }
     }
 
     pub fn trigger(&self) {
-        self.event.notify_additional(usize::MAX);
+        self.shared.triggered.store(true, Release);
+        self.shared.event.notify_additional(usize::MAX);
+    }
+
+    pub fn is_triggered(&self) -> bool {
+        self.shared.triggered.load(Acquire)
     }
 
     pub async fn wait(&self) {
-        let listener = self.event.listen();
-        listener.await;
+        if !self.is_triggered() {
+            let listener = self.shared.event.listen();
+            listener.await;
+        }
     }
 }
 


### PR DESCRIPTION
This changes the following code

```rust
// sender
active.store(true, Ordering::Release);
signal.trigger();

// receiver
while active.load(Ordering::Acquire) {
    read().race(signal.clone()).await;
}
```

to

```rust
// sender
signal.trigger();

// receiver
while !signal.is_triggered() {
    read().race(signal.clone()).await;
}
```

Plus,  in `zenoh/io/zenoh-transport/src/{unicast,multicast}/link.rs` there are parts that sets the active variable to false but does not trigger the signal. I'm not sure it's intended or an error.