### PR TITLE
Listen by default on [::] instead of 0.0.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ See other examples of zenoh usage in [examples/](examples)
   * `-c, --config <FILE>`: a [JSON5](https://json5.org) configuration file. [DEFAULT_CONFIG.json5](DEFAULT_CONFIG.json5) shows the schema of this file. All properties of this configuration are optional, so you may not need such a large configuration for your use-case.
   * `--cfg <KEY>:<VALUE>` : allows you to change specific parts of the configuration right after it has been constructed. VALUE must be a valid JSON5 value, and key must be a path through the configuration file, where each element is separated by a `/`. When inserting in parts of the config that are arrays, you may use indexes, or may use `+` to indicate that you want to append your value to the array. `--cfg` passed values will always override any previously existing value for their key in the configuration.
   * `-l, --listen <ENDPOINT>...`: An endpoint on which this router will listen for incoming sessions. 
-    Repeat this option to open several listeners. By default, `tcp/0.0.0.0:7447` is used. The following endpoints are currently supported:
+    Repeat this option to open several listeners. By default, `tcp/[::]:7447` is used. The following endpoints are currently supported:
       - TCP: `tcp/<host_name_or_IPv4_or_IPv6>:<port>`
       - UDP: `udp/<host_name_or_IPv4_or_IPv6>:<port>`
       - [TCP+TLS](https://zenoh.io/docs/manual/tls/): `tls/<host_name>:<port>`
@@ -119,7 +119,7 @@ See other examples of zenoh usage in [examples/](examples)
       - a string with format `<local_ip>:<port_number>` (to bind the HTTP server to a specific interface)
       - `"None"` to desactivate the REST plugin
 
-    If not specified, the REST plugin will be active on any interface (`0.0.0.0`) and port `8000`.
+    If not specified, the REST plugin will be active on any interface (`[::]`) and port `8000`.
 
 -------------------------------
 ## Plugins

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -116,7 +116,7 @@ validated_struct::validator! {
         ConnectConfig {
             pub endpoints: Vec<EndPoint>,
         },
-        /// Which endpoints to listen on. `zenohd` will add `tcp/0.0.0.0:7447` to these locators if left empty.
+        /// Which endpoints to listen on. `zenohd` will add `tcp/[::]:7447` to these locators if left empty.
         pub listen: #[derive(Default)]
         ListenConfig {
             pub endpoints: Vec<EndPoint>,

--- a/commons/zenoh-util/src/net/mod.rs
+++ b/commons/zenoh-util/src/net/mod.rs
@@ -195,8 +195,8 @@ pub fn get_multicast_interfaces() -> Vec<IpAddr> {
     }
     #[cfg(windows)]
     {
-        // On windows, bind to 0.0.0.0, the system will select the default interface
-        vec![IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0))]
+        // On windows, bind to [::], the system will select the default interface
+        vec![IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED)]
     }
 }
 
@@ -279,7 +279,7 @@ pub fn get_unicast_addresses_of_multicast_interfaces() -> Vec<IpAddr> {
     }
     #[cfg(windows)]
     {
-        // On windows, bind to 0.0.0.0 or [::], the system will select the default interface
+        // On windows, bind to [::] or [::], the system will select the default interface
         vec![]
     }
 }

--- a/io/zenoh-links/zenoh-link-quic/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/unicast.rs
@@ -274,9 +274,9 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastQuic {
         client_crypto.alpn_protocols = ALPN_QUIC_HTTP.iter().map(|&x| x.into()).collect();
 
         let ip_addr: IpAddr = if addr.is_ipv4() {
-            Ipv4Addr::new(0, 0, 0, 0).into()
+            Ipv4Addr::UNSPECIFIED.into()
         } else {
-            Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0).into()
+            Ipv6Addr::UNSPECIFIED.into()
         };
         let mut quic_endpoint = quinn::Endpoint::client(SocketAddr::new(ip_addr, 0))
             .map_err(|e| zerror!("Can not create a new QUIC link bound to {}: {}", host, e))?;
