### PR TITLE
New buffers interface

### DIFF
--- a/commons/zenoh-buffers/src/lib.rs
+++ b/commons/zenoh-buffers/src/lib.rs
@@ -11,6 +11,9 @@
 // Contributors:
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
+pub mod traits;
+pub use traits::*;
+
 mod zslice;
 pub use zslice::*;
 

--- a/commons/zenoh-buffers/src/traits.rs
+++ b/commons/zenoh-buffers/src/traits.rs
@@ -1,0 +1,93 @@
+use std::borrow::Cow;
+
+pub mod buffer {
+    use std::num::NonZeroUsize;
+    pub trait ConstructibleBuffer {
+        /// Constructs a split buffer that may accept `slice_capacity` segments without allocating.
+        /// It may also accept receiving cached writes for `cache_capacity` bytes before needing to reallocate its cache.
+        fn with_capacities(slice_capacity: usize, cache_capacity: usize) -> Self;
+    }
+    pub trait BoundedBuffer {
+        /// Indicates how many bytes can still be written to the buffer before it may reject further writes.
+        fn remaining_capacity(&self) -> usize;
+    }
+
+    pub trait CopyBuffer {
+        /// Copies as much of `bytes` as possible inside its cache, returning the amount actually written.
+        /// Will return `None` if the write was refused.
+        fn write(&mut self, bytes: &[u8]) -> Option<NonZeroUsize>;
+        fn write_byte(&mut self, byte: u8) -> Option<NonZeroUsize> {
+            self.write(&[byte])
+        }
+    }
+    pub trait Indexable {
+        type Index;
+        /// Returns an index-like mark that may be used for future operations at the current buffer-end
+        fn get_index(&self) -> Self::Index;
+        /// Replaces the data following `from` with the contents of `with`.
+        ///
+        /// This is an exact size operation, to avoid invalidating other marks that may have been made.
+        fn replace(&mut self, from: &Self::Index, with: &[u8]) -> bool;
+    }
+    pub trait InsertBuffer<T> {
+        /// Appends a slice to the buffer without copying its data.
+        fn append(&mut self, slice: T);
+    }
+}
+
+pub mod writer {
+    use crate::buffer::InsertBuffer;
+
+    pub trait Writer: AsRef<Self::Buffer> + AsMut<Self::Buffer> {
+        type Buffer;
+        fn copyless_write<T>(&mut self, slice: T)
+        where
+            Self::Buffer: InsertBuffer<T>,
+        {
+            self.as_mut().append(slice)
+        }
+    }
+    pub trait BacktrackableWriter {
+        fn mark(&mut self);
+        fn revert(&mut self) -> bool;
+    }
+    pub trait HasWriter {
+        type Writer: Writer;
+        /// Returns the most appropriate writer for `self`
+        fn writer(self) -> Self::Writer;
+    }
+}
+
+pub trait SplitBuffer<'a> {
+    type Slices: Iterator<Item = &'a [u8]> + ExactSizeIterator;
+    fn slices(&'a self) -> Self::Slices;
+
+    fn is_empty(&'a self) -> bool {
+        self.slices().all(|s| s.is_empty())
+    }
+    fn len(&'a self) -> usize {
+        self.slices().fold(0, |acc, it| acc + it.len())
+    }
+    fn contiguous(&'a self) -> Cow<'a, [u8]> {
+        let mut slices = self.slices();
+        match slices.len() {
+            0 => Cow::Borrowed(b""),
+            1 => Cow::Borrowed(slices.next().unwrap()),
+            _ => Cow::Owned(slices.fold(Vec::new(), |mut acc, it| {
+                acc.extend(it);
+                acc
+            })),
+        }
+    }
+}
+
+pub mod reader {
+    pub trait Reader {
+        fn read(&mut self, into: &mut [u8]) -> usize;
+        fn read_exact(&mut self, into: &mut [u8]) -> bool;
+        fn read_byte(&mut self) -> Option<u8> {
+            let mut byte = 0;
+            (self.read(std::slice::from_mut(&mut byte)) != 0).then(|| byte)
+        }
+    }
+}

--- a/commons/zenoh-buffers/src/traits.rs
+++ b/commons/zenoh-buffers/src/traits.rs
@@ -31,21 +31,13 @@ pub mod buffer {
     }
     pub trait InsertBuffer<T> {
         /// Appends a slice to the buffer without copying its data.
-        fn append(&mut self, slice: T);
+        fn append(&mut self, slice: T) -> Option<NonZeroUsize>;
     }
 }
 
 pub mod writer {
-    use crate::buffer::InsertBuffer;
-
     pub trait Writer: AsRef<Self::Buffer> + AsMut<Self::Buffer> {
         type Buffer;
-        fn copyless_write<T>(&mut self, slice: T)
-        where
-            Self::Buffer: InsertBuffer<T>,
-        {
-            self.as_mut().append(slice)
-        }
     }
     pub trait BacktrackableWriter {
         fn mark(&mut self);

--- a/commons/zenoh-buffers/src/traits.rs
+++ b/commons/zenoh-buffers/src/traits.rs
@@ -91,5 +91,13 @@ pub mod reader {
             (self.read(std::slice::from_mut(&mut byte)) != 0).then(|| byte)
         }
         fn remaining(&self) -> usize;
+        fn can_read(&self) -> bool {
+            self.remaining() != 0
+        }
+    }
+    pub trait HasReader {
+        type Reader: Reader;
+        /// Returns the most appropriate reader for `self`
+        fn reader(self) -> Self::Reader;
     }
 }

