### PR TITLE
Rename session.id() to session.zid()

### DIFF
--- a/commons/zenoh-protocol-core/src/key_expr/borrowed.rs
+++ b/commons/zenoh-protocol-core/src/key_expr/borrowed.rs
@@ -121,9 +121,9 @@ impl keyexpr {
         self.0.contains(super::SINGLE_WILD as char)
     }
 
-    /// Returns the longest prefix of `self` that doesn't contain any wildcard character ('**' or '$*').
+    /// Returns the longest prefix of `self` that doesn't contain any wildcard character (`**` or `$*`).
     ///
-    /// NOTE: this operation can typically used in a backend implementation, at creation of a Storage to get the keys prefix,
+    /// NOTE: this operation can typically be used in a backend implementation, at creation of a Storage to get the keys prefix,
     /// and then in `zenoh_backend_traits::Storage::on_sample()` this prefix has to be stripped from all received
     /// [`Sample::key_expr`](zenoh::prelude::Sample::key_expr) to retrieve the corrsponding key.
     ///

--- a/zenoh-ext/examples/z_member.rs
+++ b/zenoh-ext/examples/z_member.rs
@@ -9,7 +9,7 @@ use zenoh_ext::group::*;
 async fn main() {
     env_logger::init();
     let z = Arc::new(zenoh::open(Config::default()).res().await.unwrap());
-    let member = Member::new(z.id().to_string())
+    let member = Member::new(z.zid().to_string())
         .unwrap()
         .lease(Duration::from_secs(3));
 

--- a/zenoh-ext/examples/z_view_size.rs
+++ b/zenoh-ext/examples/z_view_size.rs
@@ -12,7 +12,7 @@ async fn main() {
     let (config, group_name, id, size, timeout) = parse_args();
 
     let z = Arc::new(zenoh::open(config).res().await.unwrap());
-    let member_id = id.unwrap_or_else(|| z.id().to_string());
+    let member_id = id.unwrap_or_else(|| z.zid().to_string());
     let member = Member::new(member_id.as_str())
         .unwrap()
         .lease(Duration::from_secs(3));

--- a/zenoh/src/info.rs
+++ b/zenoh/src/info.rs
@@ -19,7 +19,7 @@ use crate::SessionRef;
 use zenoh_config::{WhatAmI, ZenohId};
 use zenoh_core::{AsyncResolve, Resolvable, SyncResolve};
 
-/// A builder retuned by [`SessionInfos::zid()`](SessionInfos::zid) that allows
+/// A builder retuned by [`SessionInfo::zid()`](SessionInfo::zid) that allows
 /// to access the [`ZenohId`] of the current zenoh [`Session`](crate::Session).
 ///
 /// # Examples
@@ -80,7 +80,7 @@ macro_rules! closure_builder {
 }
 
 closure_builder! {
-    /// A builder retuned by [`SessionInfos::routers_zid()`](SessionInfos::routers_zid) that allows
+    /// A builder retuned by [`SessionInfo::routers_zid()`](SessionInfo::routers_zid) that allows
     /// to access the [`ZenohId`] of the zenoh routers this process is currently connected to
     /// or the [`ZenohId`] of the current router if this code is run from a router (plugin).
     ///
@@ -99,7 +99,7 @@ closure_builder! {
 }
 
 closure_builder! {
-    /// A builder retuned by [`SessionInfos::peers_zid()`](SessionInfos::peers_zid) that allows
+    /// A builder retuned by [`SessionInfo::peers_zid()`](SessionInfo::peers_zid) that allows
     /// to access the [`ZenohId`] of the zenoh peers this process is currently connected to.
     ///
     /// # Examples
@@ -131,11 +131,11 @@ closure_builder! {
 /// let zid = info.zid().res().await;
 /// # })
 /// ```
-pub struct SessionInfos<'a> {
+pub struct SessionInfo<'a> {
     pub(crate) session: SessionRef<'a>,
 }
 
-impl SessionInfos<'_> {
+impl SessionInfo<'_> {
     /// Return the [`ZenohId`] of the current zenoh [`Session`](crate::Session).
     ///
     /// # Examples

--- a/zenoh/src/session.rs
+++ b/zenoh/src/session.rs
@@ -141,22 +141,6 @@ impl SessionState {
         }
     }
 
-    // #[inline]
-    // fn local_wireid_to_str<'a>(&'a self, id: &ExprId) -> ZResult<&'a str> {
-    //     match self.local_resources.get(id) {
-    //         Some(res) => Ok(&res.name),
-    //         None => bail!("{}", id),
-    //     }
-    // }
-
-    // #[inline]
-    // fn remote_wireid_to_str<'a>(&'a self, id: &ExprId) -> ZResult<&'a str> {
-    //     match self.remote_resources.get(id) {
-    //         Some(res) => Ok(&res.name),
-    //         None => self.local_wireid_to_str(id),
-    //     }
-    // }
-
     pub(crate) fn remote_key_to_expr<'a>(&'a self, key_expr: &'a WireExpr) -> ZResult<KeyExpr<'a>> {
         if key_expr.scope == EMPTY_EXPR_ID {
             Ok(unsafe { keyexpr::from_str_unchecked(key_expr.suffix.as_ref()) }.into())
@@ -419,9 +403,10 @@ impl Session {
         Box::leak(Box::new(s))
     }
 
-    /// Returns the identifier for this session.
-    pub fn id(&self) -> ZenohId {
-        self.runtime.zid
+    /// Returns the identifier of the current session. `zid()` is a convenient shortcut.
+    /// See [`Session::info()`](`Session::info()`) and [`SessionInfo::zid()`](`SessionInfo::zid()`) for more details.
+    pub fn zid(&self) -> ZenohId {
+        self.info().zid().res_sync()
     }
 
     pub fn hlc(&self) -> Option<&HLC> {
@@ -505,8 +490,8 @@ impl Session {
     /// let info = session.info();
     /// # })
     /// ```
-    pub fn info(&self) -> SessionInfos {
-        SessionInfos {
+    pub fn info(&self) -> SessionInfo {
+        SessionInfo {
             session: SessionRef::Borrow(self),
         }
     }
@@ -1924,6 +1909,6 @@ impl Drop for Session {
 
 impl fmt::Debug for Session {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Session").field("id", &self.id()).finish()
+        f.debug_struct("Session").field("id", &self.zid()).finish()
     }
 }


### PR DESCRIPTION
This PR:
- renames `session.id()` to `session.zid()`
- clarifies in the doc that `session.zid()` is a convenient shortcut for `session.info().zid().res()`