### PR TITLE
Config defaults 2

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -75,6 +75,9 @@
     drop_future_timestamp: false,
   },
 
+  /// The default timeout to apply to queries in milliseconds.
+  queries_default_timeout: 10000,
+
   /// The routing strategy to use and it's configuration.
   routing: {
       /// The routing strategy to use in routers and it's configuration.

--- a/commons/zenoh-config/src/defaults.rs
+++ b/commons/zenoh-config/src/defaults.rs
@@ -13,6 +13,90 @@
 //
 use super::*;
 
+macro_rules! mode_accessor {
+    ($type:ty) => {
+        #[inline]
+        pub fn get(whatami: zenoh_protocol_core::WhatAmI) -> &'static $type {
+            match whatami {
+                zenoh_protocol_core::WhatAmI::Router => router,
+                zenoh_protocol_core::WhatAmI::Peer => peer,
+                zenoh_protocol_core::WhatAmI::Client => client,
+            }
+        }
+    };
+}
+
+#[allow(non_upper_case_globals)]
+#[allow(dead_code)]
+pub const mode: WhatAmI = WhatAmI::Peer;
+
+#[allow(non_upper_case_globals)]
+#[allow(dead_code)]
+pub mod scouting {
+    pub const timeout: u64 = 3000;
+    pub const delay: u64 = 200;
+    pub mod multicast {
+        pub const enabled: bool = true;
+        pub const address: ([u8; 4], u16) = ([224, 0, 0, 224], 7446);
+        pub const interface: &str = "auto";
+        pub mod autoconnect {
+            pub const router: &crate::WhatAmIMatcher = // ""
+                &crate::WhatAmIMatcher(unsafe { std::num::NonZeroU8::new_unchecked(128) });
+            pub const peer: &crate::WhatAmIMatcher = // "router|peer"
+                &crate::WhatAmIMatcher(unsafe { std::num::NonZeroU8::new_unchecked(131) });
+            pub const client: &crate::WhatAmIMatcher = // "router|peer"
+                &crate::WhatAmIMatcher(unsafe { std::num::NonZeroU8::new_unchecked(131) });
+            mode_accessor!(crate::WhatAmIMatcher);
+        }
+        pub mod listen {
+            pub const router: &bool = &true;
+            pub const peer: &bool = &true;
+            pub const client: &bool = &false;
+            mode_accessor!(bool);
+        }
+    }
+    pub mod gossip {
+        pub const enabled: bool = true;
+        pub const multihop: bool = false;
+        pub mod autoconnect {
+            pub const router: &crate::WhatAmIMatcher = // ""
+                &crate::WhatAmIMatcher(unsafe { std::num::NonZeroU8::new_unchecked(128) });
+            pub const peer: &crate::WhatAmIMatcher = // "router|peer"
+                &crate::WhatAmIMatcher(unsafe { std::num::NonZeroU8::new_unchecked(131) });
+            pub const client: &crate::WhatAmIMatcher = // "router|peer"
+                &crate::WhatAmIMatcher(unsafe { std::num::NonZeroU8::new_unchecked(131) });
+            mode_accessor!(crate::WhatAmIMatcher);
+        }
+    }
+}
+
+#[allow(non_upper_case_globals)]
+#[allow(dead_code)]
+pub mod timestamping {
+    pub mod enabled {
+        pub const router: &bool = &true;
+        pub const peer: &bool = &false;
+        pub const client: &bool = &false;
+        mode_accessor!(bool);
+    }
+    pub const drop_future_timestamp: bool = false;
+}
+
+#[allow(non_upper_case_globals)]
+#[allow(dead_code)]
+pub const queries_default_timeout: u64 = 10000;
+
+#[allow(non_upper_case_globals)]
+#[allow(dead_code)]
+pub mod routing {
+    pub mod router {
+        pub const peers_failover_brokering: bool = true;
+    }
+    pub mod peer {
+        pub const mode: &str = "peer_to_peer";
+    }
+}
+
 impl Default for TransportUnicastConf {
     fn default() -> Self {
         Self {

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -1100,6 +1100,14 @@ pub trait ModeDependent<T> {
     fn router(&self) -> Option<&T>;
     fn peer(&self) -> Option<&T>;
     fn client(&self) -> Option<&T>;
+    #[inline]
+    fn get(&self, whatami: WhatAmI) -> Option<&T> {
+        match whatami {
+            WhatAmI::Router => self.router(),
+            WhatAmI::Peer => self.peer(),
+            WhatAmI::Client => self.client(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -1113,14 +1121,17 @@ pub struct ModeValues<T> {
 }
 
 impl<T> ModeDependent<T> for ModeValues<T> {
+    #[inline]
     fn router(&self) -> Option<&T> {
         self.router.as_ref()
     }
 
+    #[inline]
     fn peer(&self) -> Option<&T> {
         self.peer.as_ref()
     }
 
+    #[inline]
     fn client(&self) -> Option<&T> {
         self.client.as_ref()
     }
@@ -1133,6 +1144,7 @@ pub enum ModeDependentValue<T> {
 }
 
 impl<T> ModeDependent<T> for ModeDependentValue<T> {
+    #[inline]
     fn router(&self) -> Option<&T> {
         match self {
             Self::Unique(v) => Some(v),
@@ -1140,6 +1152,7 @@ impl<T> ModeDependent<T> for ModeDependentValue<T> {
         }
     }
 
+    #[inline]
     fn peer(&self) -> Option<&T> {
         match self {
             Self::Unique(v) => Some(v),
@@ -1147,6 +1160,7 @@ impl<T> ModeDependent<T> for ModeDependentValue<T> {
         }
     }
 
+    #[inline]
     fn client(&self) -> Option<&T> {
         match self {
             Self::Unique(v) => Some(v),
@@ -1238,6 +1252,7 @@ impl<'a> serde::Deserialize<'a> for ModeDependentValue<WhatAmIMatcher> {
 }
 
 impl<T> ModeDependent<T> for Option<ModeDependentValue<T>> {
+    #[inline]
     fn router(&self) -> Option<&T> {
         match self {
             Some(ModeDependentValue::Unique(v)) => Some(v),
@@ -1246,6 +1261,7 @@ impl<T> ModeDependent<T> for Option<ModeDependentValue<T>> {
         }
     }
 
+    #[inline]
     fn peer(&self) -> Option<&T> {
         match self {
             Some(ModeDependentValue::Unique(v)) => Some(v),
@@ -1254,6 +1270,7 @@ impl<T> ModeDependent<T> for Option<ModeDependentValue<T>> {
         }
     }
 
+    #[inline]
     fn client(&self) -> Option<&T> {
         match self {
             Some(ModeDependentValue::Unique(v)) => Some(v),
@@ -1261,4 +1278,11 @@ impl<T> ModeDependent<T> for Option<ModeDependentValue<T>> {
             None => None,
         }
     }
+}
+
+#[macro_export]
+macro_rules! unwrap_or_default {
+    ($val:ident$(.$field:ident($($param:ident)?))*) => {
+        $val$(.$field($($param)?))*.clone().unwrap_or(zenoh_config::defaults$(::$field$(($param))?)*.into())
+    };
 }

--- a/commons/zenoh-protocol-core/src/whatami.rs
+++ b/commons/zenoh-protocol-core/src/whatami.rs
@@ -135,6 +135,10 @@ impl WhatAmIMatcher {
         self.0.get() == 128
     }
 
+    pub fn empty() -> Self {
+        WhatAmIMatcher(unsafe { NonZeroU8::new_unchecked(128) })
+    }
+
     pub fn matches(self, w: WhatAmI) -> bool {
         (self.0.get() & w as u8) != 0
     }

--- a/zenoh/src/net/runtime/orchestrator.rs
+++ b/zenoh/src/net/runtime/orchestrator.rs
@@ -20,8 +20,7 @@ use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 use std::time::Duration;
 use zenoh_buffers::reader::HasReader;
 use zenoh_buffers::SplitBuffer;
-use zenoh_cfg_properties::config::*;
-use zenoh_config::{EndPoint, ModeDependent};
+use zenoh_config::{unwrap_or_default, EndPoint, ModeDependent};
 use zenoh_core::Result as ZResult;
 use zenoh_core::{bail, zerror};
 use zenoh_link::Locator;
@@ -62,21 +61,10 @@ impl Runtime {
             let guard = self.config.lock();
             (
                 guard.connect().endpoints().clone(),
-                guard.scouting().multicast().enabled().unwrap_or(true),
-                guard
-                    .scouting()
-                    .multicast()
-                    .address()
-                    .unwrap_or_else(|| "224.0.0.224:7446".parse().unwrap()),
-                guard
-                    .scouting()
-                    .multicast()
-                    .interface()
-                    .as_ref()
-                    .map(AsRef::as_ref)
-                    .unwrap_or("auto")
-                    .to_owned(),
-                std::time::Duration::from_millis(guard.scouting().timeout().unwrap_or(3000)),
+                unwrap_or_default!(guard.scouting().multicast().enabled()),
+                unwrap_or_default!(guard.scouting().multicast().address()),
+                unwrap_or_default!(guard.scouting().multicast().interface()),
+                std::time::Duration::from_millis(unwrap_or_default!(guard.scouting().timeout())),
             )
         };
         match peers.len() {
@@ -130,39 +118,15 @@ impl Runtime {
             } else {
                 guard.listen().endpoints().clone()
             };
-            let peers = guard.connect().endpoints().clone();
             (
                 listeners,
-                peers,
-                guard.scouting().multicast().enabled().unwrap_or(true),
-                guard
-                    .scouting()
-                    .multicast()
-                    .listen()
-                    .peer()
-                    .cloned()
-                    .unwrap_or(true),
-                guard
-                    .scouting()
-                    .multicast()
-                    .autoconnect()
-                    .peer()
-                    .cloned()
-                    .unwrap_or_else(|| WhatAmIMatcher::try_from(131).unwrap()),
-                guard
-                    .scouting()
-                    .multicast()
-                    .address()
-                    .unwrap_or_else(|| ZN_MULTICAST_IPV4_ADDRESS_DEFAULT.parse().unwrap()),
-                guard
-                    .scouting()
-                    .multicast()
-                    .interface()
-                    .as_ref()
-                    .map(AsRef::as_ref)
-                    .unwrap_or_else(|| ZN_MULTICAST_INTERFACE_DEFAULT)
-                    .to_string(),
-                Duration::from_millis(guard.scouting().delay().unwrap_or(200)),
+                guard.connect().endpoints().clone(),
+                unwrap_or_default!(guard.scouting().multicast().enabled()),
+                *unwrap_or_default!(guard.scouting().multicast().listen().peer()),
+                *unwrap_or_default!(guard.scouting().multicast().autoconnect().peer()),
+                unwrap_or_default!(guard.scouting().multicast().address()),
+                unwrap_or_default!(guard.scouting().multicast().interface()),
+                Duration::from_millis(unwrap_or_default!(guard.scouting().delay())),
             )
         };
 
@@ -188,38 +152,14 @@ impl Runtime {
             } else {
                 guard.listen().endpoints().clone()
             };
-            let peers = guard.connect().endpoints().clone();
             (
                 listeners,
-                peers,
-                guard.scouting().multicast().enabled().unwrap_or(true),
-                guard
-                    .scouting()
-                    .multicast()
-                    .listen()
-                    .peer()
-                    .cloned()
-                    .unwrap_or(true),
-                guard
-                    .scouting()
-                    .multicast()
-                    .autoconnect()
-                    .peer()
-                    .cloned()
-                    .unwrap_or_else(|| WhatAmIMatcher::try_from(128).unwrap()),
-                guard
-                    .scouting()
-                    .multicast()
-                    .address()
-                    .unwrap_or_else(|| ZN_MULTICAST_IPV4_ADDRESS_DEFAULT.parse().unwrap()),
-                guard
-                    .scouting()
-                    .multicast()
-                    .interface()
-                    .as_ref()
-                    .map(AsRef::as_ref)
-                    .unwrap_or(ZN_MULTICAST_INTERFACE_DEFAULT)
-                    .to_string(),
+                guard.connect().endpoints().clone(),
+                unwrap_or_default!(guard.scouting().multicast().enabled()),
+                *unwrap_or_default!(guard.scouting().multicast().listen().router()),
+                *unwrap_or_default!(guard.scouting().multicast().autoconnect().router()),
+                unwrap_or_default!(guard.scouting().multicast().address()),
+                unwrap_or_default!(guard.scouting().multicast().interface()),
             )
         };
 

--- a/zenoh/src/session.rs
+++ b/zenoh/src/session.rs
@@ -52,6 +52,7 @@ use uhlc::HLC;
 use zenoh_collections::SingleOrVec;
 use zenoh_collections::TimedEvent;
 use zenoh_collections::Timer;
+use zenoh_config::unwrap_or_default;
 use zenoh_core::{
     zconfigurable, zread, Resolve, ResolveClosure, ResolveFuture, Result as ZResult, SyncResolve,
 };
@@ -755,12 +756,13 @@ impl Session {
         <IntoSelector as TryInto<Selector<'b>>>::Error: Into<zenoh_core::Error>,
     {
         let selector = selector.try_into().map_err(Into::into);
+        let conf = self.runtime.config.lock();
         GetBuilder {
             session: self,
             selector,
             target: QueryTarget::default(),
             consolidation: QueryConsolidation::default(),
-            timeout: Duration::from_secs(10),
+            timeout: Duration::from_millis(unwrap_or_default!(conf.queries_default_timeout())),
             handler: DefaultHandler,
         }
     }


### PR DESCRIPTION
- internal changes
  - gather defaults in Zenoh_config::defaults
- user visible changes:
  - add missing `queries_default_timeout` in `DEFAULT_CONFIG.json5`
  - `get` uses config `queries_default_timeout` as default timeout