### PR TITLE
Allow build of zenoh artifacts with specified features

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -32,28 +32,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-auth_pubkey = ["zenoh/auth_pubkey"]
-auth_usrpwd = ["zenoh/auth_usrpwd"]
-complete_n = ["zenoh/complete_n"]
 shared-memory = ["zenoh/shared-memory"]
-stats = ["zenoh/stats"]
-transport_quic = ["zenoh/transport_quic"]
-transport_tcp = ["zenoh/transport_tcp"]
-transport_tls = ["zenoh/transport_tls"]
-transport_udp = ["zenoh/transport_udp"]
-transport_unixsock-stream = ["zenoh/transport_unixsock-stream"]
-transport_serial = ["zenoh/transport_serial"]
-transport_ws = ["zenoh/transport_ws"]
-default = [
-    "auth_pubkey",
-    "auth_usrpwd",
-    "shared-memory",
-    "transport_quic",
-    "transport_tcp",
-    "transport_tls",
-    "transport_udp",
-    "transport_unixsock-stream",
-]
 
 [dependencies]
 zenoh = { path = "../zenoh/" , default-features = false }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -56,8 +56,8 @@ default = [
 ]
 
 [dependencies]
-zenoh = { path = "../zenoh/" , default-features = false}
-zenoh-ext = { path = "../zenoh-ext/", default-features=false }
+zenoh = { path = "../zenoh/" , default-features = false }
+zenoh-ext = { path = "../zenoh-ext/" }
 
 async-std = { version = "=1.12.0", default-features = false, features = [
   "attributes",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -32,11 +32,32 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+auth_pubkey = ["zenoh/auth_pubkey"]
+auth_usrpwd = ["zenoh/auth_usrpwd"]
+complete_n = ["zenoh/complete_n"]
 shared-memory = ["zenoh/shared-memory"]
+stats = ["zenoh/stats"]
+transport_quic = ["zenoh/transport_quic"]
+transport_tcp = ["zenoh/transport_tcp"]
+transport_tls = ["zenoh/transport_tls"]
+transport_udp = ["zenoh/transport_udp"]
+transport_unixsock-stream = ["zenoh/transport_unixsock-stream"]
+transport_serial = ["zenoh/transport_serial"]
+transport_ws = ["zenoh/transport_ws"]
+default = [
+    "auth_pubkey",
+    "auth_usrpwd",
+    "shared-memory",
+    "transport_quic",
+    "transport_tcp",
+    "transport_tls",
+    "transport_udp",
+    "transport_unixsock-stream",
+]
 
 [dependencies]
-zenoh = { path = "../zenoh/" }
-zenoh-ext = { path = "../zenoh-ext/" }
+zenoh = { path = "../zenoh/" , default-features = false}
+zenoh-ext = { path = "../zenoh-ext/", default-features=false }
 
 async-std = { version = "=1.12.0", default-features = false, features = [
   "attributes",

--- a/io/zenoh-transport/src/unicast/establishment/authenticator/mod.rs
+++ b/io/zenoh-transport/src/unicast/establishment/authenticator/mod.rs
@@ -142,6 +142,7 @@ pub struct PeerAuthenticator(Arc<dyn PeerAuthenticatorTrait>);
 
 impl PeerAuthenticator {
     pub async fn from_config(_config: &Config) -> ZResult<HashSet<PeerAuthenticator>> {
+        #[allow(unused_mut)]
         let mut pas = HashSet::new();
 
         #[cfg(feature = "auth_pubkey")]

--- a/io/zenoh-transport/src/unicast/establishment/open/init_ack.rs
+++ b/io/zenoh-transport/src/unicast/establishment/open/init_ack.rs
@@ -11,7 +11,6 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use crate::unicast::establishment::authenticator::PeerAuthenticatorId;
 use crate::unicast::establishment::open::OResult;
 use crate::unicast::establishment::{attachment_from_properties, properties_from_attachment};
 use crate::unicast::establishment::{
@@ -23,6 +22,9 @@ use zenoh_link::LinkUnicast;
 use zenoh_protocol::core::{Property, WhatAmI, ZInt, ZenohId};
 use zenoh_protocol::io::ZSlice;
 use zenoh_protocol::proto::{tmsg, Attachment, Close, TransportBody};
+
+#[cfg(feature = "shared-memory")]
+use crate::unicast::establishment::authenticator::PeerAuthenticatorId;
 
 /*************************************/
 /*              OPEN                 */
@@ -111,9 +113,11 @@ pub(super) async fn recv(
         None => EstablishmentProperties::new(),
     };
 
+    #[allow(unused_mut)]
     let mut is_shm = false;
     let mut ps_attachment = EstablishmentProperties::new();
     for pa in zasyncread!(manager.state.unicast.peer_authenticator).iter() {
+        #[allow(unused_mut)]
         let mut att = pa
             .handle_init_ack(
                 auth_link,

--- a/io/zenoh-transport/src/unicast/transport.rs
+++ b/io/zenoh-transport/src/unicast/transport.rs
@@ -435,7 +435,7 @@ impl TransportUnicastInner {
     /*        SCHEDULE AND SEND TX       */
     /*************************************/
     /// Schedule a Zenoh message on the transmission queue    
-    pub(crate) fn schedule(&self, mut message: ZenohMessage) -> bool {
+    pub(crate) fn schedule(&self, #[allow(unused_mut)] mut message: ZenohMessage) -> bool {
         #[cfg(feature = "shared-memory")]
         {
             let res = if self.config.is_shm {

--- a/plugins/example-plugin/Cargo.toml
+++ b/plugins/example-plugin/Cargo.toml
@@ -40,7 +40,7 @@ clap = "3.2.10"
 env_logger = "0.9.0"
 futures = "0.3.12"
 log = "0.4.14"
-zenoh = { path = "../../zenoh" }
+zenoh = { path = "../../zenoh", default-features = false}
 zenoh-util = { path = "../../commons/zenoh-util" }
 zenoh-core = { path = "../../commons/zenoh-core/" }
 zenoh-plugin-trait = { path = "../zenoh-plugin-trait" }

--- a/plugins/zenoh-backend-traits/Cargo.toml
+++ b/plugins/zenoh-backend-traits/Cargo.toml
@@ -35,6 +35,6 @@ async-std = "=1.12.0"
 async-trait = "0.1.51"
 derive_more = "0.99"
 serde_json = "1.0"
-zenoh = { path = "../../zenoh" }
+zenoh = { path = "../../zenoh", default-features = false }
 zenoh-core = { path = "../../commons/zenoh-core/" }
 zenoh-util = { path = "../../commons/zenoh-util/" }

--- a/plugins/zenoh-plugin-rest/Cargo.toml
+++ b/plugins/zenoh-plugin-rest/Cargo.toml
@@ -52,7 +52,7 @@ log = "0.4"
 serde = "1.0"
 serde_json = "1.0"
 tide = "0.16.0"
-zenoh = { path = "../../zenoh" }
+zenoh = { path = "../zenoh/" , default-features = false }
 zenoh-util = { path = "../../commons/zenoh-util/" }
 zenoh-core = { path = "../../commons/zenoh-core/" }
 zenoh-cfg-properties = { path = "../../commons/zenoh-cfg-properties" }

--- a/plugins/zenoh-plugin-rest/Cargo.toml
+++ b/plugins/zenoh-plugin-rest/Cargo.toml
@@ -52,7 +52,7 @@ log = "0.4"
 serde = "1.0"
 serde_json = "1.0"
 tide = "0.16.0"
-zenoh = { path = "../zenoh/" , default-features = false }
+zenoh = { path = "../../zenoh/" , default-features = false }
 zenoh-util = { path = "../../commons/zenoh-util/" }
 zenoh-core = { path = "../../commons/zenoh-core/" }
 zenoh-cfg-properties = { path = "../../commons/zenoh-cfg-properties" }

--- a/plugins/zenoh-plugin-storage-manager/Cargo.toml
+++ b/plugins/zenoh-plugin-storage-manager/Cargo.toml
@@ -46,7 +46,7 @@ git-version = "0.3.5"
 libloading = "0.7.0"
 log = "0.4.14"
 serde_json = "1.0"
-zenoh = { path = "../zenoh/" , default-features = false }
+zenoh = { path = "../../zenoh/" , default-features = false }
 zenoh-plugin-trait = { path = "../zenoh-plugin-trait", default-features = false }
 zenoh-util = { path = "../../commons/zenoh-util" }
 zenoh-core = { path = "../../commons/zenoh-core/" }

--- a/plugins/zenoh-plugin-storage-manager/Cargo.toml
+++ b/plugins/zenoh-plugin-storage-manager/Cargo.toml
@@ -46,7 +46,7 @@ git-version = "0.3.5"
 libloading = "0.7.0"
 log = "0.4.14"
 serde_json = "1.0"
-zenoh = { path = "../../zenoh" }
+zenoh = { path = "../zenoh/" , default-features = false }
 zenoh-plugin-trait = { path = "../zenoh-plugin-trait", default-features = false }
 zenoh-util = { path = "../../commons/zenoh-util" }
 zenoh-core = { path = "../../commons/zenoh-core/" }

--- a/zenoh-ext/Cargo.toml
+++ b/zenoh-ext/Cargo.toml
@@ -25,6 +25,30 @@ description = "Zenoh: extensions to the client API."
 [badges]
 maintenance = { status = "actively-developed" }
 
+[features]
+auth_pubkey = ["zenoh/auth_pubkey"]
+auth_usrpwd = ["zenoh/auth_usrpwd"]
+complete_n = ["zenoh/complete_n"]
+shared-memory = ["zenoh/shared-memory"]
+stats = ["zenoh/stats"]
+transport_quic = ["zenoh/transport_quic"]
+transport_tcp = ["zenoh/transport_tcp"]
+transport_tls = ["zenoh/transport_tls"]
+transport_udp = ["zenoh/transport_udp"]
+transport_unixsock-stream = ["zenoh/transport_unixsock-stream"]
+transport_serial = ["zenoh/transport_serial"]
+transport_ws = ["zenoh/transport_ws"]
+default = [
+    "auth_pubkey",
+    "auth_usrpwd",
+    "shared-memory",
+    "transport_quic",
+    "transport_tcp",
+    "transport_tls",
+    "transport_udp",
+    "transport_unixsock-stream",
+]
+
 [dependencies]
 async-std = { version = "=1.12.0", default-features = false, features = [
     "attributes",
@@ -36,7 +60,7 @@ flume = "0.10.7"
 futures = "0.3.12"
 log = "0.4"
 serde = "1.0.126"
-zenoh = { path = "../zenoh" }
+zenoh = { path = "../zenoh", default-features= false }
 zenoh-util = { path = "../commons/zenoh-util" }
 zenoh-sync = { path = "../commons/zenoh-sync" }
 zenoh-core = { path = "../commons/zenoh-core/" }

--- a/zenoh-ext/Cargo.toml
+++ b/zenoh-ext/Cargo.toml
@@ -25,30 +25,6 @@ description = "Zenoh: extensions to the client API."
 [badges]
 maintenance = { status = "actively-developed" }
 
-[features]
-auth_pubkey = ["zenoh/auth_pubkey"]
-auth_usrpwd = ["zenoh/auth_usrpwd"]
-complete_n = ["zenoh/complete_n"]
-shared-memory = ["zenoh/shared-memory"]
-stats = ["zenoh/stats"]
-transport_quic = ["zenoh/transport_quic"]
-transport_tcp = ["zenoh/transport_tcp"]
-transport_tls = ["zenoh/transport_tls"]
-transport_udp = ["zenoh/transport_udp"]
-transport_unixsock-stream = ["zenoh/transport_unixsock-stream"]
-transport_serial = ["zenoh/transport_serial"]
-transport_ws = ["zenoh/transport_ws"]
-default = [
-    "auth_pubkey",
-    "auth_usrpwd",
-    "shared-memory",
-    "transport_quic",
-    "transport_tcp",
-    "transport_tls",
-    "transport_udp",
-    "transport_unixsock-stream",
-]
-
 [dependencies]
 async-std = { version = "=1.12.0", default-features = false, features = [
     "attributes",

--- a/zenohd/Cargo.toml
+++ b/zenohd/Cargo.toml
@@ -32,28 +32,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-auth_pubkey = ["zenoh/auth_pubkey"]
-auth_usrpwd = ["zenoh/auth_usrpwd"]
-complete_n = ["zenoh/complete_n"]
 shared-memory = ["zenoh/shared-memory"]
-stats = ["zenoh/stats"]
-transport_quic = ["zenoh/transport_quic"]
-transport_tcp = ["zenoh/transport_tcp"]
-transport_tls = ["zenoh/transport_tls"]
-transport_udp = ["zenoh/transport_udp"]
-transport_unixsock-stream = ["zenoh/transport_unixsock-stream"]
-transport_serial = ["zenoh/transport_serial"]
-transport_ws = ["zenoh/transport_ws"]
-default = [
-    "auth_pubkey",
-    "auth_usrpwd",
-    "shared-memory",
-    "transport_quic",
-    "transport_tcp",
-    "transport_tls",
-    "transport_udp",
-    "transport_unixsock-stream",
-]
 
 [dependencies]
 zenoh = { path = "../zenoh/" , default-features = false}

--- a/zenohd/Cargo.toml
+++ b/zenohd/Cargo.toml
@@ -32,10 +32,31 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+auth_pubkey = ["zenoh/auth_pubkey"]
+auth_usrpwd = ["zenoh/auth_usrpwd"]
+complete_n = ["zenoh/complete_n"]
 shared-memory = ["zenoh/shared-memory"]
+stats = ["zenoh/stats"]
+transport_quic = ["zenoh/transport_quic"]
+transport_tcp = ["zenoh/transport_tcp"]
+transport_tls = ["zenoh/transport_tls"]
+transport_udp = ["zenoh/transport_udp"]
+transport_unixsock-stream = ["zenoh/transport_unixsock-stream"]
+transport_serial = ["zenoh/transport_serial"]
+transport_ws = ["zenoh/transport_ws"]
+default = [
+    "auth_pubkey",
+    "auth_usrpwd",
+    "shared-memory",
+    "transport_quic",
+    "transport_tcp",
+    "transport_tls",
+    "transport_udp",
+    "transport_unixsock-stream",
+]
 
 [dependencies]
-zenoh = { path = "../zenoh/" }
+zenoh = { path = "../zenoh/" , default-features = false}
 
 async-std = { version = "=1.12.0", default-features = false, features = [
 	"attributes",


### PR DESCRIPTION
This PR updates the `Cargo.toml` files for `zenohd`, `examples` and `zenoh-ext` crates.
Now all the features are re-exported, thus allowing compilation only of the needed dependencies.

This solves #302, thus now Zenoh can build on FreeBSD.

Now this works.
```
$ cargo build --bin zenohd --example z_pub --example z_sub --no-default-features --features transport_tcp
...
Finished dev [unoptimized + debuginfo] target(s) in 0.16s
```