### PR TITLE
Sort IPv6 unspecified locators

### DIFF
--- a/commons/zenoh-util/src/net/mod.rs
+++ b/commons/zenoh-util/src/net/mod.rs
@@ -405,8 +405,5 @@ pub fn get_ipv6_ipaddrs() -> Vec<IpAddr> {
         .map(|x| IpAddr::V6(*x));
 
     // Extend
-    ipv4_iter
-        .chain(nll_addrs)
-        .chain(yll_addrs)
-        .collect()
+    ipv4_iter.chain(nll_addrs).chain(yll_addrs).collect()
 }

--- a/commons/zenoh-util/src/net/mod.rs
+++ b/commons/zenoh-util/src/net/mod.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use async_std::net::TcpStream;
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv6Addr};
 use std::time::Duration;
 use zenoh_core::{bail, zconfigurable, Result as ZResult};
 
@@ -355,4 +355,58 @@ pub fn get_unicast_addresses_of_interface(name: &str) -> ZResult<Vec<IpAddr>> {
             Ok(addrs)
         }
     }
+}
+
+pub fn get_ipv4_ipaddrs() -> Vec<IpAddr> {
+    get_local_addresses()
+        .unwrap_or_else(|_| vec![])
+        .drain(..)
+        .filter_map(|x| match x {
+            IpAddr::V4(a) => Some(a),
+            IpAddr::V6(_) => None,
+        })
+        .filter(|x| !x.is_loopback() && !x.is_multicast())
+        .map(IpAddr::V4)
+        .collect()
+}
+
+pub fn get_ipv6_ipaddrs() -> Vec<IpAddr> {
+    const fn is_unicast_link_local(addr: &Ipv6Addr) -> bool {
+        (addr.segments()[0] & 0xffc0) == 0xfe80
+    }
+
+    let ipaddrs = get_local_addresses().unwrap_or_else(|_| vec![]);
+
+    // Get first all IPv4 addresses
+    let ipv4_iter = ipaddrs
+        .iter()
+        .filter_map(|x| match x {
+            IpAddr::V4(a) => Some(a),
+            IpAddr::V6(_) => None,
+        })
+        .filter(|x| !x.is_loopback() && !x.is_multicast())
+        .map(|x| IpAddr::V4(*x));
+
+    // Get next all IPv6 addresses
+    let ipv6_iter = ipaddrs.iter().filter_map(|x| match x {
+        IpAddr::V4(_) => None,
+        IpAddr::V6(a) => Some(a),
+    });
+
+    // First match non-linklocal IPv6 addresses
+    let nll_addrs = ipv6_iter
+        .clone()
+        .filter(|x| !x.is_loopback() && !x.is_multicast() && !is_unicast_link_local(x))
+        .map(|x| IpAddr::V6(*x));
+
+    // Second match linklocal IPv6 addresses
+    let yll_addrs = ipv6_iter
+        .filter(|x| !x.is_loopback() && !x.is_multicast() && is_unicast_link_local(x))
+        .map(|x| IpAddr::V6(*x));
+
+    // Extend
+    ipv4_iter
+        .chain(nll_addrs)
+        .chain(yll_addrs)
+        .collect()
 }

