### PR TITLE
Fix lifetimes for put/delete and KeyExpr construction

### DIFF
--- a/zenoh/src/key_expr.rs
+++ b/zenoh/src/key_expr.rs
@@ -300,7 +300,7 @@ impl<'a> From<&'a keyexpr> for KeyExpr<'a> {
         Self(KeyExprInner::Borrowed(ke))
     }
 }
-impl From<OwnedKeyExpr> for KeyExpr<'static> {
+impl<'a> From<OwnedKeyExpr> for KeyExpr<'a> {
     fn from(v: OwnedKeyExpr) -> Self {
         Self(KeyExprInner::Owned(v))
     }
@@ -350,7 +350,7 @@ impl<'a> From<KeyExpr<'a>> for String {
         }
     }
 }
-impl TryFrom<String> for KeyExpr<'static> {
+impl<'a> TryFrom<String> for KeyExpr<'a> {
     type Error = zenoh_core::Error;
     fn try_from(value: String) -> Result<Self, Self::Error> {
         Ok(Self(KeyExprInner::Owned(value.try_into()?)))

--- a/zenoh/src/session.rs
+++ b/zenoh/src/session.rs
@@ -678,14 +678,14 @@ impl Session {
     /// # })
     /// ```
     #[inline]
-    pub fn put<'a, TryIntoKeyExpr, IntoValue>(
+    pub fn put<'a, 'b: 'a, TryIntoKeyExpr, IntoValue>(
         &'a self,
         key_expr: TryIntoKeyExpr,
         value: IntoValue,
-    ) -> PutBuilder<'a, 'a>
+    ) -> PutBuilder<'a, 'b>
     where
-        TryIntoKeyExpr: TryInto<KeyExpr<'a>>,
-        <TryIntoKeyExpr as TryInto<KeyExpr<'a>>>::Error: Into<zenoh_core::Error>,
+        TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
+        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_core::Error>,
         IntoValue: Into<Value>,
     {
         PutBuilder {
@@ -711,10 +711,13 @@ impl Session {
     /// # })
     /// ```
     #[inline]
-    pub fn delete<'a, TryIntoKeyExpr>(&'a self, key_expr: TryIntoKeyExpr) -> DeleteBuilder<'a, 'a>
+    pub fn delete<'a, 'b: 'a, TryIntoKeyExpr>(
+        &'a self,
+        key_expr: TryIntoKeyExpr,
+    ) -> DeleteBuilder<'a, 'b>
     where
-        TryIntoKeyExpr: TryInto<KeyExpr<'a>>,
-        <TryIntoKeyExpr as TryInto<KeyExpr<'a>>>::Error: Into<zenoh_core::Error>,
+        TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
+        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_core::Error>,
     {
         PutBuilder {
             publisher: self.declare_publisher(key_expr),
@@ -743,7 +746,7 @@ impl Session {
     /// }
     /// # })
     /// ```
-    pub fn get<'a, 'b, IntoSelector>(
+    pub fn get<'a, 'b: 'a, IntoSelector>(
         &'a self,
         selector: IntoSelector,
     ) -> GetBuilder<'a, 'b, DefaultHandler>


### PR DESCRIPTION
`session.put(owned_ke)` would require a static borrow of the session if owned_ke's type only implemented `TryInto<KeyExpr<'static>>`, causing strange borrowing issues