### PR TITLE
compatibility with ROS2

### DIFF
--- a/commons/zenoh-buffers/src/traits.rs
+++ b/commons/zenoh-buffers/src/traits.rs
@@ -36,7 +36,7 @@ pub mod buffer {
 }
 
 pub mod writer {
-    pub trait Writer: AsRef<Self::Buffer> + AsMut<Self::Buffer> {
+    pub trait Writer {
         type Buffer;
     }
     pub trait BacktrackableWriter {


### PR DESCRIPTION
This sanity-check introduces a circular trait dependency in Rust 1.51, sad :(