--- a/io/zenoh-links/zenoh-link-quic/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/unicast.rs
@@ -438,50 +438,29 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastQuic {
     }
 
     fn get_locators(&self) -> Vec<Locator> {
-        let mut locators = Vec::new();
-        let default_ipv4 = Ipv4Addr::UNSPECIFIED;
-        let default_ipv6 = Ipv6Addr::UNSPECIFIED;
+        let mut locators = vec![];
 
         let guard = zread!(self.listeners);
         for (key, value) in guard.iter() {
             let listener_locator = &value.endpoint.locator;
-            if key.ip() == default_ipv4 {
-                match zenoh_util::net::get_local_addresses() {
-                    Ok(ipaddrs) => {
-                        for ipaddr in ipaddrs {
-                            if !ipaddr.is_loopback() && !ipaddr.is_multicast() && ipaddr.is_ipv4() {
-                                let mut l = Locator::new(
-                                    QUIC_LOCATOR_PREFIX,
-                                    &SocketAddr::new(ipaddr, key.port()),
-                                );
-                                l.metadata = value.endpoint.locator.metadata.clone();
-                                locators.push(l);
-                            }
-                        }
-                    }
-                    Err(err) => log::error!("Unable to get local addresses : {}", err),
-                }
-            } else if key.ip() == default_ipv6 {
-                match zenoh_util::net::get_local_addresses() {
-                    Ok(ipaddrs) => {
-                        for ipaddr in ipaddrs {
-                            if !ipaddr.is_loopback() && !ipaddr.is_multicast() && ipaddr.is_ipv6() {
-                                let mut l = Locator::new(
-                                    QUIC_LOCATOR_PREFIX,
-                                    &SocketAddr::new(ipaddr, key.port()),
-                                );
-                                l.metadata = value.endpoint.locator.metadata.clone();
-                                locators.push(l);
-                            }
-                        }
-                    }
-                    Err(err) => log::error!("Unable to get local addresses : {}", err),
-                }
+            let (kip, kpt) = (key.ip(), key.port());
+
+            // Either ipv4/0.0.0.0 or ipv6/[::]
+            if kip.is_unspecified() {
+                let mut addrs = match kip {
+                    IpAddr::V4(_) => zenoh_util::net::get_ipv4_ipaddrs(),
+                    IpAddr::V6(_) => zenoh_util::net::get_ipv6_ipaddrs(),
+                };
+                let iter = addrs.drain(..).map(|x| {
+                    let mut l = Locator::new(QUIC_LOCATOR_PREFIX, &SocketAddr::new(x, kpt));
+                    l.metadata = listener_locator.metadata.clone();
+                    l
+                });
+                locators.extend(iter);
             } else {
                 locators.push(listener_locator.clone());
             }
         }
-        std::mem::drop(guard);
 
         locators
     }

--- a/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
@@ -19,7 +19,7 @@ use async_trait::async_trait;
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fmt;
-use std::net::Shutdown;
+use std::net::{IpAddr, Shutdown};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
@@ -389,32 +389,23 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastTcp {
         for (key, value) in guard.iter() {
             let listener_locator = &value.endpoint.locator;
             let (kip, kpt) = (key.ip(), key.port());
+
             // Either ipv4/0.0.0.0 or ipv6/[::]
             if kip.is_unspecified() {
-                match zenoh_util::net::get_local_addresses() {
-                    Ok(mut ipaddrs) => {
-                        let iter = ipaddrs
-                            .drain(..)
-                            .filter(|x| {
-                                ((kip.is_ipv4() && x.is_ipv4()) || kip.is_ipv6())
-                                    && !x.is_loopback()
-                                    && !x.is_multicast()
-                            })
-                            .map(|x| {
-                                let mut l =
-                                    Locator::new(TCP_LOCATOR_PREFIX, &SocketAddr::new(x, kpt));
-                                l.metadata = listener_locator.metadata.clone();
-                                l
-                            });
-                        locators.extend(iter);
-                    }
-                    Err(err) => log::error!("Unable to get local addresses: {}", err),
-                }
+                let mut addrs = match kip {
+                    IpAddr::V4(_) => zenoh_util::net::get_ipv4_ipaddrs(),
+                    IpAddr::V6(_) => zenoh_util::net::get_ipv6_ipaddrs(),
+                };
+                let iter = addrs.drain(..).map(|x| {
+                    let mut l = Locator::new(TCP_LOCATOR_PREFIX, &SocketAddr::new(x, kpt));
+                    l.metadata = listener_locator.metadata.clone();
+                    l
+                });
+                locators.extend(iter);
             } else {
                 locators.push(listener_locator.clone());
             }
         }
-        std::mem::drop(guard);
 
         locators
     }


### PR DESCRIPTION
This PR sort local available IP addresses when IPv6 unspecified address (i.e. `::`) is used:
- IPv4 non-local addresses
- IPv6 non-link local addresses
- IPv6 link local addresses