### PR TITLE
Use unified async executor in one crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3468,6 +3468,7 @@ dependencies = [
  "uhlc",
  "uuid",
  "vec_map",
+ "zenoh-async-rt",
  "zenoh-buffers",
  "zenoh-cfg-properties",
  "zenoh-collections",
@@ -3481,6 +3482,14 @@ dependencies = [
  "zenoh-sync",
  "zenoh-transport",
  "zenoh-util",
+]
+
+[[package]]
+name = "zenoh-async-rt"
+version = "0.1.0"
+dependencies = [
+ "async-std",
+ "futures",
 ]
 
 [[package]]
@@ -3513,6 +3522,7 @@ dependencies = [
  "async-trait",
  "flume",
  "log",
+ "zenoh-async-rt",
  "zenoh-core",
  "zenoh-sync",
 ]
@@ -3568,6 +3578,7 @@ dependencies = [
  "rand 0.8.5",
  "rustc_version 0.4.0",
  "zenoh",
+ "zenoh-async-rt",
 ]
 
 [[package]]
@@ -3583,6 +3594,7 @@ dependencies = [
  "log",
  "serde",
  "zenoh",
+ "zenoh-async-rt",
  "zenoh-core",
  "zenoh-sync",
  "zenoh-util",
@@ -3635,6 +3647,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-pemfile 0.3.0",
  "webpki 0.22.0",
+ "zenoh-async-rt",
  "zenoh-cfg-properties",
  "zenoh-config",
  "zenoh-core",
@@ -3651,6 +3664,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "log",
+ "zenoh-async-rt",
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol-core",
@@ -3667,6 +3681,7 @@ dependencies = [
  "async-trait",
  "futures",
  "log",
+ "zenoh-async-rt",
  "zenoh-cfg-properties",
  "zenoh-config",
  "zenoh-core",
@@ -3684,6 +3699,7 @@ dependencies = [
  "async-trait",
  "log",
  "socket2",
+ "zenoh-async-rt",
  "zenoh-collections",
  "zenoh-core",
  "zenoh-link-commons",
@@ -3702,6 +3718,7 @@ dependencies = [
  "log",
  "nix 0.23.1",
  "uuid",
+ "zenoh-async-rt",
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol-core",
@@ -3719,6 +3736,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "url",
+ "zenoh-async-rt",
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol-core",
@@ -3754,6 +3772,7 @@ dependencies = [
  "serde_json",
  "tide",
  "zenoh",
+ "zenoh-async-rt",
  "zenoh-core",
  "zenoh-plugin-trait",
  "zenoh-util",
@@ -3773,6 +3792,7 @@ dependencies = [
  "log",
  "serde_json",
  "zenoh",
+ "zenoh-async-rt",
  "zenoh-collections",
  "zenoh-core",
  "zenoh-plugin-trait",
@@ -3829,6 +3849,7 @@ dependencies = [
  "flume",
  "futures",
  "tokio",
+ "zenoh-async-rt",
  "zenoh-core",
 ]
 
@@ -3847,6 +3868,7 @@ dependencies = [
  "rand 0.8.5",
  "rsa",
  "serde",
+ "zenoh-async-rt",
  "zenoh-buffers",
  "zenoh-cfg-properties",
  "zenoh-collections",
@@ -3911,6 +3933,7 @@ dependencies = [
  "rand 0.8.5",
  "rustc_version 0.4.0",
  "zenoh",
+ "zenoh-async-rt",
 ]
 
 [[package]]
@@ -3945,6 +3968,7 @@ dependencies = [
  "log",
  "serde_json",
  "zenoh",
+ "zenoh-async-rt",
  "zenoh-core",
  "zenoh-plugin-trait",
  "zenoh-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,9 +88,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
+checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
 name = "arrayref"
@@ -151,14 +151,14 @@ dependencies = [
 
 [[package]]
 name = "async-global-executor"
-version = "2.0.4"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c290043c9a95b05d45e952fb6383c67bcb61471f60cfa21e890dba6654234f43"
+checksum = "5262ed948da60dd8956c6c5aca4d4163593dddb7b32d73267c93dab7b2e98940"
 dependencies = [
  "async-channel",
  "async-executor",
  "async-io",
- "async-mutex",
+ "async-lock",
  "blocking",
  "futures-lite",
  "num_cpus",
@@ -184,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a811e6a479f2439f0c04038796b5cfb3d2ad56c230e0f2d3f7b04d68cfee607b"
+checksum = "e5e18f61464ae81cde0a23e713ae8fd299580c54d697a35820cfd0625b8b0e07"
 dependencies = [
  "concurrent-queue",
  "futures-lite",
@@ -211,19 +211,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-mutex"
+name = "async-process"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
-dependencies = [
- "event-listener",
-]
-
-[[package]]
-name = "async-process"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83137067e3a2a6a06d67168e49e68a0957d215410473a740cea95a2425c0b7c6"
+checksum = "cf2c06e30a24e8c78a3987d07f0930edf76ef35e027e7bdb063fccafdad1f60c"
 dependencies = [
  "async-io",
  "blocking",
@@ -305,7 +296,7 @@ dependencies = [
  "memchr",
  "num_cpus",
  "once_cell",
- "pin-project-lite 0.2.8",
+ "pin-project-lite 0.2.9",
  "pin-utils",
  "slab",
  "wasm-bindgen-futures",
@@ -313,15 +304,15 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30696a84d817107fc028e049980e09d5e140e8da8f1caeb17e8e950658a3cea9"
+checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.53"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
+checksum = "96cf8829f67d2eab0b2dfa42c5d0ef737e0724e4a82b01b3e292456202b19716"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -362,9 +353,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base-x"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
 name = "base64"
@@ -488,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.9.1"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
+checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 
 [[package]]
 name = "byte-tools"
@@ -526,6 +517,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,7 +550,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.43",
+ "time 0.1.44",
  "winapi",
 ]
 
@@ -592,17 +589,26 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.8"
+version = "3.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
+checksum = "d646c7ade5eb07c4aa20e907a922750df0c448892513714fd3e4acbc7130829f"
 dependencies = [
  "atty",
  "bitflags",
+ "clap_lex",
  "indexmap",
- "os_str_bytes",
  "strsim 0.10.0",
  "termcolor",
  "textwrap 0.15.0",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -688,12 +694,12 @@ checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
 name = "criterion"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
+checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
 dependencies = [
  "atty",
- "cast",
+ "cast 0.3.0",
  "clap 2.34.0",
  "criterion-plot",
  "csv",
@@ -718,15 +724,15 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
 dependencies = [
- "cast",
+ "cast 0.2.7",
  "itertools",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -745,26 +751,26 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
 dependencies = [
  "autocfg 1.1.0",
  "cfg-if 1.0.0",
  "crossbeam-utils",
- "lazy_static",
  "memoffset",
+ "once_cell",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
 dependencies = [
  "cfg-if 1.0.0",
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
@@ -780,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+checksum = "2ccfd8c0ee4cce11e45b3fd6f9d5e69e0cc62912aa6a0cb1bf4617b0eba5a12f"
 dependencies = [
  "generic-array 0.14.5",
  "typenum",
@@ -857,16 +863,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb4a30d54f7443bf3d6191dcd486aca19e67cb3c49fa7a06a319966346707e7f"
 dependencies = [
  "cipher 0.2.5",
-]
-
-[[package]]
-name = "dashmap"
-version = "4.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
-dependencies = [
- "cfg-if 1.0.0",
- "num_cpus",
 ]
 
 [[package]]
@@ -949,9 +945,9 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
 name = "env_logger"
@@ -968,9 +964,9 @@ dependencies = [
 
 [[package]]
 name = "erased-serde"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad132dd8d0d0b546348d7d86cb3191aad14b34e5f979781fc005c80d4ac67ffd"
+checksum = "81d013529d5574a60caeda29e179e695125448e5de52e3874f7b4c1d7360e18e"
 dependencies = [
  "serde",
 ]
@@ -998,9 +994,9 @@ dependencies = [
 
 [[package]]
 name = "femme"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2997b612abb06bc299486c807e68c5fd12e7618e69cf34c5958ca6b575674403"
+checksum = "cc04871e5ae3aa2952d552dae6b291b3099723bf779a8054281c1366a54613ef"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -1014,21 +1010,21 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flume"
-version = "0.10.12"
+version = "0.10.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843c03199d0c0ca54bc1ea90ac0d507274c28abcc4f691ae8b4eaa375087c76a"
+checksum = "1ceeb589a3157cac0ab8cc585feb749bd2cea5cb55a6ee802ad72d9fd38303da"
 dependencies = [
  "futures-core",
  "futures-sink",
  "nanorand",
  "pin-project",
- "spin 0.9.2",
+ "spin 0.9.4",
 ]
 
 [[package]]
@@ -1106,7 +1102,7 @@ dependencies = [
  "futures-io",
  "memchr",
  "parking",
- "pin-project-lite 0.2.8",
+ "pin-project-lite 0.2.9",
  "waker-fn",
 ]
 
@@ -1146,7 +1142,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.8",
+ "pin-project-lite 0.2.9",
  "pin-utils",
  "slab",
 ]
@@ -1192,14 +1188,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -1243,9 +1239,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d12a7f4e95cfe710f1d624fb1210b7d961a5fb05c4fd942f4feab06e61f590e"
+checksum = "5fb7d06c1c8cc2a29bee7ec961009a0b2caa0793ee4900c2ffb348734ba1c8f9"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1261,9 +1257,9 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "607c8a29735385251a339424dd462993c0fed8fa09d378f259377df08c126022"
 
 [[package]]
 name = "hermit-abi"
@@ -1331,24 +1327,23 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
+checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.1",
+ "itoa 1.0.2",
 ]
 
 [[package]]
 name = "http-client"
-version = "6.5.1"
+version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea880b03c18a7e981d7fb3608b8904a98425d53c440758fcebf7d934aa56547c"
+checksum = "1947510dc91e2bf586ea5ffb412caad7673264e14bb39fb9078da114a94ce1a5"
 dependencies = [
  "async-trait",
  "cfg-if 1.0.0",
- "dashmap",
  "http-types",
  "log",
 ]
@@ -1366,7 +1361,7 @@ dependencies = [
  "cookie",
  "futures-lite",
  "infer",
- "pin-project-lite 0.2.8",
+ "pin-project-lite 0.2.9",
  "rand 0.7.3",
  "serde",
  "serde_json",
@@ -1377,9 +1372,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4"
+checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
 
 [[package]]
 name = "humantime"
@@ -1400,9 +1395,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg 1.1.0",
  "hashbrown",
@@ -1449,15 +1444,15 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "js-sys"
-version = "0.3.56"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
+checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1475,9 +1470,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
+checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
 
 [[package]]
 name = "kv-log-macro"
@@ -1499,9 +1494,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libloading"
@@ -1521,9 +1516,9 @@ checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "lock_api"
@@ -1537,9 +1532,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -1560,9 +1555,9 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
@@ -1575,38 +1570,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.14"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "miow",
- "ntapi",
- "winapi",
-]
-
-[[package]]
-name = "mio"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
-dependencies = [
- "libc",
- "log",
- "miow",
- "ntapi",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1615,7 +1586,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom 0.2.7",
 ]
 
 [[package]]
@@ -1645,15 +1616,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ntapi"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "num-bigint-dig"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1673,9 +1635,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg 1.1.0",
  "num-traits",
@@ -1683,9 +1645,9 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
  "autocfg 1.1.0",
  "num-integer",
@@ -1694,9 +1656,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg 1.1.0",
  "libm",
@@ -1714,9 +1676,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.10.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "oorandom"
@@ -1753,12 +1715,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.0.0"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
+checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
 
 [[package]]
 name = "parking"
@@ -1774,9 +1733,9 @@ checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
 
 [[package]]
 name = "pem"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9a3b09a20e374558580a4914d3b7d89bd61b954a5a5e1dcbea98753addb1947"
+checksum = "03c64931a1a212348ec4f3b4362585eca7159d0d09cbdf4a7f74f02173596fd4"
 dependencies = [
  "base64 0.13.0",
 ]
@@ -1841,9 +1800,9 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
+checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -1851,18 +1810,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
+checksum = "78203e83c48cffbe01e4a2d35d566ca4de445d79a85372fc64e378bfc812a260"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
+checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1877,9 +1836,9 @@ checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "pin-utils"
@@ -1913,9 +1872,9 @@ dependencies = [
 
 [[package]]
 name = "plotters"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
+checksum = "9428003b84df1496fb9d6eeee9c5f8145cb41ca375eb0dad204328888832811f"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -1926,15 +1885,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
+checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
+checksum = "e0918736323d1baff32ee0eade54984f6f201ad7e97d5cfb5d6ab4a358529615"
 dependencies = [
  "plotters-backend",
 ]
@@ -2065,18 +2024,18 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quinn"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d147472bc9a09f13b06c044787b6683cdffa02e2865b7f0fb53d67c49ed2988e"
+checksum = "d7542006acd6e057ff632307d219954c44048f818898da03113d6c0086bfddd9"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2084,7 +2043,7 @@ dependencies = [
  "fxhash",
  "quinn-proto",
  "quinn-udp",
- "rustls 0.20.4",
+ "rustls 0.20.6",
  "thiserror",
  "tokio",
  "tracing",
@@ -2093,15 +2052,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "359c5eb33845f3ee05c229e65f87cdbc503eea394964b8f1330833d460b4ff3e"
+checksum = "3a13a5c0a674c1ce7150c9df7bc4a1e46c2fbbe7c710f56c0dc78b1a810e779e"
 dependencies = [
  "bytes",
  "fxhash",
  "rand 0.8.5",
  "ring",
- "rustls 0.20.4",
+ "rustls 0.20.6",
  "rustls-native-certs",
  "rustls-pemfile 0.2.1",
  "slab",
@@ -2113,13 +2072,12 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df185e5e5f7611fa6e628ed8f9633df10114b03bbaecab186ec55822c44ac727"
+checksum = "b3149f7237331015f1a6adf065c397d1be71e032fcf110ba41da52e7926b882f"
 dependencies = [
  "futures-util",
  "libc",
- "mio 0.7.14",
  "quinn-proto",
  "socket2",
  "tokio",
@@ -2128,9 +2086,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.17"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
+checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
 ]
@@ -2194,7 +2152,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom 0.2.7",
 ]
 
 [[package]]
@@ -2208,9 +2166,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 dependencies = [
  "autocfg 1.1.0",
  "crossbeam-deque",
@@ -2220,14 +2178,13 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "lazy_static",
  "num_cpus",
 ]
 
@@ -2258,16 +2215,16 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom 0.2.7",
  "redox_syscall",
  "thiserror",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.5"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2282,9 +2239,9 @@ checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "ring"
@@ -2342,7 +2299,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.7",
+ "semver 1.0.12",
 ]
 
 [[package]]
@@ -2360,9 +2317,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.4"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbfeb8d0ddb84706bc597a5574ab8912817c52a397f819e5b614e2265206921"
+checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
 dependencies = [
  "log",
  "ring",
@@ -2372,12 +2329,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca9ebdfa27d3fc180e42879037b5338ab1c040c06affd00d8338598e7800943"
+checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 0.2.1",
+ "rustls-pemfile 1.0.0",
  "schannel",
  "security-framework",
 ]
@@ -2401,10 +2358,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.9"
+name = "rustls-pemfile"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+checksum = "e7522c9de787ff061458fe9a829dc790a3f5b22dc571694fc5883f448b94d9a9"
+dependencies = [
+ "base64 0.13.0",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
 name = "same-file"
@@ -2417,12 +2383,12 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
 dependencies = [
  "lazy_static",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2485,9 +2451,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.7"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
+checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
 
 [[package]]
 name = "semver-parser"
@@ -2497,9 +2463,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
 dependencies = [
  "serde_derive",
 ]
@@ -2516,9 +2482,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2536,11 +2502,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.79"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
- "itoa 1.0.1",
+ "itoa 1.0.2",
  "ryu",
  "serde",
 ]
@@ -2563,16 +2529,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.1",
+ "itoa 1.0.2",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.23"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a521f2940385c165a24ee286aa8599633d162077a54bdcae2a6fd5a7bfa7a0"
+checksum = "1ec0091e1f5aa338283ce049bd9dfefd55e1f168ac233e85c1ffe0038fb48cbe"
 dependencies = [
  "indexmap",
  "ryu",
@@ -2667,9 +2633,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "647c97df271007dcea485bb74ffdb57f2e683f1306c854f468a0c244badabf2d"
+checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -2701,9 +2667,9 @@ checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "socket2"
@@ -2723,9 +2689,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
+checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
 dependencies = [
  "lock_api",
 ]
@@ -2806,7 +2772,7 @@ dependencies = [
  "async-channel",
  "cfg-if 1.0.0",
  "futures-core",
- "pin-project-lite 0.2.8",
+ "pin-project-lite 0.2.9",
 ]
 
 [[package]]
@@ -2838,13 +2804,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.91"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2885,18 +2851,18 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2920,7 +2886,7 @@ dependencies = [
  "http-types",
  "kv-log-macro",
  "log",
- "pin-project-lite 0.2.8",
+ "pin-project-lite 0.2.9",
  "route-recognizer",
  "serde",
  "serde_json",
@@ -2928,11 +2894,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -2986,9 +2953,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3001,16 +2968,18 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.17.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
+checksum = "57aec3cfa4c296db7255446efb4928a6be304b431a806216105542a67b6ca82e"
 dependencies = [
+ "autocfg 1.1.0",
  "bytes",
  "libc",
  "memchr",
- "mio 0.8.2",
+ "mio",
  "num_cpus",
- "pin-project-lite 0.2.8",
+ "once_cell",
+ "pin-project-lite 0.2.9",
  "socket2",
  "tokio-macros",
  "winapi",
@@ -3018,9 +2987,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3029,9 +2998,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06cda1232a49558c46f8a504d5b93101d42c0bf7f911f12a105ba48168f821ae"
+checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
 dependencies = [
  "futures-util",
  "log",
@@ -3041,21 +3010,21 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.32"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1bdf54a7c28a2bbf701e1d2233f6c77f473486b94bee4f9678da5a148dca7f"
+checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
 dependencies = [
  "cfg-if 1.0.0",
- "pin-project-lite 0.2.8",
+ "pin-project-lite 0.2.9",
  "tracing-attributes",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.20"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
+checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3064,18 +3033,18 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.24"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90442985ee2f57c9e1b548ee72ae842f4a9a20e3f417cc38dbc5dc684d9bb4ee"
+checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
 dependencies = [
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
 name = "tungstenite"
-version = "0.17.2"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96a2dea40e7570482f28eb57afbe42d97551905da6a9400acc5c328d24004f5"
+checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
 dependencies = [
  "base64 0.13.0",
  "byteorder",
@@ -3098,9 +3067,9 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+checksum = "89570599c4fe5585de2b388aab47e99f7fa4e9238a1399f707a02e356058141c"
 
 [[package]]
 name = "uhlc"
@@ -3118,15 +3087,21 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
 dependencies = [
  "tinyvec",
 ]
@@ -3139,9 +3114,9 @@ checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "universal-hash"
@@ -3195,7 +3170,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom 0.2.7",
 ]
 
 [[package]]
@@ -3224,9 +3199,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79923f7731dc61ebfba3633098bf3ac533bbd35ccd8c57e7088d9a5eebe0263f"
+checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
 dependencies = [
  "ctor",
  "erased-serde",
@@ -3273,9 +3248,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -3285,9 +3260,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.79"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
+checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -3297,9 +3272,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.79"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
+checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3312,9 +3287,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.29"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395"
+checksum = "de9a9cec1733468a8c657e57fa2413d2ae2c0129b95e87c5b72b8ace4d13f31f"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3324,9 +3299,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.79"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
+checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3334,9 +3309,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.79"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
+checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3347,15 +3322,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.79"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
+checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
 
 [[package]]
 name = "web-sys"
-version = "0.3.56"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
+checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3420,6 +3395,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "yaml-rust"
@@ -3643,7 +3661,7 @@ dependencies = [
  "futures",
  "log",
  "quinn",
- "rustls 0.20.4",
+ "rustls 0.20.6",
  "rustls-native-certs",
  "rustls-pemfile 0.3.0",
  "webpki 0.22.0",
@@ -3923,7 +3941,7 @@ name = "zenohd"
 version = "0.6.0-dev.0"
 dependencies = [
  "async-std",
- "clap 3.1.8",
+ "clap 3.2.11",
  "env_logger",
  "futures",
  "git-version",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
   "commons/zenoh-sync",
   "commons/zenoh-util",
   "commons/zenoh-macros",
+  "commons/zenoh-async-rt",
   "io/zenoh-link-commons",
   "io/zenoh-links/zenoh-link-udp/",
   "io/zenoh-links/zenoh-link-tcp/",

--- a/commons/zenoh-async-rt/Cargo.toml
+++ b/commons/zenoh-async-rt/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "zenoh-async-rt"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+async-std = { version = "=1.11.0", features = ["attributes", "unstable"] }
+futures = "0.3.21"

--- a/commons/zenoh-async-rt/src/lib.rs
+++ b/commons/zenoh-async-rt/src/lib.rs
@@ -1,0 +1,26 @@
+use std::future::Future;
+
+pub use async_std::{self, main, test};
+
+pub use spawn::*;
+mod spawn;
+
+pub use task::*;
+mod task;
+
+pub use time::*;
+mod time;
+
+pub use sleep::*;
+mod sleep;
+
+pub fn block_on<F, T>(future: F) -> T
+where
+    F: Future<Output = T>,
+{
+    async_std::task::block_on(future)
+}
+
+pub async fn yield_now() {
+    async_std::task::yield_now().await
+}

--- a/commons/zenoh-async-rt/src/sleep.rs
+++ b/commons/zenoh-async-rt/src/sleep.rs
@@ -1,0 +1,10 @@
+use std::time::{Duration, Instant};
+
+pub async fn sleep(dur: Duration) {
+    async_std::task::sleep(dur).await;
+}
+
+pub async fn sleep_until(deadline: Instant) {
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    sleep(remaining).await;
+}

--- a/commons/zenoh-async-rt/src/spawn.rs
+++ b/commons/zenoh-async-rt/src/spawn.rs
@@ -1,0 +1,45 @@
+use futures::FutureExt;
+use std::fmt;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+pub fn spawn<F, T>(future: F) -> JoinHandle<T>
+where
+    F: Future<Output = T> + Send + 'static,
+    T: Send + 'static,
+{
+    JoinHandle(async_std::task::spawn(future))
+}
+
+pub fn spawn_blocking<F, T>(f: F) -> JoinHandle<T>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    JoinHandle(async_std::task::spawn_blocking(f))
+}
+
+pub struct JoinHandle<T>(async_std::task::JoinHandle<T>);
+
+impl<T> JoinHandle<T> {
+    pub async fn cancel(self) -> Option<T> {
+        self.0.cancel().await
+    }
+}
+
+impl<T> fmt::Debug for JoinHandle<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("JoinHandle").finish()
+    }
+}
+
+impl<T> Future for JoinHandle<T> {
+    type Output = T;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.0.poll_unpin(cx)
+    }
+}

--- a/commons/zenoh-async-rt/src/task.rs
+++ b/commons/zenoh-async-rt/src/task.rs
@@ -1,0 +1,34 @@
+use std::fmt;
+
+pub fn current() -> Task {
+    let task = async_std::task::current();
+    Task { inner: task }
+}
+
+#[derive(Debug, Clone)]
+pub struct Task {
+    inner: async_std::task::Task,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TaskId {
+    inner: async_std::task::TaskId,
+}
+
+impl fmt::Display for TaskId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+impl Task {
+    pub fn id(&self) -> TaskId {
+        TaskId {
+            inner: self.inner.id(),
+        }
+    }
+
+    pub fn name(&self) -> Option<&str> {
+        self.inner.name()
+    }
+}

--- a/commons/zenoh-async-rt/src/time.rs
+++ b/commons/zenoh-async-rt/src/time.rs
@@ -1,0 +1,23 @@
+use std::{fmt, time::Duration};
+
+use futures::Future;
+
+pub async fn timeout<F, T>(dur: Duration, f: F) -> Result<T, TimeoutError>
+where
+    F: Future<Output = T>,
+{
+    async_std::future::timeout(dur, f)
+        .await
+        .map_err(|err| TimeoutError { inner: err })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TimeoutError {
+    inner: async_std::future::TimeoutError,
+}
+
+impl fmt::Display for TimeoutError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}

--- a/commons/zenoh-collections/Cargo.toml
+++ b/commons/zenoh-collections/Cargo.toml
@@ -34,3 +34,4 @@ async-trait = "0.1.42"
 async-std = { version = "=1.11.0", features = ["unstable"] }
 flume = "0.10.5"
 log = "0.4.14"
+zenoh-async-rt = { version = "0.1.0", path = "../zenoh-async-rt" }

--- a/commons/zenoh-collections/src/object_pool.rs
+++ b/commons/zenoh-collections/src/object_pool.rs
@@ -12,10 +12,10 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use super::LifoQueue;
-use async_std::task;
 use std::fmt;
 use std::ops::{Deref, DerefMut, Drop};
 use std::sync::{Arc, Weak};
+use zenoh_async_rt::block_on;
 
 /// Provides a pool of pre-allocated s that are automaticlaly reinserted into
 /// the pool when dropped.
@@ -109,7 +109,7 @@ impl<T> Drop for RecyclingObject<T> {
     fn drop(&mut self) {
         if let Some(pool) = self.pool.upgrade() {
             if let Some(obj) = self.object.take() {
-                task::block_on(pool.push(obj));
+                block_on(pool.push(obj));
             }
         }
     }

--- a/commons/zenoh-sync/Cargo.toml
+++ b/commons/zenoh-sync/Cargo.toml
@@ -34,6 +34,4 @@ event-listener = "2.5.1"
 flume = "0.10.5"
 futures = "0.3.21"
 tokio = { version = "1.17.0", features = ["sync"] }
-
-[dev-dependencies]
-async-std = { version = "=1.11.0", features = ["unstable", "attributes"] }
+zenoh-async-rt = { path = "../zenoh-async-rt" }

--- a/commons/zenoh-sync/src/backoff.rs
+++ b/commons/zenoh-sync/src/backoff.rs
@@ -11,9 +11,9 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use async_std::task;
 use std::fmt;
 use std::hint::spin_loop;
+use zenoh_async_rt::yield_now;
 
 const SPIN_LIMIT: usize = 6;
 const YIELD_LIMIT: usize = 10;
@@ -56,7 +56,7 @@ impl Backoff {
                 spin_loop();
             }
         } else {
-            task::yield_now().await;
+            yield_now().await;
         }
 
         if self.step <= YIELD_LIMIT {

--- a/commons/zenoh-sync/src/lib.rs
+++ b/commons/zenoh-sync/src/lib.rs
@@ -15,6 +15,7 @@ use futures::FutureExt;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use zenoh_async_rt::block_on;
 
 pub mod backoff;
 pub use backoff::*;
@@ -112,7 +113,7 @@ impl<T> Future for ZPinBoxFuture<T> {
 impl<T> ZFuture for ZPinBoxFuture<T> {
     #[inline]
     fn wait(self) -> T {
-        async_std::task::block_on(self.0)
+        block_on(self.0)
     }
 }
 
@@ -151,7 +152,7 @@ macro_rules! derive_zfuture{
             type Output = <Self as Runnable>::Output;
 
             #[inline]
-            fn poll(mut self: std::pin::Pin<&mut Self>, _cx: &mut async_std::task::Context<'_>) -> std::task::Poll<<Self as ::std::future::Future>::Output> {
+            fn poll(mut self: std::pin::Pin<&mut Self>, _cx: &mut ::std::task::Context<'_>) -> ::std::task::Poll<<Self as ::std::future::Future>::Output> {
                 std::task::Poll::Ready(self.run())
             }
         }

--- a/commons/zenoh-sync/src/mvar.rs
+++ b/commons/zenoh-sync/src/mvar.rs
@@ -95,9 +95,9 @@ mod tests {
     fn mvar() {
         use super::Mvar;
         use async_std::prelude::FutureExt;
-        use async_std::task;
         use std::sync::Arc;
         use std::time::Duration;
+        use zenoh_async_rt::{block_on, spawn};
 
         const TIMEOUT: Duration = Duration::from_secs(60);
 
@@ -105,21 +105,21 @@ mod tests {
         let mvar: Arc<Mvar<usize>> = Arc::new(Mvar::new());
 
         let c_mvar = mvar.clone();
-        let ch = task::spawn(async move {
+        let ch = spawn(async move {
             for _ in 0..count {
                 let n = c_mvar.take().await;
                 print!("-{} ", n);
             }
         });
 
-        let ph = task::spawn(async move {
+        let ph = spawn(async move {
             for i in 0..count {
                 mvar.put(i).await;
                 print!("+{} ", i);
             }
         });
 
-        task::block_on(async {
+        block_on(async {
             ph.timeout(TIMEOUT).await.unwrap();
             ch.timeout(TIMEOUT).await.unwrap();
         });

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -49,6 +49,7 @@ log = "0.4"
 
 [dev-dependencies]
 rand = "0.8.3"
+zenoh-async-rt = { version = "0.1.0", path = "../commons/zenoh-async-rt" }
 
 [build-dependencies]
 rustc_version = "0.4.0"

--- a/examples/examples/z_delete.rs
+++ b/examples/examples/z_delete.rs
@@ -14,7 +14,7 @@
 use clap::{App, Arg};
 use zenoh::config::Config;
 
-#[async_std::main]
+#[zenoh_async_rt::main]
 async fn main() {
     // initiate logging
     env_logger::init();

--- a/examples/examples/z_eval.rs
+++ b/examples/examples/z_eval.rs
@@ -11,7 +11,6 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use async_std::task::sleep;
 use clap::{App, Arg};
 use futures::prelude::*;
 use futures::select;
@@ -19,8 +18,9 @@ use std::time::Duration;
 use zenoh::config::Config;
 use zenoh::prelude::*;
 use zenoh::queryable::EVAL;
+use zenoh_async_rt::sleep;
 
-#[async_std::main]
+#[zenoh_async_rt::main]
 async fn main() {
     // initiate logging
     env_logger::init();

--- a/examples/examples/z_forward.rs
+++ b/examples/examples/z_forward.rs
@@ -14,7 +14,7 @@
 use clap::{App, Arg};
 use zenoh::config::Config;
 
-#[async_std::main]
+#[zenoh_async_rt::main]
 async fn main() {
     // Initiate logging
     env_logger::init();

--- a/examples/examples/z_get.rs
+++ b/examples/examples/z_get.rs
@@ -18,7 +18,7 @@ use zenoh::prelude::*;
 use zenoh::query::*;
 use zenoh::queryable;
 
-#[async_std::main]
+#[zenoh_async_rt::main]
 async fn main() {
     // initiate logging
     env_logger::init();

--- a/examples/examples/z_info.rs
+++ b/examples/examples/z_info.rs
@@ -14,7 +14,7 @@
 use clap::{App, Arg};
 use zenoh::{config::Config, prelude::*};
 
-#[async_std::main]
+#[zenoh_async_rt::main]
 async fn main() {
     // initiate logging
     env_logger::init();

--- a/examples/examples/z_pub.rs
+++ b/examples/examples/z_pub.rs
@@ -11,12 +11,12 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use async_std::task::sleep;
 use clap::{App, Arg};
 use std::time::Duration;
 use zenoh::config::Config;
+use zenoh_async_rt::sleep;
 
-#[async_std::main]
+#[zenoh_async_rt::main]
 async fn main() {
     // Initiate logging
     env_logger::init();

--- a/examples/examples/z_pub_shm.rs
+++ b/examples/examples/z_pub_shm.rs
@@ -11,16 +11,16 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use async_std::task::sleep;
 use clap::{App, Arg};
 use std::time::Duration;
 use zenoh::buf::SharedMemoryManager;
 use zenoh::config::Config;
+use zenoh_async_rt::{block_on, sleep, spawn, spawn_blocking, JoinHandle};
 
 const N: usize = 10;
 const K: u32 = 3;
 
-#[async_std::main]
+#[zenoh_async_rt::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Initiate logging
     env_logger::init();

--- a/examples/examples/z_pub_shm_thr.rs
+++ b/examples/examples/z_pub_shm_thr.rs
@@ -16,7 +16,7 @@ use zenoh::buf::SharedMemoryManager;
 use zenoh::config::Config;
 use zenoh::publication::CongestionControl;
 
-#[async_std::main]
+#[zenoh_async_rt::main]
 async fn main() {
     // initiate logging
     env_logger::init();

--- a/examples/examples/z_pull.rs
+++ b/examples/examples/z_pull.rs
@@ -11,7 +11,6 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use async_std::task::sleep;
 use clap::{App, Arg};
 use futures::prelude::*;
 use futures::select;
@@ -19,8 +18,9 @@ use std::time::Duration;
 use zenoh::config::Config;
 use zenoh::prelude::*;
 use zenoh::subscriber::SubMode;
+use zenoh_async_rt::sleep;
 
-#[async_std::main]
+#[zenoh_async_rt::main]
 async fn main() {
     // initiate logging
     env_logger::init();

--- a/examples/examples/z_put.rs
+++ b/examples/examples/z_put.rs
@@ -14,7 +14,7 @@
 use clap::{App, Arg};
 use zenoh::config::Config;
 
-#[async_std::main]
+#[zenoh_async_rt::main]
 async fn main() {
     // initiate logging
     env_logger::init();

--- a/examples/examples/z_put_float.rs
+++ b/examples/examples/z_put_float.rs
@@ -14,7 +14,7 @@
 use clap::{App, Arg};
 use zenoh::config::Config;
 
-#[async_std::main]
+#[zenoh_async_rt::main]
 async fn main() {
     // initiate logging
     env_logger::init();

--- a/examples/examples/z_scout.rs
+++ b/examples/examples/z_scout.rs
@@ -15,8 +15,9 @@ use async_std::prelude::FutureExt;
 use futures::stream::StreamExt;
 use zenoh::config::Config;
 use zenoh::scouting::WhatAmI;
+use zenoh_async_rt::sleep;
 
-#[async_std::main]
+#[zenoh_async_rt::main]
 async fn main() {
     // initiate logging
     env_logger::init();
@@ -31,7 +32,7 @@ async fn main() {
             println!("{}", hello);
         }
     };
-    let timeout = async_std::task::sleep(std::time::Duration::from_secs(1));
+    let timeout = sleep(std::time::Duration::from_secs(1));
 
     scout.race(timeout).await;
 

--- a/examples/examples/z_storage.rs
+++ b/examples/examples/z_storage.rs
@@ -13,7 +13,6 @@
 //
 #![recursion_limit = "256"]
 
-use async_std::task::sleep;
 use clap::{App, Arg};
 use futures::prelude::*;
 use futures::select;
@@ -23,8 +22,9 @@ use zenoh::config::Config;
 use zenoh::prelude::*;
 use zenoh::queryable::STORAGE;
 use zenoh::utils::key_expr;
+use zenoh_async_rt::sleep;
 
-#[async_std::main]
+#[zenoh_async_rt::main]
 async fn main() {
     // initiate logging
     env_logger::init();

--- a/examples/examples/z_sub.rs
+++ b/examples/examples/z_sub.rs
@@ -11,15 +11,15 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use async_std::task::sleep;
 use clap::{App, Arg};
 use futures::prelude::*;
 use futures::select;
 use std::time::Duration;
 use zenoh::config::Config;
 use zenoh::prelude::*;
+use zenoh_async_rt::sleep;
 
-#[async_std::main]
+#[zenoh_async_rt::main]
 async fn main() {
     // Initiate logging
     env_logger::init();

--- a/io/zenoh-link/src/lib.rs
+++ b/io/zenoh-link/src/lib.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 //
 // Copyright (c) 2022 ZettaScale Technology
 //
@@ -12,6 +11,8 @@ use std::collections::HashMap;
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
+use std::collections::HashMap;
+
 #[allow(unused_imports)]
 use std::sync::Arc;
 

--- a/io/zenoh-links/zenoh-link-quic/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-quic/Cargo.toml
@@ -52,3 +52,4 @@ rustls-native-certs = "0.6.1"
 rustls-pemfile = "0.3.0"
 webpki = { version = "0.22.0", features = ["std"] }
 futures = "0.3.21"
+zenoh-async-rt = { version = "0.1.0", path = "../../../commons/zenoh-async-rt" }

--- a/io/zenoh-links/zenoh-link-quic/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/unicast.rs
@@ -19,8 +19,6 @@ use crate::{
 use async_std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use async_std::prelude::FutureExt;
 use async_std::sync::Mutex as AsyncMutex;
-use async_std::task;
-use async_std::task::JoinHandle;
 use async_trait::async_trait;
 use futures::stream::StreamExt;
 use std::collections::HashMap;
@@ -30,6 +28,7 @@ use std::net::IpAddr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
+use zenoh_async_rt::{sleep, spawn, JoinHandle};
 use zenoh_core::{bail, Result as ZResult};
 use zenoh_core::{zasynclock, zerror, zread, zwrite};
 use zenoh_link_commons::{
@@ -395,7 +394,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastQuic {
         let c_manager = self.manager.clone();
         let c_listeners = self.listeners.clone();
         let c_addr = local_addr;
-        let handle = task::spawn(async move {
+        let handle = spawn(async move {
             // Wait for the accept loop to terminate
             let res = accept_task(quic_endpoint, acceptor, c_active, c_signal, c_manager).await;
             zwrite!(c_listeners).remove(&c_addr);
@@ -540,7 +539,7 @@ async fn accept_task(
                 //       Linux systems this limit can be changed by using the "ulimit" command line
                 //       tool. In case of systemd-based systems, this can be changed by using the
                 //       "sysctl" command line tool.
-                task::sleep(Duration::from_micros(*QUIC_ACCEPT_THROTTLE_TIME)).await;
+                sleep(Duration::from_micros(*QUIC_ACCEPT_THROTTLE_TIME)).await;
                 continue;
             }
         };

--- a/io/zenoh-links/zenoh-link-tcp/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-tcp/Cargo.toml
@@ -41,3 +41,4 @@ zenoh-link-commons = { path = "../../zenoh-link-commons/" }
 async-std = { version = "=1.11.0", default-features = false }
 async-trait = "0.1.42"
 log = "0.4"
+zenoh-async-rt = { version = "0.1.0", path = "../../../commons/zenoh-async-rt" }

--- a/io/zenoh-links/zenoh-link-tls/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-tls/Cargo.toml
@@ -45,3 +45,4 @@ async-std = { version = "=1.11.0", default-features = false }
 async-trait = "0.1.42"
 log = "0.4"
 futures = "0.3.21"
+zenoh-async-rt = { version = "0.1.0", path = "../../../commons/zenoh-async-rt" }

--- a/io/zenoh-links/zenoh-link-udp/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-udp/Cargo.toml
@@ -43,3 +43,4 @@ async-std = { version = "=1.11.0", default-features = false }
 async-trait = "0.1.42"
 log = "0.4"
 socket2 = "0.4.0"
+zenoh-async-rt = { version = "0.1.0", path = "../../../commons/zenoh-async-rt" }

--- a/io/zenoh-links/zenoh-link-udp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/unicast.rs
@@ -14,14 +14,13 @@
 use async_std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket};
 use async_std::prelude::*;
 use async_std::sync::Mutex as AsyncMutex;
-use async_std::task;
-use async_std::task::JoinHandle;
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock, Weak};
 use std::time::Duration;
+use zenoh_async_rt::{sleep, spawn, JoinHandle};
 use zenoh_collections::{RecyclingObject, RecyclingObjectPool};
 use zenoh_core::Result as ZResult;
 use zenoh_core::{bail, zasynclock, zerror, zlock, zread, zwrite};
@@ -359,7 +358,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastUdp {
         let c_manager = self.manager.clone();
         let c_listeners = self.listeners.clone();
         let c_addr = local_addr;
-        let handle = task::spawn(async move {
+        let handle = spawn(async move {
             // Wait for the accept loop to terminate
             let res = accept_read_task(socket, c_active, c_signal, c_manager).await;
             zwrite!(c_listeners).remove(&c_addr);
@@ -520,7 +519,7 @@ async fn accept_read_task(
                 //       Linux systems this limit can be changed by using the "ulimit" command line
                 //       tool. In case of systemd-based systems, this can be changed by using the
                 //       "sysctl" command line tool.
-                task::sleep(Duration::from_micros(*UDP_ACCEPT_THROTTLE_TIME)).await;
+                sleep(Duration::from_micros(*UDP_ACCEPT_THROTTLE_TIME)).await;
                 continue;
             }
         };

--- a/io/zenoh-links/zenoh-link-unixsock_stream/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-unixsock_stream/Cargo.toml
@@ -44,3 +44,4 @@ log = "0.4"
 nix = { version = "0.23.0" }
 uuid = { version = "0.8.2", features = ["v4"] }
 futures = "0.3.21"
+zenoh-async-rt = { version = "0.1.0", path = "../../../commons/zenoh-async-rt" }

--- a/io/zenoh-links/zenoh-link-ws/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-ws/Cargo.toml
@@ -48,3 +48,4 @@ async-trait = "0.1.42"
 log = "0.4"
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 url = "2.2.2"
+zenoh-async-rt = { version = "0.1.0", path = "../../../commons/zenoh-async-rt" }

--- a/io/zenoh-transport/Cargo.toml
+++ b/io/zenoh-transport/Cargo.toml
@@ -70,6 +70,7 @@ paste = "1.0"
 rand = "0.8.3"
 rsa = { version = "0.5.0", optional = true }
 serde = "1.0.123"
+zenoh-async-rt = { version = "0.1.0", path = "../../commons/zenoh-async-rt" }
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/io/zenoh-transport/src/manager.rs
+++ b/io/zenoh-transport/src/manager.rs
@@ -31,6 +31,7 @@ use std::sync::Arc;
 #[cfg(feature = "shared-memory")]
 use std::sync::RwLock;
 use std::time::Duration;
+use zenoh_async_rt::{block_on, spawn};
 use zenoh_cfg_properties::{config::*, Properties};
 use zenoh_config::{Config, QueueConf, QueueSizeConf};
 use zenoh_core::Result as ZResult;
@@ -319,7 +320,7 @@ impl TransportExecutor {
         for _ in 0..num_threads {
             let exec = executor.clone();
             let recv = receiver.clone();
-            std::thread::spawn(move || async_std::task::block_on(exec.run(recv.recv())));
+            std::thread::spawn(move || block_on(exec.run(recv.recv())));
         }
         Self { executor, sender }
     }
@@ -374,7 +375,7 @@ impl TransportManager {
         };
 
         // @TODO: this should be moved into the unicast module
-        async_std::task::spawn({
+        spawn({
             let this = this.clone();
             async move {
                 while let Ok(link) = new_unicast_link_receiver.recv_async().await {

--- a/io/zenoh-transport/src/multicast/manager.rs
+++ b/io/zenoh-transport/src/multicast/manager.rs
@@ -17,6 +17,7 @@ use crate::TransportManager;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+use zenoh_async_rt::block_on;
 use zenoh_config::{Config, ZN_LINK_KEEP_ALIVE_DEFAULT, ZN_LINK_LEASE_DEFAULT};
 use zenoh_core::{bail, Result as ZResult};
 use zenoh_core::{zerror, zlock, zparse};
@@ -124,7 +125,7 @@ impl Default for TransportManagerBuilderMulticast {
             max_sessions: 0,
             is_qos: false,
         };
-        async_std::task::block_on(tmb.from_config(&Config::default())).unwrap()
+        block_on(tmb.from_config(&Config::default())).unwrap()
     }
 }
 

--- a/io/zenoh-transport/src/unicast/link.rs
+++ b/io/zenoh-transport/src/unicast/link.rs
@@ -20,10 +20,9 @@ use super::TransportUnicastStatsAtomic;
 use crate::common::pipeline::TransmissionPipelineConf;
 use crate::TransportExecutor;
 use async_std::prelude::FutureExt;
-use async_std::task;
-use async_std::task::JoinHandle;
 use std::sync::Arc;
 use std::time::Duration;
+use zenoh_async_rt::{spawn, JoinHandle};
 use zenoh_buffers::buffer::InsertBuffer;
 use zenoh_buffers::reader::{HasReader, Reader};
 use zenoh_collections::RecyclingObjectPool;
@@ -103,7 +102,7 @@ impl TransportLinkUnicast {
                     log::debug!("{}", e);
                     // Spawn a task to avoid a deadlock waiting for this same task
                     // to finish in the close() joining its handle
-                    task::spawn(async move { c_transport.del_link(&c_link).await });
+                    spawn(async move { c_transport.del_link(&c_link).await });
                 }
             });
             self.handle_tx = Some(Arc::new(handle));
@@ -124,7 +123,7 @@ impl TransportLinkUnicast {
             let c_signal = self.signal_rx.clone();
             let c_rx_buffer_size = self.transport.config.manager.config.link_rx_buffer_size;
 
-            let handle = task::spawn(async move {
+            let handle = spawn(async move {
                 // Start the consume task
                 let res = rx_task(
                     c_link.clone(),
@@ -139,7 +138,7 @@ impl TransportLinkUnicast {
                     log::debug!("{}", e);
                     // Spawn a task to avoid a deadlock waiting for this same task
                     // to finish in the close() joining its handle
-                    task::spawn(async move { c_transport.del_link(&c_link).await });
+                    spawn(async move { c_transport.del_link(&c_link).await });
                 }
             });
             self.handle_rx = Some(Arc::new(handle));

--- a/io/zenoh-transport/src/unicast/manager.rs
+++ b/io/zenoh-transport/src/unicast/manager.rs
@@ -20,10 +20,10 @@ use crate::unicast::{
 use crate::TransportManager;
 use async_std::prelude::FutureExt;
 use async_std::sync::{Mutex as AsyncMutex, RwLock as AsyncRwLock};
-use async_std::task;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+use zenoh_async_rt::spawn;
 use zenoh_cfg_properties::config::*;
 use zenoh_config::Config;
 use zenoh_core::{
@@ -558,7 +558,7 @@ impl TransportManager {
 
         // Spawn a task to accept the link
         let c_manager = self.clone();
-        task::spawn(async move {
+        spawn(async move {
             let mut auth_link = AuthenticatedPeerLink {
                 src: link.get_src().to_owned(),
                 dst: link.get_dst().to_owned(),

--- a/io/zenoh-transport/src/unicast/rx.rs
+++ b/io/zenoh-transport/src/unicast/rx.rs
@@ -19,8 +19,8 @@ use super::protocol::proto::{
     Close, Frame, FramePayload, KeepAlive, TransportBody, TransportMessage, ZenohMessage,
 };
 use super::transport::TransportUnicastInner;
-use async_std::task;
 use std::sync::MutexGuard;
+use zenoh_async_rt::spawn;
 #[cfg(feature = "stats")]
 use zenoh_buffers::SplitBuffer;
 use zenoh_core::{bail, zerror, zlock, zread, Result as ZResult};
@@ -105,7 +105,7 @@ impl TransportUnicastInner {
         let c_link = link.clone();
         // Spawn a task to avoid a deadlock waiting for this same task
         // to finish in the link close() joining the rx handle
-        task::spawn(async move {
+        spawn(async move {
             if link_only {
                 let _ = c_transport.del_link(&c_link).await;
             } else {

--- a/io/zenoh-transport/tests/endpoints.rs
+++ b/io/zenoh-transport/tests/endpoints.rs
@@ -12,10 +12,10 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use async_std::prelude::FutureExt;
-use async_std::task;
 use std::any::Any;
 use std::sync::Arc;
 use std::time::Duration;
+use zenoh_async_rt::{block_on, sleep};
 use zenoh_core::zasync_executor_init;
 use zenoh_core::Result as ZResult;
 use zenoh_link::{EndPoint, Link};
@@ -92,7 +92,7 @@ async fn run(endpoints: &[EndPoint]) {
             ztimeout!(sm.add_listener(e.clone())).unwrap();
         }
 
-        task::sleep(SLEEP).await;
+        sleep(SLEEP).await;
 
         // Delete the listeners
         for e in endpoints.iter() {
@@ -100,7 +100,7 @@ async fn run(endpoints: &[EndPoint]) {
             ztimeout!(sm.del_listener(e)).unwrap();
         }
 
-        task::sleep(SLEEP).await;
+        sleep(SLEEP).await;
     }
 }
 
@@ -192,7 +192,7 @@ fn endpoint_parsing() {
 #[cfg(feature = "transport_tcp")]
 #[test]
 fn endpoint_tcp() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -202,13 +202,13 @@ fn endpoint_tcp() {
         "tcp/[::1]:9447".parse().unwrap(),
         "tcp/localhost:9448".parse().unwrap(),
     ];
-    task::block_on(run(&endpoints));
+    block_on(run(&endpoints));
 }
 
 #[cfg(feature = "transport_udp")]
 #[test]
 fn endpoint_udp() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -218,13 +218,13 @@ fn endpoint_udp() {
         "udp/[::1]:9447".parse().unwrap(),
         "udp/localhost:9448".parse().unwrap(),
     ];
-    task::block_on(run(&endpoints));
+    block_on(run(&endpoints));
 }
 
 #[cfg(all(feature = "transport_unixsock-stream", target_family = "unix"))]
 #[test]
 fn endpoint_unix() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -240,7 +240,7 @@ fn endpoint_unix() {
             .parse()
             .unwrap(),
     ];
-    task::block_on(run(&endpoints));
+    block_on(run(&endpoints));
     let _ = std::fs::remove_file("zenoh-test-unix-socket-0.sock");
     let _ = std::fs::remove_file("zenoh-test-unix-socket-1.sock");
     let _ = std::fs::remove_file("zenoh-test-unix-socket-0.sock.lock");
@@ -250,7 +250,7 @@ fn endpoint_unix() {
 #[cfg(feature = "transport_ws")]
 #[test]
 fn endpoint_ws() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -260,13 +260,13 @@ fn endpoint_ws() {
         "ws/[::1]:11447".parse().unwrap(),
         "ws/localhost:11448".parse().unwrap(),
     ];
-    task::block_on(run(&endpoints));
+    block_on(run(&endpoints));
 }
 
 #[cfg(all(feature = "transport_tcp", feature = "transport_udp"))]
 #[test]
 fn endpoint_tcp_udp() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -277,7 +277,7 @@ fn endpoint_tcp_udp() {
         "tcp/[::1]:9449".parse().unwrap(),
         "udp/[::1]:9449".parse().unwrap(),
     ];
-    task::block_on(run(&endpoints));
+    block_on(run(&endpoints));
 }
 
 #[cfg(all(
@@ -288,7 +288,7 @@ fn endpoint_tcp_udp() {
 ))]
 #[test]
 fn endpoint_tcp_udp_unix() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -304,7 +304,7 @@ fn endpoint_tcp_udp_unix() {
             .parse()
             .unwrap(),
     ];
-    task::block_on(run(&endpoints));
+    block_on(run(&endpoints));
     let _ = std::fs::remove_file("zenoh-test-unix-socket-2.sock");
     let _ = std::fs::remove_file("zenoh-test-unix-socket-2.sock.lock");
 }
@@ -316,7 +316,7 @@ fn endpoint_tcp_udp_unix() {
 ))]
 #[test]
 fn endpoint_tcp_unix() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -330,7 +330,7 @@ fn endpoint_tcp_unix() {
             .parse()
             .unwrap(),
     ];
-    task::block_on(run(&endpoints));
+    block_on(run(&endpoints));
     let _ = std::fs::remove_file("zenoh-test-unix-socket-3.sock");
     let _ = std::fs::remove_file("zenoh-test-unix-socket-3.sock.lock");
 }
@@ -342,7 +342,7 @@ fn endpoint_tcp_unix() {
 ))]
 #[test]
 fn endpoint_udp_unix() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -356,7 +356,7 @@ fn endpoint_udp_unix() {
             .parse()
             .unwrap(),
     ];
-    task::block_on(run(&endpoints));
+    block_on(run(&endpoints));
     let _ = std::fs::remove_file("zenoh-test-unix-socket-4.sock");
     let _ = std::fs::remove_file("zenoh-test-unix-socket-4.sock.lock");
 }
@@ -366,7 +366,7 @@ fn endpoint_udp_unix() {
 fn endpoint_tls() {
     use zenoh_link::tls::config::*;
 
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -436,7 +436,7 @@ AXVFFIgCSluyrolaD6CWD9MqOex4YOfJR2bNxI7lFvuK4AwjyUJzT1U1HXib17mM
     );
 
     let endpoints = vec![endpoint];
-    task::block_on(run(&endpoints));
+    block_on(run(&endpoints));
 }
 
 #[cfg(feature = "transport_quic")]
@@ -444,7 +444,7 @@ AXVFFIgCSluyrolaD6CWD9MqOex4YOfJR2bNxI7lFvuK4AwjyUJzT1U1HXib17mM
 fn endpoint_quic() {
     use zenoh_link::quic::config::*;
 
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -513,5 +513,5 @@ AXVFFIgCSluyrolaD6CWD9MqOex4YOfJR2bNxI7lFvuK4AwjyUJzT1U1HXib17mM
         .map(|(k, v)| ((*k).to_owned(), (*v).to_owned())),
     );
     let endpoints = vec![endpoint];
-    task::block_on(run(&endpoints));
+    block_on(run(&endpoints));
 }

--- a/io/zenoh-transport/tests/multicast_transport.rs
+++ b/io/zenoh-transport/tests/multicast_transport.rs
@@ -17,11 +17,11 @@
 #[cfg(target_os = "macos")]
 mod tests {
     use async_std::prelude::FutureExt;
-    use async_std::task;
     use std::any::Any;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
+    use zenoh_async_rt::{block_on, sleep};
     use zenoh_cfg_properties::config::*;
     use zenoh_core::zasync_executor_init;
     use zenoh_core::Result as ZResult;
@@ -177,7 +177,7 @@ mod tests {
             .unwrap();
         ztimeout!(async {
             while peer01_transport.get_peers().unwrap().is_empty() {
-                task::sleep(SLEEP_COUNT).await;
+                sleep(SLEEP_COUNT).await;
             }
         });
 
@@ -186,7 +186,7 @@ mod tests {
             .unwrap();
         ztimeout!(async {
             while peer02_transport.get_peers().unwrap().is_empty() {
-                task::sleep(SLEEP_COUNT).await;
+                sleep(SLEEP_COUNT).await;
             }
         });
 
@@ -221,7 +221,7 @@ mod tests {
         assert!(peer02.manager.get_transports_multicast().is_empty());
 
         // Wait a little bit
-        task::sleep(SLEEP).await;
+        sleep(SLEEP).await;
     }
 
     async fn test_transport(
@@ -260,21 +260,21 @@ mod tests {
             Reliability::Reliable => {
                 ztimeout!(async {
                     while peer02.handler.get_count() != MSG_COUNT {
-                        task::sleep(SLEEP_COUNT).await;
+                        sleep(SLEEP_COUNT).await;
                     }
                 });
             }
             Reliability::BestEffort => {
                 ztimeout!(async {
                     while peer02.handler.get_count() == 0 {
-                        task::sleep(SLEEP_COUNT).await;
+                        sleep(SLEEP_COUNT).await;
                     }
                 });
             }
         };
 
         // Wait a little bit
-        task::sleep(SLEEP).await;
+        sleep(SLEEP).await;
     }
 
     async fn run_single(endpoint: &EndPoint, channel: Channel, msg_size: usize) {
@@ -307,7 +307,7 @@ mod tests {
     fn transport_multicast_udp_only() {
         env_logger::init();
 
-        task::block_on(async {
+        block_on(async {
             zasync_executor_init!();
         });
 
@@ -334,6 +334,6 @@ mod tests {
             },
         ];
         // Run
-        task::block_on(run(&endpoints, &channel, &MSG_SIZE_NOFRAG));
+        block_on(run(&endpoints, &channel, &MSG_SIZE_NOFRAG));
     }
 }

--- a/io/zenoh-transport/tests/unicast_authenticator.rs
+++ b/io/zenoh-transport/tests/unicast_authenticator.rs
@@ -12,7 +12,6 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use async_std::prelude::FutureExt;
-use async_std::task;
 #[cfg(feature = "auth_pubkey")]
 use rsa::{BigUint, RsaPrivateKey, RsaPublicKey};
 use std::any::Any;
@@ -22,6 +21,7 @@ use std::collections::HashSet;
 use std::iter::FromIterator;
 use std::sync::Arc;
 use std::time::Duration;
+use zenoh_async_rt::{block_on, sleep};
 use zenoh_core::zasync_executor_init;
 use zenoh_core::Result as ZResult;
 use zenoh_link::{EndPoint, Link};
@@ -369,7 +369,7 @@ async fn authenticator_multilink(endpoint: &EndPoint) {
 
     ztimeout!(async {
         while !router_manager.get_transports().is_empty() {
-            task::sleep(SLEEP).await;
+            sleep(SLEEP).await;
         }
     });
 
@@ -406,7 +406,7 @@ async fn authenticator_multilink(endpoint: &EndPoint) {
 
     ztimeout!(async {
         while !router_manager.get_transports().is_empty() {
-            task::sleep(SLEEP).await;
+            sleep(SLEEP).await;
         }
     });
 
@@ -447,7 +447,7 @@ async fn authenticator_multilink(endpoint: &EndPoint) {
 
     ztimeout!(async {
         while !router_manager.get_transports().is_empty() {
-            task::sleep(SLEEP).await;
+            sleep(SLEEP).await;
         }
     });
 
@@ -488,7 +488,7 @@ async fn authenticator_multilink(endpoint: &EndPoint) {
 
     ztimeout!(async {
         while !router_manager.get_transports().is_empty() {
-            task::sleep(SLEEP).await;
+            sleep(SLEEP).await;
         }
     });
 
@@ -501,7 +501,7 @@ async fn authenticator_multilink(endpoint: &EndPoint) {
 
     ztimeout!(async {
         while !router_manager.get_listeners().is_empty() {
-            task::sleep(SLEEP).await;
+            sleep(SLEEP).await;
         }
     });
 
@@ -510,7 +510,7 @@ async fn authenticator_multilink(endpoint: &EndPoint) {
     ztimeout!(client01_spoof_manager.close());
 
     // Wait a little bit
-    task::sleep(SLEEP).await;
+    sleep(SLEEP).await;
 }
 
 #[cfg(feature = "auth_usrpwd")]
@@ -619,7 +619,7 @@ async fn authenticator_user_password(endpoint: &EndPoint) {
 
     ztimeout!(async {
         while !router_manager.get_transports().is_empty() {
-            task::sleep(SLEEP).await;
+            sleep(SLEEP).await;
         }
     });
 
@@ -672,7 +672,7 @@ async fn authenticator_user_password(endpoint: &EndPoint) {
 
     ztimeout!(async {
         while !router_manager.get_transports().is_empty() {
-            task::sleep(SLEEP).await;
+            sleep(SLEEP).await;
         }
     });
 
@@ -685,12 +685,12 @@ async fn authenticator_user_password(endpoint: &EndPoint) {
 
     ztimeout!(async {
         while !router_manager.get_listeners().is_empty() {
-            task::sleep(SLEEP).await;
+            sleep(SLEEP).await;
         }
     });
 
     // Wait a little bit
-    task::sleep(SLEEP).await;
+    sleep(SLEEP).await;
 }
 
 #[cfg(feature = "shared-memory")]
@@ -752,7 +752,7 @@ async fn authenticator_shared_memory(endpoint: &EndPoint) {
 
     ztimeout!(async {
         while !router_manager.get_transports().is_empty() {
-            task::sleep(SLEEP).await;
+            sleep(SLEEP).await;
         }
     });
 
@@ -765,11 +765,11 @@ async fn authenticator_shared_memory(endpoint: &EndPoint) {
 
     ztimeout!(async {
         while !router_manager.get_listeners().is_empty() {
-            task::sleep(SLEEP).await;
+            sleep(SLEEP).await;
         }
     });
 
-    task::sleep(SLEEP).await;
+    sleep(SLEEP).await;
 }
 
 async fn run(endpoint: &EndPoint) {
@@ -784,40 +784,40 @@ async fn run(endpoint: &EndPoint) {
 #[cfg(feature = "transport_tcp")]
 #[test]
 fn authenticator_tcp() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
     let endpoint: EndPoint = "tcp/127.0.0.1:11447".parse().unwrap();
-    task::block_on(run(&endpoint));
+    block_on(run(&endpoint));
 }
 
 #[cfg(feature = "transport_udp")]
 #[test]
 fn authenticator_udp() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
     let endpoint: EndPoint = "udp/127.0.0.1:11447".parse().unwrap();
-    task::block_on(run(&endpoint));
+    block_on(run(&endpoint));
 }
 
 #[cfg(feature = "transport_ws")]
 #[test]
 fn authenticator_ws() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
     let endpoint: EndPoint = "ws/127.0.0.1:11449".parse().unwrap();
-    task::block_on(run(&endpoint));
+    block_on(run(&endpoint));
 }
 
 #[cfg(all(feature = "transport_unixsock-stream", target_family = "unix"))]
 #[test]
 fn authenticator_unix() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -825,7 +825,7 @@ fn authenticator_unix() {
     let endpoint: EndPoint = "unixsock-stream/zenoh-test-unix-socket-10.sock"
         .parse()
         .unwrap();
-    task::block_on(run(&endpoint));
+    block_on(run(&endpoint));
     let _ = std::fs::remove_file("zenoh-test-unix-socket-10.sock");
     let _ = std::fs::remove_file("zenoh-test-unix-socket-10.sock.lock");
 }
@@ -835,7 +835,7 @@ fn authenticator_unix() {
 fn authenticator_tls() {
     use zenoh_link::tls::config::*;
 
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -925,7 +925,7 @@ tOzot3pwe+3SJtpk90xAQrABEO0Zh2unrC8i83ySfg==
         .map(|(k, v)| ((*k).to_owned(), (*v).to_owned())),
     );
 
-    task::block_on(run(&endpoint));
+    block_on(run(&endpoint));
 }
 
 #[cfg(feature = "transport_quic")]
@@ -933,7 +933,7 @@ tOzot3pwe+3SJtpk90xAQrABEO0Zh2unrC8i83ySfg==
 fn authenticator_quic() {
     use zenoh_link::quic::config::*;
 
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -1023,5 +1023,5 @@ tOzot3pwe+3SJtpk90xAQrABEO0Zh2unrC8i83ySfg==
         .map(|(k, v)| ((*k).to_owned(), (*v).to_owned())),
     );
 
-    task::block_on(run(&endpoint));
+    block_on(run(&endpoint));
 }

--- a/io/zenoh-transport/tests/unicast_concurrent.rs
+++ b/io/zenoh-transport/tests/unicast_concurrent.rs
@@ -13,11 +13,11 @@
 //
 use async_std::prelude::FutureExt;
 use async_std::sync::Barrier;
-use async_std::task;
 use std::any::Any;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
+use zenoh_async_rt::{block_on, sleep, spawn};
 use zenoh_core::zasync_executor_init;
 use zenoh_core::Result as ZResult;
 use zenoh_link::{EndPoint, Link};
@@ -138,7 +138,7 @@ async fn transport_concurrent(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPoin
     let c_pid02 = peer_id02;
     let c_end01 = endpoint01.clone();
     let c_end02 = endpoint02.clone();
-    let peer01_task = task::spawn(async move {
+    let peer01_task = spawn(async move {
         // Add the endpoints on the first peer
         for e in c_end01.iter() {
             let res = ztimeout!(peer01_manager.add_listener(e.clone()));
@@ -158,7 +158,7 @@ async fn transport_concurrent(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPoin
             let cc_barod = c_barod.clone();
             let c_p01m = peer01_manager.clone();
             let c_end = e.clone();
-            task::spawn(async move {
+            spawn(async move {
                 println!("[Transport Peer 01c] => Waiting for opening transport");
                 // Syncrhonize before opening the transports
                 ztimeout!(cc_barow.wait());
@@ -223,7 +223,7 @@ async fn transport_concurrent(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPoin
         // Wait for the messages to arrive to the other side
         ztimeout!(async {
             while peer_sh02.get_count() != MSG_COUNT {
-                task::sleep(SLEEP).await;
+                sleep(SLEEP).await;
             }
         });
 
@@ -246,7 +246,7 @@ async fn transport_concurrent(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPoin
     let c_pid01 = peer_id01;
     let c_end01 = endpoint01.clone();
     let c_end02 = endpoint02.clone();
-    let peer02_task = task::spawn(async move {
+    let peer02_task = spawn(async move {
         // Add the endpoints on the first peer
         for e in c_end02.iter() {
             let res = ztimeout!(peer02_manager.add_listener(e.clone()));
@@ -266,7 +266,7 @@ async fn transport_concurrent(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPoin
             let cc_barod = c_barod.clone();
             let c_p02m = peer02_manager.clone();
             let c_end = e.clone();
-            task::spawn(async move {
+            spawn(async move {
                 println!("[Transport Peer 02c] => Waiting for opening transport");
                 // Syncrhonize before opening the transports
                 ztimeout!(cc_barow.wait());
@@ -335,7 +335,7 @@ async fn transport_concurrent(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPoin
         // Wait for the messages to arrive to the other side
         ztimeout!(async {
             while peer_sh01.get_count() != MSG_COUNT {
-                task::sleep(SLEEP).await;
+                sleep(SLEEP).await;
             }
         });
 
@@ -356,13 +356,13 @@ async fn transport_concurrent(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPoin
     println!("[Transport Current 02] => ...Stopped");
 
     // Wait a little bit
-    task::sleep(SLEEP).await;
+    sleep(SLEEP).await;
 }
 
 #[cfg(feature = "transport_tcp")]
 #[test]
 fn transport_tcp_concurrent() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -387,7 +387,7 @@ fn transport_tcp_concurrent() {
         "tcp/127.0.0.1:7462".parse().unwrap(),
     ];
 
-    task::block_on(async {
+    block_on(async {
         transport_concurrent(endpoint01, endpoint02).await;
     });
 }
@@ -395,7 +395,7 @@ fn transport_tcp_concurrent() {
 #[cfg(feature = "transport_ws")]
 #[test]
 fn transport_ws_concurrent() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -420,7 +420,7 @@ fn transport_ws_concurrent() {
         "ws/127.0.0.1:7478".parse().unwrap(),
     ];
 
-    task::block_on(async {
+    block_on(async {
         transport_concurrent(endpoint01, endpoint02).await;
     });
 }

--- a/io/zenoh-transport/tests/unicast_conduits.rs
+++ b/io/zenoh-transport/tests/unicast_conduits.rs
@@ -12,12 +12,12 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use async_std::prelude::FutureExt;
-use async_std::task;
 use std::any::Any;
 use std::fmt::Write;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
+use zenoh_async_rt::{block_on, sleep};
 use zenoh_buffers::ZBuf;
 use zenoh_core::zasync_executor_init;
 use zenoh_core::Result as ZResult;
@@ -237,7 +237,7 @@ async fn close_transport(
 
     ztimeout!(async {
         while !router_manager.get_transports().is_empty() {
-            task::sleep(SLEEP).await;
+            sleep(SLEEP).await;
         }
     });
 
@@ -248,13 +248,13 @@ async fn close_transport(
     }
 
     // Wait a little bit
-    task::sleep(SLEEP).await;
+    sleep(SLEEP).await;
 
     ztimeout!(router_manager.close());
     ztimeout!(client_manager.close());
 
     // Wait a little bit
-    task::sleep(SLEEP).await;
+    sleep(SLEEP).await;
 }
 
 async fn single_run(
@@ -292,12 +292,12 @@ async fn single_run(
     // Wait for the messages to arrive to the other side
     ztimeout!(async {
         while router_handler.get_count() != MSG_COUNT {
-            task::sleep(SLEEP_COUNT).await;
+            sleep(SLEEP_COUNT).await;
         }
     });
 
     // Wait a little bit
-    task::sleep(SLEEP).await;
+    sleep(SLEEP).await;
 }
 
 async fn run(endpoints: &[EndPoint], channel: &[Channel], msg_size: &[usize]) {
@@ -314,7 +314,7 @@ async fn run(endpoints: &[EndPoint], channel: &[Channel], msg_size: &[usize]) {
 #[cfg(feature = "transport_tcp")]
 #[test]
 fn conduits_tcp_only() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
     let mut channel = vec![];
@@ -327,13 +327,13 @@ fn conduits_tcp_only() {
     // Define the locators
     let endpoints: Vec<EndPoint> = vec!["tcp/127.0.0.1:13447".parse().unwrap()];
     // Run
-    task::block_on(run(&endpoints, &channel, &MSG_SIZE_ALL));
+    block_on(run(&endpoints, &channel, &MSG_SIZE_ALL));
 }
 
 #[cfg(feature = "transport_ws")]
 #[test]
 fn conduits_ws_only() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
     let mut channel = vec![];
@@ -346,5 +346,5 @@ fn conduits_ws_only() {
     // Define the locators
     let endpoints: Vec<EndPoint> = vec!["ws/127.0.0.1:13448".parse().unwrap()];
     // Run
-    task::block_on(run(&endpoints, &channel, &MSG_SIZE_ALL));
+    block_on(run(&endpoints, &channel, &MSG_SIZE_ALL));
 }

--- a/io/zenoh-transport/tests/unicast_defragmentation.rs
+++ b/io/zenoh-transport/tests/unicast_defragmentation.rs
@@ -12,9 +12,9 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use async_std::prelude::FutureExt;
-use async_std::task;
 use std::sync::Arc;
 use std::time::Duration;
+use zenoh_async_rt::{block_on, sleep};
 use zenoh_buffers::ZBuf;
 use zenoh_core::zasync_executor_init;
 use zenoh_link::EndPoint;
@@ -93,14 +93,14 @@ async fn run(endpoint: &EndPoint, channel: Channel, msg_size: usize) {
     // Wait that the client transport has been closed
     ztimeout!(async {
         while client_transport.get_pid().is_ok() {
-            task::sleep(SLEEP).await;
+            sleep(SLEEP).await;
         }
     });
 
     // Wait on the router manager that the transport has been closed
     ztimeout!(async {
         while !router_manager.get_transports_unicast().is_empty() {
-            task::sleep(SLEEP).await;
+            sleep(SLEEP).await;
         }
     });
 
@@ -111,23 +111,23 @@ async fn run(endpoint: &EndPoint, channel: Channel, msg_size: usize) {
     // Wait a little bit
     ztimeout!(async {
         while !router_manager.get_listeners().is_empty() {
-            task::sleep(SLEEP).await;
+            sleep(SLEEP).await;
         }
     });
 
-    task::sleep(SLEEP).await;
+    sleep(SLEEP).await;
 
     ztimeout!(router_manager.close());
     ztimeout!(client_manager.close());
 
     // Wait a little bit
-    task::sleep(SLEEP).await;
+    sleep(SLEEP).await;
 }
 
 #[cfg(feature = "transport_tcp")]
 #[test]
 fn transport_unicast_defragmentation_tcp_only() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -153,7 +153,7 @@ fn transport_unicast_defragmentation_tcp_only() {
         },
     ];
     // Run
-    task::block_on(async {
+    block_on(async {
         for ch in channel.iter() {
             run(&endpoint, *ch, MSG_SIZE).await;
         }
@@ -163,7 +163,7 @@ fn transport_unicast_defragmentation_tcp_only() {
 #[cfg(feature = "transport_ws")]
 #[test]
 fn transport_unicast_defragmentation_ws_only() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -189,7 +189,7 @@ fn transport_unicast_defragmentation_ws_only() {
         },
     ];
     // Run
-    task::block_on(async {
+    block_on(async {
         for ch in channel.iter() {
             run(&endpoint, *ch, MSG_SIZE).await;
         }

--- a/io/zenoh-transport/tests/unicast_openclose.rs
+++ b/io/zenoh-transport/tests/unicast_openclose.rs
@@ -12,9 +12,9 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use async_std::prelude::FutureExt;
-use async_std::task;
 use std::sync::Arc;
 use std::time::Duration;
+use zenoh_async_rt::{block_on, sleep};
 use zenoh_core::zasync_executor_init;
 use zenoh_core::Result as ZResult;
 use zenoh_link::EndPoint;
@@ -167,7 +167,7 @@ async fn openclose_transport(endpoint: &EndPoint) {
                     assert_eq!(links.len(), links_num);
                     break;
                 }
-                None => task::sleep(SLEEP).await,
+                None => sleep(SLEEP).await,
             }
         }
     });
@@ -207,7 +207,7 @@ async fn openclose_transport(endpoint: &EndPoint) {
             if links.len() == links_num {
                 break;
             }
-            task::sleep(SLEEP).await;
+            sleep(SLEEP).await;
         }
     });
 
@@ -231,7 +231,7 @@ async fn openclose_transport(endpoint: &EndPoint) {
     // Verify that the transport has not been open on the router
     println!("Transport Open Close [3d1]");
     ztimeout!(async {
-        task::sleep(SLEEP).await;
+        sleep(SLEEP).await;
         let transports = router_manager.get_transports();
         assert_eq!(transports.len(), 1);
         let s = transports
@@ -264,7 +264,7 @@ async fn openclose_transport(endpoint: &EndPoint) {
             if index.is_none() {
                 break;
             }
-            task::sleep(SLEEP).await;
+            sleep(SLEEP).await;
         }
     });
 
@@ -291,7 +291,7 @@ async fn openclose_transport(endpoint: &EndPoint) {
     // Verify that the transport has been open on the router
     println!("Transport Open Close [5d1]");
     ztimeout!(async {
-        task::sleep(SLEEP).await;
+        sleep(SLEEP).await;
         let transports = router_manager.get_transports();
         assert_eq!(transports.len(), 1);
         let s = transports
@@ -317,7 +317,7 @@ async fn openclose_transport(endpoint: &EndPoint) {
     // Verify that the transport has not been open on the router
     println!("Transport Open Close [6c1]");
     ztimeout!(async {
-        task::sleep(SLEEP).await;
+        sleep(SLEEP).await;
         let transports = router_manager.get_transports();
         assert_eq!(transports.len(), 1);
         let s = transports
@@ -347,7 +347,7 @@ async fn openclose_transport(endpoint: &EndPoint) {
             if transports.is_empty() {
                 break;
             }
-            task::sleep(SLEEP).await;
+            sleep(SLEEP).await;
         }
     });
 
@@ -384,7 +384,7 @@ async fn openclose_transport(endpoint: &EndPoint) {
                     assert_eq!(links.len(), links_num);
                     break;
                 }
-                None => task::sleep(SLEEP).await,
+                None => sleep(SLEEP).await,
             }
         }
     });
@@ -408,7 +408,7 @@ async fn openclose_transport(endpoint: &EndPoint) {
             if transports.is_empty() {
                 break;
             }
-            task::sleep(SLEEP).await;
+            sleep(SLEEP).await;
         }
     });
 
@@ -421,58 +421,58 @@ async fn openclose_transport(endpoint: &EndPoint) {
 
     ztimeout!(async {
         while !router_manager.get_listeners().is_empty() {
-            task::sleep(SLEEP).await;
+            sleep(SLEEP).await;
         }
     });
 
     // Wait a little bit
-    task::sleep(SLEEP).await;
+    sleep(SLEEP).await;
 
     ztimeout!(router_manager.close());
     ztimeout!(client01_manager.close());
     ztimeout!(client02_manager.close());
 
     // Wait a little bit
-    task::sleep(SLEEP).await;
+    sleep(SLEEP).await;
 }
 
 #[cfg(feature = "transport_tcp")]
 #[test]
 fn openclose_tcp_only() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
     let endpoint: EndPoint = "tcp/127.0.0.1:8447".parse().unwrap();
-    task::block_on(openclose_transport(&endpoint));
+    block_on(openclose_transport(&endpoint));
 }
 
 #[cfg(feature = "transport_udp")]
 #[test]
 fn openclose_udp_only() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
     let endpoint: EndPoint = "udp/127.0.0.1:8447".parse().unwrap();
-    task::block_on(openclose_transport(&endpoint));
+    block_on(openclose_transport(&endpoint));
 }
 
 #[cfg(feature = "transport_ws")]
 #[test]
 fn openclose_ws_only() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
     let endpoint: EndPoint = "ws/127.0.0.1:8448".parse().unwrap();
-    task::block_on(openclose_transport(&endpoint));
+    block_on(openclose_transport(&endpoint));
 }
 
 #[cfg(all(feature = "transport_unixsock-stream", target_family = "unix"))]
 #[test]
 fn openclose_unix_only() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -480,7 +480,7 @@ fn openclose_unix_only() {
     let endpoint: EndPoint = "unixsock-stream/zenoh-test-unix-socket-9.sock"
         .parse()
         .unwrap();
-    task::block_on(openclose_transport(&endpoint));
+    block_on(openclose_transport(&endpoint));
     let _ = std::fs::remove_file("zenoh-test-unix-socket-9.sock");
     let _ = std::fs::remove_file("zenoh-test-unix-socket-9.sock.lock");
 }
@@ -490,7 +490,7 @@ fn openclose_unix_only() {
 fn openclose_tls_only() {
     use zenoh_link::tls::config::*;
 
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -579,7 +579,7 @@ tOzot3pwe+3SJtpk90xAQrABEO0Zh2unrC8i83ySfg==
         .map(|(k, v)| ((*k).to_owned(), (*v).to_owned())),
     );
 
-    task::block_on(openclose_transport(&endpoint));
+    block_on(openclose_transport(&endpoint));
 }
 
 #[cfg(feature = "transport_quic")]
@@ -587,7 +587,7 @@ tOzot3pwe+3SJtpk90xAQrABEO0Zh2unrC8i83ySfg==
 fn openclose_quic_only() {
     use zenoh_link::quic::config::*;
 
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -677,5 +677,5 @@ tOzot3pwe+3SJtpk90xAQrABEO0Zh2unrC8i83ySfg==
         .map(|(k, v)| ((*k).to_owned(), (*v).to_owned())),
     );
 
-    task::block_on(openclose_transport(&endpoint));
+    block_on(openclose_transport(&endpoint));
 }

--- a/io/zenoh-transport/tests/unicast_shm.rs
+++ b/io/zenoh-transport/tests/unicast_shm.rs
@@ -14,13 +14,13 @@
 #[cfg(feature = "shared-memory")]
 mod tests {
     use async_std::prelude::FutureExt;
-    use async_std::task;
     use std::any::Any;
     use std::collections::HashSet;
     use std::iter::FromIterator;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
+    use zenoh_async_rt::{block_on, sleep};
     use zenoh_buffers::SplitBuffer;
     use zenoh_core::zasync_executor_init;
     use zenoh_core::Result as ZResult;
@@ -204,7 +204,7 @@ mod tests {
                 loop {
                     match shm01.alloc(MSG_SIZE) {
                         Ok(sbuf) => break sbuf,
-                        Err(_) => task::sleep(USLEEP).await,
+                        Err(_) => sleep(USLEEP).await,
                     }
                 }
             });
@@ -239,13 +239,13 @@ mod tests {
         }
 
         // Wait a little bit
-        task::sleep(SLEEP).await;
+        sleep(SLEEP).await;
 
         // Wait for the messages to arrive to the other side
         println!("\nTransport SHM [3b]");
         ztimeout!(async {
             while peer_shm02_handler.get_count() != MSG_COUNT {
-                task::sleep(SLEEP).await;
+                sleep(SLEEP).await;
             }
         });
 
@@ -258,7 +258,7 @@ mod tests {
                 loop {
                     match shm01.alloc(MSG_SIZE) {
                         Ok(sbuf) => break sbuf,
-                        Err(_) => task::sleep(USLEEP).await,
+                        Err(_) => sleep(USLEEP).await,
                     }
                 }
             });
@@ -292,18 +292,18 @@ mod tests {
         }
 
         // Wait a little bit
-        task::sleep(SLEEP).await;
+        sleep(SLEEP).await;
 
         // Wait for the messages to arrive to the other side
         println!("\nTransport SHM [4b]");
         ztimeout!(async {
             while peer_net01_handler.get_count() != MSG_COUNT {
-                task::sleep(SLEEP).await;
+                sleep(SLEEP).await;
             }
         });
 
         // Wait a little bit
-        task::sleep(SLEEP).await;
+        sleep(SLEEP).await;
 
         // Close the transports
         println!("Transport SHM [5a]");
@@ -314,7 +314,7 @@ mod tests {
 
         ztimeout!(async {
             while !peer_shm01_manager.get_transports().is_empty() {
-                task::sleep(SLEEP).await;
+                sleep(SLEEP).await;
             }
         });
 
@@ -325,38 +325,38 @@ mod tests {
         // Wait a little bit
         ztimeout!(async {
             while !peer_shm01_manager.get_listeners().is_empty() {
-                task::sleep(SLEEP).await;
+                sleep(SLEEP).await;
             }
         });
-        task::sleep(SLEEP).await;
+        sleep(SLEEP).await;
 
         ztimeout!(peer_net01_manager.close());
         ztimeout!(peer_shm01_manager.close());
         ztimeout!(peer_shm02_manager.close());
 
         // Wait a little bit
-        task::sleep(SLEEP).await;
+        sleep(SLEEP).await;
     }
 
     #[cfg(all(feature = "transport_tcp", feature = "shared-memory"))]
     #[test]
     fn transport_tcp_shm() {
-        task::block_on(async {
+        block_on(async {
             zasync_executor_init!();
         });
 
         let endpoint: EndPoint = "tcp/127.0.0.1:16447".parse().unwrap();
-        task::block_on(run(&endpoint));
+        block_on(run(&endpoint));
     }
 
     #[cfg(all(feature = "transport_ws", feature = "shared-memory"))]
     #[test]
     fn transport_ws_shm() {
-        task::block_on(async {
+        block_on(async {
             zasync_executor_init!();
         });
 
         let endpoint: EndPoint = "ws/127.0.0.1:16448".parse().unwrap();
-        task::block_on(run(&endpoint));
+        block_on(run(&endpoint));
     }
 }

--- a/io/zenoh-transport/tests/unicast_simultaneous.rs
+++ b/io/zenoh-transport/tests/unicast_simultaneous.rs
@@ -12,11 +12,11 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use async_std::prelude::FutureExt;
-use async_std::task;
 use std::any::Any;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
+use zenoh_async_rt::{block_on, sleep, spawn};
 use zenoh_buffers::ZBuf;
 use zenoh_core::zasync_executor_init;
 use zenoh_core::Result as ZResult;
@@ -190,7 +190,7 @@ async fn transport_simultaneous(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPo
 
     // Peer01
     let c_p01m = peer01_manager.clone();
-    let peer01_task = task::spawn(async move {
+    let peer01_task = spawn(async move {
         // Open the transport with the second peer
         // These open should succeed
         for e in c_ep02.iter() {
@@ -205,12 +205,12 @@ async fn transport_simultaneous(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPo
             assert!(res.is_err());
         }
 
-        task::sleep(SLEEP).await;
+        sleep(SLEEP).await;
 
         let tp02 = ztimeout!(async {
             let mut tp02 = None;
             while tp02.is_none() {
-                task::sleep(SLEEP).await;
+                sleep(SLEEP).await;
                 println!(
                     "[Simultaneous 01e] => Transports: {:?}",
                     peer01_manager.get_transports()
@@ -226,7 +226,7 @@ async fn transport_simultaneous(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPo
             let expected = endpoint01.len() + c_ep02.len();
             let mut tl02 = vec![];
             while tl02.len() != expected {
-                task::sleep(SLEEP).await;
+                sleep(SLEEP).await;
                 tl02 = tp02.get_links().unwrap();
                 println!("[Simultaneous 01f] => Links {}/{}", tl02.len(), expected);
             }
@@ -236,7 +236,7 @@ async fn transport_simultaneous(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPo
         ztimeout!(async {
             let mut check = 0;
             while check != MSG_COUNT {
-                task::sleep(SLEEP).await;
+                sleep(SLEEP).await;
                 check = peer_sh01.get_count();
                 println!("[Simultaneous 01g] => Received {:?}/{:?}", check, MSG_COUNT);
             }
@@ -245,7 +245,7 @@ async fn transport_simultaneous(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPo
 
     // Peer02
     let c_p02m = peer02_manager.clone();
-    let peer02_task = task::spawn(async move {
+    let peer02_task = spawn(async move {
         // Open the transport with the first peer
         // These open should succeed
         for e in c_ep01.iter() {
@@ -261,12 +261,12 @@ async fn transport_simultaneous(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPo
         }
 
         // Wait a little bit
-        task::sleep(SLEEP).await;
+        sleep(SLEEP).await;
 
         let tp01 = ztimeout!(async {
             let mut tp01 = None;
             while tp01.is_none() {
-                task::sleep(SLEEP).await;
+                sleep(SLEEP).await;
                 println!(
                     "[Simultaneous 02e] => Transports: {:?}",
                     peer02_manager.get_transports()
@@ -281,7 +281,7 @@ async fn transport_simultaneous(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPo
             let expected = c_ep01.len() + endpoint02.len();
             let mut tl01 = vec![];
             while tl01.len() != expected {
-                task::sleep(SLEEP).await;
+                sleep(SLEEP).await;
                 tl01 = tp01.get_links().unwrap();
                 println!("[Simultaneous 02f] => Links {}/{}", tl01.len(), expected);
             }
@@ -291,7 +291,7 @@ async fn transport_simultaneous(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPo
         ztimeout!(async {
             let mut check = 0;
             while check != MSG_COUNT {
-                task::sleep(SLEEP).await;
+                sleep(SLEEP).await;
                 check = peer_sh02.get_count();
                 println!("[Simultaneous 02g] => Received {:?}/{:?}", check, MSG_COUNT);
             }
@@ -303,13 +303,13 @@ async fn transport_simultaneous(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPo
     println!("[Simultaneous] => Waiting for peer01 and peer02 tasks... DONE\n");
 
     // Wait a little bit
-    task::sleep(SLEEP).await;
+    sleep(SLEEP).await;
 }
 
 #[cfg(feature = "transport_tcp")]
 #[test]
 fn transport_tcp_simultaneous() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -328,7 +328,7 @@ fn transport_tcp_simultaneous() {
         "tcp/127.0.0.1:15456".parse().unwrap(),
     ];
 
-    task::block_on(async {
+    block_on(async {
         transport_simultaneous(endpoint01, endpoint02).await;
     });
 }
@@ -336,7 +336,7 @@ fn transport_tcp_simultaneous() {
 #[cfg(feature = "transport_ws")]
 #[test]
 fn transport_ws_simultaneous() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -355,7 +355,7 @@ fn transport_ws_simultaneous() {
         "ws/127.0.0.1:16456".parse().unwrap(),
     ];
 
-    task::block_on(async {
+    block_on(async {
         transport_simultaneous(endpoint01, endpoint02).await;
     });
 }

--- a/io/zenoh-transport/tests/unicast_transport.rs
+++ b/io/zenoh-transport/tests/unicast_transport.rs
@@ -12,12 +12,12 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use async_std::prelude::FutureExt;
-use async_std::task;
 use std::any::Any;
 use std::fmt::Write;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
+use zenoh_async_rt::{block_on, sleep};
 use zenoh_core::zasync_executor_init;
 use zenoh_core::Result as ZResult;
 use zenoh_link::{EndPoint, Link};
@@ -219,7 +219,7 @@ async fn close_transport(
 
     ztimeout!(async {
         while !router_manager.get_transports().is_empty() {
-            task::sleep(SLEEP).await;
+            sleep(SLEEP).await;
         }
     });
 
@@ -231,18 +231,18 @@ async fn close_transport(
 
     ztimeout!(async {
         while !router_manager.get_listeners().is_empty() {
-            task::sleep(SLEEP).await;
+            sleep(SLEEP).await;
         }
     });
 
     // Wait a little bit
-    task::sleep(SLEEP).await;
+    sleep(SLEEP).await;
 
     ztimeout!(router_manager.close());
     ztimeout!(client_manager.close());
 
     // Wait a little bit
-    task::sleep(SLEEP).await;
+    sleep(SLEEP).await;
 }
 
 async fn test_transport(
@@ -281,21 +281,21 @@ async fn test_transport(
         Reliability::Reliable => {
             ztimeout!(async {
                 while router_handler.get_count() != MSG_COUNT {
-                    task::sleep(SLEEP_COUNT).await;
+                    sleep(SLEEP_COUNT).await;
                 }
             });
         }
         Reliability::BestEffort => {
             ztimeout!(async {
                 while router_handler.get_count() == 0 {
-                    task::sleep(SLEEP_COUNT).await;
+                    sleep(SLEEP_COUNT).await;
                 }
             });
         }
     };
 
     // Wait a little bit
-    task::sleep(SLEEP).await;
+    sleep(SLEEP).await;
 }
 
 async fn run_single(endpoints: &[EndPoint], channel: Channel, msg_size: usize) {
@@ -337,7 +337,7 @@ async fn run(endpoints: &[EndPoint], channel: &[Channel], msg_size: &[usize]) {
 #[cfg(feature = "transport_tcp")]
 #[test]
 fn transport_unicast_tcp_only() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -366,13 +366,13 @@ fn transport_unicast_tcp_only() {
         },
     ];
     // Run
-    task::block_on(run(&endpoints, &channel, &MSG_SIZE_ALL));
+    block_on(run(&endpoints, &channel, &MSG_SIZE_ALL));
 }
 
 #[cfg(feature = "transport_udp")]
 #[test]
 fn transport_unicast_udp_only() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -393,13 +393,13 @@ fn transport_unicast_udp_only() {
         },
     ];
     // Run
-    task::block_on(run(&endpoints, &channel, &MSG_SIZE_NOFRAG));
+    block_on(run(&endpoints, &channel, &MSG_SIZE_NOFRAG));
 }
 
 #[cfg(all(feature = "transport_unixsock-stream", target_family = "unix"))]
 #[test]
 fn transport_unicast_unix_only() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -420,7 +420,7 @@ fn transport_unicast_unix_only() {
         },
     ];
     // Run
-    task::block_on(run(&endpoints, &channel, &MSG_SIZE_ALL));
+    block_on(run(&endpoints, &channel, &MSG_SIZE_ALL));
     let _ = std::fs::remove_file("zenoh-test-unix-socket-5.sock");
     let _ = std::fs::remove_file("zenoh-test-unix-socket-5.sock.lock");
 }
@@ -428,7 +428,7 @@ fn transport_unicast_unix_only() {
 #[cfg(feature = "transport_ws")]
 #[test]
 fn transport_unicast_ws_only() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -457,13 +457,13 @@ fn transport_unicast_ws_only() {
         },
     ];
     // Run
-    task::block_on(run(&endpoints, &channel, &MSG_SIZE_ALL));
+    block_on(run(&endpoints, &channel, &MSG_SIZE_ALL));
 }
 
 #[cfg(all(feature = "transport_tcp", feature = "transport_udp"))]
 #[test]
 fn transport_unicast_tcp_udp() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -486,7 +486,7 @@ fn transport_unicast_tcp_udp() {
         },
     ];
     // Run
-    task::block_on(run(&endpoints, &channel, &MSG_SIZE_NOFRAG));
+    block_on(run(&endpoints, &channel, &MSG_SIZE_NOFRAG));
 }
 
 #[cfg(all(
@@ -496,7 +496,7 @@ fn transport_unicast_tcp_udp() {
 ))]
 #[test]
 fn transport_unicast_tcp_unix() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -521,7 +521,7 @@ fn transport_unicast_tcp_unix() {
         },
     ];
     // Run
-    task::block_on(run(&endpoints, &channel, &MSG_SIZE_ALL));
+    block_on(run(&endpoints, &channel, &MSG_SIZE_ALL));
     let _ = std::fs::remove_file("zenoh-test-unix-socket-6.sock");
     let _ = std::fs::remove_file("zenoh-test-unix-socket-6.sock.lock");
 }
@@ -533,7 +533,7 @@ fn transport_unicast_tcp_unix() {
 ))]
 #[test]
 fn transport_unicast_udp_unix() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -558,7 +558,7 @@ fn transport_unicast_udp_unix() {
         },
     ];
     // Run
-    task::block_on(run(&endpoints, &channel, &MSG_SIZE_NOFRAG));
+    block_on(run(&endpoints, &channel, &MSG_SIZE_NOFRAG));
     let _ = std::fs::remove_file("zenoh-test-unix-socket-7.sock");
     let _ = std::fs::remove_file("zenoh-test-unix-socket-7.sock.lock");
 }
@@ -571,7 +571,7 @@ fn transport_unicast_udp_unix() {
 ))]
 #[test]
 fn transport_unicast_tcp_udp_unix() {
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -598,7 +598,7 @@ fn transport_unicast_tcp_udp_unix() {
         },
     ];
     // Run
-    task::block_on(run(&endpoints, &channel, &MSG_SIZE_NOFRAG));
+    block_on(run(&endpoints, &channel, &MSG_SIZE_NOFRAG));
     let _ = std::fs::remove_file("zenoh-test-unix-socket-8.sock");
     let _ = std::fs::remove_file("zenoh-test-unix-socket-8.sock.lock");
 }
@@ -608,7 +608,7 @@ fn transport_unicast_tcp_udp_unix() {
 fn transport_unicast_tls_only() {
     use zenoh_link::tls::config::*;
 
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
 
@@ -718,7 +718,7 @@ tOzot3pwe+3SJtpk90xAQrABEO0Zh2unrC8i83ySfg==
     ];
     // Run
     let endpoints = vec![endpoint];
-    task::block_on(run(&endpoints, &channel, &MSG_SIZE_ALL));
+    block_on(run(&endpoints, &channel, &MSG_SIZE_ALL));
 }
 
 #[cfg(feature = "transport_quic")]
@@ -726,7 +726,7 @@ tOzot3pwe+3SJtpk90xAQrABEO0Zh2unrC8i83ySfg==
 fn transport_unicast_quic_only() {
     use zenoh_link::quic::config::*;
 
-    task::block_on(async {
+    block_on(async {
         zasync_executor_init!();
     });
     // NOTE: this an auto-generated pair of certificate and key.
@@ -836,5 +836,5 @@ tOzot3pwe+3SJtpk90xAQrABEO0Zh2unrC8i83ySfg==
     ];
     // Run
     let endpoints = vec![endpoint];
-    task::block_on(run(&endpoints, &channel, &MSG_SIZE_ALL));
+    block_on(run(&endpoints, &channel, &MSG_SIZE_ALL));
 }

--- a/plugins/example-plugin/Cargo.toml
+++ b/plugins/example-plugin/Cargo.toml
@@ -39,3 +39,4 @@ zenoh-util = { path = "../../commons/zenoh-util" }
 zenoh-core = { path = "../../commons/zenoh-core/" }
 zenoh-plugin-trait = { path = "../zenoh-plugin-trait" }
 serde_json = "1.0"
+zenoh-async-rt = { version = "0.1.0", path = "../../commons/zenoh-async-rt" }

--- a/plugins/zenoh-plugin-rest/Cargo.toml
+++ b/plugins/zenoh-plugin-rest/Cargo.toml
@@ -55,6 +55,7 @@ zenoh = { path = "../../zenoh" }
 zenoh-util = { path = "../../commons/zenoh-util/" }
 zenoh-core = { path = "../../commons/zenoh-core/" }
 zenoh-plugin-trait = { path = "../zenoh-plugin-trait", default-features = false }
+zenoh-async-rt = { version = "0.1.0", path = "../../commons/zenoh-async-rt" }
 
 [[example]]
 name = "z_serve_sse"

--- a/plugins/zenoh-plugin-rest/examples/z_serve_sse.rs
+++ b/plugins/zenoh-plugin-rest/examples/z_serve_sse.rs
@@ -18,6 +18,7 @@ use zenoh::config::Config;
 use zenoh::prelude::*;
 use zenoh::publication::CongestionControl;
 use zenoh::queryable::EVAL;
+use zenoh_async_rt::{sleep, spawn};
 
 const HTML: &str = r#"
 <div id="result"></div>
@@ -32,7 +33,7 @@ if(typeof(EventSource) !== "undefined") {
 }
 </script>"#;
 
-#[async_std::main]
+#[zenoh_async_rt::main]
 async fn main() {
     // initiate logging
     env_logger::init();
@@ -47,7 +48,7 @@ async fn main() {
     println!("Creating Queryable on '{}'...", key);
     let mut queryable = session.queryable(key).kind(EVAL).await.unwrap();
 
-    async_std::task::spawn(
+    spawn(
         queryable
             .receiver()
             .clone()
@@ -80,7 +81,7 @@ async fn main() {
             .congestion_control(CongestionControl::Block)
             .await
             .unwrap();
-        async_std::task::sleep(std::time::Duration::new(1, 0)).await;
+        sleep(std::time::Duration::new(1, 0)).await;
     }
 }
 

--- a/plugins/zenoh-plugin-storage-manager/Cargo.toml
+++ b/plugins/zenoh-plugin-storage-manager/Cargo.toml
@@ -52,6 +52,7 @@ zenoh-util = { path = "../../commons/zenoh-util" }
 zenoh-core = { path = "../../commons/zenoh-core/" }
 zenoh-collections = { path = "../../commons/zenoh-collections/" }
 zenoh_backend_traits = { path = "../zenoh-backend-traits/" }
+zenoh-async-rt = { version = "0.1.0", path = "../../commons/zenoh-async-rt" }
 
 [package.metadata.deb]
 name = "zenoh-plugin-storage-manager"

--- a/plugins/zenoh-plugin-storage-manager/src/storages_mgt.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/storages_mgt.rs
@@ -12,7 +12,6 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use async_std::channel::{bounded, Sender};
-use async_std::task;
 use futures::select;
 use futures::stream::StreamExt;
 use futures::FutureExt;
@@ -22,6 +21,7 @@ use zenoh::prelude::*;
 use zenoh::query::{QueryConsolidation, QueryTarget, Target};
 use zenoh::queryable;
 use zenoh::Session;
+use zenoh_async_rt::spawn;
 use zenoh_backend_traits::Query;
 use zenoh_core::Result as ZResult;
 
@@ -41,7 +41,7 @@ pub(crate) async fn start_storage(
     debug!("Start storage {} on {}", admin_key, key_expr);
 
     let (tx, rx) = bounded(1);
-    task::spawn(async move {
+    spawn(async move {
         // subscribe on key_expr
         let mut storage_sub = match zenoh.subscribe(&key_expr).await {
             Ok(storage_sub) => storage_sub,

--- a/zenoh-ext/Cargo.toml
+++ b/zenoh-ext/Cargo.toml
@@ -40,6 +40,7 @@ zenoh = { path = "../zenoh" }
 zenoh-util = { path = "../commons/zenoh-util" }
 zenoh-sync = { path = "../commons/zenoh-sync" }
 zenoh-core = { path = "../commons/zenoh-core/" }
+zenoh-async-rt = { version = "0.1.0", path = "../commons/zenoh-async-rt" }
 
 [dev-dependencies]
 clap = "2.33.3"

--- a/zenoh-ext/examples/z_member.rs
+++ b/zenoh-ext/examples/z_member.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use zenoh::config::Config;
 use zenoh_ext::group::*;
 
-#[async_std::main]
+#[zenoh_async_rt::main]
 async fn main() {
     env_logger::init();
     let z = Arc::new(zenoh::open(Config::default()).await.unwrap());

--- a/zenoh-ext/examples/z_pub_cache.rs
+++ b/zenoh-ext/examples/z_pub_cache.rs
@@ -11,13 +11,13 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use async_std::task::sleep;
 use clap::{App, Arg};
 use std::time::Duration;
 use zenoh::config::Config;
+use zenoh_async_rt::sleep;
 use zenoh_ext::*;
 
-#[async_std::main]
+#[zenoh_async_rt::main]
 async fn main() {
     // Initiate logging
     env_logger::init();

--- a/zenoh-ext/examples/z_query_sub.rs
+++ b/zenoh-ext/examples/z_query_sub.rs
@@ -11,16 +11,16 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use async_std::task::sleep;
 use clap::{App, Arg};
 use futures::prelude::*;
 use futures::select;
 use std::time::Duration;
 use zenoh::config::Config;
 use zenoh::prelude::*;
+use zenoh_async_rt::sleep;
 use zenoh_ext::*;
 
-#[async_std::main]
+#[zenoh_async_rt::main]
 async fn main() {
     // Initiate logging
     env_logger::init();

--- a/zenoh-ext/examples/z_view_size.rs
+++ b/zenoh-ext/examples/z_view_size.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use zenoh::config::Config;
 use zenoh_ext::group::*;
 
-#[async_std::main]
+#[zenoh_async_rt::main]
 async fn main() {
     env_logger::init();
 

--- a/zenoh-ext/src/publication_cache.rs
+++ b/zenoh-ext/src/publication_cache.rs
@@ -12,20 +12,20 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use async_std::channel::{bounded, Sender};
-use async_std::pin::Pin;
-use async_std::task;
-use async_std::task::{Context, Poll};
 use futures::select;
 use futures::FutureExt;
 use futures::StreamExt;
 use std::collections::{HashMap, VecDeque};
 use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use zenoh::prelude::*;
 use zenoh::queryable::Queryable;
 use zenoh::subscriber::Subscriber;
 use zenoh::sync::zready;
 use zenoh::utils::key_expr;
 use zenoh::Session;
+use zenoh_async_rt::spawn;
 use zenoh_core::bail;
 use zenoh_core::Result as ZResult;
 
@@ -139,7 +139,7 @@ impl<'a> PublicationCache<'a> {
         let history = conf.history;
 
         let (stoptx, mut stoprx) = bounded::<bool>(1);
-        task::spawn(async move {
+        spawn(async move {
             let mut cache: HashMap<String, VecDeque<Sample>> =
                 HashMap::with_capacity(resources_limit.unwrap_or(32));
             let limit = resources_limit.unwrap_or(usize::MAX);

--- a/zenoh-ext/src/querying_subscriber.rs
+++ b/zenoh-ext/src/querying_subscriber.rs
@@ -11,12 +11,12 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use async_std::pin::Pin;
-use async_std::task::{Context, Poll};
 use futures::stream::Stream;
 use futures::StreamExt;
 use std::future::Future;
+use std::pin::Pin;
 use std::sync::{Arc, RwLock};
+use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 use zenoh::prelude::{KeyExpr, Receiver, Sample, Selector, ZFuture};
 use zenoh::query::{QueryConsolidation, QueryTarget, ReplyReceiver, Target};

--- a/zenoh-ext/src/session_ext.rs
+++ b/zenoh-ext/src/session_ext.rs
@@ -62,7 +62,7 @@ pub trait SessionExt {
     ///
     /// # Examples
     /// ```no_run
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// use futures::prelude::*;
     /// use zenoh::prelude::*;
     /// use zenoh_ext::*;

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -102,6 +102,7 @@ stop-token = "0.7.0"
 uhlc = "0.4.0"
 uuid = { version = "0.8.2", features = ["v4"] }
 vec_map = "0.8.2"
+zenoh-async-rt = { version = "0.1.0", path = "../commons/zenoh-async-rt" }
 
 [dev-dependencies]
 criterion = "0.3.4"

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -33,7 +33,7 @@
 //! ```
 //! use zenoh::prelude::*;
 //!
-//! #[async_std::main]
+//! #[zenoh_async_rt::main]
 //! async fn main() {
 //!     let session = zenoh::open(config::default()).await.unwrap();
 //!     session.put("/key/expression", "value").await.unwrap();
@@ -47,7 +47,7 @@
 //! use futures::prelude::*;
 //! use zenoh::prelude::*;
 //!
-//! #[async_std::main]
+//! #[zenoh_async_rt::main]
 //! async fn main() {
 //!     let session = zenoh::open(config::default()).await.unwrap();
 //!     let mut subscriber = session.subscribe("/key/expression").await.unwrap();
@@ -64,7 +64,7 @@
 //! use futures::prelude::*;
 //! use zenoh::prelude::*;
 //!
-//! #[async_std::main]
+//! #[zenoh_async_rt::main]
 //! async fn main() {
 //!     let session = zenoh::open(config::default()).await.unwrap();
 //!     let mut replies = session.get("/key/expression").await.unwrap();
@@ -91,6 +91,7 @@ use net::runtime::Runtime;
 use prelude::config::whatami::WhatAmIMatcher;
 use prelude::*;
 use sync::{zready, ZFuture};
+use zenoh_async_rt::spawn;
 use zenoh_cfg_properties::config::*;
 use zenoh_core::{zerror, Result as ZResult};
 use zenoh_sync::zpinbox;
@@ -196,7 +197,7 @@ pub mod properties {
 /// use zenoh::prelude::*;
 /// use zenoh::scouting::WhatAmI;
 ///
-/// #[async_std::main]
+/// #[zenoh_async_rt::main]
 /// async fn main() {
 ///     let mut receiver = zenoh::scout(WhatAmI::Router, config::default()).await.unwrap();
 ///     while let Some(hello) = receiver.next().await {
@@ -262,7 +263,7 @@ pub mod scouting {
 ///
 /// # Examples
 /// ```no_run
-/// # async_std::task::block_on(async {
+/// # zenoh_async_rt::block_on(async {
 /// use futures::prelude::*;
 /// use zenoh::prelude::*;
 /// use zenoh::scouting::WhatAmI;
@@ -319,7 +320,7 @@ where
             .filter_map(|iface| Runtime::bind_ucast_port(iface).ok())
             .collect();
         if !sockets.is_empty() {
-            async_std::task::spawn(async move {
+            spawn(async move {
                 let hello_sender = &hello_sender;
                 let mut stop_receiver = stop_receiver.stream();
                 let scout = Runtime::scout(&sockets, what, &addr, move |hello| async move {
@@ -349,7 +350,7 @@ where
 ///
 /// # Examples
 /// ```
-/// # async_std::task::block_on(async {
+/// # zenoh_async_rt::block_on(async {
 /// use zenoh::prelude::*;
 ///
 /// let session = zenoh::open(config::peer()).await.unwrap();
@@ -357,7 +358,7 @@ where
 /// ```
 ///
 /// ```
-/// # async_std::task::block_on(async {
+/// # zenoh_async_rt::block_on(async {
 /// use zenoh::prelude::*;
 ///
 /// let mut config = config::peer();

--- a/zenoh/src/net/routing/network.rs
+++ b/zenoh/src/net/routing/network.rs
@@ -16,6 +16,7 @@ use petgraph::graph::NodeIndex;
 use petgraph::visit::{IntoNodeReferences, VisitMap, Visitable};
 use std::convert::TryInto;
 use vec_map::VecMap;
+use zenoh_async_rt::sleep;
 use zenoh_link::Locator;
 use zenoh_protocol::core::{PeerId, WhatAmI, ZInt};
 use zenoh_protocol::proto::{LinkState, ZenohMessage};
@@ -480,7 +481,7 @@ impl Network {
                         let locators = locators.clone();
                         self.runtime.spawn(async move {
                             // random backoff
-                            async_std::task::sleep(std::time::Duration::from_millis(
+                            sleep(std::time::Duration::from_millis(
                                 rand::random::<u64>() % 100,
                             ))
                             .await;

--- a/zenoh/src/net/routing/router.rs
+++ b/zenoh/src/net/routing/router.rs
@@ -17,13 +17,13 @@ pub use super::pubsub::*;
 pub use super::queries::*;
 pub use super::resource::*;
 use super::runtime::Runtime;
-use async_std::task::JoinHandle;
 use std::any::Any;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Weak};
 use std::sync::{Mutex, RwLock};
 use std::time::Duration;
 use uhlc::HLC;
+use zenoh_async_rt::{sleep, spawn, JoinHandle};
 use zenoh_link::Link;
 use zenoh_protocol::proto::{ZenohBody, ZenohMessage};
 use zenoh_protocol_core::{PeerId, WhatAmI, ZInt};
@@ -217,9 +217,8 @@ impl Tables {
         if (net_type == WhatAmI::Router && self.routers_trees_task.is_none())
             || (net_type == WhatAmI::Peer && self.peers_trees_task.is_none())
         {
-            let task = Some(async_std::task::spawn(async move {
-                async_std::task::sleep(std::time::Duration::from_millis(*TREES_COMPUTATION_DELAY))
-                    .await;
+            let task = Some(spawn(async move {
+                sleep(Duration::from_millis(*TREES_COMPUTATION_DELAY)).await;
                 let mut tables = zwrite!(tables_ref);
 
                 log::trace!("Compute trees");

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -14,13 +14,13 @@ use super::routing::face::Face;
 use super::Runtime;
 use crate::plugins::PluginsManager;
 use crate::prelude::Selector;
-use async_std::task;
 use futures::future::{BoxFuture, FutureExt};
 use log::{error, trace};
 use serde_json::json;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex;
+use zenoh_async_rt::spawn;
 use zenoh_buffers::{SplitBuffer, ZBuf};
 use zenoh_config::ValidatedMap;
 use zenoh_protocol::proto::{data_kind, DataInfo, RoutingContext};
@@ -103,7 +103,7 @@ impl AdminSpace {
         });
 
         let cfg_rx = admin.context.runtime.config.subscribe();
-        task::spawn({
+        spawn({
             let admin = admin.clone();
             async move {
                 while let Ok(change) = cfg_rx.recv_async().await {
@@ -388,7 +388,7 @@ impl Primitives for AdminSpace {
         let value_selector = value_selector.to_string();
 
         // router is not re-entrant
-        task::spawn(async move {
+        spawn(async move {
             let handler_tasks = futures::future::join_all(matching_handlers.into_iter().map(
                 |(key, handler)| async {
                     let handler = handler;

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -20,7 +20,6 @@ use super::routing::router::{LinkStateInterceptor, Router};
 use crate::config::{Config, Notifier};
 use crate::GIT_VERSION;
 pub use adminspace::AdminSpace;
-use async_std::task::JoinHandle;
 use futures::stream::StreamExt;
 use futures::Future;
 use std::any::Any;
@@ -29,6 +28,7 @@ use std::time::Duration;
 use stop_token::future::FutureExt;
 use stop_token::{StopSource, TimedOutError};
 use uhlc::{HLCBuilder, HLC};
+use zenoh_async_rt::{spawn, JoinHandle};
 use zenoh_core::bail;
 use zenoh_core::Result as ZResult;
 use zenoh_link::{EndPoint, Link};
@@ -192,7 +192,7 @@ impl Runtime {
             .read()
             .unwrap()
             .as_ref()
-            .map(|source| async_std::task::spawn(future.timeout_at(source.token())))
+            .map(|source| spawn(future.timeout_at(source.token())))
     }
 }
 

--- a/zenoh/src/prelude.rs
+++ b/zenoh/src/prelude.rs
@@ -741,7 +741,7 @@ impl<'a> From<KeyExpr<'a>> for Selector<'a> {
 /// ```
 ///
 /// ```no_run
-/// # async_std::task::block_on(async {
+/// # zenoh_async_rt::block_on(async {
 /// # use futures::prelude::*;
 /// # use zenoh::prelude::*;
 /// # let session = zenoh::open(config::peer()).await.unwrap();
@@ -760,7 +760,7 @@ impl<'a> From<KeyExpr<'a>> for Selector<'a> {
 /// ```
 ///
 /// ```
-/// # async_std::task::block_on(async {
+/// # zenoh_async_rt::block_on(async {
 /// # use futures::prelude::*;
 /// # use zenoh::prelude::*;
 /// # let session = zenoh::open(config::peer()).await.unwrap();
@@ -894,13 +894,14 @@ impl<'a> TryFrom<&'a String> for ValueSelector<'a> {
 ///
 /// # Examples
 /// ```no_run
-/// # async_std::task::block_on(async {
+/// # use zenoh_async_rt::spawn;
+/// # zenoh_async_rt::block_on(async {
 /// use futures::prelude::*;
 /// use zenoh::prelude::*;
 ///
 /// let session = zenoh::open(config::peer()).await.unwrap().into_arc();
 /// let mut subscriber = session.subscribe("/key/expression").await.unwrap();
-/// async_std::task::spawn(async move {
+/// spawn(async move {
 ///     while let Some(sample) = subscriber.next().await {
 ///         println!("Received : {:?}", sample);
 ///     }
@@ -916,13 +917,14 @@ pub trait EntityFactory {
     ///
     /// # Examples
     /// ```no_run
-    /// # async_std::task::block_on(async {
+    /// # use zenoh_async_rt::spawn;
+    /// # zenoh_async_rt::block_on(async {
     /// use futures::prelude::*;
     /// use zenoh::prelude::*;
     ///
     /// let session = zenoh::open(config::peer()).await.unwrap().into_arc();
     /// let mut subscriber = session.subscribe("/key/expression").await.unwrap();
-    /// async_std::task::spawn(async move {
+    /// spawn(async move {
     ///     while let Some(sample) = subscriber.next().await {
     ///         println!("Received : {:?}", sample);
     ///     }
@@ -942,13 +944,14 @@ pub trait EntityFactory {
     ///
     /// # Examples
     /// ```no_run
-    /// # async_std::task::block_on(async {
+    /// # use zenoh_async_rt::spawn;
+    /// # zenoh_async_rt::block_on(async {
     /// use futures::prelude::*;
     /// use zenoh::prelude::*;
     ///
     /// let session = zenoh::open(config::peer()).await.unwrap().into_arc();
     /// let mut queryable = session.queryable("/key/expression").await.unwrap();
-    /// async_std::task::spawn(async move {
+    /// spawn(async move {
     ///     while let Some(query) = queryable.next().await {
     ///         query.reply_async(Sample::new(
     ///             "/key/expression".to_string(),
@@ -970,7 +973,7 @@ pub trait EntityFactory {
     ///
     /// # Examples
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// use zenoh::prelude::*;
     ///
     /// let session = zenoh::open(config::peer()).await.unwrap().into_arc();

--- a/zenoh/src/publication.rs
+++ b/zenoh/src/publication.rs
@@ -35,7 +35,7 @@ derive_zfuture! {
     ///
     /// # Examples
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// use zenoh::prelude::*;
     /// use zenoh::publication::CongestionControl;
     ///
@@ -165,7 +165,7 @@ use zenoh_core::zresult::Error;
 ///
 /// # Examples
 /// ```
-/// # async_std::task::block_on(async {
+/// # zenoh_async_rt::block_on(async {
 /// use zenoh::prelude::*;
 ///
 /// let session = zenoh::open(config::peer()).await.unwrap().into_arc();
@@ -178,7 +178,7 @@ use zenoh_core::zresult::Error;
 /// `Publisher` implements the `Sink` trait which is useful to forward
 /// streams to zenoh.
 /// ```no_run
-/// # async_std::task::block_on(async {
+/// # zenoh_async_rt::block_on(async {
 /// use zenoh::prelude::*;
 ///
 /// let session = zenoh::open(config::peer()).await.unwrap().into_arc();
@@ -194,7 +194,7 @@ impl Publisher<'_> {
     ///
     /// # Examples
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// use zenoh::prelude::*;
     ///
     /// let session = zenoh::open(config::peer()).await.unwrap().into_arc();
@@ -246,7 +246,7 @@ derive_zfuture! {
     ///
     /// # Examples
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// use zenoh::prelude::*;
     /// use zenoh::publication::CongestionControl;
     ///

--- a/zenoh/src/query.rs
+++ b/zenoh/src/query.rs
@@ -159,7 +159,7 @@ zreceiver! {
     ///
     /// ### async
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// # use futures::prelude::*;
     /// # use zenoh::prelude::*;
     /// # let session = zenoh::open(config::peer()).await.unwrap();
@@ -182,7 +182,7 @@ derive_zfuture! {
     ///
     /// # Examples
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// use futures::prelude::*;
     /// use zenoh::prelude::*;
     /// use zenoh::query::*;

--- a/zenoh/src/queryable.rs
+++ b/zenoh/src/queryable.rs
@@ -144,13 +144,15 @@ zreceiver! {
     ///
     /// Examples:
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # use zenoh_async_rt::spawn;
+    /// # use zenoh_async_rt::sleep;
+    /// # zenoh_async_rt::block_on(async {
     /// use futures::prelude::*;
     /// use zenoh::prelude::*;
     /// let session = zenoh::open(config::peer()).await.unwrap();
     ///
     /// let mut queryable = session.queryable("/key/expression").wait().unwrap();
-    /// let task1 = async_std::task::spawn({
+    /// let task1 = spawn({
     ///     let mut receiver = queryable.receiver().clone();
     ///     async move {
     ///         while let Some(query) = receiver.next().await {
@@ -158,7 +160,7 @@ zreceiver! {
     ///         }
     ///     }
     /// });
-    /// let task2 = async_std::task::spawn({
+    /// let task2 = spawn({
     ///     let mut receiver = queryable.receiver().clone();
     ///     async move {
     ///         while let Some(query) = receiver.next().await {
@@ -167,7 +169,7 @@ zreceiver! {
     ///     }
     /// });
     ///
-    /// async_std::task::sleep(std::time::Duration::from_secs(1)).await;
+    /// sleep(std::time::Duration::from_secs(1)).await;
     /// queryable.close().await.unwrap();
     /// futures::join!(task1, task2);
     /// # })
@@ -202,7 +204,7 @@ zreceiver! {
     ///
     /// ### async
     /// ```no_run
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// # use futures::prelude::*;
     /// # use zenoh::prelude::*;
     /// # let session = zenoh::open(config::peer()).await.unwrap();
@@ -235,7 +237,7 @@ impl Queryable<'_> {
     ///
     /// # Examples
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// use zenoh::prelude::*;
     ///
     /// let session = zenoh::open(config::peer()).await.unwrap();
@@ -339,7 +341,7 @@ derive_zfuture! {
     ///
     /// # Examples
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// use futures::prelude::*;
     /// use zenoh::prelude::*;
     /// use zenoh::queryable;

--- a/zenoh/src/session.rs
+++ b/zenoh/src/session.rs
@@ -30,7 +30,6 @@ use crate::Sample;
 use crate::Selector;
 use crate::Value;
 use crate::ZFuture;
-use async_std::task;
 use flume::{bounded, Sender};
 use futures::StreamExt;
 use log::{error, trace, warn};
@@ -42,6 +41,7 @@ use std::sync::Arc;
 use std::sync::RwLock;
 use std::time::Duration;
 use uhlc::HLC;
+use zenoh_async_rt::{sleep, spawn};
 use zenoh_core::{zconfigurable, zread, Result as ZResult};
 use zenoh_protocol::{
     core::{
@@ -270,7 +270,7 @@ impl Session {
                     )
                     .await;
                     // Workaround for the declare_and_shoot problem
-                    task::sleep(Duration::from_millis(*API_OPEN_SESSION_DELAY)).await;
+                    sleep(Duration::from_millis(*API_OPEN_SESSION_DELAY)).await;
                     Ok(session)
                 }
                 Err(err) => Err(err),
@@ -291,13 +291,14 @@ impl Session {
     ///
     /// # Examples
     /// ```no_run
-    /// # async_std::task::block_on(async {
+    /// # use zenoh_async_rt::spawn;
+    /// # zenoh_async_rt::block_on(async {
     /// use futures::prelude::*;
     /// use zenoh::prelude::*;
     ///
     /// let session = zenoh::open(config::peer()).await.unwrap().into_arc();
     /// let mut subscriber = session.subscribe("/key/expression").await.unwrap();
-    /// async_std::task::spawn(async move {
+    /// spawn(async move {
     ///     while let Some(sample) = subscriber.next().await {
     ///         println!("Received : {:?}", sample);
     ///     }
@@ -322,14 +323,15 @@ impl Session {
     ///
     /// # Examples
     /// ```no_run
-    /// # async_std::task::block_on(async {
+    /// # use zenoh_async_rt::spawn;
+    /// # zenoh_async_rt::block_on(async {
     /// use futures::prelude::*;
     /// use zenoh::prelude::*;
     /// use zenoh::Session;
     ///
     /// let session = Session::leak(zenoh::open(config::peer()).await.unwrap());
     /// let mut subscriber = session.subscribe("/key/expression").await.unwrap();
-    /// async_std::task::spawn(async move {
+    /// spawn(async move {
     ///     while let Some(sample) = subscriber.next().await {
     ///         println!("Received : {:?}", sample);
     ///     }
@@ -395,7 +397,7 @@ impl Session {
     ///
     /// # Examples
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// use zenoh::prelude::*;
     ///
     /// let session = zenoh::open(config::peer()).await.unwrap();
@@ -418,7 +420,7 @@ impl Session {
     /// # Examples
     /// ### Read current zenoh configuration
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// use zenoh::prelude::*;
     ///
     /// let session = zenoh::open(config::peer()).await.unwrap();
@@ -428,7 +430,7 @@ impl Session {
     ///
     /// ### Modify current zenoh configuration
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// use zenoh::prelude::*;
     ///
     /// let session = zenoh::open(config::peer()).await.unwrap();
@@ -444,7 +446,7 @@ impl Session {
     ///
     /// # Examples
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// use zenoh::prelude::*;
     ///
     /// let session = zenoh::open(config::peer()).await.unwrap();
@@ -511,7 +513,7 @@ impl Session {
     ///
     /// # Examples
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// use zenoh::prelude::*;
     ///
     /// let session = zenoh::open(config::peer()).await.unwrap();
@@ -567,7 +569,7 @@ impl Session {
     ///
     /// # Examples
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// use zenoh::prelude::*;
     ///
     /// let session = zenoh::open(config::peer()).await.unwrap();
@@ -599,7 +601,7 @@ impl Session {
     ///
     /// # Examples
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// use zenoh::prelude::*;
     ///
     /// let session = zenoh::open(config::peer()).await.unwrap();
@@ -654,7 +656,7 @@ impl Session {
     ///
     /// # Examples
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// use zenoh::prelude::*;
     ///
     /// let session = zenoh::open(config::peer()).await.unwrap();
@@ -824,7 +826,7 @@ impl Session {
     ///
     /// # Examples
     /// ```no_run
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// use futures::prelude::*;
     /// use zenoh::prelude::*;
     ///
@@ -953,7 +955,7 @@ impl Session {
     ///
     /// # Examples
     /// ```no_run
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// use futures::prelude::*;
     /// use zenoh::prelude::*;
     ///
@@ -1048,7 +1050,7 @@ impl Session {
     ///
     /// # Examples
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// use zenoh::prelude::*;
     ///
     /// let session = zenoh::open(config::peer()).await.unwrap();
@@ -1082,7 +1084,7 @@ impl Session {
     ///
     /// # Examples
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// use zenoh::prelude::*;
     ///
     /// let session = zenoh::open(config::peer()).await.unwrap();
@@ -1119,7 +1121,7 @@ impl Session {
     ///
     /// # Examples
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// use zenoh::prelude::*;
     ///
     /// let session = zenoh::open(config::peer()).await.unwrap();
@@ -1259,7 +1261,7 @@ impl Session {
     ///
     /// # Examples
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// use futures::prelude::*;
     /// use zenoh::prelude::*;
     ///
@@ -1353,7 +1355,7 @@ impl Session {
 
         if local {
             let this = self.clone();
-            task::spawn(async move {
+            spawn(async move {
                 while let Some((replier_kind, sample)) = rep_receiver.stream().next().await {
                     let (key_expr, payload, data_info) = sample.split();
                     this.send_reply_data(
@@ -1368,7 +1370,7 @@ impl Session {
                 this.send_reply_final(qid);
             });
         } else {
-            task::spawn(async move {
+            spawn(async move {
                 while let Some((replier_kind, sample)) = rep_receiver.stream().next().await {
                     let (key_expr, payload, data_info) = sample.split();
                     primitives.send_reply_data(
@@ -1400,13 +1402,14 @@ impl EntityFactory for Arc<Session> {
     ///
     /// # Examples
     /// ```no_run
-    /// # async_std::task::block_on(async {
+    /// # use zenoh_async_rt::spawn;
+    /// # zenoh_async_rt::block_on(async {
     /// use futures::prelude::*;
     /// use zenoh::prelude::*;
     ///
     /// let session = zenoh::open(config::peer()).await.unwrap().into_arc();
     /// let mut subscriber = session.subscribe("/key/expression").await.unwrap();
-    /// async_std::task::spawn(async move {
+    /// spawn(async move {
     ///     while let Some(sample) = subscriber.next().await {
     ///         println!("Received : {:?}", sample);
     ///     }
@@ -1436,13 +1439,14 @@ impl EntityFactory for Arc<Session> {
     ///
     /// # Examples
     /// ```no_run
-    /// # async_std::task::block_on(async {
+    /// # use zenoh_async_rt::spawn;
+    /// # zenoh_async_rt::block_on(async {
     /// use futures::prelude::*;
     /// use zenoh::prelude::*;
     ///
     /// let session = zenoh::open(config::peer()).await.unwrap().into_arc();
     /// let mut queryable = session.queryable("/key/expression").await.unwrap();
-    /// async_std::task::spawn(async move {
+    /// spawn(async move {
     ///     while let Some(query) = queryable.next().await {
     ///         query.reply_async(Sample::new(
     ///             "/key/expression".to_string(),
@@ -1472,7 +1476,7 @@ impl EntityFactory for Arc<Session> {
     ///
     /// # Examples
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// use zenoh::prelude::*;
     ///
     /// let session = zenoh::open(config::peer()).await.unwrap().into_arc();

--- a/zenoh/src/subscriber.rs
+++ b/zenoh/src/subscriber.rs
@@ -79,13 +79,15 @@ zreceiver! {
     ///
     /// Examples:
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # use zenoh_async_rt::spawn;
+    /// # use zenoh_async_rt::sleep;
+    /// # zenoh_async_rt::block_on(async {
     /// use futures::prelude::*;
     /// use zenoh::prelude::*;
     /// let session = zenoh::open(config::peer()).await.unwrap();
     ///
     /// let mut subscriber = session.subscribe("/key/expression").await.unwrap();
-    /// let task1 = async_std::task::spawn({
+    /// let task1 = spawn({
     ///     let mut receiver = subscriber.receiver().clone();
     ///     async move {
     ///         while let Some(sample) = receiver.next().await {
@@ -93,7 +95,7 @@ zreceiver! {
     ///         }
     ///     }
     /// });
-    /// let task2 = async_std::task::spawn({
+    /// let task2 = spawn({
     ///     let mut receiver = subscriber.receiver().clone();
     ///     async move {
     ///         while let Some(sample) = receiver.next().await {
@@ -102,7 +104,7 @@ zreceiver! {
     ///     }
     /// });
     ///
-    /// async_std::task::sleep(std::time::Duration::from_secs(1)).await;
+    /// sleep(std::time::Duration::from_secs(1)).await;
     /// subscriber.close().await.unwrap();
     /// futures::join!(task1, task2);
     /// # })
@@ -138,7 +140,7 @@ zreceiver! {
     ///
     /// ### async
     /// ```no_run
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// # use futures::prelude::*;
     /// # use zenoh::prelude::*;
     /// # let session = zenoh::open(config::peer()).await.unwrap();
@@ -168,7 +170,8 @@ impl Subscriber<'_> {
     ///
     /// # Examples
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # use zenoh_async_rt::spawn;
+    /// # zenoh_async_rt::block_on(async {
     /// use futures::prelude::*;
     /// use zenoh::prelude::*;
     /// use zenoh::subscriber::SubMode;
@@ -176,7 +179,7 @@ impl Subscriber<'_> {
     /// let session = zenoh::open(config::peer()).await.unwrap();
     /// let mut subscriber = session.subscribe("/key/expression")
     ///                             .mode(SubMode::Pull).await.unwrap();
-    /// async_std::task::spawn(subscriber.receiver().clone().for_each(
+    /// spawn(subscriber.receiver().clone().for_each(
     ///     move |sample| async move { println!("Received : {:?}", sample); }
     /// ));
     /// subscriber.pull();
@@ -194,7 +197,7 @@ impl Subscriber<'_> {
     ///
     /// # Examples
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// use zenoh::prelude::*;
     ///
     /// let session = zenoh::open(config::peer()).await.unwrap();
@@ -238,7 +241,7 @@ impl CallbackSubscriber<'_> {
     ///
     /// # Examples
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// use zenoh::prelude::*;
     /// use zenoh::subscriber::SubMode;
     ///
@@ -261,7 +264,7 @@ impl CallbackSubscriber<'_> {
     ///
     /// # Examples
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// use zenoh::prelude::*;
     ///
     /// let session = zenoh::open(config::peer()).await.unwrap();
@@ -301,7 +304,7 @@ derive_zfuture! {
     ///
     /// # Examples
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// use zenoh::prelude::*;
     ///
     /// let session = zenoh::open(config::peer()).await.unwrap();
@@ -451,7 +454,7 @@ derive_zfuture! {
     ///
     /// # Examples
     /// ```
-    /// # async_std::task::block_on(async {
+    /// # zenoh_async_rt::block_on(async {
     /// use zenoh::prelude::*;
     ///
     /// let session = zenoh::open(config::peer()).await.unwrap();

--- a/zenohd/Cargo.toml
+++ b/zenohd/Cargo.toml
@@ -47,6 +47,7 @@ git-version = "0.3.4"
 json5 = "0.4.1"
 lazy_static = "1.4.0"
 log = "0.4"
+zenoh-async-rt = { version = "0.1.0", path = "../commons/zenoh-async-rt" }
 
 [dev-dependencies]
 rand = "0.8.3"

--- a/zenohd/src/main.rs
+++ b/zenohd/src/main.rs
@@ -11,13 +11,13 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use async_std::task;
 use clap::{ArgMatches, Command};
 use futures::future;
 use git_version::git_version;
 use zenoh::config::{Config, EndPoint, PluginLoad, ValidatedMap};
 use zenoh::net::runtime::{AdminSpace, Runtime};
 use zenoh::plugins::PluginsManager;
+use zenoh_async_rt::block_on;
 
 const GIT_VERSION: &str = git_version!(prefix = "v", cargo_prefix = "v");
 
@@ -28,7 +28,7 @@ lazy_static::lazy_static!(
 const DEFAULT_LISTENER: &str = "tcp/0.0.0.0:7447";
 
 fn main() {
-    task::block_on(async {
+    block_on(async {
         let mut log_builder =
             env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("z=info"));
         #[cfg(feature = "stats")]


### PR DESCRIPTION
This PR moves commonly used runtime functions, `spawn()`, `block_on()` and `sleep()` into a `zenoh-async-rt` crate, and code to use functions from that crate. It ensures the whole repo runs on the unified runtime, and eases the version update of `async-std`. It also paves the way  to async-runtime agnostic feature.