### PR TITLE
use ZError in WhatAmI for better parsing enum match

### DIFF
--- a/commons/zenoh-protocol-core/src/whatami.rs
+++ b/commons/zenoh-protocol-core/src/whatami.rs
@@ -1,4 +1,5 @@
 use super::{NonZeroZInt, ZInt};
+use zenoh_core::{bail, zresult::ZError};
 
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -9,14 +10,14 @@ pub enum WhatAmI {
 }
 
 impl std::str::FromStr for WhatAmI {
-    type Err = ();
+    type Err = ZError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "router" => Ok(WhatAmI::Router),
             "peer" => Ok(WhatAmI::Peer),
             "client" => Ok(WhatAmI::Client),
-            _ => Err(()),
+            _ => bail!("{} is not a valid WhatAmI value. Valid values are: [\"router\", \"peer\", \"client\"].", s),
         }
     }
 }

--- a/plugins/zenoh-plugin-rest/examples/z_serve_sse.rs
+++ b/plugins/zenoh-plugin-rest/examples/z_serve_sse.rs
@@ -112,13 +112,6 @@ fn parse_args() -> Config {
     if let Some(Ok(mode)) = args.value_of("mode").map(|mode| mode.parse()) {
         config.set_mode(Some(mode)).unwrap();
     }
-    match args.value_of("mode").map(|m| m.parse()) {
-        Some(Ok(mode)) => {
-            config.set_mode(Some(mode)).unwrap();
-        }
-        Some(Err(())) => panic!("Invalid mode"),
-        None => {}
-    };
     if let Some(values) = args.values_of("peer") {
         config.peers.extend(values.map(|v| v.parse().unwrap()))
     }


### PR DESCRIPTION
As we discussed before, this PR lets users handle the enum match of WhatAmI.