### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,13 @@ jobs:
           command: build
           args: --verbose --all-targets
 
+      - name: Set rustflags
+        shell: bash
+        run: |
+          case ${{ matrix.job.target }} in
+            *windows*) RUSTFLAGS="$RUSTFLAGS -Clink-arg=/DEBUG:NONE" ;;
+          esac
+
       - name: Install nextest
         run: cargo install cargo-nextest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
         shell: bash
         run: |
           case ${{ matrix.os }} in
-            *windows*) RUSTFLAGS="$RUSTFLAGS -Clink-arg=/DEBUG:NONE" ;;
+            *windows*) echo "RUSTFLAGS=-Clink-arg=/DEBUG:NONE" >> $GITHUB_ENV ;;
           esac
 
       - name: Install nextest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,12 @@ jobs:
           command: clippy
           args: --all-targets -- -D warnings
 
+      - name: Clippy unstable
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-targets --features unstable -- -D warnings
+
   test:
     name: Run tests on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Set rustflags
         shell: bash
         run: |
-          case ${{ matrix.job.target }} in
+          case ${{ matrix.os }} in
             *windows*) RUSTFLAGS="$RUSTFLAGS -Clink-arg=/DEBUG:NONE" ;;
           esac
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,18 +70,18 @@ jobs:
       - name: Install latest Rust toolchain
         uses: actions-rs/toolchain@v1
 
-      - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --verbose --all-targets
-
       - name: Set rustflags
         shell: bash
         run: |
           case ${{ matrix.os }} in
             *windows*) echo "RUSTFLAGS=-Clink-arg=/DEBUG:NONE" >> $GITHUB_ENV ;;
           esac
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --verbose --all-targets
 
       - name: Install nextest
         run: cargo install cargo-nextest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,11 @@ jobs:
         with:
           command: clippy
           args: --all-targets -- -D warnings
+      - name: Clippy unstable check
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-targets --features unstable -- -D warnings
       - name: Environment setup
         id: env
         shell: bash


### PR DESCRIPTION
- Disable debug symbols when building tests on windows (to avoid build failure)
- Run clippy with feature `unstable` (in addition to running clips with default features) on CI and Realease
  Note: this additional step only takes few seconds for each platform