### PR TITLE
New config: "adminspace.permissions"

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -89,100 +89,6 @@
 //        // key_expression
 //      ],
 //  },
-//
-//  /// Directories where plugins configured by name should be looked for. PLugins configured by __path__ are not subject to lookup
-//  plugins_search_dirs: [],
-//  /// Plugins are only loaded if present in the configuration. When starting
-//  /// Once loaded, they may react to changes in the configuration made through the zenoh instance's adminspace.
-//  plugins: {
-//    /// If no `__path__` is given to a plugin, zenohd will automatically search for a shared library matching the plugin's name (here, `libzplugin_rest.so` would be searched for on linux)
-//
-//    /// Configure the REST API plugin
-//    rest: {
-//      /// Setting this option to true allows zenohd to panic should it detect issues with this plugin. Setting it to false politely asks the plugin not to panic.
-//      __required__: true, // defaults to false
-//      http_port: 8000,
-//    },
-//
-//    /// Configure the storage manager plugin
-//    storage_manager: {
-//      /// When a path is present, automatic search is disabled, and zenohd will instead select the first path which manages to load.
-//      __path__: [
-//        "./target/release/libzplugin_storage_manager.so",
-//        "./target/release/libzplugin_storage_manager.dylib",
-//      ],
-//      /// The "memory" volume is always available, but you may create other volumes here, with various backends to support the actual storing.
-//      volumes: {
-//        /// An influxdb backend is also available at https://github.com/eclipse-zenoh/zenoh-backend-influxdb
-//        influxdb: {
-//          url: "https://myinfluxdb.example",
-//          /// Some plugins may need passwords in their configuration.
-//          /// To avoid leaking them through the adminspace, they may be masked behind a privacy barrier.
-//          /// any value held at the key "private" will not be shown in the adminspace.
-//          private: {
-//            username: "user1",
-//            password: "pw1",
-//          },
-//        },
-//        influxdb2: {
-//          /// A second backend of the same type can be spawned using `__path__`, for examples when different DBs are needed.
-//          backend: "influxdb",
-//          private: {
-//            username: "user2",
-//            password: "pw2",
-//          },
-//          url: "https://localhost:8086",
-//        },
-//      },
-//
-//      /// Configure the storages supported by the volumes
-//      storages: {
-//        demo: {
-//          /// Storages always need to know what set of keys they must work with. These sets are defined by a key expression.
-//          key_expr: "demo/memory/**",
-//          /// Storages also need to know which volume will be used to actually store their key-value pairs.
-//          /// The "memory" volume is always available, and doesn't require any per-storage options, so requesting "memory" by string is always sufficient.
-//          volume: "memory",
-//        },
-//        demo2: {
-//          key_expr: "demo/memory2/**",
-//          volume: "memory",
-//          /// If multiple storages subscribing to the same key_expr should be synchronized, declare them as replicas.
-//          /// In the absence of this configuration, a normal storage is initialized
-//          /// Note: all the samples to be stored in replicas should be timestamped
-//          replica_config: {
-//            /// Specifying the parameters is optional, by default the values provided will be used.
-//            /// Time interval between different synchronization attempts in seconds
-//            publication_interval: 5,
-//            /// Expected propagation delay of the network in milliseconds
-//            propagation_delay: 200,
-//            /// This is the chunk that you would like your data to be divide into in time, in milliseconds.
-//            /// Higher the frequency of updates, lower the delta should be chosen
-//            /// To be efficient, delta should be the time containing no more than 100,000 samples
-//            delta: 1000,
-//          }        
-//        },
-//        influx_demo: {
-//          key_expr: "demo/influxdb/**",
-//          /// This prefix will be stripped of the received keys when storing.
-//          strip_prefix: "demo/influxdb",
-//          /// influxdb-backed volumes need a bit more configuration, which is passed like-so:
-//          volume: {
-//            id: "influxdb",
-//            db: "example",
-//          },
-//        },
-//        influx_demo2: {
-//          key_expr: "demo/influxdb2/**",
-//          strip_prefix: "demo/influxdb2",
-//          volume: {
-//            id: "influxdb2",
-//            db: "example",
-//          },
-//        },
-//      },
-//    },
-//  },
 
   /// Configure internal transport parameters
   transport: {
@@ -289,5 +195,113 @@
         known_keys_file: null,
       },
     },
+    /// Admin Space configuration
+    /// [unstable]: this configuration part might change in the future
+    adminspace: {
+      // read and/or wirte permissions on the admin space
+      permissions: {
+        read: true,
+        write: false,
+
+    },
   },
