### PR TITLE
Config defaults

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -12,6 +12,7 @@
 
   /// Which endpoints to connect to. E.g. tcp/localhost:7447.
   /// By configuring the endpoints, it is possible to tell zenoh which router/peer to connect to at startup.
+  /// Accepts a single value or different values for router, peer and client.
   connect: {
     endpoints: [
       // "<proto>/<address>"
@@ -21,10 +22,9 @@
   /// Which endpoints to listen on. E.g. tcp/localhost:7447.
   /// By configuring the endpoints, it is possible to tell zenoh which are the endpoints that other routers,
   /// peers, or client can use to establish a zenoh session.
+  /// Accepts a single value or different values for router, peer and client.
   listen: {
-    endpoints: [
-      // "<proto>/<address>"
-    ],
+    endpoints: { router: ["tcp/[::]:7447"], peer: ["tcp/[::]:0"], },
   },
   /// Configure the scouting mechanisms and their behaviours
   scouting: {

--- a/commons/zenoh-config/src/defaults.rs
+++ b/commons/zenoh-config/src/defaults.rs
@@ -32,6 +32,28 @@ pub const mode: WhatAmI = WhatAmI::Peer;
 
 #[allow(non_upper_case_globals)]
 #[allow(dead_code)]
+pub mod connect {
+    pub mod endpoints {
+        pub const router: &[&str] = &[];
+        pub const peer: &[&str] = &[];
+        pub const client: &[&str] = &[];
+        mode_accessor!([&'static str]);
+    }
+}
+
+#[allow(non_upper_case_globals)]
+#[allow(dead_code)]
+pub mod listen {
+    pub mod endpoints {
+        pub const router: &[&str] = &["tcp/[::]:7447"];
+        pub const peer: &[&str] = &["tcp/[::]:0"];
+        pub const client: &[&str] = &[];
+        mode_accessor!([&'static str]);
+    }
+}
+
+#[allow(non_upper_case_globals)]
+#[allow(dead_code)]
 pub mod scouting {
     pub const timeout: u64 = 3000;
     pub const delay: u64 = 200;

--- a/commons/zenoh-protocol-core/src/endpoints.rs
+++ b/commons/zenoh-protocol-core/src/endpoints.rs
@@ -123,3 +123,9 @@ impl FromStr for EndPoint {
         })
     }
 }
+impl TryFrom<&str> for EndPoint {
+    type Error = zenoh_core::Error;
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        Self::from_str(s)
+    }
+}

--- a/examples/examples/z_delete.rs
+++ b/examples/examples/z_delete.rs
@@ -68,14 +68,14 @@ fn parse_args() -> (Config, String) {
     if let Some(values) = args.values_of("connect") {
         config
             .connect
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if let Some(values) = args.values_of("listen") {
         config
             .listen
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if args.is_present("no-multicast-scouting") {
         config.scouting.multicast.set_enabled(Some(false)).unwrap();

--- a/examples/examples/z_forward.rs
+++ b/examples/examples/z_forward.rs
@@ -73,14 +73,14 @@ fn parse_args() -> (Config, String, String) {
     if let Some(values) = args.values_of("connect") {
         config
             .connect
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if let Some(values) = args.values_of("listeners") {
         config
             .listen
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if args.is_present("no-multicast-scouting") {
         config.scouting.multicast.set_enabled(Some(false)).unwrap();

--- a/examples/examples/z_get.rs
+++ b/examples/examples/z_get.rs
@@ -93,14 +93,14 @@ fn parse_args() -> (Config, String, QueryTarget, Duration) {
     if let Some(values) = args.values_of("connect") {
         config
             .connect
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if let Some(values) = args.values_of("listen") {
         config
             .listen
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if args.is_present("no-multicast-scouting") {
         config.scouting.multicast.set_enabled(Some(false)).unwrap();

--- a/examples/examples/z_info.rs
+++ b/examples/examples/z_info.rs
@@ -68,14 +68,14 @@ fn parse_args() -> Config {
     if let Some(values) = args.values_of("connect") {
         config
             .connect
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if let Some(values) = args.values_of("listen") {
         config
             .listen
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if args.is_present("no-multicast-scouting") {
         config.scouting.multicast.set_enabled(Some(false)).unwrap();

--- a/examples/examples/z_ping.rs
+++ b/examples/examples/z_ping.rs
@@ -114,14 +114,14 @@ fn parse_args() -> (Config, Duration, usize, usize) {
     if let Some(values) = args.values_of("connect") {
         config
             .connect
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if let Some(values) = args.values_of("listen") {
         config
             .listen
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if args.is_present("no-multicast-scouting") {
         config.scouting.multicast.set_enabled(Some(false)).unwrap();

--- a/examples/examples/z_pong.rs
+++ b/examples/examples/z_pong.rs
@@ -74,14 +74,14 @@ fn parse_args() -> Config {
     if let Some(values) = args.values_of("connect") {
         config
             .connect
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if let Some(values) = args.values_of("listen") {
         config
             .listen
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if args.is_present("no-multicast-scouting") {
         config.scouting.multicast.set_enabled(Some(false)).unwrap();

--- a/examples/examples/z_pub.rs
+++ b/examples/examples/z_pub.rs
@@ -77,14 +77,14 @@ fn parse_args() -> (Config, String, String) {
     if let Some(values) = args.values_of("connect") {
         config
             .connect
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if let Some(values) = args.values_of("listen") {
         config
             .listen
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if args.is_present("no-multicast-scouting") {
         config.scouting.multicast.set_enabled(Some(false)).unwrap();

--- a/examples/examples/z_pub_thr.rs
+++ b/examples/examples/z_pub_thr.rs
@@ -103,14 +103,14 @@ fn parse_args() -> (Config, usize, Priority, bool, usize) {
     if let Some(values) = args.values_of("connect") {
         config
             .connect
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if let Some(values) = args.values_of("listen") {
         config
             .listen
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if args.is_present("no-multicast-scouting") {
         config.scouting.multicast.set_enabled(Some(false)).unwrap();

--- a/examples/examples/z_pull.rs
+++ b/examples/examples/z_pull.rs
@@ -105,14 +105,14 @@ fn parse_args() -> (Config, String) {
     if let Some(values) = args.values_of("connect") {
         config
             .connect
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if let Some(values) = args.values_of("listen") {
         config
             .listen
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if args.is_present("no-multicast-scouting") {
         config.scouting.multicast.set_enabled(Some(false)).unwrap();

--- a/examples/examples/z_put.rs
+++ b/examples/examples/z_put.rs
@@ -68,14 +68,14 @@ fn parse_args() -> (Config, String, String) {
     if let Some(values) = args.values_of("connect") {
         config
             .connect
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if let Some(values) = args.values_of("listen") {
         config
             .listen
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if args.is_present("no-multicast-scouting") {
         config.scouting.multicast.set_enabled(Some(false)).unwrap();

--- a/examples/examples/z_put_float.rs
+++ b/examples/examples/z_put_float.rs
@@ -75,14 +75,14 @@ fn parse_args() -> (Config, String, f64) {
     if let Some(values) = args.values_of("connect") {
         config
             .connect
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if let Some(values) = args.values_of("listen") {
         config
             .listen
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if args.is_present("no-multicast-scouting") {
         config.scouting.multicast.set_enabled(Some(false)).unwrap();

--- a/examples/examples/z_queryable.rs
+++ b/examples/examples/z_queryable.rs
@@ -101,14 +101,14 @@ fn parse_args() -> (Config, String, String) {
     if let Some(values) = args.values_of("connect") {
         config
             .connect
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if let Some(values) = args.values_of("listen") {
         config
             .listen
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if args.is_present("no-multicast-scouting") {
         config.scouting.multicast.set_enabled(Some(false)).unwrap();

--- a/examples/examples/z_storage.rs
+++ b/examples/examples/z_storage.rs
@@ -112,14 +112,14 @@ fn parse_args() -> (Config, String) {
     if let Some(values) = args.values_of("connect") {
         config
             .connect
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if let Some(values) = args.values_of("listen") {
         config
             .listen
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if args.is_present("no-multicast-scouting") {
         config.scouting.multicast.set_enabled(Some(false)).unwrap();

--- a/examples/examples/z_sub.rs
+++ b/examples/examples/z_sub.rs
@@ -91,14 +91,14 @@ fn parse_args() -> (Config, KeyExpr<'static>) {
     if let Some(values) = args.values_of("connect") {
         config
             .connect
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if let Some(values) = args.values_of("listen") {
         config
             .listen
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if args.is_present("no-multicast-scouting") {
         config.scouting.multicast.set_enabled(Some(false)).unwrap();

--- a/examples/examples/z_sub_thr.rs
+++ b/examples/examples/z_sub_thr.rs
@@ -138,14 +138,14 @@ fn parse_args() -> (Config, usize, usize) {
     if let Some(values) = args.values_of("connect") {
         config
             .connect
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if let Some(values) = args.values_of("listen") {
         config
             .listen
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if args.is_present("no-multicast-scouting") {
         config.scouting.multicast.set_enabled(Some(false)).unwrap();

--- a/plugins/zenoh-plugin-rest/examples/z_serve_sse.rs
+++ b/plugins/zenoh-plugin-rest/examples/z_serve_sse.rs
@@ -122,14 +122,14 @@ fn parse_args() -> Config {
     if let Some(values) = args.values_of("connect") {
         config
             .connect
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if let Some(values) = args.values_of("listen") {
         config
             .listen
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if args.is_present("no-multicast-scouting") {
         config.scouting.multicast.set_enabled(Some(false)).unwrap();

--- a/zenoh-ext/examples/z_pub_cache.rs
+++ b/zenoh-ext/examples/z_pub_cache.rs
@@ -91,14 +91,14 @@ fn parse_args() -> (Config, String, String, usize, Option<String>) {
     if let Some(values) = args.values_of("connect") {
         config
             .connect
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if let Some(values) = args.values_of("listen") {
         config
             .listen
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if args.is_present("no-multicast-scouting") {
         config.scouting.multicast.set_enabled(Some(false)).unwrap();

--- a/zenoh-ext/examples/z_query_sub.rs
+++ b/zenoh-ext/examples/z_query_sub.rs
@@ -114,14 +114,14 @@ fn parse_args() -> (Config, String, Option<String>) {
     if let Some(values) = args.values_of("connect") {
         config
             .connect
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if let Some(values) = args.values_of("listen") {
         config
             .listen
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if args.is_present("no-multicast-scouting") {
         config.scouting.multicast.set_enabled(Some(false)).unwrap();

--- a/zenoh-ext/examples/z_view_size.rs
+++ b/zenoh-ext/examples/z_view_size.rs
@@ -90,14 +90,14 @@ fn parse_args() -> (Config, String, Option<String>, usize, u64) {
     if let Some(values) = args.values_of("connect") {
         config
             .connect
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
     if let Some(values) = args.values_of("listeners") {
         config
             .listen
-            .endpoints
-            .extend(values.map(|v| v.parse().unwrap()))
+            .set_endpoints(Some(values.map(|v| v.parse().unwrap()).collect()))
+            .unwrap();
     }
 
     let group = args.value_of("group").unwrap().to_string();

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -220,7 +220,7 @@ where
 ///
 /// let mut config = config::peer();
 /// config.set_id(ZenohId::from_str("F000").unwrap());
-/// config.connect.endpoints.extend("tcp/10.10.10.10:7447,tcp/11.11.11.11:7447".split(',').map(|s|s.parse().unwrap()));
+/// config.connect.set_endpoints(Some("tcp/10.10.10.10:7447,tcp/11.11.11.11:7447".split(',').map(|s|s.parse().unwrap()).collect()));
 ///
 /// let session = zenoh::open(config).res().await.unwrap();
 /// # })

--- a/zenoh/tests/session.rs
+++ b/zenoh/tests/session.rs
@@ -34,19 +34,13 @@ macro_rules! ztimeout {
 async fn open_session(endpoints: &[&str]) -> (Session, Session) {
     // Open the sessions
     let mut config = config::peer();
-    config.listen.endpoints = endpoints
-        .iter()
-        .map(|e| e.parse().unwrap())
-        .collect::<Vec<_>>();
+    config.listen.endpoints = Some(endpoints.iter().map(|e| e.parse().unwrap()).collect());
     config.scouting.multicast.set_enabled(Some(false)).unwrap();
     println!("[  ][01a] Opening peer01 session");
     let peer01 = ztimeout!(zenoh::open(config).res_async()).unwrap();
 
     let mut config = config::peer();
-    config.connect.endpoints = endpoints
-        .iter()
-        .map(|e| e.parse().unwrap())
-        .collect::<Vec<_>>();
+    config.connect.endpoints = Some(endpoints.iter().map(|e| e.parse().unwrap()).collect());
     config.scouting.multicast.set_enabled(Some(false)).unwrap();
     println!("[  ][02a] Opening peer02 session");
     let peer02 = ztimeout!(zenoh::open(config).res_async()).unwrap();

--- a/zenohd/src/main.rs
+++ b/zenohd/src/main.rs
@@ -27,8 +27,6 @@ lazy_static::lazy_static!(
     static ref LONG_VERSION: String = format!("{} built with {}", GIT_VERSION, env!("RUSTC_VERSION"));
 );
 
-const DEFAULT_LISTENER: &str = "tcp/[::]:7447";
-
 fn main() {
     task::block_on(async {
         let mut log_builder =
@@ -187,7 +185,7 @@ fn config_from_args(args: &ArgMatches) -> Config {
     if let Some(peers) = args.values_of("connect") {
         config
             .connect
-            .set_endpoints(
+            .set_endpoints(Some(
                 peers
                     .map(|v| match v.parse::<EndPoint>() {
                         Ok(v) => v,
@@ -196,13 +194,13 @@ fn config_from_args(args: &ArgMatches) -> Config {
                         }
                     })
                     .collect(),
-            )
+            ))
             .unwrap();
     }
     if let Some(listeners) = args.values_of("listen") {
         config
             .listen
-            .set_endpoints(
+            .set_endpoints(Some(
                 listeners
                     .map(|v| match v.parse::<EndPoint>() {
                         Ok(v) => v,
@@ -211,14 +209,8 @@ fn config_from_args(args: &ArgMatches) -> Config {
                         }
                     })
                     .collect(),
-            )
+            ))
             .unwrap();
-    }
-    if config.listen.endpoints.is_empty() {
-        config
-            .listen
-            .endpoints
-            .push(DEFAULT_LISTENER.parse().unwrap())
     }
     if args.is_present("no-timestamp") {
         config


### PR DESCRIPTION
The first commit gathers config defaults as modules and constants in `zenoh_config::defaults`.

The second commit may be more controversial. It redefines `listen.endpoints` and `connect.endpoints` as optional `ModeDependentValues`. This is more accurate and allows users to explicitly set an empty list of listen endpoints and instruct Zenoh not to open any listening port. But while remaining backward compatible concerning the config file format, it slightly changes the way to access an update the conf programmatically. Thus strictly speaking it may be considered an API change. 
Note that `connect.endpoints` did not need to be retyped to a `ModeDependentValue`, but it makes things more homogeneous to have both `listen.endpoints` and `connect.endpoints` having the same type and be accessed the same way. 