### PR TITLE
Ignore commit when checking compatibility with stable

### DIFF
--- a/plugins/zenoh-plugin-trait/src/lib.rs
+++ b/plugins/zenoh-plugin-trait/src/lib.rs
@@ -51,7 +51,11 @@ impl Compatibility {
         })
     }
     pub fn are_compatible(a: &Self, b: &Self) -> bool {
-        a == b
+        if a.stable && b.stable {
+            a.major == b.major && a.minor == b.minor && a.patch == b.patch
+        } else {
+            a == b
+        }
     }
 }
 


### PR DESCRIPTION
From the [RustConf 2022 - Bootstrapping: The once and future compiler by Joshua Nelson](https://www.youtube.com/watch?v=oUIjG-y4zaA) talk, we can infer that ABI is stable within a same compiler release.

On this assumption, we can relax the requirements for compatibility slightly with stable releases.

Pro:
- Some users have had issues where their plugins report the compiler commit as unknown, causing mismatches despite high likelihood of ABI compatibility.
Con:
- ABI dark magic is scary, more tolerance still has a small but existing likelihood of biting us. However, there are plenty of more scary ABI things that we currently have no safeguards against.