### PR TITLE
Make QuerySubscriber to use accept_replies(ReplyKeyExpr::Any)

### DIFF
--- a/zenoh-ext/src/querying_subscriber.rs
+++ b/zenoh-ext/src/querying_subscriber.rs
@@ -457,8 +457,7 @@ impl<'a, Receiver> QueryingSubscriber<'a, Receiver> {
         };
 
         // if selector for query is different than subscription keyexpr: accept Any reply
-        let query_accept_replies = if selector.key_expr != *self._subscriber.key_expr()
-        {
+        let query_accept_replies = if selector.key_expr != *self._subscriber.key_expr() {
             ReplyKeyExpr::Any
         } else {
             ReplyKeyExpr::MatchingQuery

--- a/zenoh-ext/src/querying_subscriber.rs
+++ b/zenoh-ext/src/querying_subscriber.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 use zenoh::handlers::{locked, DefaultHandler};
 use zenoh::prelude::*;
 
-use zenoh::query::{QueryConsolidation, QueryTarget};
+use zenoh::query::{QueryConsolidation, QueryTarget, ReplyKeyExpr};
 use zenoh::subscriber::{Reliability, Subscriber};
 use zenoh::time::Timestamp;
 use zenoh::Result as ZResult;
@@ -456,9 +456,18 @@ impl<'a, Receiver> QueryingSubscriber<'a, Receiver> {
             callback: self.callback.clone(),
         };
 
+        // if selector for query is different than subscription keyexpr: accept Any reply
+        let query_accept_replies = if selector.key_expr != *self._subscriber.key_expr()
+        {
+            ReplyKeyExpr::Any
+        } else {
+            ReplyKeyExpr::MatchingQuery
+        };
+
         log::debug!("Start query on {}", selector);
         self.session
             .get(selector)
+            .accept_replies(query_accept_replies)
             .target(target)
             .consolidation(consolidation)
             .timeout(timeout)

--- a/zenoh/src/query.rs
+++ b/zenoh/src/query.rs
@@ -329,6 +329,13 @@ pub enum ReplyKeyExpr {
     MatchingQuery,
 }
 
+#[zenoh_core::unstable]
+impl Default for ReplyKeyExpr {
+    fn default() -> Self {
+        ReplyKeyExpr::MatchingQuery
+    }
+}
+
 impl<Handler> Resolvable for GetBuilder<'_, '_, Handler>
 where
     Handler: crate::prelude::IntoCallbackReceiverPair<'static, Reply>,

--- a/zenoh/src/subscriber.rs
+++ b/zenoh/src/subscriber.rs
@@ -715,6 +715,11 @@ impl<'a, Receiver> PullSubscriber<'a, Receiver> {
 }
 
 impl<'a, Receiver> Subscriber<'a, Receiver> {
+    /// Returns the [`keyexpr`] this Subscriber subscribes to.
+    pub fn key_expr(&self) -> &KeyExpr<'static> {
+        &self.subscriber.state.key_expr
+    }
+
     /// Close a [`Subscriber`].
     ///
     /// Subscribers are automatically closed when dropped, but you may want to use this function to handle errors or


### PR DESCRIPTION
Following decision in https://github.com/eclipse-zenoh/roadmap/discussions/55 and its implementation in #334,
the `QueryingSubscriber` needs to be adapted in case its `query_selector` is different than its subscription `key_expr`.

This occurs when the `PublicationCache` is configured with a `prefix` for its queryable: its replies to queries will use the original publications `key_expr`, while the query is on a different `key_expr`.
In such case, the `QueryingSubscriber` needs to use the new `accept_replies(ReplyKeyExpr::Any)` for its queries to the PublicationCache.
