### PR TITLE
Fix query.reply() with a DELETE Sample

### DIFF
--- a/zenoh/src/prelude.rs
+++ b/zenoh/src/prelude.rs
@@ -437,7 +437,11 @@ impl Sample {
     #[inline]
     pub(crate) fn split(self) -> (KeyExpr<'static>, ZBuf, DataInfo) {
         let info = DataInfo {
-            kind: None,
+            kind: if self.kind == SampleKind::Put {
+                None
+            } else {
+                Some(self.kind as u64)
+            },
             encoding: Some(self.value.encoding),
             timestamp: self.timestamp,
             #[cfg(feature = "shared-memory")]


### PR DESCRIPTION
When a queryable implementation calls `query.reply(sample)` with `sample.kind == SampleKind::Delete`, the querier receives a sample with `sample.kind == SampleKind::Put`.

The root of the problem is in `Sample::split()` operation that always returns a `DataInfo` with `kind == None`.
This PR fixes copying the `sample.kind` into `DataInfo::kind` (or setting to `None` if `kind == SampleKind::Put` for wire optimisation)