+
+    ///
+    /// Plugins configurations
+    ///
+
+//  /// Directories where plugins configured by name should be looked for. PLugins configured by __path__ are not subject to lookup
+//  plugins_search_dirs: [],
+//  /// Plugins are only loaded if present in the configuration. When starting
+//  /// Once loaded, they may react to changes in the configuration made through the zenoh instance's adminspace.
+//  plugins: {
+//    /// If no `__path__` is given to a plugin, zenohd will automatically search for a shared library matching the plugin's name (here, `libzplugin_rest.so` would be searched for on linux)
+//
+//    /// Configure the REST API plugin
+//    rest: {
+//      /// Setting this option to true allows zenohd to panic should it detect issues with this plugin. Setting it to false politely asks the plugin not to panic.
+//      __required__: true, // defaults to false
+//      http_port: 8000,
+//    },
+//
+//    /// Configure the storage manager plugin
+//    storage_manager: {
+//      /// When a path is present, automatic search is disabled, and zenohd will instead select the first path which manages to load.
+//      __path__: [
+//        "./target/release/libzplugin_storage_manager.so",
+//        "./target/release/libzplugin_storage_manager.dylib",
+//      ],
+//      /// The "memory" volume is always available, but you may create other volumes here, with various backends to support the actual storing.
+//      volumes: {
+//        /// An influxdb backend is also available at https://github.com/eclipse-zenoh/zenoh-backend-influxdb
+//        influxdb: {
+//          url: "https://myinfluxdb.example",
+//          /// Some plugins may need passwords in their configuration.
+//          /// To avoid leaking them through the adminspace, they may be masked behind a privacy barrier.
+//          /// any value held at the key "private" will not be shown in the adminspace.
+//          private: {
+//            username: "user1",
+//            password: "pw1",
+//          },
+//        },
+//        influxdb2: {
+//          /// A second backend of the same type can be spawned using `__path__`, for examples when different DBs are needed.
+//          backend: "influxdb",
+//          private: {
+//            username: "user2",
+//            password: "pw2",
+//          },
+//          url: "https://localhost:8086",
+//        },
+//      },
+//
+//      /// Configure the storages supported by the volumes
+//      storages: {
+//        demo: {
+//          /// Storages always need to know what set of keys they must work with. These sets are defined by a key expression.
+//          key_expr: "demo/memory/**",
+//          /// Storages also need to know which volume will be used to actually store their key-value pairs.
+//          /// The "memory" volume is always available, and doesn't require any per-storage options, so requesting "memory" by string is always sufficient.
+//          volume: "memory",
+//        },
+//        demo2: {
+//          key_expr: "demo/memory2/**",
+//          volume: "memory",
+//          /// If multiple storages subscribing to the same key_expr should be synchronized, declare them as replicas.
+//          /// In the absence of this configuration, a normal storage is initialized
+//          /// Note: all the samples to be stored in replicas should be timestamped
+//          replica_config: {
+//            /// Specifying the parameters is optional, by default the values provided will be used.
+//            /// Time interval between different synchronization attempts in seconds
+//            publication_interval: 5,
+//            /// Expected propagation delay of the network in milliseconds
+//            propagation_delay: 200,
+//            /// This is the chunk that you would like your data to be divide into in time, in milliseconds.
+//            /// Higher the frequency of updates, lower the delta should be chosen
+//            /// To be efficient, delta should be the time containing no more than 100,000 samples
+//            delta: 1000,
+//          }        
+//        },
+//        influx_demo: {
+//          key_expr: "demo/influxdb/**",
+//          /// This prefix will be stripped of the received keys when storing.
+//          strip_prefix: "demo/influxdb",
+//          /// influxdb-backed volumes need a bit more configuration, which is passed like-so:
+//          volume: {
+//            id: "influxdb",
+//            db: "example",
+//          },
+//        },
+//        influx_demo2: {
+//          key_expr: "demo/influxdb2/**",
+//          strip_prefix: "demo/influxdb2",
+//          volume: {
+//            id: "influxdb2",
+//            db: "example",
+//          },
+//        },
+//      },
+//    },
+//  },
+
 }

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -195,21 +195,21 @@
         known_keys_file: null,
       },
     },
