### PR TITLE
Enable PushMode/PullMode switch for generic SubscriberBuilder

### DIFF
--- a/zenoh/src/subscriber.rs
+++ b/zenoh/src/subscriber.rs
@@ -444,9 +444,7 @@ impl<'a, 'b, Mode, Handler> SubscriberBuilder<'a, 'b, Mode, Handler> {
         self.local = true;
         self
     }
-}
 
-impl<'a, 'b, Handler> SubscriberBuilder<'a, 'b, PushMode, Handler> {
     /// Change the subscription mode to Pull.
     #[inline]
     pub fn pull_mode(self) -> SubscriberBuilder<'a, 'b, PullMode, Handler> {
@@ -467,8 +465,7 @@ impl<'a, 'b, Handler> SubscriberBuilder<'a, 'b, PushMode, Handler> {
             handler,
         }
     }
-}
-impl<'a, 'b, Handler> SubscriberBuilder<'a, 'b, PullMode, Handler> {
+
     /// Change the subscription mode to Push.
     #[inline]
     pub fn push_mode(self) -> SubscriberBuilder<'a, 'b, PushMode, Handler> {


### PR DESCRIPTION
During porting the zenoh-perf to api-changes, I found that the usage of SubscriberBuilder is a little bit counter-intuitive. For example, we can't set the subscriber into `push_mode` since `declare_subscriber` returns a SubscriberBuilder in PushMode by default. And only changes from PushMode to PullMode and converse way are allowed. Maybe let's consider this PR to make the switch be idempotent.

```rust
 let mut subscriber = session
    .declare_subscriber(KEY_EXPR)
    .reliable()
    .push_mode()     // unsupported
    .res()
    .await.unwrap();
```