### PR TITLE
Refactoring replica module

### DIFF
--- a/plugins/zenoh-plugin-storage-manager/Cargo.toml
+++ b/plugins/zenoh-plugin-storage-manager/Cargo.toml
@@ -37,6 +37,7 @@ name = "zplugin_storage_manager"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+async-global-executor = "2.3.1"
 async-std = "=1.12.0"
 async-trait = "0.1.59"
 clap = "3.2.23"

--- a/plugins/zenoh-plugin-storage-manager/Cargo.toml
+++ b/plugins/zenoh-plugin-storage-manager/Cargo.toml
@@ -37,7 +37,6 @@ name = "zplugin_storage_manager"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-async-global-executor = "2.3.1"
 async-std = "=1.12.0"
 async-trait = "0.1.59"
 clap = "3.2.23"
@@ -59,6 +58,9 @@ zenoh-core = { version = "0.7.0-rc", path = "../../commons/zenoh-core/" }
 zenoh-plugin-trait = { version = "0.7.0-rc", path = "../zenoh-plugin-trait", default-features = false }
 zenoh-util = { version = "0.7.0-rc", path = "../../commons/zenoh-util" }
 zenoh_backend_traits = { version = "0.7.0-rc", path = "../zenoh-backend-traits/" }
+
+[dev-dependencies]
+async-global-executor = "2.3.1"
 
 [build-dependencies]
 rustc_version = "0.4.0"

