### PR TITLE
Providing the WebSocket transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3604,6 +3604,7 @@ dependencies = [
  "zenoh-link-tls",
  "zenoh-link-udp",
  "zenoh-link-unixsock_stream",
+ "zenoh-link-ws",
  "zenoh-protocol-core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+dependencies = [
+ "generic-array 0.14.5",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,6 +779,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+dependencies = [
+ "generic-array 0.14.5",
+ "typenum",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,6 +911,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer 0.10.2",
+ "crypto-common",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,6 +1030,12 @@ dependencies = [
  "pin-project",
  "spin 0.9.2",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -1292,6 +1327,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "http"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa 1.0.1",
 ]
 
 [[package]]
@@ -1790,7 +1836,7 @@ checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
 dependencies = [
  "maplit",
  "pest",
- "sha-1",
+ "sha-1 0.8.2",
 ]
 
 [[package]]
@@ -2547,6 +2593,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "sha1"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2948,12 +3005,38 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
 dependencies = [
+ "bytes",
  "libc",
+ "memchr",
  "mio 0.8.2",
  "num_cpus",
  "pin-project-lite 0.2.8",
  "socket2",
+ "tokio-macros",
  "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06cda1232a49558c46f8a504d5b93101d42c0bf7f911f12a105ba48168f821ae"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -2986,6 +3069,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90442985ee2f57c9e1b548ee72ae842f4a9a20e3f417cc38dbc5dc684d9bb4ee"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96a2dea40e7570482f28eb57afbe42d97551905da6a9400acc5c328d24004f5"
+dependencies = [
+ "base64 0.13.0",
+ "byteorder",
+ "bytes",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha-1 0.10.0",
+ "thiserror",
+ "url",
+ "utf-8",
 ]
 
 [[package]]
@@ -3080,6 +3182,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "uuid"
@@ -3597,6 +3705,24 @@ dependencies = [
  "zenoh-link-commons",
  "zenoh-protocol-core",
  "zenoh-sync",
+]
+
+[[package]]
+name = "zenoh-link-ws"
+version = "0.6.0-dev.0"
+dependencies = [
+ "async-std",
+ "async-trait",
+ "futures-util",
+ "log",
+ "tokio",
+ "tokio-tungstenite",
+ "url",
+ "zenoh-core",
+ "zenoh-link-commons",
+ "zenoh-protocol-core",
+ "zenoh-sync",
+ "zenoh-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
   "io/zenoh-links/zenoh-link-tls/",
   "io/zenoh-links/zenoh-link-quic/",
   "io/zenoh-links/zenoh-link-unixsock_stream/",
+  "io/zenoh-links/zenoh-link-ws/",
   "io/zenoh-link",
   "io/zenoh-transport",
   "zenoh",

--- a/io/zenoh-link/Cargo.toml
+++ b/io/zenoh-link/Cargo.toml
@@ -35,6 +35,7 @@ transport_tcp = ["zenoh-link-tcp"]
 transport_tls = ["zenoh-link-tls"]
 transport_udp = ["zenoh-link-udp"]
 transport_unixsock-stream = ["zenoh-link-unixsock_stream"]
+transport_ws = ["zenoh-link-ws"]
 
 [dependencies]
 zenoh-core = { path = "../../commons/zenoh-core/" }
@@ -48,6 +49,7 @@ zenoh-link-tcp = { path = "../zenoh-links/zenoh-link-tcp/", optional = true }
 zenoh-link-tls = { path = "../zenoh-links/zenoh-link-tls/", optional = true }
 zenoh-link-udp = { path = "../zenoh-links/zenoh-link-udp/", optional = true }
 zenoh-link-unixsock_stream = { path = "../zenoh-links/zenoh-link-unixsock_stream/", optional = true }
+zenoh-link-ws = { path = "../zenoh-links/zenoh-link-ws/", optional = true }
 
 async-std = { version = "=1.11.0", default-features = false }
 async-trait = "0.1.42"

--- a/io/zenoh-link/src/lib.rs
+++ b/io/zenoh-link/src/lib.rs
@@ -68,7 +68,6 @@ pub struct LocatorInspector {
     udp_inspector: UdpLocatorInspector,
     #[cfg(feature = "transport_ws")]
     ws_inspector: WsLocatorInspector,
-
 }
 impl LocatorInspector {
     pub async fn is_multicast(&self, locator: &Locator) -> ZResult<bool> {
@@ -156,7 +155,7 @@ impl LinkManagerBuilderUnicast {
             #[cfg(all(feature = "transport_unixsock-stream", target_family = "unix"))]
             UNIXSOCKSTREAM_LOCATOR_PREFIX => {
                 Ok(Arc::new(LinkManagerUnicastUnixSocketStream::new(_manager)))
-            },
+            }
             #[cfg(feature = "transport_ws")]
             WS_LOCATOR_PREFIX => Ok(Arc::new(LinkManagerUnicastWs::new(_manager))),
             _ => bail!("Unicast not supported for {} protocol", protocol),

--- a/io/zenoh-link/src/lib.rs
+++ b/io/zenoh-link/src/lib.rs
@@ -48,6 +48,11 @@ use zenoh_link_unixsock_stream::{
     LinkManagerUnicastUnixSocketStream, UNIXSOCKSTREAM_LOCATOR_PREFIX,
 };
 
+#[cfg(feature = "transport_ws")]
+pub use zenoh_link_ws as ws;
+#[cfg(feature = "transport_ws")]
+use zenoh_link_ws::{LinkManagerUnicastWs, WsLocatorInspector, WS_LOCATOR_PREFIX};
+
 pub use zenoh_link_commons::*;
 pub use zenoh_protocol_core::{EndPoint, Locator};
 
@@ -61,6 +66,9 @@ pub struct LocatorInspector {
     tls_inspector: TlsLocatorInspector,
     #[cfg(feature = "transport_udp")]
     udp_inspector: UdpLocatorInspector,
+    #[cfg(feature = "transport_ws")]
+    ws_inspector: WsLocatorInspector,
+
 }
 impl LocatorInspector {
     pub async fn is_multicast(&self, locator: &Locator) -> ZResult<bool> {
@@ -78,6 +86,8 @@ impl LocatorInspector {
             QUIC_LOCATOR_PREFIX => self.quic_inspector.is_multicast(locator).await,
             #[cfg(all(feature = "transport_unixsock-stream", target_family = "unix"))]
             UNIXSOCKSTREAM_LOCATOR_PREFIX => Ok(false),
+            #[cfg(feature = "transport_ws")]
+            WS_LOCATOR_PREFIX => self.ws_inspector.is_multicast(locator).await,
             _ => bail!("Unsupported protocol: {}.", protocol),
         }
     }
@@ -146,7 +156,9 @@ impl LinkManagerBuilderUnicast {
             #[cfg(all(feature = "transport_unixsock-stream", target_family = "unix"))]
             UNIXSOCKSTREAM_LOCATOR_PREFIX => {
                 Ok(Arc::new(LinkManagerUnicastUnixSocketStream::new(_manager)))
-            }
+            },
+            #[cfg(feature = "transport_ws")]
+            WS_LOCATOR_PREFIX => Ok(Arc::new(LinkManagerUnicastWs::new(_manager))),
             _ => bail!("Unicast not supported for {} protocol", protocol),
         }
     }

--- a/io/zenoh-links/zenoh-link-ws/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-ws/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-name = "zenoh-link-unixsock_stream"
+name = "zenoh-link-ws"
 version = "0.6.0-dev.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"
 homepage = "http://zenoh.io"
@@ -34,13 +34,14 @@ description = "Internal crate for zenoh."
 [dependencies]
 zenoh-core = { path = "../../../commons/zenoh-core/" }
 zenoh-sync = { path = "../../../commons/zenoh-sync/" }
+zenoh-util = { path = "../../../commons/zenoh-util/" }
 zenoh-protocol-core = { path = "../../../commons/zenoh-protocol-core/" }
-
 zenoh-link-commons = { path = "../../zenoh-link-commons/" }
 
 async-std = { version = "=1.11.0", default-features = false }
+tokio-tungstenite = "0.17.1"
+tokio = { version = "1.17.0", default-features = false, features = ["io-std", "macros", "net", "rt-multi-thread", "time"] }
 async-trait = "0.1.42"
 log = "0.4"
-nix = { version = "0.23.0" }
-uuid = { version = "0.8.2", features = ["v4"] }
-futures = "0.3.21"
+futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
+url = "2.2.2"

--- a/io/zenoh-links/zenoh-link-ws/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-ws/Cargo.toml
@@ -38,7 +38,10 @@ zenoh-util = { path = "../../../commons/zenoh-util/" }
 zenoh-protocol-core = { path = "../../../commons/zenoh-protocol-core/" }
 zenoh-link-commons = { path = "../../zenoh-link-commons/" }
 
-async-std = { version = "=1.11.0", default-features = false }
+async-std = { version = "=1.11.0", default-features = false, features = [
+	"unstable",
+	"tokio1",
+] }
 tokio-tungstenite = "0.17.1"
 tokio = { version = "1.17.0", default-features = false, features = ["io-std", "macros", "net", "rt-multi-thread", "time"] }
 async-trait = "0.1.42"

--- a/io/zenoh-links/zenoh-link-ws/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-ws/src/lib.rs
@@ -1,0 +1,67 @@
+//
+// Copyright (c) 2022 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+use async_trait::async_trait;
+use std::{net::SocketAddr, str::FromStr};
+use zenoh_link_commons::LocatorInspector;
+use zenoh_core::{bail, zconfigurable, Result as ZResult};
+use zenoh_protocol_core::Locator;
+use url::Url;
+mod unicast;
+pub use unicast::*;
+
+// Default MTU (WSS PDU) in bytes.
+// NOTE: Since TCP is a byte-stream oriented transport, theoretically it has
+//       no limit regarding the MTU. However, given the batching strategy
+//       adopted in Zenoh and the usage of 16 bits in Zenoh to encode the
+//       payload length in byte-streamed, the TCP MTU is constrained to
+//       2^16 - 1 bytes (i.e., 65535).
+const WS_MAX_MTU: u16 = u16::MAX;
+
+pub const WS_LOCATOR_PREFIX: &str = "ws";
+
+#[derive(Default, Clone, Copy)]
+pub struct WsLocatorInspector;
+#[async_trait]
+impl LocatorInspector for WsLocatorInspector {
+    fn protocol(&self) -> &str {
+        WS_LOCATOR_PREFIX
+    }
+    async fn is_multicast(&self, _locator: &Locator) -> ZResult<bool> {
+        Ok(false)
+    }
+}
+
+zconfigurable! {
+    // Default MTU (TCP PDU) in bytes.
+    static ref WS_DEFAULT_MTU: u16 = WS_MAX_MTU;
+    // Amount of time in microseconds to throttle the accept loop upon an error.
+    // Default set to 100 ms.
+    static ref TCP_ACCEPT_THROTTLE_TIME: u64 = 100_000;
+}
+
+pub fn get_ws_addr(address: &Locator) -> ZResult<SocketAddr> {
+    match SocketAddr::from_str(address.address()) {
+        Ok(address) => Ok(address),
+        Err(e) => bail!("Couldn't resolve WebSocket locator address: {}: {}", address, e),
+    }
+}
+
+
+pub fn get_ws_url(address: &Locator) -> ZResult<Url> {
+    match  Url::parse(&format!("{}://{}", address.protocol(), address.address())) {
+        Ok(url) => Ok(url),
+        Err(e) => bail!("Couldn't resolve WebSocket locator address: {}: {}", address, e),
+    }
+}

--- a/io/zenoh-links/zenoh-link-ws/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-ws/src/lib.rs
@@ -14,11 +14,11 @@
 
 use async_std::net::ToSocketAddrs;
 use async_trait::async_trait;
-use std::{net::SocketAddr, str::FromStr};
-use zenoh_link_commons::LocatorInspector;
-use zenoh_core::{bail, zconfigurable, Result as ZResult};
-use zenoh_protocol_core::Locator;
+use std::net::SocketAddr;
 use url::Url;
+use zenoh_core::{bail, zconfigurable, Result as ZResult};
+use zenoh_link_commons::LocatorInspector;
+use zenoh_protocol_core::Locator;
 mod unicast;
 pub use unicast::*;
 
@@ -60,10 +60,17 @@ pub async fn get_ws_addr(address: &Locator) -> ZResult<SocketAddr> {
     }
 }
 
-
 pub async fn get_ws_url(address: &Locator) -> ZResult<Url> {
-    match  Url::parse(&format!("{}://{}", address.protocol(), get_ws_addr(address).await?)) {
+    match Url::parse(&format!(
+        "{}://{}",
+        address.protocol(),
+        get_ws_addr(address).await?
+    )) {
         Ok(url) => Ok(url),
-        Err(e) => bail!("Couldn't resolve WebSocket locator address: {}: {}", address, e),
+        Err(e) => bail!(
+            "Couldn't resolve WebSocket locator address: {}: {}",
+            address,
+            e
+        ),
     }
 }

--- a/io/zenoh-links/zenoh-link-ws/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-ws/src/unicast.rs
@@ -1,0 +1,466 @@
+//
+// Copyright (c) 2022 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+use async_std::prelude::*;
+use async_std::task;
+use async_std::task::JoinHandle;
+use async_std::sync::Mutex as AsyncMutex;
+use async_trait::async_trait;
+use futures_util::stream::SplitSink;
+use futures_util::stream::SplitStream;
+use futures_util::{StreamExt};
+use futures_util::{SinkExt};
+use tokio_tungstenite::accept_async;
+use zenoh_core::bail;
+use zenoh_core::zasynclock;
+use std::collections::HashMap;
+use std::fmt;
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+use zenoh_core::Result as ZResult;
+use zenoh_core::{zerror, zread, zwrite};
+use zenoh_link_commons::{
+    LinkManagerUnicastTrait, LinkUnicast, LinkUnicastTrait, NewLinkChannelSender,
+};
+use zenoh_protocol_core::{EndPoint, Locator};
+use zenoh_sync::Signal;
+use tokio::net::{TcpListener, TcpStream};
+use tokio_tungstenite::{WebSocketStream, MaybeTlsStream};
+use tokio_tungstenite::tungstenite::Message;
+
+use super::{
+    get_ws_addr, TCP_ACCEPT_THROTTLE_TIME, WS_DEFAULT_MTU, WS_LOCATOR_PREFIX, get_ws_url,
+};
+
+pub struct LinkUnicastWs {
+    // The underlying socket as returned from the tokio_tungstenite library
+    // socket: WebSocketStream<MaybeTlsStream<TcpStream>>,
+    // The inbound message stream as returned from the futures_util::stream::StreamExt::split method
+    recv: AsyncMutex<SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>>,
+    // // The outbound message stream as returned from the futures_util::stream::StreamExt::split method
+    send: AsyncMutex<SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>>,
+    // The source socket address of this link (address used on the local host)
+    src_addr: SocketAddr,
+    src_locator: Locator,
+    // The destination socket address of this link (address used on the remote host)
+    dst_addr: SocketAddr,
+    dst_locator: Locator,
+}
+
+impl LinkUnicastWs {
+    fn new(socket: WebSocketStream<MaybeTlsStream<TcpStream>>,
+            src_addr: SocketAddr,
+            dst_addr: SocketAddr
+        ) -> LinkUnicastWs {
+
+        // Set the TCP nodelay option
+        if let Err(err) = get_stream(&socket).set_nodelay(true) {
+            log::warn!(
+                "Unable to set NODEALY option on TCP link {} => {}: {}",
+                src_addr,
+                dst_addr,
+                err
+            );
+        }
+
+        let (send, recv) = socket.split();
+        let send = AsyncMutex::new(send);
+        let recv = AsyncMutex::new(recv);
+
+        // let socket = Mutex::new(socket);
+
+        // Build the Tcp object
+        LinkUnicastWs {
+            // socket,
+            recv,
+            send,
+            src_addr,
+            src_locator: Locator::new(WS_LOCATOR_PREFIX, &src_addr),
+            dst_addr,
+            dst_locator: Locator::new(WS_LOCATOR_PREFIX, &dst_addr),
+        }
+    }
+}
+
+#[async_trait]
+impl LinkUnicastTrait for LinkUnicastWs {
+    async fn close(&self) -> ZResult<()> {
+        log::trace!("Closing WebSocket link: {}", self);
+        let mut guard = zasynclock!(self.send);
+        // Close the underlying TCP socket
+        guard.close().await.map_err(|e| {
+            let e = zerror!("WebSocket link shutdown {}: {:?}", self, e);
+            log::trace!("{}", e);
+            e.into()
+        })
+    }
+
+    async fn write(&self, buffer: &[u8]) -> ZResult<usize> {
+        let mut guard = zasynclock!(self.send);
+        // WebSocket is message based, and a binary message requires to be Vec<u8> :(
+        let msg = Message::Binary(buffer.to_vec());
+
+        // .map_err complains...
+        guard.send(msg).await.map_err(|e| {
+            let e = zerror!("Write error on WebSocket link {}: {}", self, e);
+            log::trace!("{}", e);
+            e
+        })?;
+
+        Ok(buffer.len())
+
+    }
+
+    async fn write_all(&self, buffer: &[u8]) -> ZResult<()> {
+        self.write(buffer).await?;
+        Ok(())
+
+    }
+
+    async fn read(&self, buffer: &mut [u8]) -> ZResult<usize> {
+        let mut guard = zasynclock!(self.recv);
+
+        match guard.next().await {
+            Some(msg) => {
+                match msg {
+                    Ok(msg) => {
+                        match msg {
+                            Message::Binary(bytes) => {
+                                buffer.clone_from_slice(&bytes);
+                                Ok(bytes.len())
+                            }
+                            _ => bail!("Received wrong message type from WebSocket link {}", self),
+                        }
+                    }
+                    Err(e) => bail!("Error when receiving from WebSocket link {}: {}", self, e),
+                }
+            }
+            None =>  bail!("Error when receiving from WebSocket link {}: None", self),
+        }
+    }
+
+    async fn read_exact(&self, buffer: &mut [u8]) -> ZResult<()> {
+        self.read(buffer).await?;
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn get_src(&self) -> &Locator {
+        &self.src_locator
+    }
+
+    #[inline(always)]
+    fn get_dst(&self) -> &Locator {
+        &self.dst_locator
+    }
+
+    #[inline(always)]
+    fn get_mtu(&self) -> u16 {
+        *WS_DEFAULT_MTU
+    }
+
+    #[inline(always)]
+    fn is_reliable(&self) -> bool {
+        true
+    }
+
+    #[inline(always)]
+    fn is_streamed(&self) -> bool {
+        true
+    }
+}
+
+impl Drop for LinkUnicastWs {
+    fn drop(&mut self) {
+        // Close the underlying WebSocket socket
+        // let mut guard = zlock!(self.send);
+        // guard.close();
+    }
+}
+
+impl fmt::Display for LinkUnicastWs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} => {}", self.src_addr, self.dst_addr)?;
+        Ok(())
+    }
+}
+
+impl fmt::Debug for LinkUnicastWs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Tcp")
+            .field("src", &self.src_addr)
+            .field("dst", &self.dst_addr)
+            .finish()
+    }
+}
+
+/*************************************/
+/*          LISTENER                 */
+/*************************************/
+struct ListenerUnicastWs {
+    endpoint: EndPoint,
+    active: Arc<AtomicBool>,
+    signal: Signal,
+    handle: JoinHandle<ZResult<()>>,
+}
+
+impl ListenerUnicastWs {
+    fn new(
+        endpoint: EndPoint,
+        active: Arc<AtomicBool>,
+        signal: Signal,
+        handle: JoinHandle<ZResult<()>>,
+    ) -> ListenerUnicastWs {
+        ListenerUnicastWs {
+            endpoint,
+            active,
+            signal,
+            handle,
+        }
+    }
+}
+
+pub struct LinkManagerUnicastWs {
+    manager: NewLinkChannelSender,
+    listeners: Arc<RwLock<HashMap<SocketAddr, ListenerUnicastWs>>>,
+}
+
+impl LinkManagerUnicastWs {
+    pub fn new(manager: NewLinkChannelSender) -> Self {
+        Self {
+            manager,
+            listeners: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+}
+
+#[async_trait]
+impl LinkManagerUnicastTrait for LinkManagerUnicastWs {
+    async fn new_link(&self, endpoint: EndPoint) -> ZResult<LinkUnicast> {
+        let dst_url = get_ws_url(&endpoint.locator)?;
+
+        let (stream, _) = tokio_tungstenite::connect_async(&dst_url)
+            .await
+            .map_err(|e| zerror!("Can not create a new WebSocket link bound to {}: {}", dst_url, e))?;
+
+        let src_addr = get_stream(&stream)
+            .local_addr()
+            .map_err(|e| zerror!("Can not create a new WebSocket link bound to {}: {}", dst_url, e))?;
+
+        let dst_addr = get_stream(&stream)
+            .peer_addr()
+            .map_err(|e| zerror!("Can not create a new WebSocket link bound to {}: {}", dst_url, e))?;
+
+        let link = Arc::new(LinkUnicastWs::new(
+            stream,
+            src_addr,
+            dst_addr));
+
+        Ok(LinkUnicast(link))
+    }
+
+    async fn new_listener(&self, mut endpoint: EndPoint) -> ZResult<Locator> {
+        let addr = get_ws_addr(&endpoint.locator)?;
+
+        // Bind the TCP socket
+        let socket = TcpListener::bind(addr)
+            .await
+            .map_err(|e| zerror!("Can not create a new TCP (WebSocket) listener on {}: {}", addr, e))?;
+
+        let local_addr = socket
+            .local_addr()
+            .map_err(|e| zerror!("Can not create a new TCP (WebSocket) listener on {}: {}", addr, e))?;
+
+        // Update the endpoint locator address
+        assert!(endpoint.set_addr(&format!("{}", local_addr)));
+
+        // Spawn the accept loop for the listener
+        let active = Arc::new(AtomicBool::new(true));
+        let signal = Signal::new();
+
+        let c_active = active.clone();
+        let c_signal = signal.clone();
+        let c_manager = self.manager.clone();
+        let c_listeners = self.listeners.clone();
+        let c_addr = local_addr;
+        let handle = task::spawn(async move {
+            // Wait for the accept loop to terminate
+            let res = accept_task(socket, c_active, c_signal, c_manager).await;
+            zwrite!(c_listeners).remove(&c_addr);
+            res
+        });
+
+        let locator = endpoint.locator.clone();
+        let listener = ListenerUnicastWs::new(endpoint, active, signal, handle);
+        // Update the list of active listeners on the manager
+        zwrite!(self.listeners).insert(local_addr, listener);
+
+        Ok(locator)
+    }
+
+    async fn del_listener(&self, endpoint: &EndPoint) -> ZResult<()> {
+        let addr = get_ws_addr(&endpoint.locator)?;
+
+        // Stop the listener
+        let listener = zwrite!(self.listeners).remove(&addr).ok_or_else(|| {
+            let e = zerror!(
+                "Can not delete the TCP (WebSocket) listener because it has not been found: {}",
+                addr
+            );
+            log::trace!("{}", e);
+            e
+        })?;
+
+        // Send the stop signal
+        listener.active.store(false, Ordering::Release);
+        listener.signal.trigger();
+        listener.handle.await
+    }
+
+    fn get_listeners(&self) -> Vec<EndPoint> {
+        zread!(self.listeners)
+            .values()
+            .map(|l| l.endpoint.clone())
+            .collect()
+    }
+
+    fn get_locators(&self) -> Vec<Locator> {
+        let mut locators = Vec::new();
+        let default_ipv4 = Ipv4Addr::new(0, 0, 0, 0);
+        let default_ipv6 = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0);
+
+        let guard = zread!(self.listeners);
+        for (key, value) in guard.iter() {
+            let listener_locator = &value.endpoint.locator;
+            if key.ip() == default_ipv4 {
+                match zenoh_util::net::get_local_addresses() {
+                    Ok(ipaddrs) => {
+                        for ipaddr in ipaddrs {
+                            if !ipaddr.is_loopback() && !ipaddr.is_multicast() && ipaddr.is_ipv4() {
+                                let mut l = Locator::new(
+                                    WS_LOCATOR_PREFIX,
+                                    &SocketAddr::new(ipaddr, key.port()),
+                                );
+                                l.metadata = value.endpoint.locator.metadata.clone();
+                                locators.push(l);
+                            }
+                        }
+                    }
+                    Err(err) => log::error!("Unable to get local addresses : {}", err),
+                }
+            } else if key.ip() == default_ipv6 {
+                match zenoh_util::net::get_local_addresses() {
+                    Ok(ipaddrs) => {
+                        for ipaddr in ipaddrs {
+                            if !ipaddr.is_loopback() && !ipaddr.is_multicast() && ipaddr.is_ipv6() {
+                                let mut l = Locator::new(
+                                    WS_LOCATOR_PREFIX,
+                                    &SocketAddr::new(ipaddr, key.port()),
+                                );
+                                l.metadata = value.endpoint.locator.metadata.clone();
+                                locators.push(l);
+                            }
+                        }
+                    }
+                    Err(err) => log::error!("Unable to get local addresses : {}", err),
+                }
+            } else {
+                locators.push(listener_locator.clone());
+            }
+        }
+        std::mem::drop(guard);
+
+        locators
+    }
+}
+
+async fn accept_task(
+    socket: TcpListener,
+    active: Arc<AtomicBool>,
+    signal: Signal,
+    manager: NewLinkChannelSender,
+) -> ZResult<()> {
+    enum Action {
+        Accept((TcpStream, SocketAddr)),
+        Stop,
+    }
+
+    async fn accept(socket: &TcpListener) -> ZResult<Action> {
+        let res = socket.accept().await.map_err(|e| zerror!(e))?;
+        Ok(Action::Accept(res))
+    }
+
+    async fn stop(signal: Signal) -> ZResult<Action> {
+        signal.wait().await;
+        Ok(Action::Stop)
+    }
+
+    let src_addr = socket.local_addr().map_err(|e| {
+        let e = zerror!("Can not accept TCP (WebSocket) connections: {}", e);
+        log::warn!("{}", e);
+        e
+    })?;
+
+    log::trace!("Ready to accept TCP (WebSocket) connections on: {:?}", src_addr);
+    while active.load(Ordering::Acquire) {
+        // Wait for incoming connections
+        let (stream, dst_addr) = match accept(&socket).race(stop(signal.clone())).await {
+            Ok(action) => match action {
+                Action::Accept((stream, addr)) => (stream, addr),
+                Action::Stop => break,
+            },
+            Err(e) => {
+                log::warn!("{}. Hint: increase the system open file limit.", e);
+                // Throttle the accept loop upon an error
+                // NOTE: This might be due to various factors. However, the most common case is that
+                //       the process has reached the maximum number of open files in the system. On
+                //       Linux systems this limit can be changed by using the "ulimit" command line
+                //       tool. In case of systemd-based systems, this can be changed by using the
+                //       "sysctl" command line tool.
+                task::sleep(Duration::from_micros(*TCP_ACCEPT_THROTTLE_TIME)).await;
+                continue;
+            }
+        };
+
+        log::debug!("Accepted TCP (WebSocket) connection on {:?}: {:?}", src_addr, dst_addr);
+
+        let stream = accept_async(MaybeTlsStream::Plain(stream)).await.map_err(|e| {
+            let e = zerror!("Error when craating the WebSocket session: {}", e);
+            log::trace!("{}", e);
+            e
+        })?;
+        // Create the new link object
+        let link = Arc::new(LinkUnicastWs::new(stream, src_addr, dst_addr));
+
+
+        // Communicate the new link to the initial transport manager
+        if let Err(e) = manager.send_async(LinkUnicast(link)).await {
+            log::error!("{}-{}: {}", file!(), line!(), e)
+        }
+    }
+
+    Ok(())
+}
+
+
+fn get_stream(ws_stream: &WebSocketStream<MaybeTlsStream<TcpStream>>) -> &TcpStream {
+    match ws_stream.get_ref() {
+        MaybeTlsStream::Plain(s) => s,
+        // MaybeTlsStream::NativeTls(s) => s.get_ref().get_ref(),
+        // MaybeTlsStream::Rustls(s) => s.get_ref().0
+        _ => panic!(),
+    }
+}

--- a/io/zenoh-transport/Cargo.toml
+++ b/io/zenoh-transport/Cargo.toml
@@ -44,6 +44,7 @@ transport_quic = ["zenoh-link/transport_quic"]
 transport_tcp = ["zenoh-link/transport_tcp"]
 transport_tls = ["zenoh-link/transport_tls"]
 transport_udp = ["zenoh-link/transport_udp"]
+transport_ws = ["zenoh-link/transport_ws"]
 stats = []
 
 [dependencies]

--- a/io/zenoh-transport/tests/endpoints.rs
+++ b/io/zenoh-transport/tests/endpoints.rs
@@ -267,7 +267,6 @@ fn endpoint_ws() {
     task::block_on(run(&endpoints));
 }
 
-
 #[cfg(all(feature = "transport_tcp", feature = "transport_udp"))]
 #[test]
 fn endpoint_tcp_udp() {

--- a/io/zenoh-transport/tests/endpoints.rs
+++ b/io/zenoh-transport/tests/endpoints.rs
@@ -251,6 +251,23 @@ fn endpoint_unix() {
     let _ = std::fs::remove_file("zenoh-test-unix-socket-1.sock.lock");
 }
 
+#[cfg(feature = "transport_ws")]
+#[test]
+fn endpoint_ws() {
+    task::block_on(async {
+        zasync_executor_init!();
+    });
+
+    // Define the locators
+    let endpoints: Vec<EndPoint> = vec![
+        "ws/127.0.0.1:11447".parse().unwrap(),
+        "ws/[::1]:11447".parse().unwrap(),
+        "ws/localhost:11448".parse().unwrap(),
+    ];
+    task::block_on(run(&endpoints));
+}
+
+
 #[cfg(all(feature = "transport_tcp", feature = "transport_udp"))]
 #[test]
 fn endpoint_tcp_udp() {

--- a/io/zenoh-transport/tests/unicast_authenticator.rs
+++ b/io/zenoh-transport/tests/unicast_authenticator.rs
@@ -815,6 +815,17 @@ fn authenticator_udp() {
     task::block_on(run(&endpoint));
 }
 
+#[cfg(feature = "transport_ws")]
+#[test]
+fn authenticator_ws() {
+    task::block_on(async {
+        zasync_executor_init!();
+    });
+
+    let endpoint: EndPoint = "ws/127.0.0.1:11449".parse().unwrap();
+    task::block_on(run(&endpoint));
+}
+
 #[cfg(all(feature = "transport_unixsock-stream", target_family = "unix"))]
 #[test]
 fn authenticator_unix() {

--- a/io/zenoh-transport/tests/unicast_concurrent.rs
+++ b/io/zenoh-transport/tests/unicast_concurrent.rs
@@ -392,7 +392,6 @@ fn transport_tcp_concurrent() {
     });
 }
 
-
 #[cfg(feature = "transport_ws")]
 #[test]
 fn transport_ws_concurrent() {

--- a/io/zenoh-transport/tests/unicast_concurrent.rs
+++ b/io/zenoh-transport/tests/unicast_concurrent.rs
@@ -391,3 +391,37 @@ fn transport_tcp_concurrent() {
         transport_concurrent(endpoint01, endpoint02).await;
     });
 }
+
+
+#[cfg(feature = "transport_ws")]
+#[test]
+fn transport_ws_concurrent() {
+    task::block_on(async {
+        zasync_executor_init!();
+    });
+
+    let endpoint01: Vec<EndPoint> = vec![
+        "ws/127.0.0.1:7463".parse().unwrap(),
+        "ws/127.0.0.1:7464".parse().unwrap(),
+        "ws/127.0.0.1:7465".parse().unwrap(),
+        "ws/127.0.0.1:7466".parse().unwrap(),
+        "ws/127.0.0.1:7467".parse().unwrap(),
+        "ws/127.0.0.1:7468".parse().unwrap(),
+        "ws/127.0.0.1:7469".parse().unwrap(),
+        "ws/127.0.0.1:7470".parse().unwrap(),
+    ];
+    let endpoint02: Vec<EndPoint> = vec![
+        "ws/127.0.0.1:7471".parse().unwrap(),
+        "ws/127.0.0.1:7472".parse().unwrap(),
+        "ws/127.0.0.1:7473".parse().unwrap(),
+        "ws/127.0.0.1:7474".parse().unwrap(),
+        "ws/127.0.0.1:7475".parse().unwrap(),
+        "ws/127.0.0.1:7476".parse().unwrap(),
+        "ws/127.0.0.1:7477".parse().unwrap(),
+        "ws/127.0.0.1:7478".parse().unwrap(),
+    ];
+
+    task::block_on(async {
+        transport_concurrent(endpoint01, endpoint02).await;
+    });
+}

--- a/io/zenoh-transport/tests/unicast_conduits.rs
+++ b/io/zenoh-transport/tests/unicast_conduits.rs
@@ -328,3 +328,23 @@ fn conduits_tcp_only() {
     // Run
     task::block_on(run(&endpoints, &channel, &MSG_SIZE_ALL));
 }
+
+
+#[cfg(feature = "transport_ws")]
+#[test]
+fn conduits_ws_only() {
+    task::block_on(async {
+        zasync_executor_init!();
+    });
+    let mut channel = vec![];
+    for p in PRIORITY_ALL.iter() {
+        channel.push(Channel {
+            priority: *p,
+            reliability: Reliability::Reliable,
+        });
+    }
+    // Define the locators
+    let endpoints: Vec<EndPoint> = vec!["ws/127.0.0.1:13448".parse().unwrap()];
+    // Run
+    task::block_on(run(&endpoints, &channel, &MSG_SIZE_ALL));
+}

--- a/io/zenoh-transport/tests/unicast_conduits.rs
+++ b/io/zenoh-transport/tests/unicast_conduits.rs
@@ -329,7 +329,6 @@ fn conduits_tcp_only() {
     task::block_on(run(&endpoints, &channel, &MSG_SIZE_ALL));
 }
 
-
 #[cfg(feature = "transport_ws")]
 #[test]
 fn conduits_ws_only() {

--- a/io/zenoh-transport/tests/unicast_defragmentation.rs
+++ b/io/zenoh-transport/tests/unicast_defragmentation.rs
@@ -159,3 +159,40 @@ fn transport_unicast_defragmentation_tcp_only() {
         }
     });
 }
