### PR TITLE
WIP: fewer builder types

### DIFF
--- a/examples/examples/z_forward.rs
+++ b/examples/examples/z_forward.rs
@@ -14,7 +14,7 @@
 use clap::{App, Arg};
 use zenoh::config::Config;
 use zenoh::prelude::r#async::AsyncResolve;
-use zenoh_ext::HandlerSubscriberForward;
+use zenoh_ext::SubscriberForward;
 
 #[async_std::main]
 async fn main() {

--- a/zenoh-ext/src/lib.rs
+++ b/zenoh-ext/src/lib.rs
@@ -17,9 +17,6 @@ mod querying_subscriber;
 mod session_ext;
 mod subscriber_ext;
 pub use publication_cache::{PublicationCache, PublicationCacheBuilder};
-pub use querying_subscriber::{
-    CallbackQueryingSubscriber, CallbackQueryingSubscriberBuilder, HandlerQueryingSubscriber,
-    HandlerQueryingSubscriberBuilder, QueryingSubscriberBuilder,
-};
+pub use querying_subscriber::{QueryingSubscriber, QueryingSubscriberBuilder};
 pub use session_ext::SessionExt;
-pub use subscriber_ext::HandlerSubscriberForward;
+pub use subscriber_ext::SubscriberForward;

--- a/zenoh-ext/src/publication_cache.rs
+++ b/zenoh-ext/src/publication_cache.rs
@@ -20,7 +20,7 @@ use std::collections::{HashMap, VecDeque};
 use std::convert::TryInto;
 use std::pin::Pin;
 use zenoh::prelude::*;
-use zenoh::queryable::{HandlerQueryable, Query};
+use zenoh::queryable::{Query, Queryable};
 use zenoh::subscriber::FlumeSubscriber;
 use zenoh::Session;
 use zenoh_core::{bail, AsyncResolve, Resolvable, Resolve};
@@ -89,7 +89,7 @@ impl SyncResolve for PublicationCacheBuilder<'_, '_, '_> {
 
 pub struct PublicationCache<'a> {
     _local_sub: FlumeSubscriber<'a>,
-    _queryable: HandlerQueryable<'a, flume::Receiver<Query>>,
+    _queryable: Queryable<'a, flume::Receiver<Query>>,
     _stoptx: Sender<bool>,
 }
 

--- a/zenoh-ext/src/querying_subscriber.rs
+++ b/zenoh-ext/src/querying_subscriber.rs
@@ -107,12 +107,9 @@ impl<'a, 'b> QueryingSubscriberBuilder<'a, 'b, DefaultHandler> {
         self.callback(locked(callback))
     }
 
-    /// Make the built QueryingSubscriber a [`HandlerQueryingSubscriber`](HandlerQueryingSubscriber).
+    /// Make the built QueryingSubscriber a [`QueryingSubscriber`](QueryingSubscriber).
     #[inline]
