### PR TITLE
Implement IntoFuture for async API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,35 +14,35 @@
 [workspace]
 
 members = [
-  "commons/zenoh-config",
   "commons/zenoh-buffers",
-  "commons/zenoh-protocol-core",
-  "commons/zenoh-protocol",
   "commons/zenoh-cfg-properties",
   "commons/zenoh-collections",
+  "commons/zenoh-config",
   "commons/zenoh-core",
   "commons/zenoh-crypto",
+  "commons/zenoh-macros",
+  "commons/zenoh-protocol",
+  "commons/zenoh-protocol-core",
   "commons/zenoh-sync",
   "commons/zenoh-util",
-  "commons/zenoh-macros",
+  "examples",
+  "io/zenoh-link",
   "io/zenoh-link-commons",
-  "io/zenoh-links/zenoh-link-udp/",
+  "io/zenoh-links/zenoh-link-quic/",
   "io/zenoh-links/zenoh-link-tcp/",
   "io/zenoh-links/zenoh-link-tls/",
-  "io/zenoh-links/zenoh-link-quic/",
+  "io/zenoh-links/zenoh-link-udp/",
   "io/zenoh-links/zenoh-link-unixsock_stream/",
   "io/zenoh-links/zenoh-link-ws/",
-  "io/zenoh-link",
   "io/zenoh-transport",
+  "plugins/example-plugin",
+  "plugins/zenoh-backend-traits",
+  "plugins/zenoh-plugin-rest",
+  "plugins/zenoh-plugin-storage-manager",
+  "plugins/zenoh-plugin-trait",
   "zenoh",
   "zenoh-ext",
   "zenohd",
-  "examples",
-  "plugins/zenoh-plugin-trait",
-  "plugins/example-plugin",
-  "plugins/zenoh-plugin-rest",
-  "plugins/zenoh-plugin-storage-manager",
-  "plugins/zenoh-backend-traits",
 ]
 
 [profile.dev]
@@ -51,11 +51,11 @@ opt-level = 0
 
 [profile.fast]
 inherits = "release"
-opt-level=3
-debug=true
+opt-level = 3
+debug = true
 debug-assertions = true
 overflow-checks = true
-lto=false
+lto = false
 
 [profile.release]
 debug = false     # If you want debug symbol in release mode, set the env variable: RUSTFLAGS=-g

--- a/commons/zenoh-buffers/Cargo.toml
+++ b/commons/zenoh-buffers/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.64"
 name = "zenoh-buffers"
 version = "0.6.0-dev.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"
@@ -33,8 +34,6 @@ description = "Internal crate for zenoh."
 shared-memory = ["shared_memory", "serde", "log", "bincode"]
 
 [dependencies]
-zenoh-core = { path = "../zenoh-core/" }
-zenoh-collections = { path = "../zenoh-collections/" }
 
 async-std = { version = "=1.12.0", default-features = false }
 bincode = { version = "1.3.3", optional = true }
@@ -42,3 +41,5 @@ hex = "0.4.3"
 log = { version = "0.4.17", optional = true }
 serde = { version = "1.0.144", optional = true }
 shared_memory = { version = "=0.12.4", optional = true }
+zenoh-collections = { path = "../zenoh-collections/" }
+zenoh-core = { path = "../zenoh-core/" }

--- a/commons/zenoh-cfg-properties/Cargo.toml
+++ b/commons/zenoh-cfg-properties/Cargo.toml
@@ -11,6 +11,7 @@
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 [package]
+rust-version = "1.64"
 name = "zenoh-cfg-properties"
 version = "0.6.0-dev.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"
@@ -24,7 +25,6 @@ edition = "2018"
 license = " EPL-2.0 OR Apache-2.0"
 categories = ["network-programming"]
 description = "Internal crate for zenoh."
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/commons/zenoh-collections/Cargo.toml
+++ b/commons/zenoh-collections/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.64"
 name = "zenoh-collections"
 version = "0.6.0-dev.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"
@@ -28,9 +29,9 @@ description = "Internal crate for zenoh."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zenoh-core = { path = "../zenoh-core/" }
-zenoh-sync = { path = "../zenoh-sync/" }
-async-trait = "0.1.57"
 async-std = { version = "=1.12.0", features = ["unstable"] }
+async-trait = "0.1.57"
 flume = "0.10.14"
 log = "0.4.17"
+zenoh-core = { path = "../zenoh-core/" }
+zenoh-sync = { path = "../zenoh-sync/" }

--- a/commons/zenoh-config/Cargo.toml
+++ b/commons/zenoh-config/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.64"
 name = "zenoh-config"
 version = "0.6.0-dev.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"
@@ -28,10 +29,6 @@ license = " EPL-2.0 OR Apache-2.0"
 categories = ["network-programming"]
 description = "Internal crate for zenoh."
 [dependencies]
-zenoh-core = { path = "../zenoh-core" }
-zenoh-cfg-properties = { path = "../zenoh-cfg-properties" }
-zenoh-util = { path = "../zenoh-util" }
-zenoh-protocol-core = { path = "../zenoh-protocol-core/" }
 
 flume = "0.10.14"
 json5 = "0.4.1"