+
+
+#[cfg(feature = "transport_ws")]
+#[test]
+fn transport_unicast_defragmentation_ws_only() {
+    task::block_on(async {
+        zasync_executor_init!();
+    });
+
+    // Define the locators
+    let endpoint: EndPoint = "tcp/127.0.0.1:14448".parse().unwrap();
+    // Define the reliability and congestion control
+    let channel = [
+        Channel {
+            priority: Priority::default(),
+            reliability: Reliability::Reliable,
+        },
+        Channel {
+            priority: Priority::default(),
+            reliability: Reliability::BestEffort,
+        },
+        Channel {
+            priority: Priority::RealTime,
+            reliability: Reliability::Reliable,
+        },
+        Channel {
+            priority: Priority::RealTime,
+            reliability: Reliability::BestEffort,
+        },
+    ];
+    // Run
+    task::block_on(async {
+        for ch in channel.iter() {
+            run(&endpoint, *ch, MSG_SIZE).await;
+        }
+    });
+}

--- a/io/zenoh-transport/tests/unicast_defragmentation.rs
+++ b/io/zenoh-transport/tests/unicast_defragmentation.rs
@@ -160,7 +160,6 @@ fn transport_unicast_defragmentation_tcp_only() {
     });
 }
 
-
 #[cfg(feature = "transport_ws")]
 #[test]
 fn transport_unicast_defragmentation_ws_only() {
@@ -169,7 +168,7 @@ fn transport_unicast_defragmentation_ws_only() {
     });
 
     // Define the locators
