### PR TITLE
Reopening PR on removing queryable kind

### DIFF
--- a/commons/zenoh-protocol-core/src/lib.rs
+++ b/commons/zenoh-protocol-core/src/lib.rs
@@ -438,7 +438,7 @@ pub struct SubInfo {
     pub mode: SubMode,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct QueryableInfo {
     pub complete: ZInt,
     pub distance: ZInt,
@@ -451,12 +451,6 @@ impl Default for QueryableInfo {
             distance: 0,
         }
     }
-}
-
-pub mod queryable {
-    pub const ALL_KINDS: super::ZInt = 0x01;
-    pub const STORAGE: super::ZInt = 0x02;
-    pub const EVAL: super::ZInt = 0x04;
 }
 
 /// The kind of consolidation.
@@ -489,22 +483,6 @@ pub enum QueryTarget {
 impl Default for QueryTarget {
     fn default() -> Self {
         QueryTarget::BestMatching
-    }
-}
-
-/// The `zenoh::queryable::Queryable`s that should be target of a `zenoh::Session::get()`.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct QueryTAK {
-    pub kind: ZInt,
-    pub target: QueryTarget,
-}
-
-impl Default for QueryTAK {
-    fn default() -> Self {
-        QueryTAK {
-            kind: queryable::ALL_KINDS,
-            target: QueryTarget::default(),
-        }
     }
 }
 