--- a/commons/zenoh-buffers/src/traits.rs
+++ b/commons/zenoh-buffers/src/traits.rs
@@ -84,6 +84,7 @@ pub trait SplitBuffer<'a> {
 pub mod reader {
     pub trait Reader {
         fn read(&mut self, into: &mut [u8]) -> usize;
+        #[must_use = "returns true upon success"]
         fn read_exact(&mut self, into: &mut [u8]) -> bool;
         fn read_byte(&mut self) -> Option<u8> {
             let mut byte = 0;

--- a/commons/zenoh-buffers/src/traits.rs
+++ b/commons/zenoh-buffers/src/traits.rs
@@ -90,5 +90,6 @@ pub mod reader {
             let mut byte = 0;
             (self.read(std::slice::from_mut(&mut byte)) != 0).then(|| byte)
         }
+        fn remaining(&self) -> usize;
     }
 }

--- a/commons/zenoh-buffers/src/wbuf.rs
+++ b/commons/zenoh-buffers/src/wbuf.rs
@@ -130,7 +130,7 @@ impl WBuf {
         self.slices.push(Slice::Internal(0, None));
     }
 
-    pub fn to_zslices(self) -> Vec<ZSlice> {
+    pub(crate) fn to_zslices(self) -> Vec<ZSlice> {
         let arc_buf = Arc::new(self.buf);
         if self.contiguous {
             if !arc_buf.is_empty() {
@@ -149,26 +149,6 @@ impl WBuf {
                     Slice::Internal(start, None) => {
                         ZSlice::make(arc_buf.clone().into(), *start, arc_buf.len()).unwrap()
                     }
-                })
-                .filter(|s| !s.is_empty())
-                .collect()
-        }
-    }
-
-    pub fn as_ioslices(&self) -> Vec<IoSlice> {
-        if self.contiguous {
-            if !self.buf.is_empty() {
-                vec![IoSlice::new(&self.buf[..])]
-            } else {
-                vec![]
-            }
-        } else {
-            self.slices
-                .iter()
-                .map(|s| match s {
-                    Slice::External(arcs) => arcs.as_ioslice(),
-                    Slice::Internal(start, Some(end)) => IoSlice::new(&self.buf[*start..*end]),
-                    Slice::Internal(start, None) => IoSlice::new(&self.buf[*start..]),
                 })
                 .filter(|s| !s.is_empty())
                 .collect()

--- a/commons/zenoh-buffers/src/wbuf.rs
+++ b/commons/zenoh-buffers/src/wbuf.rs
@@ -1,3 +1,11 @@
+use crate::buffer::CopyBuffer;
+use crate::buffer::InsertBuffer;
+use crate::reader::HasReader;
+use crate::writer::BacktrackableWriter;
+use crate::writer::HasWriter;
+use crate::writer::Writer;
+use crate::SplitBuffer;
+
 //
 // Copyright (c) 2017, 2020 ADLINK Technology Inc.
 //
@@ -60,20 +68,24 @@ impl fmt::Debug for Slice {
     }
 }
 
-#[derive(Clone)]
-struct WBufMark {
-    slices: Vec<Slice>,
-    buf_idx: usize,
-}
-
 /// A writable zenoh buffer.
 #[derive(Clone)]
 pub struct WBuf {
     slices: Vec<Slice>,
     buf: Vec<u8>,
     contiguous: bool,
-    copy_pos: (usize, usize), // (index in slices, index in the slice)
-    mark: WBufMark,
+}
+#[derive(Debug, Clone)]
+pub struct WBufWriter {
+    inner: WBuf,
+    mark_slice: usize,
+    mark_byte: usize,
+}
+#[derive(Clone)]
+pub struct WBufReader<'a> {
+    inner: &'a WBuf,
+    slice: usize,
+    byte: usize,
 }
 
 impl WBuf {
@@ -81,14 +93,9 @@ impl WBuf {
         let buf = Vec::with_capacity(capacity);
         let slices = vec![Slice::Internal(0, None)];
         WBuf {
-            mark: WBufMark {
-                slices: slices.clone(),
-                buf_idx: 0,
-            },
             slices,
             buf,
             contiguous,
-            copy_pos: (0, 0),
         }
     }
 
@@ -121,9 +128,6 @@ impl WBuf {
         self.buf.clear();
         self.slices.clear();
         self.slices.push(Slice::Internal(0, None));
-        self.copy_pos = (0, 0);
-        self.mark.slices.clear();
-        self.mark.buf_idx = 0;
     }
 
     pub fn to_zslices(self) -> Vec<ZSlice> {
@@ -217,85 +221,6 @@ impl WBuf {
         }
     }
 
-    fn get_zslice_to_copy(&self) -> &[u8] {
-        match self.slices.get(self.copy_pos.0) {
-            Some(Slice::External(ref s)) => s.as_slice(),
-            Some(Slice::Internal(start, Some(end))) => &self.buf[*start..*end],
-            Some(Slice::Internal(start, None)) => &self.buf[*start..],
-            None => panic!("Shouln't happen: copy_pos.0 is out of bound in {:?}", self),
-        }
-    }
-
-    pub fn copy_into_slice(&mut self, dest: &mut [u8]) {
-        if self.copy_pos.0 >= self.slices.len() {
-            panic!("Not enough bytes to copy into dest");
-        }
-        let src = self.get_zslice_to_copy();
-        let dest_len = dest.len();
-        if src.len() - self.copy_pos.1 >= dest_len {
-            // Copy a sub-part of src into dest
-            let end_pos = self.copy_pos.1 + dest_len;
-            dest.copy_from_slice(&src[self.copy_pos.1..end_pos]);
-            // Move copy_pos
-            if end_pos < src.len() {
-                self.copy_pos.1 = end_pos
-            } else {
-                self.copy_pos = (self.copy_pos.0 + 1, 0);
-            }
-        } else {
-            // Copy the remaining of src into dest
-            let copy_len = src.len() - self.copy_pos.1;
-            dest[..copy_len].copy_from_slice(&src[self.copy_pos.1..]);
-            // Move copy_pos to next slice and recurse
-            self.copy_pos = (self.copy_pos.0 + 1, 0);
-            self.copy_into_slice(&mut dest[copy_len..]);
-        }
-    }
-
-    pub fn copy_into_wbuf(&mut self, dest: &mut WBuf, dest_len: usize) {
-        if self.copy_pos.0 >= self.slices.len() {
-            panic!("Not enough bytes to copy into dest");
-        }
-        let src = self.get_zslice_to_copy();
-        if src.len() - self.copy_pos.1 >= dest_len {
-            // Copy a sub-part of src into dest
-            let end_pos = self.copy_pos.1 + dest_len;
-            if !(dest.write_bytes(&src[self.copy_pos.1..end_pos])) {
-                panic!("Failed to copy bytes into wbuf: destination is probably not big enough");
-            };
-            // Move copy_pos
-            if end_pos < src.len() {
-                self.copy_pos.1 = end_pos
-            } else {
-                self.copy_pos = (self.copy_pos.0 + 1, 0);
-            }
-        } else {
-            // Copy the remaining of src into dest
-            let copy_len = src.len() - self.copy_pos.1;
-            if !(dest.write_bytes(&src[self.copy_pos.1..])) {
-                panic!("Failed to copy bytes into wbuf: destination is probably not big enough");
-            };
-            // Move copy_pos to next slice and recurse
-            self.copy_pos = (self.copy_pos.0 + 1, 0);
-            self.copy_into_wbuf(dest, dest_len - copy_len);
-        }
-    }
-
-    #[inline]
-    pub fn mark(&mut self) {
-        self.mark.slices.clear();
-        self.mark.slices.extend_from_slice(self.slices.as_slice());
-        self.mark.buf_idx = self.buf.len();
-    }
-
-    #[inline]
-    pub fn revert(&mut self) {
-        // restaure slices and truncate buf to saved len
-        self.slices.clear();
-        self.slices.extend_from_slice(self.mark.slices.as_slice());
-        self.buf.truncate(self.mark.buf_idx);
-    }
-
     #[inline]
     fn can_write_in_buf(&self, size: usize) -> bool {
         // We can write in buf if
@@ -304,7 +229,7 @@ impl WBuf {
         !self.contiguous || self.buf.len() + size <= self.buf.capacity()
     }
 
-    pub fn write(&mut self, b: u8) -> bool {
+    fn write(&mut self, b: u8) -> bool {
         if self.can_write_in_buf(1) {
             self.buf.push(b);
             true
@@ -314,7 +239,7 @@ impl WBuf {
     }
 
     // NOTE: this is different from write_zslice() as this makes a copy of bytes into WBuf.
-    pub fn write_bytes(&mut self, s: &[u8]) -> bool {
+    fn write_bytes(&mut self, s: &[u8]) -> bool {
         if self.can_write_in_buf(s.len()) {
             self.buf.extend_from_slice(s);
             true
@@ -325,7 +250,7 @@ impl WBuf {
 
     // NOTE: if not-contiguous, this is 0-copy (the slice is just added to slices list)
     //       otherwise, it's a copy into buf, if doesn't exceed the capacity.
-    pub fn write_zslice(&mut self, zslice: ZSlice) -> bool {
+    fn write_zslice(&mut self, zslice: ZSlice) -> bool {
         if !self.contiguous {
             // If last slice was an internal without end, set it
             if let Some(&mut Slice::Internal(start, None)) = self.slices.last_mut() {
@@ -346,8 +271,148 @@ impl WBuf {
             false
         }
     }
+    pub fn reader(&self) -> WBufReader {
+        HasReader::reader(self)
+    }
 }
+impl<'a> WBufReader<'a> {
+    fn get_zslice_to_copy(&self) -> &[u8] {
+        match self.inner.slices.get(self.slice) {
+            Some(Slice::External(s)) => s.as_slice(),
+            Some(Slice::Internal(start, Some(end))) => &self.inner.buf[*start..*end],
+            Some(Slice::Internal(start, None)) => &self.inner.buf[*start..],
+            None => panic!(
+                "Shouln't happen: copy_pos.0 is out of bound in {:?}",
+                self.inner
+            ),
+        }
+    }
 
+    pub fn copy_into_slice(&mut self, dest: &mut [u8]) {
+        if self.slice >= self.inner.slices.len() {
+            panic!("Not enough bytes to copy into dest");
+        }
+        let src = self.get_zslice_to_copy();
+        let dest_len = dest.len();
+        if src.len() - self.byte >= dest_len {
+            // Copy a sub-part of src into dest
+            let end_pos = self.byte + dest_len;
+            dest.copy_from_slice(&src[self.byte..end_pos]);
+            // Move copy_pos
+            if end_pos < src.len() {
+                self.byte = end_pos
+            } else {
+                self.slice += 1;
+                self.byte = 0;
+            }
+        } else {
+            // Copy the remaining of src into dest
+            let copy_len = src.len() - self.byte;
+            dest[..copy_len].copy_from_slice(&src[self.byte..]);
+            // Move copy_pos to next slice and recurse
+            self.slice += 1;
+            self.byte = 0;
+            self.copy_into_slice(&mut dest[copy_len..]);
+        }
+    }
+
+    pub fn copy_into_wbuf(&mut self, dest: &mut WBuf, dest_len: usize) {
+        if self.slice >= self.inner.slices.len() {
+            panic!("Not enough bytes to copy into dest");
+        }
+        let src = self.get_zslice_to_copy();
+        if src.len() - self.byte >= dest_len {
+            // Copy a sub-part of src into dest
+            let end_pos = self.byte + dest_len;
+            if !(dest.write_bytes(&src[self.byte..end_pos])) {
+                panic!("Failed to copy bytes into wbuf: destination is probably not big enough");
+            };
+            // Move copy_pos
+            if end_pos < src.len() {
+                self.byte = end_pos
+            } else {
+                self.slice += 1;
+                self.byte = 0;
+            }
+        } else {
+            // Copy the remaining of src into dest
+            let copy_len = src.len() - self.byte;
+            if !(dest.write_bytes(&src[self.byte..])) {
+                panic!("Failed to copy bytes into wbuf: destination is probably not big enough");
+            };
+            // Move copy_pos to next slice and recurse
+            self.slice += 1;
+            self.byte = 0;
+            self.copy_into_wbuf(dest, dest_len - copy_len);
+        }
+    }
+}
+impl HasWriter for WBuf {
+    type Writer = WBufWriter;
+    fn writer(self) -> Self::Writer {
+        self.into()
+    }
+}
+impl Writer for WBufWriter {
+    type Buffer = WBuf;
+}
+impl AsRef<WBuf> for WBufWriter {
+    fn as_ref(&self) -> &WBuf {
+        &self.inner
+    }
+}
+impl AsMut<WBuf> for WBufWriter {
+    fn as_mut(&mut self) -> &mut WBuf {
+        &mut self.inner
+    }
+}
+impl WBufWriter {
+    pub fn into_inner(self) -> WBuf {
+        self.inner
+    }
+    pub fn clear(&mut self) {
+        self.inner.clear();
+        self.mark_slice = 1;
+        self.mark_byte = 0;
+    }
+}
+impl CopyBuffer for WBufWriter {
+    fn write(&mut self, bytes: &[u8]) -> Option<NonZeroUsize> {
+        CopyBuffer::write(&mut self.inner, bytes)
+    }
+    fn write_byte(&mut self, byte: u8) -> Option<NonZeroUsize> {
+        CopyBuffer::write_byte(&mut self.inner, byte)
+    }
+}
+impl<T: Into<ZSlice>> InsertBuffer<T> for WBufWriter {
+    fn append(&mut self, slice: T) -> Option<NonZeroUsize> {
+        self.inner.append(slice.into())
+    }
+}
+impl BacktrackableWriter for WBufWriter {
+    fn mark(&mut self) {
+        self.mark_slice = self.inner.slices.len();
+        self.mark_byte = self.inner.buf.len();
+    }
+    fn revert(&mut self) -> bool {
+        self.inner.slices.truncate(self.mark_slice);
+        match self.inner.slices.last_mut() {
+            Some(Slice::Internal(_, end)) => *end = None,
+            _ => unreachable!(),
+        }
+        self.inner.buf.truncate(self.mark_byte);
+        true
+    }
+}
+impl From<WBuf> for WBufWriter {
+    fn from(inner: WBuf) -> Self {
+        WBufWriter {
+            inner,
+            mark_slice: 1,
+            mark_byte: 0,
+        }
+    }
+}
 impl io::Write for WBuf {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         if self.write_bytes(buf) {
@@ -452,6 +517,41 @@ impl fmt::Debug for WBuf {
     }
 }
 
+struct SizedIter<I> {
+    iter: I,
+    remaining: usize,
+}
+impl<I: Iterator + Clone> SizedIter<I> {
+    fn new(iter: I) -> Self {
+        let remaining = iter.clone().count();
+        SizedIter { iter, remaining }
+    }
+}
+impl<I: Iterator> Iterator for SizedIter<I>
+where
+    I::Item: std::fmt::Debug,
+{
+    type Item = I::Item;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining > 0 {
+            self.remaining -= 1;
+            self.iter.next()
+        } else {
+            None
+        }
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+}
+impl<I: Iterator> ExactSizeIterator for SizedIter<I>
+where
+    I::Item: std::fmt::Debug,
+{
+    fn len(&self) -> usize {
+        self.remaining
+    }
+}
 pub trait ByteSliceExactIter<'a>: Iterator<Item = &'a [u8]> + ExactSizeIterator {}
 impl<'a, T: Iterator<Item = &'a [u8]> + ExactSizeIterator> ByteSliceExactIter<'a> for T {}
 impl<'a> crate::traits::SplitBuffer<'a> for WBuf {
@@ -459,20 +559,83 @@ impl<'a> crate::traits::SplitBuffer<'a> for WBuf {
 
     fn slices(&'a self) -> Self::Slices {
         if self.contiguous {
-            Box::new(Some(self.buf.as_slice()).into_iter())
+            let slice = self.buf.as_slice();
+            Box::new(if slice.is_empty() { None } else { Some(slice) }.into_iter())
         } else {
-            Box::new(self.slices.iter().map(move |s| match s {
-                Slice::External(arcs) => arcs.as_slice(),
-                Slice::Internal(start, Some(end)) => &self.buf[*start..*end],
-                Slice::Internal(start, None) => &self.buf[*start..],
-            }))
+            let iter = SizedIter::new(self.slices.iter().filter_map(move |s| {
+                let slice = match s {
+                    Slice::External(arcs) => arcs.as_slice(),
+                    Slice::Internal(start, Some(end)) => &self.buf[*start..*end],
+                    Slice::Internal(start, None) => &self.buf[*start..],
+                };
+                if slice.is_empty() {
+                    None
+                } else {
+                    Some(slice)
+                }
+            }));
+            Box::new(iter)
         }
     }
 }
-impl crate::traits::writer::HasWriter for WBuf {
-    type Writer = Self;
-    fn writer(self) -> Self::Writer {
-        self
+impl<'a> crate::traits::reader::HasReader for &'a WBuf {
+    type Reader = WBufReader<'a>;
+    fn reader(self) -> Self::Reader {
+        WBufReader {
+            inner: self,
+            slice: 0,
+            byte: 0,
+        }
+    }
+}
+impl<'a> crate::traits::reader::Reader for WBufReader<'a> {
+    fn read(&mut self, mut into: &mut [u8]) -> usize {
+        let mut read = 0;
+        for slice in self.inner.slices().skip(self.slice) {
+            let subslice = &slice[self.byte..];
+            let copy_len = subslice.len();
+            if copy_len <= into.len() {
+                let (l, r) = into.split_at_mut(copy_len);
+                l.copy_from_slice(subslice);
+                self.slice += 1;
+                self.byte = 0;
+                into = r;
+                read += copy_len;
+            } else {
+                let copy_len = into.len();
+                into.copy_from_slice(&subslice[..copy_len]);
+                read += copy_len;
+                self.byte += copy_len;
+                break;
+            }
+        }
+        read
+    }
+    fn read_exact(&mut self, into: &mut [u8]) -> bool {
+        let fork = self.clone();
+        if self.read(into) != into.len() {
+            *self = fork;
+            return false;
+        }
+        true
+    }
+    fn remaining(&self) -> usize {
+        let mut slices = self.inner.slices().skip(self.slice);
+        let mut len = match slices.next() {
+            Some(s) => s.len() - self.byte,
+            None => 0,
+        };
+        for slice in slices {
+            len += slice.len()
+        }
+        len
+    }
+    fn can_read(&self) -> bool {
+        self.inner.slices().nth(self.slice).is_some()
+    }
+    fn read_byte(&mut self) -> Option<u8> {
+        let mut byte = 0;
+        (self.read(std::slice::from_mut(&mut byte)) != 0).then(|| byte)
     }
 }
 impl crate::traits::buffer::CopyBuffer for WBuf {
@@ -494,14 +657,9 @@ impl crate::traits::buffer::ConstructibleBuffer for WBuf {
         let mut slices = Vec::with_capacity(slice_capacity);
         slices.push(Slice::Internal(0, None));
         WBuf {
-            mark: WBufMark {
-                slices: slices.clone(),
-                buf_idx: 0,
-            },
             slices,
             buf,
             contiguous: true,
-            copy_pos: (0, 0),
         }
     }
 }
@@ -532,7 +690,7 @@ impl<T: Into<ZSlice>> crate::traits::buffer::InsertBuffer<T> for WBuf {
     fn append(&mut self, slice: T) -> Option<NonZeroUsize> {
         let slice = slice.into();
         let len = slice.len();
-        if len == 0 {
+        if len > 0 {
             self.write_zslice(slice)
                 .then(|| unsafe { NonZeroUsize::new_unchecked(len) })
         } else {
@@ -543,13 +701,16 @@ impl<T: Into<ZSlice>> crate::traits::buffer::InsertBuffer<T> for WBuf {
 
 #[cfg(test)]
 mod tests {
+    use crate::reader::Reader;
+    use crate::traits::SplitBuffer;
+
     use super::*;
 
     macro_rules! to_vec_vec {
         ($wbuf:ident) => {
             $wbuf
-                .as_ioslices()
-                .iter()
+                .as_ref()
+                .slices()
                 .map(|s| s.to_vec())
                 .collect::<Vec<Vec<u8>>>()
         };
@@ -557,12 +718,7 @@ mod tests {
 
     macro_rules! vec_vec_is_empty {
         ($wbuf:ident) => {
-            $wbuf
-                .as_ioslices()
-                .iter()
-                .map(|s| s.to_vec())
-                .next()
-                .is_none()
+            $wbuf.as_ref().slices().next().is_none()
         };
     }
 
@@ -679,25 +835,25 @@ mod tests {
 
     #[test]
     fn wbuf_contiguous_mark_reset() {
-        let mut buf = WBuf::new(6, true);
-        assert!(buf.write_bytes(&[0, 1, 2]));
+        let mut buf = WBuf::new(6, true).writer();
+        assert!(buf.write(&[0, 1, 2]).is_some());
         buf.revert();
         assert!(vec_vec_is_empty!(buf));
 
-        assert!(buf.write_bytes(&[0, 1, 2]));
+        assert!(buf.write(&[0, 1, 2]).is_some());
         buf.mark();
-        assert!(buf.write_bytes(&[3, 4]));
+        assert!(buf.write(&[3, 4]).is_some());
         buf.revert();
         assert_eq!(to_vec_vec!(buf), [[0, 1, 2]]);
 
-        assert!(buf.write_bytes(&[3, 4]));
-        assert!(!buf.write_bytes(&[5, 6]));
+        assert!(buf.write(&[3, 4]).is_some());
+        assert!(!buf.write(&[5, 6]).is_some());
         buf.revert();
         assert_eq!(to_vec_vec!(buf), [[0, 1, 2]]);
 
-        assert!(buf.write_bytes(&[3, 4]));
+        assert!(buf.write(&[3, 4]).is_some());
         buf.mark();
-        assert!(!buf.write_bytes(&[5, 6]));
+        assert!(!buf.write(&[5, 6]).is_some());
         buf.revert();
         assert_eq!(to_vec_vec!(buf), [[0, 1, 2, 3, 4]]);
     }
@@ -706,11 +862,11 @@ mod tests {
     fn wbuf_contiguous_copy_into_slice() {
         let mut buf = WBuf::new(6, true);
         assert!(buf.write_zslice(ZSlice::from(vec![0_u8, 1, 2, 3, 4, 5])));
-
+        let mut reader = buf.reader();
         let mut copy = vec![0; 10];
-        buf.copy_into_slice(&mut copy[0..3]);
+        assert!(reader.read_exact(&mut copy[0..3]));
         assert_eq!(copy, &[0, 1, 2, 0, 0, 0, 0, 0, 0, 0]);
-        buf.copy_into_slice(&mut copy[3..6]);
+        assert!(reader.read_exact(&mut copy[3..6]));
         assert_eq!(copy, &[0, 1, 2, 3, 4, 5, 0, 0, 0, 0]);
     }
 
@@ -718,11 +874,11 @@ mod tests {
     fn wbuf_contiguous_copy_into_wbuf() {
         let mut buf = WBuf::new(6, true);
         assert!(buf.write_zslice(ZSlice::from(vec![0_u8, 1, 2, 3, 4, 5])));
-
+        let mut reader = buf.reader();
         let mut copy = WBuf::new(10, true);
-        buf.copy_into_wbuf(&mut copy, 3);
+        reader.copy_into_wbuf(&mut copy, 3);
         assert_eq!(to_vec_vec!(copy), &[[0, 1, 2,]]);
-        buf.copy_into_wbuf(&mut copy, 3);
+        reader.copy_into_wbuf(&mut copy, 3);
         assert_eq!(to_vec_vec!(copy), &[[0, 1, 2, 3, 4, 5]]);
     }
 
@@ -867,53 +1023,55 @@ mod tests {
 
     #[test]
     fn wbuf_noncontiguous_mark_reset() {
-        let mut buf = WBuf::new(6, false);
-        assert!(buf.write(0));
-        assert!(buf.write(1));
+        let mut buf = WBuf::new(6, false).writer();
+        assert!(buf.write_byte(0).is_some());
+        assert!(buf.write_byte(1).is_some());
+        dbg!(&buf);
         buf.revert();
         assert!(vec_vec_is_empty!(buf));
 
-        assert!(buf.write_bytes(&[0, 1]));
+        assert!(buf.write(&[2, 3]).is_some());
+        dbg!(&buf);
         buf.revert();
         assert!(vec_vec_is_empty!(buf));
 
-        assert!(buf.write_zslice(ZSlice::from(vec![0_u8, 1])));
+        assert!(buf.append(ZSlice::from(vec![0_u8, 1])).is_some());
         buf.revert();
         assert!(vec_vec_is_empty!(buf));
 
-        assert!(buf.write_bytes(&[0, 1, 2]));
+        assert!(buf.write(&[0, 1, 2]).is_some());
         buf.mark();
-        assert!(buf.write_bytes(&[3, 4]));
-        assert!(buf.write_zslice(ZSlice::from(vec![5_u8, 6])));
-        assert!(buf.write(7));
-        assert!(buf.write_zslice(ZSlice::from(vec![8_u8, 9])));
+        assert!(buf.write(&[3, 4]).is_some());
+        assert!(buf.append(ZSlice::from(vec![5_u8, 6])).is_some());
+        assert!(buf.write_byte(7).is_some());
+        assert!(buf.append(ZSlice::from(vec![8_u8, 9])).is_some());
         buf.revert();
         assert_eq!(to_vec_vec!(buf), [[0, 1, 2]]);
 
-        assert!(buf.write_bytes(&[3, 4]));
+        assert!(buf.write(&[3, 4]).is_some());
         buf.mark();
-        assert!(buf.write_zslice(ZSlice::from(vec![5_u8, 6])));
-        assert!(buf.write(7));
-        assert!(buf.write_zslice(ZSlice::from(vec![8_u8, 9])));
+        assert!(buf.append(ZSlice::from(vec![5_u8, 6])).is_some());
+        assert!(buf.write_byte(7).is_some());
+        assert!(buf.append(ZSlice::from(vec![8_u8, 9])).is_some());
         buf.revert();
         assert_eq!(to_vec_vec!(buf), [[0, 1, 2, 3, 4]]);
 
-        assert!(buf.write_zslice(ZSlice::from(vec![5_u8, 6])));
+        assert!(buf.append(ZSlice::from(vec![5_u8, 6])).is_some());
         buf.mark();
-        assert!(buf.write(7));
-        assert!(buf.write_zslice(ZSlice::from(vec![8_u8, 9])));
+        assert!(buf.write_byte(7).is_some());
+        assert!(buf.append(ZSlice::from(vec![8_u8, 9])).is_some());
         buf.revert();
         assert_eq!(to_vec_vec!(buf), [vec![0, 1, 2, 3, 4], vec![5, 6]]);
 
-        assert!(buf.write(7));
+        assert!(buf.write_byte(7).is_some());
         buf.mark();
-        assert!(buf.write_zslice(ZSlice::from(vec![8_u8, 9])));
+        assert!(buf.append(ZSlice::from(vec![8_u8, 9])).is_some());
         buf.revert();
         assert_eq!(to_vec_vec!(buf), [vec![0, 1, 2, 3, 4], vec![5, 6], vec![7]]);
 
-        assert!(buf.write_zslice(ZSlice::from(vec![8_u8, 9])));
+        assert!(buf.append(ZSlice::from(vec![8_u8, 9])).is_some());
         buf.mark();
-        assert!(buf.write_zslice(ZSlice::from(vec![10_u8, 11])));
+        assert!(buf.append(ZSlice::from(vec![10_u8, 11])).is_some());
         buf.revert();
         assert_eq!(
             to_vec_vec!(buf),
@@ -936,14 +1094,15 @@ mod tests {
             [vec![0, 1], vec![2, 3, 4], vec![5, 6, 7, 8], vec![9, 10, 11]]
         );
 
+        let mut reader = buf.reader();
         let mut copy = vec![0; 12];
-        buf.copy_into_slice(&mut copy[0..1]);
+        reader.copy_into_slice(&mut copy[0..1]);
         assert_eq!(copy, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
-        buf.copy_into_slice(&mut copy[1..6]);
+        reader.copy_into_slice(&mut copy[1..6]);
         assert_eq!(copy, &[0, 1, 2, 3, 4, 5, 0, 0, 0, 0, 0, 0]);
-        buf.copy_into_slice(&mut copy[6..8]);
+        reader.copy_into_slice(&mut copy[6..8]);
         assert_eq!(copy, &[0, 1, 2, 3, 4, 5, 6, 7, 0, 0, 0, 0]);
-        buf.copy_into_slice(&mut copy[8..12]);
+        reader.copy_into_slice(&mut copy[8..12]);
         assert_eq!(copy, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
     }
 
@@ -962,14 +1121,15 @@ mod tests {
             [vec![0, 1], vec![2, 3, 4], vec![5, 6, 7, 8], vec![9, 10, 11]]
         );
 
+        let mut reader = buf.reader();
         let mut copy = WBuf::new(12, true);
-        buf.copy_into_wbuf(&mut copy, 1);
+        reader.copy_into_wbuf(&mut copy, 1);
         assert_eq!(to_vec_vec!(copy), &[[0]]);
-        buf.copy_into_wbuf(&mut copy, 5);
+        reader.copy_into_wbuf(&mut copy, 5);
         assert_eq!(to_vec_vec!(copy), &[[0, 1, 2, 3, 4, 5]]);
-        buf.copy_into_wbuf(&mut copy, 2);
+        reader.copy_into_wbuf(&mut copy, 2);
         assert_eq!(to_vec_vec!(copy), &[[0, 1, 2, 3, 4, 5, 6, 7]]);
-        buf.copy_into_wbuf(&mut copy, 4);
+        reader.copy_into_wbuf(&mut copy, 4);
         assert_eq!(to_vec_vec!(copy), &[[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]]);
     }
 }

--- a/commons/zenoh-buffers/src/zbuf.rs
+++ b/commons/zenoh-buffers/src/zbuf.rs
@@ -262,7 +262,7 @@ impl ZBuf {
     }
 
     #[inline(always)]
-    pub fn readable(&self) -> usize {
+    fn readable(&self) -> usize {
         self.pos.len - self.pos.read
     }
 
@@ -703,6 +703,9 @@ impl crate::traits::reader::Reader for ZBuf {
             self.skip_bytes_no_check(1);
         }
         res
+    }
+    fn remaining(&self) -> usize {
+        self.readable()
     }
 }
 impl crate::traits::buffer::ConstructibleBuffer for ZBuf {

--- a/commons/zenoh-protocol/src/io/codec.rs
+++ b/commons/zenoh-protocol/src/io/codec.rs
@@ -134,7 +134,7 @@ impl<R: Reader> Decoder<PeerId, R> for ZenohCodec {
             )
         }
         let mut id = [0; PeerId::MAX_SIZE];
-        if !reader.read_exact(&mut id) {
+        if !reader.read_exact(&mut id[..size]) {
             return Err(InsufficientDataErr.into());
         }
         Ok(PeerId::new(size, id))

--- a/commons/zenoh-protocol/src/proto/msg_reader.rs
+++ b/commons/zenoh-protocol/src/proto/msg_reader.rs
@@ -173,7 +173,7 @@ impl MessageReader for ZBuf {
         let payload = if imsg::has_flag(header, tmsg::flag::F) {
             // A fragmented frame is not supposed to be followed by
             // any other frame in the same batch. Read all the bytes.
-            let buffer = self.read_zslice(self.readable())?;
+            let buffer = self.read_zslice(self.remaining())?;
             let is_final = imsg::has_flag(header, tmsg::flag::E);
             FramePayload::Fragment { buffer, is_final }
         } else {

--- a/commons/zenoh-protocol/src/proto/msg_reader.rs
+++ b/commons/zenoh-protocol/src/proto/msg_reader.rs
@@ -140,7 +140,7 @@ impl MessageReader for ZBufReader<'_> {
                     }
                 }
                 unknown => {
-                    log::trace!("Transport message with unknown ID: {}", unknown);
+                    log::error!("Transport message with unknown ID: {}", unknown);
                     return None;
                 }
             }

--- a/commons/zenoh-protocol/src/proto/msg_reader.rs
+++ b/commons/zenoh-protocol/src/proto/msg_reader.rs
@@ -18,6 +18,7 @@ use super::msg::*;
 use crate::io::ZBufCodec;
 use std::convert::TryInto;
 use std::time::Duration;
+use zenoh_buffers::reader::Reader;
 use zenoh_protocol_core::{whatami::WhatAmIMatcher, *};
 
 pub trait MessageReader {
@@ -98,7 +99,7 @@ impl MessageReader for ZBuf {
         // Read the message
         let body = loop {
             // Read the header
-            let header = self.read()?;
+            let header = self.read_byte()?;
 
             // Read the body
             match imsg::mid(header) {
@@ -238,7 +239,7 @@ impl MessageReader for ZBuf {
         } else {
             0
         };
-        let version = self.read()?;
+        let version = self.read_byte()?;
         let whatami = WhatAmI::try_from(self.read_zint()?)?;
         let pid = self.read_peeexpr_id()?;
         let sn_resolution = if imsg::has_flag(header, tmsg::flag::S) {
@@ -317,7 +318,7 @@ impl MessageReader for ZBuf {
         } else {
             0
         };
-        let version = self.read()?;
+        let version = self.read_byte()?;
         let whatami = WhatAmI::try_from(self.read_zint()?)?;
         let pid = self.read_peeexpr_id()?;
         let lease = self.read_zint()?;
@@ -363,7 +364,7 @@ impl MessageReader for ZBuf {
         } else {
             None
         };
-        let reason = self.read()?;
+        let reason = self.read_byte()?;
 
         Some(TransportBody::Close(Close {
             pid,
@@ -462,7 +463,7 @@ impl MessageReader for ZBuf {
         // Read the message
         let body = loop {
             // Read the header
-            let header = self.read()?;
+            let header = self.read_byte()?;
 
             // Read the body
             match imsg::mid(header) {
@@ -658,7 +659,7 @@ impl MessageReader for ZBuf {
     fn read_declaration(&mut self) -> Option<Declaration> {
         use super::zmsg::declaration::id::*;
 
-        let header = self.read()?;
+        let header = self.read_byte()?;
         match imsg::mid(header) {
             RESOURCE => {
                 let expr_id = self.read_zint()?;
@@ -792,7 +793,7 @@ impl MessageReader for ZBuf {
         use super::zmsg::declaration::flag::*;
         use super::zmsg::declaration::id::*;
 
-        let mode_flag = self.read()?;
+        let mode_flag = self.read_byte()?;
         let mode = match mode_flag & !PERIOD {
             MODE_PUSH => SubMode::Push,
             MODE_PULL => SubMode::Pull,

--- a/commons/zenoh-protocol/src/proto/msg_writer.rs
+++ b/commons/zenoh-protocol/src/proto/msg_writer.rs
@@ -151,7 +151,7 @@ impl MessageWriter for WBuf {
             FramePayload::Fragment { buffer, .. } => self.append(buffer.clone()).is_some(),
             FramePayload::Messages { messages } => {
                 for m in messages.iter_mut() {
-                    zcheck!(dbg!(self.write_zenoh_message(m)));
+                    zcheck!(self.write_zenoh_message(m));
                 }
                 true
             }

--- a/commons/zenoh-protocol/src/proto/msg_writer.rs
+++ b/commons/zenoh-protocol/src/proto/msg_writer.rs
@@ -15,6 +15,7 @@ use super::core::*;
 use super::io::WBuf;
 use super::msg::*;
 use crate::io::WBufCodec;
+use zenoh_buffers::buffer::{CopyBuffer, InsertBuffer};
 use zenoh_core::zcheck;
 
 pub trait MessageWriter {
@@ -67,7 +68,7 @@ pub trait MessageWriter {
 impl MessageWriter for WBuf {
     #[inline(always)]
     fn write_deco_attachment(&mut self, attachment: &Attachment) -> bool {
-        zcheck!(self.write(attachment.header()));
+        zcheck!(self.write_byte(attachment.header()).is_some());
         #[cfg(feature = "shared-memory")]
         {
             self.write_zbuf(&attachment.buffer, attachment.buffer.has_shminfo())
@@ -81,13 +82,13 @@ impl MessageWriter for WBuf {
 
     #[inline(always)]
     fn write_deco_routing_context(&mut self, routing_context: &RoutingContext) -> bool {
-        zcheck!(self.write(routing_context.header()));
+        zcheck!(self.write_byte(routing_context.header()).is_some());
         self.write_zint(routing_context.tree_id)
     }
 
     #[inline(always)]
     fn write_deco_reply_context(&mut self, reply_context: &ReplyContext) -> bool {
-        zcheck!(self.write(reply_context.header()));
+        zcheck!(self.write_byte(reply_context.header()).is_some());
         zcheck!(self.write_zint(reply_context.qid));
         if let Some(replier) = reply_context.replier.as_ref() {
             zcheck!(self.write_zint(replier.kind));
@@ -98,7 +99,7 @@ impl MessageWriter for WBuf {
 
     #[inline(always)]
     fn write_deco_priority(&mut self, priority: Priority) -> bool {
-        self.write(priority.header())
+        self.write_byte(priority.header()).is_some()
     }
 
     /*************************************/
@@ -144,13 +145,13 @@ impl MessageWriter for WBuf {
             zcheck!(self.write_deco_priority(frame.channel.priority))
         }
 
-        zcheck!(self.write(frame.header()));
+        zcheck!(self.write_byte(frame.header()).is_some());
         zcheck!(self.write_zint(frame.sn));
         match &mut frame.payload {
-            FramePayload::Fragment { buffer, .. } => self.write_zslice(buffer.clone()),
+            FramePayload::Fragment { buffer, .. } => self.append(buffer.clone()).is_some(),
             FramePayload::Messages { messages } => {
                 for m in messages.iter_mut() {
-                    zcheck!(self.write_zenoh_message(m));
+                    zcheck!(dbg!(self.write_zenoh_message(m)));
                 }
                 true
             }
@@ -158,7 +159,7 @@ impl MessageWriter for WBuf {
     }
 
     fn write_scout(&mut self, scout: &Scout) -> bool {
-        zcheck!(self.write(scout.header()));
+        zcheck!(self.write_byte(scout.header()).is_some());
         match scout.what {
             Some(w) => self.write_zint(w.into()),
             None => true,
@@ -166,7 +167,7 @@ impl MessageWriter for WBuf {
     }
 
     fn write_hello(&mut self, hello: &Hello) -> bool {
-        zcheck!(self.write(hello.header()));
+        zcheck!(self.write_byte(hello.header()).is_some());
         if let Some(pid) = hello.pid.as_ref() {
             zcheck!(self.write_peeexpr_id(pid));
         }
@@ -183,11 +184,11 @@ impl MessageWriter for WBuf {
 
     fn write_init_syn(&mut self, init_syn: &InitSyn) -> bool {
         let header = init_syn.header();
-        zcheck!(self.write(header));
+        zcheck!(self.write_byte(header).is_some());
         if init_syn.has_options() {
             zcheck!(self.write_zint(init_syn.options()));
         }
-        zcheck!(self.write(init_syn.version));
+        zcheck!(self.write_byte(init_syn.version).is_some());
         zcheck!(self.write_zint(init_syn.whatami.into()));
         zcheck!(self.write_peeexpr_id(&init_syn.pid));
         if imsg::has_flag(header, tmsg::flag::S) {
@@ -197,7 +198,7 @@ impl MessageWriter for WBuf {
     }
 
     fn write_init_ack(&mut self, init_ack: &InitAck) -> bool {
-        zcheck!(self.write(init_ack.header()));
+        zcheck!(self.write_byte(init_ack.header()).is_some());
         if init_ack.has_options() {
             zcheck!(self.write_zint(init_ack.options()));
         }
@@ -211,7 +212,7 @@ impl MessageWriter for WBuf {
 
     fn write_open_syn(&mut self, open_syn: &OpenSyn) -> bool {
         let header = open_syn.header();
-        zcheck!(self.write(header));
+        zcheck!(self.write_byte(header).is_some());
         if imsg::has_flag(header, tmsg::flag::T2) {
             zcheck!(self.write_zint(open_syn.lease.as_secs() as ZInt));
         } else {
@@ -223,7 +224,7 @@ impl MessageWriter for WBuf {
 
     fn write_open_ack(&mut self, open_ack: &OpenAck) -> bool {
         let header = open_ack.header();
-        zcheck!(self.write(header));
+        zcheck!(self.write_byte(header).is_some());
         if imsg::has_flag(header, tmsg::flag::T2) {
             zcheck!(self.write_zint(open_ack.lease.as_secs() as ZInt));
         } else {
@@ -234,11 +235,11 @@ impl MessageWriter for WBuf {
 
     fn write_join(&mut self, join: &Join) -> bool {
         let header = join.header();
-        zcheck!(self.write(header));
+        zcheck!(self.write_byte(header).is_some());
         if join.has_options() {
             zcheck!(self.write_zint(join.options()));
         }
-        zcheck!(self.write(join.version));
+        zcheck!(self.write_byte(join.version).is_some());
         zcheck!(self.write_zint(join.whatami.into()));
         zcheck!(self.write_peeexpr_id(&join.pid));
         if imsg::has_flag(header, tmsg::flag::T1) {
@@ -265,15 +266,15 @@ impl MessageWriter for WBuf {
     }
 
     fn write_close(&mut self, close: &Close) -> bool {
-        zcheck!(self.write(close.header()));
+        zcheck!(self.write_byte(close.header()).is_some());
         if let Some(p) = close.pid.as_ref() {
             zcheck!(self.write_peeexpr_id(p));
         }
-        self.write(close.reason)
+        self.write_byte(close.reason).is_some()
     }
 
     fn write_sync(&mut self, sync: &Sync) -> bool {
-        zcheck!(self.write(sync.header()));
+        zcheck!(self.write_byte(sync.header()).is_some());
         zcheck!(self.write_zint(sync.sn));
         if let Some(c) = sync.count {
             zcheck!(self.write_zint(c));
@@ -282,7 +283,7 @@ impl MessageWriter for WBuf {
     }
 
     fn write_ack_nack(&mut self, ack_nack: &AckNack) -> bool {
-        zcheck!(self.write(ack_nack.header()));
+        zcheck!(self.write_byte(ack_nack.header()).is_some());
         zcheck!(self.write_zint(ack_nack.sn));
         if let Some(m) = ack_nack.mask {
             zcheck!(self.write_zint(m));
@@ -291,7 +292,7 @@ impl MessageWriter for WBuf {
     }
 
     fn write_keep_alive(&mut self, keep_alive: &KeepAlive) -> bool {
-        zcheck!(self.write(keep_alive.header()));
+        zcheck!(self.write_byte(keep_alive.header()).is_some());
         if let Some(p) = keep_alive.pid.as_ref() {
             zcheck!(self.write_peeexpr_id(p));
         }
@@ -299,12 +300,12 @@ impl MessageWriter for WBuf {
     }
 
     fn write_ping(&mut self, ping: &Ping) -> bool {
-        zcheck!(self.write(ping.header()));
+        zcheck!(self.write_byte(ping.header()).is_some());
         self.write_zint(ping.hash)
     }
 
     fn write_pong(&mut self, pong: &Pong) -> bool {
-        zcheck!(self.write(pong.header()));
+        zcheck!(self.write_byte(pong.header()).is_some());
         self.write_zint(pong.hash)
     }
 
@@ -325,7 +326,7 @@ impl MessageWriter for WBuf {
         }
 
         let header = Frame::make_header(reliability, is_fragment);
-        self.write(header) && self.write_zint(sn)
+        self.write_byte(header).is_some() && self.write_zint(sn)
     }
 
     /*************************************/
@@ -335,7 +336,6 @@ impl MessageWriter for WBuf {
     fn write_zenoh_message(&mut self, msg: &mut ZenohMessage) -> bool {
         #[cfg(feature = "stats")]
         let start_written = self.len();
-
         if let Some(attachment) = msg.attachment.as_ref() {
             zcheck!(self.write_deco_attachment(attachment));
         }
@@ -372,7 +372,7 @@ impl MessageWriter for WBuf {
             zcheck!(self.write_deco_reply_context(reply_context));
         }
 
-        zcheck!(self.write(data.header()));
+        zcheck!(self.write_byte(data.header()).is_some());
         zcheck!(self.write_key_expr(&data.key));
 
         #[cfg(feature = "shared-memory")]
@@ -442,7 +442,7 @@ impl MessageWriter for WBuf {
     }
 
     fn write_declare(&mut self, declare: &Declare) -> bool {
-        zcheck!(self.write(declare.header()));
+        zcheck!(self.write_byte(declare.header()).is_some());
         zcheck!(self.write_usize_as_zint(declare.declarations.len()));
         for l in declare.declarations.iter() {
             zcheck!(self.write_declaration(l));
@@ -453,14 +453,16 @@ impl MessageWriter for WBuf {
     fn write_declaration(&mut self, declaration: &Declaration) -> bool {
         match declaration {
             Declaration::Resource(r) => {
-                self.write(r.header()) && self.write_zint(r.expr_id) && self.write_key_expr(&r.key)
+                self.write_byte(r.header()).is_some()
+                    && self.write_zint(r.expr_id)
+                    && self.write_key_expr(&r.key)
             }
             Declaration::ForgetResource(fr) => {
-                self.write(fr.header()) && self.write_zint(fr.expr_id)
+                self.write_byte(fr.header()).is_some() && self.write_zint(fr.expr_id)
             }
             Declaration::Subscriber(s) => {
                 let header = s.header();
-                zcheck!(self.write(header));
+                zcheck!(self.write_byte(header).is_some());
                 zcheck!(self.write_key_expr(&s.key));
                 if imsg::has_flag(header, zmsg::flag::S) {
                     zcheck!(self.write_submode(&s.info.mode, &s.info.period))
@@ -468,15 +470,17 @@ impl MessageWriter for WBuf {
                 true
             }
             Declaration::ForgetSubscriber(fs) => {
-                self.write(fs.header()) && self.write_key_expr(&fs.key)
+                self.write_byte(fs.header()).is_some() && self.write_key_expr(&fs.key)
             }
-            Declaration::Publisher(p) => self.write(p.header()) && self.write_key_expr(&p.key),
+            Declaration::Publisher(p) => {
+                self.write_byte(p.header()).is_some() && self.write_key_expr(&p.key)
+            }
             Declaration::ForgetPublisher(fp) => {
-                self.write(fp.header()) && self.write_key_expr(&fp.key)
+                self.write_byte(fp.header()).is_some() && self.write_key_expr(&fp.key)
             }
             Declaration::Queryable(q) => {
                 let header = q.header();
-                zcheck!(self.write(header));
+                zcheck!(self.write_byte(header).is_some());
                 zcheck!(self.write_key_expr(&q.key));
                 zcheck!(self.write_zint(q.kind));
                 if imsg::has_flag(header, zmsg::flag::Q) {
@@ -485,9 +489,9 @@ impl MessageWriter for WBuf {
                 true
             }
             Declaration::ForgetQueryable(fq) => {
-                zcheck!(self.write(fq.header()) && self.write_key_expr(&fq.key));
-                zcheck!(self.write_zint(fq.kind));
-                true
+                self.write_byte(fq.header()).is_some()
+                    && self.write_key_expr(&fq.key)
+                    && self.write_zint(fq.kind)
             }
         }
     }
@@ -499,8 +503,12 @@ impl MessageWriter for WBuf {
             0
         };
         zcheck!(match mode {
-            SubMode::Push => self.write(zmsg::declaration::id::MODE_PUSH | period_mask),
-            SubMode::Pull => self.write(zmsg::declaration::id::MODE_PULL | period_mask),
+            SubMode::Push => self
+                .write_byte(zmsg::declaration::id::MODE_PUSH | period_mask)
+                .is_some(),
+            SubMode::Pull => self
+                .write_byte(zmsg::declaration::id::MODE_PULL | period_mask)
+                .is_some(),
         });
         if let Some(p) = period {
             self.write_zint(p.origin) && self.write_zint(p.period) && self.write_zint(p.duration)
@@ -514,11 +522,11 @@ impl MessageWriter for WBuf {
             zcheck!(self.write_deco_reply_context(reply_context));
         }
 
-        self.write(unit.header())
+        self.write_byte(unit.header()).is_some()
     }
 
     fn write_pull(&mut self, pull: &Pull) -> bool {
-        zcheck!(self.write(pull.header()));
+        zcheck!(self.write_byte(pull.header()).is_some());
         zcheck!(self.write_key_expr(&pull.key));
         zcheck!(self.write_zint(pull.pull_id));
         if let Some(n) = pull.max_samples {
@@ -528,7 +536,7 @@ impl MessageWriter for WBuf {
     }
 
     fn write_query(&mut self, query: &Query) -> bool {
-        zcheck!(self.write(query.header()));
+        zcheck!(self.write_byte(query.header()).is_some());
         zcheck!(self.write_key_expr(&query.key));
         zcheck!(self.write_string(&query.value_selector));
         zcheck!(self.write_zint(query.qid));
@@ -539,7 +547,7 @@ impl MessageWriter for WBuf {
     }
 
     fn write_link_state_list(&mut self, link_state_list: &LinkStateList) -> bool {
-        zcheck!(self.write(link_state_list.header()));
+        zcheck!(self.write_byte(link_state_list.header()).is_some());
         zcheck!(self.write_usize_as_zint(link_state_list.link_states.len()));
         for link_state in link_state_list.link_states.iter() {
             zcheck!(self.write_link_state(link_state));

--- a/commons/zenoh-protocol/tests/codec.rs
+++ b/commons/zenoh-protocol/tests/codec.rs
@@ -12,7 +12,7 @@
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
 
-use zenoh_buffers::{WBuf, ZBuf};
+use zenoh_buffers::{reader::HasReader, WBuf, ZBuf};
 use zenoh_protocol::io::{WBufCodec, ZBufCodec};
 use zenoh_protocol_core::{ZInt, ZINT_MAX_BYTES};
 
@@ -20,7 +20,7 @@ fn test_zint(v: ZInt) {
     let mut buf = WBuf::new(32, true);
     buf.write_zint(v);
     dbg!(&buf);
-    assert_eq!(v, ZBuf::from(buf).read_zint().unwrap());
+    assert_eq!(v, ZBuf::from(buf).reader().read_zint().unwrap());
 }
 
 #[test]

--- a/commons/zenoh-protocol/tests/msg_codec.rs
+++ b/commons/zenoh-protocol/tests/msg_codec.rs
@@ -15,6 +15,7 @@ use rand::*;
 use std::time::Duration;
 use uhlc::Timestamp;
 use zenoh_buffers::reader::HasReader;
+use zenoh_buffers::writer::{BacktrackableWriter, HasWriter};
 use zenoh_protocol::io::{WBuf, ZBuf};
 use zenoh_protocol::io::{WBufCodec, ZBufCodec};
 use zenoh_protocol::proto::defaults::SEQ_NUM_RES;
@@ -280,9 +281,11 @@ fn test_write_read_transport_message(mut msg: TransportMessage) {
 fn test_write_read_zenoh_message(mut msg: ZenohMessage) {
     let mut buf = WBuf::new(164, false);
     println!("\nWrite message: {:?}", msg);
-    buf.write_zenoh_message(&mut msg);
+    assert!(buf.write_zenoh_message(&mut msg));
     println!("Read message from: {:?}", buf);
-    let mut result = ZBuf::from(buf)
+    let buf = ZBuf::from(buf);
+    println!("Converted into   : {:?}", buf);
+    let mut result = buf
         .reader()
         .read_zenoh_message(msg.channel.reliability)
         .unwrap();
@@ -637,7 +640,7 @@ fn codec_frame() {
 fn codec_frame_batching() {
     for _ in 0..NUM_ITER {
         // Contigous batch
-        let mut wbuf = WBuf::new(64, true);
+        let mut wbuf = WBuf::new(64, true).writer();
         // Written messages
         let mut written: Vec<TransportMessage> = vec![];
 
@@ -650,7 +653,7 @@ fn codec_frame_batching() {
         let mut frame = TransportMessage::make_frame(channel, sn, payload, sattachment.clone());
 
         // Write the first frame header
-        assert!(wbuf.write_transport_message(&mut frame));
+        assert!(wbuf.as_mut().write_transport_message(&mut frame));
 
         // Create data message
         let key = "test".into();
@@ -671,7 +674,7 @@ fn codec_frame_batching() {
         );
 
         // Write the first data message
-        assert!(wbuf.write_zenoh_message(&mut data));
+        assert!(wbuf.as_mut().write_zenoh_message(&mut data));
 
         // Store the first transport message written
         let payload = FramePayload::Messages {
@@ -685,13 +688,13 @@ fn codec_frame_batching() {
         ));
 
         // Write the second frame header
-        assert!(wbuf.write_transport_message(&mut frame));
+        assert!(wbuf.as_mut().write_transport_message(&mut frame));
 
         // Write until we fill the batch
         let mut messages: Vec<ZenohMessage> = vec![];
         loop {
             wbuf.mark();
-            if wbuf.write_zenoh_message(&mut data) {
+            if wbuf.as_mut().write_zenoh_message(&mut data) {
                 messages.push(data.clone());
             } else {
                 wbuf.revert();
@@ -709,7 +712,7 @@ fn codec_frame_batching() {
         ));
 
         // Deserialize from the buffer
-        let zbuf = ZBuf::from(wbuf);
+        let zbuf = ZBuf::from(wbuf.into_inner());
         let mut zbuf = zbuf.reader();
 
         let mut read: Vec<TransportMessage> = vec![];

--- a/examples/examples/z_get.rs
+++ b/examples/examples/z_get.rs
@@ -14,6 +14,7 @@
 use clap::{App, Arg};
 use futures::prelude::*;
 use zenoh::config::Config;
+use zenoh::net::protocol::io::SplitBuffer;
 use zenoh::query::*;
 use zenoh::queryable;
 

--- a/examples/examples/z_pull.rs
+++ b/examples/examples/z_pull.rs
@@ -17,6 +17,7 @@ use futures::prelude::*;
 use futures::select;
 use std::time::Duration;
 use zenoh::config::Config;
+use zenoh::net::protocol::io::SplitBuffer;
 use zenoh::subscriber::SubMode;
 
 #[async_std::main]

--- a/examples/examples/z_storage.rs
+++ b/examples/examples/z_storage.rs
@@ -20,6 +20,7 @@ use futures::select;
 use std::collections::HashMap;
 use std::time::Duration;
 use zenoh::config::Config;
+use zenoh::net::protocol::io::SplitBuffer;
 use zenoh::prelude::*;
 use zenoh::queryable::STORAGE;
 use zenoh::utils::key_expr;

--- a/examples/examples/z_sub.rs
+++ b/examples/examples/z_sub.rs
@@ -17,6 +17,7 @@ use futures::prelude::*;
 use futures::select;
 use std::time::Duration;
 use zenoh::config::Config;
+use zenoh::net::protocol::io::SplitBuffer;
 
 #[async_std::main]
 async fn main() {

--- a/io/zenoh-link-commons/src/lib.rs
+++ b/io/zenoh-link-commons/src/lib.rs
@@ -19,6 +19,7 @@ use std::cmp::PartialEq;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
+use zenoh_buffers::reader::{HasReader, Reader};
 use zenoh_buffers::{WBuf, ZBuf};
 use zenoh_cfg_properties::Properties;
 use zenoh_core::{bail, Result as ZResult};
@@ -179,10 +180,11 @@ impl LinkUnicast {
             buffer
         };
 
-        let mut zbuf = ZBuf::from(buffer);
+        let zbuf = ZBuf::from(buffer);
         let mut messages: Vec<TransportMessage> = Vec::with_capacity(1);
-        while zbuf.can_read() {
-            match zbuf.read_transport_message() {
+        let mut zbuf_reader = zbuf.reader();
+        while zbuf_reader.can_read() {
+            match zbuf_reader.read_transport_message() {
                 Some(msg) => messages.push(msg),
                 None => {
                     bail!("Invalid Message: Decoding error on link: {}", self);

--- a/io/zenoh-link-commons/src/lib.rs
+++ b/io/zenoh-link-commons/src/lib.rs
@@ -19,8 +19,9 @@ use std::cmp::PartialEq;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
+use zenoh_buffers::buffer::CopyBuffer;
 use zenoh_buffers::reader::{HasReader, Reader};
-use zenoh_buffers::{WBuf, ZBuf};
+use zenoh_buffers::{SplitBuffer, WBuf, ZBuf};
 use zenoh_cfg_properties::Properties;
 use zenoh_core::{bail, Result as ZResult};
 use zenoh_protocol::proto::{MessageReader, MessageWriter, TransportMessage};
@@ -142,7 +143,7 @@ impl LinkUnicast {
         let mut wbuf = WBuf::new(WBUF_SIZE, false);
         if self.is_streamed() {
             // Reserve 16 bits to write the length
-            wbuf.write_bytes(&[0_u8, 0_u8]);
+            wbuf.write(&[0_u8, 0_u8]);
         }
         // Serialize the message
         wbuf.write_transport_message(msg);
@@ -152,13 +153,11 @@ impl LinkUnicast {
             let bits = wbuf.get_first_slice_mut(..2);
             bits.copy_from_slice(&length.to_le_bytes());
         }
-        let mut buffer = vec![0_u8; wbuf.len()];
-        wbuf.copy_into_slice(&mut buffer[..]);
-
+        let contiguous = wbuf.contiguous();
         // Send the message on the link
-        let _ = self.0.write_all(&buffer).await?;
+        let _ = self.0.write_all(&contiguous).await?;
 
-        Ok(buffer.len())
+        Ok(contiguous.len())
     }
 
     pub async fn read_transport_message(&self) -> ZResult<Vec<TransportMessage>> {
@@ -275,13 +274,12 @@ impl LinkMulticast {
         // Create the buffer for serializing the message
         let mut wbuf = WBuf::new(WBUF_SIZE, false);
         wbuf.write_transport_message(msg);
-        let mut buffer = vec![0_u8; wbuf.len()];
-        wbuf.copy_into_slice(&mut buffer[..]);
+        let contiguous = wbuf.contiguous();
 
         // Send the message on the link
-        let _ = self.0.write_all(&buffer).await;
+        let _ = self.0.write_all(&contiguous).await;
 
-        Ok(buffer.len())
+        Ok(contiguous.len())
     }
 
     // pub async fn read_transport_message(&self) -> ZResult<(Vec<TransportMessage>, Locator)> {
@@ -289,7 +287,6 @@ impl LinkMulticast {
     //     let mut buffer = vec![0_u8; self.get_mtu()];
     //     let (n, locator) = self.read(&mut buffer).await?;
     //     buffer.truncate(n);
-
     //     let mut zbuf = ZBuf::from(buffer);
     //     let mut messages: Vec<TransportMessage> = Vec::with_capacity(1);
     //     while zbuf.can_read() {
@@ -301,7 +298,6 @@ impl LinkMulticast {
     //             }
     //         }
     //     }
-
     //     Ok((messages, locator))
     // }
 }

--- a/io/zenoh-link/src/lib.rs
+++ b/io/zenoh-link/src/lib.rs
@@ -90,6 +90,7 @@ pub struct LinkConfigurator {
     tls_inspector: TlsConfigurator,
 }
 impl LinkConfigurator {
+    #[allow(unused_variables, unused_mut)]
     pub async fn configurations(
         &self,
         config: &Config,

--- a/io/zenoh-transport/src/common/batch.rs
+++ b/io/zenoh-transport/src/common/batch.rs
@@ -384,7 +384,7 @@ mod tests {
 
     use super::*;
     use std::convert::TryFrom;
-    use zenoh_buffers::{WBuf, ZBuf};
+    use zenoh_buffers::{SplitBuffer, WBuf, ZBuf};
     use zenoh_protocol::proto::defaults::SEQ_NUM_RES;
     use zenoh_protocol::proto::{
         Frame, FramePayload, TransportBody, TransportMessage, ZenohMessage,

--- a/io/zenoh-transport/src/common/batch.rs
+++ b/io/zenoh-transport/src/common/batch.rs
@@ -1,3 +1,6 @@
+use zenoh_buffers::buffer::CopyBuffer;
+use zenoh_buffers::writer::BacktrackableWriter;
+use zenoh_buffers::{WBufReader, WBufWriter};
 use zenoh_protocol::proto::MessageWriter;
 
 //
@@ -81,7 +84,7 @@ impl SerializationBatchStats {
 #[derive(Clone, Debug)]
 pub(crate) struct SerializationBatch {
     // The buffer to perform the batching on
-    buffer: WBuf,
+    buffer: WBufWriter,
     // It is a streamed batch
     is_streamed: bool,
     // The current frame being serialized: BestEffort/Reliable
@@ -116,7 +119,7 @@ impl SerializationBatch {
             size += 2;
         }
         let mut batch = SerializationBatch {
-            buffer: WBuf::new(size, true),
+            buffer: WBuf::new(size, true).into(),
             is_streamed,
             current_frame: CurrentFrame::None,
             sn: SerializationBatchSeqNum {
@@ -142,7 +145,7 @@ impl SerializationBatch {
     /// Get the total number of bytes that have been serialized on the [`SerializationBatch`][SerializationBatch].
     #[inline(always)]
     pub(crate) fn len(&self) -> usize {
-        let len = self.buffer.len();
+        let len = self.buffer.as_ref().len();
         if self.is_streamed() {
             len - LENGTH_BYTES.len()
         } else {
@@ -163,7 +166,7 @@ impl SerializationBatch {
         self.current_frame = CurrentFrame::None;
         self.buffer.clear();
         if self.is_streamed() {
-            self.buffer.write_bytes(&LENGTH_BYTES);
+            self.buffer.write(&LENGTH_BYTES);
         }
         self.sn.clear();
         #[cfg(feature = "stats")]
@@ -176,7 +179,10 @@ impl SerializationBatch {
     pub(crate) fn write_len(&mut self) {
         if self.is_streamed() {
             let length = self.len() as LengthType;
-            let bits = self.buffer.get_first_slice_mut(..LENGTH_BYTES.len());
+            let bits = self
+                .buffer
+                .as_mut()
+                .get_first_slice_mut(..LENGTH_BYTES.len());
             bits.copy_from_slice(&length.to_le_bytes());
         }
     }
@@ -184,7 +190,7 @@ impl SerializationBatch {
     /// Get a `&[u8]` to access the internal memory buffer, usually for transmitting it on the network.
     #[inline(always)]
     pub(crate) fn as_bytes(&self) -> &[u8] {
-        self.buffer.get_first_slice(..)
+        self.buffer.as_ref().get_first_slice(..)
     }
 
     /// Try to serialize a [`TransportMessage`][TransportMessage] on the [`SerializationBatch`][SerializationBatch].
@@ -195,7 +201,7 @@ impl SerializationBatch {
     pub(crate) fn serialize_transport_message(&mut self, message: &mut TransportMessage) -> bool {
         // Mark the write operation
         self.buffer.mark();
-        let res = self.buffer.write_transport_message(message);
+        let res = self.buffer.as_mut().write_transport_message(message);
         if res {
             // Reset the current frame value
             self.current_frame = CurrentFrame::None;
@@ -261,13 +267,13 @@ impl SerializationBatch {
             let sn = sn_gen.get();
 
             // Serialize the new frame and the zenoh message
-            let res = self.buffer.write_frame_header(
+            let res = self.buffer.as_mut().write_frame_header(
                 priority,
                 message.channel.reliability,
                 sn,
                 None,
                 None,
-            ) && self.buffer.write_zenoh_message(message);
+            ) && self.buffer.as_mut().write_zenoh_message(message);
 
             if res {
                 self.current_frame = frame;
@@ -288,7 +294,7 @@ impl SerializationBatch {
 
             res
         } else {
-            self.buffer.write_zenoh_message(message)
+            self.buffer.as_mut().write_zenoh_message(message)
         };
 
         if !res {
@@ -315,7 +321,7 @@ impl SerializationBatch {
         reliability: Reliability,
         priority: Priority,
         sn_gen: &mut SeqNumGenerator,
-        to_fragment: &mut WBuf,
+        to_fragment: &mut WBufReader,
         to_write: usize,
     ) -> usize {
         // Assume first that this is not the final fragment
@@ -327,13 +333,17 @@ impl SerializationBatch {
             // Write the frame header
             let fragment = Some(is_final);
             let attachment = None;
-            let res =
-                self.buffer
-                    .write_frame_header(priority, reliability, sn, fragment, attachment);
+            let res = self.buffer.as_mut().write_frame_header(
+                priority,
+                reliability,
+                sn,
+                fragment,
+                attachment,
+            );
 
             if res {
                 // Compute the amount left
-                let space_left = self.buffer.capacity() - self.buffer.len();
+                let space_left = self.buffer.as_ref().capacity() - self.buffer.as_ref().len();
                 // Check if it is really the final fragment
                 if !is_final && (to_write <= space_left) {
                     // Revert the buffer
@@ -344,7 +354,7 @@ impl SerializationBatch {
                 }
                 // Write the fragment
                 let written = to_write.min(space_left);
-                to_fragment.copy_into_wbuf(&mut self.buffer, written);
+                to_fragment.copy_into_wbuf(self.buffer.as_mut(), written);
 
                 // Keep track of the latest serialized SN
                 let sn_state = SerializationBatchSeqNumState { next: sn_gen.now() };
@@ -371,15 +381,16 @@ impl SerializationBatch {
     #[cfg(test)]
     pub(crate) fn get_serialized_messages(&self) -> &[u8] {
         if self.is_streamed() {
-            self.buffer.get_first_slice(LENGTH_BYTES.len()..)
+            self.buffer.as_ref().get_first_slice(LENGTH_BYTES.len()..)
         } else {
-            self.buffer.get_first_slice(..)
+            self.buffer.as_ref().get_first_slice(..)
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use zenoh_buffers::buffer::InsertBuffer;
     use zenoh_buffers::reader::HasReader;
     use zenoh_protocol::proto::MessageReader;
 
@@ -543,6 +554,7 @@ mod tests {
                 let mut batches: Vec<SerializationBatch> = vec![];
                 // Fragment the message
                 let mut to_write = wbuf.len();
+                let mut wbuf_reader = wbuf.reader();
                 while to_write > 0 {
                     // Create the serialization batch
                     let mut batch = SerializationBatch::new(batch_size, *is_streamed);
@@ -550,7 +562,7 @@ mod tests {
                         msg_in.channel.reliability,
                         msg_in.channel.priority,
                         &mut sn_gen,
-                        &mut wbuf,
+                        &mut wbuf_reader,
                         to_write,
                     );
                     assert_ne!(written, 0);
@@ -574,7 +586,7 @@ mod tests {
                             ..
                         }) => {
                             assert!(!buffer.is_empty());
-                            fragments.write_zslice(buffer.clone());
+                            fragments.append(buffer);
                             if is_final {
                                 break;
                             }

--- a/io/zenoh-transport/src/common/defragmentation.rs
+++ b/io/zenoh-transport/src/common/defragmentation.rs
@@ -16,6 +16,8 @@ use super::protocol::io::{ZBuf, ZSlice};
 use super::protocol::proto::ZenohMessage;
 use super::seq_num::SeqNum;
 
+use zenoh_buffers::buffer::InsertBuffer;
+use zenoh_buffers::SplitBuffer;
 use zenoh_core::{bail, Result as ZResult};
 use zenoh_protocol::proto::MessageReader;
 
@@ -37,7 +39,7 @@ impl DefragBuffer {
             reliability,
             sn: SeqNum::make(0, sn_resolution)?,
             capacity,
-            buffer: ZBuf::new(),
+            buffer: ZBuf::default(),
         };
         Ok(db)
     }
@@ -73,7 +75,7 @@ impl DefragBuffer {
             )
         }
 
-        self.buffer.add_zslice(zslice);
+        self.buffer.append(zslice);
         self.sn.increment();
 
         Ok(())

--- a/io/zenoh-transport/src/common/defragmentation.rs
+++ b/io/zenoh-transport/src/common/defragmentation.rs
@@ -17,6 +17,7 @@ use super::protocol::proto::ZenohMessage;
 use super::seq_num::SeqNum;
 
 use zenoh_buffers::buffer::InsertBuffer;
+use zenoh_buffers::reader::HasReader;
 use zenoh_buffers::SplitBuffer;
 use zenoh_core::{bail, Result as ZResult};
 use zenoh_protocol::proto::MessageReader;
@@ -83,8 +84,6 @@ impl DefragBuffer {
 
     #[inline(always)]
     pub(crate) fn defragment(&mut self) -> Option<ZenohMessage> {
-        let res = self.buffer.read_zenoh_message(self.reliability);
-        self.clear();
-        res
+        self.buffer.reader().read_zenoh_message(self.reliability)
     }
 }

--- a/io/zenoh-transport/src/common/pipeline.rs
+++ b/io/zenoh-transport/src/common/pipeline.rs
@@ -638,6 +638,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
     use std::time::{Duration, Instant};
+    use zenoh_buffers::reader::HasReader;
     use zenoh_protocol::io::ZBuf;
     use zenoh_protocol::proto::defaults::{BATCH_SIZE, SEQ_NUM_RES};
     use zenoh_protocol::proto::MessageReader;
@@ -694,9 +695,10 @@ mod tests {
                 batches += 1;
                 bytes += batch.len();
                 // Create a ZBuf for deserialization starting from the batch
-                let mut zbuf: ZBuf = batch.get_serialized_messages().to_vec().into();
+                let zbuf: ZBuf = batch.get_serialized_messages().to_vec().into();
                 // Deserialize the messages
-                while let Some(msg) = zbuf.read_transport_message() {
+                let mut reader = zbuf.reader();
+                while let Some(msg) = reader.read_transport_message() {
                     match msg.body {
                         TransportBody::Frame(Frame { payload, .. }) => match payload {
                             FramePayload::Messages { messages } => {

--- a/io/zenoh-transport/src/common/pipeline.rs
+++ b/io/zenoh-transport/src/common/pipeline.rs
@@ -422,6 +422,7 @@ impl TransmissionPipeline {
 
         // Fragment the whole message
         let mut to_write = fragbuf.len();
+        let mut fragbuf_reader = fragbuf.reader();
         while to_write > 0 {
             // Get the current serialization batch
             // Treat all messages as non-droppable once we start fragmenting
@@ -432,7 +433,7 @@ impl TransmissionPipeline {
                 message.channel.reliability,
                 message.channel.priority,
                 &mut ch_guard.sn,
-                &mut fragbuf,
+                &mut fragbuf_reader,
                 to_write,
             );
 

--- a/io/zenoh-transport/src/multicast/link.rs
+++ b/io/zenoh-transport/src/multicast/link.rs
@@ -23,6 +23,7 @@ use std::convert::TryInto;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use zenoh_buffers::buffer::InsertBuffer;
 use zenoh_buffers::{ZBuf, ZSlice};
 use zenoh_collections::RecyclingObjectPool;
 use zenoh_core::{bail, Result as ZResult};
@@ -336,7 +337,7 @@ async fn rx_task(
     }
 
     // The ZBuf to read a message batch onto
-    let mut zbuf = ZBuf::new();
+    let mut zbuf = ZBuf::default();
     // The pool of buffers
     let mtu = link.get_mtu() as usize;
     let n = 1 + (rx_buff_size / mtu);
@@ -362,7 +363,7 @@ async fn rx_task(
                 // Add the received bytes to the ZBuf for deserialization
                 let zs = ZSlice::make(buffer.into(), 0, n)
                     .map_err(|_| zerror!("{}: decoding error", link))?;
-                zbuf.add_zslice(zs);
+                zbuf.append(zs);
 
                 // Deserialize all the messages from the current ZBuf
                 while zbuf.can_read() {

--- a/io/zenoh-transport/src/multicast/link.rs
+++ b/io/zenoh-transport/src/multicast/link.rs
@@ -24,6 +24,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use zenoh_buffers::buffer::InsertBuffer;
+use zenoh_buffers::reader::{HasReader, Reader};
 use zenoh_buffers::{ZBuf, ZSlice};
 use zenoh_collections::RecyclingObjectPool;
 use zenoh_core::{bail, Result as ZResult};
@@ -366,8 +367,9 @@ async fn rx_task(
                 zbuf.append(zs);
 
                 // Deserialize all the messages from the current ZBuf
-                while zbuf.can_read() {
-                    match zbuf.read_transport_message() {
+                let mut reader = zbuf.reader();
+                while reader.can_read() {
+                    match reader.read_transport_message() {
                         Some(msg) => {
                             #[cfg(feature = "stats")]
                             transport.stats.inc_rx_t_msgs(1);

--- a/io/zenoh-transport/src/multicast/rx.rs
+++ b/io/zenoh-transport/src/multicast/rx.rs
@@ -20,6 +20,7 @@ use super::protocol::proto::{
 };
 use super::transport::{TransportMulticastInner, TransportMulticastPeer};
 use std::sync::MutexGuard;
+use zenoh_buffers::reader::Reader;
 use zenoh_core::{bail, zerror, zread};
 use zenoh_core::{zlock, Result as ZResult};
 use zenoh_protocol_core::Locator;
@@ -42,12 +43,12 @@ impl TransportMulticastInner {
                     Some(_) => {
                         self.stats.inc_rx_z_data_reply_msgs(1);
                         self.stats
-                            .inc_rx_z_data_reply_payload_bytes(data.payload.readable());
+                            .inc_rx_z_data_reply_payload_bytes(data.payload.remaining());
                     }
                     None => {
                         self.stats.inc_rx_z_data_msgs(1);
                         self.stats
-                            .inc_rx_z_data_payload_bytes(data.payload.readable());
+                            .inc_rx_z_data_payload_bytes(data.payload.remaining());
                     }
                 },
                 ZenohBody::Unit(unit) => match unit.reply_context {

--- a/io/zenoh-transport/src/multicast/rx.rs
+++ b/io/zenoh-transport/src/multicast/rx.rs
@@ -20,7 +20,6 @@ use super::protocol::proto::{
 };
 use super::transport::{TransportMulticastInner, TransportMulticastPeer};
 use std::sync::MutexGuard;
-use zenoh_buffers::reader::Reader;
 use zenoh_core::{bail, zerror, zread};
 use zenoh_core::{zlock, Result as ZResult};
 use zenoh_protocol_core::Locator;
@@ -37,18 +36,18 @@ impl TransportMulticastInner {
     ) -> ZResult<()> {
         #[cfg(feature = "stats")]
         {
+            use zenoh_buffers::SplitBuffer;
             self.stats.inc_rx_z_msgs(1);
             match &msg.body {
                 ZenohBody::Data(data) => match data.reply_context {
                     Some(_) => {
                         self.stats.inc_rx_z_data_reply_msgs(1);
                         self.stats
-                            .inc_rx_z_data_reply_payload_bytes(data.payload.remaining());
+                            .inc_rx_z_data_reply_payload_bytes(data.payload.len());
                     }
                     None => {
                         self.stats.inc_rx_z_data_msgs(1);
-                        self.stats
-                            .inc_rx_z_data_payload_bytes(data.payload.remaining());
+                        self.stats.inc_rx_z_data_payload_bytes(data.payload.len());
                     }
                 },
                 ZenohBody::Unit(unit) => match unit.reply_context {

--- a/io/zenoh-transport/src/multicast/tx.rs
+++ b/io/zenoh-transport/src/multicast/tx.rs
@@ -15,6 +15,7 @@
 use super::protocol::proto::ZenohBody;
 use super::protocol::proto::ZenohMessage;
 use super::transport::TransportMulticastInner;
+use zenoh_buffers::reader::Reader;
 use zenoh_core::zread;
 
 impl TransportMulticastInner {
@@ -57,12 +58,12 @@ impl TransportMulticastInner {
                 Some(_) => {
                     self.stats.inc_tx_z_data_reply_msgs(1);
                     self.stats
-                        .inc_tx_z_data_reply_payload_bytes(data.payload.readable());
+                        .inc_tx_z_data_reply_payload_bytes(data.payload.remaining());
                 }
                 None => {
                     self.stats.inc_tx_z_data_msgs(1);
                     self.stats
-                        .inc_tx_z_data_payload_bytes(data.payload.readable());
+                        .inc_tx_z_data_payload_bytes(data.payload.remaining());
                 }
             },
             ZenohBody::Unit(unit) => match unit.reply_context {

--- a/io/zenoh-transport/src/multicast/tx.rs
+++ b/io/zenoh-transport/src/multicast/tx.rs
@@ -15,7 +15,6 @@
 use super::protocol::proto::ZenohBody;
 use super::protocol::proto::ZenohMessage;
 use super::transport::TransportMulticastInner;
-use zenoh_buffers::reader::Reader;
 use zenoh_core::zread;
 
 impl TransportMulticastInner {
@@ -53,17 +52,18 @@ impl TransportMulticastInner {
     #[inline(always)]
     pub(super) fn schedule_first_fit(&self, msg: ZenohMessage) -> bool {
         #[cfg(feature = "stats")]
+        use zenoh_buffers::SplitBuffer;
+        #[cfg(feature = "stats")]
         match &msg.body {
             ZenohBody::Data(data) => match data.reply_context {
                 Some(_) => {
                     self.stats.inc_tx_z_data_reply_msgs(1);
                     self.stats
-                        .inc_tx_z_data_reply_payload_bytes(data.payload.remaining());
+                        .inc_tx_z_data_reply_payload_bytes(data.payload.len());
                 }
                 None => {
                     self.stats.inc_tx_z_data_msgs(1);
-                    self.stats
-                        .inc_tx_z_data_payload_bytes(data.payload.remaining());
+                    self.stats.inc_tx_z_data_payload_bytes(data.payload.len());
                 }
             },
             ZenohBody::Unit(unit) => match unit.reply_context {

--- a/io/zenoh-transport/src/unicast/establishment/accept/open_syn.rs
+++ b/io/zenoh-transport/src/unicast/establishment/accept/open_syn.rs
@@ -11,7 +11,7 @@
 // Contributors:
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
-use super::super::authenticator::{AuthenticatedPeerLink, PeerAuthenticatorId};
+use super::super::authenticator::AuthenticatedPeerLink;
 use super::super::{attachment_from_properties, properties_from_attachment};
 use super::super::{Cookie, EstablishmentProperties};
 use super::AResult;
@@ -35,6 +35,7 @@ pub(super) struct Output {
     pub(super) is_shm: bool,
     pub(super) open_ack_attachment: Option<Attachment>,
 }
+#[allow(unused_mut)]
 pub(super) async fn recv(
     link: &LinkUnicast,
     manager: &TransportManager,
@@ -107,7 +108,7 @@ pub(super) async fn recv(
             .await;
 
         #[cfg(feature = "shared-memory")]
-        if pa.id() == PeerAuthenticatorId::Shm {
+        if pa.id() == super::super::authenticator::PeerAuthenticatorId::Shm {
             // Check if SHM has been validated from the other side
             att = match att {
                 Ok(att) => {

--- a/io/zenoh-transport/src/unicast/establishment/authenticator/pubkey.rs
+++ b/io/zenoh-transport/src/unicast/establishment/authenticator/pubkey.rs
@@ -310,8 +310,7 @@ impl PeerAuthenticatorTrait for PubKeyAuthenticator {
             bail!("Failed to serialize InitSyn on link: {}", link);
         }
 
-        let attachment: ZBuf = wbuf.into();
-        Ok(Some(attachment.contiguous().into_owned()))
+        Ok(Some(wbuf.contiguous().into_owned()))
     }
 
     async fn handle_init_syn(
@@ -378,7 +377,7 @@ impl PeerAuthenticatorTrait for PubKeyAuthenticator {
                     bail!("Failed to serialize InitAck on link: {}", link);
                 }
 
-                let nonce_bytes: ZBuf = wbuf.into();
+                let nonce_bytes = wbuf;
                 let nonce_encrypted_with_alice_pubkey = init_syn_property.alice_pubkey.encrypt(
                     &mut guard.prng,
                     PaddingScheme::PKCS1v15Encrypt,
@@ -396,7 +395,7 @@ impl PeerAuthenticatorTrait for PubKeyAuthenticator {
                 if !res {
                     bail!("Failed to serialize InitAck on link: {}", link);
                 }
-                let cookie: ZBuf = wbuf.into();
+                let cookie = wbuf;
 
                 // Encode the InitAck property
                 let mut wbuf = WBuf::new(WBUF_SIZE, false);
@@ -404,7 +403,7 @@ impl PeerAuthenticatorTrait for PubKeyAuthenticator {
                 if !res {
                     bail!("Failed to serialize InitAck on link: {}", link);
                 }
-                let attachment: ZBuf = wbuf.into();
+                let attachment = wbuf;
 
                 Ok((
                     Some(attachment.contiguous().into_owned()),
@@ -471,7 +470,7 @@ impl PeerAuthenticatorTrait for PubKeyAuthenticator {
             bail!("Failed to serialize OpenSyn on link: {}", link);
         }
 
-        let attachment: ZBuf = wbuf.into();
+        let attachment = wbuf;
 
         Ok(Some(attachment.contiguous().into_owned()))
     }

--- a/io/zenoh-transport/src/unicast/establishment/authenticator/shm.rs
+++ b/io/zenoh-transport/src/unicast/establishment/authenticator/shm.rs
@@ -19,6 +19,7 @@ use async_trait::async_trait;
 use rand::{Rng, SeedableRng};
 use std::convert::TryInto;
 use std::sync::{Arc, RwLock};
+use zenoh_buffers::SplitBuffer;
 use zenoh_config::Config;
 use zenoh_core::zresult::ShmError;
 use zenoh_core::{bail, zcheck};
@@ -207,7 +208,7 @@ impl PeerAuthenticatorTrait for SharedMemoryAuthenticator {
         wbuf.write_init_syn_property_shm(&init_syn_property);
         let attachment: ZBuf = wbuf.into();
 
-        Ok(Some(attachment.to_vec()))
+        Ok(Some(attachment.contiguous().into_owned()))
     }
 
     async fn handle_init_syn(
@@ -268,7 +269,7 @@ impl PeerAuthenticatorTrait for SharedMemoryAuthenticator {
         wbuf.write_init_ack_property_shm(&init_ack_property);
         let attachment: ZBuf = wbuf.into();
 
-        Ok((Some(attachment.to_vec()), None))
+        Ok((Some(attachment.contiguous().into_owned()), None))
     }
 
     async fn handle_init_ack(
@@ -317,7 +318,7 @@ impl PeerAuthenticatorTrait for SharedMemoryAuthenticator {
             wbuf.write_open_syn_property_shm(&open_syn_property);
             let attachment: ZBuf = wbuf.into();
 
-            Ok(Some(attachment.to_vec()))
+            Ok(Some(attachment.contiguous().into_owned()))
         } else {
             Err(ShmError(zerror!(
                 "Received OpenSyn with invalid attachment on link: {}",

--- a/io/zenoh-transport/src/unicast/establishment/authenticator/shm.rs
+++ b/io/zenoh-transport/src/unicast/establishment/authenticator/shm.rs
@@ -207,9 +207,8 @@ impl PeerAuthenticatorTrait for SharedMemoryAuthenticator {
         };
         let mut wbuf = WBuf::new(WBUF_SIZE, false);
         wbuf.write_init_syn_property_shm(&init_syn_property);
-        let attachment: ZBuf = wbuf.into();
 
-        Ok(Some(attachment.contiguous().into_owned()))
+        Ok(Some(wbuf.contiguous().into_owned()))
     }
 
     async fn handle_init_syn(
@@ -268,9 +267,8 @@ impl PeerAuthenticatorTrait for SharedMemoryAuthenticator {
         // Encode the InitAck property
         let mut wbuf = WBuf::new(WBUF_SIZE, false);
         wbuf.write_init_ack_property_shm(&init_ack_property);
-        let attachment: ZBuf = wbuf.into();
 
-        Ok((Some(attachment.contiguous().into_owned()), None))
+        Ok((Some(wbuf.contiguous().into_owned()), None))
     }
 
     async fn handle_init_ack(
@@ -318,9 +316,8 @@ impl PeerAuthenticatorTrait for SharedMemoryAuthenticator {
             // Encode the OpenSyn property
             let mut wbuf = WBuf::new(WBUF_SIZE, false);
             wbuf.write_open_syn_property_shm(&open_syn_property);
-            let attachment: ZBuf = wbuf.into();
 
-            Ok(Some(attachment.contiguous().into_owned()))
+            Ok(Some(wbuf.contiguous().into_owned()))
         } else {
             Err(ShmError(zerror!(
                 "Received OpenSyn with invalid attachment on link: {}",

--- a/io/zenoh-transport/src/unicast/establishment/authenticator/userpassword.rs
+++ b/io/zenoh-transport/src/unicast/establishment/authenticator/userpassword.rs
@@ -20,6 +20,7 @@ use async_std::fs;
 use async_std::sync::{Arc, Mutex, RwLock};
 use async_trait::async_trait;
 use std::collections::{HashMap, HashSet};
+use zenoh_buffers::SplitBuffer;
 use zenoh_cfg_properties::Properties;
 use zenoh_config::Config;
 use zenoh_core::{bail, zasynclock, zasyncread, zasyncwrite, zerror};
@@ -237,7 +238,7 @@ impl PeerAuthenticatorTrait for UserPasswordAuthenticator {
         wbuf.write_init_syn_property_usrpwd(&init_syn_property);
         let attachment: ZBuf = wbuf.into();
 
-        Ok(Some(attachment.to_vec()))
+        Ok(Some(attachment.contiguous().into_owned()))
     }
 
     async fn handle_init_syn(
@@ -268,7 +269,7 @@ impl PeerAuthenticatorTrait for UserPasswordAuthenticator {
         wbuf.write_init_ack_property_usrpwd(&init_ack_property);
         let attachment: ZBuf = wbuf.into();
 
-        Ok((Some(attachment.to_vec()), None))
+        Ok((Some(attachment.contiguous().into_owned()), None))
     }
 
     async fn handle_init_ack(
@@ -306,7 +307,7 @@ impl PeerAuthenticatorTrait for UserPasswordAuthenticator {
         wbuf.write_open_syn_property_usrpwd(&open_syn_property);
         let attachment: ZBuf = wbuf.into();
 
-        Ok(Some(attachment.to_vec()))
+        Ok(Some(attachment.contiguous().into_owned()))
     }
 
     async fn handle_open_syn(

--- a/io/zenoh-transport/src/unicast/establishment/authenticator/userpassword.rs
+++ b/io/zenoh-transport/src/unicast/establishment/authenticator/userpassword.rs
@@ -237,7 +237,7 @@ impl PeerAuthenticatorTrait for UserPasswordAuthenticator {
         };
         let mut wbuf = WBuf::new(WBUF_SIZE, false);
         wbuf.write_init_syn_property_usrpwd(&init_syn_property);
-        let attachment: ZBuf = wbuf.into();
+        let attachment = wbuf;
 
         Ok(Some(attachment.contiguous().into_owned()))
     }
@@ -268,7 +268,7 @@ impl PeerAuthenticatorTrait for UserPasswordAuthenticator {
         // Encode the InitAck property
         let mut wbuf = WBuf::new(WBUF_SIZE, false);
         wbuf.write_init_ack_property_usrpwd(&init_ack_property);
-        let attachment: ZBuf = wbuf.into();
+        let attachment = wbuf;
 
         Ok((Some(attachment.contiguous().into_owned()), None))
     }
@@ -306,7 +306,7 @@ impl PeerAuthenticatorTrait for UserPasswordAuthenticator {
         // Encode the InitAck attachment
         let mut wbuf = WBuf::new(WBUF_SIZE, false);
         wbuf.write_open_syn_property_usrpwd(&open_syn_property);
-        let attachment: ZBuf = wbuf.into();
+        let attachment = wbuf;
 
         Ok(Some(attachment.contiguous().into_owned()))
     }

--- a/io/zenoh-transport/src/unicast/establishment/mod.rs
+++ b/io/zenoh-transport/src/unicast/establishment/mod.rs
@@ -24,6 +24,7 @@ use authenticator::AuthenticatedPeerLink;
 use rand::Rng;
 use std::ops::{Deref, DerefMut};
 use std::time::Duration;
+use zenoh_buffers::buffer::CopyBuffer;
 use zenoh_buffers::reader::{HasReader, Reader};
 use zenoh_buffers::SplitBuffer;
 use zenoh_core::{bail, zerror};
@@ -127,7 +128,7 @@ impl Cookie {
         zwrite!(wbuf.write_zint(self.whatami.into()));
         zwrite!(wbuf.write_peeexpr_id(&self.pid));
         zwrite!(wbuf.write_zint(self.sn_resolution));
-        zwrite!(wbuf.write(if self.is_qos { 1 } else { 0 }));
+        zwrite!(wbuf.write_byte(if self.is_qos { 1 } else { 0 }).is_some());
         zwrite!(wbuf.write_zint(self.nonce));
         zwrite!(wbuf.write_properties(properties.as_slice()));
 

--- a/io/zenoh-transport/src/unicast/establishment/mod.rs
+++ b/io/zenoh-transport/src/unicast/establishment/mod.rs
@@ -24,6 +24,7 @@ use authenticator::AuthenticatedPeerLink;
 use rand::Rng;
 use std::ops::{Deref, DerefMut};
 use std::time::Duration;
+use zenoh_buffers::reader::Reader;
 use zenoh_core::{bail, zerror};
 use zenoh_core::{zasynclock, zasyncread, Result as ZResult};
 use zenoh_crypto::{BlockCipher, PseudoRng};
@@ -151,7 +152,7 @@ impl Cookie {
             WhatAmI::try_from(zread!(zbuf.read_zint())).ok_or_else(|| zerror!("Invalid Cookie"))?;
         let pid = zread!(zbuf.read_peeexpr_id());
         let sn_resolution = zread!(zbuf.read_zint());
-        let is_qos = zread!(zbuf.read()) == 1;
+        let is_qos = zread!(zbuf.read_byte()) == 1;
         let nonce = zread!(zbuf.read_zint());
 
         let mut ps = zread!(zbuf.read_properties());

--- a/io/zenoh-transport/src/unicast/establishment/mod.rs
+++ b/io/zenoh-transport/src/unicast/establishment/mod.rs
@@ -25,6 +25,7 @@ use rand::Rng;
 use std::ops::{Deref, DerefMut};
 use std::time::Duration;
 use zenoh_buffers::reader::Reader;
+use zenoh_buffers::SplitBuffer;
 use zenoh_core::{bail, zerror};
 use zenoh_core::{zasynclock, zasyncread, Result as ZResult};
 use zenoh_crypto::{BlockCipher, PseudoRng};
@@ -129,7 +130,7 @@ impl Cookie {
         zwrite!(wbuf.write_zint(self.nonce));
         zwrite!(wbuf.write_properties(properties.as_slice()));
 
-        let serialized = ZBuf::from(wbuf).to_vec();
+        let serialized = ZBuf::from(wbuf).contiguous().into_owned();
         let encrypted = cipher.encrypt(serialized, prng);
         Ok(encrypted)
     }

--- a/io/zenoh-transport/src/unicast/establishment/open/init_ack.rs
+++ b/io/zenoh-transport/src/unicast/establishment/open/init_ack.rs
@@ -1,4 +1,3 @@
-use crate::unicast::establishment::authenticator::PeerAuthenticatorId;
 //
 // Copyright (c) 2017, 2020 ADLINK Technology Inc.
 //
@@ -12,6 +11,7 @@ use crate::unicast::establishment::authenticator::PeerAuthenticatorId;
 // Contributors:
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
+use crate::unicast::establishment::authenticator::PeerAuthenticatorId;
 use crate::unicast::establishment::open::OResult;
 use crate::unicast::establishment::{attachment_from_properties, properties_from_attachment};
 use crate::unicast::establishment::{

--- a/io/zenoh-transport/src/unicast/rx.rs
+++ b/io/zenoh-transport/src/unicast/rx.rs
@@ -21,7 +21,8 @@ use super::protocol::proto::{
 use super::transport::TransportUnicastInner;
 use async_std::task;
 use std::sync::MutexGuard;
-use zenoh_buffers::reader::Reader;
+#[cfg(feature = "stats")]
+use zenoh_buffers::SplitBuffer;
 use zenoh_core::{bail, zerror, zlock, zread, Result as ZResult};
 use zenoh_link::LinkUnicast;
 
@@ -42,12 +43,11 @@ impl TransportUnicastInner {
                     Some(_) => {
                         self.stats.inc_rx_z_data_reply_msgs(1);
                         self.stats
-                            .inc_rx_z_data_reply_payload_bytes(data.payload.remaining());
+                            .inc_rx_z_data_reply_payload_bytes(data.payload.len());
                     }
                     None => {
                         self.stats.inc_rx_z_data_msgs(1);
-                        self.stats
-                            .inc_rx_z_data_payload_bytes(data.payload.remaining());
+                        self.stats.inc_rx_z_data_payload_bytes(data.payload.len());
                     }
                 },
                 ZenohBody::Unit(unit) => match unit.reply_context {

--- a/io/zenoh-transport/src/unicast/rx.rs
+++ b/io/zenoh-transport/src/unicast/rx.rs
@@ -21,6 +21,7 @@ use super::protocol::proto::{
 use super::transport::TransportUnicastInner;
 use async_std::task;
 use std::sync::MutexGuard;
+use zenoh_buffers::reader::Reader;
 use zenoh_core::{bail, zerror, zlock, zread, Result as ZResult};
 use zenoh_link::LinkUnicast;
 
@@ -41,12 +42,12 @@ impl TransportUnicastInner {
                     Some(_) => {
                         self.stats.inc_rx_z_data_reply_msgs(1);
                         self.stats
-                            .inc_rx_z_data_reply_payload_bytes(data.payload.readable());
+                            .inc_rx_z_data_reply_payload_bytes(data.payload.remaining());
                     }
                     None => {
                         self.stats.inc_rx_z_data_msgs(1);
                         self.stats
-                            .inc_rx_z_data_payload_bytes(data.payload.readable());
+                            .inc_rx_z_data_payload_bytes(data.payload.remaining());
                     }
                 },
                 ZenohBody::Unit(unit) => match unit.reply_context {

--- a/io/zenoh-transport/src/unicast/tx.rs
+++ b/io/zenoh-transport/src/unicast/tx.rs
@@ -15,7 +15,8 @@
 use super::protocol::proto::ZenohBody;
 use super::protocol::proto::ZenohMessage;
 use super::transport::TransportUnicastInner;
-use zenoh_buffers::reader::Reader;
+#[cfg(feature = "stats")]
+use zenoh_buffers::SplitBuffer;
 use zenoh_core::zread;
 
 impl TransportUnicastInner {
@@ -69,12 +70,11 @@ impl TransportUnicastInner {
                 Some(_) => {
                     self.stats.inc_tx_z_data_reply_msgs(1);
                     self.stats
-                        .inc_tx_z_data_reply_payload_bytes(data.payload.remaining());
+                        .inc_tx_z_data_reply_payload_bytes(data.payload.len());
                 }
                 None => {
                     self.stats.inc_tx_z_data_msgs(1);
-                    self.stats
-                        .inc_tx_z_data_payload_bytes(data.payload.remaining());
+                    self.stats.inc_tx_z_data_payload_bytes(data.payload.len());
                 }
             },
             ZenohBody::Unit(unit) => match unit.reply_context {

--- a/io/zenoh-transport/src/unicast/tx.rs
+++ b/io/zenoh-transport/src/unicast/tx.rs
@@ -15,6 +15,7 @@
 use super::protocol::proto::ZenohBody;
 use super::protocol::proto::ZenohMessage;
 use super::transport::TransportUnicastInner;
+use zenoh_buffers::reader::Reader;
 use zenoh_core::zread;
 
 impl TransportUnicastInner {
@@ -68,12 +69,12 @@ impl TransportUnicastInner {
                 Some(_) => {
                     self.stats.inc_tx_z_data_reply_msgs(1);
                     self.stats
-                        .inc_tx_z_data_reply_payload_bytes(data.payload.readable());
+                        .inc_tx_z_data_reply_payload_bytes(data.payload.remaining());
                 }
                 None => {
                     self.stats.inc_tx_z_data_msgs(1);
                     self.stats
-                        .inc_tx_z_data_payload_bytes(data.payload.readable());
+                        .inc_tx_z_data_payload_bytes(data.payload.remaining());
                 }
             },
             ZenohBody::Unit(unit) => match unit.reply_context {

--- a/io/zenoh-transport/tests/unicast_shm.rs
+++ b/io/zenoh-transport/tests/unicast_shm.rs
@@ -21,6 +21,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
+    use zenoh_buffers::SplitBuffer;
     use zenoh_core::zasync_executor_init;
     use zenoh_core::Result as ZResult;
     use zenoh_link::{EndPoint, Link};
@@ -104,7 +105,7 @@ mod tests {
                 print!("n");
             }
             let payload = match message.body {
-                ZenohBody::Data(Data { payload, .. }) => payload.contiguous(),
+                ZenohBody::Data(Data { payload, .. }) => payload.contiguous().into_owned(),
                 _ => panic!("Unsolicited message"),
             };
             assert_eq!(payload.len(), MSG_SIZE);

--- a/io/zenoh-transport/tests/unicast_shm.rs
+++ b/io/zenoh-transport/tests/unicast_shm.rs
@@ -345,7 +345,7 @@ mod tests {
             zasync_executor_init!();
         });
 
-        let endpoint: EndPoint = "tcp/127.0.0.1:12447".parse().unwrap();
+        let endpoint: EndPoint = "tcp/127.0.0.1:16447".parse().unwrap();
         task::block_on(run(&endpoint));
     }
 }

--- a/plugins/zenoh-plugin-rest/src/lib.rs
+++ b/plugins/zenoh-plugin-rest/src/lib.rs
@@ -19,6 +19,7 @@ use std::str::FromStr;
 use tide::http::Mime;
 use tide::sse::Sender;
 use tide::{Request, Response, Server, StatusCode};
+use zenoh::net::protocol::io::SplitBuffer;
 use zenoh::net::runtime::Runtime;
 use zenoh::plugins::{Plugin, RunningPluginTrait, ZenohPlugin};
 use zenoh::prelude::*;
@@ -48,7 +49,7 @@ fn value_to_json(value: Value) -> String {
             value.to_string()
         }
         _ => {
-            format!(r#""{}""#, base64::encode(value.payload.to_vec()))
+            format!(r#""{}""#, base64::encode(value.payload.contiguous()))
         }
     }
 }

--- a/zenoh-ext/examples/z_query_sub.rs
+++ b/zenoh-ext/examples/z_query_sub.rs
@@ -17,6 +17,7 @@ use futures::prelude::*;
 use futures::select;
 use std::time::Duration;
 use zenoh::config::Config;
+use zenoh::net::protocol::io::SplitBuffer;
 use zenoh_ext::*;
 
 #[async_std::main]
@@ -52,7 +53,7 @@ async fn main() {
             sample = subscriber.next() => {
                 let sample = sample.unwrap();
                 println!(">> [Subscriber] Received {} ('{}': '{}')",
-                    sample.kind, sample.key_expr.as_str(), String::from_utf8_lossy(&sample.value.payload.to_vec()));
+                    sample.kind, sample.key_expr.as_str(), String::from_utf8_lossy(&sample.value.payload.contiguous()));
             },
 
             _ = stdin.read_exact(&mut input).fuse() => {

--- a/zenoh/benches/codec_bench.rs
+++ b/zenoh/benches/codec_bench.rs
@@ -24,6 +24,7 @@ use zenoh::net::protocol::io::{WBuf, ZBuf, ZSlice};
 use zenoh::net::protocol::proto::{
     Attachment, Frame, FramePayload, TransportMessage, ZenohMessage,
 };
+use zenoh_buffers::reader::HasReader;
 use zenoh_protocol::io::{WBufCodec, ZBufCodec};
 use zenoh_protocol::proto::MessageWriter;
 
@@ -44,13 +45,14 @@ fn _bench_zint_write_three((v, buf): (&[ZInt; 3], &mut WBuf)) {
 
 fn bench_one_zint_codec((v, buf): (ZInt, &mut WBuf)) -> Option<ZInt> {
     buf.write_zint(v);
-    ZBuf::from(buf.clone()).read_zint()
+    ZBuf::from(buf.clone()).reader().read_zint()
 }
 
 fn bench_two_zint_codec((v, buf): (&[ZInt; 2], &mut WBuf)) -> Option<ZInt> {
     buf.write_zint(v[0]);
     buf.write_zint(v[1]);
-    let mut zbuf = ZBuf::from(buf.clone());
+    let zbuf = ZBuf::from(buf.clone());
+    let mut zbuf = zbuf.reader();
     let _ = zbuf.read_zint()?;
     zbuf.read_zint()
 }
@@ -59,7 +61,8 @@ fn bench_three_zint_codec((v, buf): (&[ZInt; 3], &mut WBuf)) -> Option<ZInt> {
     buf.write_zint(v[0]);
     buf.write_zint(v[1]);
     buf.write_zint(v[2]);
-    let mut zbuf = ZBuf::from(buf.clone());
+    let zbuf = ZBuf::from(buf.clone());
+    let mut zbuf = zbuf.reader();
     let _ = zbuf.read_zint()?;
     let _ = zbuf.read_zint()?;
     zbuf.read_zint()

--- a/zenoh/benches/codec_bench.rs
+++ b/zenoh/benches/codec_bench.rs
@@ -24,6 +24,7 @@ use zenoh::net::protocol::io::{WBuf, ZBuf, ZSlice};
 use zenoh::net::protocol::proto::{
     Attachment, Frame, FramePayload, TransportMessage, ZenohMessage,
 };
+use zenoh_buffers::buffer::CopyBuffer;
 use zenoh_buffers::reader::HasReader;
 use zenoh_protocol::io::{WBufCodec, ZBufCodec};
 use zenoh_protocol::proto::MessageWriter;
@@ -117,16 +118,16 @@ fn bench_write_frame_frag(buf: &mut WBuf, data: &mut TransportMessage) {
 }
 
 fn bench_write_10bytes1((v, buf): (u8, &mut WBuf)) {
-    buf.write(v);
-    buf.write(v);
-    buf.write(v);
-    buf.write(v);
-    buf.write(v);
-    buf.write(v);
-    buf.write(v);
-    buf.write(v);
-    buf.write(v);
-    buf.write(v);
+    buf.write_byte(v);
+    buf.write_byte(v);
+    buf.write_byte(v);
+    buf.write_byte(v);
+    buf.write_byte(v);
+    buf.write_byte(v);
+    buf.write_byte(v);
+    buf.write_byte(v);
+    buf.write_byte(v);
+    buf.write_byte(v);
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/zenoh/benches/frame_codec.rs
+++ b/zenoh/benches/frame_codec.rs
@@ -19,6 +19,7 @@ use zenoh::net::protocol::core::{Channel, CongestionControl, KeyExpr, Priority, 
 use zenoh::net::protocol::io::{WBuf, ZBuf};
 use zenoh::net::protocol::proto::defaults::BATCH_SIZE;
 use zenoh::net::protocol::proto::ZenohMessage;
+use zenoh_buffers::reader::HasReader;
 use zenoh_protocol::proto::{MessageReader, MessageWriter};
 
 fn criterion_benchmark(c: &mut Criterion) {
@@ -164,7 +165,8 @@ fn criterion_benchmark(c: &mut Criterion) {
                         wbuf.write_zenoh_message(&mut msg);
                     }
 
-                    let mut zbuf = ZBuf::from(wbuf);
+                    let zbuf = ZBuf::from(wbuf);
+                    let mut zbuf = zbuf.reader();
                     b.iter(|| {
                         zbuf.reset();
                         let _ = zbuf.read_transport_message().unwrap();
@@ -186,7 +188,8 @@ fn criterion_benchmark(c: &mut Criterion) {
                         wbuf.write_zenoh_message(&mut msg);
                     }
 
-                    let mut zbuf = ZBuf::from(wbuf);
+                    let zbuf = ZBuf::from(wbuf);
+                    let mut zbuf = zbuf.reader();
                     b.iter(|| {
                         zbuf.reset();
                         let _ = zbuf.read_transport_message().unwrap();

--- a/zenoh/benches/tables_bench.rs
+++ b/zenoh/benches/tables_bench.rs
@@ -76,7 +76,7 @@ fn tables_bench(c: &mut Criterion) {
         }
 
         let face0 = face0.upgrade().unwrap();
-        let payload = ZBuf::new();
+        let payload = ZBuf::default();
 
         tables_bench.bench_function(BenchmarkId::new("direct_route", p), |b| {
             b.iter(|| {

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -21,7 +21,7 @@ use log::{error, trace};
 use serde_json::json;
 use std::collections::HashMap;
 use std::sync::Mutex;
-use zenoh_buffers::ZBuf;
+use zenoh_buffers::{SplitBuffer, ZBuf};
 use zenoh_protocol::proto::{data_kind, DataInfo, RoutingContext};
 use zenoh_protocol_core::{
     key_expr, queryable::EVAL, Channel, CongestionControl, Encoding, KeyExpr, PeerId,
@@ -318,7 +318,7 @@ impl Primitives for AdminSpace {
                     log::error!("Error deleting conf value {}: {}", key_expr, e)
                 }
             } else {
-                match std::str::from_utf8(payload.contiguous().as_slice()) {
+                match std::str::from_utf8(&payload.contiguous()) {
                     Ok(json) => {
                         log::trace!(
                             "Insert conf value /@/router/{}/config/{}:{}",

--- a/zenoh/src/net/runtime/orchestrator.rs
+++ b/zenoh/src/net/runtime/orchestrator.rs
@@ -510,7 +510,7 @@ impl Runtime {
             let mut wbuf = WBuf::new(SEND_BUF_INITIAL_SIZE, false);
             let mut scout = TransportMessage::make_scout(Some(matcher), true, None);
             wbuf.write_transport_message(&mut scout);
-            let zbuf: ZBuf = wbuf.into();
+            let zbuf = wbuf;
             let zslice = zbuf.contiguous();
             loop {
                 for socket in sockets {
@@ -729,7 +729,7 @@ impl Runtime {
                                 .map_or("unknown".to_string(), |addr| addr.ip().to_string())
                         );
                         wbuf.write_transport_message(&mut hello);
-                        let zbuf: ZBuf = wbuf.into();
+                        let zbuf = wbuf;
                         let zslice = zbuf.contiguous();
                         if let Err(err) = socket.send_to(&zslice, peer).await {
                             log::error!("Unable to send {:?} to {} : {}", hello.body, peer, err);

--- a/zenoh/src/net/runtime/orchestrator.rs
+++ b/zenoh/src/net/runtime/orchestrator.rs
@@ -17,6 +17,7 @@ use futures::prelude::*;
 use socket2::{Domain, Socket, Type};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::Duration;
+use zenoh_buffers::reader::HasReader;
 use zenoh_buffers::SplitBuffer;
 use zenoh_cfg_properties::config::*;
 use zenoh_core::Result as ZResult;
@@ -544,8 +545,8 @@ impl Runtime {
                 let mut buf = vec![0; RCV_BUF_SIZE];
                 loop {
                     let (n, peer) = socket.recv_from(&mut buf).await.unwrap();
-                    let mut zbuf = ZBuf::from(buf.as_slice()[..n].to_vec());
-                    if let Some(msg) = zbuf.read_transport_message() {
+                    let zbuf = ZBuf::from(buf.as_slice()[..n].to_vec());
+                    if let Some(msg) = zbuf.reader().read_transport_message() {
                         log::trace!("Received {:?} from {}", msg.body, peer);
                         if let TransportBody::Hello(hello) = &msg.body {
                             let whatami = hello.whatami.or(Some(WhatAmI::Router)).unwrap();
@@ -697,8 +698,8 @@ impl Runtime {
                 continue;
             }
 
-            let mut zbuf = ZBuf::from(buf.as_slice()[..n].to_vec());
-            if let Some(msg) = zbuf.read_transport_message() {
+            let zbuf = ZBuf::from(buf.as_slice()[..n].to_vec());
+            if let Some(msg) = zbuf.reader().read_transport_message() {
                 log::trace!("Received {:?} from {}", msg.body, peer);
                 if let TransportBody::Scout(Scout {
                     what, pid_request, ..

--- a/zenoh/src/net/runtime/orchestrator.rs
+++ b/zenoh/src/net/runtime/orchestrator.rs
@@ -17,6 +17,7 @@ use futures::prelude::*;
 use socket2::{Domain, Socket, Type};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::Duration;
+use zenoh_buffers::SplitBuffer;
 use zenoh_cfg_properties::config::*;
 use zenoh_core::Result as ZResult;
 use zenoh_core::{bail, zerror};
@@ -520,10 +521,7 @@ impl Runtime {
                             .local_addr()
                             .map_or("unknown".to_string(), |addr| addr.ip().to_string())
                     );
-                    if let Err(err) = socket
-                        .send_to(zslice.as_slice(), mcast_addr.to_string())
-                        .await
-                    {
+                    if let Err(err) = socket.send_to(&zslice, mcast_addr.to_string()).await {
                         log::warn!(
                             "Unable to send {:?} to {} on interface {} : {}",
                             scout.body,
@@ -732,7 +730,7 @@ impl Runtime {
                         wbuf.write_transport_message(&mut hello);
                         let zbuf: ZBuf = wbuf.into();
                         let zslice = zbuf.contiguous();
-                        if let Err(err) = socket.send_to(zslice.as_slice(), peer).await {
+                        if let Err(err) = socket.send_to(&zslice, peer).await {
                             log::error!("Unable to send {:?} to {} : {}", hello.body, peer, err);
                         }
                     }

--- a/zenoh/tests/tables.rs
+++ b/zenoh/tests/tables.rs
@@ -593,7 +593,7 @@ fn client_test() {
         Channel::default(),
         CongestionControl::default(),
         None,
-        ZBuf::new(),
+        ZBuf::default(),
         None,
     );
 
@@ -619,7 +619,7 @@ fn client_test() {
         Channel::default(),
         CongestionControl::default(),
         None,
-        ZBuf::new(),
+        ZBuf::default(),
         None,
     );
 
@@ -645,7 +645,7 @@ fn client_test() {
         Channel::default(),
         CongestionControl::default(),
         None,
-        ZBuf::new(),
+        ZBuf::default(),
         None,
     );
 
@@ -671,7 +671,7 @@ fn client_test() {
         Channel::default(),
         CongestionControl::default(),
         None,
-        ZBuf::new(),
+        ZBuf::default(),
         None,
     );
 
@@ -697,7 +697,7 @@ fn client_test() {
         Channel::default(),
         CongestionControl::default(),
         None,
-        ZBuf::new(),
+        ZBuf::default(),
         None,
     );
 


### PR DESCRIPTION
The new buffer interface is traitified: with a few more efforts, any buffer type (even `Vec<u8>`) could be used as a serialization target, making constructing big buffer types a thing of the past when we know we need a specific type later.

The new Encoder/Decoder traits will allow to specialize writing some values to specific buffer types (for copyless encoding). They will also simplify handing multiple protocol version, as the Codec structure can be used to differentiate between protocol versions. Each transport-session could have its own codec instance for things like sequence number resolution or different version support :)

`ZBuf` and `WBuf` have gone through a diet: they used to act as their own reader/backtrackable-writers on top of being buffers. To simplify future optimization of our buffers, I've moved these roles to `ZBufReader`, `WBufReader` and `WBufWriter`, as well as the fields needed to take on these roles.

For compatibility with `cargo-nextest` which runs tests in parallel, a port conflict has been fixed.