### PR TITLE
Disable shared-memory by default

### DIFF
--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -55,7 +55,6 @@ unstable = []
 default = [
     "auth_pubkey",
     "auth_usrpwd",
-    "shared-memory",
     "transport_quic",
     "transport_tcp",
     "transport_tls",


### PR DESCRIPTION
This PR addresses https://github.com/eclipse-zenoh/zenoh/issues/406 and disable shared-memory by default. 
At least, there will be no memory leaks in the case where applications are not actually using shared memory (which it seems to be the majority of the cases). 