### PR TITLE
Handle incorrect private keys and support pkcs8 keys

### DIFF
--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -41,7 +41,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use zenoh_core::Result as ZResult;
-use zenoh_core::{zasynclock, zerror, zread, zwrite, bail};
+use zenoh_core::{bail, zasynclock, zerror, zread, zwrite};
 use zenoh_link_commons::{
     LinkManagerUnicastTrait, LinkUnicast, LinkUnicastTrait, NewLinkChannelSender,
 };

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -518,6 +518,16 @@ impl TlsServerConfig {
                 .map_err(|e| zerror!(e))
                 .map(|mut keys| keys.drain(..).map(PrivateKey).collect())?;
 
+        if keys.len() == 0 {
+            keys = rustls_pemfile::pkcs8_private_keys(&mut Cursor::new(&tls_server_private_key))
+                .map_err(|e| zerror!(e))
+                .map(|mut keys| keys.drain(..).map(PrivateKey).collect())?;
+        }
+
+        if keys.len() == 0 {
+            return Err(zerror!("No private key found.").into());
+        }
+
         let certs: Vec<Certificate> =
             rustls_pemfile::certs(&mut Cursor::new(&tls_server_certificate))
                 .map_err(|e| zerror!(e))

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -41,7 +41,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use zenoh_core::Result as ZResult;
-use zenoh_core::{zasynclock, zerror, zread, zwrite};
+use zenoh_core::{zasynclock, zerror, zread, zwrite, bail};
 use zenoh_link_commons::{
     LinkManagerUnicastTrait, LinkUnicast, LinkUnicastTrait, NewLinkChannelSender,
 };
@@ -518,14 +518,14 @@ impl TlsServerConfig {
                 .map_err(|e| zerror!(e))
                 .map(|mut keys| keys.drain(..).map(PrivateKey).collect())?;
 
-        if keys.len() == 0 {
+        if keys.is_empty() {
             keys = rustls_pemfile::pkcs8_private_keys(&mut Cursor::new(&tls_server_private_key))
                 .map_err(|e| zerror!(e))
                 .map(|mut keys| keys.drain(..).map(PrivateKey).collect())?;
         }
 
-        if keys.len() == 0 {
-            return Err(zerror!("No private key found.").into());
+        if keys.is_empty() {
+            bail!("No private key found");
         }
 
         let certs: Vec<Certificate> =


### PR DESCRIPTION
When I tried using TLS transport using a certificate and key not created using minica, it would not read the key file. It instead gave the following error:
`thread 'main' panicked at 'removal index (is 0) should be < len (is 0)', io/zenoh-links/zenoh-link-tls/src/unicast.rs:380:40`

The reason turned out to be that the function used (`rustls_pemfile::rsa_private_keys`) only reads keys in the pkcs#1 format and just silently returns an empty list if no such key is found.

My solution is to check if no key was found and if not, try the pkcs#8 format and ultimately, if a key is still not found, give a better error message.