### PR TITLE
fix for issue 273: sort/dedup using BTreeMap

### DIFF
--- a/zenoh/src/prelude.rs
+++ b/zenoh/src/prelude.rs
@@ -477,9 +477,13 @@ impl Sample {
     #[inline]
     /// Ensure that an associated Timestamp is present in this Sample.
     /// If not, a new one is created with the current system time and 0x00 as id.
-    pub fn ensure_timestamp(&mut self) {
-        if self.timestamp.is_none() {
-            self.timestamp = Some(new_reception_timestamp());
+    pub fn ensure_timestamp(&mut self) -> Timestamp {
+        if let Some(timestamp) = self.timestamp {
+            timestamp
+        } else {
+            let timestamp = new_reception_timestamp();
+            self.timestamp = Some(timestamp);
+            timestamp
         }
     }
 }


### PR DESCRIPTION
Here is a fix for https://github.com/eclipse-zenoh/zenoh/issues/273 issue. ```Vec``` has been replaced to ```BTreeMap``` which allows to sort/dedup samples on the fly.
This code is not covered with unit tests, but sample z_query_sub seems to work ok. Any recommendations how to run performance test to check is this update actually useful are appreciated