### PR TITLE
Configuration updates: New rustfmt.toml file and new "fast" Cargo profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,13 @@ members = [
 debug = true
 opt-level = 0
 
+[profile.fast]
+inherits = "release"
+opt-level=3
+debug=true
+debug-assertions = true
+overflow-checks = true
+lto=false
 
 [profile.release]
 debug = false     # If you want debug symbol in release mode, set the env variable: RUSTFLAGS=-g

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,17 @@
+edition = "2018"
+use_try_shorthand = true
+use_field_init_shorthand = true
+
+# Unstable features below
+# unstable_features = true
+# version = "Two"
+# comment_width = 100             # default is 80
+# error_on_line_overflow = true
+# format_code_in_doc_comments = true
+# format_macro_bodies = true
+# format_macro_matchers = true
+# format_strings = true
+# imports_granularity = "Crate"
+# group_imports = "StdExternalCrate"
+# normalize_doc_attributes = true
+# wrap_comments = true


### PR DESCRIPTION
The `rustfmt.toml` configures `rustfmt`. The following options are provided:

```toml
edition = "2018"
use_try_shorthand = true
use_field_init_shorthand = true
```

The fast profile is an addition to builtin debug and release profiles. It's intended to build fast binaries with less compile time, and provide verbose debug information. In order to use the "fast" profile, 

```sh
cargo test --profile fast
```