### PR TITLE
GroupManagement: priority configuration

### DIFF
--- a/zenoh-ext/src/group.rs
+++ b/zenoh-ext/src/group.rs
@@ -146,7 +146,10 @@ async fn keep_alive_task(z: Arc<Session>, state: Arc<GroupState>) {
     loop {
         async_std::task::sleep(period).await;
         log::debug!("Sending Keep Alive for: {}", &state.local_member.mid);
-        let _ = z.put(&state.event_expr, buf.clone()).priority(state.local_member.priority).await;
+        let _ = z
+            .put(&state.event_expr, buf.clone())
+            .priority(state.local_member.priority)
+            .await;
     }
 }
 
@@ -305,7 +308,10 @@ impl Group {
         log::debug!("Sending Join Message for local member:\n{:?}", &with);
         let join_evt = GroupNetEvent::Join(JoinEvent { member: with });
         let buf = bincode::serialize(&join_evt).unwrap();
-        let _ = z.put(&event_expr, buf).priority(state.local_member.priority).await;
+        let _ = z
+            .put(&event_expr, buf)
+            .priority(state.local_member.priority)
+            .await;
 
         // If the liveliness is manual it is the user who has to assert it.
         if is_auto_liveliness {

--- a/zenoh-ext/src/group.rs
+++ b/zenoh-ext/src/group.rs
@@ -18,6 +18,7 @@ const GROUP_PREFIX: &str = "/zenoh/ext/net/group";
 const EVENT_POSTFIX: &str = "evt";
 const VIEW_REFRESH_LEASE_RATIO: f32 = 0.75f32;
 const DEFAULT_LEASE: Duration = Duration::from_secs(18);
+const DEFAULT_PRIORITY: Priority = Priority::DataHigh;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct JoinEvent {
@@ -74,6 +75,8 @@ pub struct Member {
     liveliness: MemberLiveliness,
     lease: Duration,
     refresh_ratio: f32,
+    #[serde(skip)]
+    priority: Priority,
 }
 
 impl Member {
@@ -84,6 +87,7 @@ impl Member {
             liveliness: MemberLiveliness::Auto,
             lease: DEFAULT_LEASE,
             refresh_ratio: VIEW_REFRESH_LEASE_RATIO,
+            priority: DEFAULT_PRIORITY,
         }
     }
 
@@ -107,6 +111,11 @@ impl Member {
 
     pub fn refresh_ratio(mut self, r: f32) -> Self {
         self.refresh_ratio = r;
+        self
+    }
+
+    pub fn priority(mut self, p: Priority) -> Self {
+        self.priority = p;
         self
     }
 }
@@ -137,7 +146,7 @@ async fn keep_alive_task(z: Arc<Session>, state: Arc<GroupState>) {
     loop {
         async_std::task::sleep(period).await;
         log::debug!("Sending Keep Alive for: {}", &state.local_member.mid);
-        let _ = z.put(&state.event_expr, buf.clone()).await;
+        let _ = z.put(&state.event_expr, buf.clone()).priority(state.local_member.priority).await;
     }
 }
 
@@ -296,7 +305,7 @@ impl Group {
         log::debug!("Sending Join Message for local member:\n{:?}", &with);
         let join_evt = GroupNetEvent::Join(JoinEvent { member: with });
         let buf = bincode::serialize(&join_evt).unwrap();
-        let _ = z.put(&event_expr, buf).await;
+        let _ = z.put(&event_expr, buf).priority(state.local_member.priority).await;
 
         // If the liveliness is manual it is the user who has to assert it.
         if is_auto_liveliness {


### PR DESCRIPTION
Make configurable the priority of the publications made by the GroupManagement algorithm.
The default priority being set to **DataHigh**.

This should avoid false fault detection that could occur in case of high traffic: the KeepAlive messages will be sent with higher priority than the regular data publications.