### PR TITLE
`no_std` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3823,6 +3823,7 @@ dependencies = [
 name = "zenoh-buffers"
 version = "0.7.0-rc"
 dependencies = [
+ "defmt",
  "rand 0.8.5",
  "zenoh-collections",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,9 +114,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anyhow"
-version = "1.0.66"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "array-init"
@@ -343,9 +343,9 @@ checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.60"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d1d8ab452a3936018a687b20e6f7cf5363d713b732b8884001317b0e48aa3"
+checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -499,9 +499,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.77"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 
 [[package]]
 name = "cfg-if"
@@ -843,9 +843,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.83"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf07d07d6531bfcdbe9b8b739b104610c6508dcc4d63b410585faf338241daf"
+checksum = "51d1075c37807dcf850c379432f0df05ba52cc30f279c5cfc43cc221ce7f8579"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -855,9 +855,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.83"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2eb5b96ecdc99f72657332953d4d9c50135af1bac34277801cc3937906ebd39"
+checksum = "5044281f61b27bc598f2f6647d480aed48d2bf52d6eb0b627d84c0361b17aa70"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -870,15 +870,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.83"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac040a39517fd1674e0f32177648334b0f4074625b5588a64519804ba0553b12"
+checksum = "61b50bc93ba22c27b0d31128d2d130a0a6b3d267ae27ef7e4fae2167dfe8781c"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.83"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1362b0ddcfc4eb0a1f57b68bd77dd99f0e826958a96abd0ae9bd092e114ffed6"
+checksum = "39e61fda7e62115119469c7b3591fd913ecca96fb766cfd3f2e2502ab7bc87a5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1017,9 +1017,9 @@ dependencies = [
 
 [[package]]
 name = "erased-serde"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54558e0ba96fbe24280072642eceb9d7d442e32c7ec0ea9e7ecd7b4ea2cf4e11"
+checksum = "e4ca605381c017ec7a5fef5e548f1cfaa419ed0f6df6367339300db74c92aa7d"
 dependencies = [
  "serde",
 ]
@@ -1282,9 +1282,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "gloo-timers"
@@ -1528,9 +1528,9 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927609f78c2913a6f6ac3c27a4fe87f43e2a35367c0c4b0f8265e8f49a104330"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
 dependencies = [
  "hermit-abi 0.2.6",
  "io-lifetimes",
@@ -1549,9 +1549,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "js-sys"
@@ -1602,9 +1602,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.138"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libloading"
@@ -1624,18 +1624,18 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "link-cplusplus"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
@@ -1842,19 +1842,19 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "oorandom"
@@ -1903,9 +1903,9 @@ checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "paste"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1c2c742266c2f1041c914ba65355a83ae8747b05f208319784083583494b4b"
+checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
 name = "pem"
@@ -1933,9 +1933,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc8bed3549e0f9b0a2a78bf7c0018237a2cdf085eecbbc048e52612438e4e9d0"
+checksum = "0f6e86fb9e7026527a0d46bc308b841d73170ef8f443e1807f6ef88526a816d4"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -1943,9 +1943,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc078600d06ff90d4ed238f0119d84ab5d43dbaad278b0e33a8820293b32344"
+checksum = "96504449aa860c8dcde14f9fba5c58dc6658688ca1fe363589d6327b8662c603"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1953,9 +1953,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a1af60b1c4148bb269006a750cff8e2ea36aff34d2d96cf7be0b14d1bed23c"
+checksum = "798e0220d1111ae63d66cb66a5dcb3fc2d986d520b98e49e1852bfdb11d7c5e7"
 dependencies = [
  "pest",
  "pest_meta",
@@ -1966,9 +1966,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec8605d59fc2ae0c6c1aefc0c7c7a9769732017c0ce07f7a9cfffa7b4404f20"
+checksum = "984298b75898e30a843e278a9f2452c31e349a073a0ce6fd950a12a74464e065"
 dependencies = [
  "once_cell",
  "pest",
@@ -2219,15 +2219,15 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.19"
+version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
@@ -2284,9 +2284,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -2450,9 +2450,9 @@ dependencies = [
 
 [[package]]
 name = "ringbuffer-spsc"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae677c20a3502f9d82efa27b24aa0d9ca49ee458c43f0fc7bb0a8db3c6b69b6"
+checksum = "2fd1938faa63a2362ee1747afb2d10567d0fb1413b9cbd6198a8541485c4f773"
 dependencies = [
  "array-init",
  "cache-padded",
@@ -2506,14 +2506,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.14",
+ "semver 1.0.16",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.36.5"
+version = "0.36.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
+checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
 dependencies = [
  "bitflags",
  "errno",
@@ -2558,9 +2558,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "same-file"
@@ -2589,9 +2589,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratch"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
 
 [[package]]
 name = "sct"
@@ -2637,9 +2637,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "semver-parser"
@@ -2678,9 +2678,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "itoa",
  "ryu",
@@ -2712,9 +2712,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.14"
+version = "0.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d232d893b10de3eb7258ff01974d6ee20663d8e833263c99409d4b13a0209da"
+checksum = "92b5b431e8907b50339b51223b97d102db8d987ced36f6e4d03621db9316c834"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2997,9 +2997,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.105"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3023,18 +3023,18 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3156,9 +3156,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.23.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
+checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3288,8 +3288,9 @@ dependencies = [
 [[package]]
 name = "uhlc"
 version = "0.5.1"
-source = "git+https://github.com/atolab/uhlc-rs.git#1ebaf15e111c39c12b513ec7d854884df789ada0"
+source = "git+https://github.com/atolab/uhlc-rs.git#956d7944e3e546cf1dc8c1d1c083bfadfef877ae"
 dependencies = [
+ "defmt",
  "hex",
  "humantime",
  "lazy_static",
@@ -3307,9 +3308,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-normalization"
@@ -3338,9 +3339,9 @@ dependencies = [
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e5fa573d8ac5f1a856f8d7be41d390ee973daf97c806b2c1a465e4e1406e68"
+checksum = "bc7ed8ba44ca06be78ea1ad2c3682a43349126c8818054231ee6f4748012aed2"
 
 [[package]]
 name = "untrusted"
@@ -3768,9 +3769,9 @@ checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "yasna"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346d34a236c9d3e5f3b9b74563f238f955bbd05fa0b8b4efa53c130c43982f4c"
+checksum = "aed2e7a52e3744ab4d0c05c20aa065258e84c49fd4226f5191b2ed29712710b4"
 dependencies = [
  "time 0.3.17",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3856,7 +3856,7 @@ version = "0.7.0-rc"
 dependencies = [
  "criterion",
  "rand 0.8.5",
- "uhlc 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uhlc 0.5.1 (git+https://github.com/atolab/uhlc-rs.git)",
  "uuid",
  "zenoh-buffers",
  "zenoh-protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,6 +886,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a0ae7494d9bff013d7b89471f4c424356a71e9752e0c78abe7e6c608a16bb3"
+dependencies = [
+ "bitflags",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8500cbe4cca056412efce4215a63d0bc20492942aeee695f23b624a53e0a6854"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0db23d29972d99baa3de2ee2ae3f104c10564a6d05a346eb3f4c4f2c0525a06e"
+
+[[package]]
 name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2163,6 +2192,30 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro-hack"
@@ -3799,6 +3852,7 @@ dependencies = [
 name = "zenoh-collections"
 version = "0.7.0-rc"
 dependencies = [
+ "defmt",
  "zenoh-core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3274,20 +3274,6 @@ checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 [[package]]
 name = "uhlc"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7908438f98a5824af02b34c2b31fb369c5764ef835d26df0badbb9897fb28245"
-dependencies = [
- "hex",
- "humantime",
- "lazy_static",
- "log",
- "serde",
- "uuid",
-]
-
-[[package]]
-name = "uhlc"
-version = "0.5.1"
 source = "git+https://github.com/atolab/uhlc-rs.git#956d7944e3e546cf1dc8c1d1c083bfadfef877ae"
 dependencies = [
  "defmt",
@@ -3815,7 +3801,7 @@ dependencies = [
  "serde_json",
  "socket2",
  "stop-token",
- "uhlc 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uhlc",
  "uuid",
  "vec_map",
  "zenoh-buffers",
@@ -3857,7 +3843,7 @@ version = "0.7.0-rc"
 dependencies = [
  "criterion",
  "rand 0.8.5",
- "uhlc 0.5.1 (git+https://github.com/atolab/uhlc-rs.git)",
+ "uhlc",
  "uuid",
  "zenoh-buffers",
  "zenoh-protocol",
@@ -4200,7 +4186,7 @@ dependencies = [
  "lazy_static",
  "rand 0.8.5",
  "serde",
- "uhlc 0.5.1 (git+https://github.com/atolab/uhlc-rs.git)",
+ "uhlc",
  "uuid",
  "zenoh-buffers",
  "zenoh-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3286,6 +3286,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "uhlc"
+version = "0.5.1"
+source = "git+https://github.com/atolab/uhlc-rs.git#1ebaf15e111c39c12b513ec7d854884df789ada0"
+dependencies = [
+ "hex",
+ "humantime",
+ "lazy_static",
+ "log",
+ "serde",
+ "spin 0.9.4",
+ "uuid",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3800,7 +3814,7 @@ dependencies = [
  "serde_json",
  "socket2",
  "stop-token",
- "uhlc",
+ "uhlc 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid",
  "vec_map",
  "zenoh-buffers",
@@ -3842,7 +3856,7 @@ version = "0.7.0-rc"
 dependencies = [
  "criterion",
  "rand 0.8.5",
- "uhlc",
+ "uhlc 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid",
  "zenoh-buffers",
  "zenoh-protocol",
@@ -4180,11 +4194,12 @@ dependencies = [
 name = "zenoh-protocol"
 version = "0.7.0-rc"
 dependencies = [
+ "defmt",
  "hex",
  "lazy_static",
  "rand 0.8.5",
  "serde",
- "uhlc",
+ "uhlc 0.5.1 (git+https://github.com/atolab/uhlc-rs.git)",
  "uuid",
  "zenoh-buffers",
  "zenoh-core",

--- a/commons/zenoh-buffers/Cargo.toml
+++ b/commons/zenoh-buffers/Cargo.toml
@@ -31,8 +31,6 @@ description = "Internal crate for zenoh."
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
-default = ["std"]
-std = ["zenoh-collections/std"]
 test = ["rand"]
 defmt = ["dep:defmt", "zenoh-collections/defmt"]
 

--- a/commons/zenoh-buffers/Cargo.toml
+++ b/commons/zenoh-buffers/Cargo.toml
@@ -31,8 +31,12 @@ description = "Internal crate for zenoh."
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
-test = [ "rand" ]
+default = ["std"]
+std = ["zenoh-collections/std"]
+test = ["rand"]
+defmt = ["dep:defmt", "zenoh-collections/defmt"]
 
 [dependencies]
+defmt = { version = "0.3.2", features = ["alloc"], optional = true }
 rand = { version = "0.8.5", optional = true }
 zenoh-collections = { version = "0.7.0-rc", path = "../zenoh-collections/", default-features = false }

--- a/commons/zenoh-buffers/src/bbuf.rs
+++ b/commons/zenoh-buffers/src/bbuf.rs
@@ -11,8 +11,6 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-extern crate alloc;
-
 use crate::{
     reader::HasReader,
     vec,
@@ -22,6 +20,7 @@ use alloc::boxed::Box;
 use core::num::NonZeroUsize;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct BBuf {
     buffer: Box<[u8]>,
     len: usize,
@@ -131,6 +130,7 @@ impl<'a> HasReader for &'a BBuf {
 #[cfg(feature = "test")]
 impl BBuf {
     pub fn rand(len: usize) -> Self {
+        #[allow(unused_imports)]
         use alloc::vec::Vec;
         use rand::Rng;
 

--- a/commons/zenoh-buffers/src/bbuf.rs
+++ b/commons/zenoh-buffers/src/bbuf.rs
@@ -130,7 +130,6 @@ impl<'a> HasReader for &'a BBuf {
 #[cfg(feature = "test")]
 impl BBuf {
     pub fn rand(len: usize) -> Self {
-        #[allow(unused_imports)]
         use alloc::vec::Vec;
         use rand::Rng;
 

--- a/commons/zenoh-buffers/src/lib.rs
+++ b/commons/zenoh-buffers/src/lib.rs
@@ -12,8 +12,8 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-//! Provide differnt buffer implementations used for serialization and deserialization.
-#![cfg_attr(not(feature = "std"), no_std)]
+//! Provide different buffer implementations used for serialization and deserialization.
+#![no_std]
 extern crate alloc;
 
 mod bbuf;

--- a/commons/zenoh-buffers/src/lib.rs
+++ b/commons/zenoh-buffers/src/lib.rs
@@ -13,7 +13,7 @@
 //
 
 //! Provide differnt buffer implementations used for serialization and deserialization.
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 extern crate alloc;
 
 mod bbuf;
@@ -32,6 +32,7 @@ pub mod writer {
     use core::num::NonZeroUsize;
 
     #[derive(Debug, Clone, Copy)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct DidntWrite;
 
     pub trait Writer {
@@ -74,6 +75,7 @@ pub mod reader {
     use core::num::NonZeroUsize;
 
     #[derive(Debug, Clone, Copy)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct DidntRead;
 
     pub trait Reader {
@@ -114,6 +116,7 @@ pub mod reader {
     }
 
     #[derive(Debug, Clone, Copy)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct DidntSiphon;
 
     pub trait SiphonableReader: Reader {

--- a/commons/zenoh-buffers/src/vec.rs
+++ b/commons/zenoh-buffers/src/vec.rs
@@ -11,8 +11,6 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-extern crate alloc;
-
 use crate::{
     reader::HasReader,
     writer::{BacktrackableWriter, DidntWrite, HasWriter, Writer},

--- a/commons/zenoh-buffers/src/zbuf.rs
+++ b/commons/zenoh-buffers/src/zbuf.rs
@@ -11,8 +11,6 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-extern crate alloc;
-
 use crate::{
     reader::{BacktrackableReader, DidntRead, DidntSiphon, HasReader, Reader, SiphonableReader},
     writer::{BacktrackableWriter, DidntWrite, HasWriter, Writer},
@@ -27,6 +25,7 @@ fn get_mut_unchecked<T>(arc: &mut Arc<T>) -> &mut T {
 }
 
 #[derive(Debug, Clone, Default, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ZBuf {
     slices: SingleOrVec<ZSlice>,
 }
@@ -125,12 +124,14 @@ where
 
 // Reader
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ZBufPos {
     slice: usize,
     byte: usize,
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ZBufReader<'a> {
     inner: &'a ZBuf,
     cursor: ZBufPos,
@@ -348,6 +349,7 @@ impl Iterator for ZBufSliceIterator<'_, '_> {
 
 // Writer
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ZBufWriter<'a> {
     inner: &'a mut ZBuf,
     cache: Arc<Vec<u8>>,

--- a/commons/zenoh-buffers/src/zslice.rs
+++ b/commons/zenoh-buffers/src/zslice.rs
@@ -11,8 +11,6 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-extern crate alloc;
-
 use crate::reader::{BacktrackableReader, DidntRead, HasReader, Reader};
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use core::{
@@ -210,6 +208,13 @@ impl fmt::Debug for ZSlice {
             self.end,
             self.buf.as_slice()
         )
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for ZSlice {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "{:02x}", self.as_slice());
     }
 }
 

--- a/commons/zenoh-buffers/src/zslice.rs
+++ b/commons/zenoh-buffers/src/zslice.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use crate::reader::{BacktrackableReader, DidntRead, HasReader, Reader};
-use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use alloc::{boxed::Box, format, sync::Arc, vec::Vec};
 use core::{
     any::Any,
     convert::AsRef,
@@ -214,7 +214,8 @@ impl fmt::Debug for ZSlice {
 #[cfg(feature = "defmt")]
 impl defmt::Format for ZSlice {
     fn format(&self, f: defmt::Formatter) {
-        defmt::write!(f, "{:02x}", self.as_slice());
+        let s = format!("{}", self); // Obtain representation computed by fmt::Display
+        defmt::write!(f, "{}", s);
     }
 }
 

--- a/commons/zenoh-buffers/src/zslice.rs
+++ b/commons/zenoh-buffers/src/zslice.rs
@@ -21,9 +21,6 @@ use core::{
     ops::{Deref, Index, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive},
 };
 
-#[cfg(feature = "defmt")]
-use alloc::format;
-
 /*************************************/
 /*           ZSLICE BUFFER           */
 /*************************************/
@@ -217,8 +214,7 @@ impl fmt::Debug for ZSlice {
 #[cfg(feature = "defmt")]
 impl defmt::Format for ZSlice {
     fn format(&self, f: defmt::Formatter) {
-        let s = format!("{}", self); // Obtain representation computed by fmt::Display
-        defmt::write!(f, "{}", s);
+        defmt::write!(f, "{:02x}", self.as_slice());
     }
 }
 

--- a/commons/zenoh-buffers/src/zslice.rs
+++ b/commons/zenoh-buffers/src/zslice.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use crate::reader::{BacktrackableReader, DidntRead, HasReader, Reader};
-use alloc::{boxed::Box, format, sync::Arc, vec::Vec};
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use core::{
     any::Any,
     convert::AsRef,
@@ -20,6 +20,9 @@ use core::{
     num::NonZeroUsize,
     ops::{Deref, Index, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive},
 };
+
+#[cfg(feature = "defmt")]
+use alloc::format;
 
 /*************************************/
 /*           ZSLICE BUFFER           */

--- a/commons/zenoh-codec/Cargo.toml
+++ b/commons/zenoh-codec/Cargo.toml
@@ -29,20 +29,34 @@ description = "Internal crate for zenoh."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-shared-memory = ["zenoh-shm", "zenoh-protocol/shared-memory"]
+default = ["std"]
+std = [
+    "uhlc/std",
+    "zenoh-buffers/std",
+    "zenoh-protocol/std"
+]
+shared-memory = [
+    "std",
+    "zenoh-shm",
+    "zenoh-protocol/shared-memory"
+]
 complete_n = ["zenoh-protocol/complete_n"]
+defmt = [
+    "zenoh-buffers/defmt",
+    "zenoh-protocol/defmt"
+]
 
 [dependencies]
-uhlc = "0.5.1"
-zenoh-buffers = { version = "0.7.0-rc", path = "../zenoh-buffers/" }
-zenoh-protocol = { version = "0.7.0-rc", path = "../zenoh-protocol/" }
+uhlc = { git = "https://github.com/atolab/uhlc-rs.git", default-features = false } # TODO: Using github source until the no_std update gets released on crates.io
+zenoh-buffers = { version = "0.7.0-rc", path = "../zenoh-buffers/", default-features = false }
+zenoh-protocol = { version = "0.7.0-rc", path = "../zenoh-protocol/", default-features = false }
 zenoh-shm = { version = "0.7.0-rc", path = "../zenoh-shm/", optional = true }
 
 [dev-dependencies]
 criterion = "0.4.0"
 rand = "0.8.5"
 uuid = { version = "1.1.2", features = ["v4"] }
-zenoh-protocol = { version = "0.7.0-rc", path = "../zenoh-protocol/", features = [ "test" ] }
+zenoh-protocol = { version = "0.7.0-rc", path = "../zenoh-protocol/", features = ["test"] }
 
 [[bench]]
 name = "codec"

--- a/commons/zenoh-codec/Cargo.toml
+++ b/commons/zenoh-codec/Cargo.toml
@@ -32,7 +32,6 @@ description = "Internal crate for zenoh."
 default = ["std"]
 std = [
     "uhlc/std",
-    "zenoh-buffers/std",
     "zenoh-protocol/std"
 ]
 shared-memory = [

--- a/commons/zenoh-codec/src/common/attachment.rs
+++ b/commons/zenoh-codec/src/common/attachment.rs
@@ -22,7 +22,7 @@ use zenoh_protocol::{
     transport::tmsg,
 };
 #[cfg(feature = "shared-memory")]
-use {crate::Zenoh060Condition, std::any::TypeId, zenoh_shm::SharedMemoryBufInfoSerialized};
+use {crate::Zenoh060Condition, core::any::TypeId, zenoh_shm::SharedMemoryBufInfoSerialized};
 
 impl<W> WCodec<&Attachment, &mut W> for Zenoh060
 where

--- a/commons/zenoh-codec/src/core/encoding.rs
+++ b/commons/zenoh-codec/src/core/encoding.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use crate::{RCodec, WCodec, Zenoh060};
+use alloc::string::String;
 use zenoh_buffers::{
     reader::{DidntRead, Reader},
     writer::{DidntWrite, Writer},

--- a/commons/zenoh-codec/src/core/endpoint.rs
+++ b/commons/zenoh-codec/src/core/endpoint.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use crate::{RCodec, WCodec, Zenoh060};
+use alloc::{string::String, vec::Vec};
 use core::convert::TryFrom;
 use zenoh_buffers::{
     reader::{DidntRead, Reader},

--- a/commons/zenoh-codec/src/core/keyexpr.rs
+++ b/commons/zenoh-codec/src/core/keyexpr.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use crate::{RCodec, WCodec, Zenoh060, Zenoh060Condition};
+use alloc::string::String;
 use zenoh_buffers::{
     reader::{DidntRead, Reader},
     writer::{DidntWrite, Writer},

--- a/commons/zenoh-codec/src/core/locator.rs
+++ b/commons/zenoh-codec/src/core/locator.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use crate::{RCodec, WCodec, Zenoh060};
+use alloc::{string::String, vec::Vec};
 use core::convert::TryFrom;
 use zenoh_buffers::{
     reader::{DidntRead, Reader},

--- a/commons/zenoh-codec/src/core/mod.rs
+++ b/commons/zenoh-codec/src/core/mod.rs
@@ -23,6 +23,7 @@ mod zint;
 mod zslice;
 
 use crate::{RCodec, WCodec, Zenoh060};
+use alloc::{string::String, vec::Vec};
 use zenoh_buffers::{
     reader::{DidntRead, Reader},
     writer::{DidntWrite, Writer},

--- a/commons/zenoh-codec/src/core/property.rs
+++ b/commons/zenoh-codec/src/core/property.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use crate::{RCodec, WCodec, Zenoh060};
+use alloc::vec::Vec;
 use zenoh_buffers::{
     reader::{DidntRead, Reader},
     writer::{DidntWrite, Writer},

--- a/commons/zenoh-codec/src/core/zbuf.rs
+++ b/commons/zenoh-codec/src/core/zbuf.rs
@@ -103,7 +103,7 @@ where
                     reader.read_zslices(len, |s| zbuf.push_zslice(s))?;
                 }
                 super::zslice::kind::SHM_INFO => {
-                    let bytes: alloc::vec::Vec<u8> = self.codec.read(&mut *reader)?;
+                    let bytes: Vec<u8> = self.codec.read(&mut *reader)?;
                     let shm_info: SharedMemoryBufInfoSerialized = bytes.into();
                     let zslice: ZSlice = shm_info.into();
                     zbuf.push_zslice(zslice);

--- a/commons/zenoh-codec/src/core/zbuf.rs
+++ b/commons/zenoh-codec/src/core/zbuf.rs
@@ -19,7 +19,7 @@ use zenoh_buffers::{
 };
 #[cfg(feature = "shared-memory")]
 use {
-    crate::Zenoh060Condition, std::any::TypeId, zenoh_buffers::ZSlice,
+    crate::Zenoh060Condition, core::any::TypeId, zenoh_buffers::ZSlice,
     zenoh_shm::SharedMemoryBufInfoSerialized,
 };
 
@@ -103,7 +103,7 @@ where
                     reader.read_zslices(len, |s| zbuf.push_zslice(s))?;
                 }
                 super::zslice::kind::SHM_INFO => {
-                    let bytes: Vec<u8> = self.codec.read(&mut *reader)?;
+                    let bytes: alloc::vec::Vec<u8> = self.codec.read(&mut *reader)?;
                     let shm_info: SharedMemoryBufInfoSerialized = bytes.into();
                     let zslice: ZSlice = shm_info.into();
                     zbuf.push_zslice(zslice);

--- a/commons/zenoh-codec/src/lib.rs
+++ b/commons/zenoh-codec/src/lib.rs
@@ -11,6 +11,9 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
+#![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
+
 mod common;
 mod core;
 mod scouting;

--- a/commons/zenoh-codec/src/scouting/hello.rs
+++ b/commons/zenoh-codec/src/scouting/hello.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use crate::{RCodec, WCodec, Zenoh060, Zenoh060Header};
+use alloc::{vec, vec::Vec};
 use zenoh_buffers::{
     reader::{DidntRead, Reader},
     writer::{DidntWrite, Writer},

--- a/commons/zenoh-codec/src/transport/frame.rs
+++ b/commons/zenoh-codec/src/transport/frame.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use crate::{RCodec, WCodec, Zenoh060, Zenoh060Header, Zenoh060Reliability};
+use alloc::vec::Vec;
 use zenoh_buffers::{
     reader::{BacktrackableReader, DidntRead, Reader},
     writer::{DidntWrite, Writer},

--- a/commons/zenoh-codec/src/transport/join.rs
+++ b/commons/zenoh-codec/src/transport/join.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use crate::{RCodec, WCodec, Zenoh060, Zenoh060Header};
+use alloc::boxed::Box;
 use core::time::Duration;
 use zenoh_buffers::{
     reader::{DidntRead, Reader},

--- a/commons/zenoh-codec/src/zenoh/declare.rs
+++ b/commons/zenoh-codec/src/zenoh/declare.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use crate::{RCodec, WCodec, Zenoh060, Zenoh060Condition, Zenoh060Header};
+use alloc::vec::Vec;
 use zenoh_buffers::{
     reader::{DidntRead, Reader},
     writer::{DidntWrite, Writer},

--- a/commons/zenoh-codec/src/zenoh/linkstate.rs
+++ b/commons/zenoh-codec/src/zenoh/linkstate.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use crate::{RCodec, WCodec, Zenoh060, Zenoh060Header};
+use alloc::vec::Vec;
 use zenoh_buffers::{
     reader::{DidntRead, Reader},
     writer::{DidntWrite, Writer},

--- a/commons/zenoh-codec/src/zenoh/query.rs
+++ b/commons/zenoh-codec/src/zenoh/query.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use crate::{RCodec, WCodec, Zenoh060, Zenoh060Condition, Zenoh060Header};
+use alloc::string::String;
 use zenoh_buffers::{
     reader::{DidntRead, Reader},
     writer::{DidntWrite, Writer},

--- a/commons/zenoh-collections/Cargo.toml
+++ b/commons/zenoh-collections/Cargo.toml
@@ -29,8 +29,10 @@ description = "Internal crate for zenoh."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-std = ["zenoh-core"]
 default = ["std"]
+std = ["zenoh-core"]
+defmt = ["dep:defmt"]
 
 [dependencies]
+defmt = { version = "0.3.2", features = ["alloc"], optional = true }
 zenoh-core = { version = "0.7.0-rc", path = "../zenoh-core/", optional = true }

--- a/commons/zenoh-collections/src/lib.rs
+++ b/commons/zenoh-collections/src/lib.rs
@@ -17,6 +17,9 @@
 //! This crate is intended for Zenoh's internal use.
 //!
 //! [Click here for Zenoh's documentation](../zenoh/index.html)
+#![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
+
 pub mod single_or_vec;
 pub use single_or_vec::*;
 

--- a/commons/zenoh-collections/src/single_or_vec.rs
+++ b/commons/zenoh-collections/src/single_or_vec.rs
@@ -19,10 +19,8 @@ use core::{
     ptr, slice,
 };
 
-#[cfg(feature = "defmt")]
-use alloc::format;
-
 #[derive(Clone, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 enum SingleOrVecInner<T> {
     Single(T),
     Vec(Vec<T>),
@@ -83,18 +81,8 @@ where
     }
 }
 
-#[cfg(feature = "defmt")]
-impl<T> defmt::Format for SingleOrVecInner<T>
-where
-    T: fmt::Debug,
-{
-    fn format(&self, f: defmt::Formatter) {
-        let s = format!("{:?}", self); // Obtain representation computed by fmt::Debug
-        defmt::write!(f, "{}", s);
-    }
-}
-
 #[derive(Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SingleOrVec<T>(SingleOrVecInner<T>);
 
 impl<T> SingleOrVec<T> {
@@ -179,17 +167,6 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
-    }
-}
-
-#[cfg(feature = "defmt")]
-impl<T> defmt::Format for SingleOrVec<T>
-where
-    T: fmt::Debug,
-{
-    fn format(&self, f: defmt::Formatter) {
-        let s = format!("{:?}", self); // Obtain representation computed by fmt::Debug
-        defmt::write!(f, "{}", s);
     }
 }
 

--- a/commons/zenoh-collections/src/single_or_vec.rs
+++ b/commons/zenoh-collections/src/single_or_vec.rs
@@ -11,13 +11,16 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use alloc::{format, vec, vec::Vec};
+use alloc::{vec, vec::Vec};
 use core::{
     cmp::PartialEq,
     fmt, iter,
     ops::{Index, IndexMut},
     ptr, slice,
 };
+
+#[cfg(feature = "defmt")]
+use alloc::format;
 
 #[derive(Clone, Eq)]
 enum SingleOrVecInner<T> {

--- a/commons/zenoh-collections/src/single_or_vec.rs
+++ b/commons/zenoh-collections/src/single_or_vec.rs
@@ -11,7 +11,7 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use alloc::{vec, vec::Vec};
+use alloc::{format, vec, vec::Vec};
 use core::{
     cmp::PartialEq,
     fmt, iter,
@@ -83,10 +83,11 @@ where
 #[cfg(feature = "defmt")]
 impl<T> defmt::Format for SingleOrVecInner<T>
 where
-    T: defmt::Format,
+    T: fmt::Debug,
 {
     fn format(&self, f: defmt::Formatter) {
-        defmt::write!(f, "{:?}", self.as_ref());
+        let s = format!("{:?}", self); // Obtain representation computed by fmt::Debug
+        defmt::write!(f, "{}", s);
     }
 }
 
@@ -181,10 +182,11 @@ where
 #[cfg(feature = "defmt")]
 impl<T> defmt::Format for SingleOrVec<T>
 where
-    T: defmt::Format,
+    T: fmt::Debug,
 {
     fn format(&self, f: defmt::Formatter) {
-        self.0.format(f);
+        let s = format!("{:?}", self); // Obtain representation computed by fmt::Debug
+        defmt::write!(f, "{}", s);
     }
 }
 

--- a/commons/zenoh-collections/src/single_or_vec.rs
+++ b/commons/zenoh-collections/src/single_or_vec.rs
@@ -11,6 +11,7 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
+use alloc::{vec, vec::Vec};
 use core::{
     cmp::PartialEq,
     fmt, iter,
@@ -76,6 +77,16 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self.as_ref())
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl<T> defmt::Format for SingleOrVecInner<T>
+where
+    T: defmt::Format,
+{
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "{:?}", self.as_ref());
     }
 }
 
@@ -167,6 +178,16 @@ where
     }
 }
 
+#[cfg(feature = "defmt")]
+impl<T> defmt::Format for SingleOrVec<T>
+where
+    T: defmt::Format,
+{
+    fn format(&self, f: defmt::Formatter) {
+        self.0.format(f);
+    }
+}
+
 impl<T> IntoIterator for SingleOrVec<T> {
     type Item = T;
     type IntoIter = IntoIter<T>;
@@ -197,7 +218,7 @@ impl<T> iter::Extend<T> for SingleOrVec<T> {
 }
 
 pub struct IntoIter<T> {
-    pub drain: std::vec::IntoIter<T>,
+    pub drain: alloc::vec::IntoIter<T>,
     pub last: Option<T>,
 }
 

--- a/commons/zenoh-protocol/Cargo.toml
+++ b/commons/zenoh-protocol/Cargo.toml
@@ -30,19 +30,31 @@ categories = ["network-programming"]
 description = "Internal crate for zenoh."
 
 [features]
-test = [ "rand", "zenoh-buffers/test" ]
-shared-memory = []
+default = ["std"]
+std = [
+    "hex/std",
+    "rand?/std",
+    "rand?/std_rng",
+    "serde/std",
+    "uhlc/std",
+    "uuid/std",
+    "zenoh-buffers/std"
+]
+test = ["rand", "zenoh-buffers/test"]
+shared-memory = ["std"]
 complete_n = []
+defmt = ["dep:defmt", "zenoh-buffers/defmt"]
 
 [dependencies]
-hex = "0.4.3"
-rand = { version = "0.8.5", optional = true }
-serde = "1.0.147"
-uhlc = "0.5.1"
-uuid = "1.2.1"
-zenoh-buffers = { version = "0.7.0-rc", path = "../zenoh-buffers/" }
+defmt = { version = "0.3.2", features = ["alloc"], optional = true }
+hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
+rand = { version = "0.8.5", default-features = false, features = ["alloc", "getrandom"], optional = true }
+serde = { version = "1.0.147", default-features = false, features = ["alloc"] }
+uhlc = { git = "https://github.com/atolab/uhlc-rs.git", default-features = false } # TODO: Using github source until the no_std update gets released on crates.io
+uuid = { version = "1.2.1", default-features = false } # Needs a getrandom::getrandom() custom implementation on embedded (in root crate)
+zenoh-buffers = { version = "0.7.0-rc", path = "../zenoh-buffers/", default-features = false }
 zenoh-core = { version = "0.7.0-rc", path = "../zenoh-core/" }
 
 [dev-dependencies]
 lazy_static = "1.4.0"
-zenoh-protocol = { version = "0.7.0-rc", path = ".", features = [ "test" ] }
+zenoh-protocol = { version = "0.7.0-rc", path = ".", features = ["test"] }

--- a/commons/zenoh-protocol/Cargo.toml
+++ b/commons/zenoh-protocol/Cargo.toml
@@ -37,8 +37,7 @@ std = [
     "rand?/std_rng",
     "serde/std",
     "uhlc/std",
-    "uuid/std",
-    "zenoh-buffers/std"
+    "uuid/std"
 ]
 test = ["rand", "zenoh-buffers/test"]
 shared-memory = ["std"]

--- a/commons/zenoh-protocol/Cargo.toml
+++ b/commons/zenoh-protocol/Cargo.toml
@@ -42,7 +42,11 @@ std = [
 test = ["rand", "zenoh-buffers/test"]
 shared-memory = ["std"]
 complete_n = []
-defmt = ["dep:defmt", "zenoh-buffers/defmt"]
+defmt = [
+    "dep:defmt",
+    "uhlc/defmt",
+    "zenoh-buffers/defmt"
+]
 
 [dependencies]
 defmt = { version = "0.3.2", features = ["alloc"], optional = true }

--- a/commons/zenoh-protocol/src/common/attachment.rs
+++ b/commons/zenoh-protocol/src/common/attachment.rs
@@ -36,6 +36,7 @@ use zenoh_buffers::ZBuf;
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Attachment {
     pub buffer: ZBuf,
 }

--- a/commons/zenoh-protocol/src/core/encoding.rs
+++ b/commons/zenoh-protocol/src/core/encoding.rs
@@ -11,8 +11,6 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-extern crate alloc;
-
 use crate::core::ZInt;
 use alloc::borrow::Cow;
 use core::{convert::TryFrom, fmt, mem};

--- a/commons/zenoh-protocol/src/core/encoding.rs
+++ b/commons/zenoh-protocol/src/core/encoding.rs
@@ -222,13 +222,8 @@ impl fmt::Display for Encoding {
 #[cfg(feature = "defmt")]
 impl defmt::Format for Encoding {
     fn format(&self, f: defmt::Formatter) {
-        match self {
-            Encoding::Exact(e) => defmt::write!(f, "{}", e.as_ref()),
-            Encoding::WithSuffix(e, s) => {
-                defmt::write!(f, "{}", e.as_ref());
-                defmt::write!(f, "{}", s);
-            }
-        };
+        let s = format!("{}", self); // Obtain representation computed by fmt::Display
+        defmt::write!(f, "{}", s);
     }
 }
 

--- a/commons/zenoh-protocol/src/core/encoding.rs
+++ b/commons/zenoh-protocol/src/core/encoding.rs
@@ -44,6 +44,7 @@ mod consts {
 
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum KnownEncoding {
     Empty = 0,
     AppOctetStream = 1,
@@ -215,6 +216,19 @@ impl fmt::Display for Encoding {
                 f.write_str(s)
             }
         }
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for Encoding {
+    fn format(&self, f: defmt::Formatter) {
+        match self {
+            Encoding::Exact(e) => defmt::write!(f, "{}", e.as_ref()),
+            Encoding::WithSuffix(e, s) => {
+                defmt::write!(f, "{}", e.as_ref());
+                defmt::write!(f, "{}", s);
+            }
+        };
     }
 }
 

--- a/commons/zenoh-protocol/src/core/encoding.rs
+++ b/commons/zenoh-protocol/src/core/encoding.rs
@@ -120,6 +120,7 @@ impl AsRef<str> for KnownEncoding {
 /// A zenoh encoding is a HTTP Mime type represented, for wire efficiency,
 /// as an integer prefix (that maps to a string) and a string suffix.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Encoding {
     Exact(KnownEncoding),
     WithSuffix(KnownEncoding, Cow<'static, str>),
@@ -216,14 +217,6 @@ impl fmt::Display for Encoding {
                 f.write_str(s)
             }
         }
-    }
-}
-
-#[cfg(feature = "defmt")]
-impl defmt::Format for Encoding {
-    fn format(&self, f: defmt::Formatter) {
-        let s = format!("{}", self); // Obtain representation computed by fmt::Display
-        defmt::write!(f, "{}", s);
     }
 }
 

--- a/commons/zenoh-protocol/src/core/endpoint.rs
+++ b/commons/zenoh-protocol/src/core/endpoint.rs
@@ -128,6 +128,13 @@ impl fmt::Display for Protocol<'_> {
     }
 }
 
+#[cfg(feature = "defmt")]
+impl defmt::Format for Protocol<'_> {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "{}", self.as_str());
+    }
+}
+
 #[repr(transparent)]
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct ProtocolMut<'a>(&'a mut EndPoint);
@@ -157,6 +164,13 @@ impl fmt::Display for ProtocolMut<'_> {
     }
 }
 
+#[cfg(feature = "defmt")]
+impl defmt::Format for ProtocolMut<'_> {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "{}", self.as_str());
+    }
+}
+
 // Address
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -177,6 +191,13 @@ impl AsRef<str> for Address<'_> {
 impl fmt::Display for Address<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for Address<'_> {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "{}", self.as_str());
     }
 }
 
@@ -206,6 +227,13 @@ impl AsRef<str> for AddressMut<'_> {
 impl fmt::Display for AddressMut<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for AddressMut<'_> {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "{}", self.as_str());
     }
 }
 
@@ -241,6 +269,13 @@ impl AsRef<str> for Metadata<'_> {
 impl fmt::Display for Metadata<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for Metadata<'_> {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "{}", self.as_str());
     }
 }
 
@@ -310,6 +345,13 @@ impl fmt::Display for MetadataMut<'_> {
     }
 }
 
+#[cfg(feature = "defmt")]
+impl defmt::Format for MetadataMut<'_> {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "{}", self.as_str());
+    }
+}
+
 // Config
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -342,6 +384,13 @@ impl AsRef<str> for Config<'_> {
 impl fmt::Display for Config<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for Config<'_> {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "{}", self.as_str());
     }
 }
 
@@ -408,6 +457,13 @@ impl AsRef<str> for ConfigMut<'_> {
 impl fmt::Display for ConfigMut<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for ConfigMut<'_> {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "{}", self.as_str());
     }
 }
 
@@ -504,6 +560,13 @@ impl From<Locator> for EndPoint {
 impl fmt::Display for EndPoint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.inner)
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for EndPoint {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "{}", &self.inner);
     }
 }
 

--- a/commons/zenoh-protocol/src/core/endpoint.rs
+++ b/commons/zenoh-protocol/src/core/endpoint.rs
@@ -108,6 +108,7 @@ where
 // Protocol
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Protocol<'a>(pub(super) &'a str);
 
 impl<'a> Protocol<'a> {
@@ -128,16 +129,9 @@ impl fmt::Display for Protocol<'_> {
     }
 }
 
-#[cfg(feature = "defmt")]
-impl defmt::Format for Protocol<'_> {
-    fn format(&self, f: defmt::Formatter) {
-        let s = format!("{}", self); // Obtain representation computed by fmt::Display
-        defmt::write!(f, "{}", s);
-    }
-}
-
 #[repr(transparent)]
 #[derive(Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ProtocolMut<'a>(&'a mut EndPoint);
 
 impl<'a> ProtocolMut<'a> {
@@ -165,17 +159,10 @@ impl fmt::Display for ProtocolMut<'_> {
     }
 }
 
-#[cfg(feature = "defmt")]
-impl defmt::Format for ProtocolMut<'_> {
-    fn format(&self, f: defmt::Formatter) {
-        let s = format!("{}", self); // Obtain representation computed by fmt::Display
-        defmt::write!(f, "{}", s);
-    }
-}
-
 // Address
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Address<'a>(pub(super) &'a str);
 
 impl<'a> Address<'a> {
@@ -196,16 +183,9 @@ impl fmt::Display for Address<'_> {
     }
 }
 
-#[cfg(feature = "defmt")]
-impl defmt::Format for Address<'_> {
-    fn format(&self, f: defmt::Formatter) {
-        let s = format!("{}", self); // Obtain representation computed by fmt::Display
-        defmt::write!(f, "{}", s);
-    }
-}
-
 #[repr(transparent)]
 #[derive(Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AddressMut<'a>(&'a mut EndPoint);
 
 impl<'a> AddressMut<'a> {
@@ -233,17 +213,10 @@ impl fmt::Display for AddressMut<'_> {
     }
 }
 
-#[cfg(feature = "defmt")]
-impl defmt::Format for AddressMut<'_> {
-    fn format(&self, f: defmt::Formatter) {
-        let s = format!("{}", self); // Obtain representation computed by fmt::Display
-        defmt::write!(f, "{}", s);
-    }
-}
-
 // Metadata
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Metadata<'a>(pub(super) &'a str);
 
 impl<'a> Metadata<'a> {
@@ -276,16 +249,9 @@ impl fmt::Display for Metadata<'_> {
     }
 }
 
-#[cfg(feature = "defmt")]
-impl defmt::Format for Metadata<'_> {
-    fn format(&self, f: defmt::Formatter) {
-        let s = format!("{}", self); // Obtain representation computed by fmt::Display
-        defmt::write!(f, "{}", s);
-    }
-}
-
 #[repr(transparent)]
 #[derive(Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct MetadataMut<'a>(&'a mut EndPoint);
 
 impl<'a> MetadataMut<'a> {
@@ -350,17 +316,10 @@ impl fmt::Display for MetadataMut<'_> {
     }
 }
 
-#[cfg(feature = "defmt")]
-impl defmt::Format for MetadataMut<'_> {
-    fn format(&self, f: defmt::Formatter) {
-        let s = format!("{}", self); // Obtain representation computed by fmt::Display
-        defmt::write!(f, "{}", s);
-    }
-}
-
 // Config
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Config<'a>(pub(super) &'a str);
 
 impl<'a> Config<'a> {
@@ -393,16 +352,9 @@ impl fmt::Display for Config<'_> {
     }
 }
 
-#[cfg(feature = "defmt")]
-impl defmt::Format for Config<'_> {
-    fn format(&self, f: defmt::Formatter) {
-        let s = format!("{}", self); // Obtain representation computed by fmt::Display
-        defmt::write!(f, "{}", s);
-    }
-}
-
 #[repr(transparent)]
 #[derive(Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ConfigMut<'a>(&'a mut EndPoint);
 
 impl<'a> ConfigMut<'a> {
@@ -466,17 +418,9 @@ impl fmt::Display for ConfigMut<'_> {
         f.write_str(self.as_str())
     }
 }
-
-#[cfg(feature = "defmt")]
-impl defmt::Format for ConfigMut<'_> {
-    fn format(&self, f: defmt::Formatter) {
-        let s = format!("{}", self); // Obtain representation computed by fmt::Display
-        defmt::write!(f, "{}", s);
-    }
-}
-
 /// A `String` that respects the [`EndPoint`] canon form: `<locator>#<config>`, such that `<locator>` is a valid [`Locator`] `<config>` is of the form `<key1>=<value1>;...;<keyN>=<valueN>` where keys are alphabetically sorted.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[serde(into = "String")]
 #[serde(try_from = "String")]
 pub struct EndPoint {
@@ -568,14 +512,6 @@ impl From<Locator> for EndPoint {
 impl fmt::Display for EndPoint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.inner)
-    }
-}
-
-#[cfg(feature = "defmt")]
-impl defmt::Format for EndPoint {
-    fn format(&self, f: defmt::Formatter) {
-        let s = format!("{}", self); // Obtain representation computed by fmt::Display
-        defmt::write!(f, "{}", s);
     }
 }
 

--- a/commons/zenoh-protocol/src/core/endpoint.rs
+++ b/commons/zenoh-protocol/src/core/endpoint.rs
@@ -131,7 +131,8 @@ impl fmt::Display for Protocol<'_> {
 #[cfg(feature = "defmt")]
 impl defmt::Format for Protocol<'_> {
     fn format(&self, f: defmt::Formatter) {
-        defmt::write!(f, "{}", self.as_str());
+        let s = format!("{}", self); // Obtain representation computed by fmt::Display
+        defmt::write!(f, "{}", s);
     }
 }
 
@@ -167,7 +168,8 @@ impl fmt::Display for ProtocolMut<'_> {
 #[cfg(feature = "defmt")]
 impl defmt::Format for ProtocolMut<'_> {
     fn format(&self, f: defmt::Formatter) {
-        defmt::write!(f, "{}", self.as_str());
+        let s = format!("{}", self); // Obtain representation computed by fmt::Display
+        defmt::write!(f, "{}", s);
     }
 }
 
@@ -197,7 +199,8 @@ impl fmt::Display for Address<'_> {
 #[cfg(feature = "defmt")]
 impl defmt::Format for Address<'_> {
     fn format(&self, f: defmt::Formatter) {
-        defmt::write!(f, "{}", self.as_str());
+        let s = format!("{}", self); // Obtain representation computed by fmt::Display
+        defmt::write!(f, "{}", s);
     }
 }
 
@@ -233,7 +236,8 @@ impl fmt::Display for AddressMut<'_> {
 #[cfg(feature = "defmt")]
 impl defmt::Format for AddressMut<'_> {
     fn format(&self, f: defmt::Formatter) {
-        defmt::write!(f, "{}", self.as_str());
+        let s = format!("{}", self); // Obtain representation computed by fmt::Display
+        defmt::write!(f, "{}", s);
     }
 }
 
@@ -275,7 +279,8 @@ impl fmt::Display for Metadata<'_> {
 #[cfg(feature = "defmt")]
 impl defmt::Format for Metadata<'_> {
     fn format(&self, f: defmt::Formatter) {
-        defmt::write!(f, "{}", self.as_str());
+        let s = format!("{}", self); // Obtain representation computed by fmt::Display
+        defmt::write!(f, "{}", s);
     }
 }
 
@@ -348,7 +353,8 @@ impl fmt::Display for MetadataMut<'_> {
 #[cfg(feature = "defmt")]
 impl defmt::Format for MetadataMut<'_> {
     fn format(&self, f: defmt::Formatter) {
-        defmt::write!(f, "{}", self.as_str());
+        let s = format!("{}", self); // Obtain representation computed by fmt::Display
+        defmt::write!(f, "{}", s);
     }
 }
 
@@ -390,7 +396,8 @@ impl fmt::Display for Config<'_> {
 #[cfg(feature = "defmt")]
 impl defmt::Format for Config<'_> {
     fn format(&self, f: defmt::Formatter) {
-        defmt::write!(f, "{}", self.as_str());
+        let s = format!("{}", self); // Obtain representation computed by fmt::Display
+        defmt::write!(f, "{}", s);
     }
 }
 
@@ -463,7 +470,8 @@ impl fmt::Display for ConfigMut<'_> {
 #[cfg(feature = "defmt")]
 impl defmt::Format for ConfigMut<'_> {
     fn format(&self, f: defmt::Formatter) {
-        defmt::write!(f, "{}", self.as_str());
+        let s = format!("{}", self); // Obtain representation computed by fmt::Display
+        defmt::write!(f, "{}", s);
     }
 }
 
@@ -566,7 +574,8 @@ impl fmt::Display for EndPoint {
 #[cfg(feature = "defmt")]
 impl defmt::Format for EndPoint {
     fn format(&self, f: defmt::Formatter) {
-        defmt::write!(f, "{}", &self.inner);
+        let s = format!("{}", self); // Obtain representation computed by fmt::Display
+        defmt::write!(f, "{}", s);
     }
 }
 

--- a/commons/zenoh-protocol/src/core/key_expr/borrowed.rs
+++ b/commons/zenoh-protocol/src/core/key_expr/borrowed.rs
@@ -326,7 +326,8 @@ impl fmt::Display for keyexpr {
 #[cfg(feature = "defmt")]
 impl defmt::Format for keyexpr {
     fn format(&self, f: defmt::Formatter) {
-        defmt::write!(f, "{}", self);
+        let s = format!("{}", self); // Obtain representation computed by fmt::Display
+        defmt::write!(f, "{}", s);
     }
 }
 

--- a/commons/zenoh-protocol/src/core/key_expr/borrowed.rs
+++ b/commons/zenoh-protocol/src/core/key_expr/borrowed.rs
@@ -39,6 +39,7 @@ use zenoh_core::{bail, Error as ZError, Result as ZResult};
 #[allow(non_camel_case_types)]
 #[repr(transparent)]
 #[derive(PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct keyexpr(str);
 
 impl keyexpr {
@@ -320,14 +321,6 @@ impl fmt::Debug for keyexpr {
 impl fmt::Display for keyexpr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self)
-    }
-}
-
-#[cfg(feature = "defmt")]
-impl defmt::Format for keyexpr {
-    fn format(&self, f: defmt::Formatter) {
-        let s = format!("{}", self); // Obtain representation computed by fmt::Display
-        defmt::write!(f, "{}", s);
     }
 }
 

--- a/commons/zenoh-protocol/src/core/key_expr/borrowed.rs
+++ b/commons/zenoh-protocol/src/core/key_expr/borrowed.rs
@@ -11,8 +11,6 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-extern crate alloc;
-
 use super::{canon::Canonizable, OwnedKeyExpr, FORBIDDEN_CHARS};
 use crate::core::WireExpr;
 use alloc::borrow::{Borrow, Cow};

--- a/commons/zenoh-protocol/src/core/key_expr/borrowed.rs
+++ b/commons/zenoh-protocol/src/core/key_expr/borrowed.rs
@@ -295,12 +295,14 @@ impl Div for &keyexpr {
 ///
 /// You can check for intersection with `level >= SetIntersecionLevel::Intersection` and for inclusion with `level >= SetIntersectionLevel::Includes`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SetIntersectionLevel {
     Disjoint,
     Intersects,
     Includes,
     Equals,
 }
+
 #[test]
 fn intersection_level_cmp() {
     use SetIntersectionLevel::*;
@@ -320,6 +322,14 @@ impl fmt::Display for keyexpr {
         f.write_str(self)
     }
 }
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for keyexpr {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "{}", self);
+    }
+}
+
 #[repr(i8)]
 enum KeyExprConstructionError {
     LoneDollarStar = -1,

--- a/commons/zenoh-protocol/src/core/key_expr/intersect/mod.rs
+++ b/commons/zenoh-protocol/src/core/key_expr/intersect/mod.rs
@@ -41,9 +41,11 @@ pub(crate) mod restiction {
 
     #[repr(transparent)]
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct NoBigWilds<T>(pub T);
     #[repr(transparent)]
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct NoSubWilds<T>(pub T);
 
     impl<T> Deref for NoBigWilds<T> {

--- a/commons/zenoh-protocol/src/core/key_expr/owned.rs
+++ b/commons/zenoh-protocol/src/core/key_expr/owned.rs
@@ -79,6 +79,7 @@ impl OwnedKeyExpr {
         OwnedKeyExpr(s.into())
     }
 }
+
 #[allow(clippy::suspicious_arithmetic_impl)]
 impl Div<&keyexpr> for OwnedKeyExpr {
     type Output = Self;
@@ -86,6 +87,7 @@ impl Div<&keyexpr> for OwnedKeyExpr {
         &self / rhs
     }
 }
+
 #[allow(clippy::suspicious_arithmetic_impl)]
 impl Div<&keyexpr> for &OwnedKeyExpr {
     type Output = OwnedKeyExpr;
@@ -94,6 +96,7 @@ impl Div<&keyexpr> for &OwnedKeyExpr {
         OwnedKeyExpr::autocanonize(s).unwrap() // Joining 2 key expressions should always result in a canonizable string.
     }
 }
+
 #[test]
 fn div() {
     let a = OwnedKeyExpr::new("a").unwrap();
@@ -101,14 +104,23 @@ fn div() {
     let k = a / &b;
     assert_eq!(k.as_str(), "a/b")
 }
+
 impl fmt::Debug for OwnedKeyExpr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.as_ref().fmt(f)
     }
 }
+
 impl fmt::Display for OwnedKeyExpr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.as_ref().fmt(f)
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for OwnedKeyExpr {
+    fn format(&self, f: defmt::Formatter) {
+        self.as_ref().format(f);
     }
 }
 
@@ -118,6 +130,7 @@ impl Deref for OwnedKeyExpr {
         unsafe { keyexpr::from_str_unchecked(&self.0) }
     }
 }