-    /// Admin Space configuration
-    /// [unstable]: this configuration part might change in the future
-    adminspace: {
-      // read and/or wirte permissions on the admin space
-      permissions: {
-        read: true,
-        write: false,
+  },
 
+  /// Configure the Admin Space
+  /// [unstable]: this configuration part might change in the future
+  adminspace: {
+    // read and/or write permissions on the admin space
+    permissions: {
+      read: true,
+      write: false,
     },
   },
 
-    ///
-    /// Plugins configurations
-    ///
-
+  ///
+  /// Plugins configurations
+  ///
 //  /// Directories where plugins configured by name should be looked for. PLugins configured by __path__ are not subject to lookup
 //  plugins_search_dirs: [],
 //  /// Plugins are only loaded if present in the configuration. When starting
@@ -280,7 +280,7 @@
 //            /// Higher the frequency of updates, lower the delta should be chosen
 //            /// To be efficient, delta should be the time containing no more than 100,000 samples
 //            delta: 1000,
-//          }        
+//          }
 //        },
 //        influx_demo: {
 //          key_expr: "demo/influxdb/**",

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ To access the v0.5 version of the code and matching README, please go to the [0.
       `curl http://localhost:8000/demo/example/test`
 
   - **router admin space via the REST API**
-    - run the zenoh router with a memory storage:  
-      `./target/release/zenohd --cfg='plugins/storage_manager/storages/demo:{key_expr:"demo/example/**",volume:"memory"}'`
+    - run the zenoh router with permission to perform config changes via the admin space, and with a memory storage:  
+      `./target/release/zenohd --adminspace-permissions=rw --cfg='plugins/storage_manager/storages/demo:{key_expr:"demo/example/**",volume:"memory"}'`
     - in another shell, get info of the zenoh router via the zenoh admin space:  
       `curl http://localhost:8000/@/router/local`
     - get the volumes of the router (only memory by default):  
@@ -90,6 +90,7 @@ See other examples of zenoh usage in [examples/](examples)
 ## zenoh router command line arguments
 `zenohd` accepts the following arguments:
 
+  * `--adminspace-permissions <[r|w|rw|none]>`: Configure the read and/or write permissions on the admin space. Default is read only.
   * `-c, --config <FILE>`: a [JSON5](https://json5.org) configuration file. [DEFAULT_CONFIG.json5](DEFAULT_CONFIG.json5) shows the schema of this file. All properties of this configuration are optional, so you may not need such a large configuration for your use-case.
   * `--cfg <KEY>:<VALUE>` : allows you to change specific parts of the configuration right after it has been constructed. VALUE must be a valid JSON5 value, and key must be a path through the configuration file, where each element is separated by a `/`. When inserting in parts of the config that are arrays, you may use indexes, or may use `+` to indicate that you want to append your value to the array. `--cfg` passed values will always override any previously existing value for their key in the configuration.
   * `-l, --listen <ENDPOINT>...`: An endpoint on which this router will listen for incoming sessions. 

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -292,6 +292,12 @@ validated_struct::validator! {
                 },
             },
         },
+        /// Configuration of the admin space.
+        pub adminspace:
+        AdminSpaceConf {
+            /// Whether the admin space accepts config changes at runtime.
+            readonly: bool,
+        },
         /// A list of directories where plugins may be searched for if no `__path__` was specified for them.
         /// The executable's current directory will be added to the search paths.
         plugins_search_dirs: Vec<String>, // TODO (low-prio): Switch this String to a PathBuf? (applies to other paths in the config as well)
@@ -300,6 +306,12 @@ validated_struct::validator! {
         ///
         /// Please refer to [`PluginsConfig`]'s documentation for further details.
         plugins: PluginsConfig,
+    }
+}
+
+impl Default for AdminSpaceConf {
+    fn default() -> Self {
+        AdminSpaceConf { readonly:true }
     }
 }
 

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -293,10 +293,11 @@ validated_struct::validator! {
             },
         },
         /// Configuration of the admin space.
-        pub adminspace:
+        pub adminspace: #[derive(Default)]
         AdminSpaceConf {
-            /// Whether the admin space accepts config changes at runtime.
-            readonly: bool,
+            /// Whether the admin space accepts config changes at runtime (false by default).
+            /// [unstable]: this configuration may change in the future.
+            changes: bool,
         },
         /// A list of directories where plugins may be searched for if no `__path__` was specified for them.
         /// The executable's current directory will be added to the search paths.
@@ -306,12 +307,6 @@ validated_struct::validator! {
         ///
         /// Please refer to [`PluginsConfig`]'s documentation for further details.
         plugins: PluginsConfig,
-    }
-}
-
-impl Default for AdminSpaceConf {
-    fn default() -> Self {
-        AdminSpaceConf { readonly:true }
     }
 }
 

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -293,11 +293,20 @@ validated_struct::validator! {
             },
         },
         /// Configuration of the admin space.
+        /// [unstable]: this configuration may change in the future.
         pub adminspace: #[derive(Default)]
         AdminSpaceConf {
-            /// Whether the admin space accepts config changes at runtime (false by default).
-            /// [unstable]: this configuration may change in the future.
-            changes: bool,
+            /// Perimissions on the admin space
+            pub permissions:
+            PermissionsConf {
+                /// Whether the admin space replies to queries (true by default).
+                #[serde(default = "set_true")]
+                pub read: bool,
+                /// Whether the admin space accepts config changes at runtime (false by default).
+                #[serde(default = "set_false")]
+                pub write: bool,
+            },
+
         },
         /// A list of directories where plugins may be searched for if no `__path__` was specified for them.
         /// The executable's current directory will be added to the search paths.
