### PR TITLE
WIP: Serial (RS232-like) transport for Zenoh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3562,6 +3562,7 @@ dependencies = [
 [[package]]
 name = "z-serial"
 version = "0.1.0"
+source = "git+https://github.com/ZettaScaleLabs/z-serial?branch=master#7e4954bbfa46383b36f31ff54dbbc9ffc7e63980"
 dependencies = [
  "futures",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3559,10 +3559,11 @@ dependencies = [
 [[package]]
 name = "z-serial"
 version = "0.1.0"
-source = "git+https://github.com/ZettaScaleLabs/z-serial?branch=feat/cobs#0f1f2b1817acace7b6bb2ada5619a5eba4a40ea4"
+source = "git+https://github.com/ZettaScaleLabs/z-serial?branch=master#01042e9b7297d0cfad6bba6c33418d9b486167c5"
 dependencies = [
  "cobs",
  "futures",
+ "log",
  "tokio",
  "tokio-serial",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,27 @@
 version = 3
 
 [[package]]
+name = "CoreFoundation-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0e9889e6db118d49d88d84728d0e964d973a5680befb5f85f55141beea5c20b"
+dependencies = [
+ "libc",
+ "mach 0.1.2",
+]
+
+[[package]]
+name = "IOKit-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99696c398cbaf669d2368076bdb3d627fb0ce51a26899d7c61228c5c0af3bf4a"
+dependencies = [
+ "CoreFoundation-sys",
+ "libc",
+ "mach 0.1.2",
+]
+
+[[package]]
 name = "aead"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1502,6 +1523,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd13ee2dd61cc82833ba05ade5a30bb3d63f7ced605ef827063c63078302de9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1537,7 +1576,29 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "winapi",
+]
+
+[[package]]
+name = "mio-serial"
+version = "5.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e0f6dc55a5aa7b8d320407c5c4ced464e23815c60f6a1e6d9e225d2b45905"
+dependencies = [
+ "log",
+ "mio 0.8.2",
+ "nix 0.23.1",
+ "serialport",
+ "winapi",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -2510,6 +2571,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "serialport"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc52fd78198e211d0e39928cbca339da52f679f4a964cdf335b33fc1855f63f"
+dependencies = [
+ "CoreFoundation-sys",
+ "IOKit-sys",
+ "bitflags",
+ "cfg-if 1.0.0",
+ "mach 0.3.2",
+ "nix 0.23.1",
+ "regex",
+ "winapi",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2954,15 +3031,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tungstenite"
-version = "0.17.2"
+name = "tokio-serial"
+version = "5.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
+checksum = "e5488e0c75c70e880823aebc3ad4ac0a6da6f48d95bc1b9a52bd3200d6f1e724"
 dependencies = [
- "futures-util",
+ "cfg-if 1.0.0",
+ "futures",
  "log",
+ "mio-serial",
  "tokio",
- "tungstenite",
 ]
 
 [[package]]
@@ -3039,7 +3117,7 @@ dependencies = [
  "lazy_static",
  "log",
  "serde",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -3122,6 +3200,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
 dependencies = [
  "getrandom 0.2.7",
+]
+
+[[package]]
+name = "uuid"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfcd319456c4d6ea10087ed423473267e1a071f3bc0aa89f80d60997843c6f0"
+dependencies = [
+ "getrandom 0.2.6",
 ]
 
 [[package]]
@@ -3488,7 +3575,7 @@ dependencies = [
  "socket2",
  "stop-token",
  "uhlc",
- "uuid",
+ "uuid 0.8.2",
  "vec_map",
  "zenoh-buffers",
  "zenoh-cfg-properties",
@@ -3624,6 +3711,7 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-link-quic",
+ "zenoh-link-serial",
  "zenoh-link-tcp",
  "zenoh-link-tls",
  "zenoh-link-udp",
@@ -3661,6 +3749,25 @@ dependencies = [
  "webpki 0.22.0",
  "zenoh-cfg-properties",
  "zenoh-config",
+ "zenoh-core",
+ "zenoh-link-commons",
+ "zenoh-protocol-core",
+ "zenoh-sync",
+ "zenoh-util",
+]
+
+[[package]]
+name = "zenoh-link-serial"
+version = "0.6.0-dev.0"
+dependencies = [
+ "async-std",
+ "async-trait",
+ "futures",
+ "log",
+ "tokio",
+ "tokio-serial",
+ "uuid 1.0.0",
+ "zenoh-collections",
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol-core",
@@ -3724,8 +3831,8 @@ dependencies = [
  "async-trait",
  "futures",
  "log",
- "nix 0.24.2",
- "uuid",
+ "nix 0.23.1",
+ "uuid 0.8.2",
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol-core",
@@ -3824,7 +3931,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "uhlc",
- "uuid",
+ "uuid 0.8.2",
  "zenoh-buffers",
  "zenoh-core",
  "zenoh-protocol-core",
@@ -3841,7 +3948,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "uhlc",
- "uuid",
+ "uuid 0.8.2",
  "zenoh-core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3560,6 +3560,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "z-serial"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "tokio",
+ "tokio-serial",
+]
+
+[[package]]
 name = "zenoh"
 version = "0.6.0-dev.0"
 dependencies = [
@@ -3777,9 +3786,11 @@ dependencies = [
  "futures",
  "log",
  "tokio",
- "tokio-serial",
  "uuid 1.0.0",
+ "z-serial",
+ "zenoh-cfg-properties",
  "zenoh-collections",
+ "zenoh-config",
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3044,6 +3044,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06cda1232a49558c46f8a504d5b93101d42c0bf7f911f12a105ba48168f821ae"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3550,7 +3550,6 @@ dependencies = [
 [[package]]
 name = "z-serial"
 version = "0.1.0"
-source = "git+https://github.com/ZettaScaleLabs/z-serial?branch=master#01042e9b7297d0cfad6bba6c33418d9b486167c5"
 dependencies = [
  "cobs",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,6 +585,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
 name = "cobs"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1573,7 +1582,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1583,18 +1592,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531e0f6dc55a5aa7b8d320407c5c4ced464e23815c60f6a1e6d9e225d2b45905"
 dependencies = [
  "log",
- "mio 0.8.2",
+ "mio",
  "nix 0.23.1",
  "serialport",
- "winapi",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
  "winapi",
 ]
 
@@ -3126,7 +3126,7 @@ dependencies = [
  "lazy_static",
  "log",
  "serde",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
@@ -3209,15 +3209,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
 dependencies = [
  "getrandom 0.2.7",
-]
-
-[[package]]
-name = "uuid"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cfcd319456c4d6ea10087ed423473267e1a071f3bc0aa89f80d60997843c6f0"
-dependencies = [
- "getrandom 0.2.6",
 ]
 
 [[package]]
@@ -3596,7 +3587,7 @@ dependencies = [
  "socket2",
  "stop-token",
  "uhlc",
- "uuid 0.8.2",
+ "uuid",
  "vec_map",
  "zenoh-buffers",
  "zenoh-cfg-properties",
@@ -3786,7 +3777,7 @@ dependencies = [
  "futures",
  "log",
  "tokio",
- "uuid 1.0.0",
+ "uuid",
  "z-serial",
  "zenoh-cfg-properties",
  "zenoh-collections",
@@ -3854,8 +3845,8 @@ dependencies = [
  "async-trait",
  "futures",
  "log",
- "nix 0.23.1",
- "uuid 0.8.2",
+ "nix 0.24.2",
+ "uuid",
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol-core",
@@ -3954,7 +3945,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "uhlc",
- "uuid 0.8.2",
+ "uuid",
  "zenoh-buffers",
  "zenoh-core",
  "zenoh-protocol-core",
@@ -3971,7 +3962,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "uhlc",
- "uuid 0.8.2",
+ "uuid",
  "zenoh-core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,13 +585,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap_lex"
-version = "0.2.4"
+name = "cobs"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
 name = "concurrent-queue"
@@ -3562,8 +3559,9 @@ dependencies = [
 [[package]]
 name = "z-serial"
 version = "0.1.0"
-source = "git+https://github.com/ZettaScaleLabs/z-serial?branch=master#7e4954bbfa46383b36f31ff54dbbc9ffc7e63980"
+source = "git+https://github.com/ZettaScaleLabs/z-serial?branch=feat/cobs#0f1f2b1817acace7b6bb2ada5619a5eba4a40ea4"
 dependencies = [
+ "cobs",
  "futures",
  "tokio",
  "tokio-serial",

--- a/examples/examples/z_put.rs
+++ b/examples/examples/z_put.rs
@@ -33,8 +33,6 @@ async fn main() {
     loop {
         async_std::task::sleep(std::time::Duration::from_secs(10)).await;
     }
-
-
 }
 
 fn parse_args() -> (Config, String, String) {

--- a/examples/examples/z_put.rs
+++ b/examples/examples/z_put.rs
@@ -25,14 +25,8 @@ async fn main() {
     println!("Opening session...");
     let session = zenoh::open(config).res().await.unwrap();
 
-    async_std::task::sleep(std::time::Duration::from_secs(2)).await;
-
-    //println!("Putting Data ('{}': '{}')...", key_expr, value);
-    //session.put(&key_expr, value).await.unwrap();
-
-    loop {
-        async_std::task::sleep(std::time::Duration::from_secs(10)).await;
-    }
+    println!("Putting Data ('{}': '{}')...", key_expr, value);
+    session.put(&key_expr, value).await.unwrap();
 }
 
 fn parse_args() -> (Config, String, String) {

--- a/examples/examples/z_put.rs
+++ b/examples/examples/z_put.rs
@@ -25,8 +25,16 @@ async fn main() {
     println!("Opening session...");
     let session = zenoh::open(config).res().await.unwrap();
 
-    println!("Putting Data ('{}': '{}')...", key_expr, value);
-    session.put(&key_expr, value).res().await.unwrap();
+    async_std::task::sleep(std::time::Duration::from_secs(2)).await;
+
+    //println!("Putting Data ('{}': '{}')...", key_expr, value);
+    //session.put(&key_expr, value).await.unwrap();
+
+    loop {
+        async_std::task::sleep(std::time::Duration::from_secs(10)).await;
+    }
+
+
 }
 
 fn parse_args() -> (Config, String, String) {

--- a/io/zenoh-link/Cargo.toml
+++ b/io/zenoh-link/Cargo.toml
@@ -35,6 +35,7 @@ transport_tcp = ["zenoh-link-tcp"]
 transport_tls = ["zenoh-link-tls"]
 transport_udp = ["zenoh-link-udp"]
 transport_unixsock-stream = ["zenoh-link-unixsock_stream"]
+transport_ws = ["zenoh-link-ws"]
 transport_serial = ["zenoh-link-serial"]
 
 [dependencies]

--- a/io/zenoh-link/Cargo.toml
+++ b/io/zenoh-link/Cargo.toml
@@ -35,7 +35,7 @@ transport_tcp = ["zenoh-link-tcp"]
 transport_tls = ["zenoh-link-tls"]
 transport_udp = ["zenoh-link-udp"]
 transport_unixsock-stream = ["zenoh-link-unixsock_stream"]
-transport_ws = ["zenoh-link-ws"]
+transport_serial = ["zenoh-link-serial"]
 
 [dependencies]
 zenoh-core = { path = "../../commons/zenoh-core/" }
@@ -48,6 +48,7 @@ zenoh-link-quic = { path = "../zenoh-links/zenoh-link-quic/", optional = true }
 zenoh-link-tcp = { path = "../zenoh-links/zenoh-link-tcp/", optional = true }
 zenoh-link-tls = { path = "../zenoh-links/zenoh-link-tls/", optional = true }
 zenoh-link-udp = { path = "../zenoh-links/zenoh-link-udp/", optional = true }
+zenoh-link-serial = { path = "../zenoh-links/zenoh-link-serial/", optional = true }
 zenoh-link-unixsock_stream = { path = "../zenoh-links/zenoh-link-unixsock_stream/", optional = true }
 zenoh-link-ws = { path = "../zenoh-links/zenoh-link-ws/", optional = true }
 

--- a/io/zenoh-link/src/lib.rs
+++ b/io/zenoh-link/src/lib.rs
@@ -25,6 +25,10 @@ pub use zenoh_link_quic as quic;
 use zenoh_link_quic::{
     LinkManagerUnicastQuic, QuicConfigurator, QuicLocatorInspector, QUIC_LOCATOR_PREFIX,
 };
+#[cfg(feature = "transport_serial")]
+pub use zenoh_link_serial as serial;
+#[cfg(feature = "transport_serial")]
+use zenoh_link_serial::{LinkManagerUnicastSerial, SERIAL_LOCATOR_PREFIX};
 #[cfg(feature = "transport_tcp")]
 pub use zenoh_link_tcp as tcp;
 #[cfg(feature = "transport_tcp")]
@@ -51,10 +55,6 @@ use zenoh_link_unixsock_stream::{
 pub use zenoh_link_ws as ws;
 #[cfg(feature = "transport_ws")]
 use zenoh_link_ws::{LinkManagerUnicastWs, WsLocatorInspector, WS_LOCATOR_PREFIX};
-#[cfg(feature = "transport_serial")]
-pub use zenoh_link_serial as serial;
-#[cfg(feature = "transport_serial")]
-use zenoh_link_serial::{LinkManagerUnicastSerial, SERIAL_LOCATOR_PREFIX};
 
 pub use zenoh_link_commons::*;
 pub use zenoh_protocol_core::{EndPoint, Locator};

--- a/io/zenoh-link/src/lib.rs
+++ b/io/zenoh-link/src/lib.rs
@@ -47,7 +47,10 @@ pub use zenoh_link_unixsock_stream as unixsock_stream;
 use zenoh_link_unixsock_stream::{
     LinkManagerUnicastUnixSocketStream, UNIXSOCKSTREAM_LOCATOR_PREFIX,
 };
-
+#[cfg(feature = "transport_ws")]
+pub use zenoh_link_ws as ws;
+#[cfg(feature = "transport_ws")]
+use zenoh_link_ws::{LinkManagerUnicastWs, WsLocatorInspector, WS_LOCATOR_PREFIX};
 #[cfg(feature = "transport_serial")]
 pub use zenoh_link_serial as serial;
 #[cfg(feature = "transport_serial")]

--- a/io/zenoh-link/src/lib.rs
+++ b/io/zenoh-link/src/lib.rs
@@ -48,10 +48,10 @@ use zenoh_link_unixsock_stream::{
     LinkManagerUnicastUnixSocketStream, UNIXSOCKSTREAM_LOCATOR_PREFIX,
 };
 
-#[cfg(feature = "transport_ws")]
-pub use zenoh_link_ws as ws;
-#[cfg(feature = "transport_ws")]
-use zenoh_link_ws::{LinkManagerUnicastWs, WsLocatorInspector, WS_LOCATOR_PREFIX};
+#[cfg(feature = "transport_serial")]
+pub use zenoh_link_serial as serial;
+#[cfg(feature = "transport_serial")]
+use zenoh_link_serial::{LinkManagerUnicastSerial, SERIAL_LOCATOR_PREFIX};
 
 pub use zenoh_link_commons::*;
 pub use zenoh_protocol_core::{EndPoint, Locator};
@@ -83,6 +83,8 @@ impl LocatorInspector {
             TLS_LOCATOR_PREFIX => self.tls_inspector.is_multicast(locator).await,
             #[cfg(feature = "transport_quic")]
             QUIC_LOCATOR_PREFIX => self.quic_inspector.is_multicast(locator).await,
+            #[cfg(feature = "transport_serial")]
+            SERIAL_LOCATOR_PREFIX => Ok(false),
             #[cfg(all(feature = "transport_unixsock-stream", target_family = "unix"))]
             UNIXSOCKSTREAM_LOCATOR_PREFIX => Ok(false),
             #[cfg(feature = "transport_ws")]
@@ -152,6 +154,8 @@ impl LinkManagerBuilderUnicast {
             TLS_LOCATOR_PREFIX => Ok(Arc::new(LinkManagerUnicastTls::new(_manager))),
             #[cfg(feature = "transport_quic")]
             QUIC_LOCATOR_PREFIX => Ok(Arc::new(LinkManagerUnicastQuic::new(_manager))),
+            #[cfg(feature = "transport_serial")]
+            SERIAL_LOCATOR_PREFIX => Ok(Arc::new(LinkManagerUnicastSerial::new(_manager))),
             #[cfg(all(feature = "transport_unixsock-stream", target_family = "unix"))]
             UNIXSOCKSTREAM_LOCATOR_PREFIX => {
                 Ok(Arc::new(LinkManagerUnicastUnixSocketStream::new(_manager)))

--- a/io/zenoh-links/zenoh-link-serial/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-serial/Cargo.toml
@@ -49,5 +49,6 @@ tokio = { version = "1.17.0", default-features = false, features = ["io-std", "m
 async-trait = "0.1.42"
 log = "0.4"
 futures = "0.3.21"
-z-serial = {git = "https://github.com/ZettaScaleLabs/z-serial", branch = "master"}
+# z-serial = {git = "https://github.com/ZettaScaleLabs/z-serial", branch = "master"}
+z-serial = {path = "../../../../z-serial"}
 uuid = { version = "1.1.2", features = ["v4"] }

--- a/io/zenoh-links/zenoh-link-serial/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-serial/Cargo.toml
@@ -49,6 +49,5 @@ tokio = { version = "1.17.0", default-features = false, features = ["io-std", "m
 async-trait = "0.1.42"
 log = "0.4"
 futures = "0.3.21"
-# z-serial = {git = "https://github.com/ZettaScaleLabs/z-serial", branch = "master"}
-z-serial = {path = "../../../../z-serial"}
+z-serial = "0.1.0 "
 uuid = { version = "1.1.2", features = ["v4"] }

--- a/io/zenoh-links/zenoh-link-serial/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-serial/Cargo.toml
@@ -37,7 +37,8 @@ zenoh-util = { path = "../../../commons/zenoh-util/" }
 zenoh-collections = { path = "../../../commons/zenoh-collections/" }
 zenoh-sync = { path = "../../../commons/zenoh-sync/" }
 zenoh-protocol-core = { path = "../../../commons/zenoh-protocol-core/" }
-
+zenoh-config = { path = "../../../commons/zenoh-config/" }
+zenoh-cfg-properties = { path = "../../../commons/zenoh-cfg-properties/" }
 zenoh-link-commons = { path = "../../zenoh-link-commons/" }
 
 async-std = { version = "=1.11.0", default-features = false, features = [
@@ -48,5 +49,6 @@ tokio = { version = "1.17.0", default-features = false, features = ["io-std", "m
 async-trait = "0.1.42"
 log = "0.4"
 futures = "0.3.21"
-tokio-serial = "5.4.1"
+#z-serial = {git = "https://github.com/ZettaScaleLabs/z-serial", branch = "master"}
+z-serial = {path = "../../../../z-serial"}
 uuid = { version = "1.0", features = ["v4"] }

--- a/io/zenoh-links/zenoh-link-serial/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-serial/Cargo.toml
@@ -1,0 +1,52 @@
+#
+# Copyright (c) 2022 ZettaScale Technology
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+#   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+#
+[package]
+name = "zenoh-link-serial"
+version = "0.6.0-dev.0"
+repository = "https://github.com/eclipse-zenoh/zenoh"
+homepage = "http://zenoh.io"
+authors = [
+	"kydos <angelo@icorsaro.net>",
+	"Julien Enoch <julien@enoch.fr>",
+	"Olivier Hécart <olivier.hecart@zettascale.tech>",
+	"Luca Cominardi <luca.cominardi@zettascale.tech>",
+	"Pierre Avital <pierre.avital@zettascale.tech>",
+	"Gabriele Baldoni <gabriele.baldoni@zettascale.tech>"
+]
+edition = "2018"
+license = " EPL-2.0 OR Apache-2.0"
+categories = ["network-programming"]
+description = "Internal crate for zenoh."
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+zenoh-core = { path = "../../../commons/zenoh-core/" }
+zenoh-util = { path = "../../../commons/zenoh-util/" }
+zenoh-collections = { path = "../../../commons/zenoh-collections/" }
+zenoh-sync = { path = "../../../commons/zenoh-sync/" }
+zenoh-protocol-core = { path = "../../../commons/zenoh-protocol-core/" }
+
+zenoh-link-commons = { path = "../../zenoh-link-commons/" }
+
+async-std = { version = "=1.11.0", default-features = false, features = [
+	"unstable",
+	"tokio1",
+] }
+tokio = { version = "1.17.0", default-features = false, features = ["io-std", "macros", "net", "rt-multi-thread", "time", "io-util"] }
+async-trait = "0.1.42"
+log = "0.4"
+futures = "0.3.21"
+tokio-serial = "5.4.1"
+uuid = { version = "1.0", features = ["v4"] }

--- a/io/zenoh-links/zenoh-link-serial/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-serial/Cargo.toml
@@ -41,7 +41,7 @@ zenoh-config = { path = "../../../commons/zenoh-config/" }
 zenoh-cfg-properties = { path = "../../../commons/zenoh-cfg-properties/" }
 zenoh-link-commons = { path = "../../zenoh-link-commons/" }
 
-async-std = { version = "=1.11.0", default-features = false, features = [
+async-std = { version = "=1.12.0", default-features = false, features = [
 	"unstable",
 	"tokio1",
 ] }
@@ -50,4 +50,4 @@ async-trait = "0.1.42"
 log = "0.4"
 futures = "0.3.21"
 z-serial = {git = "https://github.com/ZettaScaleLabs/z-serial", branch = "master"}
-uuid = { version = "1.0", features = ["v4"] }
+uuid = { version = "1.1.2", features = ["v4"] }

--- a/io/zenoh-links/zenoh-link-serial/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-serial/Cargo.toml
@@ -49,6 +49,5 @@ tokio = { version = "1.17.0", default-features = false, features = ["io-std", "m
 async-trait = "0.1.42"
 log = "0.4"
 futures = "0.3.21"
-#z-serial = {git = "https://github.com/ZettaScaleLabs/z-serial", branch = "master"}
-z-serial = {path = "../../../../z-serial"}
+z-serial = {git = "https://github.com/ZettaScaleLabs/z-serial", branch = "master"}
 uuid = { version = "1.0", features = ["v4"] }

--- a/io/zenoh-links/zenoh-link-serial/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-serial/Cargo.toml
@@ -49,5 +49,5 @@ tokio = { version = "1.17.0", default-features = false, features = ["io-std", "m
 async-trait = "0.1.42"
 log = "0.4"
 futures = "0.3.21"
-z-serial = {git = "https://github.com/ZettaScaleLabs/z-serial", branch = "feat/cobs"}
+z-serial = {git = "https://github.com/ZettaScaleLabs/z-serial", branch = "master"}
 uuid = { version = "1.0", features = ["v4"] }

--- a/io/zenoh-links/zenoh-link-serial/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-serial/Cargo.toml
@@ -49,5 +49,5 @@ tokio = { version = "1.17.0", default-features = false, features = ["io-std", "m
 async-trait = "0.1.42"
 log = "0.4"
 futures = "0.3.21"
-z-serial = {git = "https://github.com/ZettaScaleLabs/z-serial", branch = "master"}
+z-serial = {git = "https://github.com/ZettaScaleLabs/z-serial", branch = "feat/cobs"}
 uuid = { version = "1.0", features = ["v4"] }

--- a/io/zenoh-links/zenoh-link-serial/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-serial/src/lib.rs
@@ -34,6 +34,8 @@ const SERIAL_MTU_LIMIT: u16 = SERIAL_MAX_MTU;
 zconfigurable! {
     // Default MTU (UDP PDU) in bytes.
     static ref SERIAL_DEFAULT_MTU: u16 = SERIAL_MTU_LIMIT;
+
+    static ref SERIAL_ACCEPT_THROTTLE_TIME: u64 = 100_000;
 }
 
 #[derive(Default, Clone, Copy)]

--- a/io/zenoh-links/zenoh-link-serial/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-serial/src/lib.rs
@@ -1,0 +1,55 @@
+//
+// Copyright (c) 2022 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+mod unicast;
+
+use std::{convert::TryFrom, net::SocketAddr, path::Path};
+
+use async_trait::async_trait;
+pub use unicast::*;
+use zenoh_core::{bail, zconfigurable, Result as ZResult};
+use zenoh_link_commons::LocatorInspector;
+use zenoh_protocol_core::Locator;
+
+// Maximum MTU (Serial PDU) in bytes.
+const SERIAL_MAX_MTU: u16 = 8_192;
+
+pub const SERIAL_LOCATOR_PREFIX: &str = "serial";
+
+const SERIAL_MTU_LIMIT: u16 = SERIAL_MAX_MTU;
+
+zconfigurable! {
+    // Default MTU (UDP PDU) in bytes.
+    static ref SERIAL_DEFAULT_MTU: u16 = SERIAL_MTU_LIMIT;
+}
+
+#[derive(Default, Clone, Copy)]
+pub struct SerialLocatorInspector;
+#[async_trait]
+impl LocatorInspector for SerialLocatorInspector {
+    fn protocol(&self) -> &str {
+        SERIAL_LOCATOR_PREFIX
+    }
+    async fn is_multicast(&self, locator: &Locator) -> ZResult<bool> {
+        Ok(false)
+    }
+}
+
+pub fn get_unix_path(locator: &Locator) -> &Path {
+    locator.address().as_ref()
+}
+
+pub fn get_unix_path_as_string(locator: &Locator) -> String {
+    locator.address().to_owned()
+}

--- a/io/zenoh-links/zenoh-link-serial/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-serial/src/unicast.rs
@@ -89,7 +89,18 @@ impl LinkUnicastSerial {
     }
 
     fn is_ready(&self) -> bool {
-        if self.get_port_mut().bytes_to_read().unwrap_or(0) > 0 {
+        let res = match self.get_port_mut().bytes_to_read() {
+            Ok(b) => b,
+            Err(e) => {
+                log::warn!(
+                    "Unable to check if there are bytes to read in serial {}: {}",
+                    self.src_locator,
+                    e
+                );
+                0
+            }
+        };
+        if res > 0 {
             return true;
         }
         false

--- a/io/zenoh-links/zenoh-link-serial/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-serial/src/unicast.rs
@@ -1,0 +1,348 @@
+//
+// Copyright (c) 2022 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+use async_std::prelude::*;
+use async_std::sync::Mutex as AsyncMutex;
+use async_std::task;
+use async_std::task::JoinHandle;
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, RwLock, Weak};
+use std::time::Duration;
+use zenoh_core::Result as ZResult;
+use zenoh_core::{bail, zasynclock, zerror, zlock, zread, zwrite};
+use zenoh_link_commons::{
+    ConstructibleLinkManagerUnicast, LinkManagerUnicastTrait, LinkUnicast, LinkUnicastTrait,
+    NewLinkChannelSender,
+};
+use zenoh_protocol_core::{EndPoint, Locator};
+use zenoh_sync::{Mvar, Signal};
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio_serial::{DataBits, FlowControl, Parity, SerialPort, SerialPortBuilderExt, SerialStream, ClearBuffer};
+
+use super::{get_unix_path, get_unix_path_as_string, SERIAL_DEFAULT_MTU, SERIAL_LOCATOR_PREFIX};
+
+struct LinkUnicastSerial {
+    // The underlying serial port
+    port: Arc<AsyncMutex<SerialStream>>,
+    // The serial port path
+    src_locator: Locator,
+    // The serial destination path (random UUIDv4)
+    dst_locator: Locator,
+    // A flag that tells if the link is connected or not
+    is_connected: Arc<AtomicBool>,
+}
+
+impl LinkUnicastSerial {
+    fn new(port: Arc<AsyncMutex<SerialStream>>, src_path: &str, dst_path: &str, is_connected: Arc<AtomicBool>,) -> Self {
+        Self {
+            port,
+            src_locator: Locator::new(SERIAL_LOCATOR_PREFIX, &src_path),
+            dst_locator: Locator::new(SERIAL_LOCATOR_PREFIX, &dst_path),
+            is_connected,
+        }
+    }
+}
+
+#[async_trait]
+impl LinkUnicastTrait for LinkUnicastSerial {
+    async fn close(&self) -> ZResult<()> {
+        log::trace!("Closing Serial link: {}", self);
+        let guard = zasynclock!(self.port);
+        guard.clear(ClearBuffer::All).map_err(|e| {
+            let e = zerror!("Unable to close Serial link {}: {}", self, e);
+            log::trace!("{}", e);
+            e
+        })?;
+        self.is_connected.store(false, Ordering::Release);
+        Ok(())
+    }
+
+    async fn write(&self, buffer: &[u8]) -> ZResult<usize> {
+
+        let mut guard = zasynclock!(self.port);
+        Ok(guard.write(buffer).await.map_err(|e| {
+            let e = zerror!("Write error on Serial link {}: {}", self, e);
+            log::trace!("{}", e);
+            e
+        })?)
+    }
+
+    async fn write_all(&self, buffer: &[u8]) -> ZResult<()> {
+        let mut written: usize = 0;
+        while written < buffer.len() {
+            written += self.write(&buffer[written..]).await?;
+        }
+        Ok(())
+    }
+
+    async fn read(&self, buffer: &mut [u8]) -> ZResult<usize> {
+        let mut guard = zasynclock!(self.port);
+        Ok(guard.read(buffer).await.map_err(|e| {
+            let e = zerror!("Read error on Serial link {}: {}", self, e);
+            log::trace!("{}", e);
+            e
+        })?)
+    }
+
+    async fn read_exact(&self, buffer: &mut [u8]) -> ZResult<()> {
+        let mut read: usize = 0;
+        while read < buffer.len() {
+            let n = self.read(&mut buffer[read..]).await?;
+            read += n;
+        }
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn get_src(&self) -> &Locator {
+        &self.src_locator
+    }
+
+    #[inline(always)]
+    fn get_dst(&self) -> &Locator {
+        &self.dst_locator
+    }
+
+    #[inline(always)]
+    fn get_mtu(&self) -> u16 {
+        *SERIAL_DEFAULT_MTU
+    }
+
+    #[inline(always)]
+    fn is_reliable(&self) -> bool {
+        false
+    }
+
+    #[inline(always)]
+    fn is_streamed(&self) -> bool {
+        true
+    }
+}
+
+impl fmt::Display for LinkUnicastSerial {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} => {}", self.src_locator, self.dst_locator)?;
+        Ok(())
+    }
+}
+
+impl fmt::Debug for LinkUnicastSerial {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Serial")
+            .field("src", &self.src_locator)
+            .field("dst", &self.dst_locator)
+            .finish()
+    }
+}
+
+/*************************************/
+/*          LISTENER                 */
+/*************************************/
+struct ListenerUnicastSerial {
+    endpoint: EndPoint,
+    active: Arc<AtomicBool>,
+    signal: Signal,
+    handle: JoinHandle<ZResult<()>>,
+}
+
+impl ListenerUnicastSerial {
+    fn new(
+        endpoint: EndPoint,
+        active: Arc<AtomicBool>,
+        signal: Signal,
+        handle: JoinHandle<ZResult<()>>,
+    ) -> Self {
+        Self {
+            endpoint,
+            active,
+            signal,
+            handle,
+        }
+    }
+}
+
+pub struct LinkManagerUnicastSerial {
+    manager: NewLinkChannelSender,
+    listeners: Arc<RwLock<HashMap<String, ListenerUnicastSerial>>>,
+}
+
+impl LinkManagerUnicastSerial {
+    pub fn new(manager: NewLinkChannelSender) -> Self {
+        Self {
+            manager,
+            listeners: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+}
+impl ConstructibleLinkManagerUnicast<()> for LinkManagerUnicastSerial {
+    fn new(new_link_sender: NewLinkChannelSender, _: ()) -> ZResult<Self> {
+        Ok(Self::new(new_link_sender))
+    }
+}
+
+#[async_trait]
+impl LinkManagerUnicastTrait for LinkManagerUnicastSerial {
+    async fn new_link(&self, endpoint: EndPoint) -> ZResult<LinkUnicast> {
+        let path = get_unix_path_as_string(&endpoint.locator);
+
+        let port = tokio_serial::new(&path, 9600)
+            .open_native_async()
+            .map_err(|e| {
+                let e = zerror!(
+                    "Can not create a new Serial link bound to {:?}: {}",
+                    path,
+                    e
+                );
+                log::warn!("{}", e);
+                e
+            })?;
+
+        // Create Serial link
+        let link = Arc::new(LinkUnicastSerial::new(Arc::new(AsyncMutex::new(port)), &path, &path,  Arc::new(AtomicBool::new(true))));
+
+        Ok(LinkUnicast(link))
+    }
+
+    async fn new_listener(&self, mut endpoint: EndPoint) -> ZResult<Locator> {
+        let path = get_unix_path_as_string(&endpoint.locator);
+
+        // Open the serial port
+        let port = tokio_serial::new(&path, 9600)
+            .open_native_async()
+            .map_err(|e| {
+                let e = zerror!(
+                    "Can not create a new Serial link bound to {:?}: {}",
+                    path,
+                    e
+                );
+                log::warn!("{}", e);
+                e
+            })?;
+
+        // Spawn the accept loop for the listener
+        let active = Arc::new(AtomicBool::new(true));
+        let signal = Signal::new();
+        let c_path = path.clone();
+        let c_active = active.clone();
+        let c_signal = signal.clone();
+        let c_manager = self.manager.clone();
+        let c_listeners = self.listeners.clone();
+        let handle = task::spawn(async move {
+            // Wait for the accept loop to terminate
+            let res = accept_read_task(
+                Arc::new(AsyncMutex::new(port)),
+                c_active,
+                c_signal,
+                c_manager,
+                c_path.clone(),
+            )
+            .await;
+            zwrite!(c_listeners).remove(&c_path);
+            res
+        });
+
+        let locator = endpoint.locator.clone();
+        let listener = ListenerUnicastSerial::new(endpoint, active, signal, handle);
+        // Update the list of active listeners on the manager
+        zwrite!(self.listeners).insert(path, listener);
+
+        Ok(locator)
+    }
+
+    async fn del_listener(&self, endpoint: &EndPoint) -> ZResult<()> {
+        let path = get_unix_path_as_string(&endpoint.locator);
+
+        // Stop the listener
+        let listener = zwrite!(self.listeners).remove(&path).ok_or_else(|| {
+            let e = zerror!(
+                "Can not delete the Serial listener because it has not been found: {}",
+                path
+            );
+            log::trace!("{}", e);
+            e
+        })?;
+
+        // Send the stop signal
+        listener.active.store(false, Ordering::Release);
+        listener.signal.trigger();
+        listener.handle.await
+    }
+
+    fn get_listeners(&self) -> Vec<EndPoint> {
+        zread!(self.listeners)
+            .values()
+            .map(|l| l.endpoint.clone())
+            .collect()
+    }
+
+    fn get_locators(&self) -> Vec<Locator> {
+        zread!(self.listeners)
+            .values()
+            .map(|x| x.endpoint.locator.clone())
+            .collect()
+    }
+}
+
+async fn accept_read_task(
+    port: Arc<AsyncMutex<SerialStream>>,
+    active: Arc<AtomicBool>,
+    signal: Signal,
+    manager: NewLinkChannelSender,
+    src_path: String,
+) -> ZResult<()> {
+    enum Action {
+        Receive(SerialStream),
+        Stop,
+    }
+
+    async fn stop(signal: Signal) -> ZResult<Action> {
+        signal.wait().await;
+        Ok(Action::Stop)
+    }
+
+    let is_connected = Arc::new(AtomicBool::new(false));
+
+    log::trace!("Ready to accept Serial connections on: {:?}", src_path);
+
+    while active.load(Ordering::Acquire) {
+        if !is_connected.load(Ordering::Acquire) {
+            let c_port  = port.clone();
+            let guard = zasynclock!(c_port);
+
+            if guard.bytes_to_read().unwrap() > 0 {
+                log::trace!("Ready to read from Serial connection on {:?}", src_path);
+                // Create the new link object
+                let dst_path = format!("{}", uuid::Uuid::new_v4());
+
+                let link = Arc::new(LinkUnicastSerial::new(port.clone(), &src_path, &dst_path, is_connected.clone()));
+                is_connected.store(true, Ordering::Release);
+
+                log::trace!("Creating new link from {:?}", src_path);
+
+                // Communicate the new link to the initial transport manager
+                if let Err(e) = manager.send_async(LinkUnicast(link)).await {
+                    log::error!("{}-{}: {}", file!(), line!(), e)
+                }
+            }
+        } else {
+            ()
+            //task::sleep(Duration::from_secs(10)).await;
+        }
+    }
+
+    Ok(())
+}

--- a/io/zenoh-links/zenoh-link-serial/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-serial/src/unicast.rs
@@ -285,7 +285,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastSerial {
         let dst_path = format!("{}", uuid::Uuid::new_v4());
         let link = Arc::new(LinkUnicastSerial::new(
             UnsafeCell::new(port),
-            &path.clone(),
+            &path,
             &dst_path,
             is_connected.clone(),
         ));
@@ -316,7 +316,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastSerial {
         let locator = endpoint.locator.clone();
         let listener = ListenerUnicastSerial::new(endpoint, active, signal, handle);
         // Update the list of active listeners on the manager
-        zwrite!(self.listeners).insert(path.clone(), listener);
+        zwrite!(self.listeners).insert(path, listener);
 
         Ok(locator)
     }

--- a/io/zenoh-links/zenoh-link-serial/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-serial/src/unicast.rs
@@ -114,7 +114,7 @@ impl LinkUnicastTrait for LinkUnicastSerial {
         let _guard = zasynclock!(self.write_lock);
         self.get_port_mut().clear().map_err(|e| {
             let e = zerror!("Unable to close Serial link {}: {}", self, e);
-            log::trace!("{}", e);
+            log::error!("{}", e);
             e
         })?;
         self.is_connected.store(false, Ordering::Release);
@@ -125,7 +125,7 @@ impl LinkUnicastTrait for LinkUnicastSerial {
         let _guard = zasynclock!(self.write_lock);
         self.get_port_mut().write(buffer).await.map_err(|e| {
             let e = zerror!("Unable to write on Serial link {}: {}", self, e);
-            log::trace!("{}", e);
+            log::error!("{}", e);
             e
         })?;
         Ok(buffer.len())
@@ -146,7 +146,7 @@ impl LinkUnicastTrait for LinkUnicastSerial {
                 Ok(read) => return Ok(read),
                 Err(e) => {
                     let e = zerror!("Read error on Serial link {}: {}", self, e);
-                    log::trace!("{}", e);
+                    log::error!("{}", e);
                     drop(_guard);
                     async_std::task::sleep(std::time::Duration::from_millis(1)).await;
                     continue;
@@ -256,6 +256,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastSerial {
     async fn new_link(&self, endpoint: EndPoint) -> ZResult<LinkUnicast> {
         let path = get_unix_path_as_string(&endpoint.locator);
         let baud_rate = get_baud_rate(&endpoint);
+        log::trace!("Opening Serial Link on device {path:?}, with baudrate {baud_rate}");
         let port = ZSerial::new(path.clone(), baud_rate).map_err(|e| {
             let e = zerror!(
                 "Can not create a new Serial link bound to {:?}: {}",
@@ -280,7 +281,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastSerial {
     async fn new_listener(&self, endpoint: EndPoint) -> ZResult<Locator> {
         let path = get_unix_path_as_string(&endpoint.locator);
         let baud_rate = get_baud_rate(&endpoint);
-
+        log::trace!("Creating Serial listener on device {path:?}, with baudrate {baud_rate}");
         let port = ZSerial::new(path.clone(), baud_rate).map_err(|e| {
             let e = zerror!(
                 "Can not create a new Serial link bound to {:?}: {}",

--- a/io/zenoh-transport/Cargo.toml
+++ b/io/zenoh-transport/Cargo.toml
@@ -44,7 +44,7 @@ transport_quic = ["zenoh-link/transport_quic"]
 transport_tcp = ["zenoh-link/transport_tcp"]
 transport_tls = ["zenoh-link/transport_tls"]
 transport_udp = ["zenoh-link/transport_udp"]
-transport_ws = ["zenoh-link/transport_ws"]
+transport_serial = ["zenoh-link/transport_serial"]
 stats = []
 
 [dependencies]

--- a/io/zenoh-transport/tests/unicast_conduits.rs
+++ b/io/zenoh-transport/tests/unicast_conduits.rs
@@ -14,8 +14,7 @@
 use async_std::prelude::FutureExt;
 use async_std::task;
 use std::any::Any;
-use std::convert::TryFrom;
-use std::fmt::Write as _;
+use std::fmt::Write;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -231,7 +230,7 @@ async fn close_transport(
     // Close the client transport
     let mut ee = String::new();
     for e in endpoints.iter() {
-        let _ = write!(ee, "{} ", e);
+        write!(ee, "{} ", e).unwrap();
     }
     println!("Closing transport with {}", ee);
     ztimeout!(client_transport.close()).unwrap();

--- a/io/zenoh-transport/tests/unicast_openclose.rs
+++ b/io/zenoh-transport/tests/unicast_openclose.rs
@@ -706,17 +706,13 @@ fn openclose_serial_only() {
 
     task::spawn(create_ports());
 
-
-
     task::block_on(async move {
         let endpoint_router: EndPoint = "serial/ttyVIRT0".parse().unwrap();
         let endpoint_client: EndPoint = "serial/ttyVIRT1".parse().unwrap();
         async_std::task::sleep(std::time::Duration::from_secs(10)).await;
         openclose_serial_transport(&endpoint_router, &endpoint_client).await;
-
     });
 }
-
 
 #[cfg(all(feature = "transport_serial", target_os = "linux"))]
 async fn openclose_serial_transport(router_endpoint: &EndPoint, client_endpoint: &EndPoint) {
@@ -811,7 +807,6 @@ async fn openclose_serial_transport(router_endpoint: &EndPoint, client_endpoint:
         }
     });
     println!("Transport Open Close [1f2]: {:?}", res);
-
 
     /* [10] */
     // Perform clean up of the open locators

--- a/io/zenoh-transport/tests/unicast_transport.rs
+++ b/io/zenoh-transport/tests/unicast_transport.rs
@@ -14,8 +14,7 @@
 use async_std::prelude::FutureExt;
 use async_std::task;
 use std::any::Any;
-use std::convert::TryFrom;
-use std::fmt::Write as _;
+use std::fmt::Write;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -213,7 +212,7 @@ async fn close_transport(
     // Close the client transport
     let mut ee = String::new();
     for e in endpoints.iter() {
-        let _ = write!(ee, "{} ", e);
+        write!(ee, "{} ", e).unwrap();
     }
     println!("Closing transport with {}", ee);
     ztimeout!(client_transport.close()).unwrap();

--- a/zenoh-ext/src/publication_cache.rs
+++ b/zenoh-ext/src/publication_cache.rs
@@ -72,7 +72,7 @@ impl<'a, 'b, 'c> PublicationCacheBuilder<'a, 'b, 'c> {
     }
 }
 
-impl<'a> Resolvable for PublicationCacheBuilder<'a, '_, '_> {
+impl<'a> Future for PublicationCacheBuilder<'a, '_> {
     type Output = ZResult<PublicationCache<'a>>;
 }
 impl AsyncResolve for PublicationCacheBuilder<'_, '_, '_> {

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -49,6 +49,7 @@ transport_tcp = ["zenoh-transport/transport_tcp"]
 transport_tls = ["zenoh-transport/transport_tls"]
 transport_udp = ["zenoh-transport/transport_udp"]
 transport_unixsock-stream = ["zenoh-link/transport_unixsock-stream"]
+transport_serial = ["zenoh-link/transport_serial"]
 default = [
     "auth_pubkey",
     "auth_usrpwd",

--- a/zenoh/src/net/routing/network.rs
+++ b/zenoh/src/net/routing/network.rs
@@ -478,7 +478,7 @@ impl Network {
                 edges.push(edge);
             }
             for (eidx, idx2) in edges {
-                if !links.contains(&self.graph[idx2].zid) {
+                if !links.contains(&self.graph[idx2].pid) {
                     log::trace!(
                         "{} Remove edge (state) {} {}",
                         self.name,

--- a/zenohd/Cargo.toml
+++ b/zenohd/Cargo.toml
@@ -33,9 +33,11 @@ readme = "README.md"
 
 [features]
 shared-memory = ["zenoh/shared-memory"]
+transport_serial = ["zenoh/transport_serial"]
+transport_tcp = ["zenoh/transport_tcp"]
 
 [dependencies]
-zenoh = { path = "../zenoh/" }
+zenoh = { path = "../zenoh/",  default-features = false}
 
 async-std = { version = "=1.12.0", default-features = false, features = [
 	"attributes",


### PR DESCRIPTION
Hi, this PR contains a transport for Zenoh over Serial ports (RS232-like), it builds atop [Zenoh Serial Framing](https://github.com/ZettaScaleLabs/z-serial) to provide a datagram-based non-reliable abstraction to the Zenoh transport layer.

It will land once the following tasks are completed.

- [x] implementation of the `zenoh-link-serial` crate
- [x] tests
- [x] release on `crates.io` for `z-serial`
- [x] check interoperability with zenoh-pico

 