-    pub fn with<Handler, Receiver>(
-        self,
-        handler: Handler,
-    ) -> QueryingSubscriberBuilder<'a, 'b, Handler>
+    pub fn with<Handler>(self, handler: Handler) -> QueryingSubscriberBuilder<'a, 'b, Handler>
     where
         Handler: zenoh::prelude::IntoCallbackReceiverPair<'static, Sample>,
     {

--- a/zenoh-ext/src/session_ext.rs
+++ b/zenoh-ext/src/session_ext.rs
@@ -47,14 +47,14 @@ impl fmt::Debug for SessionRef<'_> {
 
 /// Some extensions to the [zenoh::Session](zenoh::Session)
 pub trait SessionExt {
-    /// Create a [QueryingSubscriber](super::HandlerQueryingSubscriber) with the given key expression.
+    /// Create a [QueryingSubscriber](super::QueryingSubscriber) with the given key expression.
     ///
     /// This operation returns a [QueryingSubscriberBuilder](QueryingSubscriberBuilder) that can be used to finely configure the subscriber.  
     /// As soon as built (calling `.wait()` or `.await` on the QueryingSubscriberBuilder), the QueryingSubscriber
     /// will issue a query on a given key expression (by default it uses the same key expression than it subscribes to).
     /// The results of the query will be merged with the received publications and made available in the receiver.
-    /// Later on, new queries can be issued again, calling [QueryingSubscriber::query()](super::HandlerQueryingSubscriber::query()) or
-    /// [QueryingSubscriber::query_on()](super::HandlerQueryingSubscriber::query_on()).
+    /// Later on, new queries can be issued again, calling [QueryingSubscriber::query()](super::QueryingSubscriber::query()) or
+    /// [QueryingSubscriber::query_on()](super::QueryingSubscriber::query_on()).
     ///
     /// A typical usage of the QueryingSubscriber is to retrieve publications that were made in the past, but stored in some zenoh Storage.
     ///

--- a/zenoh-ext/src/session_ext.rs
+++ b/zenoh-ext/src/session_ext.rs
@@ -16,7 +16,7 @@ use std::convert::TryInto;
 use std::fmt;
 use std::ops::Deref;
 use std::sync::Arc;
-use zenoh::prelude::KeyExpr;
+use zenoh::prelude::{DefaultHandler, KeyExpr};
 use zenoh::Session;
 
 #[derive(Clone)]
@@ -78,7 +78,7 @@ pub trait SessionExt {
     fn subscribe_with_query<'a, 'b, TryIntoKeyExpr>(
         &'a self,
         sub_key_expr: TryIntoKeyExpr,
-    ) -> QueryingSubscriberBuilder<'a, 'b>
+    ) -> QueryingSubscriberBuilder<'a, 'b, DefaultHandler>
     where
         TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
         <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_core::Error>;
@@ -96,7 +96,7 @@ impl SessionExt for Session {
     fn subscribe_with_query<'a, 'b, TryIntoKeyExpr>(
         &'a self,
         sub_key_expr: TryIntoKeyExpr,
-    ) -> QueryingSubscriberBuilder<'a, 'b>
+    ) -> QueryingSubscriberBuilder<'a, 'b, DefaultHandler>
     where
         TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
         <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_core::Error>,
@@ -123,7 +123,7 @@ impl SessionExt for Arc<Session> {
     fn subscribe_with_query<'a, 'b, TryIntoKeyExpr>(
         &'a self,
         sub_key_expr: TryIntoKeyExpr,
-    ) -> QueryingSubscriberBuilder<'a, 'b>
+    ) -> QueryingSubscriberBuilder<'a, 'b, DefaultHandler>
     where
         TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
         <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_core::Error>,

--- a/zenoh-ext/src/subscriber_ext.rs
+++ b/zenoh-ext/src/subscriber_ext.rs
@@ -1,13 +1,13 @@
 use flume::r#async::RecvStream;
 use futures::stream::{Forward, Map};
-use zenoh::{prelude::Sample, subscriber::HandlerSubscriber};
+use zenoh::{prelude::Sample, subscriber::Subscriber};
 
 /// Allows writing `subscriber.forward(receiver)` instead of `subscriber.stream().map(Ok).forward(publisher)`
-pub trait HandlerSubscriberForward<'a, S> {
+pub trait SubscriberForward<'a, S> {
     type Output;
     fn forward(&'a mut self, sink: S) -> Self::Output;
 }
-impl<'a, S> HandlerSubscriberForward<'a, S> for HandlerSubscriber<'_, flume::Receiver<Sample>>
+impl<'a, S> SubscriberForward<'a, S> for Subscriber<'_, flume::Receiver<Sample>>
 where
     S: futures::sink::Sink<Sample>,
 {

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -155,7 +155,7 @@ pub mod scouting;
 ///
 /// [`scout`] spawns a task that periodically sends scout messages and waits for [`Hello`](crate::scouting::Hello) replies.
 ///
-/// Drop the returned [`HandlerScout`](crate::scouting::HandlerScout) to stop the scouting task.
+/// Drop the returned [`Scout`](crate::scouting::Scout) to stop the scouting task.
 ///
 /// # Arguments
 ///

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -177,12 +177,16 @@ pub mod scouting;
 pub fn scout<I: Into<WhatAmIMatcher>, TryIntoConfig>(
     what: I,
     config: TryIntoConfig,
-) -> ScoutBuilder<I, TryIntoConfig>
+) -> ScoutBuilder<DefaultHandler>
 where
     TryIntoConfig: std::convert::TryInto<crate::config::Config> + Send + 'static,
-    <TryIntoConfig as std::convert::TryInto<crate::config::Config>>::Error: std::fmt::Debug,
+    <TryIntoConfig as std::convert::TryInto<crate::config::Config>>::Error: Into<zenoh_core::Error>,
 {
-    ScoutBuilder { what, config }
+    ScoutBuilder {
+        what: what.into(),
+        config: config.try_into().map_err(|e| e.into()),
+        handler: DefaultHandler,
+    }
 }
 
 /// Open a zenoh [`Session`].

--- a/zenoh/src/prelude.rs
+++ b/zenoh/src/prelude.rs
@@ -670,8 +670,8 @@ pub(crate) mod common {
     /// Functions to create zenoh entities with `'static` lifetime.
     ///
     /// This trait contains functions to create zenoh entities like
-    /// [`Subscriber`](crate::subscriber::HandlerSubscriber), and
-    /// [`Queryable`](crate::queryable::HandlerQueryable) with a `'static` lifetime.
+    /// [`Subscriber`](crate::subscriber::Subscriber), and
+    /// [`Queryable`](crate::queryable::Queryable) with a `'static` lifetime.
     /// This is useful to move zenoh entities to several threads and tasks.
     ///
     /// This trait is implemented for `Arc<Session>`.
@@ -692,7 +692,7 @@ pub(crate) mod common {
     /// # })
     /// ```
     pub trait SessionDeclarations {
-        /// Create a [`Subscriber`](crate::subscriber::HandlerSubscriber) for the given key expression.
+        /// Create a [`Subscriber`](crate::subscriber::Subscriber) for the given key expression.
         ///
         /// # Arguments
         ///
@@ -721,12 +721,12 @@ pub(crate) mod common {
             TryIntoKeyExpr: TryInto<KeyExpr<'a>>,
             <TryIntoKeyExpr as TryInto<KeyExpr<'a>>>::Error: Into<zenoh_core::Error>;
 
-        /// Create a [`Queryable`](crate::queryable::HandlerQueryable) for the given key expression.
+        /// Create a [`Queryable`](crate::queryable::Queryable) for the given key expression.
         ///
         /// # Arguments
         ///
         /// * `key_expr` - The key expression matching the queries the
-        /// [`Queryable`](crate::queryable::HandlerQueryable) will reply to
+        /// [`Queryable`](crate::queryable::Queryable) will reply to
         ///
         /// # Examples
         /// ```no_run
@@ -785,11 +785,14 @@ pub(crate) mod common {
     /// An immutable callback function.
     pub type Callback<'a, T> = Dyn<dyn Fn(T) + Send + Sync + 'a>;
 
-    /// A value-to-value conversion that consumes the input value and
-    /// transforms it into a [`Handler`].
+    /// A type that can be converted into a [`Callback`]-receiver pair.
+    ///
+    /// When Zenoh functions accept types that implement these, it intends to use the [`Callback`] as just that,
+    /// while granting you access to the receiver through the returned value via [`std::ops::Deref`] and [`std::ops::DerefMut`].
+    ///
+    /// Any closure that accepts `T` can be converted into a pair of itself and `()`.
     pub trait IntoCallbackReceiverPair<'a, T> {
         type Receiver;
-        /// Converts this type into a [`Handler`].
         fn into_cb_receiver_pair(self) -> (Callback<'a, T>, Self::Receiver);
     }
     impl<'a, T, F> IntoCallbackReceiverPair<'a, T> for F

--- a/zenoh/src/query.rs
+++ b/zenoh/src/query.rs
@@ -26,7 +26,7 @@ use zenoh_collections::Timed;
 use zenoh_core::zresult::ZResult;
 use zenoh_core::{AsyncResolve, Resolvable, SyncResolve};
 
-/// The [`Queryable`](crate::queryable::HandlerQueryable)s that should be target of a [`get`](Session::get).
+/// The [`Queryable`](crate::queryable::Queryable)s that should be target of a [`get`](Session::get).
 pub use zenoh_protocol_core::QueryTarget;
 
 /// The kind of consolidation.
@@ -260,7 +260,7 @@ impl<'a, 'b> GetBuilder<'a, 'b, DefaultHandler> {
         self.callback(locked(callback))
     }
 
-    /// Receive the replies for this query with a [`Handler`](crate::prelude::Handler).
+    /// Receive the replies for this query with a [`Handler`](crate::prelude::IntoCallbackReceiverPair).
     ///
     /// # Examples
     /// ```

--- a/zenoh/src/queryable.rs
+++ b/zenoh/src/queryable.rs
@@ -26,7 +26,7 @@ use std::task::{Context, Poll};
 use zenoh_core::{AsyncResolve, Resolvable, Resolve, Result as ZResult, SyncResolve};
 use zenoh_protocol_core::WireExpr;
 
-/// Structs received by a [`Queryable`](HandlerQueryable).
+/// Structs received by a [`Queryable`](Queryable).
 pub struct Query {
     /// The key_selector of this Query.
     pub(crate) key_expr: KeyExpr<'static>,
@@ -250,7 +250,7 @@ impl Drop for CallbackQueryable<'_> {
     }
 }
 
-/// A builder for initializing a [`FlumeQueryable`].
+/// A builder for initializing a [`Queryable`].
 ///
 /// # Examples
 /// ```
@@ -344,7 +344,7 @@ impl<'a, 'b> QueryableBuilder<'a, 'b, DefaultHandler> {
         self.callback(locked(callback))
     }
 
-    /// Receive the queries for this Queryable with a [`Handler`](crate::prelude::Handler).
+    /// Receive the queries for this Queryable with a [`Handler`](crate::prelude::IntoCallbackReceiverPair).
     ///
     /// # Examples
     /// ```no_run
@@ -393,9 +393,9 @@ impl<'a, 'b> QueryableBuilder<'a, 'b, DefaultHandler> {
     }
 }
 
-/// A queryable that provides data through a [`Handler`](crate::prelude::Handler).
+/// A queryable that provides data through a [`Handler`](crate::prelude::IntoCallbackReceiverPair).
 ///
-/// HandlerQueryables can be created from a zenoh [`Session`](crate::Session)
+/// Queryables can be created from a zenoh [`Session`](crate::Session)
 /// with the [`declare_queryable`](crate::Session::declare_queryable) function
 /// and the [`with`](QueryableBuilder::with) function
 /// of the resulting builder.

--- a/zenoh/src/scouting.rs
+++ b/zenoh/src/scouting.rs
@@ -114,7 +114,7 @@ impl ScoutBuilder<DefaultHandler> {
         self.callback(locked(callback))
     }
 
-    /// Receive the [`Hello`] messages from this scout with a [`Handler`](crate::prelude::Handler).
+    /// Receive the [`Hello`] messages from this scout with a [`Handler`](crate::prelude::IntoCallbackReceiverPair).
     ///
     /// # Examples
     /// ```no_run
@@ -133,7 +133,7 @@ impl ScoutBuilder<DefaultHandler> {
     /// # })
     /// ```
     #[inline]
-    pub fn with<Handler, Receiver>(self, handler: Handler) -> ScoutBuilder<Handler>
+    pub fn with<Handler>(self, handler: Handler) -> ScoutBuilder<Handler>
     where
         Handler: crate::prelude::IntoCallbackReceiverPair<'static, Hello>,
     {
@@ -228,7 +228,7 @@ impl fmt::Debug for ScoutInner {
     }
 }
 
-/// A scout that returns [`Hello`] messages through a [`Handler`](crate::prelude::Handler).
+/// A scout that returns [`Hello`] messages through a [`Handler`](crate::prelude::IntoCallbackReceiverPair).
 ///
 /// # Examples
 /// ```no_run
@@ -283,9 +283,6 @@ impl<Receiver> Scout<Receiver> {
         self.scout.stop()
     }
 }
-
-/// A [`HandlerScout`] that provides [`Hello`] messages through a `flume` channel.
-pub type FlumeScout = Scout<flume::Receiver<Hello>>;
 
 fn scout(
     what: WhatAmIMatcher,

--- a/zenoh/src/scouting.rs
+++ b/zenoh/src/scouting.rs
@@ -13,11 +13,11 @@
 //
 use crate::{
     net::runtime::{orchestrator::Loop, Runtime},
-    prelude::{locked, Callback, IntoHandler},
+    prelude::{locked, sync::DefaultHandler, Callback},
 };
 use async_std::net::UdpSocket;
 use futures::StreamExt;
-use std::{fmt, marker::PhantomData, ops::Deref, sync::Arc};
+use std::{fmt, ops::Deref, sync::Arc};
 use zenoh_config::{
     whatami::WhatAmIMatcher, ZN_MULTICAST_INTERFACE_DEFAULT, ZN_MULTICAST_IPV4_ADDRESS_DEFAULT,
 };
@@ -44,29 +44,14 @@ pub use zenoh_protocol::proto::Hello;
 /// # })
 /// ```
 #[must_use = "Resolvables do nothing unless you resolve them using the `res` method from either `SyncResolve` or `AsyncResolve`"]
-#[derive(Debug, Clone)]
-pub struct ScoutBuilder<IntoWhatAmI, TryIntoConfig>
-where
-    IntoWhatAmI: Into<WhatAmIMatcher>,
-    TryIntoConfig: std::convert::TryInto<crate::config::Config> + Send + 'static,
-{
-    pub(crate) what: IntoWhatAmI,
-    pub(crate) config: TryIntoConfig,
+#[derive(Debug)]
+pub struct ScoutBuilder<Handler> {
+    pub(crate) what: WhatAmIMatcher,
+    pub(crate) config: ZResult<crate::config::Config>,
+    pub(crate) handler: Handler,
 }
 
-impl<IntoWhatAmI, TryIntoConfig> Resolvable for ScoutBuilder<IntoWhatAmI, TryIntoConfig>
-where
-    IntoWhatAmI: Into<WhatAmIMatcher>,
-    TryIntoConfig: std::convert::TryInto<crate::config::Config> + Send + 'static,
-{
-    type Output = ZResult<FlumeScout>;
-}
-
-impl<IntoWhatAmI, TryIntoConfig> ScoutBuilder<IntoWhatAmI, TryIntoConfig>
-where
-    IntoWhatAmI: Into<WhatAmIMatcher>,
-    TryIntoConfig: std::convert::TryInto<crate::config::Config> + Send + 'static,
-{
+impl ScoutBuilder<DefaultHandler> {
     /// Receive the [`Hello`] messages from this scout with a callback.
     ///
     /// # Examples
@@ -83,16 +68,19 @@ where
     /// # })
     /// ```
     #[inline]
-    pub fn callback<Callback>(
-        self,
-        callback: Callback,
-    ) -> CallbackScoutBuilder<IntoWhatAmI, TryIntoConfig, Callback>
+    pub fn callback<Callback>(self, callback: Callback) -> ScoutBuilder<Callback>
     where
         Callback: Fn(Hello) + Send + Sync + 'static,
     {
-        CallbackScoutBuilder {
-            builder: self,
-            callback,
+        let ScoutBuilder {
+            what,
+            config,
+            handler: _,
+        } = self;
+        ScoutBuilder {
+            what,
+            config,
+            handler: callback,
         }
     }
 
@@ -119,7 +107,7 @@ where
     pub fn callback_mut<CallbackMut>(
         self,
         callback: CallbackMut,
-    ) -> CallbackScoutBuilder<IntoWhatAmI, TryIntoConfig, impl Fn(Hello) + Send + Sync + 'static>
+    ) -> ScoutBuilder<impl Fn(Hello) + Send + Sync + 'static>
     where
         CallbackMut: FnMut(Hello) + Send + Sync + 'static,
     {
@@ -145,25 +133,34 @@ where
     /// # })
     /// ```
     #[inline]
-    pub fn with<IntoHandler, Receiver>(
-        self,
-        handler: IntoHandler,
-    ) -> HandlerScoutBuilder<IntoWhatAmI, TryIntoConfig, IntoHandler, Receiver>
+    pub fn with<Handler, Receiver>(self, handler: Handler) -> ScoutBuilder<Handler>
     where
-        IntoHandler: crate::prelude::IntoHandler<Hello, Receiver>,
+        Handler: crate::prelude::IntoCallbackReceiverPair<'static, Hello>,
     {
-        HandlerScoutBuilder {
-            builder: self,
+        let ScoutBuilder {
+            what,
+            config,
+            handler: _,
+        } = self;
+        ScoutBuilder {
+            what,
+            config,
             handler,
-            receiver: PhantomData,
         }
     }
 }
 
-impl<IntoWhatAmI, TryIntoConfig> AsyncResolve for ScoutBuilder<IntoWhatAmI, TryIntoConfig>
+impl<Handler> Resolvable for ScoutBuilder<Handler>
 where
-    IntoWhatAmI: Into<WhatAmIMatcher>,
-    TryIntoConfig: 'static + Send + std::convert::TryInto<crate::config::Config>,
+    Handler: crate::prelude::IntoCallbackReceiverPair<'static, Hello>,
+{
+    type Output = ZResult<Scout<Handler::Receiver>>;
+}
+
+impl<Handler> AsyncResolve for ScoutBuilder<Handler>
+where
+    Handler: crate::prelude::IntoCallbackReceiverPair<'static, Hello>,
+    Handler::Receiver: Send,
 {
     type Future = futures::future::Ready<Self::Output>;
 
@@ -172,80 +169,14 @@ where
     }
 }
 
-impl<IntoWhatAmI, TryIntoConfig> SyncResolve for ScoutBuilder<IntoWhatAmI, TryIntoConfig>
+impl<Handler> SyncResolve for ScoutBuilder<Handler>
 where
-    IntoWhatAmI: Into<WhatAmIMatcher>,
-    TryIntoConfig: std::convert::TryInto<crate::config::Config> + Send + 'static,
+    Handler: crate::prelude::IntoCallbackReceiverPair<'static, Hello>,
+    Handler::Receiver: Send,
 {
     fn res_sync(self) -> Self::Output {
-        let (callback, receiver) = flume::bounded(1).into_handler();
-        scout(self.what, self.config, callback).map(|scout| HandlerScout { scout, receiver })
-    }
-}
-
-/// A builder for initializing a [`CallbackScout`].
-///
-/// # Examples
-/// ```
-/// # async_std::task::block_on(async {
-/// use zenoh::prelude::r#async::*;
-/// use zenoh::scouting::WhatAmI;
-///
-/// let scout = zenoh::scout(WhatAmI::Peer | WhatAmI::Router, config::default())
-///     .callback(|hello| { println!("{}", hello); })
-///     .res()
-///     .await
-///     .unwrap();
-/// # })
-/// ```
-#[must_use = "Resolvables do nothing unless you resolve them using the `res` method from either `SyncResolve` or `AsyncResolve`"]
-#[derive(Debug, Clone)]
-pub struct CallbackScoutBuilder<IntoWhatAmI, TryIntoConfig, Callback>
-where
-    IntoWhatAmI: Into<WhatAmIMatcher>,
-    TryIntoConfig: std::convert::TryInto<crate::config::Config> + Send + 'static,
-    Callback: Fn(Hello) + Send + Sync + 'static,
-{
-    builder: ScoutBuilder<IntoWhatAmI, TryIntoConfig>,
-    callback: Callback,
-}
-impl<IntoWhatAmI, TryIntoConfig, Callback> Resolvable
-    for CallbackScoutBuilder<IntoWhatAmI, TryIntoConfig, Callback>
-where
-    IntoWhatAmI: Into<WhatAmIMatcher>,
-    TryIntoConfig: std::convert::TryInto<crate::config::Config> + Send + 'static,
-    Callback: Fn(Hello) + Send + Sync + 'static,
-{
-    type Output = ZResult<CallbackScout>;
-}
-
-impl<IntoWhatAmI, TryIntoConfig, Callback> AsyncResolve
-    for CallbackScoutBuilder<IntoWhatAmI, TryIntoConfig, Callback>
-where
-    Callback: 'static + Fn(Hello) + Send + Sync,
-    IntoWhatAmI: Into<WhatAmIMatcher>,
-    TryIntoConfig: 'static + Send + std::convert::TryInto<crate::config::Config>,
-{
-    type Future = futures::future::Ready<Self::Output>;
-
-    fn res_async(self) -> Self::Future {
-        futures::future::ready(self.res_sync())
-    }
-}
-
-impl<IntoWhatAmI, TryIntoConfig, Callback> SyncResolve
-    for CallbackScoutBuilder<IntoWhatAmI, TryIntoConfig, Callback>
-where
-    IntoWhatAmI: Into<WhatAmIMatcher>,
-    TryIntoConfig: std::convert::TryInto<crate::config::Config> + Send + 'static,
-    Callback: Fn(Hello) + Send + Sync + 'static,
-{
-    fn res_sync(self) -> Self::Output {
-        scout(
-            self.builder.what,
-            self.builder.config,
-            Box::new(self.callback),
-        )
+        let (callback, receiver) = self.handler.into_cb_receiver_pair();
+        scout(self.what, self.config?, Box::new(callback)).map(|scout| Scout { scout, receiver })
     }
 }
 
@@ -264,12 +195,12 @@ where
 ///     .unwrap();
 /// # })
 /// ```
-pub struct CallbackScout {
+pub(crate) struct ScoutInner {
     #[allow(dead_code)]
     pub(crate) stop_sender: flume::Sender<()>,
 }
 
-impl CallbackScout {
+impl ScoutInner {
     /// Stop scouting.
     ///
     /// # Examples
@@ -291,62 +222,9 @@ impl CallbackScout {
     }
 }
 
-impl fmt::Debug for CallbackScout {
+impl fmt::Debug for ScoutInner {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("CallbackScout").finish()
-    }
-}
-
-/// A builder for initializing a [`HandlerScout`].
-#[derive(Debug, Clone)]
-#[must_use = "Resolvables do nothing unless you resolve them using the `res` method from either `SyncResolve` or `AsyncResolve`"]
-pub struct HandlerScoutBuilder<IntoWhatAmI, TryIntoConfig, IntoHandler, Receiver>
-where
-    IntoWhatAmI: Into<WhatAmIMatcher>,
-    TryIntoConfig: std::convert::TryInto<crate::config::Config> + Send + 'static,
-    IntoHandler: crate::prelude::IntoHandler<Hello, Receiver>,
-{
-    builder: ScoutBuilder<IntoWhatAmI, TryIntoConfig>,
-    handler: IntoHandler,
-    receiver: PhantomData<Receiver>,
-}
-
-impl<IntoWhatAmI, TryIntoConfig, IntoHandler, Receiver> Resolvable
-    for HandlerScoutBuilder<IntoWhatAmI, TryIntoConfig, IntoHandler, Receiver>
-where
-    IntoWhatAmI: Into<WhatAmIMatcher>,
-    TryIntoConfig: std::convert::TryInto<crate::config::Config> + Send + 'static,
-    IntoHandler: crate::prelude::IntoHandler<Hello, Receiver>,
-{
-    type Output = ZResult<HandlerScout<Receiver>>;
-}
-
-impl<IntoWhatAmI, TryIntoConfig, IntoHandler, Receiver> AsyncResolve
-    for HandlerScoutBuilder<IntoWhatAmI, TryIntoConfig, IntoHandler, Receiver>
-where
-    IntoWhatAmI: Into<WhatAmIMatcher>,
-    TryIntoConfig: 'static + Send + std::convert::TryInto<crate::config::Config>,
-    IntoHandler: crate::prelude::IntoHandler<Hello, Receiver>,
-    Receiver: Send,
-{
-    type Future = futures::future::Ready<Self::Output>;
-    fn res_async(self) -> Self::Future {
-        futures::future::ready(self.res_sync())
-    }
-}
-
-impl<IntoWhatAmI, TryIntoConfig, IntoHandler, Receiver> SyncResolve
-    for HandlerScoutBuilder<IntoWhatAmI, TryIntoConfig, IntoHandler, Receiver>
-where
-    IntoWhatAmI: Into<WhatAmIMatcher>,
-    TryIntoConfig: std::convert::TryInto<crate::config::Config> + Send + 'static,
-    IntoHandler: crate::prelude::IntoHandler<Hello, Receiver>,
-    Receiver: Send,
-{
-    fn res_sync(self) -> Self::Output {
-        let (callback, receiver) = self.handler.into_handler();
-        scout(self.builder.what, self.builder.config, callback)
-            .map(|scout| HandlerScout { scout, receiver })
     }
 }
 
@@ -370,12 +248,12 @@ where
 /// ```
 #[non_exhaustive]
 #[derive(Debug)]
-pub struct HandlerScout<Receiver> {
-    pub scout: CallbackScout,
+pub struct Scout<Receiver> {
+    pub(crate) scout: ScoutInner,
     pub receiver: Receiver,
 }
 
-impl<Receiver> Deref for HandlerScout<Receiver> {
+impl<Receiver> Deref for Scout<Receiver> {
     type Target = Receiver;
 
     fn deref(&self) -> &Self::Target {
@@ -383,7 +261,7 @@ impl<Receiver> Deref for HandlerScout<Receiver> {
     }
 }
 
-impl<Receiver> HandlerScout<Receiver> {
+impl<Receiver> Scout<Receiver> {
     /// Stop scouting.
     ///
     /// # Examples
@@ -406,48 +284,14 @@ impl<Receiver> HandlerScout<Receiver> {
     }
 }
 
-impl crate::prelude::IntoHandler<Hello, flume::Receiver<Hello>>
-    for (flume::Sender<Hello>, flume::Receiver<Hello>)
-{
-    fn into_handler(self) -> crate::prelude::Handler<Hello, flume::Receiver<Hello>> {
-        let (sender, receiver) = self;
-        (
-            Box::new(move |s| {
-                if let Err(e) = sender.send(s) {
-                    log::warn!("Error sending Hello into flume channel: {}", e)
-                }
-            }),
-            receiver,
-        )
-    }
-}
-
 /// A [`HandlerScout`] that provides [`Hello`] messages through a `flume` channel.
-pub type FlumeScout = HandlerScout<flume::Receiver<Hello>>;
+pub type FlumeScout = Scout<flume::Receiver<Hello>>;
 
-fn scout<IntoWhatAmI, TryIntoConfig>(
-    what: IntoWhatAmI,
-    config: TryIntoConfig,
-    callback: Callback<Hello>,
-) -> ZResult<CallbackScout>
-where
-    IntoWhatAmI: Into<WhatAmIMatcher>,
-    TryIntoConfig: std::convert::TryInto<crate::config::Config> + Send + 'static,
-{
-    let what = what.into();
-    let config: crate::config::Config = match config.try_into() {
-        Ok(config) => config,
-        Err(_) => bail!("invalid configuration"),
-    };
-
-    _scout(what, config, callback)
-}
-
-fn _scout(
+fn scout(
     what: WhatAmIMatcher,
     config: zenoh_config::Config,
-    callback: Callback<Hello>,
-) -> ZResult<CallbackScout> {
+    callback: Callback<'static, Hello>,
+) -> ZResult<ScoutInner> {
     log::trace!("scout({}, {})", what, &config);
     let default_addr = match ZN_MULTICAST_IPV4_ADDRESS_DEFAULT.parse() {
         Ok(addr) => addr,
@@ -492,5 +336,5 @@ fn _scout(
             });
         }
     }
-    Ok(CallbackScout { stop_sender })
+    Ok(ScoutInner { stop_sender })
 }

--- a/zenoh/src/session.rs
+++ b/zenoh/src/session.rs
@@ -345,8 +345,8 @@ impl Session {
     /// pointer to it (`Arc<Session>`). This is equivalent to `Arc::new(session)`.
     ///
     /// This is useful to share ownership of the `Session` between several threads
-    /// and tasks. It also alows to create [`Subscriber`](HandlerSubscriber) and
-    /// [`Queryable`](HandlerQueryable) with static lifetime that can be moved to several
+    /// and tasks. It also alows to create [`Subscriber`](Subscriber) and
+    /// [`Queryable`](Queryable) with static lifetime that can be moved to several
     /// threads and tasks
     ///
     /// Note: the given zenoh `Session` will be closed when the last reference to
@@ -376,7 +376,7 @@ impl Session {
     /// the program's life. Dropping the returned reference will cause a memory
     /// leak.
     ///
-    /// This is useful to move entities (like [`Subscriber`](HandlerSubscriber)) which
+    /// This is useful to move entities (like [`Subscriber`](Subscriber)) which
     /// lifetimes are bound to the session lifetime in several threads or tasks.
     ///
     /// Note: the given zenoh `Session` cannot be closed any more. At process
@@ -496,7 +496,7 @@ impl Session {
         }
     }
 
-    /// Create a [`Subscriber`](HandlerSubscriber) for the given key expression.
+    /// Create a [`Subscriber`](Subscriber) for the given key expression.
     ///
     /// # Arguments
     ///
@@ -533,12 +533,12 @@ impl Session {
         }
     }
 
-    /// Create a [`Queryable`](HandlerQueryable) for the given key expression.
+    /// Create a [`Queryable`](Queryable) for the given key expression.
     ///
     /// # Arguments
     ///
     /// * `key_expr` - The key expression matching the queries the
-    /// [`Queryable`](HandlerQueryable) will reply to
+    /// [`Queryable`](Queryable) will reply to
     ///
     /// # Examples
     /// ```no_run
@@ -1540,7 +1540,7 @@ impl Session {
 }
 
 impl SessionDeclarations for Arc<Session> {
-    /// Create a [`Subscriber`](HandlerSubscriber) for the given key expression.
+    /// Create a [`Subscriber`](Subscriber) for the given key expression.
     ///
     /// # Arguments
     ///
@@ -1579,12 +1579,12 @@ impl SessionDeclarations for Arc<Session> {
         }
     }
 
-    /// Create a [`Queryable`](HandlerQueryable) for the given key expression.
+    /// Create a [`Queryable`](Queryable) for the given key expression.
     ///
     /// # Arguments
     ///
     /// * `key_expr` - The key expression matching the queries the
-    /// [`Queryable`](HandlerQueryable) will reply to
+    /// [`Queryable`](Queryable) will reply to
     ///
     /// # Examples
     /// ```no_run

--- a/zenoh/src/session.rs
+++ b/zenoh/src/session.rs
@@ -21,8 +21,7 @@ use crate::key_expr::OwnedKeyExpr;
 use crate::net::routing::face::Face;
 use crate::net::runtime::Runtime;
 use crate::net::transport::Primitives;
-use crate::prelude::sync::ValueSelector;
-use crate::prelude::{Callback, KeyExpr, SessionDeclarations};
+use crate::prelude::{Callback, DefaultHandler, KeyExpr, SessionDeclarations, ValueSelector};
 use crate::publication::*;
 use crate::query::*;
 use crate::queryable::*;
@@ -519,7 +518,7 @@ impl Session {
     pub fn declare_subscriber<'a, 'b, TryIntoKeyExpr>(
         &'a self,
         key_expr: TryIntoKeyExpr,
-    ) -> SubscriberBuilder<'a, 'b, PushMode>
+    ) -> SubscriberBuilder<'a, 'b, PushMode, DefaultHandler>
     where
         TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
         <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_core::Error>,
@@ -530,6 +529,7 @@ impl Session {
             reliability: Reliability::default(),
             mode: PushMode,
             local: false,
+            handler: DefaultHandler,
         }
     }
 
@@ -559,7 +559,7 @@ impl Session {
     pub fn declare_queryable<'a, 'b, TryIntoKeyExpr>(
         &'a self,
         key_expr: TryIntoKeyExpr,
-    ) -> QueryableBuilder<'a, 'b>
+    ) -> QueryableBuilder<'a, 'b, DefaultHandler>
     where
         TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
         <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_core::Error>,
@@ -569,6 +569,7 @@ impl Session {
             key_expr: key_expr.try_into().map_err(Into::into),
             kind: zenoh_protocol_core::queryable::ALL_KINDS,
             complete: true,
+            handler: DefaultHandler,
         }
     }
 
@@ -748,7 +749,10 @@ impl Session {
     /// }
     /// # })
     /// ```
-    pub fn get<'a, 'b, IntoSelector>(&'a self, selector: IntoSelector) -> GetBuilder<'a, 'b>
+    pub fn get<'a, 'b, IntoSelector>(
+        &'a self,
+        selector: IntoSelector,
+    ) -> GetBuilder<'a, 'b, DefaultHandler>
     where
         IntoSelector: TryInto<Selector<'b>>,
         <IntoSelector as TryInto<Selector<'b>>>::Error: Into<zenoh_core::Error>,
@@ -761,6 +765,7 @@ impl Session {
             consolidation: QueryConsolidation::default(),
             local_routing: None,
             timeout: Duration::from_secs(10),
+            handler: DefaultHandler,
         }
     }
 }
@@ -925,7 +930,7 @@ impl Session {
     pub(crate) fn declare_subscriber_inner(
         &self,
         key_expr: &KeyExpr,
-        callback: Callback<Sample>,
+        callback: Callback<'static, Sample>,
         info: &SubInfo,
     ) -> ZResult<Arc<SubscriberState>> {
         let mut state = zwrite!(self.state);
@@ -1010,7 +1015,7 @@ impl Session {
     pub(crate) fn declare_local_subscriber(
         &self,
         key_expr: &KeyExpr,
-        callback: Callback<Sample>,
+        callback: Callback<'static, Sample>,
     ) -> ZResult<Arc<SubscriberState>> {
         let mut state = zwrite!(self.state);
         log::trace!("subscribe({:?})", key_expr);
@@ -1119,7 +1124,7 @@ impl Session {
         key_expr: &WireExpr,
         kind: ZInt,
         complete: bool,
-        callback: Callback<Query>,
+        callback: Callback<'static, Query>,
     ) -> ZResult<Arc<QueryableState>> {
         let mut state = zwrite!(self.state);
         log::trace!("queryable({:?})", key_expr);
@@ -1362,7 +1367,7 @@ impl Session {
         consolidation: QueryConsolidation,
         local_routing: Option<bool>,
         timeout: Duration,
-        callback: Callback<Reply>,
+        callback: Callback<'static, Reply>,
     ) -> ZResult<()> {
         log::trace!("get({}, {:?}, {:?})", selector, target, consolidation);
         let mut state = zwrite!(self.state);
@@ -1559,7 +1564,7 @@ impl SessionDeclarations for Arc<Session> {
     fn declare_subscriber<'b, TryIntoKeyExpr>(
         &self,
         key_expr: TryIntoKeyExpr,
-    ) -> SubscriberBuilder<'static, 'b, PushMode>
+    ) -> SubscriberBuilder<'static, 'b, PushMode, DefaultHandler>
     where
         TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
         <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_core::Error>,
@@ -1570,6 +1575,7 @@ impl SessionDeclarations for Arc<Session> {
             reliability: Reliability::default(),
             mode: PushMode,
             local: false,
+            handler: DefaultHandler,
         }
     }
 
@@ -1601,7 +1607,7 @@ impl SessionDeclarations for Arc<Session> {
     fn declare_queryable<'b, TryIntoKeyExpr>(
         &self,
         key_expr: TryIntoKeyExpr,
-    ) -> QueryableBuilder<'static, 'b>
+    ) -> QueryableBuilder<'static, 'b, DefaultHandler>
     where
         TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
         <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_core::Error>,
@@ -1611,6 +1617,7 @@ impl SessionDeclarations for Arc<Session> {
             key_expr: key_expr.try_into().map_err(Into::into),
             kind: zenoh_protocol_core::queryable::EVAL,
             complete: true,
+            handler: DefaultHandler,
         }
     }
 

--- a/zenoh/src/subscriber.rs
+++ b/zenoh/src/subscriber.rs
@@ -13,11 +13,12 @@
 //
 
 //! Subscribing primitives.
-use crate::prelude::{locked, Callback, Id, KeyExpr, Sample};
+use crate::prelude::{
+    locked, Callback, DefaultHandler, Id, IntoCallbackReceiverPair, KeyExpr, Sample,
+};
+use crate::Undeclarable;
 use crate::{Result as ZResult, SessionRef};
-use crate::{Undeclarable, API_DATA_RECEPTION_CHANNEL_SIZE};
 use std::fmt;
-use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 use zenoh_core::{AsyncResolve, Resolvable, Resolve, SyncResolve};
@@ -32,7 +33,7 @@ pub use zenoh_protocol_core::Reliability;
 pub(crate) struct SubscriberState {
     pub(crate) id: Id,
     pub(crate) key_expr: KeyExpr<'static>,
-    pub(crate) callback: Callback<Sample>,
+    pub(crate) callback: Callback<'static, Sample>,
 }
 
 impl fmt::Debug for SubscriberState {
@@ -69,7 +70,7 @@ impl fmt::Debug for SubscriberState {
 /// # })
 /// ```
 #[derive(Debug)]
-pub struct CallbackSubscriber<'a> {
+pub(crate) struct SubscriberInner<'a> {
     pub(crate) session: SessionRef<'a>,
     pub(crate) state: Arc<SubscriberState>,
     pub(crate) alive: bool,
@@ -104,11 +105,11 @@ pub struct CallbackSubscriber<'a> {
 /// subscriber.pull();
 /// # })
 /// ```
-pub struct CallbackPullSubscriber<'a> {
-    inner: CallbackSubscriber<'a>,
+pub(crate) struct PullSubscriberInner<'a> {
+    inner: SubscriberInner<'a>,
 }
 
-impl<'a> CallbackPullSubscriber<'a> {
+impl<'a> PullSubscriberInner<'a> {
     /// Pull available data for a [`CallbackPullSubscriber`].
     ///
     /// # Examples
@@ -162,7 +163,7 @@ impl<'a> CallbackPullSubscriber<'a> {
     }
 }
 
-impl<'l> CallbackSubscriber<'l> {
+impl<'l> SubscriberInner<'l> {
     /// Close a [`CallbackSubscriber`](CallbackSubscriber).
     ///
     /// `CallbackSubscribers` are automatically closed when dropped, but you may want to use this function to handle errors or
@@ -191,7 +192,7 @@ impl<'l> CallbackSubscriber<'l> {
     }
 }
 
-impl<'a> Undeclarable<()> for CallbackSubscriber<'a> {
+impl<'a> Undeclarable<()> for SubscriberInner<'a> {
     type Output = ZResult<()>;
     type Undeclaration = SubscriberUndeclaration<'a>;
     fn undeclare(self, _: ()) -> Self::Undeclaration {
@@ -217,7 +218,7 @@ impl<'a> Undeclarable<()> for CallbackSubscriber<'a> {
 /// # })
 /// ```
 pub struct SubscriberUndeclaration<'a> {
-    subscriber: CallbackSubscriber<'a>,
+    subscriber: SubscriberInner<'a>,
 }
 
 impl Resolvable for SubscriberUndeclaration<'_> {
@@ -240,7 +241,7 @@ impl AsyncResolve for SubscriberUndeclaration<'_> {
     }
 }
 
-impl Drop for CallbackSubscriber<'_> {
+impl Drop for SubscriberInner<'_> {
     fn drop(&mut self) {
         if self.alive {
             let _ = self.session.unsubscribe(self.state.id);
@@ -290,15 +291,16 @@ impl From<PushMode> for SubMode {
 /// ```
 #[derive(Debug)]
 #[must_use = "Resolvables do nothing unless you resolve them using the `res` method from either `SyncResolve` or `AsyncResolve`"]
-pub struct SubscriberBuilder<'a, 'b, Mode> {
+pub struct SubscriberBuilder<'a, 'b, Mode, Handler> {
     pub(crate) session: SessionRef<'a>,
     pub(crate) key_expr: ZResult<KeyExpr<'b>>,
     pub(crate) reliability: Reliability,
     pub(crate) mode: Mode,
     pub(crate) local: bool,
+    pub(crate) handler: Handler,
 }
 
-impl<'a, 'b, Mode> SubscriberBuilder<'a, 'b, Mode> {
+impl<'a, 'b, Mode> SubscriberBuilder<'a, 'b, Mode, DefaultHandler> {
     /// Receive the samples for this subscription with a callback.
     ///
     /// # Examples
@@ -317,16 +319,25 @@ impl<'a, 'b, Mode> SubscriberBuilder<'a, 'b, Mode> {
     /// # })
     /// ```
     #[inline]
-    pub fn callback<Callback>(
-        self,
-        callback: Callback,
-    ) -> CallbackSubscriberBuilder<'a, 'b, Mode, Callback>
+    pub fn callback<Callback>(self, callback: Callback) -> SubscriberBuilder<'a, 'b, Mode, Callback>
     where
         Callback: Fn(Sample) + Send + Sync + 'static,
     {
-        CallbackSubscriberBuilder {
-            builder: self,
-            callback,
+        let SubscriberBuilder {
+            session,
+            key_expr,
+            reliability,
+            mode,
+            local,
+            handler: _,
+        } = self;
+        SubscriberBuilder {
+            session,
+            key_expr,
+            reliability,
+            mode,
+            local,
+            handler: callback,
         }
     }
 
@@ -355,7 +366,7 @@ impl<'a, 'b, Mode> SubscriberBuilder<'a, 'b, Mode> {
     pub fn callback_mut<CallbackMut>(
         self,
         callback: CallbackMut,
-    ) -> CallbackSubscriberBuilder<'a, 'b, Mode, impl Fn(Sample) + Send + Sync + 'static>
+    ) -> SubscriberBuilder<'a, 'b, Mode, impl Fn(Sample) + Send + Sync + 'static>
     where
         CallbackMut: FnMut(Sample) + Send + Sync + 'static,
     {
@@ -383,20 +394,29 @@ impl<'a, 'b, Mode> SubscriberBuilder<'a, 'b, Mode> {
     /// # })
     /// ```
     #[inline]
-    pub fn with<IntoHandler, Receiver>(
-        self,
-        handler: IntoHandler,
-    ) -> HandlerSubscriberBuilder<'a, 'b, Mode, IntoHandler, Receiver>
+    pub fn with<Handler>(self, handler: Handler) -> SubscriberBuilder<'a, 'b, Mode, Handler>
     where
-        IntoHandler: crate::prelude::IntoHandler<Sample, Receiver>,
+        Handler: crate::prelude::IntoCallbackReceiverPair<'static, Sample>,
     {
-        HandlerSubscriberBuilder {
-            builder: self,
+        let SubscriberBuilder {
+            session,
+            key_expr,
+            reliability,
+            mode,
+            local,
+            handler: _,
+        } = self;
+        SubscriberBuilder {
+            session,
+            key_expr,
+            reliability,
+            mode,
+            local,
             handler,
-            receiver: PhantomData,
         }
     }
-
+}
+impl<'a, 'b, Mode, Handler> SubscriberBuilder<'a, 'b, Mode, Handler> {
     /// Change the subscription reliability.
     #[inline]
     pub fn reliability(mut self, reliability: Reliability) -> Self {
@@ -426,16 +446,17 @@ impl<'a, 'b, Mode> SubscriberBuilder<'a, 'b, Mode> {
     }
 }
 
-impl<'a, 'b> SubscriberBuilder<'a, 'b, PushMode> {
+impl<'a, 'b, Handler> SubscriberBuilder<'a, 'b, PushMode, Handler> {
     /// Change the subscription mode to Pull.
     #[inline]
-    pub fn pull_mode(self) -> SubscriberBuilder<'a, 'b, PullMode> {
+    pub fn pull_mode(self) -> SubscriberBuilder<'a, 'b, PullMode, Handler> {
         let SubscriberBuilder {
             session,
             key_expr,
             reliability,
             mode: _,
             local,
+            handler,
         } = self;
         SubscriberBuilder {
             session,
@@ -443,19 +464,21 @@ impl<'a, 'b> SubscriberBuilder<'a, 'b, PushMode> {
             reliability,
             mode: PullMode,
             local,
+            handler,
         }
     }
 }
-impl<'a, 'b> SubscriberBuilder<'a, 'b, PullMode> {
+impl<'a, 'b, Handler> SubscriberBuilder<'a, 'b, PullMode, Handler> {
     /// Change the subscription mode to Push.
     #[inline]
-    pub fn push_mode(self) -> SubscriberBuilder<'a, 'b, PushMode> {
+    pub fn push_mode(self) -> SubscriberBuilder<'a, 'b, PushMode, Handler> {
         let SubscriberBuilder {
             session,
             key_expr,
             reliability,
             mode: _,
             local,
+            handler,
         } = self;
         SubscriberBuilder {
             session,
@@ -463,161 +486,36 @@ impl<'a, 'b> SubscriberBuilder<'a, 'b, PullMode> {
             reliability,
             mode: PushMode,
             local,
+            handler,
         }
     }
 }
 
-impl<'a> Resolvable for SubscriberBuilder<'a, '_, PushMode> {
-    type Output = ZResult<HandlerSubscriber<'a, flume::Receiver<Sample>>>;
+impl<'a, Handler: IntoCallbackReceiverPair<'static, Sample>> Resolvable
+    for SubscriberBuilder<'a, '_, PushMode, Handler>
+{
+    type Output = ZResult<Subscriber<'a, Handler::Receiver>>;
 }
 
-impl<'a> Resolvable for SubscriberBuilder<'a, '_, PullMode> {
-    type Output = ZResult<HandlerPullSubscriber<'a, flume::Receiver<Sample>>>;
+impl<'a, Handler: IntoCallbackReceiverPair<'static, Sample>> Resolvable
+    for SubscriberBuilder<'a, '_, PullMode, Handler>
+{
+    type Output = ZResult<PullSubscriber<'a, Handler::Receiver>>;
 }
 
-impl<'a> SyncResolve for SubscriberBuilder<'a, '_, PushMode> {
+impl<'a, Handler: IntoCallbackReceiverPair<'static, Sample>> SyncResolve
+    for SubscriberBuilder<'a, '_, PushMode, Handler>
+where
+    Handler::Receiver: Send,
+{
     fn res_sync(self) -> Self::Output {
-        HandlerSubscriberBuilder {
-            builder: self,
-            handler: flume::bounded(*API_DATA_RECEPTION_CHANNEL_SIZE),
-            receiver: PhantomData,
-        }
-        .res_sync()
-    }
-}
-impl<'a> AsyncResolve for SubscriberBuilder<'a, '_, PushMode> {
-    type Future = futures::future::Ready<Self::Output>;
-    fn res_async(self) -> Self::Future {
-        futures::future::ready(self.res_sync())
-    }
-}
-impl<'a> SyncResolve for SubscriberBuilder<'a, '_, PullMode> {
-    fn res_sync(self) -> Self::Output {
-        HandlerSubscriberBuilder {
-            builder: self,
-            handler: flume::bounded(*API_DATA_RECEPTION_CHANNEL_SIZE),
-            receiver: PhantomData,
-        }
-        .res_sync()
-    }
-}
-impl<'a> AsyncResolve for SubscriberBuilder<'a, '_, PullMode> {
-    type Future = futures::future::Ready<Self::Output>;
-    fn res_async(self) -> Self::Future {
-        futures::future::ready(self.res_sync())
-    }
-}
-
-/// A builder for initializing a [`CallbackSubscriber`].
-///
-/// # Examples
-/// ```
-/// # async_std::task::block_on(async {
-/// use zenoh::prelude::*;
-/// use r#async::AsyncResolve;
-///
-/// let session = zenoh::open(config::peer()).res().await.unwrap();
-/// let subscriber = session
-///     .declare_subscriber("key/expression")
-///     .callback(|sample| { println!("Received : {} {}", sample.key_expr, sample.value); })
-///     .best_effort()
-///     .pull_mode()
-///     .res()
-///     .await
-///     .unwrap();
-/// # })
-/// ```
-#[derive(Debug)]
-#[must_use = "Resolvables do nothing unless you resolve them using the `res` method from either `SyncResolve` or `AsyncResolve`"]
-pub struct CallbackSubscriberBuilder<'a, 'b, Mode, Callback>
-where
-    Callback: Fn(Sample) + Send + Sync + 'static,
-{
-    pub(crate) builder: SubscriberBuilder<'a, 'b, Mode>,
-    pub(crate) callback: Callback,
-}
-
-impl<'a, 'b, Mode, Callback> CallbackSubscriberBuilder<'a, 'b, Mode, Callback>
-where
-    Callback: Fn(Sample) + Send + Sync + 'static,
-{
-    /// Change the subscription reliability.
-    #[inline]
-    pub fn reliability(mut self, reliability: Reliability) -> Self {
-        self.builder = self.builder.reliability(reliability);
-        self
-    }
-
-    /// Change the subscription reliability to `Reliable`.
-    #[inline]
-    pub fn reliable(mut self) -> Self {
-        self.builder = self.builder.reliable();
-        self
-    }
-
-    /// Change the subscription reliability to `BestEffort`.
-    #[inline]
-    pub fn best_effort(mut self) -> Self {
-        self.builder = self.builder.best_effort();
-        self
-    }
-    /// Make the subscription local onlyu.
-    #[inline]
-    pub fn local(mut self) -> Self {
-        self.builder = self.builder.local();
-        self
-    }
-}
-impl<'a, 'b, Callback> CallbackSubscriberBuilder<'a, 'b, PushMode, Callback>
-where
-    Callback: Fn(Sample) + Send + Sync + 'static,
-{
-    /// Change the subscription mode to Pull.
-    #[inline]
-    pub fn pull_mode(self) -> CallbackSubscriberBuilder<'a, 'b, PullMode, Callback> {
-        let CallbackSubscriberBuilder { builder, callback } = self;
-        CallbackSubscriberBuilder {
-            builder: builder.pull_mode(),
-            callback,
-        }
-    }
-}
-impl<'a, 'b, Callback> CallbackSubscriberBuilder<'a, 'b, PullMode, Callback>
-where
-    Callback: Fn(Sample) + Send + Sync + 'static,
-{
-    /// Change the subscription mode to Push.
-    #[inline]
-    pub fn push_mode(self) -> CallbackSubscriberBuilder<'a, 'b, PushMode, Callback> {
-        let CallbackSubscriberBuilder { builder, callback } = self;
-        CallbackSubscriberBuilder {
-            builder: builder.push_mode(),
-            callback,
-        }
-    }
-}
-
-impl<'a, Callback> Resolvable for CallbackSubscriberBuilder<'a, '_, PushMode, Callback>
-where
-    Callback: Fn(Sample) + Send + Sync + 'static,
-{
-    type Output = ZResult<CallbackSubscriber<'a>>;
-}
-impl<'a, Callback> Resolvable for CallbackSubscriberBuilder<'a, '_, PullMode, Callback>
-where
-    Callback: Fn(Sample) + Send + Sync + 'static,
-{
-    type Output = ZResult<CallbackPullSubscriber<'a>>;
-}
-
-impl<F: Fn(Sample) + Send + Sync> SyncResolve for CallbackSubscriberBuilder<'_, '_, PushMode, F> {
-    fn res_sync(self) -> Self::Output {
-        let key_expr = self.builder.key_expr?;
-        let session = self.builder.session;
-        if self.builder.local {
+        let (callback, receiver) = self.handler.into_cb_receiver_pair();
+        let key_expr = self.key_expr?;
+        let session = self.session;
+        let inner = if self.local {
             session
-                .declare_local_subscriber(&key_expr, Box::new(self.callback))
-                .map(|sub_state| CallbackSubscriber {
+                .declare_local_subscriber(&key_expr, Box::new(callback))
+                .map(|sub_state| SubscriberInner {
                     session,
                     state: sub_state,
                     alive: true,
@@ -626,36 +524,48 @@ impl<F: Fn(Sample) + Send + Sync> SyncResolve for CallbackSubscriberBuilder<'_, 
             session
                 .declare_subscriber_inner(
                     &key_expr,
-                    Box::new(self.callback),
+                    Box::new(callback),
                     &SubInfo {
-                        reliability: self.builder.reliability,
-                        mode: self.builder.mode.into(),
+                        reliability: self.reliability,
+                        mode: self.mode.into(),
                     },
                 )
-                .map(|sub_state| CallbackSubscriber {
+                .map(|sub_state| SubscriberInner {
                     session,
                     state: sub_state,
                     alive: true,
                 })
-        }
+        };
+        Ok(Subscriber {
+            subscriber: inner?,
+            receiver,
+        })
     }
 }
-impl<F: Fn(Sample) + Send + Sync> AsyncResolve for CallbackSubscriberBuilder<'_, '_, PushMode, F> {
+impl<'a, Handler: IntoCallbackReceiverPair<'static, Sample>> AsyncResolve
+    for SubscriberBuilder<'a, '_, PushMode, Handler>
+where
+    Handler::Receiver: Send,
+{
     type Future = futures::future::Ready<Self::Output>;
     fn res_async(self) -> Self::Future {
         futures::future::ready(self.res_sync())
     }
 }
-
-impl<F: Fn(Sample) + Send + Sync> SyncResolve for CallbackSubscriberBuilder<'_, '_, PullMode, F> {
+impl<'a, Handler: IntoCallbackReceiverPair<'static, Sample>> SyncResolve
+    for SubscriberBuilder<'a, '_, PullMode, Handler>
+where
+    Handler::Receiver: Send,
+{
     fn res_sync(self) -> Self::Output {
-        let key_expr = self.builder.key_expr?;
-        let session = self.builder.session;
-        if self.builder.local {
+        let (callback, receiver) = self.handler.into_cb_receiver_pair();
+        let key_expr = self.key_expr?;
+        let session = self.session;
+        let inner = if self.local {
             session
-                .declare_local_subscriber(&key_expr, Box::new(self.callback))
-                .map(|sub_state| CallbackPullSubscriber {
-                    inner: CallbackSubscriber {
+                .declare_local_subscriber(&key_expr, Box::new(callback))
+                .map(|sub_state| PullSubscriberInner {
+                    inner: SubscriberInner {
                         session,
                         state: sub_state,
                         alive: true,
@@ -665,130 +575,34 @@ impl<F: Fn(Sample) + Send + Sync> SyncResolve for CallbackSubscriberBuilder<'_, 
             session
                 .declare_subscriber_inner(
                     &key_expr,
-                    Box::new(self.callback),
+                    Box::new(callback),
                     &SubInfo {
-                        reliability: self.builder.reliability,
-                        mode: self.builder.mode.into(),
+                        reliability: self.reliability,
+                        mode: self.mode.into(),
                     },
                 )
-                .map(|sub_state| CallbackPullSubscriber {
-                    inner: CallbackSubscriber {
+                .map(|sub_state| PullSubscriberInner {
+                    inner: SubscriberInner {
                         session,
                         state: sub_state,
                         alive: true,
                     },
                 })
-        }
+        };
+        Ok(PullSubscriber {
+            subscriber: inner?,
+            receiver,
+        })
     }
 }
-impl<F: Fn(Sample) + Send + Sync> AsyncResolve for CallbackSubscriberBuilder<'_, '_, PullMode, F> {
+impl<'a, Handler: IntoCallbackReceiverPair<'static, Sample>> AsyncResolve
+    for SubscriberBuilder<'a, '_, PullMode, Handler>
+where
+    Handler::Receiver: Send,
+{
     type Future = futures::future::Ready<Self::Output>;
     fn res_async(self) -> Self::Future {
         futures::future::ready(self.res_sync())
-    }
-}
-
-/// A builder for initializing a [`HandlerSubscriber`].
-///
-/// # Examples
-/// ```
-/// # async_std::task::block_on(async {
-/// use zenoh::prelude::*;
-/// use r#async::AsyncResolve;
-///
-/// let session = zenoh::open(config::peer()).res().await.unwrap();
-/// let subscriber = session
-///     .declare_subscriber("key/expression")
-///     .with(flume::bounded(32))
-///     .best_effort()
-///     .pull_mode()
-///     .res()
-///     .await
-///     .unwrap();
-/// # })
-/// ```
-#[derive(Debug)]
-#[must_use = "Resolvables do nothing unless you resolve them using the `res` method from either `SyncResolve` or `AsyncResolve`"]
-pub struct HandlerSubscriberBuilder<'a, 'b, Mode, IntoHandler, Receiver>
-where
-    IntoHandler: crate::prelude::IntoHandler<Sample, Receiver>,
-{
-    pub(crate) builder: SubscriberBuilder<'a, 'b, Mode>,
-    pub(crate) handler: IntoHandler,
-    pub(crate) receiver: PhantomData<Receiver>,
-}
-
-impl<'a, 'b, Mode, IntoHandler, Receiver>
-    HandlerSubscriberBuilder<'a, 'b, Mode, IntoHandler, Receiver>
-where
-    IntoHandler: crate::prelude::IntoHandler<Sample, Receiver>,
-{
-    /// Change the subscription reliability.
-    #[inline]
-    pub fn reliability(mut self, reliability: Reliability) -> Self {
-        self.builder = self.builder.reliability(reliability);
-        self
-    }
-
-    /// Change the subscription reliability to `Reliable`.
-    #[inline]
-    pub fn reliable(mut self) -> Self {
-        self.builder = self.builder.reliable();
-        self
-    }
-
-    /// Change the subscription reliability to `BestEffort`.
-    #[inline]
-    pub fn best_effort(mut self) -> Self {
-        self.builder = self.builder.best_effort();
-        self
-    }
-
-    /// Make the subscription local only.
-    #[inline]
-    pub fn local(mut self) -> Self {
-        self.builder = self.builder.local();
-        self
-    }
-}
-impl<'a, 'b, IntoHandler, Receiver>
-    HandlerSubscriberBuilder<'a, 'b, PushMode, IntoHandler, Receiver>
-where
-    IntoHandler: crate::prelude::IntoHandler<Sample, Receiver>,
-{
-    /// Change the subscription mode to Pull.
-    #[inline]
-    pub fn pull_mode(self) -> HandlerSubscriberBuilder<'a, 'b, PullMode, IntoHandler, Receiver> {
-        let HandlerSubscriberBuilder {
-            builder,
-            handler,
-            receiver,
-        } = self;
-        HandlerSubscriberBuilder {
-            builder: builder.pull_mode(),
-            handler,
-            receiver,
-        }
-    }
-}
-impl<'a, 'b, IntoHandler, Receiver>
-    HandlerSubscriberBuilder<'a, 'b, PullMode, IntoHandler, Receiver>
-where
-    IntoHandler: crate::prelude::IntoHandler<Sample, Receiver>,
-{
-    /// Change the subscription mode to Pull.
-    #[inline]
-    pub fn push_mode(self) -> HandlerSubscriberBuilder<'a, 'b, PushMode, IntoHandler, Receiver> {
-        let HandlerSubscriberBuilder {
-            builder,
-            handler,
-            receiver,
-        } = self;
-        HandlerSubscriberBuilder {
-            builder: builder.push_mode(),
-            handler,
-            receiver,
-        }
     }
 }
 
@@ -821,8 +635,8 @@ where
 /// ```
 #[non_exhaustive]
 #[derive(Debug)]
-pub struct HandlerSubscriber<'a, Receiver> {
-    pub subscriber: CallbackSubscriber<'a>,
+pub struct Subscriber<'a, Receiver> {
+    pub(crate) subscriber: SubscriberInner<'a>,
     pub receiver: Receiver,
 }
 
@@ -856,25 +670,25 @@ pub struct HandlerSubscriber<'a, Receiver> {
 /// # })
 /// ```
 #[non_exhaustive]
-pub struct HandlerPullSubscriber<'a, Receiver> {
-    pub subscriber: CallbackPullSubscriber<'a>,
+pub struct PullSubscriber<'a, Receiver> {
+    pub(crate) subscriber: PullSubscriberInner<'a>,
     pub receiver: Receiver,
 }
 
-impl<'a, Receiver> Deref for HandlerPullSubscriber<'a, Receiver> {
+impl<'a, Receiver> Deref for PullSubscriber<'a, Receiver> {
     type Target = Receiver;
     fn deref(&self) -> &Self::Target {
         &self.receiver
     }
 }
 
-impl<'a, Receiver> DerefMut for HandlerPullSubscriber<'a, Receiver> {
+impl<'a, Receiver> DerefMut for PullSubscriber<'a, Receiver> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.receiver
     }
 }
 
-impl<'a, Receiver> HandlerPullSubscriber<'a, Receiver> {
+impl<'a, Receiver> PullSubscriber<'a, Receiver> {
     /// Pull available data for a [`HandlerPullSubscriber`].
     ///
     /// # Examples
@@ -921,7 +735,7 @@ impl<'a, Receiver> HandlerPullSubscriber<'a, Receiver> {
     }
 }
 
-impl<'a, Receiver> HandlerSubscriber<'a, Receiver> {
+impl<'a, Receiver> Subscriber<'a, Receiver> {
     /// Close a [`HandlerSubscriber`].
     ///
     /// Subscribers are automatically closed when dropped, but you may want to use this function to handle errors or
@@ -943,112 +757,26 @@ impl<'a, Receiver> HandlerSubscriber<'a, Receiver> {
         self.subscriber.undeclare()
     }
 }
-impl<'a, T> Undeclarable<()> for HandlerSubscriber<'a, T> {
-    type Output = <CallbackSubscriber<'a> as Undeclarable<()>>::Output;
-    type Undeclaration = <CallbackSubscriber<'a> as Undeclarable<()>>::Undeclaration;
+impl<'a, T> Undeclarable<()> for Subscriber<'a, T> {
+    type Output = ZResult<()>;
+    type Undeclaration = SubscriberUndeclaration<'a>;
     fn undeclare(self, _: ()) -> Self::Undeclaration {
         Undeclarable::undeclare(self.subscriber, ())
     }
 }
 
-impl<Receiver> Deref for HandlerSubscriber<'_, Receiver> {
+impl<Receiver> Deref for Subscriber<'_, Receiver> {
     type Target = Receiver;
 
     fn deref(&self) -> &Self::Target {
         &self.receiver
     }
 }
-impl<Receiver> DerefMut for HandlerSubscriber<'_, Receiver> {
+impl<Receiver> DerefMut for Subscriber<'_, Receiver> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.receiver
     }
 }
 
-impl<'a, 'b, IntoHandler, Receiver> Resolvable
-    for HandlerSubscriberBuilder<'a, 'b, PushMode, IntoHandler, Receiver>
-where
-    IntoHandler: crate::prelude::IntoHandler<Sample, Receiver>,
-{
-    type Output = ZResult<HandlerSubscriber<'a, Receiver>>;
-}
-
-impl<'a, 'b, IntoHandler, Receiver: Send> SyncResolve
-    for HandlerSubscriberBuilder<'a, 'b, PushMode, IntoHandler, Receiver>
-where
-    IntoHandler: crate::prelude::IntoHandler<Sample, Receiver>,
-{
-    fn res_sync(self) -> Self::Output {
-        let (callback, receiver) = self.handler.into_handler();
-        self.builder
-            .callback(callback)
-            .res_sync()
-            .map(|subscriber| HandlerSubscriber {
-                subscriber,
-                receiver,
-            })
-    }
-}
-impl<'a, 'b, IntoHandler, Receiver: Send> AsyncResolve
-    for HandlerSubscriberBuilder<'a, 'b, PushMode, IntoHandler, Receiver>
-where
-    IntoHandler: crate::prelude::IntoHandler<Sample, Receiver>,
-{
-    type Future = futures::future::Ready<Self::Output>;
-    fn res_async(self) -> Self::Future {
-        futures::future::ready(self.res_sync())
-    }
-}
-
-impl<'a, 'b, IntoHandler, Receiver> Resolvable
-    for HandlerSubscriberBuilder<'a, 'b, PullMode, IntoHandler, Receiver>
-where
-    IntoHandler: crate::prelude::IntoHandler<Sample, Receiver>,
-{
-    type Output = ZResult<HandlerPullSubscriber<'a, Receiver>>;
-}
-
-impl<'a, 'b, IntoHandler, Receiver: Send> SyncResolve
-    for HandlerSubscriberBuilder<'a, 'b, PullMode, IntoHandler, Receiver>
-where
-    IntoHandler: crate::prelude::IntoHandler<Sample, Receiver>,
-{
-    fn res_sync(self) -> Self::Output {
-        let (callback, receiver) = self.handler.into_handler();
-        self.builder
-            .callback(callback)
-            .res_sync()
-            .map(|subscriber| HandlerPullSubscriber {
-                subscriber,
-                receiver,
-            })
-    }
-}
-impl<'a, 'b, IntoHandler, Receiver: Send> AsyncResolve
-    for HandlerSubscriberBuilder<'a, 'b, PullMode, IntoHandler, Receiver>
-where
-    IntoHandler: crate::prelude::IntoHandler<Sample, Receiver>,
-{
-    type Future = futures::future::Ready<Self::Output>;
-    fn res_async(self) -> Self::Future {
-        futures::future::ready(self.res_sync())
-    }
-}
-
-impl crate::prelude::IntoHandler<Sample, flume::Receiver<Sample>>
-    for (flume::Sender<Sample>, flume::Receiver<Sample>)
-{
-    fn into_handler(self) -> crate::prelude::Handler<Sample, flume::Receiver<Sample>> {
-        let (sender, receiver) = self;
-        (
-            Box::new(move |s| {
-                if let Err(e) = sender.send(s) {
-                    log::warn!("Error sending sample into flume channel: {}", e)
-                }
-            }),
-            receiver,
-        )
-    }
-}
-
 /// A [`HandlerSubscriber`] that provides data through a `flume` channel.
-pub type FlumeSubscriber<'a> = HandlerSubscriber<'a, flume::Receiver<Sample>>;
+pub type FlumeSubscriber<'a> = Subscriber<'a, flume::Receiver<Sample>>;

--- a/zenoh/src/subscriber.rs
+++ b/zenoh/src/subscriber.rs
@@ -373,7 +373,7 @@ impl<'a, 'b, Mode> SubscriberBuilder<'a, 'b, Mode, DefaultHandler> {
         self.callback(locked(callback))
     }
 
-    /// Receive the samples for this subscription with a [`Handler`](crate::prelude::Handler).
+    /// Receive the samples for this subscription with a [`Handler`](crate::prelude::IntoCallbackReceiverPair).
     ///
     /// # Examples
     /// ```no_run
@@ -606,9 +606,9 @@ where
     }
 }
 
-/// A subscriber that provides data through a [`Handler`](crate::prelude::Handler).
+/// A subscriber that provides data through a [`Handler`](crate::prelude::IntoCallbackReceiverPair).
 ///
-/// HandlerSubscribers can be created from a zenoh [`Session`](crate::Session)
+/// Subscribers can be created from a zenoh [`Session`](crate::Session)
 /// with the [`declare_subscriber`](crate::Session::declare_subscriber) function
 /// and the [`with`](SubscriberBuilder::with) function
 /// of the resulting builder.
@@ -640,11 +640,11 @@ pub struct Subscriber<'a, Receiver> {
     pub receiver: Receiver,
 }
 
-/// A [`PullMode`] subscriber that provides data through a [`Handler`](crate::prelude::Handler).
+/// A [`PullMode`] subscriber that provides data through a [`Handler`](crate::prelude::IntoCallbackReceiverPair).
 ///
-/// HandlerPullSubscribers only provide data when explicitely pulled by the
-/// application with the [`pull`](HandlerPullSubscriber::pull) function.
-/// HandlerPullSubscribers can be created from a zenoh [`Session`](crate::Session)
+/// PullSubscribers only provide data when explicitely pulled by the
+/// application with the [`pull`](PullSubscriber::pull) function.
+/// PullSubscribers can be created from a zenoh [`Session`](crate::Session)
 /// with the [`declare_subscriber`](crate::Session::declare_subscriber) function,
 /// the [`with`](SubscriberBuilder::with) function
 /// and the [`pull_mode`](SubscriberBuilder::pull_mode) function
@@ -689,7 +689,7 @@ impl<'a, Receiver> DerefMut for PullSubscriber<'a, Receiver> {
 }
 
 impl<'a, Receiver> PullSubscriber<'a, Receiver> {
-    /// Pull available data for a [`HandlerPullSubscriber`].
+    /// Pull available data for a [`PullSubscriber`].
     ///
     /// # Examples
     /// ```
@@ -713,7 +713,7 @@ impl<'a, Receiver> PullSubscriber<'a, Receiver> {
     pub fn pull(&self) -> impl Resolve<ZResult<()>> + '_ {
         self.subscriber.pull()
     }
-    /// Close a [`HandlerPullSubscriber`].
+    /// Close a [`PullSubscriber`].
     ///
     /// Subscribers are automatically closed when dropped, but you may want to use this function to handle errors or
     /// close the Subscriber asynchronously.
@@ -736,7 +736,7 @@ impl<'a, Receiver> PullSubscriber<'a, Receiver> {
 }
 
 impl<'a, Receiver> Subscriber<'a, Receiver> {
-    /// Close a [`HandlerSubscriber`].
+    /// Close a [`Subscriber`].
     ///
     /// Subscribers are automatically closed when dropped, but you may want to use this function to handle errors or
     /// close the Subscriber asynchronously.
@@ -778,5 +778,5 @@ impl<Receiver> DerefMut for Subscriber<'_, Receiver> {
     }
 }
 
-/// A [`HandlerSubscriber`] that provides data through a `flume` channel.
+/// A [`Subscriber`] that provides data through a `flume` channel.
 pub type FlumeSubscriber<'a> = Subscriber<'a, flume::Receiver<Sample>>;


### PR DESCRIPTION
Remove the unnecessary distinction between `X`, `CallbackX`, and `HandlerX` (where X is Subscriber, Queryable... and their builders). The API is unchanged code-wise, but some typenames have changed (for the better).

This comes with many niceties:
- Build time (all-targets, debug, on a Ryzen 3800x, release seems unaffected): 3m55s -> 2m55s.
- Better naming: who cares that a Subscriber was constructed with a Handler or a Callback? All that matters is what receiver it can deref to so it can be used as a handler when appropriate.
- More approachable API, here's a before/after on the doc for the `subscriber` module's structs, where 10 types have been turned into 6, with less duplication that can lead a reader to start diagonalizing instead of reading:
![image](https://user-images.githubusercontent.com/6801863/183914064-65247dcc-4df2-46f2-a176-7ccc00967f08.png)
![image](https://user-images.githubusercontent.com/6801863/183914129-6e3a5718-7d32-457c-b665-6a2dc1cf8ca5.png)
- Less code and documentation to maintain: no more having to write everything thrice!