@@ -308,6 +317,22 @@ validated_struct::validator! {
         /// Please refer to [`PluginsConfig`]'s documentation for further details.
         plugins: PluginsConfig,
     }
+}
+
+impl Default for PermissionsConf {
+    fn default() -> Self {
+        PermissionsConf {
+            read: true,
+            write: false,
+        }
+    }
+}
+
+fn set_true() -> bool {
+    true
+}
+fn set_false() -> bool {
+    false
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -309,9 +309,9 @@ impl Primitives for AdminSpace {
 
         {
             let conf = self.context.runtime.config.lock();
-            if !*conf.adminspace.changes() {
-                error!(
-                    "Received PUT on '{}' but adminspace doesn't accept configuration changes!",
+            if !conf.adminspace.permissions().write {
+                log::error!(
+                    "Received PUT on '{}' but adminspace.permissions.write=false in configuration",
                     key_expr
                 );
                 return;
@@ -382,13 +382,29 @@ impl Primitives for AdminSpace {
             target,
             _consolidation
         );
+        let primitives = zlock!(self.primitives).as_ref().unwrap().clone();
+
+        {
+            let conf = self.context.runtime.config.lock();
+            if !conf.adminspace.permissions().read {
+                log::error!(
+                    "Received GET on '{}' but adminspace.permissions.read=false in configuration",
+                    key_expr
+                );
+                // router is not re-entrant
+                task::spawn(async move {
+                    primitives.send_reply_final(qid);
+                });
+                return;
+            }
+        }
+
         let zid = self.zid;
         let plugin_key: OwnedKeyExpr = format!("@/router/{}/status/plugins/**", &zid)
             .try_into()
             .unwrap();
         let mut ask_plugins = false;
         let context = self.context.clone();
-        let primitives = zlock!(self.primitives).as_ref().unwrap().clone();
 
         let mut matching_handlers = vec![];
         match self.key_expr_to_string(key_expr) {

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -309,9 +309,9 @@ impl Primitives for AdminSpace {
 
         {
             let conf = self.context.runtime.config.lock();
-            if *conf.adminspace.readonly() {
+            if !*conf.adminspace.changes() {
                 error!(
-                    "Received PUT on '{}' but adminspace is read-only!",
+                    "Received PUT on '{}' but adminspace doesn't accept configuration changes!",
                     key_expr
                 );
                 return;

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -307,6 +307,17 @@ impl Primitives for AdminSpace {
             data_info,
         );
 
+        {
+            let conf = self.context.runtime.config.lock();
+            if *conf.adminspace.readonly() {
+                error!(
+                    "Received PUT on '{}' but adminspace is read-only!",
+                    key_expr
+                );
+                return;
+            }
+        }
+
         if let Some(key) = key_expr
             .as_str()
             .strip_prefix(&format!("@/router/{}/config/", &self.context.zid_str))

--- a/zenohd/src/main.rs
+++ b/zenohd/src/main.rs
@@ -66,7 +66,8 @@ r#"Allows arbitrary configuration changes as column-separated KEY:VALUE pairs, w
   - VALUE must be a valid JSON5 string that can be deserialized to the expected type for the KEY field.
 Examples:
 --cfg='startup/subscribe:["demo/**"]'
---cfg='plugins/storage_manager/storages/demo:{key_expr:"demo/example/**",volume:"memory"}'"#)
+--cfg='plugins/storage_manager/storages/demo:{key_expr:"demo/example/**",volume:"memory"}'"#),
+clap::arg!(--"adminspace-changes" r"By default zenohd doesn't accept any runtime configuration changes via its admin space. This option allows such changes"),
                 ]
             );
         let args = app.get_matches();
@@ -234,6 +235,9 @@ fn config_from_args(args: &ArgMatches) -> Config {
             config.scouting.multicast.set_enabled(Some(true)).unwrap();
         }
         (false, false) => {}
+    };
+    if args.is_present("adminspace-changes") {
+        config.adminspace.set_changes(true).unwrap();
     };
     for json in args.values_of("cfg").unwrap_or_default() {
         if let Some((key, value)) = json.split_once(':') {


### PR DESCRIPTION
This PR adds a new configuration:
```json5
{
  adminspace: {
    permissions: {
      read: true,
      write: false,
  }
}
```
The equivalent command line option for `zenohd` is `--adminspace-permissions=<[r|w|rw|none]>`.

By default the admin space is now read only, meaning that by default configuration changes at runtime is no longer possible (including loading of plugins and backends libraries).