--- a/plugins/zenoh-plugin-storage-manager/src/replica/align_queryable.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/align_queryable.rs
@@ -129,7 +129,7 @@ impl AlignQueryable {
         // TODO: Discuss if having timestamp is useful
         match diff_required {
             AlignComponent::Era(era) => {
-                let intervals = self.get_intervals(era).await;
+                let intervals = self.get_intervals(&era).await;
                 let mut result = Vec::new();
                 for (i, c) in intervals {
                     result.push(AlignData::Interval(i, c));
@@ -249,7 +249,7 @@ impl AlignQueryable {
         None
     }
 
-    async fn get_intervals(&self, era: EraType) -> HashMap<u64, u64> {
+    async fn get_intervals(&self, era: &EraType) -> HashMap<u64, u64> {
         let digest = self.snapshotter.get_digest().await;
         digest.get_era_content(era)
     }

--- a/plugins/zenoh-plugin-storage-manager/src/replica/aligner.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/aligner.rs
@@ -16,7 +16,7 @@ use super::{Digest, EraType, LogEntry, Snapshotter};
 use super::{CONTENTS, ERA, INTERVALS, SUBINTERVALS};
 use async_std::sync::{Arc, RwLock};
 use flume::{Receiver, Sender};
-use log::{error, trace};
+use log::{error, debug, trace};
 use std::collections::{HashMap, HashSet};
 use std::str;
 use zenoh::key_expr::{KeyExpr, OwnedKeyExpr};
@@ -69,7 +69,7 @@ impl Aligner {
                 continue;
             } else {
                 // process this digest
-                trace!(
+                debug!(
                     "[ALIGNER]Processing digest: {:?} from {}",
                     incoming_digest,
                     from
@@ -103,7 +103,7 @@ impl Aligner {
 
             for (key, (ts, value)) in missing_data {
                 let sample = Sample::new(key, value).with_timestamp(ts);
-                trace!("[ALIGNER] Adding sample {:?} to storage", sample);
+                debug!("[ALIGNER] Adding sample {:?} to storage", sample);
                 match self.tx_sample.send_async(sample).await {
                     Ok(()) => continue,
                     Err(e) => error!("[ALIGNER] Error adding sample to storage: {}", e),
@@ -317,7 +317,7 @@ impl Aligner {
             .join(&from)
             .unwrap()
             .with_parameters(&properties);
-        trace!("[ALIGNER]Sending Query '{}'...", selector);
+        trace!("[ALIGNER] Sending Query '{}'...", selector);
         let mut return_val = Vec::new();
         let replies = self
             .session

--- a/plugins/zenoh-plugin-storage-manager/src/replica/aligner.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/aligner.rs
@@ -55,19 +55,19 @@ impl Aligner {
 
     pub async fn start(&self) {
         while let Ok((from, incoming_digest)) = self.rx_digest.recv_async().await {
-            trace!(
-                "[ALIGNER]Processing digest: {:?} from {}",
-                incoming_digest,
-                from
-            );
             if self.in_processed(incoming_digest.checksum).await {
-                trace!("[ALIGNER]Skipping already processed digest");
+                trace!("[ALIGNER]Skipping already processed digest: {}", incoming_digest.checksum);
                 continue;
             } else if self.snapshotter.get_digest().await.checksum == incoming_digest.checksum {
-                trace!("[ALIGNER]Skipping matching digest");
+                trace!("[ALIGNER]Skipping matching digest: {}", incoming_digest.checksum);
                 continue;
             } else {
                 // process this digest
+                trace!(
+                    "[ALIGNER]Processing digest: {:?} from {}",
+                    incoming_digest,
+                    from
+                );
                 self.process_incoming_digest(incoming_digest, &from).await;
             }
         }
@@ -239,7 +239,6 @@ impl Aligner {
                 }
                 // get subintervals diff
                 let result = this.get_full_content_diff(other_content);
-                trace!("[ALIGNER] The missing content is {:?}", result);
                 return result;
             }
         }

--- a/plugins/zenoh-plugin-storage-manager/src/replica/aligner.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/aligner.rs
@@ -63,6 +63,9 @@ impl Aligner {
             if self.in_processed(incoming_digest.checksum).await {
                 trace!("[ALIGNER]Skipping already processed digest");
                 continue;
+            } else if self.snapshotter.get_digest().await.checksum == incoming_digest.checksum {
+                trace!("[ALIGNER]Skipping matching digest");
+                continue;
             } else {
                 // process this digest
                 self.process_incoming_digest(incoming_digest, &from).await;
@@ -72,14 +75,7 @@ impl Aligner {
 
     async fn in_processed(&self, checksum: u64) -> bool {
         let processed_set = self.digests_processed.read().await;
-        let processed = processed_set.contains(&checksum);
-        drop(processed_set);
-        if processed {
-            trace!("[ALIGNER]Dropping {} since already processed", checksum);
-            true
-        } else {
-            false
-        }
+        processed_set.contains(&checksum)
     }
 
     //identify alignment requirements

--- a/plugins/zenoh-plugin-storage-manager/src/replica/aligner.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/aligner.rs
@@ -339,8 +339,8 @@ impl Aligner {
                         }
                     }
                 }
-            },
-            Err(err) =>   {
+            }
+            Err(err) => {
                 error!("[ALIGNER] Query failed on selector `{}`: {}", selector, err);
                 no_err = false;
             }

--- a/plugins/zenoh-plugin-storage-manager/src/replica/aligner.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/aligner.rs
@@ -271,7 +271,7 @@ impl Aligner {
                     );
                     return_val.push(sample);
                 }
-                Err(err) => error!("[ALIGNER] Query failed on selector '{}' ::{}", selector, err),
+                Err(err) => error!("[ALIGNER] Query failed on selector {} :{}", selector, err),
             }
         }
         return_val

--- a/plugins/zenoh-plugin-storage-manager/src/replica/aligner.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/aligner.rs
@@ -16,7 +16,7 @@ use super::{Digest, EraType, LogEntry, Snapshotter};
 use super::{CONTENTS, ERA, INTERVALS, SUBINTERVALS};
 use async_std::sync::{Arc, RwLock};
 use flume::{Receiver, Sender};
-use log::{error, debug, trace};
+use log::{debug, error, trace};
 use std::collections::{HashMap, HashSet};
 use std::str;
 use zenoh::key_expr::{KeyExpr, OwnedKeyExpr};
@@ -71,8 +71,7 @@ impl Aligner {
                 // process this digest
                 debug!(
                     "[ALIGNER]Processing digest: {:?} from {}",
-                    incoming_digest,
-                    from
+                    incoming_digest, from
                 );
                 self.process_incoming_digest(incoming_digest, &from).await;
             }

--- a/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
@@ -238,14 +238,20 @@ impl Digest {
         // update and compute digest
         digest_hash.insert(curr_era, checksum);
         let mut digest_content = Vec::new();
-        if digest_hash.contains_key(&EraType::Cold) {
-            digest_content.push(digest_hash[&EraType::Cold]);
+        if let Some(checksum) = digest_hash.get(&EraType::Cold) {
+            digest_content.push(*checksum);
+        } else {
+            digest_content.push(0);
         }
-        if digest_hash.contains_key(&EraType::Warm) {
-            digest_content.push(digest_hash[&EraType::Warm]);
+        if let Some(checksum) = digest_hash.get(&EraType::Warm) {
+            digest_content.push(*checksum);
+        } else {
+            digest_content.push(0);
         }
-        if digest_hash.contains_key(&EraType::Hot) {
-            digest_content.push(digest_hash[&EraType::Hot]);
+        if let Some(checksum) = digest_hash.get(&EraType::Hot) {
+            digest_content.push(*checksum);
+        } else {
+            digest_content.push(0);
         }
         let checksum = Digest::get_content_hash(&digest_content);
 
@@ -385,11 +391,23 @@ impl Digest {
 
     // compute the checksum of the digest
     fn get_digest_checksum(content: &HashMap<EraType, Interval>) -> u64 {
-        let mut hashable_content = Vec::new();
-        for i_cont in content.values() {
-            hashable_content.push(i_cont.checksum);
+        let mut digest_content = Vec::new();
+        if let Some(interval) = content.get(&EraType::Cold) {
+            digest_content.push(interval.checksum);
+        } else {
+            digest_content.push(0);
         }
-        Digest::get_content_hash(&hashable_content)
+        if let Some(interval) = content.get(&EraType::Warm) {
+            digest_content.push(interval.checksum);
+        } else {
+            digest_content.push(0);
+        }
+        if let Some(interval) = content.get(&EraType::Hot) {
+            digest_content.push(interval.checksum);
+        } else {
+            digest_content.push(0);
+        }
+        Digest::get_content_hash(&digest_content)
     }
 
     // update the digest with new content

--- a/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
@@ -666,9 +666,9 @@ impl Digest {
     }
 
     // get the intervals of a given era
-    pub fn get_era_content(&self, era: EraType) -> HashMap<u64, u64> {
+    pub fn get_era_content(&self, era: &EraType) -> HashMap<u64, u64> {
         let mut result = HashMap::new();
-        for int in self.eras.get(&era).unwrap().content.clone() {
+        for int in self.eras.get(era).unwrap().content.clone() {
             result.insert(int, self.intervals.get(&int).unwrap().checksum);
         }
         result

--- a/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
@@ -786,6 +786,9 @@ impl Digest {
 
 #[test]
 fn test_create_digest_empty_initial() {
+    async_std::task::block_on(async {
+        zenoh_core::zasync_executor_init!();
+    });
     let created = Digest::create_digest(
         Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
         DigestConfig {
@@ -815,6 +818,9 @@ fn test_create_digest_empty_initial() {
 
 #[test]
 fn test_create_digest_with_initial_hot() {
+    async_std::task::block_on(async {
+        zenoh_core::zasync_executor_init!();
+    });
     let created = Digest::create_digest(
         Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
         DigestConfig {
@@ -868,6 +874,9 @@ fn test_create_digest_with_initial_hot() {
 
 #[test]
 fn test_create_digest_with_initial_warm() {
+    async_std::task::block_on(async {
+        zenoh_core::zasync_executor_init!();
+    });
     let created = Digest::create_digest(
         Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
         DigestConfig {
@@ -921,6 +930,9 @@ fn test_create_digest_with_initial_warm() {
 
 #[test]
 fn test_create_digest_with_initial_cold() {
+    async_std::task::block_on(async {
+        zenoh_core::zasync_executor_init!();
+    });
     let created = Digest::create_digest(
         Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
         DigestConfig {
@@ -974,6 +986,9 @@ fn test_create_digest_with_initial_cold() {
 
 #[test]
 fn test_update_digest_add_content() {
+    async_std::task::block_on(async {
+        zenoh_core::zasync_executor_init!();
+    });
     let created = async_std::task::block_on(Digest::update_digest(
         Digest {
             timestamp: Timestamp::from_str("2022-12-21T13:00:00.000000000Z/01").unwrap(),
@@ -1035,6 +1050,9 @@ fn test_update_digest_add_content() {
 
 #[test]
 fn test_update_digest_remove_content() {
+    async_std::task::block_on(async {
+        zenoh_core::zasync_executor_init!();
+    });
     let created = async_std::task::block_on(Digest::update_digest(
         Digest {
             timestamp: Timestamp::from_str("2022-12-21T13:00:00.000000000Z/01").unwrap(),
@@ -1097,6 +1115,9 @@ fn test_update_digest_remove_content() {
 
 #[test]
 fn test_update_remove_digest() {
+    async_std::task::block_on(async {
+        zenoh_core::zasync_executor_init!();
+    });
     let created = Digest::create_digest(
         Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
         DigestConfig {

--- a/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
@@ -211,8 +211,9 @@ impl Digest {
         }
         if !sub_content.is_empty() {
             // close subinterval
-            let checksum =
-                Digest::get_content_hash(&sub_content.clone().into_iter().collect::<Vec<LogEntry>>());
+            let checksum = Digest::get_content_hash(
+                &sub_content.clone().into_iter().collect::<Vec<LogEntry>>(),
+            );
             let s = SubInterval {
                 checksum,
                 content: sub_content,
@@ -242,13 +243,13 @@ impl Digest {
         let mut digest_content = Vec::new();
         if let Some(checksum) = digest_hash.get(&EraType::Cold) {
             digest_content.push(*checksum);
-        } 
+        }
         if let Some(checksum) = digest_hash.get(&EraType::Warm) {
             digest_content.push(*checksum);
-        } 
+        }
         if let Some(checksum) = digest_hash.get(&EraType::Hot) {
             digest_content.push(*checksum);
-        } 
+        }
         let checksum = Digest::get_content_hash(&digest_content);
 
         Digest {
@@ -292,17 +293,11 @@ impl Digest {
 
         // reconstruct updated parts of the digest
         for sub in subintervals_to_update {
-            let content = &subintervals
-                .get(&sub)
-                .unwrap()
-                .content;
+            let content = &subintervals.get(&sub).unwrap().content;
             if !content.is_empty() {
                 // order the content, hash them
                 let checksum = Digest::get_subinterval_checksum(
-                    &content
-                        .clone()
-                        .into_iter()
-                        .collect::<Vec<LogEntry>>(),
+                    &content.clone().into_iter().collect::<Vec<LogEntry>>(),
                 );
 
                 subintervals.get_mut(&sub).unwrap().checksum = checksum;
@@ -312,10 +307,7 @@ impl Digest {
         }
 
         for int in intervals_to_update {
-            let content = &intervals
-                .get(&int)
-                .unwrap()
-                .content;
+            let content = &intervals.get(&int).unwrap().content;
             if !content.is_empty() {
                 // order the content, hash them
                 let checksum = Digest::get_interval_checksum(
@@ -336,10 +328,7 @@ impl Digest {
         }
 
         for era in eras_to_update {
-            let content = &eras
-                .get(&era)
-                .unwrap()
-                .content;
+            let content = &eras.get(&era).unwrap().content;
             if !content.is_empty() {
                 // order the content, hash them
                 let checksum = Digest::get_era_checksum(
@@ -411,13 +400,13 @@ impl Digest {
         let mut digest_content = Vec::new();
         if let Some(interval) = content.get(&EraType::Cold) {
             digest_content.push(interval.checksum);
-        } 
+        }
         if let Some(interval) = content.get(&EraType::Warm) {
             digest_content.push(interval.checksum);
-        } 
+        }
         if let Some(interval) = content.get(&EraType::Hot) {
             digest_content.push(interval.checksum);
-        } 
+        }
         Digest::get_content_hash(&digest_content)
     }
 
@@ -1119,12 +1108,39 @@ fn test_update_remove_digest() {
         Vec::new(),
         1671612730,
     );
-    let added = async_std::task::block_on(Digest::update_digest(created.clone(), 1671612730, Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(), HashSet::from([LogEntry{ timestamp: Timestamp::from_str("2022-12-21T12:00:00.000000000Z/01").unwrap(), key: OwnedKeyExpr::from_str("a/b/c").unwrap()}]), HashSet::new()));
+    let added = async_std::task::block_on(Digest::update_digest(
+        created.clone(),
+        1671612730,
+        Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+        HashSet::from([LogEntry {
+            timestamp: Timestamp::from_str("2022-12-21T12:00:00.000000000Z/01").unwrap(),
+            key: OwnedKeyExpr::from_str("a/b/c").unwrap(),
+        }]),
+        HashSet::new(),
+    ));
     assert_ne!(created, added);
 
-    let removed = async_std::task::block_on(Digest::update_digest(added.clone(), 1671612730, Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(), HashSet::new(), HashSet::from([LogEntry{ timestamp: Timestamp::from_str("2022-12-21T12:00:00.000000000Z/01").unwrap(), key: OwnedKeyExpr::from_str("a/b/c").unwrap()}])));
+    let removed = async_std::task::block_on(Digest::update_digest(
+        added.clone(),
+        1671612730,
+        Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+        HashSet::new(),
+        HashSet::from([LogEntry {
+            timestamp: Timestamp::from_str("2022-12-21T12:00:00.000000000Z/01").unwrap(),
+            key: OwnedKeyExpr::from_str("a/b/c").unwrap(),
+        }]),
+    ));
     assert_eq!(created, removed);
 
-    let added_again = async_std::task::block_on(Digest::update_digest(removed, 1671612730, Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(), HashSet::from([LogEntry{ timestamp: Timestamp::from_str("2022-12-21T12:00:00.000000000Z/01").unwrap(), key: OwnedKeyExpr::from_str("a/b/c").unwrap()}]), HashSet::new()));
+    let added_again = async_std::task::block_on(Digest::update_digest(
+        removed,
+        1671612730,
+        Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+        HashSet::from([LogEntry {
+            timestamp: Timestamp::from_str("2022-12-21T12:00:00.000000000Z/01").unwrap(),
+            key: OwnedKeyExpr::from_str("a/b/c").unwrap(),
+        }]),
+        HashSet::new(),
+    ));
     assert_eq!(added, added_again);
 }

--- a/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
@@ -971,3 +971,126 @@ fn test_create_digest_with_initial_cold() {
     };
     assert_eq!(created, expected);
 }
+
+#[test]
+fn test_update_digest_add_content() {
+    let created = async_std::task::block_on(Digest::update_digest(
+        Digest {
+            timestamp: Timestamp::from_str("2022-12-21T13:00:00.000000000Z/01").unwrap(),
+            config: DigestConfig {
+                delta: Duration::from_millis(1000),
+                sub_intervals: 10,
+                hot: 6,
+                warm: 30,
+            },
+            checksum: 0,
+            eras: HashMap::new(),
+            intervals: HashMap::new(),
+            subintervals: HashMap::new(),
+        },
+        1671634910,
+        Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+        HashSet::from([LogEntry {
+            timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+            key: OwnedKeyExpr::from_str("demo/example/a").unwrap(),
+        }]),
+        HashSet::new(),
+    ));
+    let expected = Digest {
+        timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+        config: DigestConfig {
+            delta: Duration::from_millis(1000),
+            sub_intervals: 10,
+            hot: 6,
+            warm: 30,
+        },
+        checksum: 9981730533083018288,
+        eras: HashMap::from([(
+            EraType::Cold,
+            Interval {
+                checksum: 8238986480495191270,
+                content: BTreeSet::from([1671634800]),
+            },
+        )]),
+        intervals: HashMap::from([(
+            1671634800,
+            Interval {
+                checksum: 12344398372324783476,
+                content: BTreeSet::from([16716348000]),
+            },
+        )]),
+        subintervals: HashMap::from([(
+            16716348000,
+            SubInterval {
+                checksum: 10007212639402189432,
+                content: BTreeSet::from([LogEntry {
+                    timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+                    key: OwnedKeyExpr::from_str("demo/example/a").unwrap(),
+                }]),
+            },
+        )]),
+    };
+    assert_eq!(created, expected);
+}
+
+#[test]
+fn test_update_digest_remove_content() {
+    let created = async_std::task::block_on(Digest::update_digest(
+        Digest {
+            timestamp: Timestamp::from_str("2022-12-21T13:00:00.000000000Z/01").unwrap(),
+            config: DigestConfig {
+                delta: Duration::from_millis(1000),
+                sub_intervals: 10,
+                hot: 6,
+                warm: 30,
+            },
+            checksum: 9981730533083018288,
+            eras: HashMap::from([(
+                EraType::Cold,
+                Interval {
+                    checksum: 8238986480495191270,
+                    content: BTreeSet::from([1671634800]),
+                },
+            )]),
+            intervals: HashMap::from([(
+                1671634800,
+                Interval {
+                    checksum: 12344398372324783476,
+                    content: BTreeSet::from([16716348000]),
+                },
+            )]),
+            subintervals: HashMap::from([(
+                16716348000,
+                SubInterval {
+                    checksum: 10007212639402189432,
+                    content: BTreeSet::from([LogEntry {
+                        timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01")
+                            .unwrap(),
+                        key: OwnedKeyExpr::from_str("demo/example/a").unwrap(),
+                    }]),
+                },
+            )]),
+        },
+        1671634910,
+        Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+        HashSet::new(),
+        HashSet::from([LogEntry {
+            timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+            key: OwnedKeyExpr::from_str("demo/example/a").unwrap(),
+        }]),
+    ));
+    let expected = Digest {
+        timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+        config: DigestConfig {
+            delta: Duration::from_millis(1000),
+            sub_intervals: 10,
+            hot: 6,
+            warm: 30,
+        },
+        checksum: 0,
+        eras: HashMap::new(),
+        intervals: HashMap::new(),
+        subintervals: HashMap::new(),
+    };
+    assert_eq!(created, expected);
+}

--- a/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
@@ -701,21 +701,18 @@ impl Digest {
 
 // functions for alignment
 impl Digest {
-    // return mismatching eras
-    pub fn get_era_diff(&self, other: HashMap<EraType, Interval>) -> HashSet<EraType> {
-        let mut result = HashSet::new();
-        for era in vec![EraType::Hot, EraType::Warm, EraType::Cold] {
-            if other.contains_key(&era) && other.get(&era).unwrap().checksum != 0 {
-                if self.eras.contains_key(&era) {
-                    if self.eras.get(&era).unwrap().checksum != other.get(&era).unwrap().checksum {
-                        result.insert(era);
-                    }
-                } else {
-                    result.insert(era);
+    // check of the other era has more content
+    pub fn era_has_diff(&self, era: &EraType, other: &HashMap<EraType, Interval>) -> bool {
+        if other.contains_key(era) {
+            if self.eras.contains_key(era) {
+                if self.eras.get(era).unwrap().checksum != other.get(era).unwrap().checksum {
+                    return true;
                 }
-            } // else no need to check
+            } else {
+                return true;
+            }
         }
-        result
+        false
     }
 
     // return mismatching intervals in an era

--- a/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
@@ -814,7 +814,7 @@ fn test_create_digest_empty_initial() {
 }
 
 #[test]
-fn test_create_digest_with_initial() {
+fn test_create_digest_with_initial_hot() {
     let created = Digest::create_digest(
         Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
         DigestConfig {
@@ -827,7 +827,7 @@ fn test_create_digest_with_initial() {
             timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
             key: OwnedKeyExpr::from_str("demo/example/a").unwrap(),
         }],
-        1671612730,
+        1671634800,
     );
     let expected = Digest {
         timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
@@ -840,6 +840,112 @@ fn test_create_digest_with_initial() {
         checksum: 7304841855083503815,
         eras: HashMap::from([(
             EraType::Hot,
+            Interval {
+                checksum: 8238986480495191270,
+                content: BTreeSet::from([1671634800]),
+            },
+        )]),
+        intervals: HashMap::from([(
+            1671634800,
+            Interval {
+                checksum: 12344398372324783476,
+                content: BTreeSet::from([16716348000]),
+            },
+        )]),
+        subintervals: HashMap::from([(
+            16716348000,
+            SubInterval {
+                checksum: 10007212639402189432,
+                content: BTreeSet::from([LogEntry {
+                    timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+                    key: OwnedKeyExpr::from_str("demo/example/a").unwrap(),
+                }]),
+            },
+        )]),
+    };
+    assert_eq!(created, expected);
+}
+
+#[test]
+fn test_create_digest_with_initial_warm() {
+    let created = Digest::create_digest(
+        Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+        DigestConfig {
+            delta: Duration::from_millis(1000),
+            sub_intervals: 10,
+            hot: 6,
+            warm: 30,
+        },
+        vec![LogEntry {
+            timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+            key: OwnedKeyExpr::from_str("demo/example/a").unwrap(),
+        }],
+        1671634810,
+    );
+    let expected = Digest {
+        timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+        config: DigestConfig {
+            delta: Duration::from_millis(1000),
+            sub_intervals: 10,
+            hot: 6,
+            warm: 30,
+        },
+        checksum: 10166157512612218546,
+        eras: HashMap::from([(
+            EraType::Warm,
+            Interval {
+                checksum: 8238986480495191270,
+                content: BTreeSet::from([1671634800]),
+            },
+        )]),
+        intervals: HashMap::from([(
+            1671634800,
+            Interval {
+                checksum: 12344398372324783476,
+                content: BTreeSet::from([16716348000]),
+            },
+        )]),
+        subintervals: HashMap::from([(
+            16716348000,
+            SubInterval {
+                checksum: 10007212639402189432,
+                content: BTreeSet::from([LogEntry {
+                    timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+                    key: OwnedKeyExpr::from_str("demo/example/a").unwrap(),
+                }]),
+            },
+        )]),
+    };
+    assert_eq!(created, expected);
+}
+
+#[test]
+fn test_create_digest_with_initial_cold() {
+    let created = Digest::create_digest(
+        Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+        DigestConfig {
+            delta: Duration::from_millis(1000),
+            sub_intervals: 10,
+            hot: 6,
+            warm: 30,
+        },
+        vec![LogEntry {
+            timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+            key: OwnedKeyExpr::from_str("demo/example/a").unwrap(),
+        }],
+        1671634910,
+    );
+    let expected = Digest {
+        timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+        config: DigestConfig {
+            delta: Duration::from_millis(1000),
+            sub_intervals: 10,
+            hot: 6,
+            warm: 30,
+        },
+        checksum: 9981730533083018288,
+        eras: HashMap::from([(
+            EraType::Cold,
             Interval {
                 checksum: 8238986480495191270,
                 content: BTreeSet::from([1671634800]),

--- a/plugins/zenoh-plugin-storage-manager/src/replica/mod.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/mod.rs
@@ -82,11 +82,11 @@ impl Replica {
         name: &str,
         rx: Receiver<StorageMessage>,
     ) {
-        trace!("[REPLICA]Opening session...");
+        trace!("[REPLICA] Opening session...");
         let startup_entries = match store_intercept.storage.get_all_entries().await {
             Ok(entries) => entries,
             Err(e) => {
-                error!("Error fetching entries from storage: {}", e);
+                error!("[REPLICA] Error fetching entries from storage: {}", e);
                 return;
             }
         };
@@ -164,12 +164,12 @@ impl Replica {
         );
 
         select!(
-            () = digest_sub => trace!("[Replica] Exiting digest subscriber"),
-            () = align_q => trace!("[Replica] Exiting align queryable"),
-            () = aligner => trace!("[Replica] Exiting aligner"),
-            () = digest_pub => trace!("[Replica] Exiting digest publisher"),
-            () = snapshot_task => trace!("[Replica] Exiting snapshot task"),
-            () = storage_task => trace!("[Replica] Exiting storage task"),
+            () = digest_sub => trace!("[REPLICA] Exiting digest subscriber"),
+            () = align_q => trace!("[REPLICA] Exiting align queryable"),
+            () = aligner => trace!("[REPLICA] Exiting aligner"),
+            () = digest_pub => trace!("[REPLICA] Exiting digest publisher"),
+            () = snapshot_task => trace!("[REPLICA] Exiting snapshot task"),
+            () = storage_task => trace!("[REPLICA] Exiting storage task"),
         )
     }
 
@@ -197,7 +197,7 @@ impl Replica {
             let sample = match subscriber.recv_async().await {
                 Ok(sample) => sample,
                 Err(e) => {
-                    error!("Error receiving sample: {}", e);
+                    error!("[DIGEST_SUB] Error receiving sample: {}", e);
                     continue;
                 }
             };
@@ -213,7 +213,7 @@ impl Replica {
             let digest: Digest = match serde_json::from_str(&format!("{}", sample.value)) {
                 Ok(digest) => digest,
                 Err(e) => {
-                    error!("Error in decoding the digest: {}", e);
+                    error!("[DIGEST_SUB] Error in decoding the digest: {}", e);
                     continue;
                 }
             };
@@ -231,7 +231,7 @@ impl Replica {
                 trace!("[DIGEST_SUB] sending {} to aligner", digest.checksum);
                 match tx.send_async((from.to_string(), digest)).await {
                     Ok(()) => {}
-                    Err(e) => error!("Error sending digest to aligner: {}", e),
+                    Err(e) => error!("[DIGEST_SUB] Error sending digest to aligner: {}", e),
                 }
             };
             received.insert(from.to_string(), ts);
@@ -267,7 +267,7 @@ impl Replica {
             trace!("[DIGEST_PUB] Putting Digest : {} ...", digest_json);
             match publisher.put(digest_json).res().await {
                 Ok(()) => {}
-                Err(e) => error!("Digest publication failed: {}", e),
+                Err(e) => error!("[DIGEST_PUB] Digest publication failed: {}", e),
             }
         }
     }
@@ -303,7 +303,7 @@ impl Replica {
                     self.replica_config.delta,
                 )
         {
-            error!("[DIGEST_SUB] mismatching digest configs, cannot be aligned");
+            error!("[DIGEST_SUB] Mismatching digest configs, cannot be aligned");
             return false;
         }
         true

--- a/plugins/zenoh-plugin-storage-manager/src/replica/mod.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/mod.rs
@@ -284,6 +284,11 @@ impl Replica {
             // no values to align
             return false;
         }
+        let digests_published = self.digests_published.read().await;
+        if digests_published.contains(&checksum) {
+            trace!("[DIGEST_SUB] Dropping since matching digest already seen");
+            return false;
+        }
         // TODO: test this part
         if received.contains_key(from) && *received.get(from).unwrap() > ts {
             // not the latest from that replica

--- a/plugins/zenoh-plugin-storage-manager/src/replica/snapshotter.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/snapshotter.rs
@@ -308,6 +308,7 @@ impl Snapshotter {
         )
         .await;
         *digest = updated_digest;
+        drop(digest);
 
         self.flush().await;
     }
@@ -317,8 +318,10 @@ impl Snapshotter {
         let replica_data = &self.content;
         let stable = replica_data.stable_log.read().await;
         let volatile = replica_data.volatile_log.read().await;
-        trace!("Stable log updated:: {:?}", stable);
-        trace!("Volatile log updated:: {:?}", volatile);
+        let digest = replica_data.digest.read().await;
+        trace!("Stable log:: {:?}", stable);
+        trace!("Volatile log:: {:?}", volatile);
+        trace!("Digest:: {:?}", digest);
     }
 
     // Expose digest


### PR DESCRIPTION
This PR fixes a bug in the alignment protocol that keeps on identifying misalignment: 
- When a replica starts with an empty log, it creates a digest with 0 subinterval, which changes the digest checksums even though it has no impact semantically. When a replica starts with some data, the digest will not have this 0 subinterval, leading the replica to detect misalignment. 

This PR also refactors the replica module, includes more tests, and improves logging.