### PR TITLE
impl ValidatedMap for &Notifier<T>

### DIFF
--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -344,8 +344,7 @@ impl Primitives for AdminSpace {
                             key,
                             json
                         );
-                        if let Err(e) = self.context.runtime.config.clone().insert_json5(key, json)
-                        {
+                        if let Err(e) = (&self.context.runtime.config).insert_json5(key, json) {
                             error!(
                                 "Error inserting conf value /@/router/{}/config/{}:{} - {}",
                                 &self.context.zid_str, key, json, e

--- a/zenoh/src/session.rs
+++ b/zenoh/src/session.rs
@@ -461,8 +461,7 @@ impl Session {
     /// use r#async::AsyncResolve;
     ///
     /// let session = zenoh::open(config::peer()).res().await.unwrap();
-    /// let mut config = session.config().clone();
-    /// let _ = config.insert_json5("connect/endpoints", r#"["tcp/127.0.0.1/7447"]"#);
+    /// let _ = session.config().insert_json5("connect/endpoints", r#"["tcp/127.0.0.1/7447"]"#);
     /// # })
     /// ```
     pub fn config(&self) -> &Notifier<Config> {


### PR DESCRIPTION
As described in #316, the trait could be implemented for immutable references, discarding the need for mutable references (cloned or transmuted) to the Notifier directly.