### PR TITLE
zenoh-ext: SessionExt operations renaming

### DIFF
--- a/zenoh-ext/examples/z_pub_cache.rs
+++ b/zenoh-ext/examples/z_pub_cache.rs
@@ -29,7 +29,7 @@ async fn main() {
     let session = zenoh::open(config).res().await.unwrap();
 
     println!("Creating PublicationCache on {}", &key_expr);
-    let mut publication_cache_builder = session.publication_cache(&key_expr).history(history);
+    let mut publication_cache_builder = session.declare_publication_cache(&key_expr).history(history);
     if let Some(prefix) = prefix {
         publication_cache_builder = publication_cache_builder.queryable_prefix(prefix);
     }

--- a/zenoh-ext/examples/z_pub_cache.rs
+++ b/zenoh-ext/examples/z_pub_cache.rs
@@ -29,7 +29,9 @@ async fn main() {
     let session = zenoh::open(config).res().await.unwrap();
 
     println!("Creating PublicationCache on {}", &key_expr);
-    let mut publication_cache_builder = session.declare_publication_cache(&key_expr).history(history);
+    let mut publication_cache_builder = session
+        .declare_publication_cache(&key_expr)
+        .history(history);
     if let Some(prefix) = prefix {
         publication_cache_builder = publication_cache_builder.queryable_prefix(prefix);
     }

--- a/zenoh-ext/examples/z_query_sub.rs
+++ b/zenoh-ext/examples/z_query_sub.rs
@@ -38,13 +38,13 @@ async fn main() {
     );
     let mut subscriber = if let Some(selector) = query {
         session
-            .subscribe_with_query(key_expr)
+            .declare_querying_subscriber(key_expr)
             .query_selector(&selector)
             .res()
             .await
             .unwrap()
     } else {
-        session.subscribe_with_query(key_expr).res().await.unwrap()
+        session.declare_querying_subscriber(key_expr).res().await.unwrap()
     };
 
     println!("Enter 'd' to issue the query again, or 'q' to quit...");

--- a/zenoh-ext/examples/z_query_sub.rs
+++ b/zenoh-ext/examples/z_query_sub.rs
@@ -44,7 +44,11 @@ async fn main() {
             .await
             .unwrap()
     } else {
-        session.declare_querying_subscriber(key_expr).res().await.unwrap()
+        session
+            .declare_querying_subscriber(key_expr)
+            .res()
+            .await
+            .unwrap()
     };
 
     println!("Enter 'd' to issue the query again, or 'q' to quit...");

--- a/zenoh-ext/src/session_ext.rs
+++ b/zenoh-ext/src/session_ext.rs
@@ -70,13 +70,13 @@ pub trait SessionExt {
     /// use zenoh_ext::*;
     ///
     /// let session = zenoh::open(config::peer()).res().await.unwrap();
-    /// let subscriber = session.subscribe_with_query("key/expr").res().await.unwrap();
+    /// let subscriber = session.declare_querying_subscriber("key/expr").res().await.unwrap();
     /// while let Ok(sample) = subscriber.recv_async().await {
     ///     println!("Received : {:?}", sample);
     /// }
     /// # })
     /// ```
-    fn subscribe_with_query<'a, 'b, TryIntoKeyExpr>(
+    fn declare_querying_subscriber<'a, 'b, TryIntoKeyExpr>(
         &'a self,
         sub_key_expr: TryIntoKeyExpr,
     ) -> QueryingSubscriberBuilder<'a, 'b, DefaultHandler>
@@ -84,7 +84,7 @@ pub trait SessionExt {
         TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
         <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_core::Error>;
 
-    fn publication_cache<'a, 'b, 'c, TryIntoKeyExpr>(
+    fn declare_publication_cache<'a, 'b, 'c, TryIntoKeyExpr>(
         &'a self,
         pub_key_expr: TryIntoKeyExpr,
     ) -> PublicationCacheBuilder<'a, 'b, 'c>
@@ -94,7 +94,7 @@ pub trait SessionExt {
 }
 
 impl SessionExt for Session {
-    fn subscribe_with_query<'a, 'b, TryIntoKeyExpr>(
+    fn declare_querying_subscriber<'a, 'b, TryIntoKeyExpr>(
         &'a self,
         sub_key_expr: TryIntoKeyExpr,
     ) -> QueryingSubscriberBuilder<'a, 'b, DefaultHandler>
@@ -108,7 +108,7 @@ impl SessionExt for Session {
         )
     }
 
-    fn publication_cache<'a, 'b, 'c, TryIntoKeyExpr>(
+    fn declare_publication_cache<'a, 'b, 'c, TryIntoKeyExpr>(
         &'a self,
         pub_key_expr: TryIntoKeyExpr,
     ) -> PublicationCacheBuilder<'a, 'b, 'c>
@@ -121,7 +121,7 @@ impl SessionExt for Session {
 }
 
 impl SessionExt for Arc<Session> {
-    fn subscribe_with_query<'a, 'b, TryIntoKeyExpr>(
+    fn declare_querying_subscriber<'a, 'b, TryIntoKeyExpr>(
         &'a self,
         sub_key_expr: TryIntoKeyExpr,
     ) -> QueryingSubscriberBuilder<'a, 'b, DefaultHandler>
@@ -135,7 +135,7 @@ impl SessionExt for Arc<Session> {
         )
     }
 
-    fn publication_cache<'a, 'b, 'c, TryIntoKeyExpr>(
+    fn declare_publication_cache<'a, 'b, 'c, TryIntoKeyExpr>(
         &'a self,
         pub_key_expr: TryIntoKeyExpr,
     ) -> PublicationCacheBuilder<'a, 'b, 'c>


### PR DESCRIPTION
To comply with what has been decided in https://github.com/eclipse-zenoh/roadmap/discussions/23 those `SessionExt` operations are renamed as such:
 - `SessionExt::subscribe_with_query` => `SessionExt::declare_querying_subscriber()`
 - `SessionExt::publication_cache()` => `SessionExt::declare_publication_cache()`