-    let endpoint: EndPoint = "tcp/127.0.0.1:14448".parse().unwrap();
+    let endpoint: EndPoint = "ws/127.0.0.1:14448".parse().unwrap();
     // Define the reliability and congestion control
     let channel = [
         Channel {

--- a/io/zenoh-transport/tests/unicast_intermittent.rs
+++ b/io/zenoh-transport/tests/unicast_intermittent.rs
@@ -399,7 +399,6 @@ fn transport_tcp_intermittent() {
     task::block_on(transport_intermittent(&endpoint));
 }
 
-
 #[cfg(feature = "transport_ws")]
 #[test]
 fn transport_ws_intermittent() {

--- a/io/zenoh-transport/tests/unicast_intermittent.rs
+++ b/io/zenoh-transport/tests/unicast_intermittent.rs
@@ -398,3 +398,17 @@ fn transport_tcp_intermittent() {
     let endpoint: EndPoint = "tcp/127.0.0.1:12447".parse().unwrap();
     task::block_on(transport_intermittent(&endpoint));
 }
+
+
+#[cfg(feature = "transport_ws")]
+#[test]
+fn transport_ws_intermittent() {
+    env_logger::init();
+
+    task::block_on(async {
+        zasync_executor_init!();
+    });
+
+    let endpoint: EndPoint = "ws/127.0.0.1:12448".parse().unwrap();
+    task::block_on(transport_intermittent(&endpoint));
+}

--- a/io/zenoh-transport/tests/unicast_openclose.rs
+++ b/io/zenoh-transport/tests/unicast_openclose.rs
@@ -467,6 +467,17 @@ fn openclose_udp_only() {
     task::block_on(openclose_transport(&endpoint));
 }
 
+#[cfg(feature = "transport_ws")]
+#[test]
+fn openclose_ws_only() {
+    task::block_on(async {
+        zasync_executor_init!();
+    });
+
+    let endpoint: EndPoint = "ws/127.0.0.1:8448".parse().unwrap();
+    task::block_on(openclose_transport(&endpoint));
+}
+
 #[cfg(all(feature = "transport_unixsock-stream", target_family = "unix"))]
 #[test]
 fn openclose_unix_only() {

--- a/io/zenoh-transport/tests/unicast_shm.rs
+++ b/io/zenoh-transport/tests/unicast_shm.rs
@@ -349,7 +349,6 @@ mod tests {
         task::block_on(run(&endpoint));
     }
 
-
     #[cfg(all(feature = "transport_ws", feature = "shared-memory"))]
     #[test]
     fn transport_ws_shm() {

--- a/io/zenoh-transport/tests/unicast_shm.rs
+++ b/io/zenoh-transport/tests/unicast_shm.rs
@@ -348,4 +348,16 @@ mod tests {
         let endpoint: EndPoint = "tcp/127.0.0.1:16447".parse().unwrap();
         task::block_on(run(&endpoint));
     }
+
+
+    #[cfg(all(feature = "transport_ws", feature = "shared-memory"))]
+    #[test]
+    fn transport_ws_shm() {
+        task::block_on(async {
+            zasync_executor_init!();
+        });
+
+        let endpoint: EndPoint = "ws/127.0.0.1:16448".parse().unwrap();
+        task::block_on(run(&endpoint));
+    }
 }

--- a/io/zenoh-transport/tests/unicast_simultaneous.rs
+++ b/io/zenoh-transport/tests/unicast_simultaneous.rs
@@ -333,7 +333,6 @@ fn transport_tcp_simultaneous() {
     });
 }
 
-
 #[cfg(feature = "transport_ws")]
 #[test]
 fn transport_ws_simultaneous() {

--- a/io/zenoh-transport/tests/unicast_simultaneous.rs
+++ b/io/zenoh-transport/tests/unicast_simultaneous.rs
@@ -332,3 +332,31 @@ fn transport_tcp_simultaneous() {
         transport_simultaneous(endpoint01, endpoint02).await;
     });
 }
+
+
+#[cfg(feature = "transport_ws")]
+#[test]
+fn transport_ws_simultaneous() {
+    task::block_on(async {
+        zasync_executor_init!();
+    });
+
+    let endpoint01: Vec<EndPoint> = vec![
+        "ws/127.0.0.1:16447".parse().unwrap(),
+        "ws/127.0.0.1:16448".parse().unwrap(),
+        "ws/127.0.0.1:16449".parse().unwrap(),
+        "ws/127.0.0.1:16450".parse().unwrap(),
+        "ws/127.0.0.1:16451".parse().unwrap(),
+        "ws/127.0.0.1:16452".parse().unwrap(),
+        "ws/127.0.0.1:16453".parse().unwrap(),
+    ];
+    let endpoint02: Vec<EndPoint> = vec![
+        "ws/127.0.0.1:16454".parse().unwrap(),
+        "ws/127.0.0.1:16455".parse().unwrap(),
+        "ws/127.0.0.1:16456".parse().unwrap(),
+    ];
+
+    task::block_on(async {
+        transport_simultaneous(endpoint01, endpoint02).await;
+    });
+}

--- a/io/zenoh-transport/tests/unicast_transport.rs
+++ b/io/zenoh-transport/tests/unicast_transport.rs
@@ -424,6 +424,41 @@ fn transport_unicast_unix_only() {
     let _ = std::fs::remove_file("zenoh-test-unix-socket-5.sock.lock");
 }
 
+#[cfg(feature = "transport_ws")]
+#[test]
+fn transport_unicast_ws_only() {
+    task::block_on(async {
+        zasync_executor_init!();
+    });
+
+    // Define the locators
+    let endpoints: Vec<EndPoint> = vec![
+        "ws/127.0.0.1:11447".parse().unwrap(),
+        "ws/[::1]:11447".parse().unwrap(),
+    ];
+    // Define the reliability and congestion control
+    let channel = [
+        Channel {
+            priority: Priority::default(),
+            reliability: Reliability::Reliable,
+        },
+        Channel {
+            priority: Priority::default(),
+            reliability: Reliability::BestEffort,
+        },
+        Channel {
+            priority: Priority::RealTime,
+            reliability: Reliability::Reliable,
+        },
+        Channel {
+            priority: Priority::RealTime,
+            reliability: Reliability::BestEffort,
+        },
+    ];
+    // Run
+    task::block_on(run(&endpoints, &channel, &MSG_SIZE_ALL));
+}
+
 #[cfg(all(feature = "transport_tcp", feature = "transport_udp"))]
 #[test]
 fn transport_unicast_tcp_udp() {


### PR DESCRIPTION
This PR provides an implementation for a WebSocket-based transport for Zenoh routers, clients and peers.

- [x] Choice of a locator format `ws/<address>:<port>`  
- [x] Implement the traits for the WebSocket transport: `LinkUnicastTrait`, `LinkManagerUnicastTrait` 
- [x] Add the relevant tests

The feature is disabled by default but the tests can be run with:
```bash
$  cargo test -p zenoh-transport --no-default-features --features transport_ws
```