@@ -40,3 +37,7 @@ serde = "1.0.144"
 serde_json = "1.0.85"
 serde_yaml = "0.9.13"
 validated_struct = { version = "2.1.0", features = ["json5", "json_get"] }
+zenoh-cfg-properties = { path = "../zenoh-cfg-properties" }
+zenoh-core = { path = "../zenoh-core" }
+zenoh-protocol-core = { path = "../zenoh-protocol-core/" }
+zenoh-util = { path = "../zenoh-util" }

--- a/commons/zenoh-core/Cargo.toml
+++ b/commons/zenoh-core/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.64"
 name = "zenoh-core"
 version = "0.6.0-dev.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"

--- a/commons/zenoh-crypto/Cargo.toml
+++ b/commons/zenoh-crypto/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.64"
 name = "zenoh-crypto"
 version = "0.6.0-dev.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"
@@ -28,9 +29,9 @@ description = "Internal crate for zenoh."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zenoh-core = { path = "../zenoh-core/" }
 aes = "0.8.1"
 hmac = { version = "0.12.1", features = ["std"] }
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 sha3 = "0.10.5"
+zenoh-core = { path = "../zenoh-core/" }

--- a/commons/zenoh-macros/Cargo.toml
+++ b/commons/zenoh-macros/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.64"
 name = "zenoh-macros"
 version = "0.6.0-dev.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"
@@ -31,10 +32,10 @@ description = "Internal crate for zenoh."
 
 [dependencies]
 proc-macro2 = "1.0.43"
-syn = { version = "1.0.100", features = ["full"] }
 quote = "1.0.21"
-unzip-n = "0.1.2"
 rustc_version = "0.4.0"
+syn = { version = "1.0.100", features = ["full"] }
+unzip-n = "0.1.2"
 
 [lib]
 proc-macro = true

--- a/commons/zenoh-protocol-core/Cargo.toml
+++ b/commons/zenoh-protocol-core/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.64"
 name = "zenoh-protocol-core"
 version = "0.6.0-dev.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"
@@ -27,7 +28,6 @@ edition = "2018"
 license = " EPL-2.0 OR Apache-2.0"
 categories = ["network-programming"]
 description = "Internal crate for zenoh."
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
@@ -35,15 +35,15 @@ complete_n = []
 fuzzer = []
 
 [dependencies]
-zenoh-core = { path = "../zenoh-core/" }
 
 hex = "0.4.3"
+itertools = "0.10.5"
 lazy_static = "1.4.0"
+rand = "0.8.5"
+serde = "1.0.144"
 uhlc = "0.5.1"
 uuid = { version = "1.1.2", features = ["v4"] }
-serde = "1.0.144"
-rand = "0.8.5"
-itertools = "0.10.5"
+zenoh-core = { path = "../zenoh-core/" }
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/commons/zenoh-protocol/Cargo.toml
+++ b/commons/zenoh-protocol/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.64"
 name = "zenoh-protocol"
 version = "0.6.0-dev.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"
@@ -33,19 +34,18 @@ shared-memory = ["zenoh-buffers/shared-memory"]
 complete_n = ["zenoh-protocol-core/complete_n"]
 
 [dependencies]
-zenoh-core = { path = "../zenoh-core/" }
-
-zenoh-protocol-core = { path = "../zenoh-protocol-core/" }
-zenoh-buffers = { path = "../zenoh-buffers/" }
 
 log = "0.4.17"
 uhlc = "0.5.1"
+zenoh-buffers = { path = "../zenoh-buffers/" }
+zenoh-core = { path = "../zenoh-core/" }
+
+zenoh-protocol-core = { path = "../zenoh-protocol-core/" }
 
 [dev-dependencies]
+criterion = "0.4.0"
 rand = "0.8.5"
 uuid = { version = "1.1.2", features = ["v4"] }
-criterion = "0.4.0"
-
 
 [[bench]]
 name = "codec_bench"

--- a/commons/zenoh-sync/Cargo.toml
+++ b/commons/zenoh-sync/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.64"
 name = "zenoh-sync"
 version = "0.6.0-dev.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"
@@ -28,12 +29,12 @@ description = "Internal crate for zenoh."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zenoh-core = { path = "../zenoh-core/" }
 async-std = { version = "=1.12.0", features = ["unstable"] }
 event-listener = "2.5.3"
 flume = "0.10.14"
 futures = "0.3.24"
 tokio = { version = "1.17.0", features = ["sync"] }
+zenoh-core = { path = "../zenoh-core/" }
 
 [dev-dependencies]
 async-std = { version = "=1.12.0", features = ["unstable", "attributes"] }

--- a/commons/zenoh-util/Cargo.toml
+++ b/commons/zenoh-util/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.64"
 name = "zenoh-util"
 version = "0.6.0-dev.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"