+
 impl AsRef<str> for OwnedKeyExpr {
     fn as_ref(&self) -> &str {
         &self.0

--- a/commons/zenoh-protocol/src/core/key_expr/owned.rs
+++ b/commons/zenoh-protocol/src/core/key_expr/owned.rs
@@ -120,7 +120,8 @@ impl fmt::Display for OwnedKeyExpr {
 #[cfg(feature = "defmt")]
 impl defmt::Format for OwnedKeyExpr {
     fn format(&self, f: defmt::Formatter) {
-        self.as_ref().format(f);
+        let s = format!("{}", self); // Obtain representation computed by fmt::Display
+        defmt::write!(f, "{}", s);
     }
 }
 

--- a/commons/zenoh-protocol/src/core/key_expr/owned.rs
+++ b/commons/zenoh-protocol/src/core/key_expr/owned.rs
@@ -27,6 +27,7 @@ use core::{
 ///
 /// See [`keyexpr`](super::borrowed::keyexpr).
 #[derive(Clone, PartialEq, Eq, Hash, serde::Deserialize)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[serde(try_from = "String")]
 pub struct OwnedKeyExpr(pub(crate) Arc<str>);
 impl serde::Serialize for OwnedKeyExpr {
@@ -114,14 +115,6 @@ impl fmt::Debug for OwnedKeyExpr {
 impl fmt::Display for OwnedKeyExpr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.as_ref().fmt(f)
-    }
-}
-
-#[cfg(feature = "defmt")]
-impl defmt::Format for OwnedKeyExpr {
-    fn format(&self, f: defmt::Formatter) {
-        let s = format!("{}", self); // Obtain representation computed by fmt::Display
-        defmt::write!(f, "{}", s);
     }
 }
 

--- a/commons/zenoh-protocol/src/core/key_expr/utils.rs
+++ b/commons/zenoh-protocol/src/core/key_expr/utils.rs
@@ -31,6 +31,7 @@ impl Writer {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Splitter<'a, S: ?Sized, D: ?Sized> {
     s: Option<&'a S>,
     d: &'a D,

--- a/commons/zenoh-protocol/src/core/locator.rs
+++ b/commons/zenoh-protocol/src/core/locator.rs
@@ -109,6 +109,13 @@ impl fmt::Display for Locator {
     }
 }
 
+#[cfg(feature = "defmt")]
+impl defmt::Format for Locator {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "{}", self.0.as_str());
+    }
+}
+
 pub type LocatorProtocol = str;
 
 impl Locator {

--- a/commons/zenoh-protocol/src/core/locator.rs
+++ b/commons/zenoh-protocol/src/core/locator.rs
@@ -112,7 +112,8 @@ impl fmt::Display for Locator {
 #[cfg(feature = "defmt")]
 impl defmt::Format for Locator {
     fn format(&self, f: defmt::Formatter) {
-        defmt::write!(f, "{}", self.0.as_str());
+        let s = format!("{}", self); // Obtain representation computed by fmt::Display
+        defmt::write!(f, "{}", s);
     }
 }
 

--- a/commons/zenoh-protocol/src/core/locator.rs
+++ b/commons/zenoh-protocol/src/core/locator.rs
@@ -19,6 +19,7 @@ use zenoh_core::{Error as ZError, Result as ZResult};
 /// A `String` that respects the [`Locator`] canon form: `<proto>/<address>[?<metadata>]`,
 /// such that `<metadata>` is of the form `<key1>=<value1>;...;<keyN>=<valueN>` where keys are alphabetically sorted.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[serde(into = "String")]
 #[serde(try_from = "String")]
 pub struct Locator(pub(super) EndPoint);
@@ -106,14 +107,6 @@ impl FromStr for Locator {
 impl fmt::Display for Locator {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.0.as_str())
-    }
-}
-
-#[cfg(feature = "defmt")]
-impl defmt::Format for Locator {
-    fn format(&self, f: defmt::Formatter) {
-        let s = format!("{}", self); // Obtain representation computed by fmt::Display
-        defmt::write!(f, "{}", s);
     }
 }
 

--- a/commons/zenoh-protocol/src/core/mod.rs
+++ b/commons/zenoh-protocol/src/core/mod.rs
@@ -66,8 +66,9 @@ pub struct Property {
 }
 
 /// The kind of a `Sample`.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SampleKind {
     /// if the `Sample` was issued by a `put` operation.
     Put = 0,
@@ -90,14 +91,6 @@ impl fmt::Display for SampleKind {
     }
 }
 
-#[cfg(feature = "defmt")]
-impl defmt::Format for SampleKind {
-    fn format(&self, f: defmt::Formatter) {
-        let s = format!("{}", self); // Obtain representation computed by fmt::Display
-        defmt::write!(f, "{}", s);
-    }
-}
-
 impl TryFrom<ZInt> for SampleKind {
     type Error = ZInt;
     fn try_from(kind: ZInt) -> Result<Self, ZInt> {
@@ -111,6 +104,7 @@ impl TryFrom<ZInt> for SampleKind {
 
 /// The global unique id of a zenoh peer.
 #[derive(Clone, Copy, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ZenohId(uhlc::ID);
 
 impl ZenohId {
@@ -225,14 +219,6 @@ impl fmt::Debug for ZenohId {
 impl fmt::Display for ZenohId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(self, f)
-    }
-}
-
-#[cfg(feature = "defmt")]
-impl defmt::Format for ZenohId {
-    fn format(&self, f: defmt::Formatter) {
-        let s = format!("{}", self); // Obtain representation computed by fmt::Display
-        defmt::write!(f, "{}", s);
     }
 }
 
@@ -382,6 +368,7 @@ pub struct Channel {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ConduitSnList {
     Plain(ConduitSn),
     QoS(Box<[ConduitSn; Priority::NUM]>),
@@ -415,14 +402,6 @@ impl fmt::Display for ConduitSnList {
             }
         }
         write!(f, " ]")
-    }
-}
-
-#[cfg(feature = "defmt")]
-impl defmt::Format for ConduitSnList {
-    fn format(&self, f: defmt::Formatter) {
-        let s = format!("{}", self); // Obtain representation computed by fmt::Display
-        defmt::write!(f, "{}", s);
     }
 }
 

--- a/commons/zenoh-protocol/src/core/mod.rs
+++ b/commons/zenoh-protocol/src/core/mod.rs
@@ -439,7 +439,9 @@ impl defmt::Format for ConduitSnList {
                     defmt::write!(
                         f,
                         "{:?} {{ reliable: {}, best effort: {} }}",
-                        p, sn.reliable, sn.best_effort
+                        p,
+                        sn.reliable,
+                        sn.best_effort,
                     );
                     if p != Priority::Background {
                         defmt::write!(f, ", ");

--- a/commons/zenoh-protocol/src/core/mod.rs
+++ b/commons/zenoh-protocol/src/core/mod.rs
@@ -491,6 +491,7 @@ impl Default for SubMode {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SubInfo {
     pub reliability: Reliability,
     pub mode: SubMode,

--- a/commons/zenoh-protocol/src/core/mod.rs
+++ b/commons/zenoh-protocol/src/core/mod.rs
@@ -93,10 +93,8 @@ impl fmt::Display for SampleKind {
 #[cfg(feature = "defmt")]
 impl defmt::Format for SampleKind {
     fn format(&self, f: defmt::Formatter) {
-        match self {
-            SampleKind::Put => defmt::write!(f, "PUT"),
-            SampleKind::Delete => defmt::write!(f, "DELETE"),
-        };
+        let s = format!("{}", self); // Obtain representation computed by fmt::Display
+        defmt::write!(f, "{}", s);
     }
 }
 
@@ -233,7 +231,8 @@ impl fmt::Display for ZenohId {
 #[cfg(feature = "defmt")]
 impl defmt::Format for ZenohId {
     fn format(&self, f: defmt::Formatter) {
-        defmt::write!(f, "{}", hex::encode_upper(self.as_slice()));
+        let s = format!("{}", self); // Obtain representation computed by fmt::Display
+        defmt::write!(f, "{}", s);
     }
 }
 
@@ -422,34 +421,8 @@ impl fmt::Display for ConduitSnList {
 #[cfg(feature = "defmt")]
 impl defmt::Format for ConduitSnList {
     fn format(&self, f: defmt::Formatter) {
-        defmt::write!(f, "[ ");
-        match self {
-            ConduitSnList::Plain(sn) => {
-                defmt::write!(
-                    f,
-                    "{:?} {{ reliable: {}, best effort: {} }}",
-                    Priority::default(),
-                    sn.reliable,
-                    sn.best_effort
-                );
-            }
-            ConduitSnList::QoS(ref sns) => {
-                for (prio, sn) in sns.iter().enumerate() {
-                    let p: Priority = (prio as u8).try_into().unwrap();
-                    defmt::write!(
-                        f,
-                        "{:?} {{ reliable: {}, best effort: {} }}",
-                        p,
-                        sn.reliable,
-                        sn.best_effort,
-                    );
-                    if p != Priority::Background {
-                        defmt::write!(f, ", ");
-                    }
-                }
-            }
-        }
-        defmt::write!(f, " ]");
+        let s = format!("{}", self); // Obtain representation computed by fmt::Display
+        defmt::write!(f, "{}", s);
     }
 }
 

--- a/commons/zenoh-protocol/src/core/mod.rs
+++ b/commons/zenoh-protocol/src/core/mod.rs
@@ -59,6 +59,7 @@ pub mod endpoint;
 pub use endpoint::EndPoint;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Property {
     pub key: ZInt,
     pub value: Vec<u8>,
@@ -86,6 +87,16 @@ impl fmt::Display for SampleKind {
             SampleKind::Put => write!(f, "PUT"),
             SampleKind::Delete => write!(f, "DELETE"),
         }
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for SampleKind {
+    fn format(&self, f: defmt::Formatter) {
+        match self {
+            SampleKind::Put => defmt::write!(f, "PUT"),
+            SampleKind::Delete => defmt::write!(f, "DELETE"),
+        };
     }
 }
 
@@ -219,6 +230,13 @@ impl fmt::Display for ZenohId {
     }
 }
 
+#[cfg(feature = "defmt")]
+impl defmt::Format for ZenohId {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "{}", hex::encode_upper(self.as_slice()));
+    }
+}
+
 // A PeerID can be converted into a Timestamp's ID
 impl From<&ZenohId> for uhlc::ID {
     fn from(zid: &ZenohId) -> Self {
@@ -292,6 +310,7 @@ impl<'de> serde::Deserialize<'de> for ZenohId {
 }
 
 #[derive(Debug, Copy, Clone, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum Priority {
     Control = 0,
@@ -343,6 +362,7 @@ impl TryFrom<u8> for Priority {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum Reliability {
     BestEffort,
@@ -356,6 +376,7 @@ impl Default for Reliability {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Channel {
     pub priority: Priority,
     pub reliability: Reliability,
@@ -398,8 +419,41 @@ impl fmt::Display for ConduitSnList {
     }
 }
 
+#[cfg(feature = "defmt")]
+impl defmt::Format for ConduitSnList {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "[ ");
+        match self {
+            ConduitSnList::Plain(sn) => {
+                defmt::write!(
+                    f,
+                    "{:?} {{ reliable: {}, best effort: {} }}",
+                    Priority::default(),
+                    sn.reliable,
+                    sn.best_effort
+                );
+            }
+            ConduitSnList::QoS(ref sns) => {
+                for (prio, sn) in sns.iter().enumerate() {
+                    let p: Priority = (prio as u8).try_into().unwrap();
+                    defmt::write!(
+                        f,
+                        "{:?} {{ reliable: {}, best effort: {} }}",
+                        p, sn.reliable, sn.best_effort
+                    );
+                    if p != Priority::Background {
+                        defmt::write!(f, ", ");
+                    }
+                }
+            }
+        }
+        defmt::write!(f, " ]");
+    }
+}
+
 /// The kind of reliability.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ConduitSn {
     pub reliable: ZInt,
     pub best_effort: ZInt,
@@ -407,6 +461,7 @@ pub struct ConduitSn {
 
 /// The kind of congestion control.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum CongestionControl {
     Block,
@@ -421,6 +476,7 @@ impl Default for CongestionControl {
 
 /// The subscription mode.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum SubMode {
     Push,
@@ -441,6 +497,7 @@ pub struct SubInfo {
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct QueryableInfo {
     pub complete: ZInt, // Default 0: incomplete
     pub distance: ZInt, // Default 0: no distance
@@ -448,6 +505,7 @@ pub struct QueryableInfo {
 
 /// The kind of consolidation.
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ConsolidationMode {
     /// No consolidation applied: multiple samples may be received for the same key-timestamp.
     None,
@@ -465,6 +523,7 @@ pub enum ConsolidationMode {
 
 /// The `zenoh::queryable::Queryable`s that should be target of a `zenoh::Session::get()`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum QueryTarget {
     BestMatching,
     All,

--- a/commons/zenoh-protocol/src/core/whatami.rs
+++ b/commons/zenoh-protocol/src/core/whatami.rs
@@ -15,8 +15,9 @@ use super::ZInt;
 use core::{convert::TryInto, fmt, num::NonZeroU8, ops::BitOr, str::FromStr};
 use zenoh_core::{bail, zresult::ZError};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum WhatAmI {
     Router = 1,
     Peer = 1 << 1,
@@ -71,14 +72,6 @@ impl WhatAmI {
 impl fmt::Display for WhatAmI {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.to_str())
-    }
-}
-
-#[cfg(feature = "defmt")]
-impl defmt::Format for WhatAmI {
-    fn format(&self, f: defmt::Formatter) {
-        let s = format!("{}", self); // Obtain representation computed by fmt::Display
-        defmt::write!(f, "{}", s);
     }
 }
 
@@ -137,6 +130,7 @@ impl From<WhatAmI> for ZInt {
 
 #[repr(transparent)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct WhatAmIMatcher(pub NonZeroU8);
 
 impl WhatAmIMatcher {
@@ -210,6 +204,7 @@ impl serde::Serialize for WhatAmIMatcher {
         serializer.serialize_str(self.to_str())
     }
 }
+
 pub struct WhatAmIMatcherVisitor;
 impl<'de> serde::de::Visitor<'de> for WhatAmIMatcherVisitor {
     type Value = WhatAmIMatcher;
@@ -253,14 +248,6 @@ impl<'de> serde::Deserialize<'de> for WhatAmIMatcher {
 impl fmt::Display for WhatAmIMatcher {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.to_str())
-    }
-}
-
-#[cfg(feature = "defmt")]
-impl defmt::Format for WhatAmIMatcher {
-    fn format(&self, f: defmt::Formatter) {
-        let s = format!("{}", self); // Obtain representation computed by fmt::Display
-        defmt::write!(f, "{}", s);
     }
 }
 

--- a/commons/zenoh-protocol/src/core/whatami.rs
+++ b/commons/zenoh-protocol/src/core/whatami.rs
@@ -74,6 +74,13 @@ impl fmt::Display for WhatAmI {
     }
 }
 
+#[cfg(feature = "defmt")]
+impl defmt::Format for WhatAmI {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "{}", self.to_str());
+    }
+}
+
 impl serde::Serialize for WhatAmI {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -245,6 +252,13 @@ impl<'de> serde::Deserialize<'de> for WhatAmIMatcher {
 impl fmt::Display for WhatAmIMatcher {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.to_str())
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for WhatAmIMatcher {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "{}", self.to_str());
     }
 }
 

--- a/commons/zenoh-protocol/src/core/whatami.rs
+++ b/commons/zenoh-protocol/src/core/whatami.rs
@@ -77,7 +77,8 @@ impl fmt::Display for WhatAmI {
 #[cfg(feature = "defmt")]
 impl defmt::Format for WhatAmI {
     fn format(&self, f: defmt::Formatter) {
-        defmt::write!(f, "{}", self.to_str());
+        let s = format!("{}", self); // Obtain representation computed by fmt::Display
+        defmt::write!(f, "{}", s);
     }
 }
 
@@ -258,7 +259,8 @@ impl fmt::Display for WhatAmIMatcher {
 #[cfg(feature = "defmt")]
 impl defmt::Format for WhatAmIMatcher {
     fn format(&self, f: defmt::Formatter) {
-        defmt::write!(f, "{}", self.to_str());
+        let s = format!("{}", self); // Obtain representation computed by fmt::Display
+        defmt::write!(f, "{}", s);
     }
 }
 

--- a/commons/zenoh-protocol/src/core/wire_expr.rs
+++ b/commons/zenoh-protocol/src/core/wire_expr.rs
@@ -141,6 +141,17 @@ impl fmt::Display for WireExpr<'_> {
     }
 }
 
+#[cfg(feature = "defmt")]
+impl defmt::Format for WireExpr<'_> {
+    fn format(&self, f: defmt::Formatter) {
+        if self.scope == 0 {
+            defmt::write!(f, "{}", self.suffix);
+        } else {
+            defmt::write!(f, "{}:{}", self.scope, self.suffix);
+        }
+    }
+}
+
 impl<'a> From<&WireExpr<'a>> for WireExpr<'a> {
     #[inline]
     fn from(key: &WireExpr<'a>) -> WireExpr<'a> {

--- a/commons/zenoh-protocol/src/core/wire_expr.rs
+++ b/commons/zenoh-protocol/src/core/wire_expr.rs
@@ -144,11 +144,8 @@ impl fmt::Display for WireExpr<'_> {
 #[cfg(feature = "defmt")]
 impl defmt::Format for WireExpr<'_> {
     fn format(&self, f: defmt::Formatter) {
-        if self.scope == 0 {
-            defmt::write!(f, "{}", self.suffix);
-        } else {
-            defmt::write!(f, "{}:{}", self.scope, self.suffix);
-        }
+        let s = format!("{}", self); // Obtain representation computed by fmt::Display
+        defmt::write!(f, "{}", s);
     }
 }
 

--- a/commons/zenoh-protocol/src/core/wire_expr.rs
+++ b/commons/zenoh-protocol/src/core/wire_expr.rs
@@ -13,8 +13,6 @@
 //
 
 //! This module defines the wire representation of Key Expressions.
-extern crate alloc;
-
 use crate::core::ExprId;
 use alloc::borrow::Cow;
 use core::{convert::TryInto, fmt};

--- a/commons/zenoh-protocol/src/core/wire_expr.rs
+++ b/commons/zenoh-protocol/src/core/wire_expr.rs
@@ -44,6 +44,7 @@ use zenoh_core::{bail, Result as ZResult};
 // +---------------+
 //
 #[derive(PartialEq, Eq, Hash, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct WireExpr<'a> {
     pub scope: ExprId, // 0 marks global scope
     pub suffix: Cow<'a, str>,
@@ -138,14 +139,6 @@ impl fmt::Display for WireExpr<'_> {
         } else {
             write!(f, "{}:{}", self.scope, self.suffix)
         }
-    }
-}
-
-#[cfg(feature = "defmt")]
-impl defmt::Format for WireExpr<'_> {
-    fn format(&self, f: defmt::Formatter) {
-        let s = format!("{}", self); // Obtain representation computed by fmt::Display
-        defmt::write!(f, "{}", s);
     }
 }
 

--- a/commons/zenoh-protocol/src/lib.rs
+++ b/commons/zenoh-protocol/src/lib.rs
@@ -17,6 +17,9 @@
 //! This crate is intended for Zenoh's internal use.
 //!
 //! [Click here for Zenoh's documentation](../zenoh/index.html)
+#![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
+
 pub mod common;
 pub mod core;
 pub mod defaults;

--- a/commons/zenoh-protocol/src/scouting/hello.rs
+++ b/commons/zenoh-protocol/src/scouting/hello.rs
@@ -63,18 +63,18 @@ impl fmt::Display for Hello {
     }
 }
 
-// #[cfg(feature = "defmt")]
-// impl defmt::Format for Hello {
-//     fn format(&self, f: defmt::Formatter) {
-//         defmt::write!(
-//             f,
-//             "Hello {{ zid: {}, whatami: {}, locators: {} }}",
-//             &self.zid,
-//             &self.whatami,
-//             &self.locators,
-//         );
-//     }
-// }
+#[cfg(feature = "defmt")]
+impl defmt::Format for Hello {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "Hello {{ zid: {}, whatami: {}, locators: {} }}",
+            &self.zid,
+            &self.whatami,
+            &self.locators,
+        );
+    }
+}
 
 impl Hello {
     #[cfg(feature = "test")]

--- a/commons/zenoh-protocol/src/scouting/hello.rs
+++ b/commons/zenoh-protocol/src/scouting/hello.rs
@@ -63,6 +63,19 @@ impl fmt::Display for Hello {
     }
 }
 
+// #[cfg(feature = "defmt")]
+// impl defmt::Format for Hello {
+//     fn format(&self, f: defmt::Formatter) {
+//         defmt::write!(
+//             f,
+//             "Hello {{ zid: {}, whatami: {}, locators: {} }}",
+//             &self.zid,
+//             &self.whatami,
+//             &self.locators,
+//         );
+//     }
+// }
+
 impl Hello {
     #[cfg(feature = "test")]
     pub fn rand() -> Self {

--- a/commons/zenoh-protocol/src/scouting/hello.rs
+++ b/commons/zenoh-protocol/src/scouting/hello.rs
@@ -66,13 +66,8 @@ impl fmt::Display for Hello {
 #[cfg(feature = "defmt")]
 impl defmt::Format for Hello {
     fn format(&self, f: defmt::Formatter) {
-        defmt::write!(
-            f,
-            "Hello {{ zid: {}, whatami: {}, locators: {} }}",
-            &self.zid,
-            &self.whatami,
-            &self.locators,
-        );
+        let s = format!("{}", self); // Obtain representation computed by fmt::Display
+        defmt::write!(f, "{}", s);
     }
 }
 

--- a/commons/zenoh-protocol/src/scouting/hello.rs
+++ b/commons/zenoh-protocol/src/scouting/hello.rs
@@ -47,6 +47,7 @@ use core::fmt;
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Hello {
     pub zid: Option<ZenohId>,
     pub whatami: WhatAmI,
@@ -60,14 +61,6 @@ impl fmt::Display for Hello {
             .field("whatami", &self.whatami)
             .field("locators", &self.locators)
             .finish()
-    }
-}
-
-#[cfg(feature = "defmt")]
-impl defmt::Format for Hello {
-    fn format(&self, f: defmt::Formatter) {
-        let s = format!("{}", self); // Obtain representation computed by fmt::Display
-        defmt::write!(f, "{}", s);
     }
 }
 

--- a/commons/zenoh-protocol/src/scouting/mod.rs
+++ b/commons/zenoh-protocol/src/scouting/mod.rs
@@ -23,14 +23,14 @@ pub use scout::*;
 
 // Zenoh messages at scouting level
 #[derive(Debug, Clone, PartialEq, Eq)]
-// #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ScoutingBody {
     Scout(Scout),
     Hello(Hello),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-// #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ScoutingMessage {
     pub body: ScoutingBody,
     pub attachment: Option<Attachment>,

--- a/commons/zenoh-protocol/src/scouting/mod.rs
+++ b/commons/zenoh-protocol/src/scouting/mod.rs
@@ -23,12 +23,14 @@ pub use scout::*;
 
 // Zenoh messages at scouting level
 #[derive(Debug, Clone, PartialEq, Eq)]
+// #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ScoutingBody {
     Scout(Scout),
     Hello(Hello),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+// #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ScoutingMessage {
     pub body: ScoutingBody,
     pub attachment: Option<Attachment>,

--- a/commons/zenoh-protocol/src/scouting/scout.rs
+++ b/commons/zenoh-protocol/src/scouting/scout.rs
@@ -32,6 +32,7 @@ use crate::core::whatami::WhatAmIMatcher;
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+// #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Scout {
     pub what: Option<WhatAmIMatcher>,
     pub zid_request: bool,

--- a/commons/zenoh-protocol/src/scouting/scout.rs
+++ b/commons/zenoh-protocol/src/scouting/scout.rs
@@ -32,7 +32,7 @@ use crate::core::whatami::WhatAmIMatcher;
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-// #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Scout {
     pub what: Option<WhatAmIMatcher>,
     pub zid_request: bool,

--- a/commons/zenoh-protocol/src/transport/close.rs
+++ b/commons/zenoh-protocol/src/transport/close.rs
@@ -41,6 +41,7 @@ use crate::core::ZenohId;
 ///           the transport's lease period expires.
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Close {
     pub zid: Option<ZenohId>,
     pub reason: u8,

--- a/commons/zenoh-protocol/src/transport/frame.rs
+++ b/commons/zenoh-protocol/src/transport/frame.rs
@@ -52,6 +52,7 @@ use zenoh_buffers::ZSlice;
 ///       place at this stage. Then, the F bit is used to detect the last fragment during re-ordering.
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+// #[cfg_attr(feature = "defmt", derive(defmt::Format))] // FIXME: Requires defmt::Format for FramePayload
 pub struct Frame {
     pub channel: Channel,
     pub sn: ZInt,
@@ -59,6 +60,7 @@ pub struct Frame {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+// #[cfg_attr(feature = "defmt", derive(defmt::Format))] // FIXME: Requires defmt::Format for ZenohMessage
 pub enum FramePayload {
     /// ```text
     /// The Payload of a fragmented Frame.
@@ -138,6 +140,7 @@ impl Frame {
 
 // FrameHeader
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum FrameKind {
     Messages,
@@ -146,6 +149,7 @@ pub enum FrameKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct FrameHeader {
     pub channel: Channel,
     pub sn: ZInt,

--- a/commons/zenoh-protocol/src/transport/frame.rs
+++ b/commons/zenoh-protocol/src/transport/frame.rs
@@ -52,7 +52,7 @@ use zenoh_buffers::ZSlice;
 ///       place at this stage. Then, the F bit is used to detect the last fragment during re-ordering.
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-// #[cfg_attr(feature = "defmt", derive(defmt::Format))] // FIXME: Requires defmt::Format for FramePayload
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Frame {
     pub channel: Channel,
     pub sn: ZInt,
@@ -60,7 +60,7 @@ pub struct Frame {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-// #[cfg_attr(feature = "defmt", derive(defmt::Format))] // FIXME: Requires defmt::Format for ZenohMessage
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum FramePayload {
     /// ```text
     /// The Payload of a fragmented Frame.

--- a/commons/zenoh-protocol/src/transport/init.rs
+++ b/commons/zenoh-protocol/src/transport/init.rs
@@ -54,6 +54,7 @@ use zenoh_buffers::ZSlice;
 /// - if Q==1 then the initiator/responder support QoS.
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct InitSyn {
     pub version: u8,
     pub whatami: WhatAmI,
@@ -90,6 +91,7 @@ impl InitSyn {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct InitAck {
     pub whatami: WhatAmI,
     pub zid: ZenohId,

--- a/commons/zenoh-protocol/src/transport/join.rs
+++ b/commons/zenoh-protocol/src/transport/join.rs
@@ -53,6 +53,7 @@ use core::time::Duration;
 ///
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Join {
     pub version: u8,
     pub whatami: WhatAmI,

--- a/commons/zenoh-protocol/src/transport/keepalive.rs
+++ b/commons/zenoh-protocol/src/transport/keepalive.rs
@@ -33,6 +33,7 @@ use crate::core::ZenohId;
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct KeepAlive {
     pub zid: Option<ZenohId>,
 }

--- a/commons/zenoh-protocol/src/transport/mod.rs
+++ b/commons/zenoh-protocol/src/transport/mod.rs
@@ -129,6 +129,7 @@ pub mod tmsg {
 
 // Zenoh messages at zenoh-transport level
 #[derive(Debug, Clone, PartialEq, Eq)]
+// #[cfg_attr(feature = "defmt", derive(defmt::Format))] // FIXME: Requires defmt::Format for Frame
 pub enum TransportBody {
     InitSyn(InitSyn),
     InitAck(InitAck),
@@ -141,6 +142,7 @@ pub enum TransportBody {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+// #[cfg_attr(feature = "defmt", derive(defmt::Format))] // FIXME: Requires defmt::Format for TransportBody
 pub struct TransportMessage {
     pub body: TransportBody,
     pub attachment: Option<Attachment>,

--- a/commons/zenoh-protocol/src/transport/mod.rs
+++ b/commons/zenoh-protocol/src/transport/mod.rs
@@ -129,7 +129,7 @@ pub mod tmsg {
 
 // Zenoh messages at zenoh-transport level
 #[derive(Debug, Clone, PartialEq, Eq)]
-// #[cfg_attr(feature = "defmt", derive(defmt::Format))] // FIXME: Requires defmt::Format for Frame
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TransportBody {
     InitSyn(InitSyn),
     InitAck(InitAck),
@@ -142,7 +142,7 @@ pub enum TransportBody {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-// #[cfg_attr(feature = "defmt", derive(defmt::Format))] // FIXME: Requires defmt::Format for TransportBody
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct TransportMessage {
     pub body: TransportBody,
     pub attachment: Option<Attachment>,

--- a/commons/zenoh-protocol/src/transport/open.rs
+++ b/commons/zenoh-protocol/src/transport/open.rs
@@ -43,6 +43,7 @@ use zenoh_buffers::ZSlice;
 /// (***) the cookie MUST be the same received in the INIT message with A==1 from the corresponding peer
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct OpenSyn {
     pub lease: Duration,
     pub initial_sn: ZInt,
@@ -76,6 +77,7 @@ impl OpenSyn {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct OpenAck {
     pub lease: Duration,
     pub initial_sn: ZInt,

--- a/commons/zenoh-protocol/src/zenoh/data.rs
+++ b/commons/zenoh-protocol/src/zenoh/data.rs
@@ -36,10 +36,12 @@ use zenoh_buffers::ZBuf;
 /// - if F==1 then the message is a REPLY_FINAL
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ReplierInfo {
     pub id: ZenohId,
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ReplyContext {
     pub qid: ZInt,
     pub replier: Option<ReplierInfo>,
@@ -115,6 +117,7 @@ impl ReplyContext {
 ///
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+// #[cfg_attr(feature = "defmt", derive(defmt::Format))] // FIXME: Requires defmt::Format for uhlc::Timestamp
 pub struct DataInfo {
     #[cfg(feature = "shared-memory")]
     pub sliced: bool,
@@ -172,6 +175,7 @@ impl DataInfo {
 ///
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+// #[cfg_attr(feature = "defmt", derive(defmt::Format))] // FIXME: Requires defmt::Format for DataInfo
 pub struct Data {
     pub key: WireExpr<'static>,
     pub data_info: Option<DataInfo>,

--- a/commons/zenoh-protocol/src/zenoh/data.rs
+++ b/commons/zenoh-protocol/src/zenoh/data.rs
@@ -117,7 +117,7 @@ impl ReplyContext {
 ///
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-// #[cfg_attr(feature = "defmt", derive(defmt::Format))] // FIXME: Requires defmt::Format for uhlc::Timestamp
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct DataInfo {
     #[cfg(feature = "shared-memory")]
     pub sliced: bool,
@@ -175,7 +175,7 @@ impl DataInfo {
 ///
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-// #[cfg_attr(feature = "defmt", derive(defmt::Format))] // FIXME: Requires defmt::Format for DataInfo
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Data {
     pub key: WireExpr<'static>,
     pub data_info: Option<DataInfo>,

--- a/commons/zenoh-protocol/src/zenoh/declare.rs
+++ b/commons/zenoh-protocol/src/zenoh/declare.rs
@@ -24,6 +24,7 @@ use crate::core::{QueryableInfo, Reliability, SubInfo, SubMode, WireExpr, ZInt};
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Declare {
     pub declarations: Vec<Declaration>,
 }
@@ -45,6 +46,7 @@ impl Declare {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Declaration {
     Resource(Resource),
     ForgetResource(ForgetResource),
@@ -88,6 +90,7 @@ impl Declaration {
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Resource {
     pub expr_id: ZInt,
     pub key: WireExpr<'static>,
@@ -116,6 +119,7 @@ impl Resource {
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ForgetResource {
     pub expr_id: ZInt,
 }
@@ -142,6 +146,7 @@ impl ForgetResource {
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Publisher {
     pub key: WireExpr<'static>,
 }
@@ -164,6 +169,7 @@ impl Publisher {
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ForgetPublisher {
     pub key: WireExpr<'static>,
 }
@@ -188,6 +194,7 @@ impl ForgetPublisher {
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Subscriber {
     pub key: WireExpr<'static>,
     pub info: SubInfo,
@@ -226,6 +233,7 @@ impl Subscriber {
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ForgetSubscriber {
     pub key: WireExpr<'static>,
 }
@@ -250,6 +258,7 @@ impl ForgetSubscriber {
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Queryable {
     pub key: WireExpr<'static>,
     pub info: QueryableInfo,
@@ -280,6 +289,7 @@ impl Queryable {
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ForgetQueryable {
     pub key: WireExpr<'static>,
 }

--- a/commons/zenoh-protocol/src/zenoh/linkstate.rs
+++ b/commons/zenoh-protocol/src/zenoh/linkstate.rs
@@ -30,6 +30,7 @@ use crate::core::{Locator, WhatAmI, ZInt, ZenohId};
 // ~    [links]    ~
 // +---------------+
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct LinkState {
     pub psid: ZInt,
     pub sn: ZInt,
@@ -89,6 +90,7 @@ impl LinkState {
 // ~ [link_states] ~
 // +---------------+
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct LinkStateList {
     pub link_states: Vec<LinkState>,
 }

--- a/commons/zenoh-protocol/src/zenoh/mod.rs
+++ b/commons/zenoh-protocol/src/zenoh/mod.rs
@@ -388,16 +388,8 @@ impl fmt::Display for ZenohMessage {
 #[cfg(feature = "defmt")]
 impl defmt::Format for ZenohMessage {
     fn format(&self, f: defmt::Formatter) {
-        defmt::write!(
-            f,
-            "{} {} {} {}",
-            self.body,
-            self.channel,
-            self.routing_context,
-            self.attachment
-        );
-        #[cfg(feature = "stats")]
-        defmt::write!(f, " {}", self.size);
+        let s = format!("{}", self); // Obtain representation computed by fmt::Display
+        defmt::write!(f, "{}", s);
     }
 }
 

--- a/commons/zenoh-protocol/src/zenoh/mod.rs
+++ b/commons/zenoh-protocol/src/zenoh/mod.rs
@@ -193,7 +193,7 @@ pub mod zmsg {
 // Zenoh messages at zenoh level
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Eq)]
-// #[cfg_attr(feature = "defmt", derive(defmt::Format))] // FIXME: Requires defmt::Format for Data and Query
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ZenohBody {
     Data(Data),
     Unit(Unit),
@@ -385,19 +385,18 @@ impl fmt::Display for ZenohMessage {
     }
 }
 
-// FIXME: Requires defmt::Format for ZenohBody
-// #[cfg(feature = "defmt")]
-// impl defmt::Format for ZenohMessage {
-//     fn format(&self, f: defmt::Formatter) {
-//         defmt::write!(
-//             f,
-//             "{} {} {} {}",
-//             self.body, self.channel, self.routing_context, self.attachment
-//         );
-//         #[cfg(feature = "stats")]
-//         defmt::write!(f, " {}", self.size);
-//     }
-// }
+#[cfg(feature = "defmt")]
+impl defmt::Format for ZenohMessage {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "{} {} {} {}",
+            self.body, self.channel, self.routing_context, self.attachment
+        );
+        #[cfg(feature = "stats")]
+        defmt::write!(f, " {}", self.size);
+    }
+}
 
 impl ZenohMessage {
     #[cfg(feature = "test")]

--- a/commons/zenoh-protocol/src/zenoh/mod.rs
+++ b/commons/zenoh-protocol/src/zenoh/mod.rs
@@ -204,6 +204,7 @@ pub enum ZenohBody {
 }
 
 #[derive(Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ZenohMessage {
     pub body: ZenohBody,
     pub channel: Channel,
@@ -382,14 +383,6 @@ impl fmt::Debug for ZenohMessage {
 impl fmt::Display for ZenohMessage {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(self, f)
-    }
-}
-
-#[cfg(feature = "defmt")]
-impl defmt::Format for ZenohMessage {
-    fn format(&self, f: defmt::Formatter) {
-        let s = format!("{}", self); // Obtain representation computed by fmt::Display
-        defmt::write!(f, "{}", s);
     }
 }
 

--- a/commons/zenoh-protocol/src/zenoh/mod.rs
+++ b/commons/zenoh-protocol/src/zenoh/mod.rs
@@ -193,6 +193,7 @@ pub mod zmsg {
 // Zenoh messages at zenoh level
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Eq)]
+// #[cfg_attr(feature = "defmt", derive(defmt::Format))] // FIXME: Requires defmt::Format for Data and Query
 pub enum ZenohBody {
     Data(Data),
     Unit(Unit),
@@ -383,6 +384,20 @@ impl fmt::Display for ZenohMessage {
         fmt::Debug::fmt(self, f)
     }
 }
+
+// FIXME: Requires defmt::Format for ZenohBody
+// #[cfg(feature = "defmt")]
+// impl defmt::Format for ZenohMessage {
+//     fn format(&self, f: defmt::Formatter) {
+//         defmt::write!(
+//             f,
+//             "{} {} {} {}",
+//             self.body, self.channel, self.routing_context, self.attachment
+//         );
+//         #[cfg(feature = "stats")]
+//         defmt::write!(f, " {}", self.size);
+//     }
+// }
 
 impl ZenohMessage {
     #[cfg(feature = "test")]

--- a/commons/zenoh-protocol/src/zenoh/mod.rs
+++ b/commons/zenoh-protocol/src/zenoh/mod.rs
@@ -391,7 +391,10 @@ impl defmt::Format for ZenohMessage {
         defmt::write!(
             f,
             "{} {} {} {}",
-            self.body, self.channel, self.routing_context, self.attachment
+            self.body,
+            self.channel,
+            self.routing_context,
+            self.attachment
         );
         #[cfg(feature = "stats")]
         defmt::write!(f, " {}", self.size);

--- a/commons/zenoh-protocol/src/zenoh/pull.rs
+++ b/commons/zenoh-protocol/src/zenoh/pull.rs
@@ -28,6 +28,7 @@ use crate::core::{WireExpr, ZInt};
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Pull {
     pub key: WireExpr<'static>,
     pub pull_id: ZInt,

--- a/commons/zenoh-protocol/src/zenoh/query.rs
+++ b/commons/zenoh-protocol/src/zenoh/query.rs
@@ -30,7 +30,7 @@ use zenoh_buffers::ZBuf;
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-// #[cfg_attr(feature = "defmt", derive(defmt::Format))] // FIXME: Requires defmt::Format for DataInfo
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct QueryBody {
     pub data_info: DataInfo,
     pub payload: ZBuf,
@@ -73,7 +73,7 @@ impl QueryBody {
 /// ~   QueryBody   ~ if B==1
 /// +---------------+
 #[derive(Debug, Clone, PartialEq, Eq)]
-// #[cfg_attr(feature = "defmt", derive(defmt::Format))] // FIXME: Requires defmt::Format for QueryBody
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Query {
     pub key: WireExpr<'static>,
     pub parameters: String,

--- a/commons/zenoh-protocol/src/zenoh/query.rs
+++ b/commons/zenoh-protocol/src/zenoh/query.rs
@@ -30,6 +30,7 @@ use zenoh_buffers::ZBuf;
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+// #[cfg_attr(feature = "defmt", derive(defmt::Format))] // FIXME: Requires defmt::Format for DataInfo
 pub struct QueryBody {
     pub data_info: DataInfo,
     pub payload: ZBuf,
@@ -72,6 +73,7 @@ impl QueryBody {
 /// ~   QueryBody   ~ if B==1
 /// +---------------+
 #[derive(Debug, Clone, PartialEq, Eq)]
+// #[cfg_attr(feature = "defmt", derive(defmt::Format))] // FIXME: Requires defmt::Format for QueryBody
 pub struct Query {
     pub key: WireExpr<'static>,
     pub parameters: String,

--- a/commons/zenoh-protocol/src/zenoh/routing.rs
+++ b/commons/zenoh-protocol/src/zenoh/routing.rs
@@ -27,6 +27,7 @@ use crate::core::ZInt;
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct RoutingContext {
     pub tree_id: ZInt,
 }

--- a/commons/zenoh-protocol/src/zenoh/unit.rs
+++ b/commons/zenoh-protocol/src/zenoh/unit.rs
@@ -24,6 +24,7 @@ use crate::core::CongestionControl;
 ///
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Unit {
     pub congestion_control: CongestionControl,
     pub reply_context: Option<ReplyContext>,

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -88,7 +88,7 @@ serde = "1.0.149"
 serde_json = "1.0.89"
 socket2 = "0.4.7"
 stop-token = "0.7.0"
-uhlc = "0.5.1"
+uhlc = { git = "https://github.com/atolab/uhlc-rs.git", default-features = false } # TODO: Using github source until the no_std update gets released on crates.io
 uuid = { version = "1.2.2", features = ["v4"] }
 vec_map = "0.8.2"
 zenoh-buffers = { version = "0.7.0-rc", path = "../commons/zenoh-buffers/" }


### PR DESCRIPTION
Main changes:
- `zenoh-collections` and `zenoh-buffers` tested and working on STM32F7 board (minor fixes);
- in `zenoh-collections`/`zenoh-buffers` added `defmt` feature (opt-in) useful for debugging in `no_std`;
- [WIP] `zenoh-protocol` should be also ok in `no_std`, apart from the few dependencies that it still has in `zenoh-core`. `zenoh-codec` depends on `zenoh-protocol`;
- [WIP] `uhlc` dependency now relies on the GitHub version instead of the `crates.io` one, in order to have `no_std` support;
- ~[WIP] `defmt` feature for `zenoh-protocol`/`zenoh-codec` is almost done, but needs a couple of additions dependent on `defmt` feature in `uhlc` ([PR waiting](https://github.com/atolab/uhlc-rs/pull/6))~ `defmt::Format` is implemented also for structures in `zenoh-protocol`/`zenoh-codec`.