--- a/commons/zenoh-protocol/src/proto/msg.rs
+++ b/commons/zenoh-protocol/src/proto/msg.rs
@@ -389,8 +389,6 @@ impl Attachment {
 /// +-+-+-+---------+
 /// ~      qid      ~
 /// +---------------+
-/// ~  replier_kind ~ if F==0
-/// +---------------+
 /// ~   replier_id  ~ if F==0
 /// +---------------+
 ///
@@ -398,7 +396,6 @@ impl Attachment {
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReplierInfo {
-    pub kind: ZInt,
     pub id: ZenohId,
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -827,15 +824,12 @@ impl Header for ForgetSubscriber {
 /// +---------------+
 /// ~    KeyExpr     ~ if K==1 then key_expr has suffix
 /// +---------------+
-/// ~     Kind      ~
-/// +---------------+
 /// ~   QablInfo    ~ if Q==1
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Queryable {
     pub key: WireExpr<'static>,
-    pub kind: ZInt,
     pub info: QueryableInfo,
 }
 
@@ -860,22 +854,16 @@ impl Header for Queryable {
 /// +---------------+
 /// ~    KeyExpr     ~ if K==1 then key_expr has suffix
 /// +---------------+
-/// ~     Kind      ~
-/// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ForgetQueryable {
     pub key: WireExpr<'static>,
-    pub kind: ZInt,
 }
 
 impl Header for ForgetQueryable {
     #[inline(always)]
     fn header(&self) -> u8 {
         let mut header = zmsg::declaration::id::FORGET_QUERYABLE;
-        if self.kind != queryable::EVAL {
-            header |= zmsg::flag::Q
-        }
         if self.key.has_suffix() {
             header |= zmsg::flag::K
         }
@@ -967,7 +955,7 @@ pub struct Query {
     pub key: WireExpr<'static>,
     pub value_selector: String,
     pub qid: ZInt,
-    pub target: Option<QueryTAK>,
+    pub target: Option<QueryTarget>,
     pub consolidation: ConsolidationMode,
 }
 
@@ -1187,7 +1175,7 @@ impl ZenohMessage {
         key: WireExpr<'static>,
         value_selector: String,
         qid: ZInt,
-        target: Option<QueryTAK>,
+        target: Option<QueryTarget>,
         consolidation: ConsolidationMode,
         routing_context: Option<RoutingContext>,
         attachment: Option<Attachment>,

--- a/commons/zenoh-protocol/src/proto/msg_reader.rs
+++ b/commons/zenoh-protocol/src/proto/msg_reader.rs
@@ -54,7 +54,6 @@ pub trait MessageReader {
     fn read_link_state_list(&mut self, _header: u8) -> Option<ZenohBody>;
     fn read_link_state(&mut self) -> Option<LinkState>;
     fn read_submode(&mut self) -> Option<SubMode>;
-    fn read_query_tak(&mut self) -> Option<QueryTAK>;
     fn read_query_target(&mut self) -> Option<QueryTarget>;
     fn read_consolidation_mode(mode: ZInt) -> Option<ConsolidationMode>;
     fn read_consolidation(&mut self) -> Option<ConsolidationMode>;
@@ -438,7 +437,6 @@ impl MessageReader for ZBufReader<'_> {
             None
         } else {
             Some(ReplierInfo {
-                kind: self.read_zint()?,
                 id: self.read_zid()?,
             })
         };
@@ -697,18 +695,16 @@ impl MessageReader for ZBufReader<'_> {
             }
             QUERYABLE => {
                 let key = self.read_key_expr(imsg::has_flag(header, zmsg::flag::K))?;
-                let kind = self.read_zint()?;
                 let info = if imsg::has_flag(header, zmsg::flag::Q) {
                     self.read_queryable_info()?
                 } else {
                     QueryableInfo::default()
                 };
-                Some(Declaration::Queryable(Queryable { key, kind, info }))
+                Some(Declaration::Queryable(Queryable { key, info }))
             }
             FORGET_QUERYABLE => {
                 let key = self.read_key_expr(imsg::has_flag(header, zmsg::flag::K))?;
-                let kind = self.read_zint()?;
-                Some(Declaration::ForgetQueryable(ForgetQueryable { key, kind }))
+                Some(Declaration::ForgetQueryable(ForgetQueryable { key }))
             }
             unknown => {
                 log::trace!("Invalid ID for Declaration: {}", unknown);
@@ -722,7 +718,7 @@ impl MessageReader for ZBufReader<'_> {
         let value_selector = self.read_string()?;
         let qid = self.read_zint()?;
         let target = if imsg::has_flag(header, zmsg::flag::T) {
-            Some(self.read_query_tak()?)
+            Some(self.read_query_target()?)
         } else {
             None
         };
@@ -798,12 +794,6 @@ impl MessageReader for ZBufReader<'_> {
             return None;
         }
         Some(mode)
-    }
-
-    fn read_query_tak(&mut self) -> Option<QueryTAK> {
-        let kind = self.read_zint()?;
-        let target = self.read_query_target()?;
-        Some(QueryTAK { kind, target })
     }
 
     fn read_query_target(&mut self) -> Option<QueryTarget> {

--- a/commons/zenoh-protocol/tests/msg_codec.rs
+++ b/commons/zenoh-protocol/tests/msg_codec.rs
@@ -83,10 +83,7 @@ fn gen_routing_context() -> RoutingContext {
 fn gen_reply_context(is_final: bool) -> ReplyContext {
     let qid = gen!(ZInt);
     let replier = if !is_final {
-        Some(ReplierInfo {
-            kind: thread_rng().gen_range(0..4),
-            id: gen_zid(),
-        })
+        Some(ReplierInfo { id: gen_zid() })
     } else {
         None
     };
@@ -144,7 +141,6 @@ fn gen_declarations() -> Vec<Declaration> {
         Declaration::ForgetSubscriber(ForgetSubscriber { key: gen_key() }),
         Declaration::Queryable(Queryable {
             key: gen_key(),
-            kind: queryable::ALL_KINDS,
             info: QueryableInfo {
                 complete: 1,
                 distance: 0,
@@ -152,7 +148,6 @@ fn gen_declarations() -> Vec<Declaration> {
         }),
         Declaration::Queryable(Queryable {
             key: gen_key(),
-            kind: queryable::STORAGE,
             info: QueryableInfo {
                 complete: 0,
                 distance: 10,
@@ -160,24 +155,14 @@ fn gen_declarations() -> Vec<Declaration> {
         }),
         Declaration::Queryable(Queryable {
             key: gen_key(),
-            kind: queryable::EVAL,
             info: QueryableInfo {
                 complete: 10,
                 distance: 0,
             },
         }),
-        Declaration::ForgetQueryable(ForgetQueryable {
-            key: gen_key(),
-            kind: queryable::ALL_KINDS,
-        }),
-        Declaration::ForgetQueryable(ForgetQueryable {
-            key: gen_key(),
-            kind: queryable::STORAGE,
-        }),
-        Declaration::ForgetQueryable(ForgetQueryable {
-            key: gen_key(),
-            kind: queryable::EVAL,
-        }),
+        Declaration::ForgetQueryable(ForgetQueryable { key: gen_key() }),
+        Declaration::ForgetQueryable(ForgetQueryable { key: gen_key() }),
+        Declaration::ForgetQueryable(ForgetQueryable { key: gen_key() }),
     ]
 }
 
@@ -190,13 +175,7 @@ fn gen_key() -> WireExpr<'static> {
     key[thread_rng().gen_range(0..key.len())].clone()
 }
 
-fn gen_query_target() -> QueryTAK {
-    let kind: ZInt = thread_rng().gen_range(0..4);
-    let target = gen_target();
-    QueryTAK { kind, target }
-}
-
-fn gen_target() -> QueryTarget {
+fn gen_query_target() -> QueryTarget {
     let tgt = [
         QueryTarget::BestMatching,
         QueryTarget::All,
@@ -849,7 +828,7 @@ fn codec_query() {
                             gen_key(),
                             p.clone(),
                             gen!(ZInt),
-                            t.clone(),
+                            *t,
                             gen_consolidation_mode(),
                             *roc,
                             a.clone(),

--- a/io/zenoh-transport/src/primitives/demux.rs
+++ b/io/zenoh-transport/src/primitives/demux.rs
@@ -47,12 +47,8 @@ impl<P: 'static + Primitives> TransportPeerEventHandler for DeMux<P> {
                                 .decl_subscriber(&s.key, &s.info, msg.routing_context);
                         }
                         Declaration::Queryable(q) => {
-                            self.primitives.decl_queryable(
-                                &q.key,
-                                q.kind,
-                                &q.info,
-                                msg.routing_context,
-                            );
+                            self.primitives
+                                .decl_queryable(&q.key, &q.info, msg.routing_context);
                         }
                         Declaration::ForgetResource(fr) => {
                             self.primitives.forget_resource(fr.expr_id);
@@ -67,7 +63,7 @@ impl<P: 'static + Primitives> TransportPeerEventHandler for DeMux<P> {
                         }
                         Declaration::ForgetQueryable(q) => {
                             self.primitives
-                                .forget_queryable(&q.key, q.kind, msg.routing_context);
+                                .forget_queryable(&q.key, msg.routing_context);
                         }
                     }
                 }
@@ -92,14 +88,8 @@ impl<P: 'static + Primitives> TransportPeerEventHandler for DeMux<P> {
                 }
                 Some(rep) => match rep.replier {
                     Some(replier) => {
-                        self.primitives.send_reply_data(
-                            rep.qid,
-                            replier.kind,
-                            replier.id,
-                            key,
-                            data_info,
-                            payload,
-                        );
+                        self.primitives
+                            .send_reply_data(rep.qid, replier.id, key, data_info, payload);
                     }
                     None => {
                         bail!("ReplyData with no replier_id")

--- a/io/zenoh-transport/src/primitives/mod.rs
+++ b/io/zenoh-transport/src/primitives/mod.rs
@@ -16,7 +16,7 @@ mod mux;
 
 use super::protocol;
 use super::protocol::core::{
-    Channel, CongestionControl, QueryTAK, QueryableInfo, SubInfo, WireExpr, ZInt, ZenohId,
+    Channel, CongestionControl, QueryTarget, QueryableInfo, SubInfo, WireExpr, ZInt, ZenohId,
 };
 use super::protocol::io::ZBuf;
 use super::protocol::proto::{DataInfo, RoutingContext};
@@ -42,16 +42,10 @@ pub trait Primitives: Send + Sync {
     fn decl_queryable(
         &self,
         key_expr: &WireExpr,
-        kind: ZInt,
         qabl_info: &QueryableInfo,
         routing_context: Option<RoutingContext>,
     );
-    fn forget_queryable(
-        &self,
-        key_expr: &WireExpr,
-        kind: ZInt,
-        routing_context: Option<RoutingContext>,
-    );
+    fn forget_queryable(&self, key_expr: &WireExpr, routing_context: Option<RoutingContext>);
 
     fn send_data(
         &self,
@@ -68,7 +62,7 @@ pub trait Primitives: Send + Sync {
         key_expr: &WireExpr,
         value_selector: &str,
         qid: ZInt,
-        target: QueryTAK,
+        target: QueryTarget,
         consolidation: ConsolidationMode,
         routing_context: Option<RoutingContext>,
     );
@@ -76,7 +70,6 @@ pub trait Primitives: Send + Sync {
     fn send_reply_data(
         &self,
         qid: ZInt,
-        replier_kind: ZInt,
         replier_id: ZenohId,
         key_expr: WireExpr,
         info: Option<DataInfo>,
@@ -124,18 +117,11 @@ impl Primitives for DummyPrimitives {
     fn decl_queryable(
         &self,
         _key_expr: &WireExpr,
-        _kind: ZInt,
         _qable_info: &QueryableInfo,
         _routing_context: Option<RoutingContext>,
     ) {
     }
-    fn forget_queryable(
-        &self,
-        _key_expr: &WireExpr,
-        _kind: ZInt,
-        _routing_context: Option<RoutingContext>,
-    ) {
-    }
+    fn forget_queryable(&self, _key_expr: &WireExpr, _routing_context: Option<RoutingContext>) {}
 
     fn send_data(
         &self,
@@ -152,7 +138,7 @@ impl Primitives for DummyPrimitives {
         _key_expr: &WireExpr,
         _value_selector: &str,
         _qid: ZInt,
-        _target: QueryTAK,
+        _target: QueryTarget,
         _consolidation: ConsolidationMode,
         _routing_context: Option<RoutingContext>,
     ) {
@@ -160,7 +146,6 @@ impl Primitives for DummyPrimitives {
     fn send_reply_data(
         &self,
         _qid: ZInt,
-        _replier_kind: ZInt,
         _replier_id: ZenohId,
         _key_expr: WireExpr,
         _info: Option<DataInfo>,

--- a/io/zenoh-transport/src/primitives/mux.rs
+++ b/io/zenoh-transport/src/primitives/mux.rs
@@ -15,7 +15,7 @@ use zenoh_protocol_core::ConsolidationMode;
 //
 use super::super::TransportUnicast;
 use super::protocol::core::{
-    Channel, CongestionControl, QueryTAK, QueryableInfo, SubInfo, WireExpr, ZInt, ZenohId,
+    Channel, CongestionControl, QueryTarget, QueryableInfo, SubInfo, WireExpr, ZInt, ZenohId,
 };
 use super::protocol::io::ZBuf;
 use super::protocol::proto::{
@@ -104,13 +104,11 @@ impl Primitives for Mux {
     fn decl_queryable(
         &self,
         key_expr: &WireExpr,
-        kind: ZInt,
         qabl_info: &QueryableInfo,
         routing_context: Option<RoutingContext>,
     ) {
         let d = Declaration::Queryable(Queryable {
             key: key_expr.to_owned(),
-            kind,
             info: qabl_info.clone(),
         });
         let decls = vec![d];
@@ -119,15 +117,9 @@ impl Primitives for Mux {
                 .handle_message(ZenohMessage::make_declare(decls, routing_context, None));
     }
 
-    fn forget_queryable(
-        &self,
-        key_expr: &WireExpr,
-        kind: ZInt,
-        routing_context: Option<RoutingContext>,
-    ) {
+    fn forget_queryable(&self, key_expr: &WireExpr, routing_context: Option<RoutingContext>) {
         let d = Declaration::ForgetQueryable(ForgetQueryable {
             key: key_expr.to_owned(),
-            kind,
         });
         let decls = vec![d];
         let _ =
@@ -161,11 +153,11 @@ impl Primitives for Mux {
         key_expr: &WireExpr,
         value_selector: &str,
         qid: ZInt,
-        target: QueryTAK,
+        target: QueryTarget,
         consolidation: ConsolidationMode,
         routing_context: Option<RoutingContext>,
     ) {
-        let target_opt = if target == QueryTAK::default() {
+        let target_opt = if target == QueryTarget::default() {
             None
         } else {
             Some(target)
@@ -184,7 +176,6 @@ impl Primitives for Mux {
     fn send_reply_data(
         &self,
         qid: ZInt,
-        replier_kind: ZInt,
         replier_id: ZenohId,
         key_expr: WireExpr,
         data_info: Option<DataInfo>,
@@ -197,13 +188,7 @@ impl Primitives for Mux {
             zmsg::default_congestion_control::REPLY,
             data_info,
             None,
-            Some(ReplyContext::new(
-                qid,
-                Some(ReplierInfo {
-                    kind: replier_kind,
-                    id: replier_id,
-                }),
-            )),
+            Some(ReplyContext::new(qid, Some(ReplierInfo { id: replier_id }))),
             None,
         ));
     }

--- a/zenoh/src/net/routing/face.rs
+++ b/zenoh/src/net/routing/face.rs
@@ -19,7 +19,7 @@ use std::sync::RwLock;
 use zenoh_protocol::io::ZBuf;
 use zenoh_protocol::proto::{DataInfo, RoutingContext};
 use zenoh_protocol_core::{
-    Channel, CongestionControl, ConsolidationMode, QueryTAK, QueryableInfo, SubInfo, WhatAmI,
+    Channel, CongestionControl, ConsolidationMode, QueryTarget, QueryableInfo, SubInfo, WhatAmI,
     WireExpr, ZInt, ZenohId,
 };
 use zenoh_transport::Primitives;
@@ -34,8 +34,8 @@ pub struct FaceState {
     pub(super) remote_mappings: HashMap<ZInt, Arc<Resource>>,
     pub(super) local_subs: HashSet<Arc<Resource>>,
     pub(super) remote_subs: HashSet<Arc<Resource>>,
-    pub(super) local_qabls: HashMap<(Arc<Resource>, ZInt), QueryableInfo>,
-    pub(super) remote_qabls: HashSet<(Arc<Resource>, ZInt)>,
+    pub(super) local_qabls: HashMap<Arc<Resource>, QueryableInfo>,
+    pub(super) remote_qabls: HashSet<Arc<Resource>>,
     pub(super) next_qid: ZInt,
     pub(super) pending_queries: HashMap<ZInt, Arc<Query>>,
 }
@@ -264,7 +264,6 @@ impl Primitives for Face {
     fn decl_queryable(
         &self,
         key_expr: &WireExpr,
-        kind: ZInt,
         qabl_info: &QueryableInfo,
         routing_context: Option<RoutingContext>,
     ) {
@@ -276,7 +275,6 @@ impl Primitives for Face {
                         &mut tables,
                         &mut self.state.clone(),
                         key_expr,
-                        kind,
                         qabl_info,
                         router,
                     )
@@ -291,7 +289,6 @@ impl Primitives for Face {
                             &mut tables,
                             &mut self.state.clone(),
                             key_expr,
-                            kind,
                             qabl_info,
                             peer,
                         )
@@ -301,38 +298,22 @@ impl Primitives for Face {
                         &mut tables,
                         &mut self.state.clone(),
                         key_expr,
-                        kind,
                         qabl_info,
                     )
                 }
             }
-            _ => declare_client_queryable(
-                &mut tables,
-                &mut self.state.clone(),
-                key_expr,
-                kind,
-                qabl_info,
-            ),
+            _ => {
+                declare_client_queryable(&mut tables, &mut self.state.clone(), key_expr, qabl_info)
+            }
         }
     }
 
-    fn forget_queryable(
-        &self,
-        key_expr: &WireExpr,
-        kind: ZInt,
-        routing_context: Option<RoutingContext>,
-    ) {
+    fn forget_queryable(&self, key_expr: &WireExpr, routing_context: Option<RoutingContext>) {
         let mut tables = zwrite!(self.tables);
         match (tables.whatami, self.state.whatami) {
             (WhatAmI::Router, WhatAmI::Router) => {
                 if let Some(router) = self.state.get_router(&tables, routing_context) {
-                    forget_router_queryable(
-                        &mut tables,
-                        &mut self.state.clone(),
-                        key_expr,
-                        kind,
-                        &router,
-                    )
+                    forget_router_queryable(&mut tables, &mut self.state.clone(), key_expr, &router)
                 }
             }
             (WhatAmI::Router, WhatAmI::Peer)
@@ -340,19 +321,13 @@ impl Primitives for Face {
             | (WhatAmI::Peer, WhatAmI::Peer) => {
                 if tables.full_net(WhatAmI::Peer) {
                     if let Some(peer) = self.state.get_peer(&tables, routing_context) {
-                        forget_peer_queryable(
-                            &mut tables,
-                            &mut self.state.clone(),
-                            key_expr,
-                            kind,
-                            &peer,
-                        )
+                        forget_peer_queryable(&mut tables, &mut self.state.clone(), key_expr, &peer)
                     }
                 } else {
-                    forget_client_queryable(&mut tables, &mut self.state.clone(), key_expr, kind)
+                    forget_client_queryable(&mut tables, &mut self.state.clone(), key_expr)
                 }
             }
-            _ => forget_client_queryable(&mut tables, &mut self.state.clone(), key_expr, kind),
+            _ => forget_client_queryable(&mut tables, &mut self.state.clone(), key_expr),
         }
     }
 
@@ -382,7 +357,7 @@ impl Primitives for Face {
         key_expr: &WireExpr,
         value_selector: &str,
         qid: ZInt,
-        target: QueryTAK,
+        target: QueryTarget,
         consolidation: ConsolidationMode,
         routing_context: Option<RoutingContext>,
     ) {
@@ -401,7 +376,6 @@ impl Primitives for Face {
     fn send_reply_data(
         &self,
         qid: ZInt,
-        replier_kind: ZInt,
         replier_id: ZenohId,
         key_expr: WireExpr,
         info: Option<DataInfo>,
@@ -412,7 +386,6 @@ impl Primitives for Face {
             &mut tables,
             &mut self.state.clone(),
             qid,
-            replier_kind,
             replier_id,
             key_expr,
             info,

--- a/zenoh/src/net/routing/pubsub.rs
+++ b/zenoh/src/net/routing/pubsub.rs
@@ -296,7 +296,7 @@ fn register_client_subscription(
                         local_expr_id: None,
                         remote_expr_id: None,
                         subs: Some(sub_info.clone()),
-                        qabl: HashMap::new(),
+                        qabl: None,
                         last_values: HashMap::new(),
                     }),
                 );

--- a/zenoh/src/net/routing/queries.rs
+++ b/zenoh/src/net/routing/queries.rs
@@ -19,8 +19,6 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::sync::Arc;
 use std::sync::{RwLock, Weak};
-// use std::time::Instant;
-// use zenoh_collections::{Timed, TimedEvent};
 use zenoh_collections::Timed;
 use zenoh_sync::get_mut_unchecked;
 
@@ -736,6 +734,7 @@ pub(crate) fn undeclare_client_queryable(
 ) {
     log::debug!("Unregister client queryable {} for {}", res.expr(), face);
     if let Some(ctx) = get_mut_unchecked(res).session_ctxs.get_mut(&face.id) {
+        get_mut_unchecked(ctx).qabl = None;
         if ctx.qabl.is_none() {
             get_mut_unchecked(face).remote_qabls.remove(res);
         }

--- a/zenoh/src/net/routing/queries.rs
+++ b/zenoh/src/net/routing/queries.rs
@@ -944,18 +944,16 @@ pub(crate) fn queries_tree_change(
                         WhatAmI::Router => &res.context().router_qabls,
                         _ => &res.context().peer_qabls,
                     };
-                    for (qabl, qabl_info) in qabls {
-                        if *qabl == tree_id {
-                            send_sourced_queryable_to_net_childs(
-                                tables,
-                                net,
-                                tree_childs,
-                                res,
-                                qabl_info,
-                                None,
-                                Some(RoutingContext::new(tree_sid as ZInt)),
-                            );
-                        }
+                    if let Some(qabl_info) = qabls.get(&tree_id) {
+                        send_sourced_queryable_to_net_childs(
+                            tables,
+                            net,
+                            tree_childs,
+                            res,
+                            qabl_info,
+                            None,
+                            Some(RoutingContext::new(tree_sid as ZInt)),
+                        );
                     }
                 }
             }

--- a/zenoh/src/net/routing/queries.rs
+++ b/zenoh/src/net/routing/queries.rs
@@ -1115,7 +1115,7 @@ fn compute_query_route(
                     _ => source_type == WhatAmI::Client || context.face.whatami == WhatAmI::Client,
                 } {
                     let key_expr = Resource::get_best_key(prefix, suffix, *sid);
-                    for qabl_info in context.qabl.iter() {
+                    if let Some(qabl_info) = context.qabl.as_ref() {
                         route.push(QueryTargetQabl {
                             direction: (context.face.clone(), key_expr.to_owned(), None),
                             complete: if complete { qabl_info.complete } else { 0 },

--- a/zenoh/src/net/routing/queries.rs
+++ b/zenoh/src/net/routing/queries.rs
@@ -28,8 +28,7 @@ use zenoh_protocol::io::ZBuf;
 use zenoh_protocol::proto::{DataInfo, RoutingContext};
 use zenoh_protocol_core::key_expr::include::{Includer, DEFAULT_INCLUDER};
 use zenoh_protocol_core::{
-    queryable, ConsolidationMode, QueryTAK, QueryTarget, QueryableInfo, WhatAmI, WireExpr, ZInt,
-    ZenohId,
+    ConsolidationMode, QueryTarget, QueryableInfo, WhatAmI, WireExpr, ZInt, ZenohId,
 };
 
 use crate::prelude::sync::KeyExpr;
@@ -66,11 +65,11 @@ fn merge_qabl_infos(mut this: QueryableInfo, info: &QueryableInfo) -> QueryableI
     this
 }
 
-fn local_router_qabl_info(tables: &Tables, res: &Arc<Resource>, kind: ZInt) -> QueryableInfo {
+fn local_router_qabl_info(tables: &Tables, res: &Arc<Resource>) -> QueryableInfo {
     let info = if tables.full_net(WhatAmI::Peer) {
         res.context.as_ref().and_then(|ctx| {
-            ctx.peer_qabls.iter().fold(None, |accu, ((zid, k), info)| {
-                if *zid != tables.zid && *k == kind {
+            ctx.peer_qabls.iter().fold(None, |accu, (zid, info)| {
+                if *zid != tables.zid {
                     Some(match accu {
                         Some(accu) => merge_qabl_infos(accu, info),
                         None => info.clone(),
@@ -86,7 +85,7 @@ fn local_router_qabl_info(tables: &Tables, res: &Arc<Resource>, kind: ZInt) -> Q
     res.session_ctxs
         .values()
         .fold(info, |accu, ctx| {
-            if let Some(info) = ctx.qabl.get(&kind) {
+            if let Some(info) = ctx.qabl.as_ref() {
                 Some(match accu {
                     Some(accu) => merge_qabl_infos(accu, info),
                     None => info.clone(),
@@ -101,13 +100,13 @@ fn local_router_qabl_info(tables: &Tables, res: &Arc<Resource>, kind: ZInt) -> Q
         })
 }
 
-fn local_peer_qabl_info(tables: &Tables, res: &Arc<Resource>, kind: ZInt) -> QueryableInfo {
+fn local_peer_qabl_info(tables: &Tables, res: &Arc<Resource>) -> QueryableInfo {
     let info = if tables.whatami == WhatAmI::Router && res.context.is_some() {
         res.context()
             .router_qabls
             .iter()
-            .fold(None, |accu, ((zid, k), info)| {
-                if *zid != tables.zid && *k == kind {
+            .fold(None, |accu, (zid, info)| {
+                if *zid != tables.zid {
                     Some(match accu {
                         Some(accu) => merge_qabl_infos(accu, info),
                         None => info.clone(),
@@ -122,7 +121,7 @@ fn local_peer_qabl_info(tables: &Tables, res: &Arc<Resource>, kind: ZInt) -> Que
     res.session_ctxs
         .values()
         .fold(info, |accu, ctx| {
-            if let Some(info) = ctx.qabl.get(&kind) {
+            if let Some(info) = ctx.qabl.as_ref() {
                 Some(match accu {
                     Some(accu) => merge_qabl_infos(accu, info),
                     None => info.clone(),
@@ -142,15 +141,14 @@ fn local_qabl_info(
     full_peers_net: bool,
     local_zid: &ZenohId,
     res: &Arc<Resource>,
-    kind: ZInt,
     face: &Arc<FaceState>,
 ) -> QueryableInfo {
     let mut info = if whatami == WhatAmI::Router && res.context.is_some() {
         res.context()
             .router_qabls
             .iter()
-            .fold(None, |accu, ((zid, k), info)| {
-                if *zid != *local_zid && *k == kind {
+            .fold(None, |accu, (zid, info)| {
+                if *zid != *local_zid {
                     Some(match accu {
                         Some(accu) => merge_qabl_infos(accu, info),
                         None => info.clone(),
@@ -167,8 +165,8 @@ fn local_qabl_info(
             .context()
             .peer_qabls
             .iter()
-            .fold(info, |accu, ((zid, k), info)| {
-                if *zid != *local_zid && *k == kind {
+            .fold(info, |accu, (zid, info)| {
+                if *zid != *local_zid {
                     Some(match accu {
                         Some(accu) => merge_qabl_infos(accu, info),
                         None => info.clone(),
@@ -182,7 +180,7 @@ fn local_qabl_info(
         .values()
         .fold(info, |accu, ctx| {
             if ctx.face.id != face.id {
-                if let Some(info) = ctx.qabl.get(&kind) {
+                if let Some(info) = ctx.qabl.as_ref() {
                     Some(match accu {
                         Some(accu) => merge_qabl_infos(accu, info),
                         None => info.clone(),
@@ -207,7 +205,6 @@ fn send_sourced_queryable_to_net_childs(
     net: &Network,
     childs: &[NodeIndex],
     res: &Arc<Resource>,
-    kind: ZInt,
     qabl_info: &QueryableInfo,
     src_face: Option<&mut Arc<FaceState>>,
     routing_context: Option<RoutingContext>,
@@ -219,19 +216,11 @@ fn send_sourced_queryable_to_net_childs(
                     if src_face.is_none() || someface.id != src_face.as_ref().unwrap().id {
                         let key_expr = Resource::decl_key(res, &mut someface);
 
-                        log::debug!(
-                            "Send queryable {} (kind: {}) on {}",
-                            res.expr(),
-                            kind,
-                            someface
-                        );
+                        log::debug!("Send queryable {} on {}", res.expr(), someface);
 
-                        someface.primitives.decl_queryable(
-                            &key_expr,
-                            kind,
-                            qabl_info,
-                            routing_context,
-                        );
+                        someface
+                            .primitives
+                            .decl_queryable(&key_expr, qabl_info, routing_context);
                     }
                 }
                 None => log::trace!("Unable to find face for zid {}", net.graph[*child].zid),
@@ -243,15 +232,14 @@ fn send_sourced_queryable_to_net_childs(
 fn propagate_simple_queryable(
     tables: &mut Tables,
     res: &Arc<Resource>,
-    kind: ZInt,
     src_face: Option<&mut Arc<FaceState>>,
 ) {
     let whatami = tables.whatami;
     let full_peers_net = tables.full_net(WhatAmI::Peer);
     let zid = tables.zid;
     for dst_face in &mut tables.faces.values_mut() {
-        let info = local_qabl_info(whatami, full_peers_net, &zid, res, kind, dst_face);
-        let current_info = dst_face.local_qabls.get(&(res.clone(), kind));
+        let info = local_qabl_info(whatami, full_peers_net, &zid, res, dst_face);
+        let current_info = dst_face.local_qabls.get(res);
         if (src_face.is_none() || src_face.as_ref().unwrap().id != dst_face.id)
             && (current_info.is_none() || *current_info.unwrap() != info)
             && match tables.whatami {
@@ -283,11 +271,9 @@ fn propagate_simple_queryable(
         {
             get_mut_unchecked(dst_face)
                 .local_qabls
-                .insert((res.clone(), kind), info.clone());
+                .insert(res.clone(), info.clone());
             let key_expr = Resource::decl_key(res, dst_face);
-            dst_face
-                .primitives
-                .decl_queryable(&key_expr, kind, &info, None);
+            dst_face.primitives.decl_queryable(&key_expr, &info, None);
         }
     }
 }
@@ -295,7 +281,6 @@ fn propagate_simple_queryable(
 fn propagate_sourced_queryable(
     tables: &Tables,
     res: &Arc<Resource>,
-    kind: ZInt,
     qabl_info: &QueryableInfo,
     src_face: Option<&mut Arc<FaceState>>,
     source: &ZenohId,
@@ -310,7 +295,6 @@ fn propagate_sourced_queryable(
                     net,
                     &net.trees[tree_sid.index()].childs,
                     res,
-                    kind,
                     qabl_info,
                     src_face,
                     Some(RoutingContext::new(tree_sid.index() as ZInt)),
@@ -336,24 +320,22 @@ fn register_router_queryable(
     tables: &mut Tables,
     mut face: Option<&mut Arc<FaceState>>,
     res: &mut Arc<Resource>,
-    kind: ZInt,
     qabl_info: &QueryableInfo,
     router: ZenohId,
 ) {
-    let current_info = res.context().router_qabls.get(&(router, kind));
+    let current_info = res.context().router_qabls.get(&router);
     if current_info.is_none() || current_info.unwrap() != qabl_info {
         // Register router queryable
         {
             log::debug!(
-                "Register router queryable {} (router: {}, kind:{})",
+                "Register router queryable {} (router: {})",
                 res.expr(),
                 router,
-                kind,
             );
             get_mut_unchecked(res)
                 .context_mut()
                 .router_qabls
-                .insert((router, kind), qabl_info.clone());
+                .insert(router, qabl_info.clone());
             tables.router_qabls.insert(res.clone());
         }
 
@@ -361,7 +343,6 @@ fn register_router_queryable(
         propagate_sourced_queryable(
             tables,
             res,
-            kind,
             qabl_info,
             face.as_deref_mut(),
             &router,
@@ -372,27 +353,19 @@ fn register_router_queryable(
     if tables.full_net(WhatAmI::Peer) {
         // Propagate queryable to peers
         if face.is_none() || face.as_ref().unwrap().whatami != WhatAmI::Peer {
-            let local_info = local_peer_qabl_info(tables, res, kind);
-            register_peer_queryable(
-                tables,
-                face.as_deref_mut(),
-                res,
-                kind,
-                &local_info,
-                tables.zid,
-            )
+            let local_info = local_peer_qabl_info(tables, res);
+            register_peer_queryable(tables, face.as_deref_mut(), res, &local_info, tables.zid)
         }
     }
 
     // Propagate queryable to clients
-    propagate_simple_queryable(tables, res, kind, face);
+    propagate_simple_queryable(tables, res, face);
 }
 
 pub fn declare_router_queryable(
     tables: &mut Tables,
     face: &mut Arc<FaceState>,
     expr: &WireExpr,
-    kind: ZInt,
     qabl_info: &QueryableInfo,
     router: ZenohId,
 ) {
@@ -400,7 +373,7 @@ pub fn declare_router_queryable(
         Some(mut prefix) => {
             let mut res = Resource::make_resource(tables, &mut prefix, expr.suffix.as_ref());
             Resource::match_resource(tables, &mut res);
-            register_router_queryable(tables, Some(face), &mut res, kind, qabl_info, router);
+            register_router_queryable(tables, Some(face), &mut res, qabl_info, router);
 
             compute_matches_query_routes(tables, &mut res);
         }
@@ -412,24 +385,18 @@ fn register_peer_queryable(
     tables: &mut Tables,
     mut face: Option<&mut Arc<FaceState>>,
     res: &mut Arc<Resource>,
-    kind: ZInt,
     qabl_info: &QueryableInfo,
     peer: ZenohId,
 ) {
-    let current_info = res.context().peer_qabls.get(&(peer, kind));
+    let current_info = res.context().peer_qabls.get(&peer);
     if current_info.is_none() || current_info.unwrap() != qabl_info {
         // Register peer queryable
         {
-            log::debug!(
-                "Register peer queryable {} (peer: {}, kind:{})",
-                res.expr(),
-                peer,
-                kind,
-            );
+            log::debug!("Register peer queryable {} (peer: {})", res.expr(), peer,);
             get_mut_unchecked(res)
                 .context_mut()
                 .peer_qabls
-                .insert((peer, kind), qabl_info.clone());
+                .insert(peer, qabl_info.clone());
             tables.peer_qabls.insert(res.clone());
         }
 
@@ -437,7 +404,6 @@ fn register_peer_queryable(
         propagate_sourced_queryable(
             tables,
             res,
-            kind,
             qabl_info,
             face.as_deref_mut(),
             &peer,
@@ -447,7 +413,7 @@ fn register_peer_queryable(
 
     if tables.whatami == WhatAmI::Peer {
         // Propagate queryable to clients
-        propagate_simple_queryable(tables, res, kind, face);
+        propagate_simple_queryable(tables, res, face);
     }
 }
 
@@ -455,7 +421,6 @@ pub fn declare_peer_queryable(
     tables: &mut Tables,
     face: &mut Arc<FaceState>,
     expr: &WireExpr,
-    kind: ZInt,
     qabl_info: &QueryableInfo,
     peer: ZenohId,
 ) {
@@ -464,11 +429,11 @@ pub fn declare_peer_queryable(
             let mut face = Some(face);
             let mut res = Resource::make_resource(tables, &mut prefix, expr.suffix.as_ref());
             Resource::match_resource(tables, &mut res);
-            register_peer_queryable(tables, face.as_deref_mut(), &mut res, kind, qabl_info, peer);
+            register_peer_queryable(tables, face.as_deref_mut(), &mut res, qabl_info, peer);
 
             if tables.whatami == WhatAmI::Router {
-                let local_info = local_router_qabl_info(tables, &res, kind);
-                register_router_queryable(tables, face, &mut res, kind, &local_info, tables.zid);
+                let local_info = local_router_qabl_info(tables, &res);
+                register_router_queryable(tables, face, &mut res, &local_info, tables.zid);
             }
 
             compute_matches_query_routes(tables, &mut res);
@@ -481,41 +446,31 @@ fn register_client_queryable(
     _tables: &mut Tables,
     face: &mut Arc<FaceState>,
     res: &mut Arc<Resource>,
-    kind: ZInt,
     qabl_info: &QueryableInfo,
 ) {
     // Register queryable
     {
         let res = get_mut_unchecked(res);
-        log::debug!(
-            "Register queryable {} (face: {}, kind: {})",
-            res.expr(),
-            face,
-            kind,
-        );
+        log::debug!("Register queryable {} (face: {})", res.expr(), face,);
         get_mut_unchecked(res.session_ctxs.entry(face.id).or_insert_with(|| {
             Arc::new(SessionContext {
                 face: face.clone(),
                 local_expr_id: None,
                 remote_expr_id: None,
                 subs: None,
-                qabl: HashMap::new(),
+                qabl: None,
                 last_values: HashMap::new(),
             })
         }))
-        .qabl
-        .insert(kind, qabl_info.clone());
+        .qabl = Some(qabl_info.clone());
     }
-    get_mut_unchecked(face)
-        .remote_qabls
-        .insert((res.clone(), kind));
+    get_mut_unchecked(face).remote_qabls.insert(res.clone());
 }
 
 pub fn declare_client_queryable(
     tables: &mut Tables,
     face: &mut Arc<FaceState>,
     expr: &WireExpr,
-    kind: ZInt,
     qabl_info: &QueryableInfo,
 ) {
     match tables.get_mapping(face, &expr.scope).cloned() {
@@ -523,37 +478,35 @@ pub fn declare_client_queryable(
             let mut res = Resource::make_resource(tables, &mut prefix, expr.suffix.as_ref());
             Resource::match_resource(tables, &mut res);
 
-            register_client_queryable(tables, face, &mut res, kind, qabl_info);
+            register_client_queryable(tables, face, &mut res, qabl_info);
 
             match tables.whatami {
                 WhatAmI::Router => {
-                    let local_details = local_router_qabl_info(tables, &res, kind);
+                    let local_details = local_router_qabl_info(tables, &res);
                     register_router_queryable(
                         tables,
                         Some(face),
                         &mut res,
-                        kind,
                         &local_details,
                         tables.zid,
                     );
                 }
                 WhatAmI::Peer => {
                     if tables.full_net(WhatAmI::Peer) {
-                        let local_details = local_peer_qabl_info(tables, &res, kind);
+                        let local_details = local_peer_qabl_info(tables, &res);
                         register_peer_queryable(
                             tables,
                             Some(face),
                             &mut res,
-                            kind,
                             &local_details,
                             tables.zid,
                         );
                     } else {
-                        propagate_simple_queryable(tables, &res, kind, Some(face));
+                        propagate_simple_queryable(tables, &res, Some(face));
                     }
                 }
                 _ => {
-                    propagate_simple_queryable(tables, &res, kind, Some(face));
+                    propagate_simple_queryable(tables, &res, Some(face));
                 }
             }
 
@@ -564,36 +517,30 @@ pub fn declare_client_queryable(
 }
 
 #[inline]
-fn remote_router_qabls(tables: &Tables, res: &Arc<Resource>, kind: ZInt) -> bool {
+fn remote_router_qabls(tables: &Tables, res: &Arc<Resource>) -> bool {
     res.context.is_some()
         && res
             .context()
             .router_qabls
             .keys()
-            .any(|(router, k)| router != &tables.zid && *k == kind)
+            .any(|router| router != &tables.zid)
 }
 
 #[inline]
-fn remote_peer_qabls(tables: &Tables, res: &Arc<Resource>, kind: ZInt) -> bool {
+fn remote_peer_qabls(tables: &Tables, res: &Arc<Resource>) -> bool {
     res.context.is_some()
         && res
             .context()
             .peer_qabls
             .keys()
-            .any(|(peer, k)| peer != &tables.zid && *k == kind)
+            .any(|peer| peer != &tables.zid)
 }
 
 #[inline]
-fn client_qabls(res: &Arc<Resource>, kind: ZInt) -> Vec<Arc<FaceState>> {
+fn client_qabls(res: &Arc<Resource>) -> Vec<Arc<FaceState>> {
     res.session_ctxs
         .values()
-        .filter_map(|ctx| {
-            if ctx.qabl.get(&kind).is_some() {
-                Some(ctx.face.clone())
-            } else {
-                None
-            }
-        })
+        .map(|ctx| ctx.face.clone())
         .collect()
 }
 
@@ -603,7 +550,6 @@ fn send_forget_sourced_queryable_to_net_childs(
     net: &Network,
     childs: &[NodeIndex],
     res: &Arc<Resource>,
-    kind: ZInt,
     src_face: Option<&Arc<FaceState>>,
     routing_context: Option<RoutingContext>,
 ) {
@@ -614,16 +560,11 @@ fn send_forget_sourced_queryable_to_net_childs(
                     if src_face.is_none() || someface.id != src_face.unwrap().id {
                         let key_expr = Resource::decl_key(res, &mut someface);
 
-                        log::debug!(
-                            "Send forget queryable {} (kind: {}) on {}",
-                            res.expr(),
-                            kind,
-                            someface
-                        );
+                        log::debug!("Send forget queryable {}  on {}", res.expr(), someface);
 
                         someface
                             .primitives
-                            .forget_queryable(&key_expr, kind, routing_context);
+                            .forget_queryable(&key_expr, routing_context);
                     }
                 }
                 None => log::trace!("Unable to find face for zid {}", net.graph[*child].zid),
@@ -632,15 +573,13 @@ fn send_forget_sourced_queryable_to_net_childs(
     }
 }
 
-fn propagate_forget_simple_queryable(tables: &mut Tables, res: &mut Arc<Resource>, kind: ZInt) {
+fn propagate_forget_simple_queryable(tables: &mut Tables, res: &mut Arc<Resource>) {
     for face in tables.faces.values_mut() {
-        if face.local_qabls.contains_key(&(res.clone(), kind)) {
+        if face.local_qabls.contains_key(res) {
             let key_expr = Resource::get_best_key(res, "", face.id);
-            face.primitives.forget_queryable(&key_expr, kind, None);
+            face.primitives.forget_queryable(&key_expr, None);
 
-            get_mut_unchecked(face)
-                .local_qabls
-                .remove(&(res.clone(), kind));
+            get_mut_unchecked(face).local_qabls.remove(res);
         }
     }
 }
@@ -648,7 +587,6 @@ fn propagate_forget_simple_queryable(tables: &mut Tables, res: &mut Arc<Resource
 fn propagate_forget_sourced_queryable(
     tables: &mut Tables,
     res: &mut Arc<Resource>,
-    kind: ZInt,
     src_face: Option<&Arc<FaceState>>,
     source: &ZenohId,
     net_type: WhatAmI,
@@ -662,7 +600,6 @@ fn propagate_forget_sourced_queryable(
                     net,
                     &net.trees[tree_sid.index()].childs,
                     res,
-                    kind,
                     src_face,
                     Some(RoutingContext::new(tree_sid.index() as ZInt)),
                 );
@@ -683,30 +620,24 @@ fn propagate_forget_sourced_queryable(
     }
 }
 
-fn unregister_router_queryable(
-    tables: &mut Tables,
-    res: &mut Arc<Resource>,
-    kind: ZInt,
-    router: &ZenohId,
-) {
+fn unregister_router_queryable(tables: &mut Tables, res: &mut Arc<Resource>, router: &ZenohId) {
     log::debug!(
-        "Unregister router queryable {} (router: {}, kind: {})",
+        "Unregister router queryable {} (router: {})",
         res.expr(),
         router,
-        kind,
     );
     get_mut_unchecked(res)
         .context_mut()
         .router_qabls
-        .remove(&(*router, kind));
+        .remove(router);
 
     if res.context().router_qabls.is_empty() {
         tables.router_qabls.retain(|qabl| !Arc::ptr_eq(qabl, res));
 
         if tables.full_net(WhatAmI::Peer) {
-            undeclare_peer_queryable(tables, None, res, kind, &tables.zid.clone());
+            undeclare_peer_queryable(tables, None, res, &tables.zid.clone());
         }
-        propagate_forget_simple_queryable(tables, res, kind);
+        propagate_forget_simple_queryable(tables, res);
     }
 }
 
@@ -714,12 +645,11 @@ fn undeclare_router_queryable(
     tables: &mut Tables,
     face: Option<&Arc<FaceState>>,
     res: &mut Arc<Resource>,
-    kind: ZInt,
     router: &ZenohId,
 ) {
-    if res.context().router_qabls.contains_key(&(*router, kind)) {
-        unregister_router_queryable(tables, res, kind, router);
-        propagate_forget_sourced_queryable(tables, res, kind, face, router, WhatAmI::Router);
+    if res.context().router_qabls.contains_key(router) {
+        unregister_router_queryable(tables, res, router);
+        propagate_forget_sourced_queryable(tables, res, face, router, WhatAmI::Router);
     }
 }
 
@@ -727,13 +657,12 @@ pub fn forget_router_queryable(
     tables: &mut Tables,
     face: &mut Arc<FaceState>,
     expr: &WireExpr,
-    kind: ZInt,
     router: &ZenohId,
 ) {
     match tables.get_mapping(face, &expr.scope) {
         Some(prefix) => match Resource::get_resource(prefix, expr.suffix.as_ref()) {
             Some(mut res) => {
-                undeclare_router_queryable(tables, Some(face), &mut res, kind, router);
+                undeclare_router_queryable(tables, Some(face), &mut res, router);
 
                 compute_matches_query_routes(tables, &mut res);
                 Resource::clean(&mut res)
@@ -744,28 +673,15 @@ pub fn forget_router_queryable(
     }
 }
 
-fn unregister_peer_queryable(
-    tables: &mut Tables,
-    res: &mut Arc<Resource>,
-    kind: ZInt,
-    peer: &ZenohId,
-) {
-    log::debug!(
-        "Unregister peer queryable {} (peer: {}, kind: {})",
-        res.expr(),
-        peer,
-        kind
-    );
-    get_mut_unchecked(res)
-        .context_mut()
-        .peer_qabls
-        .remove(&(*peer, kind));
+fn unregister_peer_queryable(tables: &mut Tables, res: &mut Arc<Resource>, peer: &ZenohId) {
+    log::debug!("Unregister peer queryable {} (peer: {})", res.expr(), peer,);
+    get_mut_unchecked(res).context_mut().peer_qabls.remove(peer);
 
     if res.context().peer_qabls.is_empty() {
         tables.peer_qabls.retain(|qabl| !Arc::ptr_eq(qabl, res));
 
         if tables.whatami == WhatAmI::Peer {
-            propagate_forget_simple_queryable(tables, res, kind);
+            propagate_forget_simple_queryable(tables, res);
         }
     }
 }
@@ -774,12 +690,11 @@ fn undeclare_peer_queryable(
     tables: &mut Tables,
     face: Option<&Arc<FaceState>>,
     res: &mut Arc<Resource>,
-    kind: ZInt,
     peer: &ZenohId,
 ) {
-    if res.context().peer_qabls.contains_key(&(*peer, kind)) {
-        unregister_peer_queryable(tables, res, kind, peer);
-        propagate_forget_sourced_queryable(tables, res, kind, face, peer, WhatAmI::Peer);
+    if res.context().peer_qabls.contains_key(peer) {
+        unregister_peer_queryable(tables, res, peer);
+        propagate_forget_sourced_queryable(tables, res, face, peer, WhatAmI::Peer);
     }
 }
 
@@ -787,38 +702,21 @@ pub fn forget_peer_queryable(
     tables: &mut Tables,
     face: &mut Arc<FaceState>,
     expr: &WireExpr,
-    kind: ZInt,
     peer: &ZenohId,
 ) {
     match tables.get_mapping(face, &expr.scope) {
         Some(prefix) => match Resource::get_resource(prefix, expr.suffix.as_ref()) {
             Some(mut res) => {
-                undeclare_peer_queryable(tables, Some(face), &mut res, kind, peer);
+                undeclare_peer_queryable(tables, Some(face), &mut res, peer);
 
                 if tables.whatami == WhatAmI::Router {
-                    let client_qabls = res
-                        .session_ctxs
-                        .values()
-                        .any(|ctx| ctx.qabl.get(&kind).is_some());
-                    let peer_qabls = remote_peer_qabls(tables, &res, kind);
+                    let client_qabls = res.session_ctxs.values().any(|ctx| ctx.qabl.is_some());
+                    let peer_qabls = remote_peer_qabls(tables, &res);
                     if !client_qabls && !peer_qabls {
-                        undeclare_router_queryable(
-                            tables,
-                            None,
-                            &mut res,
-                            kind,
-                            &tables.zid.clone(),
-                        );
+                        undeclare_router_queryable(tables, None, &mut res, &tables.zid.clone());
                     } else {
-                        let local_info = local_router_qabl_info(tables, &res, kind);
-                        register_router_queryable(
-                            tables,
-                            None,
-                            &mut res,
-                            kind,
-                            &local_info,
-                            tables.zid,
-                        );
+                        let local_info = local_router_qabl_info(tables, &res);
+                        register_router_queryable(tables, None, &mut res, &local_info, tables.zid);
                     }
                 }
 
@@ -835,68 +733,57 @@ pub(crate) fn undeclare_client_queryable(
     tables: &mut Tables,
     face: &mut Arc<FaceState>,
     res: &mut Arc<Resource>,
-    kind: ZInt,
 ) {
-    log::debug!(
-        "Unregister client queryable {} (kind: {}) for {}",
-        res.expr(),
-        kind,
-        face
-    );
+    log::debug!("Unregister client queryable {} for {}", res.expr(), face);
     if let Some(ctx) = get_mut_unchecked(res).session_ctxs.get_mut(&face.id) {
-        get_mut_unchecked(ctx).qabl.remove(&kind);
-        if ctx.qabl.is_empty() {
-            get_mut_unchecked(face)
-                .remote_qabls
-                .remove(&(res.clone(), kind));
+        if ctx.qabl.is_none() {
+            get_mut_unchecked(face).remote_qabls.remove(res);
         }
     }
 
-    let mut client_qabls = client_qabls(res, kind);
-    let router_qabls = remote_router_qabls(tables, res, kind);
-    let peer_qabls = remote_peer_qabls(tables, res, kind);
+    let mut client_qabls = client_qabls(res);
+    let router_qabls = remote_router_qabls(tables, res);
+    let peer_qabls = remote_peer_qabls(tables, res);
 
     match tables.whatami {
         WhatAmI::Router => {
             if client_qabls.is_empty() && !peer_qabls {
-                undeclare_router_queryable(tables, None, res, kind, &tables.zid.clone());
+                undeclare_router_queryable(tables, None, res, &tables.zid.clone());
             } else {
-                let local_info = local_router_qabl_info(tables, res, kind);
-                register_router_queryable(tables, None, res, kind, &local_info, tables.zid);
+                let local_info = local_router_qabl_info(tables, res);
+                register_router_queryable(tables, None, res, &local_info, tables.zid);
             }
         }
         WhatAmI::Peer => {
             if tables.full_net(WhatAmI::Peer) {
                 if client_qabls.is_empty() {
-                    undeclare_peer_queryable(tables, None, res, kind, &tables.zid.clone());
+                    undeclare_peer_queryable(tables, None, res, &tables.zid.clone());
                 } else {
-                    let local_info = local_peer_qabl_info(tables, res, kind);
-                    register_peer_queryable(tables, None, res, kind, &local_info, tables.zid);
+                    let local_info = local_peer_qabl_info(tables, res);
+                    register_peer_queryable(tables, None, res, &local_info, tables.zid);
                 }
             } else if client_qabls.is_empty() {
-                propagate_forget_simple_queryable(tables, res, kind);
+                propagate_forget_simple_queryable(tables, res);
             } else {
-                propagate_simple_queryable(tables, res, kind, None);
+                propagate_simple_queryable(tables, res, None);
             }
         }
         _ => {
             if client_qabls.is_empty() {
-                propagate_forget_simple_queryable(tables, res, kind);
+                propagate_forget_simple_queryable(tables, res);
             } else {
-                propagate_simple_queryable(tables, res, kind, None);
+                propagate_simple_queryable(tables, res, None);
             }
         }
     }
 
     if client_qabls.len() == 1 && !router_qabls && !peer_qabls {
         let face = &mut client_qabls[0];
-        if face.local_qabls.contains_key(&(res.clone(), kind)) {
+        if face.local_qabls.contains_key(res) {
             let key_expr = Resource::get_best_key(res, "", face.id);
-            face.primitives.forget_queryable(&key_expr, kind, None);
+            face.primitives.forget_queryable(&key_expr, None);
 
-            get_mut_unchecked(face)
-                .local_qabls
-                .remove(&(res.clone(), kind));
+            get_mut_unchecked(face).local_qabls.remove(res);
         }
     }
 
@@ -904,16 +791,11 @@ pub(crate) fn undeclare_client_queryable(
     Resource::clean(res)
 }
 
-pub fn forget_client_queryable(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    expr: &WireExpr,
-    kind: ZInt,
-) {
+pub fn forget_client_queryable(tables: &mut Tables, face: &mut Arc<FaceState>, expr: &WireExpr) {
     match tables.get_mapping(face, &expr.scope) {
         Some(prefix) => match Resource::get_resource(prefix, expr.suffix.as_ref()) {
             Some(mut res) => {
-                undeclare_client_queryable(tables, face, &mut res, kind);
+                undeclare_client_queryable(tables, face, &mut res);
             }
             None => log::error!("Undeclare unknown queryable!"),
         },
@@ -925,24 +807,20 @@ pub(crate) fn queries_new_face(tables: &mut Tables, face: &mut Arc<FaceState>) {
     match tables.whatami {
         WhatAmI::Router => {
             if face.whatami == WhatAmI::Client {
-                for qabl in &tables.router_qabls {
-                    if let Some(ctx) = qabl.context.as_ref() {
-                        for (_, kind) in ctx.router_qabls.keys() {
-                            let info = local_qabl_info(
-                                tables.whatami,
-                                tables.full_net(WhatAmI::Peer),
-                                &tables.zid,
-                                qabl,
-                                *kind,
-                                face,
-                            );
-                            get_mut_unchecked(face)
-                                .local_qabls
-                                .insert((qabl.clone(), *kind), info.clone());
-                            let key_expr = Resource::decl_key(qabl, face);
-                            face.primitives
-                                .decl_queryable(&key_expr, *kind, &info, None);
-                        }
+                for qabl in tables.router_qabls.iter() {
+                    if qabl.context.is_some() {
+                        let info = local_qabl_info(
+                            tables.whatami,
+                            tables.full_net(WhatAmI::Peer),
+                            &tables.zid,
+                            qabl,
+                            face,
+                        );
+                        get_mut_unchecked(face)
+                            .local_qabls
+                            .insert(qabl.clone(), info.clone());
+                        let key_expr = Resource::decl_key(qabl, face);
+                        face.primitives.decl_queryable(&key_expr, &info, None);
                     }
                 }
             }
@@ -951,23 +829,19 @@ pub(crate) fn queries_new_face(tables: &mut Tables, face: &mut Arc<FaceState>) {
             if tables.full_net(WhatAmI::Peer) {
                 if face.whatami == WhatAmI::Client {
                     for qabl in &tables.peer_qabls {
-                        if let Some(ctx) = qabl.context.as_ref() {
-                            for (_, kind) in ctx.peer_qabls.keys() {
-                                let info = local_qabl_info(
-                                    tables.whatami,
-                                    tables.full_net(WhatAmI::Peer),
-                                    &tables.zid,
-                                    qabl,
-                                    *kind,
-                                    face,
-                                );
-                                get_mut_unchecked(face)
-                                    .local_qabls
-                                    .insert((qabl.clone(), *kind), info.clone());
-                                let key_expr = Resource::decl_key(qabl, face);
-                                face.primitives
-                                    .decl_queryable(&key_expr, *kind, &info, None);
-                            }
+                        if qabl.context.is_some() {
+                            let info = local_qabl_info(
+                                tables.whatami,
+                                tables.full_net(WhatAmI::Peer),
+                                &tables.zid,
+                                qabl,
+                                face,
+                            );
+                            get_mut_unchecked(face)
+                                .local_qabls
+                                .insert(qabl.clone(), info.clone());
+                            let key_expr = Resource::decl_key(qabl, face);
+                            face.primitives.decl_queryable(&key_expr, &info, None);
                         }
                     }
                 }
@@ -978,8 +852,8 @@ pub(crate) fn queries_new_face(tables: &mut Tables, face: &mut Arc<FaceState>) {
                     .cloned()
                     .collect::<Vec<Arc<FaceState>>>()
                 {
-                    for (qabl, kind) in &face.remote_qabls {
-                        propagate_simple_queryable(tables, qabl, *kind, Some(&mut face.clone()));
+                    for qabl in face.remote_qabls.iter() {
+                        propagate_simple_queryable(tables, qabl, Some(&mut face.clone()));
                     }
                 }
             }
@@ -991,8 +865,8 @@ pub(crate) fn queries_new_face(tables: &mut Tables, face: &mut Arc<FaceState>) {
                 .cloned()
                 .collect::<Vec<Arc<FaceState>>>()
             {
-                for (qabl, kind) in &face.remote_qabls {
-                    propagate_simple_queryable(tables, qabl, *kind, Some(&mut face.clone()));
+                for qabl in face.remote_qabls.iter() {
+                    propagate_simple_queryable(tables, qabl, Some(&mut face.clone()));
                 }
             }
         }
@@ -1004,14 +878,14 @@ pub(crate) fn queries_remove_node(tables: &mut Tables, node: &ZenohId, net_type:
         WhatAmI::Router => {
             let mut qabls = vec![];
             for res in tables.router_qabls.iter() {
-                for (qabl, kind) in res.context().router_qabls.keys() {
+                for qabl in res.context().router_qabls.keys() {
                     if qabl == node {
-                        qabls.push((res.clone(), *kind));
+                        qabls.push(res.clone());
                     }
                 }
             }
-            for (mut res, kind) in qabls {
-                unregister_router_queryable(tables, &mut res, kind, node);
+            for mut res in qabls {
+                unregister_router_queryable(tables, &mut res, node);
 
                 compute_matches_query_routes(tables, &mut res);
                 Resource::clean(&mut res);
@@ -1020,39 +894,23 @@ pub(crate) fn queries_remove_node(tables: &mut Tables, node: &ZenohId, net_type:
         WhatAmI::Peer => {
             let mut qabls = vec![];
             for res in tables.router_qabls.iter() {
-                for (qabl, kind) in res.context().router_qabls.keys() {
+                for qabl in res.context().router_qabls.keys() {
                     if qabl == node {
-                        qabls.push((res.clone(), *kind));
+                        qabls.push(res.clone());
                     }
                 }
             }
-            for (mut res, kind) in qabls {
-                unregister_peer_queryable(tables, &mut res, kind, node);
+            for mut res in qabls {
+                unregister_peer_queryable(tables, &mut res, node);
 
                 if tables.whatami == WhatAmI::Router {
-                    let client_qabls = res
-                        .session_ctxs
-                        .values()
-                        .any(|ctx| ctx.qabl.get(&kind).is_some());
-                    let peer_qabls = remote_peer_qabls(tables, &res, kind);
+                    let client_qabls = res.session_ctxs.values().any(|ctx| ctx.qabl.is_some());
+                    let peer_qabls = remote_peer_qabls(tables, &res);
                     if !client_qabls && !peer_qabls {
-                        undeclare_router_queryable(
-                            tables,
-                            None,
-                            &mut res,
-                            kind,
-                            &tables.zid.clone(),
-                        );
+                        undeclare_router_queryable(tables, None, &mut res, &tables.zid.clone());
                     } else {
-                        let local_info = local_router_qabl_info(tables, &res, kind);
-                        register_router_queryable(
-                            tables,
-                            None,
-                            &mut res,
-                            kind,
-                            &local_info,
-                            tables.zid,
-                        );
+                        let local_info = local_router_qabl_info(tables, &res);
+                        register_router_queryable(tables, None, &mut res, &local_info, tables.zid);
                     }
                 }
 
@@ -1087,14 +945,13 @@ pub(crate) fn queries_tree_change(
                         WhatAmI::Router => &res.context().router_qabls,
                         _ => &res.context().peer_qabls,
                     };
-                    for ((qabl, kind), qabl_info) in qabls {
+                    for (qabl, qabl_info) in qabls {
                         if *qabl == tree_id {
                             send_sourced_queryable_to_net_childs(
                                 tables,
                                 net,
                                 tree_childs,
                                 res,
-                                *kind,
                                 qabl_info,
                                 None,
                                 Some(RoutingContext::new(tree_sid as ZInt)),
@@ -1110,11 +967,6 @@ pub(crate) fn queries_tree_change(
     compute_query_routes_from(tables, &mut tables.root_res.clone());
 }
 
-#[inline(always)]
-fn matching_kind(query_kind: ZInt, qabl_kind: ZInt) -> bool {
-    (query_kind & queryable::ALL_KINDS != 0) || (query_kind & qabl_kind != 0)
-}
-
 #[inline]
 #[allow(clippy::too_many_arguments)]
 fn insert_target_for_qabls(
@@ -1124,11 +976,11 @@ fn insert_target_for_qabls(
     tables: &Tables,
     net: &Network,
     source: usize,
-    qabls: &HashMap<(ZenohId, ZInt), QueryableInfo>,
+    qabls: &HashMap<ZenohId, QueryableInfo>,
     complete: bool,
 ) {
     if net.trees.len() > source {
-        for ((qabl, qabl_kind), qabl_info) in qabls {
+        for (qabl, qabl_info) in qabls {
             if let Some(qabl_idx) = net.get_idx(qabl) {
                 if net.trees[source].directions.len() > qabl_idx.index() {
                     if let Some(direction) = net.trees[source].directions[qabl_idx.index()] {
@@ -1147,7 +999,6 @@ fn insert_target_for_qabls(
                                             },
                                         ),
                                         complete: if complete { qabl_info.complete } else { 0 },
-                                        kind: *qabl_kind,
                                         distance: net.distances[qabl_idx.index()],
                                     });
                                 }
@@ -1264,11 +1115,10 @@ fn compute_query_route(
                     _ => source_type == WhatAmI::Client || context.face.whatami == WhatAmI::Client,
                 } {
                     let key_expr = Resource::get_best_key(prefix, suffix, *sid);
-                    for (qabl_kind, qabl_info) in &context.qabl {
+                    for qabl_info in context.qabl.iter() {
                         route.push(QueryTargetQabl {
                             direction: (context.face.clone(), key_expr.to_owned(), None),
                             complete: if complete { qabl_info.complete } else { 0 },
-                            kind: *qabl_kind,
                             distance: 0.5,
                         });
                     }
@@ -1358,13 +1208,13 @@ pub(crate) fn compute_matches_query_routes(tables: &mut Tables, res: &mut Arc<Re
 fn compute_final_route(
     qabls: &Arc<QueryTargetQablSet>,
     src_face: &Arc<FaceState>,
-    target: &QueryTAK,
+    target: &QueryTarget,
 ) -> QueryRoute {
-    match &target.target {
+    match target {
         QueryTarget::All => {
             let mut route = HashMap::new();
             for qabl in qabls.iter() {
-                if qabl.direction.0.id != src_face.id && matching_kind(target.kind, qabl.kind) {
+                if qabl.direction.0.id != src_face.id {
                     #[cfg(feature = "complete_n")]
                     {
                         route
@@ -1384,10 +1234,7 @@ fn compute_final_route(
         QueryTarget::AllComplete => {
             let mut route = HashMap::new();
             for qabl in qabls.iter() {
-                if qabl.direction.0.id != src_face.id
-                    && matching_kind(target.kind, qabl.kind)
-                    && qabl.complete > 0
-                {
+                if qabl.direction.0.id != src_face.id && qabl.complete > 0 {
                     #[cfg(feature = "complete_n")]
                     {
                         route
@@ -1409,10 +1256,7 @@ fn compute_final_route(
             let mut route = HashMap::new();
             let mut remaining = *n;
             for qabl in qabls.iter() {
-                if qabl.direction.0.id != src_face.id
-                    && matching_kind(target.kind, qabl.kind)
-                    && qabl.complete > 0
-                {
+                if qabl.direction.0.id != src_face.id && qabl.complete > 0 {
                     let nb = std::cmp::min(qabl.complete, remaining);
                     route
                         .entry(qabl.direction.0.id)
@@ -1426,11 +1270,10 @@ fn compute_final_route(
             route
         }
         QueryTarget::BestMatching => {
-            if let Some(qabl) = qabls.iter().find(|qabl| {
-                qabl.direction.0.id != src_face.id
-                    && qabl.complete > 0
-                    && matching_kind(target.kind, qabl.kind)
-            }) {
+            if let Some(qabl) = qabls
+                .iter()
+                .find(|qabl| qabl.direction.0.id != src_face.id && qabl.complete > 0)
+            {
                 let mut route = HashMap::new();
                 #[cfg(feature = "complete_n")]
                 {
@@ -1442,14 +1285,7 @@ fn compute_final_route(
                 }
                 route
             } else {
-                compute_final_route(
-                    qabls,
-                    src_face,
-                    &QueryTAK {
-                        kind: target.kind,
-                        target: QueryTarget::All,
-                    },
-                )
+                compute_final_route(qabls, src_face, &QueryTarget::All)
             }
         }
     }
@@ -1490,7 +1326,7 @@ pub fn route_query(
     expr: &WireExpr,
     value_selector: &str,
     qid: ZInt,
-    target: QueryTAK,
+    target: QueryTarget,
     consolidation: ConsolidationMode,
     routing_context: Option<RoutingContext>,
 ) {
@@ -1663,10 +1499,7 @@ pub fn route_query(
                         key_expr,
                         value_selector,
                         qid,
-                        QueryTAK {
-                            kind: target.kind,
-                            target: *t,
-                        },
+                        *t,
                         consolidation,
                         *context,
                     );
@@ -1682,7 +1515,7 @@ pub fn route_query(
                     // timer.add(TimedEvent::once(
                     //     Instant::now() + timeout,
                     //     QueryCleanup {
-                    //         tables: tables_ref.clone(),
+                    //         tables: tables_ref,
                     //         face: Arc::downgrade(&outface),
                     //         qid,
                     //     },
@@ -1694,7 +1527,7 @@ pub fn route_query(
                         key_expr,
                         value_selector,
                         qid,
-                        target.clone(),
+                        target,
                         consolidation,
                         *context,
                     );
@@ -1716,7 +1549,6 @@ pub(crate) fn route_send_reply_data(
     _tables: &mut Tables,
     face: &mut Arc<FaceState>,
     qid: ZInt,
-    replier_kind: ZInt,
     replier_id: ZenohId,
     key_expr: WireExpr,
     info: Option<DataInfo>,
@@ -1726,7 +1558,6 @@ pub(crate) fn route_send_reply_data(
         Some(query) => {
             query.src_face.primitives.clone().send_reply_data(
                 query.src_qid,
-                replier_kind,
                 replier_id,
                 key_expr,
                 info,

--- a/zenoh/src/net/routing/resource.rs
+++ b/zenoh/src/net/routing/resource.rs
@@ -32,7 +32,6 @@ pub(super) type QueryRoute = HashMap<usize, (Direction, zenoh_protocol_core::Que
 pub(super) type QueryRoute = Route;
 pub(super) struct QueryTargetQabl {
     pub(super) direction: Direction,
-    pub(super) kind: ZInt,
     pub(super) complete: ZInt,
     pub(super) distance: f64,
 }
@@ -44,15 +43,15 @@ pub(super) struct SessionContext {
     pub(super) local_expr_id: Option<ZInt>,
     pub(super) remote_expr_id: Option<ZInt>,
     pub(super) subs: Option<SubInfo>,
-    pub(super) qabl: HashMap<ZInt, QueryableInfo>,
+    pub(super) qabl: Option<QueryableInfo>,
     pub(super) last_values: HashMap<String, (Option<DataInfo>, ZBuf)>,
 }
 
 pub(super) struct ResourceContext {
     pub(super) router_subs: HashSet<ZenohId>,
     pub(super) peer_subs: HashSet<ZenohId>,
-    pub(super) router_qabls: HashMap<(ZenohId, ZInt), QueryableInfo>,
-    pub(super) peer_qabls: HashMap<(ZenohId, ZInt), QueryableInfo>,
+    pub(super) router_qabls: HashMap<ZenohId, QueryableInfo>,
+    pub(super) peer_qabls: HashMap<ZenohId, QueryableInfo>,
     pub(super) matches: Vec<Weak<Resource>>,
     pub(super) matching_pulls: Arc<PullCaches>,
     pub(super) routers_data_routes: Vec<Arc<Route>>,
@@ -375,7 +374,7 @@ impl Resource {
                             local_expr_id: None,
                             remote_expr_id: None,
                             subs: None,
-                            qabl: HashMap::new(),
+                            qabl: None,
                             last_values: HashMap::new(),
                         })
                     });
@@ -586,7 +585,7 @@ pub fn register_expr(
                             local_expr_id: None,
                             remote_expr_id: Some(expr_id),
                             subs: None,
-                            qabl: HashMap::new(),
+                            qabl: None,
                             last_values: HashMap::new(),
                         })
                     })
@@ -620,25 +619,6 @@ pub fn unregister_expr(_tables: &mut Tables, face: &mut Arc<FaceState>, expr_id:
         None => log::error!("Undeclare unknown resource!"),
     }
 }
-
-// pub(super) struct QueryableRef {
-//     pub(super) res: Arc<Resource>,
-//     pub(super) kind: ZInt,
-// }
-
-// impl PartialEq for QueryableRef {
-//     fn eq(&self, other: &Self) -> bool {
-//         self.res.eq(&other.res)
-//     }
-// }
-
-// impl Eq for QueryableRef {}
-
-// impl Hash for QueryableRef {
-//     fn hash<H: Hasher>(&self, state: &mut H) {
-//         self.res.hash(state)
-//     }
-// }
 
 #[inline]
 pub(super) fn elect_router<'a>(key_expr: &str, routers: &'a [ZenohId]) -> &'a ZenohId {

--- a/zenoh/src/net/routing/router.rs
+++ b/zenoh/src/net/routing/router.rs
@@ -199,9 +199,9 @@ impl Tables {
                     undeclare_client_subscription(self, &mut face_clone, &mut res);
                     Resource::clean(&mut res);
                 }
-                for (mut res, kind) in face.remote_qabls.drain() {
+                for mut res in face.remote_qabls.drain() {
                     get_mut_unchecked(&mut res).session_ctxs.remove(&face.id);
-                    undeclare_client_queryable(self, &mut face_clone, &mut res, kind);
+                    undeclare_client_queryable(self, &mut face_clone, &mut res);
                     Resource::clean(&mut res);
                 }
                 self.faces.remove(&face.id);

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -31,8 +31,8 @@ use zenoh_protocol::proto::{DataInfo, RoutingContext};
 use zenoh_protocol_core::key_expr::OwnedKeyExpr;
 use zenoh_protocol_core::ConsolidationMode;
 use zenoh_protocol_core::{
-    queryable::EVAL, Channel, CongestionControl, Encoding, KnownEncoding, QueryTAK, QueryableInfo,
-    SubInfo, WireExpr, ZInt, ZenohId, EMPTY_EXPR_ID,
+    Channel, CongestionControl, Encoding, KnownEncoding, QueryTarget, QueryableInfo, SubInfo,
+    WireExpr, ZInt, ZenohId, EMPTY_EXPR_ID,
 };
 use zenoh_transport::{Primitives, TransportUnicast};
 
@@ -209,7 +209,6 @@ impl AdminSpace {
 
         primitives.decl_queryable(
             &[&root_key, "/**"].concat().into(),
-            EVAL,
             &QueryableInfo {
                 complete: 0,
                 distance: 0,
@@ -280,19 +279,13 @@ impl Primitives for AdminSpace {
     fn decl_queryable(
         &self,
         _key_expr: &WireExpr,
-        _kind: ZInt,
         _qabl_info: &QueryableInfo,
         _routing_context: Option<RoutingContext>,
     ) {
         trace!("recv Queryable {:?}", _key_expr);
     }
 
-    fn forget_queryable(
-        &self,
-        _key_expr: &WireExpr,
-        _kind: ZInt,
-        _routing_context: Option<RoutingContext>,
-    ) {
+    fn forget_queryable(&self, _key_expr: &WireExpr, _routing_context: Option<RoutingContext>) {
         trace!("recv Forget Queryable {:?}", _key_expr);
     }
 
@@ -367,7 +360,7 @@ impl Primitives for AdminSpace {
         key_expr: &WireExpr,
         value_selector: &str,
         qid: ZInt,
-        target: QueryTAK,
+        target: QueryTarget,
         _consolidation: ConsolidationMode,
         _routing_context: Option<RoutingContext>,
     ) {
@@ -413,7 +406,6 @@ impl Primitives for AdminSpace {
 
                     primitives.send_reply_data(
                         qid,
-                        EVAL,
                         zid,
                         String::from(key).into(),
                         Some(data_info),
@@ -438,7 +430,6 @@ impl Primitives for AdminSpace {
 
                         primitives.send_reply_data(
                             qid,
-                            EVAL,
                             zid,
                             key.into(),
                             Some(data_info),
@@ -457,16 +448,14 @@ impl Primitives for AdminSpace {
     fn send_reply_data(
         &self,
         qid: ZInt,
-        replier_kind: ZInt,
         replier_id: ZenohId,
         key_expr: WireExpr,
         info: Option<DataInfo>,
         payload: ZBuf,
     ) {
         trace!(
-            "recv ReplyData {:?} {:?} {:?} {:?} {:?} {:?}",
+            "recv ReplyData {:?} {:?} {:?} {:?} {:?}",
             qid,
-            replier_kind,
             replier_id,
             key_expr,
             info,

--- a/zenoh/src/net/tests/tables.rs
+++ b/zenoh/src/net/tests/tables.rs
@@ -22,8 +22,8 @@ use zenoh_core::zlock;
 use zenoh_protocol::io::ZBuf;
 use zenoh_protocol::proto::{DataInfo, RoutingContext};
 use zenoh_protocol_core::{
-    Channel, CongestionControl, ConsolidationMode, QueryTAK, QueryableInfo, Reliability, SubInfo,
-    SubMode, WhatAmI, WireExpr, ZInt, ZenohId, EMPTY_EXPR_ID,
+    Channel, CongestionControl, ConsolidationMode, QueryTarget, QueryableInfo, Reliability,
+    SubInfo, SubMode, WhatAmI, WireExpr, ZInt, ZenohId, EMPTY_EXPR_ID,
 };
 use zenoh_transport::{DummyPrimitives, Primitives};
 
@@ -434,18 +434,11 @@ impl Primitives for ClientPrimitives {
     fn decl_queryable(
         &self,
         _key_expr: &WireExpr,
-        _kind: ZInt,
         _qabl_info: &QueryableInfo,
         _routing_context: Option<RoutingContext>,
     ) {
     }
-    fn forget_queryable(
-        &self,
-        _key_expr: &WireExpr,
-        _kind: ZInt,
-        _routing_context: Option<RoutingContext>,
-    ) {
-    }
+    fn forget_queryable(&self, _key_expr: &WireExpr, _routing_context: Option<RoutingContext>) {}
 
     fn send_data(
         &self,
@@ -464,7 +457,7 @@ impl Primitives for ClientPrimitives {
         _key_expr: &WireExpr,
         _value_selector: &str,
         _qid: ZInt,
-        _target: QueryTAK,
+        _target: QueryTarget,
         _consolidation: ConsolidationMode,
         _routing_context: Option<RoutingContext>,
     ) {
@@ -473,7 +466,6 @@ impl Primitives for ClientPrimitives {
     fn send_reply_data(
         &self,
         _qid: ZInt,
-        _replier_kind: ZInt,
         _replier_id: ZenohId,
         _key_expr: WireExpr,
         _info: Option<DataInfo>,

--- a/zenoh/src/selector.rs
+++ b/zenoh/src/selector.rs
@@ -371,7 +371,11 @@ impl std::fmt::Debug for Selector<'_> {
 
 impl std::fmt::Display for Selector<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}?{}", self.key_expr, self.value_selector)
+        write!(f, "{}", self.key_expr)?;
+        if !self.value_selector.is_empty() {
+            write!(f, "?{}", self.value_selector)?;
+        }
+        Ok(())
     }
 }
 

--- a/zenoh/src/session.rs
+++ b/zenoh/src/session.rs
@@ -59,8 +59,8 @@ use zenoh_core::SyncResolve;
 use zenoh_core::{zconfigurable, zread, Result as ZResult};
 use zenoh_protocol::{
     core::{
-        queryable, AtomicZInt, Channel, CongestionControl, ExprId, QueryTarget, QueryableInfo,
-        SubInfo, WireExpr, ZInt,
+        AtomicZInt, Channel, CongestionControl, ExprId, QueryTarget, QueryableInfo, SubInfo,
+        WireExpr, ZInt,
     },
     io::ZBuf,
     proto::{DataInfo, RoutingContext},
@@ -569,7 +569,6 @@ impl Session {
         QueryableBuilder {
             session: SessionRef::Borrow(self),
             key_expr: key_expr.try_into().map_err(Into::into),
-            kind: zenoh_protocol_core::queryable::ALL_KINDS,
             complete: true,
             handler: DefaultHandler,
         }
@@ -1124,7 +1123,6 @@ impl Session {
     pub(crate) fn declare_queryable_inner(
         &self,
         key_expr: &WireExpr,
-        kind: ZInt,
         complete: bool,
         callback: Callback<'static, Query>,
     ) -> ZResult<Arc<QueryableState>> {
@@ -1134,7 +1132,6 @@ impl Session {
         let qable_state = Arc::new(QueryableState {
             id,
             key_expr: key_expr.to_owned(),
-            kind,
             complete,
             callback,
         });
@@ -1144,20 +1141,19 @@ impl Session {
 
             if complete {
                 let primitives = state.primitives.as_ref().unwrap().clone();
-                let complete = Session::complete_twin_qabls(&state, key_expr, kind);
+                let complete = Session::complete_twin_qabls(&state, key_expr);
                 drop(state);
                 let qabl_info = QueryableInfo {
                     complete,
                     distance: 0,
                 };
-                primitives.decl_queryable(key_expr, kind, &qabl_info, None);
+                primitives.decl_queryable(key_expr, &qabl_info, None);
             }
         }
         #[cfg(not(feature = "complete_n"))]
         {
-            let twin_qabl = Session::twin_qabl(&state, key_expr, kind);
-            let complete_twin_qabl =
-                twin_qabl && Session::complete_twin_qabl(&state, key_expr, kind);
+            let twin_qabl = Session::twin_qabl(&state, key_expr);
+            let complete_twin_qabl = twin_qabl && Session::complete_twin_qabl(&state, key_expr);
 
             state.queryables.insert(id, qable_state.clone());
 
@@ -1173,38 +1169,35 @@ impl Session {
                     complete,
                     distance: 0,
                 };
-                primitives.decl_queryable(key_expr, kind, &qabl_info, None);
+                primitives.decl_queryable(key_expr, &qabl_info, None);
             }
         }
         Ok(qable_state)
     }
 
-    pub(crate) fn twin_qabl(state: &SessionState, key: &WireExpr, kind: ZInt) -> bool {
+    pub(crate) fn twin_qabl(state: &SessionState, key: &WireExpr) -> bool {
         state.queryables.values().any(|q| {
-            q.kind == kind
-                && state.local_wireexpr_to_expr(&q.key_expr).unwrap()
-                    == state.local_wireexpr_to_expr(key).unwrap()
+            state.local_wireexpr_to_expr(&q.key_expr).unwrap()
+                == state.local_wireexpr_to_expr(key).unwrap()
         })
     }
 
     #[cfg(not(feature = "complete_n"))]
-    pub(crate) fn complete_twin_qabl(state: &SessionState, key: &WireExpr, kind: ZInt) -> bool {
+    pub(crate) fn complete_twin_qabl(state: &SessionState, key: &WireExpr) -> bool {
         state.queryables.values().any(|q| {
             q.complete
-                && q.kind == kind
                 && state.local_wireexpr_to_expr(&q.key_expr).unwrap()
                     == state.local_wireexpr_to_expr(key).unwrap()
         })
     }
 
     #[cfg(feature = "complete_n")]
-    pub(crate) fn complete_twin_qabls(state: &SessionState, key: &WireExpr, kind: ZInt) -> ZInt {
+    pub(crate) fn complete_twin_qabls(state: &SessionState, key: &WireExpr) -> ZInt {
         state
             .queryables
             .values()
             .filter(|q| {
                 q.complete
-                    && q.kind == kind
                     && state.local_wireexpr_to_expr(&q.key_expr).unwrap()
                         == state.local_wireexpr_to_expr(key).unwrap()
             })
@@ -1214,53 +1207,35 @@ impl Session {
         let mut state = zwrite!(self.state);
         if let Some(qable_state) = state.queryables.remove(&qid) {
             trace!("close_queryable({:?})", qable_state);
-            if Session::twin_qabl(&state, &qable_state.key_expr, qable_state.kind) {
+            if Session::twin_qabl(&state, &qable_state.key_expr) {
                 // There still exist Queryables on the same KeyExpr.
                 if qable_state.complete {
                     #[cfg(feature = "complete_n")]
                     {
-                        let complete = Session::complete_twin_qabls(
-                            &state,
-                            &qable_state.key_expr,
-                            qable_state.kind,
-                        );
+                        let complete = Session::complete_twin_qabls(&state, &qable_state.key_expr);
                         let primitives = state.primitives.as_ref().unwrap();
                         let qabl_info = QueryableInfo {
                             complete,
                             distance: 0,
                         };
-                        primitives.decl_queryable(
-                            &qable_state.key_expr,
-                            qable_state.kind,
-                            &qabl_info,
-                            None,
-                        );
+                        primitives.decl_queryable(&qable_state.key_expr, &qabl_info, None);
                     }
                     #[cfg(not(feature = "complete_n"))]
                     {
-                        if !Session::complete_twin_qabl(
-                            &state,
-                            &qable_state.key_expr,
-                            qable_state.kind,
-                        ) {
+                        if !Session::complete_twin_qabl(&state, &qable_state.key_expr) {
                             let primitives = state.primitives.as_ref().unwrap();
                             let qabl_info = QueryableInfo {
                                 complete: 0,
                                 distance: 0,
                             };
-                            primitives.decl_queryable(
-                                &qable_state.key_expr,
-                                qable_state.kind,
-                                &qabl_info,
-                                None,
-                            );
+                            primitives.decl_queryable(&qable_state.key_expr, &qabl_info, None);
                         }
                     }
                 }
             } else {
                 // There are no more Queryables on the same KeyExpr.
                 let primitives = state.primitives.as_ref().unwrap();
-                primitives.forget_queryable(&qable_state.key_expr, qable_state.kind, None);
+                primitives.forget_queryable(&qable_state.key_expr, None);
             }
             Ok(())
         } else {
@@ -1404,10 +1379,7 @@ impl Session {
             &selector.key_expr.to_wire(self),
             selector.value_selector(),
             qid,
-            zenoh_protocol_core::QueryTAK {
-                kind: zenoh_protocol_core::queryable::ALL_KINDS,
-                target,
-            },
+            target,
             consolidation,
             None,
         );
@@ -1417,10 +1389,7 @@ impl Session {
                 &selector.key_expr.to_wire(self),
                 selector.value_selector(),
                 qid,
-                zenoh_protocol_core::QueryTAK {
-                    kind: zenoh_protocol_core::queryable::ALL_KINDS,
-                    target,
-                },
+                target,
                 consolidation,
             );
         }
@@ -1433,23 +1402,20 @@ impl Session {
         key_expr: &WireExpr,
         value_selector: &str,
         qid: ZInt,
-        target: zenoh_protocol_core::QueryTAK,
+        _target: QueryTarget,
         _consolidation: ConsolidationMode,
     ) {
-        let (primitives, key_expr, kinds_and_senders) = {
+        let (primitives, key_expr, senders) = {
             let state = zread!(self.state);
             match state.wireexpr_to_keyexpr(key_expr, local) {
                 Ok(key_expr) => {
-                    let kinds_and_senders = state
+                    let senders = state
                         .queryables
                         .values()
                         .filter(
                             |queryable| match state.local_wireexpr_to_expr(&queryable.key_expr) {
                                 Ok(qablname) => {
                                     qablname.intersects(&key_expr)
-                                        && ((queryable.kind == queryable::ALL_KINDS
-                                            || target.kind == queryable::ALL_KINDS)
-                                            || (queryable.kind & target.kind != 0))
                                 }
                                 Err(err) => {
                                     error!(
@@ -1460,12 +1426,12 @@ impl Session {
                                 }
                             },
                         )
-                        .map(|qable| (qable.kind, qable.callback.clone()))
-                        .collect::<Vec<(ZInt, Arc<dyn Fn(Query) + Send + Sync>)>>();
+                        .map(|qable| qable.callback.clone())
+                        .collect::<Vec<Arc<dyn Fn(Query) + Send + Sync>>>();
                     (
                         state.primitives.as_ref().unwrap().clone(),
                         key_expr.into_owned(),
-                        kinds_and_senders,
+                        senders,
                     )
                 }
                 Err(err) => {
@@ -1480,11 +1446,10 @@ impl Session {
 
         let zid = self.runtime.zid; // @TODO build/use prebuilt specific zid
 
-        for (kind, req_sender) in kinds_and_senders {
+        for req_sender in senders.iter() {
             req_sender(Query {
                 key_expr: key_expr.clone().into_owned(),
                 value_selector: value_selector.clone(),
-                kind,
                 replies_sender: rep_sender.clone(),
             });
         }
@@ -1495,11 +1460,10 @@ impl Session {
         if local {
             let this = self.clone();
             task::spawn(async move {
-                while let Some((replier_kind, sample)) = rep_receiver.stream().next().await {
+                while let Some(sample) = rep_receiver.stream().next().await {
                     let (key_expr, payload, data_info) = sample.split();
                     this.send_reply_data(
                         qid,
-                        replier_kind,
                         zid,
                         key_expr.to_wire(&this).to_owned(),
                         Some(data_info),
@@ -1511,11 +1475,10 @@ impl Session {
         } else {
             let this = self.clone();
             task::spawn(async move {
-                while let Some((replier_kind, sample)) = rep_receiver.stream().next().await {
+                while let Some(sample) = rep_receiver.stream().next().await {
                     let (key_expr, payload, data_info) = sample.split();
                     primitives.send_reply_data(
                         qid,
-                        replier_kind,
                         zid,
                         key_expr.to_wire(&this).to_owned(),
                         Some(data_info),
@@ -1604,7 +1567,6 @@ impl SessionDeclarations for Arc<Session> {
         QueryableBuilder {
             session: SessionRef::Shared(self.clone()),
             key_expr: key_expr.try_into().map_err(Into::into),
-            kind: zenoh_protocol_core::queryable::EVAL,
             complete: true,
             handler: DefaultHandler,
         }
@@ -1700,19 +1662,13 @@ impl Primitives for Session {
     fn decl_queryable(
         &self,
         _key_expr: &WireExpr,
-        _kind: ZInt,
         _qabl_info: &QueryableInfo,
         _routing_context: Option<RoutingContext>,
     ) {
         trace!("recv Decl Queryable {:?}", _key_expr);
     }
 
-    fn forget_queryable(
-        &self,
-        _key_expr: &WireExpr,
-        _kind: ZInt,
-        _routing_context: Option<RoutingContext>,
-    ) {
+    fn forget_queryable(&self, _key_expr: &WireExpr, _routing_context: Option<RoutingContext>) {
         trace!("recv Forget Queryable {:?}", _key_expr);
     }
 
@@ -1741,7 +1697,7 @@ impl Primitives for Session {
         key_expr: &WireExpr,
         value_selector: &str,
         qid: ZInt,
-        target: zenoh_protocol_core::QueryTAK,
+        target: QueryTarget,
         consolidation: ConsolidationMode,
         _routing_context: Option<RoutingContext>,
     ) {
@@ -1758,16 +1714,14 @@ impl Primitives for Session {
     fn send_reply_data(
         &self,
         qid: ZInt,
-        replier_kind: ZInt,
         replier_id: ZenohId,
         key_expr: WireExpr,
         data_info: Option<DataInfo>,
         payload: ZBuf,
     ) {
         trace!(
-            "recv ReplyData {:?} {:?} {:?} {:?} {:?} {:?}",
+            "recv ReplyData {:?} {:?} {:?} {:?} {:?}",
             qid,
-            replier_kind,
             replier_id,
             key_expr,
             data_info,

--- a/zenoh/tests/session.rs
+++ b/zenoh/tests/session.rs
@@ -1,0 +1,179 @@
+//
+// Copyright (c) 2022 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+use async_std::prelude::FutureExt;
+use async_std::task;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use zenoh::prelude::r#async::*;
+use zenoh_core::zasync_executor_init;
+
+const TIMEOUT: Duration = Duration::from_secs(60);
+const SLEEP: Duration = Duration::from_secs(1);
+
+const MSG_COUNT: usize = 1_000;
+const MSG_SIZE: [usize; 2] = [1_024, 131_072];
+
+macro_rules! ztimeout {
+    ($f:expr) => {
+        $f.timeout(TIMEOUT).await.unwrap()
+    };
+}
+
+async fn open_session(endpoints: &[&str]) -> (Session, Session) {
+    // Open the sessions
+    let mut config = config::peer();
+    config.listen.endpoints = endpoints
+        .iter()
+        .map(|e| e.parse().unwrap())
+        .collect::<Vec<_>>();
+    config.scouting.multicast.set_enabled(Some(false)).unwrap();
+    println!("[  ][01a] Opening peer01 session");
+    let peer01 = ztimeout!(zenoh::open(config).res()).unwrap();
+
+    let mut config = config::peer();
+    config.connect.endpoints = endpoints
+        .iter()
+        .map(|e| e.parse().unwrap())
+        .collect::<Vec<_>>();
+    config.scouting.multicast.set_enabled(Some(false)).unwrap();
+    println!("[  ][02a] Opening peer02 session");
+    let peer02 = ztimeout!(zenoh::open(config).res()).unwrap();
+
+    (peer01, peer02)
+}
+
+async fn close_session(peer01: Session, peer02: Session) {
+    println!("[  ][01d] Closing peer02 session");
+    ztimeout!(peer01.close().res()).unwrap();
+    println!("[  ][02d] Closing peer02 session");
+    ztimeout!(peer02.close().res()).unwrap();
+}
+
+async fn test_session_pubsub(peer01: &Session, peer02: &Session) {
+    let key_expr = "test/session";
+
+    let msgs = Arc::new(AtomicUsize::new(0));
+
+    for size in MSG_SIZE {
+        msgs.store(0, Ordering::SeqCst);
+
+        // Subscribe to data
+        println!("[PS][01b] Subscribing on peer01 session");
+        let c_msgs = msgs.clone();
+        let sub = ztimeout!(peer01
+            .declare_subscriber(key_expr)
+            .callback(move |sample| {
+                assert_eq!(sample.value.payload.len(), size);
+                c_msgs.fetch_add(1, Ordering::SeqCst);
+            })
+            .res())
+        .unwrap();
+
+        // Wait for the declaration to propagate
+        task::sleep(SLEEP).await;
+
+        // Put data
+        println!(
+            "[PS][02b] Putting on peer02 session. {} msgs of {} bytes.",
+            MSG_COUNT, size
+        );
+        for _ in 0..MSG_COUNT {
+            ztimeout!(peer02
+                .put(key_expr, vec![0u8; size])
+                .congestion_control(CongestionControl::Block)
+                .res())
+            .unwrap();
+        }
+
+        ztimeout!(async {
+            loop {
+                let cnt = msgs.load(Ordering::SeqCst);
+                println!("[PS][03b] Received {}/{}.", cnt, MSG_COUNT);
+                if cnt < MSG_COUNT {
+                    task::sleep(SLEEP).await;
+                } else {
+                    break;
+                }
+            }
+        });
+
+        println!("[PS][03b] Unsubscribing on peer01 session");
+        ztimeout!(sub.undeclare().res()).unwrap();
+
+        // Wait for the declaration to propagate
+        task::sleep(SLEEP).await;
+    }
+}
+
+async fn test_session_qryrep(peer01: &Session, peer02: &Session) {
+    let key_expr = "test/session";
+
+    let msgs = Arc::new(AtomicUsize::new(0));
+
+    for size in MSG_SIZE {
+        msgs.store(0, Ordering::SeqCst);
+
+        // Queryable to data
+        println!("[QR][01c] Queryable on peer01 session");
+        let c_msgs = msgs.clone();
+        let qbl = ztimeout!(peer01
+            .declare_queryable(key_expr)
+            .callback(move |sample| {
+                c_msgs.fetch_add(1, Ordering::SeqCst);
+                let rep = Sample::try_from(key_expr, vec![0u8; size]).unwrap();
+                task::block_on(async { ztimeout!(sample.reply(Ok(rep)).res()).unwrap() });
+            })
+            .res())
+        .unwrap();
+
+        // Wait for the declaration to propagate
+        task::sleep(SLEEP).await;
+
+        // Get data
+        println!("[QR][02c] Getting on peer02 session. {} msgs.", MSG_COUNT);
+        let mut cnt = 0;
+        for _ in 0..MSG_COUNT {
+            let rs = ztimeout!(peer02.get(key_expr).res()).unwrap();
+            while let Ok(s) = ztimeout!(rs.recv_async()) {
+                assert_eq!(s.sample.unwrap().value.payload.len(), size);
+                cnt += 1;
+            }
+        }
+        println!(
+            "[QR][02c] Got on peer02 session. {}/{} msgs.",
+            cnt, MSG_COUNT
+        );
+        assert_eq!(msgs.load(Ordering::SeqCst), MSG_COUNT);
+        assert_eq!(cnt, MSG_COUNT);
+
+        println!("[PS][03c] Unqueryable on peer01 session");
+        ztimeout!(qbl.undeclare().res()).unwrap();
+
+        // Wait for the declaration to propagate
+        task::sleep(SLEEP).await;
+    }
+}
+
+#[test]
+fn zenoh_session() {
+    task::block_on(async {
+        zasync_executor_init!();
+
+        let (peer01, peer02) = open_session(&["tcp/127.0.0.1:17447"]).await;
+        test_session_pubsub(&peer01, &peer02).await;
+        test_session_qryrep(&peer01, &peer02).await;
+        close_session(peer01, peer02).await;
+    });
+}


### PR DESCRIPTION
It seems that a regression is still in place when interoperating with zenoh-pico that needs to be fixed.