@@ -39,11 +40,6 @@ default = ["compat"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-zenoh-core = { path = "../zenoh-core" }
-zenoh-cfg-properties = { path = "../zenoh-cfg-properties", optional = true }
-zenoh-crypto = { path = "../zenoh-crypto/", optional = true }
-zenoh-sync = { path = "../zenoh-sync/", optional = true }
-zenoh-collections = { path = "../zenoh-collections/", optional = true }
 async-std = { version = "=1.12.0" }
 clap = "3.2.22"
 futures = "0.3.24"
@@ -54,6 +50,11 @@ lazy_static = "1.4.0"
 libloading = "0.7.3"
 log = "0.4.17"
 shellexpand = "2.1.2"
+zenoh-cfg-properties = { path = "../zenoh-cfg-properties", optional = true }
+zenoh-collections = { path = "../zenoh-collections/", optional = true }
+zenoh-core = { path = "../zenoh-core" }
+zenoh-crypto = { path = "../zenoh-crypto/", optional = true }
+zenoh-sync = { path = "../zenoh-sync/", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["iphlpapi"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.64"
 name = "zenoh-examples"
 version = "0.6.0-dev.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"
@@ -28,15 +29,12 @@ license = " EPL-2.0 OR Apache-2.0"
 categories = ["network-programming"]
 description = "Internal crate for zenoh."
 readme = "README.md"
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
 shared-memory = ["zenoh/shared-memory"]
 
 [dependencies]
-zenoh = { path = "../zenoh/" , default-features = false }
-zenoh-ext = { path = "../zenoh-ext/" }
 
 async-std = { version = "=1.12.0", default-features = false, features = [
   "attributes",
@@ -48,6 +46,8 @@ futures = "0.3.24"
 git-version = "0.3.5"
 json5 = "0.4.1"
 log = "0.4.17"
+zenoh = { path = "../zenoh/", default-features = false }
+zenoh-ext = { path = "../zenoh-ext/" }
 
 [dev-dependencies]
 rand = "0.8.5"
@@ -69,7 +69,6 @@ assets = [
   # service
   [".service/zenohd.service", "/lib/systemd/system/zenohd.service", "644"],
 ]
-
 
 [[example]]
 name = "z_scout"

--- a/io/zenoh-link-commons/Cargo.toml
+++ b/io/zenoh-link-commons/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.64"
 name = "zenoh-link-commons"
 version = "0.6.0-dev.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"
@@ -27,17 +28,16 @@ edition = "2018"
 license = " EPL-2.0 OR Apache-2.0"
 categories = ["network-programming"]
 description = "Internal crate for zenoh."
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zenoh-core = { path = "../../commons/zenoh-core/" }
-zenoh-cfg-properties = { path = "../../commons/zenoh-cfg-properties/" }
-
-zenoh-buffers = { path = "../../commons/zenoh-buffers/" }
-zenoh-protocol-core = { path = "../../commons/zenoh-protocol-core/" }
-zenoh-protocol = { path = "../../commons/zenoh-protocol/" }
+async-std = { version = "=1.12.0", default-features = false }
 
 async-trait = "0.1.57"
-async-std = { version = "=1.12.0", default-features = false }
 flume = "0.10.14"
+
+zenoh-buffers = { path = "../../commons/zenoh-buffers/" }
+zenoh-cfg-properties = { path = "../../commons/zenoh-cfg-properties/" }
+zenoh-core = { path = "../../commons/zenoh-core/" }
+zenoh-protocol = { path = "../../commons/zenoh-protocol/" }
+zenoh-protocol-core = { path = "../../commons/zenoh-protocol-core/" }

--- a/io/zenoh-link/Cargo.toml
+++ b/io/zenoh-link/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.64"
 name = "zenoh-link"
 version = "0.6.0-dev.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"
@@ -39,21 +40,21 @@ transport_ws = ["zenoh-link-ws"]
 transport_serial = ["zenoh-link-serial"]
 
 [dependencies]
-zenoh-core = { path = "../../commons/zenoh-core/" }
-zenoh-cfg-properties = { path = "../../commons/zenoh-cfg-properties/" }
-zenoh-config = { path = "../../commons/zenoh-config/" }
-zenoh-protocol-core = { path = "../../commons/zenoh-protocol-core/" }
-
-zenoh-link-commons = { path = "../zenoh-link-commons/" }
-zenoh-link-quic = { path = "../zenoh-links/zenoh-link-quic/", optional = true }
-zenoh-link-tcp = { path = "../zenoh-links/zenoh-link-tcp/", optional = true }
-zenoh-link-tls = { path = "../zenoh-links/zenoh-link-tls/", optional = true }
-zenoh-link-udp = { path = "../zenoh-links/zenoh-link-udp/", optional = true }
-zenoh-link-unixsock_stream = { path = "../zenoh-links/zenoh-link-unixsock_stream/", optional = true }
-zenoh-link-ws = { path = "../zenoh-links/zenoh-link-ws/", optional = true }
-zenoh-link-serial = { path = "../zenoh-links/zenoh-link-serial/", optional = true }
 
 async-std = { version = "=1.12.0", default-features = false }
 async-trait = "0.1.57"
 
 rcgen = { version = "0.9.3", optional = true }
+zenoh-cfg-properties = { path = "../../commons/zenoh-cfg-properties/" }
+zenoh-config = { path = "../../commons/zenoh-config/" }
+zenoh-core = { path = "../../commons/zenoh-core/" }
+
+zenoh-link-commons = { path = "../zenoh-link-commons/" }
+zenoh-link-quic = { path = "../zenoh-links/zenoh-link-quic/", optional = true }
+zenoh-link-serial = { path = "../zenoh-links/zenoh-link-serial/", optional = true }
+zenoh-link-tcp = { path = "../zenoh-links/zenoh-link-tcp/", optional = true }
+zenoh-link-tls = { path = "../zenoh-links/zenoh-link-tls/", optional = true }
+zenoh-link-udp = { path = "../zenoh-links/zenoh-link-udp/", optional = true }
+zenoh-link-unixsock_stream = { path = "../zenoh-links/zenoh-link-unixsock_stream/", optional = true }
+zenoh-link-ws = { path = "../zenoh-links/zenoh-link-ws/", optional = true }
+zenoh-protocol-core = { path = "../../commons/zenoh-protocol-core/" }

--- a/io/zenoh-links/zenoh-link-quic/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-quic/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.64"
 name = "zenoh-link-quic"
 version = "0.6.0-dev.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"
@@ -27,28 +28,27 @@ edition = "2018"
 license = " EPL-2.0 OR Apache-2.0"
 categories = ["network-programming"]
 description = "Internal crate for zenoh."
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zenoh-core = { path = "../../../commons/zenoh-core/" }
-zenoh-cfg-properties = { path = "../../../commons/zenoh-cfg-properties/" }
-zenoh-sync = { path = "../../../commons/zenoh-sync/" }
-zenoh-util = { path = "../../../commons/zenoh-util/" }
-zenoh-config = { path = "../../../commons/zenoh-config/" }
-zenoh-protocol-core = { path = "../../../commons/zenoh-protocol-core/" }
-
-zenoh-link-commons = { path = "../../zenoh-link-commons/" }
 
 async-std = { version = "=1.12.0", default-features = false, features = [
 	"unstable",
 	"tokio1",
 ] }
 async-trait = "0.1.57"
+futures = "0.3.24"
 log = "0.4.17"
 quinn = "0.8.5" 
 rustls = "0.20.6"
 rustls-native-certs = "0.6.2"
 rustls-pemfile = "1.0.1"
 webpki = { version = "0.22.0", features = ["std"] }
-futures = "0.3.24"
+zenoh-cfg-properties = { path = "../../../commons/zenoh-cfg-properties/" }
+zenoh-config = { path = "../../../commons/zenoh-config/" }
+zenoh-core = { path = "../../../commons/zenoh-core/" }
+
+zenoh-link-commons = { path = "../../zenoh-link-commons/" }
+zenoh-protocol-core = { path = "../../../commons/zenoh-protocol-core/" }
+zenoh-sync = { path = "../../../commons/zenoh-sync/" }
+zenoh-util = { path = "../../../commons/zenoh-util/" }

--- a/io/zenoh-links/zenoh-link-serial/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-serial/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.64"
 name = "zenoh-link-serial"
 version = "0.6.0-dev.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"
@@ -28,26 +29,25 @@ edition = "2018"
 license = " EPL-2.0 OR Apache-2.0"
 categories = ["network-programming"]
 description = "Internal crate for zenoh."
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zenoh-core = { path = "../../../commons/zenoh-core/" }
-zenoh-util = { path = "../../../commons/zenoh-util/" }
-zenoh-collections = { path = "../../../commons/zenoh-collections/" }
-zenoh-sync = { path = "../../../commons/zenoh-sync/" }
-zenoh-protocol-core = { path = "../../../commons/zenoh-protocol-core/" }
-zenoh-config = { path = "../../../commons/zenoh-config/" }
-zenoh-cfg-properties = { path = "../../../commons/zenoh-cfg-properties/" }
-zenoh-link-commons = { path = "../../zenoh-link-commons/" }
 
 async-std = { version = "=1.12.0", default-features = false, features = [
 	"unstable",
 	"tokio1",
 ] }
-tokio = { version = "1.21.1", default-features = false, features = ["io-std", "macros", "net", "rt-multi-thread", "time", "io-util"] }
 async-trait = "0.1.57"
-log = "0.4.17"
 futures = "0.3.24"
-z-serial = "0.2.0 "
+log = "0.4.17"
+tokio = { version = "1.21.1", default-features = false, features = ["io-std", "macros", "net", "rt-multi-thread", "time", "io-util"] }
 uuid = { version = "1.1.2", features = ["v4"] }
+z-serial = "0.2.0 "
+zenoh-cfg-properties = { path = "../../../commons/zenoh-cfg-properties/" }
+zenoh-collections = { path = "../../../commons/zenoh-collections/" }
+zenoh-config = { path = "../../../commons/zenoh-config/" }
+zenoh-core = { path = "../../../commons/zenoh-core/" }
+zenoh-link-commons = { path = "../../zenoh-link-commons/" }
+zenoh-protocol-core = { path = "../../../commons/zenoh-protocol-core/" }
+zenoh-sync = { path = "../../../commons/zenoh-sync/" }
+zenoh-util = { path = "../../../commons/zenoh-util/" }

--- a/io/zenoh-links/zenoh-link-tcp/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-tcp/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.64"
 name = "zenoh-link-tcp"
 version = "0.6.0-dev.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"
@@ -27,17 +28,16 @@ edition = "2018"
 license = " EPL-2.0 OR Apache-2.0"
 categories = ["network-programming"]
 description = "Internal crate for zenoh."
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zenoh-core = { path = "../../../commons/zenoh-core/" }
-zenoh-sync = { path = "../../../commons/zenoh-sync/" }
-zenoh-util = { path = "../../../commons/zenoh-util/" }
-zenoh-protocol-core = { path = "../../../commons/zenoh-protocol-core/" }
-
-zenoh-link-commons = { path = "../../zenoh-link-commons/" }
 
 async-std = { version = "=1.12.0", default-features = false }
 async-trait = "0.1.57"
 log = "0.4.17"
+zenoh-core = { path = "../../../commons/zenoh-core/" }
+
+zenoh-link-commons = { path = "../../zenoh-link-commons/" }
+zenoh-protocol-core = { path = "../../../commons/zenoh-protocol-core/" }
+zenoh-sync = { path = "../../../commons/zenoh-sync/" }
+zenoh-util = { path = "../../../commons/zenoh-util/" }

--- a/io/zenoh-links/zenoh-link-tls/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-tls/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.64"
 name = "zenoh-link-tls"
 version = "0.6.0-dev.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"
@@ -27,21 +28,20 @@ edition = "2018"
 license = " EPL-2.0 OR Apache-2.0"
 categories = ["network-programming"]
 description = "Internal crate for zenoh."
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zenoh-core = { path = "../../../commons/zenoh-core/" }
-zenoh-util = { path = "../../../commons/zenoh-util/" }
-zenoh-cfg-properties = { path = "../../../commons/zenoh-cfg-properties/" }
-zenoh-sync = { path = "../../../commons/zenoh-sync/" }
-zenoh-config = { path = "../../../commons/zenoh-config/" }
-zenoh-protocol-core = { path = "../../../commons/zenoh-protocol-core/" }
-
-zenoh-link-commons = { path = "../../zenoh-link-commons/" }
 
 async-rustls = { version = "=0.2.0" }
 async-std = { version = "=1.12.0", default-features = false }
 async-trait = "0.1.57"
-log = "0.4.17"
 futures = "0.3.24"
+log = "0.4.17"
+zenoh-cfg-properties = { path = "../../../commons/zenoh-cfg-properties/" }
+zenoh-config = { path = "../../../commons/zenoh-config/" }
+zenoh-core = { path = "../../../commons/zenoh-core/" }
+
+zenoh-link-commons = { path = "../../zenoh-link-commons/" }
+zenoh-protocol-core = { path = "../../../commons/zenoh-protocol-core/" }
+zenoh-sync = { path = "../../../commons/zenoh-sync/" }
+zenoh-util = { path = "../../../commons/zenoh-util/" }

--- a/io/zenoh-links/zenoh-link-udp/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-udp/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.64"
 name = "zenoh-link-udp"
 version = "0.6.0-dev.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"
@@ -27,19 +28,18 @@ edition = "2018"
 license = " EPL-2.0 OR Apache-2.0"
 categories = ["network-programming"]
 description = "Internal crate for zenoh."
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zenoh-core = { path = "../../../commons/zenoh-core/" }
-zenoh-util = { path = "../../../commons/zenoh-util/" }
-zenoh-collections = { path = "../../../commons/zenoh-collections/" }
-zenoh-sync = { path = "../../../commons/zenoh-sync/" }
-zenoh-protocol-core = { path = "../../../commons/zenoh-protocol-core/" }
-
-zenoh-link-commons = { path = "../../zenoh-link-commons/" }
 
 async-std = { version = "=1.12.0", default-features = false }
 async-trait = "0.1.57"
 log = "0.4.17"
 socket2 = "0.4.7"
+zenoh-collections = { path = "../../../commons/zenoh-collections/" }
+zenoh-core = { path = "../../../commons/zenoh-core/" }
+
+zenoh-link-commons = { path = "../../zenoh-link-commons/" }
+zenoh-protocol-core = { path = "../../../commons/zenoh-protocol-core/" }
+zenoh-sync = { path = "../../../commons/zenoh-sync/" }
+zenoh-util = { path = "../../../commons/zenoh-util/" }

--- a/io/zenoh-links/zenoh-link-unixsock_stream/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-unixsock_stream/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.64"
 name = "zenoh-link-unixsock_stream"
 version = "0.6.0-dev.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"
@@ -28,19 +29,18 @@ edition = "2018"
 license = " EPL-2.0 OR Apache-2.0"
 categories = ["network-programming"]
 description = "Internal crate for zenoh."
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zenoh-core = { path = "../../../commons/zenoh-core/" }
-zenoh-sync = { path = "../../../commons/zenoh-sync/" }
-zenoh-protocol-core = { path = "../../../commons/zenoh-protocol-core/" }
-
-zenoh-link-commons = { path = "../../zenoh-link-commons/" }
 
 async-std = { version = "=1.12.0", default-features = false }
 async-trait = "0.1.57"
+futures = "0.3.24"
 log = "0.4.17"
 nix = { version = "0.25.0" }
 uuid = { version = "1.1.2", features = ["v4"] }
-futures = "0.3.24"
+zenoh-core = { path = "../../../commons/zenoh-core/" }
+
+zenoh-link-commons = { path = "../../zenoh-link-commons/" }
+zenoh-protocol-core = { path = "../../../commons/zenoh-protocol-core/" }
+zenoh-sync = { path = "../../../commons/zenoh-sync/" }

--- a/io/zenoh-links/zenoh-link-ws/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-ws/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.64"
 name = "zenoh-link-ws"
 version = "0.6.0-dev.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"
@@ -28,23 +29,22 @@ edition = "2018"
 license = " EPL-2.0 OR Apache-2.0"
 categories = ["network-programming"]
 description = "Internal crate for zenoh."
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zenoh-core = { path = "../../../commons/zenoh-core/" }
-zenoh-sync = { path = "../../../commons/zenoh-sync/" }
-zenoh-util = { path = "../../../commons/zenoh-util/" }
-zenoh-protocol-core = { path = "../../../commons/zenoh-protocol-core/" }
-zenoh-link-commons = { path = "../../zenoh-link-commons/" }
 
 async-std = { version = "=1.12.0", default-features = false, features = [
 	"unstable",
 	"tokio1",
 ] }
-tokio-tungstenite = "0.17.2"
-tokio = { version = "1.21.1", default-features = false, features = ["io-std", "macros", "net", "rt-multi-thread", "time"] }
 async-trait = "0.1.57"
-log = "0.4.17"
 futures-util = { version = "0.3.24", default-features = false, features = ["sink", "std"] }
+log = "0.4.17"
+tokio = { version = "1.21.1", default-features = false, features = ["io-std", "macros", "net", "rt-multi-thread", "time"] }
+tokio-tungstenite = "0.17.2"
 url = "2.3.1"
+zenoh-core = { path = "../../../commons/zenoh-core/" }
+zenoh-link-commons = { path = "../../zenoh-link-commons/" }
+zenoh-protocol-core = { path = "../../../commons/zenoh-protocol-core/" }
+zenoh-sync = { path = "../../../commons/zenoh-sync/" }
+zenoh-util = { path = "../../../commons/zenoh-util/" }

--- a/io/zenoh-transport/Cargo.toml
+++ b/io/zenoh-transport/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.64"
 name = "zenoh-transport"
 version = "0.6.0-dev.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"
@@ -27,7 +28,6 @@ edition = "2018"
 license = " EPL-2.0 OR Apache-2.0"
 categories = ["network-programming"]
 description = "Internal crate for zenoh."
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
@@ -50,17 +50,6 @@ transport_serial = ["zenoh-link/transport_serial"]
 stats = []
 
 [dependencies]
-zenoh-cfg-properties = { path = "../../commons/zenoh-cfg-properties/" }
-zenoh-collections = { path = "../../commons/zenoh-collections/" }
-zenoh-core = { path = "../../commons/zenoh-core/" }
-zenoh-crypto = { path = "../../commons/zenoh-crypto/" }
-zenoh-sync = { path = "../../commons/zenoh-sync/" }
-zenoh-buffers = { path = "../../commons/zenoh-buffers/" }
-zenoh-config = { path = "../../commons/zenoh-config/" }
-zenoh-protocol-core = { path = "../../commons/zenoh-protocol-core/" }
-zenoh-protocol = { path = "../../commons/zenoh-protocol/" }
-
-zenoh-link = { path = "../zenoh-link/" }
 
 async-executor = "1.4.1"
 async-global-executor = "2.3.0"
@@ -73,6 +62,17 @@ rand = "0.8.3"
 ringbuffer-spsc = "0.1.6"
 rsa = { version = "0.6.1", optional = true }
 serde = "1.0.144"
+zenoh-buffers = { path = "../../commons/zenoh-buffers/" }
+zenoh-cfg-properties = { path = "../../commons/zenoh-cfg-properties/" }
+zenoh-collections = { path = "../../commons/zenoh-collections/" }
+zenoh-config = { path = "../../commons/zenoh-config/" }
+zenoh-core = { path = "../../commons/zenoh-core/" }
+zenoh-crypto = { path = "../../commons/zenoh-crypto/" }
+
+zenoh-link = { path = "../zenoh-link/" }
+zenoh-protocol = { path = "../../commons/zenoh-protocol/" }
+zenoh-protocol-core = { path = "../../commons/zenoh-protocol-core/" }
+zenoh-sync = { path = "../../commons/zenoh-sync/" }
 
 [dev-dependencies]
 env_logger = "0.9.1"

--- a/plugins/example-plugin/Cargo.toml
+++ b/plugins/example-plugin/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.64"
 name = "zplugin-example"
 version = "0.6.0-dev.0"
 authors = [
@@ -33,15 +34,14 @@ name = "zplugin_example"
 # This crate type will make `cargo` output a dynamic library instead of a rust static library
 crate-type = ["cdylib"]
 
-
 [dependencies]
 async-std = "=1.12.0"
 clap = "3.2.22"
 env_logger = "0.9.1"
 futures = "0.3.24"
 log = "0.4.17"
-zenoh = { path = "../../zenoh", default-features = false}
-zenoh-util = { path = "../../commons/zenoh-util" }
+serde_json = "1.0.85"
+zenoh = { path = "../../zenoh", default-features = false }
 zenoh-core = { path = "../../commons/zenoh-core/" }
 zenoh-plugin-trait = { path = "../zenoh-plugin-trait" }
-serde_json = "1.0.85"
+zenoh-util = { path = "../../commons/zenoh-util" }

--- a/plugins/zenoh-backend-traits/Cargo.toml
+++ b/plugins/zenoh-backend-traits/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.64"
 name = "zenoh_backend_traits"
 version = "0.6.0-dev.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"

--- a/plugins/zenoh-plugin-rest/Cargo.toml
+++ b/plugins/zenoh-plugin-rest/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.64"
 name = "zenoh-plugin-rest"
 version = "0.6.0-dev.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"
@@ -32,11 +33,9 @@ description = "The zenoh REST plugin"
 no_mangle = ["zenoh-plugin-trait/no_mangle"]
 default = ["no_mangle"]
 
-
 [lib]
 name = "zplugin_rest"
 crate-type = ["cdylib", "rlib"]
-
 
 [dependencies]
 anyhow = "1.0.65"
@@ -48,16 +47,16 @@ flume = "0.10.14"
 futures = "0.3.24"
 git-version = "0.3.5"
 http-types = "2.12.0"
+lazy_static = "1.4.0"
 log = "0.4.17"
 serde = "1.0.144"
 serde_json = "1.0.85"
 tide = "0.16.0"
-lazy_static = "1.4.0"
-zenoh = { path = "../../zenoh/" , default-features = false }
-zenoh-util = { path = "../../commons/zenoh-util/" }
-zenoh-core = { path = "../../commons/zenoh-core/" }
+zenoh = { path = "../../zenoh/", default-features = false }
 zenoh-cfg-properties = { path = "../../commons/zenoh-cfg-properties" }
+zenoh-core = { path = "../../commons/zenoh-core/" }
 zenoh-plugin-trait = { path = "../zenoh-plugin-trait", default-features = false }
+zenoh-util = { path = "../../commons/zenoh-util/" }
 
 [build-dependencies]
 rustc_version = "0.4.0"

--- a/plugins/zenoh-plugin-storage-manager/Cargo.toml
+++ b/plugins/zenoh-plugin-storage-manager/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.64"
 name = "zenoh-plugin-storage-manager"
 version = "0.6.0-dev.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"
@@ -35,28 +36,27 @@ default = ["no_mangle"]
 name = "zplugin_storage_manager"
 crate-type = ["cdylib"]
 
-
 [dependencies]
 async-std = "=1.12.0"
 async-trait = "0.1.57"
 clap = "3.2.22"
+crc = "3.0.0"
+derive-new = "0.5.9"
 env_logger = "0.9.1"
+flume = "0.10.14"
 futures = "0.3.24"
 git-version = "0.3.5"
+lazy_static = "1.4.0"
 libloading = "0.7.3"
 log = "0.4.17"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.85"
-crc = "3.0.0"
-derive-new = "0.5.9"
-flume = "0.10.14"
 urlencoding = "2.1.2"
-lazy_static = "1.4.0"
-zenoh = { path = "../../zenoh/" , default-features = false }
+zenoh = { path = "../../zenoh/", default-features = false }
+zenoh-collections = { path = "../../commons/zenoh-collections/" }
+zenoh-core = { path = "../../commons/zenoh-core/" }
 zenoh-plugin-trait = { path = "../zenoh-plugin-trait", default-features = false }
 zenoh-util = { path = "../../commons/zenoh-util" }
-zenoh-core = { path = "../../commons/zenoh-core/" }
-zenoh-collections = { path = "../../commons/zenoh-collections/" }
 zenoh_backend_traits = { path = "../zenoh-backend-traits/" }
 
 [build-dependencies]

--- a/plugins/zenoh-plugin-trait/Cargo.toml
+++ b/plugins/zenoh-plugin-trait/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.64"
 name = "zenoh-plugin-trait"
 version = "0.6.0-dev.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"
@@ -36,9 +37,9 @@ no_mangle = []
 default = ["no_mangle"]
 
 [dependencies]
-zenoh-core = { path = "../../commons/zenoh-core/" }
-zenoh-util = { path = "../../commons/zenoh-util" }
-zenoh-macros = { path = "../../commons/zenoh-macros/" }
 libloading = "0.7.3"
 log = "0.4.17"
 serde_json = "1.0.85"
+zenoh-core = { path = "../../commons/zenoh-core/" }
+zenoh-macros = { path = "../../commons/zenoh-macros/" }
+zenoh-util = { path = "../../commons/zenoh-util" }

--- a/zenoh-ext/Cargo.toml
+++ b/zenoh-ext/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.64"
 name = "zenoh-ext"
 version = "0.6.0-dev.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"
@@ -41,14 +42,13 @@ futures = "0.3.24"
 log = "0.4.17"
 serde = "1.0.144"
 zenoh = { path = "../zenoh", default-features = false, features = ["unstable"] }
-zenoh-util = { path = "../commons/zenoh-util" }
-zenoh-sync = { path = "../commons/zenoh-sync" }
 zenoh-core = { path = "../commons/zenoh-core/" }
+zenoh-sync = { path = "../commons/zenoh-sync" }
+zenoh-util = { path = "../commons/zenoh-util" }
 
 [dev-dependencies]
 clap = "3.2.22"
 env_logger = "0.9.1"
-
 
 [[example]]
 name = "z_query_sub"

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.64"
 name = "zenoh"
 version = "0.6.0-dev.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"
@@ -28,7 +29,6 @@ license = " EPL-2.0 OR Apache-2.0"
 categories = ["network-programming"]
 description = "Zenoh: Zero Overhead Pub/sub, Store/Query and Compute."
 readme = "../README.md"
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [badges]
@@ -64,21 +64,6 @@ default = [
 ]
 
 [dependencies]
-zenoh-core = { path = "../commons/zenoh-core/" }
-zenoh-crypto = { path = "../commons/zenoh-crypto/" }
-zenoh-cfg-properties = { path = "../commons/zenoh-cfg-properties/" }
-zenoh-collections = { path = "../commons/zenoh-collections/" }
-zenoh-sync = { path = "../commons/zenoh-sync/" }
-zenoh-util = { path = "../commons/zenoh-util" }
-zenoh-buffers = { path = "../commons/zenoh-buffers/" }
-zenoh-config = { path = "../commons/zenoh-config/" }
-zenoh-protocol-core = { path = "../commons/zenoh-protocol-core/" }
-zenoh-protocol = { path = "../commons/zenoh-protocol/" }
-
-zenoh-link = { path = "../io/zenoh-link/" }
-zenoh-transport = { path = "../io/zenoh-transport/" }
-
-zenoh-plugin-trait = { path = "../plugins/zenoh-plugin-trait", default-features = false }
 
 async-global-executor = "2.3.0"
 async-std = { version = "=1.12.0", default-features = false, features = [
@@ -88,9 +73,9 @@ async-trait = "0.1.57"
 base64 = "0.13.0"
 env_logger = "0.9.1"
 event-listener = "2.5.3"
+flume = "0.10.14"
 form_urlencoded = "1.1.0"
 futures = "0.3.24"
-flume = "0.10.14"
 git-version = "0.3.5"
 hex = "0.4.3"
 lazy_static = "1.4.0"
@@ -99,13 +84,28 @@ ordered-float = "3.1.0"
 petgraph = "0.6.2"
 rand = "0.8.5"
 regex = "1.6.0"
-serde_json = "1.0.85"
 serde = "1.0.123"
+serde_json = "1.0.85"
 socket2 = "0.4.0"
 stop-token = "0.7.0"
 uhlc = "0.5.0"
 uuid = { version = "1.1.2", features = ["v4"] }
 vec_map = "0.8.2"
+zenoh-buffers = { path = "../commons/zenoh-buffers/" }
+zenoh-cfg-properties = { path = "../commons/zenoh-cfg-properties/" }
+zenoh-collections = { path = "../commons/zenoh-collections/" }
+zenoh-config = { path = "../commons/zenoh-config/" }
+zenoh-core = { path = "../commons/zenoh-core/" }
+zenoh-crypto = { path = "../commons/zenoh-crypto/" }
+
+zenoh-link = { path = "../io/zenoh-link/" }
+
+zenoh-plugin-trait = { path = "../plugins/zenoh-plugin-trait", default-features = false }
+zenoh-protocol = { path = "../commons/zenoh-protocol/" }
+zenoh-protocol-core = { path = "../commons/zenoh-protocol-core/" }
+zenoh-sync = { path = "../commons/zenoh-sync/" }
+zenoh-transport = { path = "../io/zenoh-transport/" }
+zenoh-util = { path = "../commons/zenoh-util" }
 
 [build-dependencies]
 rustc_version = "0.4.0"

--- a/zenohd/Cargo.toml
+++ b/zenohd/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.64"
 name = "zenohd"
 version = "0.6.0-dev.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"
@@ -28,16 +29,12 @@ license = " EPL-2.0 OR Apache-2.0"
 categories = ["network-programming"]
 description = "Zenoh: Zero Overhead Pub/sub, Store/Query and Compute."
 readme = "README.md"
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
 shared-memory = ["zenoh/shared-memory"]
 
 [dependencies]
-zenoh = { path = "../zenoh/", features = [
-	"unstable",
-], default-features = false }
 
 async-std = { version = "=1.12.0", default-features = false, features = [
 	"attributes",
@@ -49,6 +46,9 @@ git-version = "0.3.5"
 json5 = "0.4.1"
 lazy_static = "1.4.0"
 log = "0.4.17"
+zenoh = { path = "../zenoh/", features = [
+	"unstable",
+], default-features = false }
 
 [dev-dependencies]
 rand = "0.8.5"


### PR DESCRIPTION
As announced in the latest [Rust 1.64](https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html) release, the trait `IntoFuture` has been finally finalised. 

Since Zenoh API adopts a builder pattern, it would be highly beneficial for the async API to implement the `IntoFuture` trait for the sake of API ergonomics.