### PR TITLE
Faster mutex macros

### DIFF
--- a/commons/zenoh-core/src/macros.rs
+++ b/commons/zenoh-core/src/macros.rs
@@ -18,10 +18,7 @@
 #[macro_export]
 macro_rules! zlock {
     ($var:expr) => {
-        match $var.try_lock() {
-            Ok(guard) => guard,
-            Err(_) => $var.lock().unwrap(),
-        }
+        $var.lock().unwrap()
     };
 }
 
@@ -31,10 +28,7 @@ macro_rules! zlock {
 #[macro_export]
 macro_rules! zread {
     ($var:expr) => {
-        match $var.try_read() {
-            Ok(guard) => guard,
-            Err(_) => $var.read().unwrap(),
-        }
+        $var.read().unwrap()
     };
 }
 
@@ -44,10 +38,7 @@ macro_rules! zread {
 #[macro_export]
 macro_rules! zwrite {
     ($var:expr) => {
-        match $var.try_write() {
-            Ok(guard) => guard,
-            Err(_) => $var.write().unwrap(),
-        }
+        $var.write().unwrap()
     };
 }
 


### PR DESCRIPTION
The `zlock`, `zread` and `zwrite` macros were written long ago. The stdlib has improved and now does the `try_lock` trick that these macros implement internally.

When benched alone, these macros yielded 10-20% worse performance than simply calling the `lock` method.

On my machine, this modification to the macros yields a 1-2% increase in throughput. This might be noise though, as my machine has a noisy CPU. Requesting @Mallets to try it out on c18 to judge whether this is worth it.