@@ -439,8 +439,8 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastQuic {
 
     fn get_locators(&self) -> Vec<Locator> {
         let mut locators = Vec::new();
-        let default_ipv4 = Ipv4Addr::new(0, 0, 0, 0);
-        let default_ipv6 = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0);
+        let default_ipv4 = Ipv4Addr::UNSPECIFIED;
+        let default_ipv6 = Ipv6Addr::UNSPECIFIED;
 
         let guard = zread!(self.listeners);
         for (key, value) in guard.iter() {

--- a/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
@@ -11,7 +11,7 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use async_std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener, TcpStream};
+use async_std::net::{SocketAddr, TcpListener, TcpStream};
 use async_std::prelude::*;
 use async_std::task;
 use async_std::task::JoinHandle;
@@ -305,44 +305,32 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastTcp {
     }
 
     fn get_locators(&self) -> Vec<Locator> {
-        let mut locators = Vec::new();
-        let default_ipv4 = Ipv4Addr::new(0, 0, 0, 0);
-        let default_ipv6 = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0);
+        let mut locators = vec![];
 
         let guard = zread!(self.listeners);
         for (key, value) in guard.iter() {
             let listener_locator = &value.endpoint.locator;
-            if key.ip() == default_ipv4 {
+            let (kip, kpt) = (key.ip(), key.port());
+            // Either ipv4/0.0.0.0 or ipv6/[::]
+            if kip.is_unspecified() {
                 match zenoh_util::net::get_local_addresses() {
-                    Ok(ipaddrs) => {
-                        for ipaddr in ipaddrs {
-                            if !ipaddr.is_loopback() && !ipaddr.is_multicast() && ipaddr.is_ipv4() {
-                                let mut l = Locator::new(
-                                    TCP_LOCATOR_PREFIX,
-                                    &SocketAddr::new(ipaddr, key.port()),
-                                );
-                                l.metadata = value.endpoint.locator.metadata.clone();
-                                locators.push(l);
-                            }
-                        }
+                    Ok(mut ipaddrs) => {
+                        let iter = ipaddrs
+                            .drain(..)
+                            .filter(|x| {
+                                ((kip.is_ipv4() && x.is_ipv4()) || kip.is_ipv6())
+                                    && !x.is_loopback()
+                                    && !x.is_multicast()
+                            })
+                            .map(|x| {
+                                let mut l =
+                                    Locator::new(TCP_LOCATOR_PREFIX, &SocketAddr::new(x, kpt));
+                                l.metadata = listener_locator.metadata.clone();
+                                l
+                            });
+                        locators.extend(iter);
                     }
-                    Err(err) => log::error!("Unable to get local addresses : {}", err),
-                }
-            } else if key.ip() == default_ipv6 {
-                match zenoh_util::net::get_local_addresses() {
-                    Ok(ipaddrs) => {
-                        for ipaddr in ipaddrs {
-                            if !ipaddr.is_loopback() && !ipaddr.is_multicast() && ipaddr.is_ipv6() {
-                                let mut l = Locator::new(
-                                    TCP_LOCATOR_PREFIX,
-                                    &SocketAddr::new(ipaddr, key.port()),
-                                );
-                                l.metadata = value.endpoint.locator.metadata.clone();
-                                locators.push(l);
-                            }
-                        }
-                    }
-                    Err(err) => log::error!("Unable to get local addresses : {}", err),
+                    Err(err) => log::error!("Unable to get local addresses: {}", err),
                 }
             } else {
                 locators.push(listener_locator.clone());

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -446,8 +446,8 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastTls {
 
     fn get_locators(&self) -> Vec<Locator> {
         let mut locators = Vec::new();
-        let default_ipv4 = Ipv4Addr::new(0, 0, 0, 0);
-        let default_ipv6 = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0);
+        let default_ipv4 = Ipv4Addr::UNSPECIFIED;
+        let default_ipv6 = Ipv6Addr::UNSPECIFIED;
 
         let guard = zread!(self.listeners);
         for (key, value) in guard.iter() {

--- a/io/zenoh-links/zenoh-link-udp/src/multicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/multicast.rs
@@ -169,10 +169,10 @@ impl LinkManagerMulticastTrait for LinkManagerMulticastUdp {
         }
 
         // Defaults
-        let _default_ipv4_iface = Ipv4Addr::new(0, 0, 0, 0);
+        let _default_ipv4_iface = Ipv4Addr::UNSPECIFIED;
         let default_ipv6_iface = 0;
-        let default_ipv4_addr = Ipv4Addr::new(0, 0, 0, 0);
-        let default_ipv6_addr = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0);
+        let default_ipv4_addr = Ipv4Addr::UNSPECIFIED;
+        let default_ipv6_addr = Ipv6Addr::UNSPECIFIED;
 
         // Get default iface address to bind the socket on if provided
         let mut iface_addr: Option<IpAddr> = None;

--- a/io/zenoh-links/zenoh-link-udp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/unicast.rs
@@ -11,6 +11,7 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
+use super::UDP_LOCATOR_PREFIX;
 use async_std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket};
 use async_std::prelude::*;
 use async_std::sync::Mutex as AsyncMutex;
@@ -286,13 +287,15 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastUdp {
         let dst_addr = get_udp_addr(&endpoint.locator).await?;
 
         // Establish a UDP socket
-        let socket = if dst_addr.is_ipv4() {
-            // IPv4 format
-            UdpSocket::bind("0.0.0.0:0").await
-        } else {
-            // IPv6 format
-            UdpSocket::bind(":::0").await
-        }
+        let socket = UdpSocket::bind(SocketAddr::new(
+            if dst_addr.is_ipv4() {
+                Ipv4Addr::UNSPECIFIED.into()
+            } else {
+                Ipv6Addr::UNSPECIFIED.into()
+            }, // UDP addr
+            0, // UDP port
+        ))
+        .await
         .map_err(|e| {
             let e = zerror!("Can not create a new UDP link bound to {}: {}", dst_addr, e);
             log::warn!("{}", e);
@@ -401,44 +404,32 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastUdp {
     }
 
     fn get_locators(&self) -> Vec<Locator> {
-        let mut locators = Vec::new();
-        let default_ipv4 = Ipv4Addr::new(0, 0, 0, 0);
-        let default_ipv6 = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0);
+        let mut locators = vec![];
 
         let guard = zread!(self.listeners);
         for (key, value) in guard.iter() {
             let listener_locator = &value.endpoint.locator;
-            if key.ip() == default_ipv4 {
+            let (kip, kpt) = (key.ip(), key.port());
+            // Either ipv4/0.0.0.0 or ipv6/[::]
+            if kip.is_unspecified() {
                 match zenoh_util::net::get_local_addresses() {
-                    Ok(ipaddrs) => {
-                        for ipaddr in ipaddrs {
-                            if !ipaddr.is_loopback() && !ipaddr.is_multicast() && ipaddr.is_ipv4() {
-                                let mut l = Locator::new(
-                                    crate::UDP_LOCATOR_PREFIX,
-                                    &SocketAddr::new(ipaddr, key.port()),
-                                );
-                                l.metadata = value.endpoint.locator.metadata.clone();
-                                locators.push(l);
-                            }
-                        }
+                    Ok(mut ipaddrs) => {
+                        let iter = ipaddrs
+                            .drain(..)
+                            .filter(|x| {
+                                ((kip.is_ipv4() && x.is_ipv4()) || kip.is_ipv6())
+                                    && !x.is_loopback()
+                                    && !x.is_multicast()
+                            })
+                            .map(|x| {
+                                let mut l =
+                                    Locator::new(UDP_LOCATOR_PREFIX, &SocketAddr::new(x, kpt));
+                                l.metadata = listener_locator.metadata.clone();
+                                l
+                            });
+                        locators.extend(iter);
                     }
-                    Err(err) => log::error!("Unable to get local addresses : {}", err),
-                }
-            } else if key.ip() == default_ipv6 {
-                match zenoh_util::net::get_local_addresses() {
-                    Ok(ipaddrs) => {
-                        for ipaddr in ipaddrs {
-                            if !ipaddr.is_loopback() && !ipaddr.is_multicast() && ipaddr.is_ipv6() {
-                                let mut l = Locator::new(
-                                    crate::UDP_LOCATOR_PREFIX,
-                                    &SocketAddr::new(ipaddr, key.port()),
-                                );
-                                l.metadata = value.endpoint.locator.metadata.clone();
-                                locators.push(l);
-                            }
-                        }
-                    }
-                    Err(err) => log::error!("Unable to get local addresses : {}", err),
+                    Err(err) => log::error!("Unable to get local addresses: {}", err),
                 }
             } else {
                 locators.push(listener_locator.clone());

--- a/io/zenoh-links/zenoh-link-ws/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-ws/src/unicast.rs
@@ -399,8 +399,8 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastWs {
 
     fn get_locators(&self) -> Vec<Locator> {
         let mut locators = Vec::new();
-        let default_ipv4 = Ipv4Addr::new(0, 0, 0, 0);
-        let default_ipv6 = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0);
+        let default_ipv4 = Ipv4Addr::UNSPECIFIED;
+        let default_ipv6 = Ipv6Addr::UNSPECIFIED;
 
         let guard = zread!(self.listeners);
         for (key, value) in guard.iter() {

--- a/plugins/zenoh-plugin-rest/src/config.rs
+++ b/plugins/zenoh-plugin-rest/src/config.rs
@@ -15,7 +15,7 @@ use serde::de::{Unexpected, Visitor};
 use serde::{de, Deserialize, Deserializer};
 use std::fmt;
 
-const DEFAULT_HTTP_INTERFACE: &str = "0.0.0.0";
+const DEFAULT_HTTP_INTERFACE: &str = "[::]";
 
 #[derive(Deserialize, serde::Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]

--- a/zenoh/src/net/runtime/orchestrator.rs
+++ b/zenoh/src/net/runtime/orchestrator.rs
@@ -394,14 +394,14 @@ impl Runtime {
             } // See UNIX Network Programmping p.212
             #[cfg(windows)]
             {
-                Ipv4Addr::UNSPECIFIED.into()
+                std::net::Ipv4Addr::UNSPECIFIED.into()
             }
         };
         match socket.bind(&SocketAddr::new(addr, sockaddr.port()).into()) {
             Ok(()) => log::debug!("UDP port bound to {}", sockaddr),
             Err(err) => {
-                log::error!("Unable to bind udp port {} : {}", sockaddr, err);
-                bail!(err => "Unable to bind udp port {}", sockaddr);
+                log::error!("Unable to bind UDP port {} : {}", sockaddr, err);
+                bail!(err => "Unable to bind UDP port {}", sockaddr);
             }
         }
 

--- a/zenohd/.service/zenohd.json5
+++ b/zenohd/.service/zenohd.json5
@@ -16,7 +16,7 @@
    * Which endpoints to listen on. E.g. tcp/localhost:7447.
    * By configuring the endpoints, it is possible to tell zenoh which are the endpoints that other routers,
    * peers, or client can use to establish a zenoh session.
-   * If none are specified, "tcp/0.0.0.0:7447" will be used (i.e. any interface)
+   * If none are specified, "tcp/[::]:7447" will be used (i.e. any interface)
    */
   listen: {
     endpoints: [

--- a/zenohd/src/main.rs
+++ b/zenohd/src/main.rs
@@ -27,7 +27,7 @@ lazy_static::lazy_static!(
     static ref LONG_VERSION: String = format!("{} built with {}", GIT_VERSION, env!("RUSTC_VERSION"));
 );
 
-const DEFAULT_LISTENER: &str = "tcp/0.0.0.0:7447";
+const DEFAULT_LISTENER: &str = "tcp/[::]:7447";
 
 fn main() {
     task::block_on(async {
@@ -45,7 +45,7 @@ fn main() {
             .long_version(LONG_VERSION.as_str()).args(
                 &[
 clap::arg!(-c --config [FILE] "The configuration file. Currently, this file must be a valid JSON5 or YAML file."),
-clap::Arg::new("listen").short('l').long("listen").value_name("ENDPOINT]").help(r"A locator on which this router will listen for incoming sessions.
+clap::Arg::new("listen").short('l').long("listen").value_name("ENDPOINT").help(r"A locator on which this router will listen for incoming sessions.
 Repeat this option to open several listeners.").takes_value(true).multiple_occurrences(true),
 clap::Arg::new("connect").short('e').long("connect").value_name("ENDPOINT").help(r"A peer locator this router will try to connect to.
 Repeat this option to connect to several peers.").takes_value(true).multiple_occurrences(true),


### PR DESCRIPTION
IPv6 is enabled by default in the largest majority of today's systems along with IPv4 stack, making all of them dual stack.

This PR changes the default endpoint to listen on in zenoh (e.g. by zenohd and peer mode) as follows:
- The IPv4 unspecified address `0.0.0.0` is replaced by the IPv6 unspecified address `::`.
- In case of dual stack systems, `::` automatically includes `0.0.0.0` and zenoh can be reached on both IPv4 and IPv6.
- In the unlikely event of a system not supporting IPv6, it would be enough to configure the listener endpoint to `0.0.0.0` to override the default value of `::`.
