### PR TITLE
Rename Reply.data attribute as Reply.sample

### DIFF
--- a/examples/examples/z_get.rs
+++ b/examples/examples/z_get.rs
@@ -33,8 +33,8 @@ async fn main() {
     while let Some(reply) = replies.next().await {
         println!(
             ">> Received ('{}': '{}')",
-            reply.data.key_expr.as_str(),
-            String::from_utf8_lossy(&reply.data.value.payload.contiguous())
+            reply.sample.key_expr.as_str(),
+            String::from_utf8_lossy(&reply.sample.value.payload.contiguous())
         )
     }
 }

--- a/plugins/zenoh-plugin-rest/src/lib.rs
+++ b/plugins/zenoh-plugin-rest/src/lib.rs
@@ -70,7 +70,7 @@ fn sample_to_json(sample: Sample) -> String {
 
 async fn to_json(results: ReplyReceiver) -> String {
     let values = results
-        .filter_map(move |reply| async move { Some(sample_to_json(reply.data)) })
+        .filter_map(move |reply| async move { Some(sample_to_json(reply.sample)) })
         .collect::<Vec<String>>()
         .await
         .join(",\n");
@@ -87,7 +87,7 @@ fn sample_to_html(sample: Sample) -> String {
 
 async fn to_html(results: ReplyReceiver) -> String {
     let values = results
-        .filter_map(move |reply| async move { Some(sample_to_html(reply.data)) })
+        .filter_map(move |reply| async move { Some(sample_to_html(reply.sample)) })
         .collect::<Vec<String>>()
         .await
         .join("\n");

--- a/plugins/zenoh-plugin-storage-manager/src/storages_mgt.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/storages_mgt.rs
@@ -70,12 +70,16 @@ pub(crate) async fn start_storage(
             }
         };
         while let Some(reply) = replies.next().await {
-            log::trace!("Storage {} aligns data {}", admin_key, reply.data.key_expr);
+            log::trace!(
+                "Storage {} aligns data {}",
+                admin_key,
+                reply.sample.key_expr
+            );
             // Call incoming data interceptor (if any)
             let sample = if let Some(ref interceptor) = in_interceptor {
-                interceptor(reply.data)
+                interceptor(reply.sample)
             } else {
-                reply.data
+                reply.sample
             };
             // Call storage
             if let Err(e) = storage.on_sample(sample).await {

--- a/zenoh-ext/src/group.rs
+++ b/zenoh-ext/src/group.rs
@@ -244,9 +244,9 @@ async fn net_event_handler(z: Arc<Session>, state: Arc<GroupState>) {
                                 log::debug!("Issuing Query for {}", &qres);
                                 let mut receiver = z.get(&qres).consolidation(qc).await.unwrap();
 
-                                while let Some(sample) = receiver.next().await {
+                                while let Some(reply) = receiver.next().await {
                                     match bincode::deserialize::<Member>(
-                                        &sample.data.value.payload.contiguous(),
+                                        &reply.sample.value.payload.contiguous(),
                                     ) {
                                         Ok(m) => {
                                             let mut expiry = Instant::now();

--- a/zenoh-ext/src/querying_subscriber.rs
+++ b/zenoh-ext/src/querying_subscriber.rs
@@ -417,9 +417,9 @@ impl Stream for InnerState {
                 loop {
                     match mself.replies_recv_queue[i].poll_next(cx) {
                         Poll::Ready(Some(mut reply)) => {
-                            log::trace!("Reply received: {}", reply.data.key_expr);
-                            reply.data.ensure_timestamp();
-                            mself.merge_queue.push(reply.data);
+                            log::trace!("Reply received: {}", reply.sample.key_expr);
+                            reply.sample.ensure_timestamp();
+                            mself.merge_queue.push(reply.sample);
                         }
                         Poll::Ready(None) => {
                             // query completed - remove the receiver and break loop
@@ -491,9 +491,9 @@ impl InnerState {
             // get all replies and add them to merge_queue
             for recv in self.replies_recv_queue.drain(..) {
                 while let Ok(mut reply) = recv.recv() {
-                    log::trace!("Reply received: {}", reply.data.key_expr);
-                    reply.data.ensure_timestamp();
-                    self.merge_queue.push(reply.data);
+                    log::trace!("Reply received: {}", reply.sample.key_expr);
+                    reply.sample.ensure_timestamp();
+                    self.merge_queue.push(reply.sample);
                 }
             }
             log::debug!(
@@ -543,9 +543,9 @@ impl InnerState {
                 loop {
                     match self.replies_recv_queue[i].try_recv() {
                         Ok(mut reply) => {
-                            log::trace!("Reply received: {}", reply.data.key_expr);
-                            reply.data.ensure_timestamp();
-                            self.merge_queue.push(reply.data);
+                            log::trace!("Reply received: {}", reply.sample.key_expr);
+                            reply.sample.ensure_timestamp();
+                            self.merge_queue.push(reply.sample);
                         }
                         Err(TryRecvError::Disconnected) => {
                             // query completed - remove the receiver and break loop
@@ -614,9 +614,9 @@ impl InnerState {
                 loop {
                     match self.replies_recv_queue[i].recv_deadline(deadline) {
                         Ok(mut reply) => {
-                            log::trace!("Reply received: {}", reply.data.key_expr);
-                            reply.data.ensure_timestamp();
-                            self.merge_queue.push(reply.data);
+                            log::trace!("Reply received: {}", reply.sample.key_expr);
+                            reply.sample.ensure_timestamp();
+                            self.merge_queue.push(reply.sample);
                         }
                         Err(RecvTimeoutError::Disconnected) => {
                             // query completed - remove the receiver and break loop

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -69,7 +69,7 @@
 //!     let session = zenoh::open(config::default()).await.unwrap();
 //!     let mut replies = session.get("/key/expression").await.unwrap();
 //!     while let Some(reply) = replies.next().await {
-//!         println!(">> Received {}", reply.data);
+//!         println!(">> Received {}", reply.sample);
 //!     }
 //! }
 //! ```

--- a/zenoh/src/query.rs
+++ b/zenoh/src/query.rs
@@ -117,7 +117,7 @@ impl Default for QueryConsolidation {
 #[derive(Clone, Debug)]
 pub struct Reply {
     /// The [`Sample`] for this Reply.
-    pub data: Sample,
+    pub sample: Sample,
     /// The kind of [`Queryable`](crate::queryable::Queryable) that answered this Reply.
     pub replier_kind: ZInt,
     /// The id of the zenoh instance that answered this Reply.
@@ -153,7 +153,7 @@ zreceiver! {
     ///
     /// let mut replies = session.get("/key/expression").wait().unwrap();
     /// while let Ok(reply) = replies.recv() {
-    ///     println!(">> Received {:?}", reply.data);
+    ///     println!(">> Received {:?}", reply.sample);
     /// }
     /// ```
     ///
@@ -166,7 +166,7 @@ zreceiver! {
     ///
     /// let mut replies = session.get("/key/expression").await.unwrap();
     /// while let Some(reply) = replies.next().await {
-    ///     println!(">> Received {:?}", reply.data);
+    ///     println!(">> Received {:?}", reply.sample);
     /// }
     /// # })
     /// ```

--- a/zenoh/src/session.rs
+++ b/zenoh/src/session.rs
@@ -1266,7 +1266,7 @@ impl Session {
     /// let session = zenoh::open(config::peer()).await.unwrap();
     /// let mut replies = session.get("/key/expression").await.unwrap();
     /// while let Some(reply) = replies.next().await {
-    ///     println!(">> Received {:?}", reply.data);
+    ///     println!(">> Received {:?}", reply.sample);
     /// }
     /// # })
     /// ```
@@ -1629,7 +1629,7 @@ impl Primitives for Session {
         match state.queries.get_mut(&qid) {
             Some(query) => {
                 let new_reply = Reply {
-                    data: Sample::with_info(key_expr.into(), payload, data_info),
+                    sample: Sample::with_info(key_expr.into(), payload, data_info),
                     replier_kind,
                     replier_id,
                 };
@@ -1642,23 +1642,22 @@ impl Primitives for Session {
                             .replies
                             .as_ref()
                             .unwrap()
-                            .get(new_reply.data.key_expr.as_str())
+                            .get(new_reply.sample.key_expr.as_str())
                         {
                             Some(reply) => {
-                                if new_reply.data.timestamp > reply.data.timestamp {
+                                if new_reply.sample.timestamp > reply.sample.timestamp {
                                     query.replies.as_mut().unwrap().insert(
-                                        new_reply.data.key_expr.to_string(),
+                                        new_reply.sample.key_expr.to_string(),
                                         new_reply.clone(),
                                     );
                                     let _ = query.rep_sender.send(new_reply);
                                 }
                             }
                             None => {
-                                query
-                                    .replies
-                                    .as_mut()
-                                    .unwrap()
-                                    .insert(new_reply.data.key_expr.to_string(), new_reply.clone());
+                                query.replies.as_mut().unwrap().insert(
+                                    new_reply.sample.key_expr.to_string(),
+                                    new_reply.clone(),
+                                );
                                 let _ = query.rep_sender.send(new_reply);
                             }
                         }
@@ -1668,22 +1667,21 @@ impl Primitives for Session {
                             .replies
                             .as_ref()
                             .unwrap()
-                            .get(new_reply.data.key_expr.as_str())
+                            .get(new_reply.sample.key_expr.as_str())
                         {
                             Some(reply) => {
-                                if new_reply.data.timestamp > reply.data.timestamp {
+                                if new_reply.sample.timestamp > reply.sample.timestamp {
                                     query.replies.as_mut().unwrap().insert(
-                                        new_reply.data.key_expr.to_string(),
+                                        new_reply.sample.key_expr.to_string(),
                                         new_reply.clone(),
                                     );
                                 }
                             }
                             None => {
-                                query
-                                    .replies
-                                    .as_mut()
-                                    .unwrap()
-                                    .insert(new_reply.data.key_expr.to_string(), new_reply.clone());
+                                query.replies.as_mut().unwrap().insert(
+                                    new_reply.sample.key_expr.to_string(),
+                                    new_reply.clone(),
+                                );
                             }
                         };
                     }


### PR DESCRIPTION
Currently the `Reply` struct as the following definition:
```Rust
pub struct Reply {
    pub data: Sample,
    pub replier_kind: ZInt,
    pub replier_id: PeerId,
}
```
Renaming `data` attribute as `sample` makes more sense since:
 - `Sample` type is not only a "data" but a key/value + context (timestamp, kind, source).
 - in languages where the type is not explicit (Python :eyes:), the attribute name gives a hint