### PR TITLE
Tries multiple entries on DNS lookup when opening TCP or UDP link

### DIFF
--- a/commons/zenoh-protocol-core/src/endpoints.rs
+++ b/commons/zenoh-protocol-core/src/endpoints.rs
@@ -58,8 +58,9 @@ impl From<EndPoint> for String {
 impl EndPoint {
     #[must_use = "returns true on success"]
     pub fn set_addr(&mut self, addr: &str) -> bool {
-        unsafe { std::mem::transmute::<_, &mut Locator>(self) }.set_addr(addr)
+        self.locator.set_addr(addr)
     }
+
     pub fn extend_configuration(&mut self, extension: impl IntoIterator<Item = (String, String)>) {
         match self.config.is_some() {
             true => match &mut self.config {

--- a/io/zenoh-links/zenoh-link-tcp/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/lib.rs
@@ -22,7 +22,7 @@ use async_trait::async_trait;
 use std::net::SocketAddr;
 use zenoh_link_commons::LocatorInspector;
 
-use zenoh_core::{bail, zconfigurable, Result as ZResult};
+use zenoh_core::{zconfigurable, Result as ZResult};
 use zenoh_protocol_core::Locator;
 
 mod unicast;
@@ -63,10 +63,7 @@ zconfigurable! {
     static ref TCP_ACCEPT_THROTTLE_TIME: u64 = 100_000;
 }
 
-pub async fn get_tcp_addr(address: &Locator) -> ZResult<SocketAddr> {
-    let mut addrs = address.address().to_socket_addrs().await?;
-    match addrs.next() {
-        Some(address) => Ok(address),
-        None => bail!("Couldn't resolve TCP locator address: {}", address),
-    }
+pub async fn get_tcp_addrs(address: &Locator) -> ZResult<Vec<SocketAddr>> {
+    let addrs = address.address().to_socket_addrs().await?;
+    Ok(addrs.collect())
 }

--- a/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
@@ -23,8 +23,7 @@ use std::net::Shutdown;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
-use zenoh_core::Result as ZResult;
-use zenoh_core::{zerror, zread, zwrite};
+use zenoh_core::{bail, zerror, zread, zwrite, Error as ZError, Result as ZResult};
 use zenoh_link_commons::{
     LinkManagerUnicastTrait, LinkUnicast, LinkUnicastTrait, NewLinkChannelSender,
 };
@@ -32,7 +31,8 @@ use zenoh_protocol_core::{EndPoint, Locator};
 use zenoh_sync::Signal;
 
 use super::{
-    get_tcp_addr, TCP_ACCEPT_THROTTLE_TIME, TCP_DEFAULT_MTU, TCP_LINGER_TIMEOUT, TCP_LOCATOR_PREFIX,
+    get_tcp_addrs, TCP_ACCEPT_THROTTLE_TIME, TCP_DEFAULT_MTU, TCP_LINGER_TIMEOUT,
+    TCP_LOCATOR_PREFIX,
 };
 
 pub struct LinkUnicastTcp {
@@ -217,84 +217,146 @@ impl LinkManagerUnicastTcp {
     }
 }
 
-#[async_trait]
-impl LinkManagerUnicastTrait for LinkManagerUnicastTcp {
-    async fn new_link(&self, endpoint: EndPoint) -> ZResult<LinkUnicast> {
-        let dst_addr = get_tcp_addr(&endpoint.locator).await?;
-
+impl LinkManagerUnicastTcp {
+    async fn new_link_inner(
+        &self,
+        dst_addr: &SocketAddr,
+    ) -> ZResult<(TcpStream, SocketAddr, SocketAddr)> {
         let stream = TcpStream::connect(dst_addr)
             .await
-            .map_err(|e| zerror!("Can not create a new TCP link bound to {}: {}", dst_addr, e))?;
+            .map_err(|e| zerror!("{}: {}", dst_addr, e))?;
 
         let src_addr = stream
             .local_addr()
-            .map_err(|e| zerror!("Can not create a new TCP link bound to {}: {}", dst_addr, e))?;
+            .map_err(|e| zerror!("{}: {}", dst_addr, e))?;
 
         let dst_addr = stream
             .peer_addr()
-            .map_err(|e| zerror!("Can not create a new TCP link bound to {}: {}", dst_addr, e))?;
+            .map_err(|e| zerror!("{}: {}", dst_addr, e))?;
 
-        let link = Arc::new(LinkUnicastTcp::new(stream, src_addr, dst_addr));
-
-        Ok(LinkUnicast(link))
+        Ok((stream, src_addr, dst_addr))
     }
 
-    async fn new_listener(&self, mut endpoint: EndPoint) -> ZResult<Locator> {
-        let addr = get_tcp_addr(&endpoint.locator).await?;
-
+    async fn new_listener_inner(&self, addr: &SocketAddr) -> ZResult<(TcpListener, SocketAddr)> {
         // Bind the TCP socket
         let socket = TcpListener::bind(addr)
             .await
-            .map_err(|e| zerror!("Can not create a new TCP listener on {}: {}", addr, e))?;
+            .map_err(|e| zerror!("{}: {}", addr, e))?;
 
         let local_addr = socket
             .local_addr()
-            .map_err(|e| zerror!("Can not create a new TCP listener on {}: {}", addr, e))?;
+            .map_err(|e| zerror!("{}: {}", addr, e))?;
 
-        // Update the endpoint locator address
-        assert!(endpoint.set_addr(&format!("{}", local_addr)));
+        Ok((socket, local_addr))
+    }
+}
 
-        // Spawn the accept loop for the listener
-        let active = Arc::new(AtomicBool::new(true));
-        let signal = Signal::new();
+#[async_trait]
+impl LinkManagerUnicastTrait for LinkManagerUnicastTcp {
+    async fn new_link(&self, endpoint: EndPoint) -> ZResult<LinkUnicast> {
+        let dst_addrs = get_tcp_addrs(&endpoint.locator).await?;
 
-        let c_active = active.clone();
-        let c_signal = signal.clone();
-        let c_manager = self.manager.clone();
-        let c_listeners = self.listeners.clone();
-        let c_addr = local_addr;
-        let handle = task::spawn(async move {
-            // Wait for the accept loop to terminate
-            let res = accept_task(socket, c_active, c_signal, c_manager).await;
-            zwrite!(c_listeners).remove(&c_addr);
-            res
-        });
+        let mut errs: Vec<ZError> = vec![];
+        for da in dst_addrs.iter() {
+            match self.new_link_inner(da).await {
+                Ok((stream, src_addr, dst_addr)) => {
+                    let link = Arc::new(LinkUnicastTcp::new(stream, src_addr, dst_addr));
+                    return Ok(LinkUnicast(link));
+                }
+                Err(e) => {
+                    errs.push(e);
+                }
+            }
+        }
 
-        let locator = endpoint.locator.clone();
-        let listener = ListenerUnicastTcp::new(endpoint, active, signal, handle);
-        // Update the list of active listeners on the manager
-        zwrite!(self.listeners).insert(local_addr, listener);
+        bail!(
+            "Can not create a new TCP link bound to {}: {:?}",
+            endpoint,
+            errs
+        )
+    }
 
-        Ok(locator)
+    async fn new_listener(&self, mut endpoint: EndPoint) -> ZResult<Locator> {
+        let addrs = get_tcp_addrs(&endpoint.locator).await?;
+
+        let mut errs: Vec<ZError> = vec![];
+        for da in addrs.iter() {
+            match self.new_listener_inner(da).await {
+                Ok((socket, local_addr)) => {
+                    // Update the endpoint locator address
+                    assert!(endpoint.set_addr(&format!("{}", local_addr)));
+
+                    // Spawn the accept loop for the listener
+                    let active = Arc::new(AtomicBool::new(true));
+                    let signal = Signal::new();
+
+                    let c_active = active.clone();
+                    let c_signal = signal.clone();
+                    let c_manager = self.manager.clone();
+                    let c_listeners = self.listeners.clone();
+                    let c_addr = local_addr;
+                    let handle = task::spawn(async move {
+                        // Wait for the accept loop to terminate
+                        let res = accept_task(socket, c_active, c_signal, c_manager).await;
+                        zwrite!(c_listeners).remove(&c_addr);
+                        res
+                    });
+
+                    let locator = endpoint.locator.clone();
+                    let listener = ListenerUnicastTcp::new(endpoint, active, signal, handle);
+                    // Update the list of active listeners on the manager
+                    zwrite!(self.listeners).insert(local_addr, listener);
+
+                    return Ok(locator);
+                }
+                Err(e) => {
+                    errs.push(e);
+                }
+            }
+        }
+
+        bail!(
+            "Can not create a new TCP listener bound to {}: {:?}",
+            endpoint,
+            errs
+        )
     }
 
     async fn del_listener(&self, endpoint: &EndPoint) -> ZResult<()> {
-        let addr = get_tcp_addr(&endpoint.locator).await?;
+        let addrs = get_tcp_addrs(&endpoint.locator).await?;
 
         // Stop the listener
-        let listener = zwrite!(self.listeners).remove(&addr).ok_or_else(|| {
-            let e = zerror!(
-                "Can not delete the TCP listener because it has not been found: {}",
-                addr
-            );
-            log::trace!("{}", e);
-            e
-        })?;
+        let mut errs: Vec<ZError> = vec![];
+        let mut listener = None;
+        for a in addrs.iter() {
+            match zwrite!(self.listeners).remove(a) {
+                Some(l) => {
+                    // We cannot keep a sync guard across a .await
+                    // Break the loop and assign the listener.
+                    listener = Some(l);
+                    break;
+                }
+                None => {
+                    errs.push(zerror!("{}", a).into());
+                }
+            }
+        }
 
-        // Send the stop signal
-        listener.active.store(false, Ordering::Release);
-        listener.signal.trigger();
-        listener.handle.await
+        match listener {
+            Some(l) => {
+                // Send the stop signal
+                l.active.store(false, Ordering::Release);
+                l.signal.trigger();
+                l.handle.await
+            }
+            None => {
+                bail!(
+                    "Can not delete the TCP listener bound to {}: {:?}",
+                    endpoint,
+                    errs
+                )
+            }
+        }
     }
 
     fn get_listeners(&self) -> Vec<EndPoint> {

--- a/io/zenoh-links/zenoh-link-udp/src/multicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/multicast.rs
@@ -307,7 +307,7 @@ impl LinkManagerMulticastTrait for LinkManagerMulticastUdp {
         }
 
         if errs.is_empty() {
-            errs.push(zerror!("No multicast address available").into());
+            errs.push(zerror!("No multicast addresses available").into());
         }
 
         bail!(

--- a/io/zenoh-links/zenoh-link-udp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/unicast.rs
@@ -23,8 +23,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock, Weak};
 use std::time::Duration;
 use zenoh_collections::{RecyclingObject, RecyclingObjectPool};
-use zenoh_core::Result as ZResult;
-use zenoh_core::{bail, zasynclock, zerror, zlock, zread, zwrite};
+use zenoh_core::{
+    bail, zasynclock, zerror, zlock, zread, zwrite, Error as ZError, Result as ZResult,
+};
 use zenoh_link_commons::{
     ConstructibleLinkManagerUnicast, LinkManagerUnicastTrait, LinkUnicast, LinkUnicastTrait,
     NewLinkChannelSender,
@@ -33,7 +34,7 @@ use zenoh_protocol_core::{EndPoint, Locator};
 use zenoh_sync::{Mvar, Signal};
 
 use super::{
-    get_udp_addr, socket_addr_to_udp_locator, UDP_ACCEPT_THROTTLE_TIME, UDP_DEFAULT_MTU,
+    get_udp_addrs, socket_addr_to_udp_locator, UDP_ACCEPT_THROTTLE_TIME, UDP_DEFAULT_MTU,
     UDP_MAX_MTU,
 };
 
@@ -280,11 +281,11 @@ impl ConstructibleLinkManagerUnicast<()> for LinkManagerUnicastUdp {
     }
 }
 
-#[async_trait]
-impl LinkManagerUnicastTrait for LinkManagerUnicastUdp {
-    async fn new_link(&self, endpoint: EndPoint) -> ZResult<LinkUnicast> {
-        let dst_addr = get_udp_addr(&endpoint.locator).await?;
-
+impl LinkManagerUnicastUdp {
+    async fn new_link_inner(
+        &self,
+        dst_addr: &SocketAddr,
+    ) -> ZResult<(UdpSocket, SocketAddr, SocketAddr)> {
         // Establish a UDP socket
         let socket = if dst_addr.is_ipv4() {
             // IPv4 format
@@ -319,21 +320,10 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastUdp {
             e
         })?;
 
-        // Create UDP link
-        let link = Arc::new(LinkUnicastUdp::new(
-            src_addr,
-            dst_addr,
-            LinkUnicastUdpVariant::Connected(LinkUnicastUdpConnected {
-                socket: Arc::new(socket),
-            }),
-        ));
-
-        Ok(LinkUnicast(link))
+        Ok((socket, src_addr, dst_addr))
     }
 
-    async fn new_listener(&self, mut endpoint: EndPoint) -> ZResult<Locator> {
-        let addr = get_udp_addr(&endpoint.locator).await?;
-
+    async fn new_listener_inner(&self, addr: &SocketAddr) -> ZResult<(UdpSocket, SocketAddr)> {
         // Bind the UDP socket
         let socket = UdpSocket::bind(addr).await.map_err(|e| {
             let e = zerror!("Can not create a new UDP listener on {}: {}", addr, e);
@@ -347,50 +337,124 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastUdp {
             e
         })?;
 
-        // Update the endpoint locator address
-        assert!(endpoint.set_addr(&format!("{}", local_addr)));
+        Ok((socket, local_addr))
+    }
+}
 
-        // Spawn the accept loop for the listener
-        let active = Arc::new(AtomicBool::new(true));
-        let signal = Signal::new();
+#[async_trait]
+impl LinkManagerUnicastTrait for LinkManagerUnicastUdp {
+    async fn new_link(&self, endpoint: EndPoint) -> ZResult<LinkUnicast> {
+        let dst_addrs = get_udp_addrs(&endpoint.locator).await?;
 
-        let c_active = active.clone();
-        let c_signal = signal.clone();
-        let c_manager = self.manager.clone();
-        let c_listeners = self.listeners.clone();
-        let c_addr = local_addr;
-        let handle = task::spawn(async move {
-            // Wait for the accept loop to terminate
-            let res = accept_read_task(socket, c_active, c_signal, c_manager).await;
-            zwrite!(c_listeners).remove(&c_addr);
-            res
-        });
+        let mut errs: Vec<ZError> = vec![];
+        for da in dst_addrs.iter() {
+            match self.new_link_inner(da).await {
+                Ok((socket, src_addr, dst_addr)) => {
+                    // Create UDP link
+                    let link = Arc::new(LinkUnicastUdp::new(
+                        src_addr,
+                        dst_addr,
+                        LinkUnicastUdpVariant::Connected(LinkUnicastUdpConnected {
+                            socket: Arc::new(socket),
+                        }),
+                    ));
 
-        let locator = endpoint.locator.clone();
-        let listener = ListenerUnicastUdp::new(endpoint, active, signal, handle);
-        // Update the list of active listeners on the manager
-        zwrite!(self.listeners).insert(local_addr, listener);
+                    return Ok(LinkUnicast(link));
+                }
+                Err(e) => {
+                    errs.push(e);
+                }
+            }
+        }
 
-        Ok(locator)
+        bail!(
+            "Can not create a new UDP link bound to {}: {:?}",
+            endpoint,
+            errs
+        )
+    }
+
+    async fn new_listener(&self, mut endpoint: EndPoint) -> ZResult<Locator> {
+        let addrs = get_udp_addrs(&endpoint.locator).await?;
+
+        let mut errs: Vec<ZError> = vec![];
+        for da in addrs.iter() {
+            match self.new_listener_inner(da).await {
+                Ok((socket, local_addr)) => {
+                    // Update the endpoint locator address
+                    assert!(endpoint.set_addr(&format!("{}", local_addr)));
+
+                    // Spawn the accept loop for the listener
+                    let active = Arc::new(AtomicBool::new(true));
+                    let signal = Signal::new();
+
+                    let c_active = active.clone();
+                    let c_signal = signal.clone();
+                    let c_manager = self.manager.clone();
+                    let c_listeners = self.listeners.clone();
+                    let c_addr = local_addr;
+                    let handle = task::spawn(async move {
+                        // Wait for the accept loop to terminate
+                        let res = accept_read_task(socket, c_active, c_signal, c_manager).await;
+                        zwrite!(c_listeners).remove(&c_addr);
+                        res
+                    });
+
+                    let locator = endpoint.locator.clone();
+                    let listener = ListenerUnicastUdp::new(endpoint, active, signal, handle);
+                    // Update the list of active listeners on the manager
+                    zwrite!(self.listeners).insert(local_addr, listener);
+
+                    return Ok(locator);
+                }
+                Err(e) => {
+                    errs.push(e);
+                }
+            }
+        }
+
+        bail!(
+            "Can not create a new UDP listener bound to {}: {:?}",
+            endpoint,
+            errs
+        )
     }
 
     async fn del_listener(&self, endpoint: &EndPoint) -> ZResult<()> {
-        let addr = get_udp_addr(&endpoint.locator).await?;
+        let addrs = get_udp_addrs(&endpoint.locator).await?;
 
         // Stop the listener
-        let listener = zwrite!(self.listeners).remove(&addr).ok_or_else(|| {
-            let e = zerror!(
-                "Can not delete the UDP listener because it has not been found: {}",
-                addr
-            );
-            log::trace!("{}", e);
-            e
-        })?;
+        let mut errs: Vec<ZError> = vec![];
+        let mut listener = None;
+        for a in addrs.iter() {
+            match zwrite!(self.listeners).remove(a) {
+                Some(l) => {
+                    // We cannot keep a sync guard across a .await
+                    // Break the loop and assign the listener.
+                    listener = Some(l);
+                    break;
+                }
+                None => {
+                    errs.push(zerror!("{}", a).into());
+                }
+            }
+        }
 
-        // Send the stop signal
-        listener.active.store(false, Ordering::Release);
-        listener.signal.trigger();
-        listener.handle.await
+        match listener {
+            Some(l) => {
+                // Send the stop signal
+                l.active.store(false, Ordering::Release);
+                l.signal.trigger();
+                l.handle.await
+            }
+            None => {
+                bail!(
+                    "Can not delete the UDP listener bound to {}: {:?}",
+                    endpoint,
+                    errs
+                )
+            }
+        }
     }
 
     fn get_listeners(&self) -> Vec<EndPoint> {

--- a/io/zenoh-links/zenoh-link-udp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/unicast.rs
@@ -383,7 +383,11 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastUdp {
     }
 
     async fn new_listener(&self, mut endpoint: EndPoint) -> ZResult<Locator> {
-        let addrs = get_udp_addrs(&endpoint.locator).await?;
+        let addrs = get_udp_addrs(&endpoint.locator)
+            .await?
+            .drain(..)
+            .filter(|a| !a.ip().is_multicast())
+            .collect::<Vec<SocketAddr>>();
 
         let mut errs: Vec<ZError> = vec![];
         for da in addrs.iter() {

--- a/io/zenoh-transport/tests/unicast_transport.rs
+++ b/io/zenoh-transport/tests/unicast_transport.rs
@@ -346,7 +346,7 @@ fn transport_unicast_tcp_only() {
     let endpoints: Vec<EndPoint> = vec![
         "tcp/127.0.0.1:10447".parse().unwrap(),
         "tcp/[::1]:10447".parse().unwrap(),
-        "tcp/localhost:10448".parse().unwrap(),
+        "tcp/localhost:10453".parse().unwrap(),
     ];
     // Define the reliability and congestion control
     let channel = [
@@ -382,7 +382,7 @@ fn transport_unicast_udp_only() {
     let endpoints: Vec<EndPoint> = vec![
         "udp/127.0.0.1:10447".parse().unwrap(),
         "udp/[::1]:10447".parse().unwrap(),
-        "udp/localhost:10448".parse().unwrap(),
+        "udp/localhost:10453".parse().unwrap(),
     ];
     // Define the reliability and congestion control
     let channel = [

--- a/io/zenoh-transport/tests/unicast_transport.rs
+++ b/io/zenoh-transport/tests/unicast_transport.rs
@@ -346,6 +346,7 @@ fn transport_unicast_tcp_only() {
     let endpoints: Vec<EndPoint> = vec![
         "tcp/127.0.0.1:10447".parse().unwrap(),
         "tcp/[::1]:10447".parse().unwrap(),
+        "tcp/localhost:10448".parse().unwrap(),
     ];
     // Define the reliability and congestion control
     let channel = [
@@ -381,6 +382,7 @@ fn transport_unicast_udp_only() {
     let endpoints: Vec<EndPoint> = vec![
         "udp/127.0.0.1:10447".parse().unwrap(),
         "udp/[::1]:10447".parse().unwrap(),
+        "udp/localhost:10448".parse().unwrap(),
     ];
     // Define the reliability and congestion control
     let channel = [


### PR DESCRIPTION
When establishing a TCP or UDP link a DNS query might be performed in case the locator contains a DNS name.
Today only the first IP address returned by the DNS lookup is used to establish a TCP or UDP link. 

This PR handles multiple IP addresses in DNS queries:
- When establishing a TCP or UDP link the IP addresses are tried in order
- The first successful IP address is used
- TCP or UDP link establishment fails iff none of the returned IP addresses can be used