### PR TITLE
`no_std`: `zenoh-protocol` and `zenoh-codec`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,42 @@ jobs:
         with:
           command: clippy
           args: --all-targets --features unstable -- -D warnings
+      
+      - name: Install nono (no_std-ness check)
+        run: cargo install cargo-nono
+      
+      - name: Install no-dev-deps
+        run: cargo install cargo-no-dev-deps --locked
+      
+      - name: No_std-ness check (zenoh-collections)
+        uses: actions-rs/cargo@v1
+        with:
+          command: no-dev-deps
+          args: nono check --package zenoh-collections --no-default-features
+      
+      - name: No_std-ness check (zenoh-result)
+        uses: actions-rs/cargo@v1
+        with:
+          command: no-dev-deps
+          args: nono check --package zenoh-result --no-default-features
+      
+      - name: No_std-ness check (zenoh-buffers)
+        uses: actions-rs/cargo@v1
+        with:
+          command: no-dev-deps
+          args: nono check --package zenoh-buffers --no-default-features
+      
+      - name: No_std-ness check (zenoh-protocol)
+        uses: actions-rs/cargo@v1
+        with:
+          command: no-dev-deps
+          args: nono check --package zenoh-protocol --no-default-features
+      
+      - name: No_std-ness check (zenoh-codec)
+        uses: actions-rs/cargo@v1
+        with:
+          command: no-dev-deps
+          args: nono check --package zenoh-codec --no-default-features
 
   test:
     name: Run tests on ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,20 +123,20 @@ jobs:
       - name: Check zenoh-collections
         uses: actions-rs/cargo@v1
         with:
-          command: no-dev-deps
-          args: nono check --package zenoh-collections --no-default-features
+          command: nono
+          args: check --package zenoh-collections --no-default-features
       
       - name: Check zenoh-result
         uses: actions-rs/cargo@v1
         with:
-          command: no-dev-deps
-          args: nono check --package zenoh-result --no-default-features
+          command: nono
+          args: check --package zenoh-result --no-default-features
       
       - name: Check zenoh-buffers
         uses: actions-rs/cargo@v1
         with:
-          command: no-dev-deps
-          args: nono check --package zenoh-buffers --no-default-features
+          command: nono
+          args: check --package zenoh-buffers
       
       - name: Check zenoh-protocol
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
   nostd:
     name: Run no_std-ness checks
     runs-on: ubuntu-latest
+    needs: check
     strategy:
       fail-fast: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,42 +55,6 @@ jobs:
         with:
           command: clippy
           args: --all-targets --features unstable -- -D warnings
-      
-      - name: Install nono (no_std-ness check)
-        run: cargo install cargo-nono
-      
-      - name: Install no-dev-deps
-        run: cargo install cargo-no-dev-deps --locked
-      
-      - name: No_std-ness check (zenoh-collections)
-        uses: actions-rs/cargo@v1
-        with:
-          command: no-dev-deps
-          args: nono check --package zenoh-collections --no-default-features
-      
-      - name: No_std-ness check (zenoh-result)
-        uses: actions-rs/cargo@v1
-        with:
-          command: no-dev-deps
-          args: nono check --package zenoh-result --no-default-features
-      
-      - name: No_std-ness check (zenoh-buffers)
-        uses: actions-rs/cargo@v1
-        with:
-          command: no-dev-deps
-          args: nono check --package zenoh-buffers --no-default-features
-      
-      - name: No_std-ness check (zenoh-protocol)
-        uses: actions-rs/cargo@v1
-        with:
-          command: no-dev-deps
-          args: nono check --package zenoh-protocol --no-default-features
-      
-      - name: No_std-ness check (zenoh-codec)
-        uses: actions-rs/cargo@v1
-        with:
-          command: no-dev-deps
-          args: nono check --package zenoh-codec --no-default-features
 
   test:
     name: Run tests on ${{ matrix.os }}
@@ -137,3 +101,50 @@ jobs:
           args: --doc
         env:
           ASYNC_STD_THREAD_COUNT: 4
+
+  nostd:
+    name: Run no_std-ness checks
+    needs: check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install latest Rust toolchain
+        uses: actions-rs/toolchain@v1
+      
+      - name: Install cargo-nono
+        run: cargo install cargo-nono
+      
+      - name: Install cargo-no-dev-deps
+        run: cargo install cargo-no-dev-deps --locked
+      
+      - name: Check zenoh-collections
+        uses: actions-rs/cargo@v1
+        with:
+          command: no-dev-deps
+          args: nono check --package zenoh-collections --no-default-features
+      
+      - name: Check zenoh-result
+        uses: actions-rs/cargo@v1
+        with:
+          command: no-dev-deps
+          args: nono check --package zenoh-result --no-default-features
+      
+      - name: Check zenoh-buffers
+        uses: actions-rs/cargo@v1
+        with:
+          command: no-dev-deps
+          args: nono check --package zenoh-buffers --no-default-features
+      
+      - name: Check zenoh-protocol
+        uses: actions-rs/cargo@v1
+        with:
+          command: no-dev-deps
+          args: nono check --package zenoh-protocol --no-default-features
+      
+      - name: Check zenoh-codec
+        uses: actions-rs/cargo@v1
+        with:
+          command: no-dev-deps
+          args: nono check --package zenoh-codec --no-default-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,9 @@ jobs:
 
   nostd:
     name: Run no_std-ness checks
-    needs: check
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,12 +107,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anes"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
-
-[[package]]
 name = "anyhow"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,12 +486,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
-name = "cast"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
-
-[[package]]
 name = "cc"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,33 +517,6 @@ dependencies = [
  "time 0.1.45",
  "wasm-bindgen",
  "winapi",
-]
-
-[[package]]
-name = "ciborium"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
-dependencies = [
- "ciborium-io",
- "half",
 ]
 
 [[package]]
@@ -712,76 +673,6 @@ name = "crc-catalog"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
-
-[[package]]
-name = "criterion"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
-dependencies = [
- "anes",
- "atty",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "itertools",
- "lazy_static",
- "num-traits",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
-dependencies = [
- "cast",
- "itertools",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
-dependencies = [
- "autocfg",
- "cfg-if 1.0.0",
- "crossbeam-utils",
- "memoffset 0.7.1",
- "scopeguard",
-]
 
 [[package]]
 name = "crossbeam-utils"
@@ -995,12 +886,6 @@ name = "discard"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
-
-[[package]]
-name = "either"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "env_logger"
@@ -1299,12 +1184,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1536,15 +1415,6 @@ dependencies = [
  "io-lifetimes",
  "rustix",
  "windows-sys",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -1857,12 +1727,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
-name = "oorandom"
-version = "11.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
-
-[[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1888,12 +1752,6 @@ name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
-
-[[package]]
-name = "panic-message"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384e52fd8fbd4cbe3c317e8216260c21a0f9134de108cea8a4dd4e7e152c472d"
 
 [[package]]
 name = "parking"
@@ -2043,34 +1901,6 @@ checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
  "der",
  "spki",
-]
-
-[[package]]
-name = "plotters"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
-dependencies = [
- "plotters-backend",
 ]
 
 [[package]]
@@ -2363,28 +2193,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-utils",
- "num_cpus",
-]
-
-[[package]]
 name = "rcgen"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2561,15 +2369,6 @@ name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
 
 [[package]]
 name = "schannel"
@@ -3140,16 +2939,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinytemplate"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3444,17 +3233,6 @@ name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
-
-[[package]]
-name = "walkdir"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
-dependencies = [
- "same-file",
- "winapi",
- "winapi-util",
-]
 
 [[package]]
 name = "wasi"
@@ -3809,10 +3587,7 @@ dependencies = [
 name = "zenoh-codec"
 version = "0.7.0-rc"
 dependencies = [
- "criterion",
- "rand 0.8.5",
  "uhlc",
- "uuid",
  "zenoh-buffers",
  "zenoh-protocol",
  "zenoh-shm",
@@ -3876,7 +3651,6 @@ dependencies = [
  "git-version",
  "json5",
  "log",
- "rand 0.8.5",
  "rustc_version 0.4.0",
  "zenoh",
  "zenoh-ext",
@@ -3888,7 +3662,6 @@ version = "0.7.0-rc"
 dependencies = [
  "async-std",
  "bincode",
- "clap",
  "env_logger",
  "flume",
  "futures",
@@ -4115,7 +3888,6 @@ dependencies = [
 name = "zenoh-plugin-storage-manager"
 version = "0.7.0-rc"
 dependencies = [
- "async-global-executor",
  "async-std",
  "async-trait",
  "clap",
@@ -4159,13 +3931,11 @@ version = "0.7.0-rc"
 dependencies = [
  "defmt",
  "hex",
- "lazy_static",
  "rand 0.8.5",
  "serde",
  "uhlc",
  "uuid",
  "zenoh-buffers",
- "zenoh-protocol",
  "zenoh-result",
 ]
 
@@ -4175,6 +3945,7 @@ version = "0.7.0-rc"
 dependencies = [
  "anyhow",
  "defmt",
+ "uhlc",
 ]
 
 [[package]]
@@ -4211,10 +3982,8 @@ dependencies = [
  "async-global-executor",
  "async-std",
  "async-trait",
- "env_logger",
  "flume",
  "log",
- "panic-message",
  "paste",
  "rand 0.8.5",
  "ringbuffer-spsc",
@@ -4288,7 +4057,6 @@ dependencies = [
  "json5",
  "lazy_static",
  "log",
- "rand 0.8.5",
  "rustc_version 0.4.0",
  "zenoh",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1919,9 +1919,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4257b4a04d91f7e9e6290be5d3da4804dd5784fafde3a497d73eb2b4a158c30a"
+checksum = "4ab62d2fa33726dbe6321cc97ef96d8cde531e3eeaf858a058de53a8a6d40d8f"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -1929,9 +1929,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241cda393b0cdd65e62e07e12454f1f25d57017dcc514b1514cd3c4645e3a0a6"
+checksum = "8bf026e2d0581559db66d837fe5242320f525d85c76283c61f4d51a1238d65ea"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1939,9 +1939,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46b53634d8c8196302953c74d5352f33d0c512a9499bd2ce468fc9f4128fa27c"
+checksum = "2b27bd18aa01d91c8ed2b61ea23406a676b42d82609c6e2581fba42f0c15f17f"
 dependencies = [
  "pest",
  "pest_meta",
@@ -1952,9 +1952,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef4f1332a8d4678b41966bb4cc1d0676880e84183a1ecc3f4b69f03e99c7a51"
+checksum = "9f02b677c1859756359fc9983c2e56a0237f18624a3789528804406b7e915e5d"
 dependencies = [
  "once_cell",
  "pest",
@@ -2590,9 +2590,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645926f31b250a2dca3c232496c2d898d91036e45ca0e97e0e2390c54e11be36"
+checksum = "7c4437699b6d34972de58652c68b98cb5b53a4199ab126db8e20ec8ded29a721"
 dependencies = [
  "bitflags",
  "core-foundation",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,9 +343,9 @@ checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.61"
+version = "0.1.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
+checksum = "689894c2db1ea643a50834b999abf1c110887402542955ff5451dab8f861f9ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -469,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byteorder"
@@ -843,9 +843,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d1075c37807dcf850c379432f0df05ba52cc30f279c5cfc43cc221ce7f8579"
+checksum = "b61a7545f753a88bcbe0a70de1fcc0221e10bfc752f576754fa91e663db1622e"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -855,9 +855,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5044281f61b27bc598f2f6647d480aed48d2bf52d6eb0b627d84c0361b17aa70"
+checksum = "f464457d494b5ed6905c63b0c4704842aba319084a0a3561cdc1359536b53200"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -870,15 +870,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b50bc93ba22c27b0d31128d2d130a0a6b3d267ae27ef7e4fae2167dfe8781c"
+checksum = "43c7119ce3a3701ed81aca8410b9acf6fc399d2629d057b87e2efa4e63a3aaea"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e61fda7e62115119469c7b3591fd913ecca96fb766cfd3f2e2502ab7bc87a5"
+checksum = "65e07508b90551e610910fa648a1878991d367064997a596135b86df30daf07e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1720,7 +1720,7 @@ checksum = "58a4717ec0fd1b8a842d40635b8df912334826ee181a88ee638d7c080cea1485"
 dependencies = [
  "log",
  "mio",
- "nix 0.26.1",
+ "nix 0.26.2",
  "serialport",
  "winapi",
 ]
@@ -1760,9 +1760,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a58d1d356c6597d08cde02c2f09d785b09e28711837b1ed667dc652c08a694"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -2497,9 +2497,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.6"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
+checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
 dependencies = [
  "bitflags",
  "errno",
@@ -2590,9 +2590,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+checksum = "645926f31b250a2dca3c232496c2d898d91036e45ca0e97e0e2390c54e11be36"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2603,9 +2603,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.6.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2697,9 +2697,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.16"
+version = "0.9.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b5b431e8907b50339b51223b97d102db8d987ced36f6e4d03621db9316c834"
+checksum = "8fb06d4b6cdaef0e0c51fa881acb721bed3c924cfaa71d9c94a3b771dfdf6567"
 dependencies = [
  "indexmap",
  "itoa",
@@ -3152,9 +3152,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.24.1"
+version = "1.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
+checksum = "597a12a59981d9e3c38d216785b0c37399f6e415e8d0712047620f189371b0bb"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3284,9 +3284,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "0046be40136ef78dc325e0edefccf84ccddacd0afcc1ca54103fa3c61bbdab1d"
 
 [[package]]
 name = "unicode-ident"
@@ -4032,7 +4032,7 @@ dependencies = [
  "async-trait",
  "futures",
  "log",
- "nix 0.26.1",
+ "nix 0.26.2",
  "uuid",
  "zenoh-core",
  "zenoh-link-commons",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,9 +343,9 @@ checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.62"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "689894c2db1ea643a50834b999abf1c110887402542955ff5451dab8f861f9ed"
+checksum = "eff18d764974428cf3a9328e23fc5c986f5fbed46e6cd4cdf42544df5d297ec1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1288,9 +1288,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c4a8d6391675c6b2ee1a6c8d06e8e2d03605c44cec1270675985a4c2a5500b"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2360,9 +2360,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.1"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
+checksum = "356a0625f1954f730c0201cdab48611198dc6ce21f4acff55089b5a78e6e835b"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -3269,8 +3269,9 @@ checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "uhlc"
-version = "0.5.1"
-source = "git+https://github.com/atolab/uhlc-rs.git#956d7944e3e546cf1dc8c1d1c083bfadfef877ae"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d291a7454d390b753ef68df8145da18367e32883ec2fa863959f0aefb915cdb"
 dependencies = [
  "defmt",
  "hex",
@@ -3284,9 +3285,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046be40136ef78dc325e0edefccf84ccddacd0afcc1ca54103fa3c61bbdab1d"
+checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
 
 [[package]]
 name = "unicode-ident"
@@ -3836,6 +3837,7 @@ dependencies = [
  "async-std",
  "lazy_static",
  "zenoh-macros",
+ "zenoh-result",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anyhow"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "atomic-waker"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
+checksum = "debc29dde2e69f9e47506b525f639ed42300fc014a3e007832592448fa8e4599"
 
 [[package]]
 name = "atty"
@@ -486,6 +492,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,6 +529,33 @@ dependencies = [
  "time 0.1.45",
  "wasm-bindgen",
  "winapi",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -580,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7bef69dc86e3c610e4e7aed41035e2a7ed12e72dd7530f61327a6579a4390b"
+checksum = "c278839b831783b70278b14df4d45e1beb1aad306c07bb796637de9a0e323e8e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -673,6 +712,76 @@ name = "crc-catalog"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
+
+[[package]]
+name = "criterion"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+dependencies = [
+ "anes",
+ "atty",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "memoffset 0.7.1",
+ "scopeguard",
+]
 
 [[package]]
 name = "crossbeam-utils"
@@ -886,6 +995,12 @@ name = "discard"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "env_logger"
@@ -1184,6 +1299,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1388,9 +1509,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
 dependencies = [
  "libc",
  "windows-sys",
@@ -1415,6 +1536,15 @@ dependencies = [
  "io-lifetimes",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1584,13 +1714,13 @@ dependencies = [
 
 [[package]]
 name = "mio-serial"
-version = "5.0.3"
+version = "5.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff736ea7e2501db099ae3f82aabc14db416a01958c8354b3f353dd961a18773"
+checksum = "58a4717ec0fd1b8a842d40635b8df912334826ee181a88ee638d7c080cea1485"
 dependencies = [
  "log",
  "mio",
- "nix 0.25.1",
+ "nix 0.26.1",
  "serialport",
  "winapi",
 ]
@@ -1626,20 +1756,6 @@ dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "libc",
-]
-
-[[package]]
-name = "nix"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
-dependencies = [
- "autocfg",
- "bitflags",
- "cfg-if 1.0.0",
- "libc",
- "memoffset 0.6.5",
- "pin-utils",
 ]
 
 [[package]]
@@ -1727,6 +1843,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1752,6 +1874,12 @@ name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
+name = "panic-message"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384e52fd8fbd4cbe3c317e8216260c21a0f9134de108cea8a4dd4e7e152c472d"
 
 [[package]]
 name = "parking"
@@ -1901,6 +2029,34 @@ checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
  "der",
  "spki",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -2055,9 +2211,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
 dependencies = [
  "unicode-ident",
 ]
@@ -2190,6 +2346,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rayon"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
 ]
 
 [[package]]
@@ -2333,9 +2511,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.7"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
 dependencies = [
  "log",
  "ring",
@@ -2369,6 +2547,15 @@ name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -2817,9 +3004,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
@@ -2936,6 +3123,16 @@ dependencies = [
  "quote",
  "standback",
  "syn",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3235,6 +3432,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3418,19 +3626,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.0",
- "windows_i686_gnu 0.42.0",
- "windows_i686_msvc 0.42.0",
- "windows_x86_64_gnu 0.42.0",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.0",
+ "windows_x86_64_msvc 0.42.1",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3440,9 +3648,9 @@ checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3452,9 +3660,9 @@ checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3464,9 +3672,9 @@ checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3476,15 +3684,15 @@ checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3494,9 +3702,9 @@ checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "yasna"
@@ -3509,9 +3717,9 @@ dependencies = [
 
 [[package]]
 name = "z-serial"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aeb1171fec219009470121feb6eca34ddf6ab140041180b5d174cac99fcb650"
+checksum = "a74ab200b318928231fa62809ca06397f2790d29ffb58d9cbbc7d517e93a6b17"
 dependencies = [
  "cobs",
  "futures",
@@ -3587,7 +3795,10 @@ dependencies = [
 name = "zenoh-codec"
 version = "0.7.0-rc"
 dependencies = [
+ "criterion",
+ "rand 0.8.5",
  "uhlc",
+ "uuid",
  "zenoh-buffers",
  "zenoh-protocol",
  "zenoh-shm",
@@ -3651,6 +3862,7 @@ dependencies = [
  "git-version",
  "json5",
  "log",
+ "rand 0.8.5",
  "rustc_version 0.4.0",
  "zenoh",
  "zenoh-ext",
@@ -3662,6 +3874,7 @@ version = "0.7.0-rc"
 dependencies = [
  "async-std",
  "bincode",
+ "clap",
  "env_logger",
  "flume",
  "futures",
@@ -3888,6 +4101,7 @@ dependencies = [
 name = "zenoh-plugin-storage-manager"
 version = "0.7.0-rc"
 dependencies = [
+ "async-global-executor",
  "async-std",
  "async-trait",
  "clap",
@@ -3931,11 +4145,13 @@ version = "0.7.0-rc"
 dependencies = [
  "defmt",
  "hex",
+ "lazy_static",
  "rand 0.8.5",
  "serde",
  "uhlc",
  "uuid",
  "zenoh-buffers",
+ "zenoh-protocol",
  "zenoh-result",
 ]
 
@@ -3945,7 +4161,6 @@ version = "0.7.0-rc"
 dependencies = [
  "anyhow",
  "defmt",
- "uhlc",
 ]
 
 [[package]]
@@ -3982,8 +4197,10 @@ dependencies = [
  "async-global-executor",
  "async-std",
  "async-trait",
+ "env_logger",
  "flume",
  "log",
+ "panic-message",
  "paste",
  "rand 0.8.5",
  "ringbuffer-spsc",
@@ -4057,6 +4274,7 @@ dependencies = [
  "json5",
  "lazy_static",
  "log",
+ "rand 0.8.5",
  "rustc_version 0.4.0",
  "zenoh",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3781,6 +3781,7 @@ dependencies = [
  "zenoh-link",
  "zenoh-plugin-trait",
  "zenoh-protocol",
+ "zenoh-result",
  "zenoh-shm",
  "zenoh-sync",
  "zenoh-transport",
@@ -3800,8 +3801,8 @@ dependencies = [
 name = "zenoh-cfg-properties"
 version = "0.7.0-rc"
 dependencies = [
- "zenoh-core",
  "zenoh-macros",
+ "zenoh-result",
 ]
 
 [[package]]
@@ -3822,7 +3823,6 @@ name = "zenoh-collections"
 version = "0.7.0-rc"
 dependencies = [
  "defmt",
- "zenoh-core",
 ]
 
 [[package]]
@@ -3839,6 +3839,7 @@ dependencies = [
  "zenoh-cfg-properties",
  "zenoh-core",
  "zenoh-protocol",
+ "zenoh-result",
  "zenoh-util",
 ]
 
@@ -3846,7 +3847,6 @@ dependencies = [
 name = "zenoh-core"
 version = "0.7.0-rc"
 dependencies = [
- "anyhow",
  "async-std",
  "lazy_static",
  "zenoh-macros",
@@ -3861,7 +3861,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "sha3",
- "zenoh-core",
+ "zenoh-result",
 ]
 
 [[package]]
@@ -3896,6 +3896,7 @@ dependencies = [
  "serde",
  "zenoh",
  "zenoh-core",
+ "zenoh-result",
  "zenoh-sync",
  "zenoh-util",
 ]
@@ -3909,7 +3910,6 @@ dependencies = [
  "rcgen",
  "zenoh-cfg-properties",
  "zenoh-config",
- "zenoh-core",
  "zenoh-link-commons",
  "zenoh-link-quic",
  "zenoh-link-serial",
@@ -3919,6 +3919,7 @@ dependencies = [
  "zenoh-link-unixsock_stream",
  "zenoh-link-ws",
  "zenoh-protocol",
+ "zenoh-result",
 ]
 
 [[package]]
@@ -3933,8 +3934,8 @@ dependencies = [
  "zenoh-buffers",
  "zenoh-cfg-properties",
  "zenoh-codec",
- "zenoh-core",
  "zenoh-protocol",
+ "zenoh-result",
 ]
 
 [[package]]
@@ -3955,6 +3956,7 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
+ "zenoh-result",
  "zenoh-sync",
  "zenoh-util",
 ]
@@ -3976,6 +3978,7 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
+ "zenoh-result",
  "zenoh-sync",
  "zenoh-util",
 ]
@@ -3990,6 +3993,7 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
+ "zenoh-result",
  "zenoh-sync",
  "zenoh-util",
 ]
@@ -4011,6 +4015,7 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
+ "zenoh-result",
  "zenoh-sync",
  "zenoh-util",
 ]
@@ -4028,6 +4033,7 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
+ "zenoh-result",
  "zenoh-sync",
  "zenoh-util",
 ]
@@ -4045,6 +4051,7 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
+ "zenoh-result",
  "zenoh-sync",
 ]
 
@@ -4062,6 +4069,7 @@ dependencies = [
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
+ "zenoh-result",
  "zenoh-sync",
  "zenoh-util",
 ]
@@ -4098,8 +4106,8 @@ dependencies = [
  "tide",
  "zenoh",
  "zenoh-cfg-properties",
- "zenoh-core",
  "zenoh-plugin-trait",
+ "zenoh-result",
  "zenoh-util",
 ]
 
@@ -4128,6 +4136,7 @@ dependencies = [
  "zenoh-collections",
  "zenoh-core",
  "zenoh-plugin-trait",
+ "zenoh-result",
  "zenoh-util",
  "zenoh_backend_traits",
 ]
@@ -4139,8 +4148,8 @@ dependencies = [
  "libloading",
  "log",
  "serde_json",
- "zenoh-core",
  "zenoh-macros",
+ "zenoh-result",
  "zenoh-util",
 ]
 
@@ -4156,8 +4165,16 @@ dependencies = [
  "uhlc",
  "uuid",
  "zenoh-buffers",
- "zenoh-core",
  "zenoh-protocol",
+ "zenoh-result",
+]
+
+[[package]]
+name = "zenoh-result"
+version = "0.7.0-rc"
+dependencies = [
+ "anyhow",
+ "defmt",
 ]
 
 [[package]]
@@ -4169,7 +4186,7 @@ dependencies = [
  "serde",
  "shared_memory",
  "zenoh-buffers",
- "zenoh-core",
+ "zenoh-result",
 ]
 
 [[package]]
@@ -4212,6 +4229,7 @@ dependencies = [
  "zenoh-crypto",
  "zenoh-link",
  "zenoh-protocol",
+ "zenoh-result",
  "zenoh-shm",
  "zenoh-sync",
  "zenoh-util",
@@ -4241,6 +4259,7 @@ dependencies = [
  "zenoh-collections",
  "zenoh-core",
  "zenoh-crypto",
+ "zenoh-result",
  "zenoh-sync",
 ]
 
@@ -4253,7 +4272,7 @@ dependencies = [
  "derive_more",
  "serde_json",
  "zenoh",
- "zenoh-core",
+ "zenoh-result",
  "zenoh-util",
 ]
 
@@ -4293,5 +4312,6 @@ dependencies = [
  "zenoh",
  "zenoh-core",
  "zenoh-plugin-trait",
+ "zenoh-result",
  "zenoh-util",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,8 +133,7 @@ tide = "0.16.0"
 tokio = { version = "1.23.1", default-features = false } # Default features are disabled due to some crates' requirements
 tokio-tungstenite = "0.18.0"
 typenum = "1.15.0"
-uhlc = { git = "https://github.com/atolab/uhlc-rs.git", default-features = false } # TODO: Using github source until the no_std update gets released on crates.io
-                                                                                   # Default features are disabled due to usage in no_std crates
+uhlc = { version = "0.5.2", default-features = false } # Default features are disabled due to usage in no_std crates
 unzip-n = "0.1.2"
 url = "2.3.1"
 urlencoding = "2.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
   "commons/zenoh-crypto",
   "commons/zenoh-macros",
   "commons/zenoh-protocol",
+  "commons/zenoh-result",
   "commons/zenoh-shm",
   "commons/zenoh-sync",
   "commons/zenoh-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,13 +64,15 @@ license = " EPL-2.0 OR Apache-2.0"
 categories = ["network-programming"]
 description = "Zenoh: Zero Overhead Pub/sub, Store/Query and Compute."
 
+# DEFAULT-FEATURES NOTE: Be careful with default-features and additivity!
+#                        (https://github.com/rust-lang/cargo/issues/11329)
 [workspace.dependencies]
 aes = "0.8.2"
-anyhow = "1.0.66"
+anyhow = { version = "1.0.66", default-features = false } # Default features are disabled due to usage in no_std crates
 async-executor = "1.5.0"
 async-global-executor = "2.3.1"
 async-rustls = "0.3.0"
-async-std = "=1.12.0"
+async-std = { version = "=1.12.0", default-features = false } # Default features are disabled due to some crates' requirements
 async-trait = "0.1.60"
 base64 = "0.21.0"
 bincode = "1.3.3"
@@ -85,9 +87,9 @@ event-listener = "2.5.3"
 flume = "0.10.14"
 form_urlencoded = "1.1.0"
 futures = "0.3.25"
-futures-util = "0.3.25"
+futures-util = { version = "0.3.25", default-features = false } # Default features are disabled due to some crates' requirements
 git-version = "0.3.5"
-hex = "0.4.3"
+hex = { version = "0.4.3", default-features = false } # Default features are disabled due to usage in no_std crates
 hmac = { version = "0.12.1", features = ["std"] }
 home = "0.5.4"
 http-types = "2.12.0"
@@ -108,7 +110,7 @@ pnet_datalink = "0.31.0"
 proc-macro2 = "1.0.47"
 quinn = "0.9.3" 
 quote = "1.0.21"
-rand = "0.8.5"
+rand = { version = "0.8.5", default-features = false } # Default features are disabled due to usage in no_std crates
 rand_chacha = "0.3.1"
 rcgen = "0.10.0"
 regex = "1.7.0"
@@ -118,7 +120,7 @@ rustc_version = "0.4.0"
 rustls = "0.20.6"
 rustls-native-certs = "0.6.2"
 rustls-pemfile = "1.0.1"
-serde = { version = "1.0.152", features = ["derive"] }
+serde = { version = "1.0.152", default-features = false, features = ["derive"] } # Default features are disabled due to usage in no_std crates
 serde_json = "1.0.89"
 serde_yaml = "0.9.14"
 sha3 = "0.10.6"
@@ -128,14 +130,15 @@ socket2 = "0.4.7"
 stop-token = "0.7.0"
 syn = "1.0.105"
 tide = "0.16.0"
-tokio = "1.23.1"
+tokio = { version = "1.23.1", default-features = false } # Default features are disabled due to some crates' requirements
 tokio-tungstenite = "0.18.0"
 typenum = "1.15.0"
-uhlc = { git = "https://github.com/atolab/uhlc-rs.git" } # TODO: Using github source until the no_std update gets released on crates.io
+uhlc = { git = "https://github.com/atolab/uhlc-rs.git", default-features = false } # TODO: Using github source until the no_std update gets released on crates.io
+                                                                                   # Default features are disabled due to usage in no_std crates
 unzip-n = "0.1.2"
 url = "2.3.1"
 urlencoding = "2.1.2"
-uuid = { version = "1.2.2", features = ["v4"] }
+uuid = { version = "1.2.2", default-features = false, features = ["v4"] } # Default features are disabled due to usage in no_std crates
 validated_struct = "2.1.0"
 vec_map = "0.8.2"
 webpki = "0.22.0"

--- a/commons/zenoh-cfg-properties/Cargo.toml
+++ b/commons/zenoh-cfg-properties/Cargo.toml
@@ -28,5 +28,5 @@ description = "Internal crate for zenoh."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zenoh-core = { path = "../zenoh-core/" }
 zenoh-macros = { path = "../zenoh-macros/" }
+zenoh-result = { path = "../zenoh-result/" }

--- a/commons/zenoh-cfg-properties/src/lib.rs
+++ b/commons/zenoh-cfg-properties/src/lib.rs
@@ -301,7 +301,7 @@ impl From<&[(&str, &str)]> for Properties {
 }
 
 impl TryFrom<&std::path::Path> for Properties {
-    type Error = zenoh_core::Error;
+    type Error = zenoh_result::Error;
     fn try_from(p: &std::path::Path) -> Result<Self, Self::Error> {
         Ok(Self::from(std::fs::read_to_string(p)?))
     }

--- a/commons/zenoh-codec/Cargo.toml
+++ b/commons/zenoh-codec/Cargo.toml
@@ -54,8 +54,8 @@ zenoh-shm = { path = "../zenoh-shm/", optional = true }
 # INFO: May cause problems when testing no_std stuff. Check this tool: https://docs.rs/crate/cargo-no-dev-deps/0.1.0
 [dev-dependencies]
 criterion = { workspace = true }
-rand = { workspace = true, default-features = true }
-uuid = { workspace = true, default-features = true }
+rand = { workspace = true, features = ["default"] }
+uuid = { workspace = true, features = ["default"] }
 zenoh-protocol = { path = "../zenoh-protocol/", features = ["test"] }
 
 [[bench]]

--- a/commons/zenoh-codec/Cargo.toml
+++ b/commons/zenoh-codec/Cargo.toml
@@ -51,6 +51,7 @@ zenoh-buffers = { path = "../zenoh-buffers/", default-features = false }
 zenoh-protocol = { path = "../zenoh-protocol/", default-features = false }
 zenoh-shm = { path = "../zenoh-shm/", optional = true }
 
+# INFO: May cause problems when testing no_std stuff. Check this tool: https://docs.rs/crate/cargo-no-dev-deps/0.1.0
 [dev-dependencies]
 criterion = { workspace = true }
 rand = { workspace = true, default-features = true }

--- a/commons/zenoh-codec/Cargo.toml
+++ b/commons/zenoh-codec/Cargo.toml
@@ -46,15 +46,15 @@ defmt = [
 ]
 
 [dependencies]
-uhlc = { workspace = true, default-features = false }
+uhlc = { workspace = true }
 zenoh-buffers = { path = "../zenoh-buffers/", default-features = false }
 zenoh-protocol = { path = "../zenoh-protocol/", default-features = false }
 zenoh-shm = { path = "../zenoh-shm/", optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
-rand = { workspace = true }
-uuid = { workspace = true }
+rand = { workspace = true, default-features = true }
+uuid = { workspace = true, default-features = true }
 zenoh-protocol = { path = "../zenoh-protocol/", features = ["test"] }
 
 [[bench]]

--- a/commons/zenoh-collections/Cargo.toml
+++ b/commons/zenoh-collections/Cargo.toml
@@ -30,9 +30,8 @@ description = "Internal crate for zenoh."
 
 [features]
 default = ["std"]
-std = ["zenoh-core"]
+std = []
 defmt = ["dep:defmt"]
 
 [dependencies]
 defmt = { workspace = true, optional = true }
-zenoh-core = { path = "../zenoh-core/", optional = true }

--- a/commons/zenoh-config/Cargo.toml
+++ b/commons/zenoh-config/Cargo.toml
@@ -27,7 +27,7 @@ description = "Internal crate for zenoh."
 flume = { workspace = true }
 json5 = { workspace = true }
 num_cpus = { workspace = true }
-serde = { workspace = true, default-features = true }
+serde = { workspace = true, features = ["default"] }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 validated_struct = { workspace = true, features = ["json5", "json_get"] }

--- a/commons/zenoh-config/Cargo.toml
+++ b/commons/zenoh-config/Cargo.toml
@@ -34,4 +34,5 @@ validated_struct = { workspace = true, features = ["json5", "json_get"] }
 zenoh-cfg-properties = { path = "../zenoh-cfg-properties/" }
 zenoh-core = { path = "../zenoh-core/" }
 zenoh-protocol = { path = "../zenoh-protocol/" }
+zenoh-result = { path = "../zenoh-result/" }
 zenoh-util = { path = "../zenoh-util/" }

--- a/commons/zenoh-config/Cargo.toml
+++ b/commons/zenoh-config/Cargo.toml
@@ -27,7 +27,7 @@ description = "Internal crate for zenoh."
 flume = { workspace = true }
 json5 = { workspace = true }
 num_cpus = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, default-features = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 validated_struct = { workspace = true, features = ["json5", "json_get"] }

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -32,7 +32,8 @@ use std::{
 use validated_struct::ValidatedMapAssociatedTypes;
 pub use validated_struct::{GetError, ValidatedMap};
 pub use zenoh_cfg_properties::config::*;
-use zenoh_core::{bail, zerror, zlock, Result as ZResult};
+use zenoh_core::zlock;
+use zenoh_result::{bail, zerror, ZResult};
 use zenoh_protocol::core::{
     key_expr::OwnedKeyExpr,
     whatami::{WhatAmIMatcher, WhatAmIMatcherVisitor},

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -33,12 +33,12 @@ use validated_struct::ValidatedMapAssociatedTypes;
 pub use validated_struct::{GetError, ValidatedMap};
 pub use zenoh_cfg_properties::config::*;
 use zenoh_core::zlock;
-use zenoh_result::{bail, zerror, ZResult};
 use zenoh_protocol::core::{
     key_expr::OwnedKeyExpr,
     whatami::{WhatAmIMatcher, WhatAmIMatcherVisitor},
 };
 pub use zenoh_protocol::core::{whatami, EndPoint, Locator, Priority, WhatAmI, ZenohId};
+use zenoh_result::{bail, zerror, ZResult};
 use zenoh_util::LibLoader;
 
 pub type ValidationFunction = std::sync::Arc<

--- a/commons/zenoh-core/Cargo.toml
+++ b/commons/zenoh-core/Cargo.toml
@@ -29,7 +29,7 @@ description = "Internal crate for zenoh."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-std = { workspace = true, default-features = true }
+async-std = { workspace = true, features = ["default"] }
 lazy_static = { workspace = true }
 zenoh-macros = { path = "../zenoh-macros/" }
 zenoh-result = { path = "../zenoh-result/" }

--- a/commons/zenoh-core/Cargo.toml
+++ b/commons/zenoh-core/Cargo.toml
@@ -29,6 +29,6 @@ description = "Internal crate for zenoh."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-std = { workspace = true }
+async-std = { workspace = true, default-features = true }
 lazy_static = { workspace = true }
 zenoh-macros = { path = "../zenoh-macros/" }

--- a/commons/zenoh-core/Cargo.toml
+++ b/commons/zenoh-core/Cargo.toml
@@ -32,3 +32,4 @@ description = "Internal crate for zenoh."
 async-std = { workspace = true, default-features = true }
 lazy_static = { workspace = true }
 zenoh-macros = { path = "../zenoh-macros/" }
+zenoh-result = { path = "../zenoh-result/" }

--- a/commons/zenoh-core/Cargo.toml
+++ b/commons/zenoh-core/Cargo.toml
@@ -29,7 +29,6 @@ description = "Internal crate for zenoh."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = { workspace = true }
 async-std = { workspace = true }
 lazy_static = { workspace = true }
 zenoh-macros = { path = "../zenoh-macros/" }

--- a/commons/zenoh-core/src/lib.rs
+++ b/commons/zenoh-core/src/lib.rs
@@ -22,8 +22,8 @@ pub mod macros;
 pub use macros::*;
 use std::future::{Future, Ready};
 pub use zenoh_macros::*;
-pub use zenoh_result::*;
 pub use zenoh_result::ZResult as Result;
+pub use zenoh_result::*;
 
 pub trait Resolvable {
     type To: Sized + Send;

--- a/commons/zenoh-core/src/lib.rs
+++ b/commons/zenoh-core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod macros;
 pub use macros::*;
 use std::future::{Future, Ready};
 pub use zenoh_macros::*;
+pub use zenoh_result::*;
 
 pub trait Resolvable {
     type To: Sized + Send;

--- a/commons/zenoh-core/src/lib.rs
+++ b/commons/zenoh-core/src/lib.rs
@@ -22,9 +22,6 @@ pub mod macros;
 pub use macros::*;
 use std::future::{Future, Ready};
 pub use zenoh_macros::*;
-pub mod zresult;
-pub use zresult::Error;
-pub use zresult::ZResult as Result;
 
 pub trait Resolvable {
     type To: Sized + Send;

--- a/commons/zenoh-core/src/lib.rs
+++ b/commons/zenoh-core/src/lib.rs
@@ -23,6 +23,7 @@ pub use macros::*;
 use std::future::{Future, Ready};
 pub use zenoh_macros::*;
 pub use zenoh_result::*;
+pub use zenoh_result::ZResult as Result;
 
 pub trait Resolvable {
     type To: Sized + Send;

--- a/commons/zenoh-core/src/lib.rs
+++ b/commons/zenoh-core/src/lib.rs
@@ -24,6 +24,7 @@ use std::future::{Future, Ready};
 pub use zenoh_macros::*;
 
 // Re-exports after moving ZError/ZResult to zenoh-result
+pub use zenoh_result::{bail, to_zerror, zerror};
 pub mod zresult {
     pub use zenoh_result::*;
 }

--- a/commons/zenoh-core/src/lib.rs
+++ b/commons/zenoh-core/src/lib.rs
@@ -19,8 +19,8 @@
 //! [Click here for Zenoh's documentation](../zenoh/index.html)
 pub use lazy_static::lazy_static;
 pub mod macros;
-use std::future::{Future, Ready};
 pub use macros::*;
+use std::future::{Future, Ready};
 pub use zenoh_macros::*;
 
 pub trait Resolvable {

--- a/commons/zenoh-core/src/lib.rs
+++ b/commons/zenoh-core/src/lib.rs
@@ -22,8 +22,13 @@ pub mod macros;
 pub use macros::*;
 use std::future::{Future, Ready};
 pub use zenoh_macros::*;
-pub use zenoh_result::ZResult as Result;
-pub use zenoh_result::*;
+
+// Re-exports after moving ZError/ZResult to zenoh-result
+pub mod zresult {
+    pub use zenoh_result::*;
+}
+pub use zresult::Error;
+pub use zresult::ZResult as Result;
 
 pub trait Resolvable {
     type To: Sized + Send;

--- a/commons/zenoh-core/src/macros.rs
+++ b/commons/zenoh-core/src/macros.rs
@@ -113,17 +113,6 @@ macro_rules! zasyncrecv {
     };
 }
 
-// This macro checks the boolean results of an operation and returns in case
-// the result is false. Basically, it implements the ? operator for booleans
-// #[macro_export]
-// macro_rules! zcheck {
-//     ($op:expr) => {
-//         if !$op {
-//             return false;
-//         }
-//     };
-// }
-
 // This macro allows to define some compile time configurable static constants
 #[macro_export]
 macro_rules! zconfigurable {

--- a/commons/zenoh-core/src/macros.rs
+++ b/commons/zenoh-core/src/macros.rs
@@ -115,14 +115,14 @@ macro_rules! zasyncrecv {
 
 // This macro checks the boolean results of an operation and returns in case
 // the result is false. Basically, it implements the ? operator for booleans
-#[macro_export]
-macro_rules! zcheck {
-    ($op:expr) => {
-        if !$op {
-            return false;
-        }
-    };
-}
+// #[macro_export]
+// macro_rules! zcheck {
+//     ($op:expr) => {
+//         if !$op {
+//             return false;
+//         }
+//     };
+// }
 
 // This macro allows to define some compile time configurable static constants
 #[macro_export]
@@ -149,51 +149,6 @@ macro_rules! zconfigurable {
         $crate::zconfigurable!($($t)*);
     };
     () => ()
-}
-pub use anyhow::anyhow;
-#[macro_export]
-macro_rules! zerror {
-    (($errno:expr) $source: expr => $($t: tt)*) => {
-        $crate::zresult::ZError::new($crate::anyhow!($($t)*), file!(), line!(), $crate::zresult::NegativeI8::new($errno as i8)).set_source($source)
-    };
-    (($errno:expr) $t: literal) => {
-        $crate::zresult::ZError::new($crate::anyhow!($t), file!(), line!(), $crate::zresult::NegativeI8::new($errno as i8))
-    };
-    (($errno:expr) $t: expr) => {
-        $crate::zresult::ZError::new($t, file!(), line!(), $crate::zresult::NegativeI8::new($errno as i8))
-    };
-    (($errno:expr) $($t: tt)*) => {
-        $crate::zresult::ZError::new($crate::anyhow!($($t)*), file!(), line!(), $crate::zresult::NegativeI8::new($errno as i8))
-    };
-    ($source: expr => $($t: tt)*) => {
-        $crate::zresult::ZError::new($crate::anyhow!($($t)*), file!(), line!(), $crate::zresult::NegativeI8::MIN).set_source($source)
-    };
-    ($t: literal) => {
-        $crate::zresult::ZError::new($crate::anyhow!($t), file!(), line!(), $crate::zresult::NegativeI8::MIN)
-    };
-    ($t: expr) => {
-        $crate::zresult::ZError::new($t, file!(), line!(), $crate::zresult::NegativeI8::MIN)
-    };
-    ($($t: tt)*) => {
-        $crate::zresult::ZError::new($crate::anyhow!($($t)*), file!(), line!(), $crate::zresult::NegativeI8::MIN)
-    };
-}
-
-// @TODO: re-design ZError and macros
-// This macro is a shorthand for the creation of a ZError
-#[macro_export]
-macro_rules! bail{
-    ($($t: tt)*) => {
-        return Err($crate::zerror!($($t)*).into())
-    };
-}
-
-// This macro is a shorthand for the conversion of any Error into a ZError
-#[macro_export]
-macro_rules! to_zerror {
-    ($kind:ident, $descr:expr) => {
-        |e| Err(zerror!($kind, $descr, e))
-    };
 }
 
 // This macro is a shorthand for the conversion to ZInt
@@ -238,7 +193,7 @@ macro_rules! zasync_executor_init {
 macro_rules! zparse {
     ($str:expr) => {
         $str.parse().map_err(|_| {
-            let e = $crate::zerror!(
+            let e = zenoh_result::zerror!(
                 "Failed to read configuration: {} is not a valid value",
                 $str
             );

--- a/commons/zenoh-crypto/Cargo.toml
+++ b/commons/zenoh-crypto/Cargo.toml
@@ -31,7 +31,7 @@ description = "Internal crate for zenoh."
 [dependencies]
 aes = { workspace = true }
 hmac = { workspace = true }
-rand = { workspace = true }
+rand = { workspace = true, default-features = true }
 rand_chacha = { workspace = true }
 sha3 = { workspace = true }
 zenoh-result = { path = "../zenoh-result/" }

--- a/commons/zenoh-crypto/Cargo.toml
+++ b/commons/zenoh-crypto/Cargo.toml
@@ -34,4 +34,4 @@ hmac = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 sha3 = { workspace = true }
-zenoh-core = { path = "../zenoh-core/" }
+zenoh-result = { path = "../zenoh-result/" }

--- a/commons/zenoh-crypto/Cargo.toml
+++ b/commons/zenoh-crypto/Cargo.toml
@@ -31,7 +31,7 @@ description = "Internal crate for zenoh."
 [dependencies]
 aes = { workspace = true }
 hmac = { workspace = true }
-rand = { workspace = true, default-features = true }
+rand = { workspace = true, features = ["default"] }
 rand_chacha = { workspace = true }
 sha3 = { workspace = true }
 zenoh-result = { path = "../zenoh-result/" }

--- a/commons/zenoh-crypto/src/cipher.rs
+++ b/commons/zenoh-crypto/src/cipher.rs
@@ -15,7 +15,7 @@ use super::PseudoRng;
 use aes::cipher::{generic_array::GenericArray, BlockDecrypt, BlockEncrypt, KeyInit};
 use aes::Aes128;
 use rand::Rng;
-use zenoh_core::{bail, Result as ZResult};
+use zenoh_result::{bail, ZResult};
 
 pub struct BlockCipher {
     inner: Aes128,

--- a/commons/zenoh-crypto/src/hmac.rs
+++ b/commons/zenoh-crypto/src/hmac.rs
@@ -13,7 +13,7 @@
 //
 use hmac::{Hmac, Mac};
 use sha3::{Digest, Sha3_256};
-use zenoh_core::Result as ZResult;
+use zenoh_result::ZResult;
 
 pub fn sign(key: &[u8], data: &[u8]) -> ZResult<Vec<u8>> {
     let mut hmac = Hmac::<Sha3_256>::new_from_slice(key)?;

--- a/commons/zenoh-protocol/Cargo.toml
+++ b/commons/zenoh-protocol/Cargo.toml
@@ -31,7 +31,8 @@ std = [
     "rand?/std_rng",
     "serde/std",
     "uhlc/std",
-    "uuid/std"
+    "uuid/std",
+    "zenoh-result/std"
 ]
 test = ["rand", "zenoh-buffers/test"]
 shared-memory = ["std"]
@@ -50,7 +51,7 @@ serde = { workspace = true, default-features = false, features = ["alloc"] }
 uhlc = { workspace = true, default-features = false }
 uuid = { workspace = true, default-features = false } # Needs a getrandom::getrandom() custom implementation on embedded (in root crate)
 zenoh-buffers = { path = "../zenoh-buffers/", default-features = false }
-zenoh-core = { path = "../zenoh-core/" }
+zenoh-result = { path = "../zenoh-result/", default-features = false }
 
 [dev-dependencies]
 lazy_static = { workspace = true }

--- a/commons/zenoh-protocol/Cargo.toml
+++ b/commons/zenoh-protocol/Cargo.toml
@@ -53,6 +53,7 @@ uuid = { workspace = true } # Needs a getrandom::getrandom() custom implementati
 zenoh-buffers = { path = "../zenoh-buffers/", default-features = false }
 zenoh-result = { path = "../zenoh-result/", default-features = false }
 
+# INFO: May cause problems when testing no_std stuff. Check this tool: https://docs.rs/crate/cargo-no-dev-deps/0.1.0
 [dev-dependencies]
 lazy_static = { workspace = true }
 zenoh-protocol = { path = ".", features = ["test"] }

--- a/commons/zenoh-protocol/Cargo.toml
+++ b/commons/zenoh-protocol/Cargo.toml
@@ -45,11 +45,11 @@ defmt = [
 
 [dependencies]
 defmt = { workspace = true, optional = true }
-hex = { workspace = true, default-features = false, features = ["alloc"] }
-rand = { workspace = true, default-features = false, features = ["alloc", "getrandom"], optional = true }
-serde = { workspace = true, default-features = false, features = ["alloc"] }
-uhlc = { workspace = true, default-features = false }
-uuid = { workspace = true, default-features = false } # Needs a getrandom::getrandom() custom implementation on embedded (in root crate)
+hex = { workspace = true, features = ["alloc"] }
+rand = { workspace = true, features = ["alloc", "getrandom"], optional = true }
+serde = { workspace = true, features = ["alloc"] }
+uhlc = { workspace = true }
+uuid = { workspace = true } # Needs a getrandom::getrandom() custom implementation on embedded (in root crate)
 zenoh-buffers = { path = "../zenoh-buffers/", default-features = false }
 zenoh-result = { path = "../zenoh-result/", default-features = false }
 

--- a/commons/zenoh-protocol/src/core/encoding.rs
+++ b/commons/zenoh-protocol/src/core/encoding.rs
@@ -12,11 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use crate::core::ZInt;
-use alloc::{
-    borrow::Cow,
-    format,
-    string::String,
-};
+use alloc::{borrow::Cow, format, string::String};
 use core::{convert::TryFrom, fmt, mem};
 
 mod consts {

--- a/commons/zenoh-protocol/src/core/encoding.rs
+++ b/commons/zenoh-protocol/src/core/encoding.rs
@@ -12,7 +12,11 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use crate::core::ZInt;
-use alloc::borrow::Cow;
+use alloc::{
+    borrow::Cow,
+    format,
+    string::String,
+};
 use core::{convert::TryFrom, fmt, mem};
 
 mod consts {

--- a/commons/zenoh-protocol/src/core/endpoint.rs
+++ b/commons/zenoh-protocol/src/core/endpoint.rs
@@ -14,7 +14,7 @@
 use super::locator::*;
 use crate::core::split_once;
 use core::{convert::TryFrom, fmt, str::FromStr};
-use zenoh_core::{zerror, Error as ZError, Result as ZResult};
+use zenoh_result::{zerror, Error as ZError, ZResult};
 
 // Parsing chars
 pub const PROTO_SEPARATOR: char = '/';

--- a/commons/zenoh-protocol/src/core/endpoint.rs
+++ b/commons/zenoh-protocol/src/core/endpoint.rs
@@ -13,12 +13,7 @@
 //
 use super::locator::*;
 use crate::core::split_once;
-use alloc::{
-    borrow::ToOwned,
-    format,
-    string::String,
-    vec::Vec,
-};
+use alloc::{borrow::ToOwned, format, string::String, vec::Vec};
 use core::{convert::TryFrom, fmt, str::FromStr};
 use zenoh_result::{zerror, Error as ZError, ZResult};
 

--- a/commons/zenoh-protocol/src/core/endpoint.rs
+++ b/commons/zenoh-protocol/src/core/endpoint.rs
@@ -13,6 +13,12 @@
 //
 use super::locator::*;
 use crate::core::split_once;
+use alloc::{
+    borrow::ToOwned,
+    format,
+    string::String,
+    vec::Vec,
+};
 use core::{convert::TryFrom, fmt, str::FromStr};
 use zenoh_result::{zerror, Error as ZError, ZResult};
 

--- a/commons/zenoh-protocol/src/core/key_expr/borrowed.rs
+++ b/commons/zenoh-protocol/src/core/key_expr/borrowed.rs
@@ -13,7 +13,13 @@
 //
 use super::{canon::Canonizable, OwnedKeyExpr, FORBIDDEN_CHARS};
 use crate::core::WireExpr;
-use alloc::borrow::{Borrow, Cow};
+use alloc::{
+    borrow::{Borrow, Cow, ToOwned},
+    format,
+    string::String,
+    vec,
+    vec::Vec,
+};
 use core::{
     convert::{TryFrom, TryInto},
     fmt,

--- a/commons/zenoh-protocol/src/core/key_expr/borrowed.rs
+++ b/commons/zenoh-protocol/src/core/key_expr/borrowed.rs
@@ -19,7 +19,7 @@ use core::{
     fmt,
     ops::{Deref, Div},
 };
-use zenoh_core::{bail, Error as ZError, Result as ZResult};
+use zenoh_result::{bail, Error as ZError, ZResult};
 
 /// A [`str`] newtype that is statically known to be a valid key expression.
 ///

--- a/commons/zenoh-protocol/src/core/key_expr/canon.rs
+++ b/commons/zenoh-protocol/src/core/key_expr/canon.rs
@@ -15,6 +15,7 @@ use crate::core::key_expr::{
     utils::{Split, Writer},
     DELIMITER, DOUBLE_WILD, SINGLE_WILD,
 };
+use alloc::string::String;
 use core::{slice, str};
 
 pub trait Canonizable {

--- a/commons/zenoh-protocol/src/core/key_expr/owned.rs
+++ b/commons/zenoh-protocol/src/core/key_expr/owned.rs
@@ -15,7 +15,12 @@ extern crate alloc;
 
 use super::{canon::Canonizable, keyexpr};
 use crate::core::WireExpr;
-use alloc::{borrow::Cow, sync::Arc};
+use alloc::{
+    borrow::{Cow, ToOwned},
+    boxed::Box,
+    string::String,
+    sync::Arc,
+};
 use core::{
     convert::TryFrom,
     fmt,

--- a/commons/zenoh-protocol/src/core/key_expr/owned.rs
+++ b/commons/zenoh-protocol/src/core/key_expr/owned.rs
@@ -131,19 +131,19 @@ impl AsRef<str> for OwnedKeyExpr {
     }
 }
 impl FromStr for OwnedKeyExpr {
-    type Err = zenoh_core::Error;
+    type Err = zenoh_result::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Self::try_from(s.to_owned())
     }
 }
 impl TryFrom<&str> for OwnedKeyExpr {
-    type Error = zenoh_core::Error;
+    type Error = zenoh_result::Error;
     fn try_from(s: &str) -> Result<Self, Self::Error> {
         Self::try_from(s.to_owned())
     }
 }
 impl TryFrom<String> for OwnedKeyExpr {
-    type Error = zenoh_core::Error;
+    type Error = zenoh_result::Error;
     fn try_from(value: String) -> Result<Self, Self::Error> {
         <&keyexpr as TryFrom<&str>>::try_from(value.as_str())?;
         Ok(Self(value.into()))

--- a/commons/zenoh-protocol/src/core/locator.rs
+++ b/commons/zenoh-protocol/src/core/locator.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use super::endpoint::*;
+use alloc::{borrow::ToOwned, string::String};
 use core::{convert::TryFrom, fmt, hash::Hash, str::FromStr};
 use zenoh_result::{Error as ZError, ZResult};
 

--- a/commons/zenoh-protocol/src/core/locator.rs
+++ b/commons/zenoh-protocol/src/core/locator.rs
@@ -13,7 +13,7 @@
 //
 use super::endpoint::*;
 use core::{convert::TryFrom, fmt, hash::Hash, str::FromStr};
-use zenoh_core::{Error as ZError, Result as ZResult};
+use zenoh_result::{Error as ZError, ZResult};
 
 // Locator
 /// A `String` that respects the [`Locator`] canon form: `<proto>/<address>[?<metadata>]`,

--- a/commons/zenoh-protocol/src/core/mod.rs
+++ b/commons/zenoh-protocol/src/core/mod.rs
@@ -24,7 +24,7 @@ use core::{
 use key_expr::OwnedKeyExpr;
 pub use uhlc::{Timestamp, NTP64};
 use uuid::Uuid;
-use zenoh_core::{bail, zerror};
+use zenoh_result::{bail, zerror};
 
 /// The unique Id of the [`HLC`](uhlc::HLC) that generated the concerned [`Timestamp`].
 pub type TimestampId = uhlc::ID;
@@ -145,7 +145,7 @@ impl From<uuid::Uuid> for ZenohId {
 macro_rules! derive_tryfrom {
     ($T: ty) => {
         impl TryFrom<$T> for ZenohId {
-            type Error = zenoh_core::Error;
+            type Error = zenoh_result::Error;
             fn try_from(val: $T) -> Result<Self, Self::Error> {
                 Ok(Self(val.try_into()?))
             }
@@ -187,7 +187,7 @@ derive_tryfrom!(&[u8; 16]);
 derive_tryfrom!(&[u8]);
 
 impl FromStr for ZenohId {
-    type Err = zenoh_core::Error;
+    type Err = zenoh_result::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // filter-out '-' characters (in case s has UUID format)
@@ -324,7 +324,7 @@ impl Default for Priority {
 }
 
 impl TryFrom<u8> for Priority {
-    type Error = zenoh_core::Error;
+    type Error = zenoh_result::Error;
 
     fn try_from(conduit: u8) -> Result<Self, Self::Error> {
         match conduit {

--- a/commons/zenoh-protocol/src/core/mod.rs
+++ b/commons/zenoh-protocol/src/core/mod.rs
@@ -13,6 +13,12 @@
 //
 pub mod key_expr;
 
+use alloc::{
+    boxed::Box,
+    format,
+    string::{String, ToString},
+    vec::Vec,
+};
 use core::{
     convert::{From, TryFrom, TryInto},
     fmt,

--- a/commons/zenoh-protocol/src/core/whatami.rs
+++ b/commons/zenoh-protocol/src/core/whatami.rs
@@ -13,7 +13,7 @@
 //
 use super::ZInt;
 use core::{convert::TryInto, fmt, num::NonZeroU8, ops::BitOr, str::FromStr};
-use zenoh_core::{bail, zresult::ZError};
+use zenoh_result::{bail, ZError};
 
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/commons/zenoh-protocol/src/core/whatami.rs
+++ b/commons/zenoh-protocol/src/core/whatami.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use super::ZInt;
+use alloc::string::String;
 use core::{convert::TryInto, fmt, num::NonZeroU8, ops::BitOr, str::FromStr};
 use zenoh_result::{bail, ZError};
 

--- a/commons/zenoh-protocol/src/core/wire_expr.rs
+++ b/commons/zenoh-protocol/src/core/wire_expr.rs
@@ -14,7 +14,10 @@
 
 //! This module defines the wire representation of Key Expressions.
 use crate::core::ExprId;
-use alloc::borrow::Cow;
+use alloc::{
+    borrow::Cow,
+    string::{String, ToString},
+};
 use core::{convert::TryInto, fmt};
 use zenoh_result::{bail, ZResult};
 

--- a/commons/zenoh-protocol/src/core/wire_expr.rs
+++ b/commons/zenoh-protocol/src/core/wire_expr.rs
@@ -16,7 +16,7 @@
 use crate::core::ExprId;
 use alloc::borrow::Cow;
 use core::{convert::TryInto, fmt};
-use zenoh_core::{bail, Result as ZResult};
+use zenoh_result::{bail, ZResult};
 
 /// A zenoh **resource** is represented by a pair composed by a **key** and a
 /// **value**, such as, ```(/car/telemetry/speed, 320)```.  A **resource key**
@@ -105,7 +105,7 @@ impl<'a> WireExpr<'a> {
 }
 
 impl TryInto<String> for WireExpr<'_> {
-    type Error = zenoh_core::Error;
+    type Error = zenoh_result::Error;
     fn try_into(self) -> Result<String, Self::Error> {
         if self.scope == 0 {
             Ok(self.suffix.into_owned())
@@ -116,7 +116,7 @@ impl TryInto<String> for WireExpr<'_> {
 }
 
 impl TryInto<ExprId> for WireExpr<'_> {
-    type Error = zenoh_core::Error;
+    type Error = zenoh_result::Error;
     fn try_into(self) -> Result<ExprId, Self::Error> {
         self.try_as_id()
     }

--- a/commons/zenoh-protocol/src/scouting/hello.rs
+++ b/commons/zenoh-protocol/src/scouting/hello.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use crate::core::{Locator, WhatAmI, ZenohId};
+use alloc::vec::Vec;
 use core::fmt;
 
 /// # Hello message

--- a/commons/zenoh-protocol/src/scouting/mod.rs
+++ b/commons/zenoh-protocol/src/scouting/mod.rs
@@ -18,6 +18,7 @@ use crate::{
     common::Attachment,
     core::{whatami::WhatAmIMatcher, Locator, WhatAmI, ZenohId},
 };
+use alloc::vec::Vec;
 pub use hello::*;
 pub use scout::*;
 

--- a/commons/zenoh-protocol/src/transport/frame.rs
+++ b/commons/zenoh-protocol/src/transport/frame.rs
@@ -15,6 +15,7 @@ use crate::{
     core::{Channel, ZInt},
     zenoh::ZenohMessage,
 };
+use alloc::vec::Vec;
 use zenoh_buffers::ZSlice;
 
 /// # Frame message

--- a/commons/zenoh-protocol/src/zenoh/declare.rs
+++ b/commons/zenoh-protocol/src/zenoh/declare.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use crate::core::{QueryableInfo, SubInfo, WireExpr, ZInt};
+use alloc::vec::Vec;
 
 /// ```text
 ///  7 6 5 4 3 2 1 0

--- a/commons/zenoh-protocol/src/zenoh/linkstate.rs
+++ b/commons/zenoh-protocol/src/zenoh/linkstate.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use crate::core::{Locator, WhatAmI, ZInt, ZenohId};
+use alloc::vec::Vec;
 
 //  7 6 5 4 3 2 1 0
 // +-+-+-+-+-+-+-+-+

--- a/commons/zenoh-protocol/src/zenoh/mod.rs
+++ b/commons/zenoh-protocol/src/zenoh/mod.rs
@@ -25,6 +25,7 @@ use crate::{
         Channel, CongestionControl, ConsolidationMode, QueryTarget, Reliability, WireExpr, ZInt,
     },
 };
+use alloc::{string::String, vec::Vec};
 use core::fmt;
 pub use data::*;
 pub use declare::*;

--- a/commons/zenoh-protocol/src/zenoh/query.rs
+++ b/commons/zenoh-protocol/src/zenoh/query.rs
@@ -15,6 +15,7 @@ use crate::{
     core::{ConsolidationMode, QueryTarget, WireExpr, ZInt},
     zenoh::DataInfo,
 };
+use alloc::string::String;
 use zenoh_buffers::ZBuf;
 
 /// # QueryBody

--- a/commons/zenoh-protocol/tests/keyexpr.rs
+++ b/commons/zenoh-protocol/tests/keyexpr.rs
@@ -88,8 +88,8 @@ fn intersections() {
 
 fn includes<
     'a,
-    A: TryInto<&'a keyexpr, Error = zenoh_core::Error>,
-    B: TryInto<&'a keyexpr, Error = zenoh_core::Error>,
+    A: TryInto<&'a keyexpr, Error = zenoh_result::Error>,
+    B: TryInto<&'a keyexpr, Error = zenoh_result::Error>,
 >(
     l: A,
     r: B,

--- a/commons/zenoh-result/Cargo.toml
+++ b/commons/zenoh-result/Cargo.toml
@@ -30,5 +30,5 @@ std = ["anyhow/std"]
 defmt = ["dep:defmt"]
 
 [dependencies]
-anyhow = { workspace = true, default-features = false }
+anyhow = { workspace = true }
 defmt = { workspace = true, optional = true }

--- a/commons/zenoh-result/Cargo.toml
+++ b/commons/zenoh-result/Cargo.toml
@@ -26,9 +26,10 @@ description = "Internal crate for zenoh."
 
 [features]
 default = ["std"]
-std = ["anyhow/std"]
-defmt = ["dep:defmt"]
+std = ["anyhow/std", "uhlc/std"]
+defmt = ["dep:defmt", "uhlc/defmt"]
 
 [dependencies]
 anyhow = { workspace = true }
 defmt = { workspace = true, optional = true }
+uhlc = { workspace = true } # FIXME: Dependency on uhlc won't be needed anymore once we switch to core::error::Error

--- a/commons/zenoh-result/Cargo.toml
+++ b/commons/zenoh-result/Cargo.toml
@@ -13,7 +13,7 @@
 #
 [package]
 rust-version = { workspace = true }
-name = "zenoh-link-quic"
+name = "zenoh-result"
 version = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
@@ -24,21 +24,11 @@ categories = { workspace = true }
 description = "Internal crate for zenoh."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["std"]
+std = ["anyhow/std"]
+defmt = ["dep:defmt"]
+
 [dependencies]
-async-std = { workspace = true, default-features = false, features = ["unstable", "tokio1"] }
-async-trait = { workspace = true }
-futures = { workspace = true }
-log = { workspace = true }
-quinn = { workspace = true }
-rustls = { workspace = true }
-rustls-native-certs = { workspace = true }
-rustls-pemfile = { workspace = true }
-webpki = { workspace = true }
-zenoh-cfg-properties = { path = "../../../commons/zenoh-cfg-properties/" }
-zenoh-config = { path = "../../../commons/zenoh-config/" }
-zenoh-core = { path = "../../../commons/zenoh-core/" }
-zenoh-link-commons = { path = "../../zenoh-link-commons/" }
-zenoh-protocol = { path = "../../../commons/zenoh-protocol/" }
-zenoh-result = { path = "../../../commons/zenoh-result/" }
-zenoh-sync = { path = "../../../commons/zenoh-sync/" }
-zenoh-util = { path = "../../../commons/zenoh-util/" }
+anyhow = { workspace = true, default-features = false }
+defmt = { workspace = true, optional = true }

--- a/commons/zenoh-result/Cargo.toml
+++ b/commons/zenoh-result/Cargo.toml
@@ -26,10 +26,9 @@ description = "Internal crate for zenoh."
 
 [features]
 default = ["std"]
-std = ["anyhow/std", "uhlc/std"]
-defmt = ["dep:defmt", "uhlc/defmt"]
+std = ["anyhow/std"]
+defmt = ["dep:defmt"]
 
 [dependencies]
 anyhow = { workspace = true }
 defmt = { workspace = true, optional = true }
-uhlc = { workspace = true } # FIXME: Dependency on uhlc won't be needed anymore once we switch to core::error::Error

--- a/commons/zenoh-result/src/lib.rs
+++ b/commons/zenoh-result/src/lib.rs
@@ -37,6 +37,13 @@ pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 #[cfg(not(feature = "std"))]
 pub type Error = Box<dyn IError + Send + Sync + 'static>;
 
+// #[cfg(not(feature = "std"))]
+// impl<T> From<T> for Error where T: IError {
+//     fn from(value: T) -> Self {
+//         Box::new(value)
+//     }
+// }
+
 // +---------+
 // | ZRESULT |
 // +---------+

--- a/commons/zenoh-result/src/lib.rs
+++ b/commons/zenoh-result/src/lib.rs
@@ -70,7 +70,8 @@ pub struct ZError {
     file: &'static str,
     line: u32,
     errno: NegativeI8,
-    #[cfg_attr(all(feature = "defmt", feature = "std"), defmt(Debug2Format))] // Use fmt::Debug only for std version of Error
+    #[cfg_attr(all(feature = "defmt", feature = "std"), defmt(Debug2Format))]
+    // Use fmt::Debug only for std version of Error
     source: Option<Error>,
 }
 

--- a/commons/zenoh-result/src/lib.rs
+++ b/commons/zenoh-result/src/lib.rs
@@ -28,12 +28,11 @@ use core::{any::Any, fmt};
 // | ERROR |
 // +-------+
 
-#[cfg(feature = "std")]
-pub type Error = Box<dyn IError + Send + Sync + 'static>;
-#[cfg(not(feature = "std"))]
-pub type Error = alloc::boxed::Box<dyn IError + Send + Sync + 'static>;
-
 pub use std_impl::IError;
+pub type Error = Box<dyn IError + Send + Sync + 'static>;
+
+// FIXME: Until core::error::Error is stabilized, we rescue to our own implementation of an error trait
+// See tracking issue for most recent updates: https://github.com/rust-lang/rust/issues/103765
 
 impl dyn IError {
     pub fn is<T: 'static>(&self) -> bool {
@@ -123,6 +122,7 @@ mod std_impl {
     }
     impl IError for super::ShmError {}
     impl IError for super::ZError {}
+    impl IError for uhlc::SizeError {} // FIXME: Dependency on uhlc won't be needed anymore once we switch to core::error::Error
     impl ErrNo for dyn IError {
         fn errno(&self) -> NegativeI8 {
             match self.downcast_ref::<ZError>() {

--- a/commons/zenoh-shm/Cargo.toml
+++ b/commons/zenoh-shm/Cargo.toml
@@ -31,7 +31,7 @@ description = "Internal crate for zenoh."
 [dependencies]
 bincode = { workspace = true }
 log = { workspace = true }
-serde = { workspace = true, default-features = true }
+serde = { workspace = true, features = ["default"] }
 shared_memory = { workspace = true }
 zenoh-buffers = { path = "../zenoh-buffers/" }
 zenoh-result = { path = "../zenoh-result/" }

--- a/commons/zenoh-shm/Cargo.toml
+++ b/commons/zenoh-shm/Cargo.toml
@@ -31,7 +31,7 @@ description = "Internal crate for zenoh."
 [dependencies]
 bincode = { workspace = true }
 log = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, default-features = true }
 shared_memory = { workspace = true }
 zenoh-buffers = { path = "../zenoh-buffers/" }
 zenoh-result = { path = "../zenoh-result/" }

--- a/commons/zenoh-shm/Cargo.toml
+++ b/commons/zenoh-shm/Cargo.toml
@@ -34,4 +34,4 @@ log = { workspace = true }
 serde = { workspace = true }
 shared_memory = { workspace = true }
 zenoh-buffers = { path = "../zenoh-buffers/" }
-zenoh-core = { path = "../zenoh-core/" }
+zenoh-result = { path = "../zenoh-result/" }

--- a/commons/zenoh-shm/src/lib.rs
+++ b/commons/zenoh-shm/src/lib.rs
@@ -21,7 +21,7 @@ use std::{
     sync::atomic::{AtomicPtr, AtomicUsize, Ordering},
 };
 use zenoh_buffers::ZSliceBuffer;
-use zenoh_core::{bail, zerror, zresult::ShmError, Result as ZResult};
+use zenoh_result::{bail, zerror, ShmError, ZResult};
 
 const MIN_FREE_CHUNK_SIZE: usize = 1_024;
 const ACCOUNTED_OVERHEAD: usize = 4_096;

--- a/commons/zenoh-sync/Cargo.toml
+++ b/commons/zenoh-sync/Cargo.toml
@@ -29,14 +29,14 @@ description = "Internal crate for zenoh."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-std = { workspace = true, features = ["unstable"] }
+async-std = { workspace = true, default-features = true, features = ["unstable"] }
 event-listener = { workspace = true }
 flume = { workspace = true }
 futures = { workspace = true }
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, default-features = true, features = ["sync"] }
 zenoh-buffers = { path = "../zenoh-buffers/" }
 zenoh-collections = { path = "../zenoh-collections/" }
 zenoh-core = { path = "../zenoh-core/" }
 
 [dev-dependencies]
-async-std = { workspace = true, features = ["unstable", "attributes"] }
+async-std = { workspace = true, default-features = true, features = ["unstable", "attributes"] }

--- a/commons/zenoh-sync/Cargo.toml
+++ b/commons/zenoh-sync/Cargo.toml
@@ -29,14 +29,14 @@ description = "Internal crate for zenoh."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-std = { workspace = true, default-features = true, features = ["unstable"] }
+async-std = { workspace = true, features = ["default", "unstable"] }
 event-listener = { workspace = true }
 flume = { workspace = true }
 futures = { workspace = true }
-tokio = { workspace = true, default-features = true, features = ["sync"] }
+tokio = { workspace = true, features = ["default", "sync"] }
 zenoh-buffers = { path = "../zenoh-buffers/" }
 zenoh-collections = { path = "../zenoh-collections/" }
 zenoh-core = { path = "../zenoh-core/" }
 
 [dev-dependencies]
-async-std = { workspace = true, default-features = true, features = ["unstable", "attributes"] }
+async-std = { workspace = true, features = ["default", "unstable", "attributes"] }

--- a/commons/zenoh-util/Cargo.toml
+++ b/commons/zenoh-util/Cargo.toml
@@ -41,12 +41,12 @@ compat = [
 ]
 
 [dependencies]
-async-std = { workspace = true }
+async-std = { workspace = true, default-features = true }
 async-trait = { workspace = true }
 clap = { workspace = true }
 flume = { workspace = true }
 futures = { workspace = true }
-hex = { workspace = true }
+hex = { workspace = true, default-features = true }
 home = { workspace = true }
 humantime = { workspace = true }
 lazy_static = { workspace = true }

--- a/commons/zenoh-util/Cargo.toml
+++ b/commons/zenoh-util/Cargo.toml
@@ -41,12 +41,12 @@ compat = [
 ]
 
 [dependencies]
-async-std = { workspace = true, default-features = true }
+async-std = { workspace = true, features = ["default"] }
 async-trait = { workspace = true }
 clap = { workspace = true }
 flume = { workspace = true }
 futures = { workspace = true }
-hex = { workspace = true, default-features = true }
+hex = { workspace = true, features = ["default"] }
 home = { workspace = true }
 humantime = { workspace = true }
 lazy_static = { workspace = true }

--- a/commons/zenoh-util/Cargo.toml
+++ b/commons/zenoh-util/Cargo.toml
@@ -57,6 +57,7 @@ zenoh-cfg-properties = { path = "../zenoh-cfg-properties/", optional = true }
 zenoh-collections = { path = "../zenoh-collections/", optional = true }
 zenoh-core = { path = "../zenoh-core/" }
 zenoh-crypto = { path = "../zenoh-crypto/", optional = true }
+zenoh-result = { path = "../zenoh-result/" }
 zenoh-sync = { path = "../zenoh-sync/", optional = true }
 
 [target.'cfg(windows)'.dependencies]

--- a/commons/zenoh-util/src/lib_loader.rs
+++ b/commons/zenoh-util/src/lib_loader.rs
@@ -17,7 +17,8 @@ use std::env::consts::{DLL_PREFIX, DLL_SUFFIX};
 use std::ffi::OsString;
 use std::ops::Deref;
 use std::path::PathBuf;
-use zenoh_core::{bail, zconfigurable, Result as ZResult};
+use zenoh_core::zconfigurable;
+use zenoh_result::{bail, ZResult};
 
 zconfigurable! {
     /// The libraries prefix for the current platform (usually: `"lib"`)

--- a/commons/zenoh-util/src/net/mod.rs
+++ b/commons/zenoh-util/src/net/mod.rs
@@ -14,7 +14,8 @@
 use async_std::net::TcpStream;
 use std::net::{IpAddr, Ipv6Addr};
 use std::time::Duration;
-use zenoh_core::{bail, zconfigurable, Result as ZResult};
+use zenoh_core::zconfigurable;
+use zenoh_result::{bail, ZResult};
 
 zconfigurable! {
     static ref WINDOWS_GET_ADAPTERS_ADDRESSES_BUF_SIZE: u32 = 8192;

--- a/commons/zenoh-util/src/time_range.rs
+++ b/commons/zenoh-util/src/time_range.rs
@@ -20,7 +20,7 @@ use std::{
     str::FromStr,
     time::{Duration, SystemTime},
 };
-use zenoh_core::{bail, zerror, zresult::ZError};
+use zenoh_result::{bail, zerror, ZError};
 
 const U_TO_SECS: f64 = 0.000001;
 const MS_TO_SECS: f64 = 0.001;

--- a/commons/zenoh-util/tests/zresult.rs
+++ b/commons/zenoh-util/tests/zresult.rs
@@ -11,7 +11,7 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use zenoh_core::{zerror, Result as ZResult};
+use zenoh_result::{zerror, ZResult};
 
 #[test]
 fn error_simple() {

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -41,7 +41,7 @@ zenoh = { path = "../zenoh/", default-features = false }
 zenoh-ext = { path = "../zenoh-ext/" }
 
 [dev-dependencies]
-rand = { workspace = true, default-features = true }
+rand = { workspace = true, features = ["default"] }
 
 [build-dependencies]
 rustc_version = { workspace = true }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -29,7 +29,7 @@ readme = "README.md"
 shared-memory = ["zenoh/shared-memory"]
 
 [dependencies]
-async-std = { workspace = true, default-features = false, features = ["attributes"] }
+async-std = { workspace = true, features = ["attributes"] }
 clap = { workspace = true }
 env_logger = { workspace = true }
 flume = { workspace = true }
@@ -41,7 +41,7 @@ zenoh = { path = "../zenoh/", default-features = false }
 zenoh-ext = { path = "../zenoh-ext/" }
 
 [dev-dependencies]
-rand = { workspace = true }
+rand = { workspace = true, default-features = true }
 
 [build-dependencies]
 rustc_version = { workspace = true }

--- a/io/zenoh-link-commons/Cargo.toml
+++ b/io/zenoh-link-commons/Cargo.toml
@@ -28,7 +28,7 @@ description = "Internal crate for zenoh."
 async-std = { workspace = true }
 async-trait = { workspace = true }
 flume = { workspace = true }
-serde = { workspace = true, default-features = true }
+serde = { workspace = true, features = ["default"] }
 typenum = { workspace = true }
 zenoh-buffers = { path = "../../commons/zenoh-buffers/" }
 zenoh-cfg-properties = { path = "../../commons/zenoh-cfg-properties/" }

--- a/io/zenoh-link-commons/Cargo.toml
+++ b/io/zenoh-link-commons/Cargo.toml
@@ -25,10 +25,10 @@ description = "Internal crate for zenoh."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-std = { workspace = true, default-features = false }
+async-std = { workspace = true }
 async-trait = { workspace = true }
 flume = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, default-features = true }
 typenum = { workspace = true }
 zenoh-buffers = { path = "../../commons/zenoh-buffers/" }
 zenoh-cfg-properties = { path = "../../commons/zenoh-cfg-properties/" }

--- a/io/zenoh-link-commons/Cargo.toml
+++ b/io/zenoh-link-commons/Cargo.toml
@@ -33,5 +33,5 @@ typenum = { workspace = true }
 zenoh-buffers = { path = "../../commons/zenoh-buffers/" }
 zenoh-cfg-properties = { path = "../../commons/zenoh-cfg-properties/" }
 zenoh-codec = { path = "../../commons/zenoh-codec/" }
-zenoh-core = { path = "../../commons/zenoh-core/" }
+zenoh-result = { path = "../../commons/zenoh-result/" }
 zenoh-protocol = { path = "../../commons/zenoh-protocol/" }

--- a/io/zenoh-link-commons/src/lib.rs
+++ b/io/zenoh-link-commons/src/lib.rs
@@ -34,11 +34,11 @@ use zenoh_buffers::{
 };
 use zenoh_cfg_properties::Properties;
 use zenoh_codec::{RCodec, WCodec, Zenoh060};
-use zenoh_result::{zerror, ZResult};
 use zenoh_protocol::{
     core::{EndPoint, Locator},
     transport::TransportMessage,
 };
+use zenoh_result::{zerror, ZResult};
 
 /*************************************/
 /*            GENERAL                */

--- a/io/zenoh-link-commons/src/lib.rs
+++ b/io/zenoh-link-commons/src/lib.rs
@@ -34,7 +34,7 @@ use zenoh_buffers::{
 };
 use zenoh_cfg_properties::Properties;
 use zenoh_codec::{RCodec, WCodec, Zenoh060};
-use zenoh_core::{zerror, Result as ZResult};
+use zenoh_result::{zerror, ZResult};
 use zenoh_protocol::{
     core::{EndPoint, Locator},
     transport::TransportMessage,

--- a/io/zenoh-link/Cargo.toml
+++ b/io/zenoh-link/Cargo.toml
@@ -34,7 +34,7 @@ transport_ws = ["zenoh-link-ws"]
 transport_serial = ["zenoh-link-serial"]
 
 [dependencies]
-async-std = { workspace = true, default-features = false }
+async-std = { workspace = true }
 async-trait = { workspace = true }
 rcgen = { workspace = true, optional = true }
 zenoh-cfg-properties = { path = "../../commons/zenoh-cfg-properties/" }

--- a/io/zenoh-link/Cargo.toml
+++ b/io/zenoh-link/Cargo.toml
@@ -39,7 +39,7 @@ async-trait = { workspace = true }
 rcgen = { workspace = true, optional = true }
 zenoh-cfg-properties = { path = "../../commons/zenoh-cfg-properties/" }
 zenoh-config = { path = "../../commons/zenoh-config/" }
-zenoh-core = { path = "../../commons/zenoh-core/" }
+zenoh-result = { path = "../../commons/zenoh-result/" }
 zenoh-link-commons = { path = "../zenoh-link-commons/" }
 zenoh-link-quic = { path = "../zenoh-links/zenoh-link-quic/", optional = true }
 zenoh-link-serial = { path = "../zenoh-links/zenoh-link-serial/", optional = true }

--- a/io/zenoh-link/src/lib.rs
+++ b/io/zenoh-link/src/lib.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 
 use zenoh_cfg_properties::Properties;
 use zenoh_config::Config;
-use zenoh_core::{bail, Result as ZResult};
+use zenoh_result::{bail, ZResult};
 
 #[cfg(feature = "transport_quic")]
 pub use zenoh_link_quic as quic;
@@ -119,7 +119,7 @@ impl LinkConfigurator {
         config: &Config,
     ) -> (
         HashMap<String, Properties>,
-        HashMap<String, zenoh_core::Error>,
+        HashMap<String, zenoh_result::Error>,
     ) {
         let mut configs = HashMap::new();
         let mut errors = HashMap::new();

--- a/io/zenoh-links/zenoh-link-quic/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-quic/Cargo.toml
@@ -25,7 +25,7 @@ description = "Internal crate for zenoh."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-std = { workspace = true, default-features = false, features = ["unstable", "tokio1"] }
+async-std = { workspace = true, features = ["unstable", "tokio1"] }
 async-trait = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }

--- a/io/zenoh-links/zenoh-link-quic/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/lib.rs
@@ -26,9 +26,10 @@ use std::net::SocketAddr;
 use webpki::DnsNameRef;
 use zenoh_cfg_properties::Properties;
 use zenoh_config::{Config, Locator};
-use zenoh_core::{bail, zconfigurable, zerror, Result as ZResult};
+use zenoh_core::zconfigurable;
 use zenoh_link_commons::{ConfigurationInspector, LocatorInspector};
 use zenoh_protocol::core::endpoint::Address;
+use zenoh_result::{bail, zerror, ZResult};
 
 mod unicast;
 pub use unicast::*;

--- a/io/zenoh-links/zenoh-link-quic/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/unicast.rs
@@ -29,12 +29,12 @@ use std::net::IpAddr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
-use zenoh_core::{bail, Result as ZResult};
-use zenoh_core::{zasynclock, zerror, zread, zwrite};
+use zenoh_core::{zasynclock, zread, zwrite};
 use zenoh_link_commons::{
     LinkManagerUnicastTrait, LinkUnicast, LinkUnicastTrait, NewLinkChannelSender,
 };
 use zenoh_protocol::core::{EndPoint, Locator};
+use zenoh_result::{bail, zerror, ZResult};
 use zenoh_sync::Signal;
 
 pub struct LinkUnicastQuic {

--- a/io/zenoh-links/zenoh-link-serial/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-serial/Cargo.toml
@@ -32,12 +32,12 @@ description = "Internal crate for zenoh."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-std = { workspace = true, default-features = false, features = ["unstable", "tokio1"] }
+async-std = { workspace = true, features = ["unstable", "tokio1"] }
 async-trait = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }
-tokio = { workspace = true, default-features = false, features = ["io-std", "macros", "net", "rt-multi-thread", "time", "io-util"] }
-uuid = { workspace = true }
+tokio = { workspace = true, features = ["io-std", "macros", "net", "rt-multi-thread", "time", "io-util"] }
+uuid = { workspace = true, default-features = true }
 z-serial = { workspace = true }
 zenoh-cfg-properties = { path = "../../../commons/zenoh-cfg-properties/" }
 zenoh-collections = { path = "../../../commons/zenoh-collections/" }

--- a/io/zenoh-links/zenoh-link-serial/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-serial/Cargo.toml
@@ -45,5 +45,6 @@ zenoh-config = { path = "../../../commons/zenoh-config/" }
 zenoh-core = { path = "../../../commons/zenoh-core/" }
 zenoh-link-commons = { path = "../../zenoh-link-commons/" }
 zenoh-protocol = { path = "../../../commons/zenoh-protocol/" }
+zenoh-result = { path = "../../../commons/zenoh-result/" }
 zenoh-sync = { path = "../../../commons/zenoh-sync/" }
 zenoh-util = { path = "../../../commons/zenoh-util/" }

--- a/io/zenoh-links/zenoh-link-serial/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-serial/src/lib.rs
@@ -22,9 +22,10 @@ mod unicast;
 use async_trait::async_trait;
 use std::str::FromStr;
 pub use unicast::*;
-use zenoh_core::{zconfigurable, Result as ZResult};
+use zenoh_core::zconfigurable;
 use zenoh_link_commons::LocatorInspector;
 use zenoh_protocol::core::{endpoint::Address, EndPoint, Locator};
+use zenoh_result::ZResult;
 
 // Maximum MTU (Serial PDU) in bytes.
 const SERIAL_MAX_MTU: u16 = z_serial::MAX_MTU as u16;

--- a/io/zenoh-links/zenoh-link-serial/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-serial/src/unicast.rs
@@ -23,13 +23,13 @@ use std::fmt;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
-use zenoh_core::Result as ZResult;
-use zenoh_core::{zasynclock, zerror, zread, zwrite};
+use zenoh_core::{zasynclock, zread, zwrite};
 use zenoh_link_commons::{
     ConstructibleLinkManagerUnicast, LinkManagerUnicastTrait, LinkUnicast, LinkUnicastTrait,
     NewLinkChannelSender,
 };
 use zenoh_protocol::core::{EndPoint, Locator};
+use zenoh_result::{zerror, ZResult};
 use zenoh_sync::Signal;
 
 use z_serial::ZSerial;

--- a/io/zenoh-links/zenoh-link-tcp/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-tcp/Cargo.toml
@@ -31,5 +31,6 @@ log = { workspace = true }
 zenoh-core = { path = "../../../commons/zenoh-core/" }
 zenoh-link-commons = { path = "../../zenoh-link-commons/" }
 zenoh-protocol = { path = "../../../commons/zenoh-protocol/" }
+zenoh-result = { path = "../../../commons/zenoh-result/" }
 zenoh-sync = { path = "../../../commons/zenoh-sync/" }
 zenoh-util = { path = "../../../commons/zenoh-util/" }

--- a/io/zenoh-links/zenoh-link-tcp/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-tcp/Cargo.toml
@@ -25,7 +25,7 @@ description = "Internal crate for zenoh."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-std = { workspace = true, default-features = false }
+async-std = { workspace = true }
 async-trait = { workspace = true }
 log = { workspace = true }
 zenoh-core = { path = "../../../commons/zenoh-core/" }

--- a/io/zenoh-links/zenoh-link-tcp/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/lib.rs
@@ -20,9 +20,10 @@
 use async_std::net::ToSocketAddrs;
 use async_trait::async_trait;
 use std::net::SocketAddr;
-use zenoh_core::{zconfigurable, zerror, Result as ZResult};
+use zenoh_core::zconfigurable;
 use zenoh_link_commons::LocatorInspector;
 use zenoh_protocol::core::{endpoint::Address, Locator};
+use zenoh_result::{zerror, ZResult};
 
 mod unicast;
 pub use unicast::*;

--- a/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
@@ -23,11 +23,12 @@ use std::net::{IpAddr, Shutdown};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
-use zenoh_core::{bail, zerror, zread, zwrite, Error as ZError, Result as ZResult};
+use zenoh_core::{zread, zwrite};
 use zenoh_link_commons::{
     LinkManagerUnicastTrait, LinkUnicast, LinkUnicastTrait, NewLinkChannelSender,
 };
 use zenoh_protocol::core::{EndPoint, Locator};
+use zenoh_result::{bail, zerror, Error as ZError, ZResult};
 use zenoh_sync::Signal;
 
 use super::{

--- a/io/zenoh-links/zenoh-link-tls/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-tls/Cargo.toml
@@ -26,7 +26,7 @@ description = "Internal crate for zenoh."
 
 [dependencies]
 async-rustls = { workspace = true }
-async-std = { workspace = true, default-features = false }
+async-std = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }

--- a/io/zenoh-links/zenoh-link-tls/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-tls/Cargo.toml
@@ -38,5 +38,6 @@ zenoh-config = { path = "../../../commons/zenoh-config/" }
 zenoh-core = { path = "../../../commons/zenoh-core/" }
 zenoh-link-commons = { path = "../../zenoh-link-commons/" }
 zenoh-protocol = { path = "../../../commons/zenoh-protocol/" }
+zenoh-result = { path = "../../../commons/zenoh-result/" }
 zenoh-sync = { path = "../../../commons/zenoh-sync/" }
 zenoh-util = { path = "../../../commons/zenoh-util/" }

--- a/io/zenoh-links/zenoh-link-tls/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/lib.rs
@@ -27,9 +27,10 @@ use config::{
 };
 use zenoh_cfg_properties::Properties;
 use zenoh_config::{Config, ZN_FALSE, ZN_TRUE};
-use zenoh_core::{bail, zconfigurable, zerror, Result as ZResult};
+use zenoh_core::zconfigurable;
 use zenoh_link_commons::{ConfigurationInspector, LocatorInspector};
 use zenoh_protocol::core::{endpoint::Address, Locator};
+use zenoh_result::{bail, zerror, ZResult};
 
 mod unicast;
 pub use unicast::*;

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -40,12 +40,13 @@ use std::net::{IpAddr, Shutdown};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
-use zenoh_core::{bail, zasynclock, zerror, zread, zwrite, Result as ZResult};
+use zenoh_core::{zasynclock, zread, zwrite};
 use zenoh_link_commons::{
     LinkManagerUnicastTrait, LinkUnicast, LinkUnicastTrait, NewLinkChannelSender,
 };
 use zenoh_protocol::core::endpoint::Config;
 use zenoh_protocol::core::{EndPoint, Locator};
+use zenoh_result::{bail, zerror, ZResult};
 use zenoh_sync::Signal;
 
 pub struct LinkUnicastTls {

--- a/io/zenoh-links/zenoh-link-udp/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-udp/Cargo.toml
@@ -34,5 +34,6 @@ zenoh-collections = { path = "../../../commons/zenoh-collections/" }
 zenoh-core = { path = "../../../commons/zenoh-core/" }
 zenoh-link-commons = { path = "../../zenoh-link-commons/" }
 zenoh-protocol = { path = "../../../commons/zenoh-protocol/" }
+zenoh-result = { path = "../../../commons/zenoh-result/" }
 zenoh-sync = { path = "../../../commons/zenoh-sync/" }
 zenoh-util = { path = "../../../commons/zenoh-util/" }

--- a/io/zenoh-links/zenoh-link-udp/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-udp/Cargo.toml
@@ -25,7 +25,7 @@ description = "Internal crate for zenoh."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-std = { workspace = true, default-features = false }
+async-std = { workspace = true }
 async-trait = { workspace = true }
 log = { workspace = true }
 socket2 = { workspace = true }

--- a/io/zenoh-links/zenoh-link-udp/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/lib.rs
@@ -26,9 +26,10 @@ use async_std::net::ToSocketAddrs;
 use async_trait::async_trait;
 pub use multicast::*;
 pub use unicast::*;
-use zenoh_core::{zconfigurable, zerror, Result as ZResult};
+use zenoh_core::zconfigurable;
 use zenoh_link_commons::LocatorInspector;
 use zenoh_protocol::core::{endpoint::Address, Locator};
+use zenoh_result::{zerror, ZResult};
 
 // NOTE: In case of using UDP in high-throughput scenarios, it is recommended to set the
 //       UDP buffer size on the host to a reasonable size. Usually, default values for UDP buffers

--- a/io/zenoh-links/zenoh-link-udp/src/multicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/multicast.rs
@@ -18,9 +18,9 @@ use async_trait::async_trait;
 use socket2::{Domain, Protocol, Socket, Type};
 use std::sync::Arc;
 use std::{borrow::Cow, fmt};
-use zenoh_core::{bail, zerror, Error as ZError, Result as ZResult};
 use zenoh_link_commons::{LinkManagerMulticastTrait, LinkMulticast, LinkMulticastTrait};
 use zenoh_protocol::core::{EndPoint, Locator};
+use zenoh_result::{bail, zerror, Error as ZError, ZResult};
 
 pub struct LinkMulticastUdp {
     // The unicast socket address of this link

--- a/io/zenoh-links/zenoh-link-udp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/unicast.rs
@@ -27,14 +27,13 @@ use std::net::IpAddr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock, Weak};
 use std::time::Duration;
-use zenoh_core::{
-    bail, zasynclock, zerror, zlock, zread, zwrite, Error as ZError, Result as ZResult,
-};
+use zenoh_core::{zasynclock, zlock, zread, zwrite};
 use zenoh_link_commons::{
     ConstructibleLinkManagerUnicast, LinkManagerUnicastTrait, LinkUnicast, LinkUnicastTrait,
     NewLinkChannelSender,
 };
 use zenoh_protocol::core::{EndPoint, Locator};
+use zenoh_result::{bail, zerror, Error as ZError, ZResult};
 use zenoh_sync::Mvar;
 use zenoh_sync::Signal;
 

--- a/io/zenoh-links/zenoh-link-unixsock_stream/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-unixsock_stream/Cargo.toml
@@ -37,7 +37,7 @@ async-trait = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }
 nix = { workspace = true }
-uuid = { workspace = true, default-features = true }
+uuid = { workspace = true, features = ["default"] }
 zenoh-core = { path = "../../../commons/zenoh-core/" }
 zenoh-link-commons = { path = "../../zenoh-link-commons/" }
 zenoh-protocol = { path = "../../../commons/zenoh-protocol/" }

--- a/io/zenoh-links/zenoh-link-unixsock_stream/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-unixsock_stream/Cargo.toml
@@ -41,4 +41,5 @@ uuid = { workspace = true }
 zenoh-core = { path = "../../../commons/zenoh-core/" }
 zenoh-link-commons = { path = "../../zenoh-link-commons/" }
 zenoh-protocol = { path = "../../../commons/zenoh-protocol/" }
+zenoh-result = { path = "../../../commons/zenoh-result/" }
 zenoh-sync = { path = "../../../commons/zenoh-sync/" }

--- a/io/zenoh-links/zenoh-link-unixsock_stream/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-unixsock_stream/Cargo.toml
@@ -32,12 +32,12 @@ description = "Internal crate for zenoh."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-std = { workspace = true, default-features = false }
+async-std = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }
 nix = { workspace = true }
-uuid = { workspace = true }
+uuid = { workspace = true, default-features = true }
 zenoh-core = { path = "../../../commons/zenoh-core/" }
 zenoh-link-commons = { path = "../../zenoh-link-commons/" }
 zenoh-protocol = { path = "../../../commons/zenoh-protocol/" }

--- a/io/zenoh-links/zenoh-link-unixsock_stream/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-unixsock_stream/src/unicast.rs
@@ -29,12 +29,12 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use uuid::Uuid;
-use zenoh_core::Result as ZResult;
-use zenoh_core::{zerror, zread, zwrite};
+use zenoh_core::{zread, zwrite};
 use zenoh_link_commons::{
     LinkManagerUnicastTrait, LinkUnicast, LinkUnicastTrait, NewLinkChannelSender,
 };
 use zenoh_protocol::core::{EndPoint, Locator};
+use zenoh_result::{zerror, ZResult};
 use zenoh_sync::Signal;
 
 use super::{get_unix_path_as_string, UNIXSOCKSTREAM_DEFAULT_MTU, UNIXSOCKSTREAM_LOCATOR_PREFIX};

--- a/io/zenoh-links/zenoh-link-ws/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-ws/Cargo.toml
@@ -42,5 +42,6 @@ url = { workspace = true }
 zenoh-core = { path = "../../../commons/zenoh-core/" }
 zenoh-link-commons = { path = "../../zenoh-link-commons/" }
 zenoh-protocol = { path = "../../../commons/zenoh-protocol/" }
+zenoh-result = { path = "../../../commons/zenoh-result/" }
 zenoh-sync = { path = "../../../commons/zenoh-sync/" }
 zenoh-util = { path = "../../../commons/zenoh-util/" }

--- a/io/zenoh-links/zenoh-link-ws/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-ws/Cargo.toml
@@ -32,11 +32,11 @@ description = "Internal crate for zenoh."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-std = { workspace = true, default-features = false, features = ["unstable", "tokio1"] }
+async-std = { workspace = true, features = ["unstable", "tokio1"] }
 async-trait = { workspace = true }
-futures-util = { workspace = true, default-features = false, features = ["sink", "std"] }
+futures-util = { workspace = true, features = ["sink", "std"] }
 log = { workspace = true }
-tokio = { workspace = true, default-features = false, features = ["io-std", "macros", "net", "rt-multi-thread", "time"] }
+tokio = { workspace = true, features = ["io-std", "macros", "net", "rt-multi-thread", "time"] }
 tokio-tungstenite = { workspace = true }
 url = { workspace = true }
 zenoh-core = { path = "../../../commons/zenoh-core/" }

--- a/io/zenoh-links/zenoh-link-ws/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-ws/src/lib.rs
@@ -21,9 +21,10 @@ use async_std::net::ToSocketAddrs;
 use async_trait::async_trait;
 use std::net::SocketAddr;
 use url::Url;
-use zenoh_core::{bail, zconfigurable, Result as ZResult};
+use zenoh_core::zconfigurable;
 use zenoh_link_commons::LocatorInspector;
 use zenoh_protocol::core::{endpoint::Address, Locator};
+use zenoh_result::{bail, ZResult};
 mod unicast;
 pub use unicast::*;
 

--- a/io/zenoh-links/zenoh-link-ws/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-ws/src/unicast.rs
@@ -31,14 +31,12 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio_tungstenite::accept_async;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
-use zenoh_core::bail;
-use zenoh_core::zasynclock;
-use zenoh_core::Result as ZResult;
-use zenoh_core::{zerror, zread, zwrite};
+use zenoh_core::{zasynclock, zread, zwrite};
 use zenoh_link_commons::{
     LinkManagerUnicastTrait, LinkUnicast, LinkUnicastTrait, NewLinkChannelSender,
 };
 use zenoh_protocol::core::{EndPoint, Locator};
+use zenoh_result::{bail, zerror, ZResult};
 use zenoh_sync::Signal;
 
 use super::{get_ws_addr, get_ws_url, TCP_ACCEPT_THROTTLE_TIME, WS_DEFAULT_MTU, WS_LOCATOR_PREFIX};

--- a/io/zenoh-transport/Cargo.toml
+++ b/io/zenoh-transport/Cargo.toml
@@ -44,15 +44,15 @@ stats = []
 [dependencies]
 async-executor = { workspace = true }
 async-global-executor = { workspace = true }
-async-std = { workspace = true, default-features = false }
+async-std = { workspace = true }
 async-trait = { workspace = true }
 flume = { workspace = true }
 log = { workspace = true }
 paste = { workspace = true }
-rand = { workspace = true }
+rand = { workspace = true, default-features = true }
 ringbuffer-spsc = { workspace = true }
 rsa = { workspace = true, optional = true }
-serde = { workspace = true }
+serde = { workspace = true, default-features = true }
 zenoh-buffers = { path = "../../commons/zenoh-buffers/" }
 zenoh-cfg-properties = { path = "../../commons/zenoh-cfg-properties/" }
 zenoh-codec = { path = "../../commons/zenoh-codec/" }

--- a/io/zenoh-transport/Cargo.toml
+++ b/io/zenoh-transport/Cargo.toml
@@ -49,10 +49,10 @@ async-trait = { workspace = true }
 flume = { workspace = true }
 log = { workspace = true }
 paste = { workspace = true }
-rand = { workspace = true, default-features = true }
+rand = { workspace = true, features = ["default"] }
 ringbuffer-spsc = { workspace = true }
 rsa = { workspace = true, optional = true }
-serde = { workspace = true, default-features = true }
+serde = { workspace = true, features = ["default"] }
 zenoh-buffers = { path = "../../commons/zenoh-buffers/" }
 zenoh-cfg-properties = { path = "../../commons/zenoh-cfg-properties/" }
 zenoh-codec = { path = "../../commons/zenoh-codec/" }

--- a/io/zenoh-transport/Cargo.toml
+++ b/io/zenoh-transport/Cargo.toml
@@ -62,6 +62,7 @@ zenoh-core = { path = "../../commons/zenoh-core/" }
 zenoh-crypto = { path = "../../commons/zenoh-crypto/" }
 zenoh-link = { path = "../zenoh-link/" }
 zenoh-protocol = { path = "../../commons/zenoh-protocol/" }
+zenoh-result = { path = "../../commons/zenoh-result/" }
 zenoh-shm = { path = "../../commons/zenoh-shm/", optional = true }
 zenoh-sync = { path = "../../commons/zenoh-sync/" }
 zenoh-util = { path = "../../commons/zenoh-util/" }

--- a/io/zenoh-transport/src/common/conduit.rs
+++ b/io/zenoh-transport/src/common/conduit.rs
@@ -15,8 +15,8 @@ use super::defragmentation::DefragBuffer;
 use super::seq_num::{SeqNum, SeqNumGenerator};
 use std::sync::{Arc, Mutex};
 use zenoh_core::zlock;
-use zenoh_core::zresult::ZResult;
 use zenoh_protocol::core::{ConduitSn, Reliability, ZInt};
+use zenoh_result::ZResult;
 
 #[derive(Debug)]
 pub(crate) struct TransportChannelTx {

--- a/io/zenoh-transport/src/common/defragmentation.rs
+++ b/io/zenoh-transport/src/common/defragmentation.rs
@@ -14,11 +14,11 @@
 use super::seq_num::SeqNum;
 use zenoh_buffers::{reader::HasReader, SplitBuffer, ZBuf, ZSlice};
 use zenoh_codec::{RCodec, Zenoh060Reliability};
-use zenoh_core::{bail, Result as ZResult};
 use zenoh_protocol::{
     core::{Reliability, ZInt},
     zenoh::ZenohMessage,
 };
+use zenoh_result::{bail, ZResult};
 
 #[derive(Debug)]
 pub(crate) struct DefragBuffer {

--- a/io/zenoh-transport/src/common/seq_num.rs
+++ b/io/zenoh-transport/src/common/seq_num.rs
@@ -11,8 +11,8 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use zenoh_core::{bail, Result as ZResult};
 use zenoh_protocol::core::ZInt;
+use zenoh_result::{bail, ZResult};
 
 /// Sequence Number
 ///

--- a/io/zenoh-transport/src/lib.rs
+++ b/io/zenoh-transport/src/lib.rs
@@ -32,10 +32,10 @@ use serde::Serialize;
 use std::any::Any;
 use std::sync::Arc;
 pub use unicast::*;
-use zenoh_core::Result as ZResult;
 use zenoh_link::Link;
 use zenoh_protocol::core::{WhatAmI, ZenohId};
 use zenoh_protocol::zenoh::ZenohMessage;
+use zenoh_result::ZResult;
 
 /*************************************/
 /*            TRANSPORT              */

--- a/io/zenoh-transport/src/manager.rs
+++ b/io/zenoh-transport/src/manager.rs
@@ -29,13 +29,14 @@ use std::sync::RwLock;
 use std::time::Duration;
 use zenoh_cfg_properties::{config::*, Properties};
 use zenoh_config::{Config, QueueConf, QueueSizeConf};
-use zenoh_core::{bail, zparse, Result as ZResult};
+use zenoh_core::zparse;
 use zenoh_crypto::{BlockCipher, PseudoRng};
 use zenoh_link::NewLinkChannelSender;
 use zenoh_protocol::{
     core::{EndPoint, Locator, Priority, WhatAmI, ZInt, ZenohId},
     defaults::{BATCH_SIZE, SEQ_NUM_RES, VERSION},
 };
+use zenoh_result::{bail, ZResult};
 #[cfg(feature = "shared-memory")]
 use zenoh_shm::SharedMemoryReader;
 
@@ -45,7 +46,7 @@ use zenoh_shm::SharedMemoryReader;
 /// use std::time::Duration;
 /// use zenoh_protocol::core::{ZenohId, WhatAmI, whatami};
 /// use zenoh_transport::*;
-/// use zenoh_core::Result as ZResult;
+/// use zenoh_result::ZResult;
 ///
 /// // Create my transport handler to be notified when a new transport is initiated with me
 /// #[derive(Default)]

--- a/io/zenoh-transport/src/multicast/establishment.rs
+++ b/io/zenoh-transport/src/multicast/establishment.rs
@@ -15,10 +15,10 @@ use crate::multicast::{TransportMulticast, TransportMulticastConfig, TransportMu
 use crate::TransportManager;
 use rand::Rng;
 use std::sync::Arc;
-use zenoh_core::Result as ZResult;
 use zenoh_core::{zasynclock, zlock};
 use zenoh_link::LinkMulticast;
 use zenoh_protocol::core::{ConduitSn, ConduitSnList, Priority};
+use zenoh_result::ZResult;
 
 pub(crate) async fn open_link(
     manager: &TransportManager,

--- a/io/zenoh-transport/src/multicast/link.rs
+++ b/io/zenoh-transport/src/multicast/link.rs
@@ -27,12 +27,13 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use zenoh_buffers::reader::{HasReader, Reader};
 use zenoh_codec::{RCodec, Zenoh060};
-use zenoh_core::{bail, zerror, zlock, Result as ZResult};
+use zenoh_core::zlock;
 use zenoh_link::{LinkMulticast, Locator};
 use zenoh_protocol::{
     core::{ConduitSn, ConduitSnList, Priority, WhatAmI, ZInt, ZenohId},
     transport::TransportMessage,
 };
+use zenoh_result::{bail, zerror, ZResult};
 use zenoh_sync::RecyclingObjectPool;
 use zenoh_sync::Signal;
 

--- a/io/zenoh-transport/src/multicast/manager.rs
+++ b/io/zenoh-transport/src/multicast/manager.rs
@@ -18,10 +18,10 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use zenoh_config::{Config, ZN_LINK_KEEP_ALIVE_DEFAULT, ZN_LINK_LEASE_DEFAULT};
-use zenoh_core::{bail, Result as ZResult};
-use zenoh_core::{zerror, zlock, zparse};
+use zenoh_core::{zlock, zparse};
 use zenoh_link::*;
 use zenoh_protocol::{core::locator::LocatorProtocol, transport::tmsg};
+use zenoh_result::{bail, zerror, ZResult};
 
 pub struct TransportManagerConfigMulticast {
     pub lease: Duration,

--- a/io/zenoh-transport/src/multicast/mod.rs
+++ b/io/zenoh-transport/src/multicast/mod.rs
@@ -28,10 +28,10 @@ use std::{
     sync::{Arc, Weak},
 };
 use transport::{TransportMulticastConfig, TransportMulticastInner};
-use zenoh_core::Result as ZResult;
-use zenoh_core::{zerror, zread};
+use zenoh_core::zread;
 use zenoh_link::Link;
 use zenoh_protocol::{core::ZInt, transport::tmsg, zenoh::ZenohMessage};
+use zenoh_result::{zerror, ZResult};
 
 /*************************************/
 /*              STATS                */

--- a/io/zenoh-transport/src/multicast/rx.rs
+++ b/io/zenoh-transport/src/multicast/rx.rs
@@ -14,7 +14,7 @@
 use super::common::conduit::TransportChannelRx;
 use super::transport::{TransportMulticastInner, TransportMulticastPeer};
 use std::sync::MutexGuard;
-use zenoh_core::{bail, zerror, zlock, zread, Result as ZResult};
+use zenoh_core::{zlock, zread};
 #[cfg(feature = "stats")]
 use zenoh_protocol::zenoh::ZenohBody;
 use zenoh_protocol::{
@@ -22,6 +22,7 @@ use zenoh_protocol::{
     transport::{Frame, FramePayload, Join, TransportBody, TransportMessage},
     zenoh::ZenohMessage,
 };
+use zenoh_result::{bail, zerror, ZResult};
 
 /*************************************/
 /*            TRANSPORT RX           */

--- a/io/zenoh-transport/src/multicast/transport.rs
+++ b/io/zenoh-transport/src/multicast/transport.rs
@@ -27,13 +27,14 @@ use std::{
     },
     time::Duration,
 };
-use zenoh_core::{bail, zread, zwrite, Result as ZResult};
+use zenoh_core::{zread, zwrite};
 use zenoh_link::{Link, LinkMulticast, Locator};
 use zenoh_protocol::{
     core::{ConduitSnList, Priority, WhatAmI, ZInt, ZenohId},
     transport::{tmsg, Join, TransportMessage},
     zenoh::ZenohMessage,
 };
+use zenoh_result::{bail, ZResult};
 use zenoh_util::{Timed, TimedEvent, TimedHandle, Timer};
 
 /*************************************/

--- a/io/zenoh-transport/src/primitives/demux.rs
+++ b/io/zenoh-transport/src/primitives/demux.rs
@@ -14,11 +14,11 @@
 use super::Primitives;
 use crate::TransportPeerEventHandler;
 use std::any::Any;
-use zenoh_core::{bail, Result as ZResult};
 use zenoh_link::Link;
 use zenoh_protocol::zenoh::{
     Data, Declaration, Declare, LinkStateList, Pull, Query, Unit, ZenohBody, ZenohMessage,
 };
+use zenoh_result::{bail, ZResult};
 
 pub struct DeMux<P: Primitives> {
     primitives: P,

--- a/io/zenoh-transport/src/shm.rs
+++ b/io/zenoh-transport/src/shm.rs
@@ -13,8 +13,9 @@
 //
 use std::{any::TypeId, sync::RwLock};
 use zenoh_buffers::{ZBuf, ZSlice};
-use zenoh_core::{zread, zwrite, Result as ZResult};
+use zenoh_core::{zread, zwrite};
 use zenoh_protocol::zenoh::*;
+use zenoh_result::ZResult;
 use zenoh_shm::{
     SharedMemoryBuf, SharedMemoryBufInfo, SharedMemoryBufInfoSerialized, SharedMemoryReader,
 };

--- a/io/zenoh-transport/src/unicast/establishment/accept/init_ack.rs
+++ b/io/zenoh-transport/src/unicast/establishment/accept/init_ack.rs
@@ -22,7 +22,7 @@ use rand::Rng;
 use std::convert::TryFrom;
 use zenoh_buffers::{writer::HasWriter, ZSlice};
 use zenoh_codec::{WCodec, Zenoh060};
-use zenoh_core::{zasynclock, zasyncread, zerror};
+use zenoh_core::{zasynclock, zasyncread};
 use zenoh_crypto::hmac;
 use zenoh_link::LinkUnicast;
 use zenoh_protocol::{
@@ -30,6 +30,7 @@ use zenoh_protocol::{
     core::Property,
     transport::{tmsg, TransportMessage},
 };
+use zenoh_result::zerror;
 
 // Send an InitAck
 pub(super) struct Output {

--- a/io/zenoh-transport/src/unicast/establishment/accept/init_syn.rs
+++ b/io/zenoh-transport/src/unicast/establishment/accept/init_syn.rs
@@ -16,12 +16,12 @@ use std::convert::TryFrom;
 use super::super::{AuthenticatedPeerLink, EstablishmentProperties};
 use super::AResult;
 use crate::TransportManager;
-use zenoh_core::zerror;
 use zenoh_link::LinkUnicast;
 use zenoh_protocol::{
     core::{WhatAmI, ZInt, ZenohId},
     transport::{tmsg, TransportBody},
 };
+use zenoh_result::zerror;
 
 /*************************************/
 /*             ACCEPT                */

--- a/io/zenoh-transport/src/unicast/establishment/accept/mod.rs
+++ b/io/zenoh-transport/src/unicast/establishment/accept/mod.rs
@@ -21,11 +21,11 @@ use crate::unicast::establishment::{
     close_link, transport_finalize, transport_init, InputFinalize,
 };
 use crate::TransportManager;
-use zenoh_core::Result as ZResult;
 use zenoh_link::{LinkUnicast, LinkUnicastDirection};
 use zenoh_protocol::transport::tmsg;
+use zenoh_result::ZResult;
 
-pub(super) type AError = (zenoh_core::Error, Option<u8>);
+pub(super) type AError = (zenoh_result::Error, Option<u8>);
 pub(super) type AResult<T> = Result<T, AError>;
 
 pub(crate) async fn accept_link(

--- a/io/zenoh-transport/src/unicast/establishment/accept/open_syn.rs
+++ b/io/zenoh-transport/src/unicast/establishment/accept/open_syn.rs
@@ -20,7 +20,7 @@ use crate::{unicast::establishment::cookie::Zenoh060Cookie, TransportManager};
 use std::{convert::TryFrom, time::Duration};
 use zenoh_buffers::reader::HasReader;
 use zenoh_codec::{RCodec, Zenoh060};
-use zenoh_core::{zasynclock, zasyncread, zerror};
+use zenoh_core::{zasynclock, zasyncread};
 use zenoh_crypto::hmac;
 use zenoh_link::LinkUnicast;
 use zenoh_protocol::{
@@ -28,6 +28,7 @@ use zenoh_protocol::{
     core::{Property, ZInt},
     transport::{tmsg, Close, TransportBody},
 };
+use zenoh_result::zerror;
 
 /*************************************/
 /*             ACCEPT                */
@@ -133,7 +134,7 @@ pub(super) async fn recv(
                         Ok(att)
                     }
                     Err(e) => {
-                        if e.is::<zenoh_core::zresult::ShmError>() {
+                        if e.is::<zenoh_result::ShmError>() {
                             is_shm = false;
                             Ok(None)
                         } else {

--- a/io/zenoh-transport/src/unicast/establishment/authenticator/mod.rs
+++ b/io/zenoh-transport/src/unicast/establishment/authenticator/mod.rs
@@ -32,9 +32,9 @@ use std::sync::Arc;
 #[cfg(feature = "auth_usrpwd")]
 pub use userpassword::*;
 use zenoh_config::Config;
-use zenoh_core::Result as ZResult;
 use zenoh_link::{Link, Locator};
 use zenoh_protocol::core::{ZInt, ZenohId};
+use zenoh_result::ZResult;
 
 /*************************************/
 /*              LINK                 */

--- a/io/zenoh-transport/src/unicast/establishment/authenticator/pubkey.rs
+++ b/io/zenoh-transport/src/unicast/establishment/authenticator/pubkey.rs
@@ -31,10 +31,10 @@ use zenoh_buffers::{
 use zenoh_cfg_properties::config::ZN_AUTH_RSA_KEY_SIZE_DEFAULT;
 use zenoh_codec::{RCodec, WCodec, Zenoh060};
 use zenoh_config::Config;
-use zenoh_core::{bail, zparse, Result as ZResult};
-use zenoh_core::{zasynclock, zerror};
+use zenoh_core::{zasynclock, zparse};
 use zenoh_crypto::PseudoRng;
 use zenoh_protocol::core::{ZInt, ZenohId};
+use zenoh_result::{bail, zerror, ZResult};
 
 const MULTILINK_VERSION: ZInt = 1;
 

--- a/io/zenoh-transport/src/unicast/establishment/authenticator/shm.rs
+++ b/io/zenoh-transport/src/unicast/establishment/authenticator/shm.rs
@@ -28,9 +28,9 @@ use zenoh_buffers::{
 };
 use zenoh_codec::{RCodec, WCodec, Zenoh060};
 use zenoh_config::Config;
-use zenoh_core::{bail, zerror, zresult::ShmError, Result as ZResult};
 use zenoh_crypto::PseudoRng;
 use zenoh_protocol::core::{ZInt, ZenohId};
+use zenoh_result::{bail, zerror, ShmError, ZResult};
 use zenoh_shm::{
     SharedMemoryBuf, SharedMemoryBufInfoSerialized, SharedMemoryManager, SharedMemoryReader,
 };

--- a/io/zenoh-transport/src/unicast/establishment/authenticator/userpassword.rs
+++ b/io/zenoh-transport/src/unicast/establishment/authenticator/userpassword.rs
@@ -28,8 +28,9 @@ use zenoh_buffers::{
 use zenoh_cfg_properties::Properties;
 use zenoh_codec::{RCodec, WCodec, Zenoh060};
 use zenoh_config::Config;
-use zenoh_core::{bail, zasynclock, zasyncread, zasyncwrite, zerror, Result as ZResult};
+use zenoh_core::{zasynclock, zasyncread, zasyncwrite};
 use zenoh_crypto::hmac;
+use zenoh_result::{bail, zerror, ZResult};
 
 const USRPWD_VERSION: ZInt = 1;
 

--- a/io/zenoh-transport/src/unicast/establishment/mod.rs
+++ b/io/zenoh-transport/src/unicast/establishment/mod.rs
@@ -24,12 +24,13 @@ use cookie::*;
 use properties::*;
 use rand::Rng;
 use std::time::Duration;
-use zenoh_core::{zasynclock, zasyncread, Result as ZResult};
+use zenoh_core::{zasynclock, zasyncread};
 use zenoh_link::{Link, LinkUnicast};
 use zenoh_protocol::{
     core::{WhatAmI, ZInt, ZenohId},
     transport::TransportMessage,
 };
+use zenoh_result::ZResult;
 
 pub(super) async fn close_link(
     link: &LinkUnicast,

--- a/io/zenoh-transport/src/unicast/establishment/open/init_ack.rs
+++ b/io/zenoh-transport/src/unicast/establishment/open/init_ack.rs
@@ -18,13 +18,14 @@ use crate::unicast::establishment::{
 use crate::TransportManager;
 use std::convert::TryFrom;
 use zenoh_buffers::ZSlice;
-use zenoh_core::{zasyncread, zerror};
+use zenoh_core::zasyncread;
 use zenoh_link::LinkUnicast;
 use zenoh_protocol::{
     common::Attachment,
     core::{Property, WhatAmI, ZInt, ZenohId},
     transport::{tmsg, Close, TransportBody},
 };
+use zenoh_result::zerror;
 
 #[cfg(feature = "shared-memory")]
 use crate::unicast::establishment::authenticator::PeerAuthenticatorId;
@@ -140,7 +141,7 @@ pub(super) async fn recv(
                     Ok(att)
                 }
                 Err(e) => {
-                    if e.is::<zenoh_core::zresult::ShmError>() {
+                    if e.is::<zenoh_result::ShmError>() {
                         is_shm = false;
                         Ok(None)
                     } else {

--- a/io/zenoh-transport/src/unicast/establishment/open/mod.rs
+++ b/io/zenoh-transport/src/unicast/establishment/open/mod.rs
@@ -19,11 +19,11 @@ mod open_syn;
 use super::authenticator::AuthenticatedPeerLink;
 use crate::unicast::establishment::{close_link, transport_finalize, InputFinalize, InputInit};
 use crate::{TransportManager, TransportUnicast};
-use zenoh_core::Result as ZResult;
 use zenoh_link::{LinkUnicast, LinkUnicastDirection};
 use zenoh_protocol::transport::tmsg;
+use zenoh_result::ZResult;
 
-type OError = (zenoh_core::Error, Option<u8>);
+type OError = (zenoh_result::Error, Option<u8>);
 type OResult<T> = Result<T, OError>;
 
 pub(crate) async fn open_link(

--- a/io/zenoh-transport/src/unicast/establishment/open/open_ack.rs
+++ b/io/zenoh-transport/src/unicast/establishment/open/open_ack.rs
@@ -18,12 +18,13 @@ use crate::{
     TransportManager,
 };
 use std::{convert::TryFrom, time::Duration};
-use zenoh_core::{zasyncread, zerror};
+use zenoh_core::zasyncread;
 use zenoh_link::LinkUnicast;
 use zenoh_protocol::{
     core::ZInt,
     transport::{tmsg, Close, TransportBody},
 };
+use zenoh_result::zerror;
 
 pub(super) struct Output {
     pub(super) initial_sn: ZInt,

--- a/io/zenoh-transport/src/unicast/establishment/properties.rs
+++ b/io/zenoh-transport/src/unicast/establishment/properties.rs
@@ -17,11 +17,11 @@ use std::{
 };
 use zenoh_buffers::{reader::HasReader, writer::HasWriter, ZBuf};
 use zenoh_codec::{RCodec, WCodec, Zenoh060};
-use zenoh_core::{bail, zerror, Error as ZError, Result as ZResult};
 use zenoh_protocol::{
     common::Attachment,
     core::{Property, ZInt},
 };
+use zenoh_result::{bail, zerror, Error as ZError, ZResult};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct EstablishmentProperties(Vec<Property>);

--- a/io/zenoh-transport/src/unicast/link.rs
+++ b/io/zenoh-transport/src/unicast/link.rs
@@ -28,9 +28,9 @@ use std::time::Duration;
 use zenoh_buffers::reader::{HasReader, Reader};
 use zenoh_buffers::ZSlice;
 use zenoh_codec::{RCodec, Zenoh060};
-use zenoh_core::{bail, zerror, Result as ZResult};
 use zenoh_link::{LinkUnicast, LinkUnicastDirection};
 use zenoh_protocol::transport::TransportMessage;
+use zenoh_result::{bail, zerror, ZResult};
 use zenoh_sync::{RecyclingObjectPool, Signal};
 
 #[derive(Clone)]

--- a/io/zenoh-transport/src/unicast/manager.rs
+++ b/io/zenoh-transport/src/unicast/manager.rs
@@ -25,14 +25,13 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use zenoh_cfg_properties::config::*;
 use zenoh_config::Config;
-use zenoh_core::{
-    bail, zasynclock, zasyncread, zasyncwrite, zerror, zlock, zparse, Result as ZResult,
-};
+use zenoh_core::{zasynclock, zasyncread, zasyncwrite, zlock, zparse};
 use zenoh_link::*;
 use zenoh_protocol::{
     core::{locator::LocatorProtocol, ZenohId},
     transport::tmsg,
 };
+use zenoh_result::{bail, zerror, ZResult};
 
 /*************************************/
 /*         TRANSPORT CONFIG          */

--- a/io/zenoh-transport/src/unicast/mod.rs
+++ b/io/zenoh-transport/src/unicast/mod.rs
@@ -26,13 +26,13 @@ pub use manager::*;
 use std::fmt;
 use std::sync::{Arc, Weak};
 use transport::TransportUnicastInner;
-use zenoh_core::{zerror, Result as ZResult};
 use zenoh_link::Link;
 use zenoh_protocol::{
     core::{WhatAmI, ZInt, ZenohId},
     transport::tmsg,
     zenoh::ZenohMessage,
 };
+use zenoh_result::{zerror, ZResult};
 
 /*************************************/
 /*              STATS                */

--- a/io/zenoh-transport/src/unicast/reliability.rs
+++ b/io/zenoh-transport/src/unicast/reliability.rs
@@ -17,7 +17,7 @@ use std::fmt;
 use super::common::seq_num::SeqNum;
 use super::core::ZInt;
 
-use zenoh_core::{ZError, ZErrorKind, ZResult};
+use zenoh_result::{ZError, ZErrorKind, ZResult};
 use zenoh_util::zerror;
 
 pub(super) struct ReliabilityQueue<T> {

--- a/io/zenoh-transport/src/unicast/rx.rs
+++ b/io/zenoh-transport/src/unicast/rx.rs
@@ -17,7 +17,7 @@ use async_std::task;
 use std::sync::MutexGuard;
 #[cfg(feature = "stats")]
 use zenoh_buffers::SplitBuffer;
-use zenoh_core::{bail, zerror, zlock, zread, Result as ZResult};
+use zenoh_core::{zlock, zread};
 use zenoh_link::LinkUnicast;
 #[cfg(feature = "stats")]
 use zenoh_protocol::zenoh::ZenohBody;
@@ -26,6 +26,7 @@ use zenoh_protocol::{
     transport::{tmsg, Close, Frame, FramePayload, KeepAlive, TransportBody, TransportMessage},
     zenoh::ZenohMessage,
 };
+use zenoh_result::{bail, zerror, ZResult};
 
 /*************************************/
 /*            TRANSPORT RX           */

--- a/io/zenoh-transport/src/unicast/transport.rs
+++ b/io/zenoh-transport/src/unicast/transport.rs
@@ -19,13 +19,14 @@ use super::TransportUnicastStatsAtomic;
 use async_std::sync::{Mutex as AsyncMutex, MutexGuard as AsyncMutexGuard};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
-use zenoh_core::{bail, zasynclock, zerror, zread, zwrite, Result as ZResult};
+use zenoh_core::{zasynclock, zread, zwrite};
 use zenoh_link::{Link, LinkUnicast, LinkUnicastDirection};
 use zenoh_protocol::{
     core::{ConduitSn, Priority, WhatAmI, ZInt, ZenohId},
     transport::TransportMessage,
     zenoh::ZenohMessage,
 };
+use zenoh_result::{bail, zerror, ZResult};
 
 macro_rules! zlinkget {
     ($guard:expr, $link:expr) => {

--- a/io/zenoh-transport/tests/endpoints.rs
+++ b/io/zenoh-transport/tests/endpoints.rs
@@ -13,12 +13,13 @@
 //
 use async_std::{prelude::FutureExt, task};
 use std::{any::Any, convert::TryFrom, sync::Arc, time::Duration};
-use zenoh_core::{zasync_executor_init, Result as ZResult};
+use zenoh_core::zasync_executor_init;
 use zenoh_link::{EndPoint, Link};
 use zenoh_protocol::{
     core::{WhatAmI, ZenohId},
     zenoh::ZenohMessage,
 };
+use zenoh_result::ZResult;
 use zenoh_transport::{
     TransportEventHandler, TransportManager, TransportMulticast, TransportMulticastEventHandler,
     TransportPeer, TransportPeerEventHandler, TransportUnicast,

--- a/io/zenoh-transport/tests/multicast_transport.rs
+++ b/io/zenoh-transport/tests/multicast_transport.rs
@@ -24,12 +24,13 @@ mod tests {
     use std::time::Duration;
     use zenoh_buffers::ZBuf;
     use zenoh_cfg_properties::config::*;
-    use zenoh_core::{zasync_executor_init, Result as ZResult};
+    use zenoh_core::zasync_executor_init;
     use zenoh_link::Link;
     use zenoh_protocol::{
         core::{Channel, CongestionControl, EndPoint, Priority, Reliability, WhatAmI, ZenohId},
         zenoh::ZenohMessage,
     };
+    use zenoh_result::ZResult;
     use zenoh_transport::{
         TransportEventHandler, TransportManager, TransportMulticast,
         TransportMulticastEventHandler, TransportPeer, TransportPeerEventHandler, TransportUnicast,

--- a/io/zenoh-transport/tests/unicast_authenticator.rs
+++ b/io/zenoh-transport/tests/unicast_authenticator.rs
@@ -17,12 +17,13 @@ use rsa::{BigUint, RsaPrivateKey, RsaPublicKey};
 #[cfg(feature = "auth_usrpwd")]
 use std::collections::HashMap;
 use std::{any::Any, collections::HashSet, iter::FromIterator, sync::Arc, time::Duration};
-use zenoh_core::{zasync_executor_init, Result as ZResult};
+use zenoh_core::zasync_executor_init;
 use zenoh_link::Link;
 use zenoh_protocol::{
     core::{EndPoint, WhatAmI, ZenohId},
     zenoh::ZenohMessage,
 };
+use zenoh_result::ZResult;
 #[cfg(feature = "auth_pubkey")]
 use zenoh_transport::unicast::establishment::authenticator::PubKeyAuthenticator;
 #[cfg(feature = "shared-memory")]

--- a/io/zenoh-transport/tests/unicast_concurrent.rs
+++ b/io/zenoh-transport/tests/unicast_concurrent.rs
@@ -20,12 +20,13 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use zenoh_buffers::ZBuf;
-use zenoh_core::{zasync_executor_init, Result as ZResult};
+use zenoh_core::zasync_executor_init;
 use zenoh_link::Link;
 use zenoh_protocol::{
     core::{Channel, CongestionControl, EndPoint, Priority, Reliability, WhatAmI, ZenohId},
     zenoh::ZenohMessage,
 };
+use zenoh_result::ZResult;
 use zenoh_transport::{
     TransportEventHandler, TransportManager, TransportMulticast, TransportMulticastEventHandler,
     TransportPeer, TransportPeerEventHandler, TransportUnicast,

--- a/io/zenoh-transport/tests/unicast_conduits.rs
+++ b/io/zenoh-transport/tests/unicast_conduits.rs
@@ -20,12 +20,13 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use zenoh_buffers::ZBuf;
-use zenoh_core::{zasync_executor_init, Result as ZResult};
+use zenoh_core::zasync_executor_init;
 use zenoh_link::Link;
 use zenoh_protocol::{
     core::{Channel, CongestionControl, EndPoint, Priority, Reliability, WhatAmI, ZenohId},
     zenoh::ZenohMessage,
 };
+use zenoh_result::ZResult;
 use zenoh_transport::{
     TransportEventHandler, TransportManager, TransportMulticast, TransportMulticastEventHandler,
     TransportPeer, TransportPeerEventHandler, TransportUnicast,

--- a/io/zenoh-transport/tests/unicast_intermittent.rs
+++ b/io/zenoh-transport/tests/unicast_intermittent.rs
@@ -21,12 +21,13 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 use zenoh_buffers::ZBuf;
-use zenoh_core::{zasync_executor_init, Result as ZResult};
+use zenoh_core::zasync_executor_init;
 use zenoh_link::Link;
 use zenoh_protocol::{
     core::{Channel, CongestionControl, EndPoint, Priority, Reliability, WhatAmI, ZenohId},
     zenoh::ZenohMessage,
 };
+use zenoh_result::ZResult;
 use zenoh_transport::{
     DummyTransportPeerEventHandler, TransportEventHandler, TransportManager, TransportMulticast,
     TransportMulticastEventHandler, TransportPeer, TransportPeerEventHandler, TransportUnicast,

--- a/io/zenoh-transport/tests/unicast_openclose.rs
+++ b/io/zenoh-transport/tests/unicast_openclose.rs
@@ -13,9 +13,10 @@
 //
 use async_std::{prelude::FutureExt, task};
 use std::{convert::TryFrom, sync::Arc, time::Duration};
-use zenoh_core::{zasync_executor_init, Result as ZResult};
+use zenoh_core::zasync_executor_init;
 use zenoh_link::EndPoint;
 use zenoh_protocol::core::{WhatAmI, ZenohId};
+use zenoh_result::ZResult;
 use zenoh_transport::{
     DummyTransportPeerEventHandler, TransportEventHandler, TransportManager, TransportMulticast,
     TransportMulticastEventHandler, TransportPeer, TransportPeerEventHandler, TransportUnicast,

--- a/io/zenoh-transport/tests/unicast_shm.rs
+++ b/io/zenoh-transport/tests/unicast_shm.rs
@@ -26,12 +26,13 @@ mod tests {
         time::Duration,
     };
     use zenoh_buffers::{SplitBuffer, ZBuf};
-    use zenoh_core::{zasync_executor_init, Result as ZResult};
+    use zenoh_core::zasync_executor_init;
     use zenoh_link::Link;
     use zenoh_protocol::{
         core::{Channel, CongestionControl, EndPoint, Priority, Reliability, WhatAmI, ZenohId},
         zenoh::{Data, ZenohBody, ZenohMessage},
     };
+    use zenoh_result::ZResult;
     use zenoh_shm::SharedMemoryManager;
     use zenoh_transport::{
         unicast::establishment::authenticator::SharedMemoryAuthenticator, TransportEventHandler,

--- a/io/zenoh-transport/tests/unicast_simultaneous.rs
+++ b/io/zenoh-transport/tests/unicast_simultaneous.rs
@@ -21,12 +21,13 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
     use zenoh_buffers::ZBuf;
-    use zenoh_core::{zasync_executor_init, Result as ZResult};
+    use zenoh_core::zasync_executor_init;
     use zenoh_link::Link;
     use zenoh_protocol::{
         core::{Channel, CongestionControl, EndPoint, Priority, Reliability, WhatAmI, ZenohId},
         zenoh::ZenohMessage,
     };
+    use zenoh_result::ZResult;
     use zenoh_transport::{
         TransportEventHandler, TransportManager, TransportMulticast,
         TransportMulticastEventHandler, TransportPeer, TransportPeerEventHandler, TransportUnicast,

--- a/io/zenoh-transport/tests/unicast_transport.rs
+++ b/io/zenoh-transport/tests/unicast_transport.rs
@@ -23,12 +23,13 @@ use std::{
     time::Duration,
 };
 use zenoh_buffers::ZBuf;
-use zenoh_core::{zasync_executor_init, Result as ZResult};
+use zenoh_core::zasync_executor_init;
 use zenoh_link::Link;
 use zenoh_protocol::{
     core::{Channel, CongestionControl, EndPoint, Priority, Reliability, WhatAmI, ZenohId},
     zenoh::ZenohMessage,
 };
+use zenoh_result::ZResult;
 use zenoh_transport::{
     TransportEventHandler, TransportManager, TransportMulticast, TransportMulticastEventHandler,
     TransportPeer, TransportPeerEventHandler, TransportUnicast,

--- a/plugins/example-plugin/Cargo.toml
+++ b/plugins/example-plugin/Cargo.toml
@@ -29,7 +29,7 @@ name = "zplugin_example"
 crate-type = ["cdylib"]
 
 [dependencies]
-async-std = { workspace = true, default-features = true }
+async-std = { workspace = true, features = ["default"] }
 clap = { workspace = true }
 env_logger = { workspace = true }
 futures = { workspace = true }

--- a/plugins/example-plugin/Cargo.toml
+++ b/plugins/example-plugin/Cargo.toml
@@ -38,4 +38,5 @@ serde_json = { workspace = true }
 zenoh = { path = "../../zenoh/", default-features = false }
 zenoh-core = { path = "../../commons/zenoh-core/" }
 zenoh-plugin-trait = { path = "../zenoh-plugin-trait/" }
+zenoh-result = { path = "../../commons/zenoh-result/" }
 zenoh-util = { path = "../../commons/zenoh-util/" }

--- a/plugins/example-plugin/Cargo.toml
+++ b/plugins/example-plugin/Cargo.toml
@@ -29,7 +29,7 @@ name = "zplugin_example"
 crate-type = ["cdylib"]
 
 [dependencies]
-async-std = { workspace = true }
+async-std = { workspace = true, default-features = true }
 clap = { workspace = true }
 env_logger = { workspace = true }
 futures = { workspace = true }

--- a/plugins/example-plugin/src/lib.rs
+++ b/plugins/example-plugin/src/lib.rs
@@ -24,7 +24,8 @@ use std::sync::{
 use zenoh::plugins::{Plugin, RunningPluginTrait, ValidationFunction, ZenohPlugin};
 use zenoh::prelude::r#async::*;
 use zenoh::runtime::Runtime;
-use zenoh_core::{bail, zlock, Result as ZResult};
+use zenoh_core::zlock;
+use zenoh_result::{bail, ZResult};
 
 // The struct implementing the ZenohPlugin and ZenohPlugin traits
 pub struct ExamplePlugin {}

--- a/plugins/zenoh-backend-traits/Cargo.toml
+++ b/plugins/zenoh-backend-traits/Cargo.toml
@@ -37,5 +37,5 @@ async-trait = { workspace = true }
 derive_more = { workspace = true }
 serde_json = { workspace = true }
 zenoh = { path = "../../zenoh/", default-features = false }
-zenoh-core = { path = "../../commons/zenoh-core/" }
+zenoh-result = { path = "../../commons/zenoh-result/" }
 zenoh-util = { path = "../../commons/zenoh-util/" }

--- a/plugins/zenoh-backend-traits/Cargo.toml
+++ b/plugins/zenoh-backend-traits/Cargo.toml
@@ -32,7 +32,7 @@ description = "Zenoh: traits to be implemented by backends libraries"
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-async-std = { workspace = true }
+async-std = { workspace = true, default-features = true }
 async-trait = { workspace = true }
 derive_more = { workspace = true }
 serde_json = { workspace = true }

--- a/plugins/zenoh-backend-traits/Cargo.toml
+++ b/plugins/zenoh-backend-traits/Cargo.toml
@@ -32,7 +32,7 @@ description = "Zenoh: traits to be implemented by backends libraries"
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-async-std = { workspace = true, default-features = true }
+async-std = { workspace = true, features = ["default"] }
 async-trait = { workspace = true }
 derive_more = { workspace = true }
 serde_json = { workspace = true }

--- a/plugins/zenoh-backend-traits/src/config.rs
+++ b/plugins/zenoh-backend-traits/src/config.rs
@@ -16,7 +16,7 @@ use serde_json::{Map, Value};
 use std::convert::TryFrom;
 use std::time::Duration;
 use zenoh::{key_expr::keyexpr, prelude::OwnedKeyExpr, Result as ZResult};
-use zenoh_core::{bail, zerror, Error};
+use zenoh_result::{bail, zerror, Error};
 
 #[derive(Debug, Clone, AsMut, AsRef)]
 pub struct PluginConfig {

--- a/plugins/zenoh-plugin-rest/Cargo.toml
+++ b/plugins/zenoh-plugin-rest/Cargo.toml
@@ -48,8 +48,8 @@ serde_json = { workspace = true }
 tide = { workspace = true }
 zenoh = { path = "../../zenoh/", default-features = false, features = [ "unstable" ] }
 zenoh-cfg-properties = { path = "../../commons/zenoh-cfg-properties/" }
-zenoh-core = { path = "../../commons/zenoh-core/" }
 zenoh-plugin-trait = { path = "../zenoh-plugin-trait/", default-features = false }
+zenoh-result = { path = "../../commons/zenoh-result/" }
 zenoh-util = { path = "../../commons/zenoh-util/" }
 
 [build-dependencies]

--- a/plugins/zenoh-plugin-rest/Cargo.toml
+++ b/plugins/zenoh-plugin-rest/Cargo.toml
@@ -32,8 +32,8 @@ name = "zplugin_rest"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-anyhow = { workspace = true }
-async-std = { workspace = true }
+anyhow = { workspace = true, default-features = true }
+async-std = { workspace = true, default-features = true }
 base64 = { workspace = true }
 clap = { workspace = true }
 env_logger = { workspace = true }
@@ -43,7 +43,7 @@ git-version = { workspace = true }
 http-types = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, default-features = true }
 serde_json = { workspace = true }
 tide = { workspace = true }
 zenoh = { path = "../../zenoh/", default-features = false, features = [ "unstable" ] }

--- a/plugins/zenoh-plugin-rest/Cargo.toml
+++ b/plugins/zenoh-plugin-rest/Cargo.toml
@@ -32,8 +32,8 @@ name = "zplugin_rest"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-anyhow = { workspace = true, default-features = true }
-async-std = { workspace = true, default-features = true }
+anyhow = { workspace = true, features = ["default"] }
+async-std = { workspace = true, features = ["default"] }
 base64 = { workspace = true }
 clap = { workspace = true }
 env_logger = { workspace = true }
@@ -43,12 +43,10 @@ git-version = { workspace = true }
 http-types = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
-serde = { workspace = true, default-features = true }
+serde = { workspace = true, features = ["default"] }
 serde_json = { workspace = true }
 tide = { workspace = true }
-zenoh = { path = "../../zenoh/", default-features = false, features = [
-	"unstable",
-] }
+zenoh = { path = "../../zenoh/", default-features = false, features = ["unstable"] }
 zenoh-cfg-properties = { path = "../../commons/zenoh-cfg-properties/" }
 zenoh-plugin-trait = { path = "../zenoh-plugin-trait/", default-features = false }
 zenoh-result = { path = "../../commons/zenoh-result/" }

--- a/plugins/zenoh-plugin-rest/src/lib.rs
+++ b/plugins/zenoh-plugin-rest/src/lib.rs
@@ -29,7 +29,7 @@ use zenoh::runtime::Runtime;
 use zenoh::selector::TIME_RANGE_KEY;
 use zenoh::Session;
 use zenoh_cfg_properties::Properties;
-use zenoh_core::{zerror, Result as ZResult};
+use zenoh_result::{zerror, ZResult};
 
 mod config;
 pub use config::Config;

--- a/plugins/zenoh-plugin-storage-manager/Cargo.toml
+++ b/plugins/zenoh-plugin-storage-manager/Cargo.toml
@@ -37,7 +37,7 @@ name = "zplugin_storage_manager"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-async-std = { workspace = true, default-features = true }
+async-std = { workspace = true, features = ["default"] }
 async-trait = { workspace = true }
 clap = { workspace = true }
 crc = { workspace = true }
@@ -49,7 +49,7 @@ git-version = { workspace = true }
 lazy_static = { workspace = true }
 libloading = { workspace = true }
 log = { workspace = true }
-serde = { workspace = true, default-features = true }
+serde = { workspace = true, features = ["default"] }
 serde_json = { workspace = true }
 urlencoding = { workspace = true }
 zenoh = { path = "../../zenoh/", default-features = false, features = [ "unstable" ] }

--- a/plugins/zenoh-plugin-storage-manager/Cargo.toml
+++ b/plugins/zenoh-plugin-storage-manager/Cargo.toml
@@ -56,6 +56,7 @@ zenoh = { path = "../../zenoh/", default-features = false, features = [ "unstabl
 zenoh-collections = { path = "../../commons/zenoh-collections/" }
 zenoh-core = { path = "../../commons/zenoh-core/" }
 zenoh-plugin-trait = { path = "../zenoh-plugin-trait/", default-features = false }
+zenoh-result = { path = "../../commons/zenoh-result/" }
 zenoh-util = { path = "../../commons/zenoh-util/" }
 zenoh_backend_traits = { path = "../zenoh-backend-traits/" }
 

--- a/plugins/zenoh-plugin-storage-manager/Cargo.toml
+++ b/plugins/zenoh-plugin-storage-manager/Cargo.toml
@@ -37,7 +37,7 @@ name = "zplugin_storage_manager"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-async-std = { workspace = true }
+async-std = { workspace = true, default-features = true }
 async-trait = { workspace = true }
 clap = { workspace = true }
 crc = { workspace = true }
@@ -49,7 +49,7 @@ git-version = { workspace = true }
 lazy_static = { workspace = true }
 libloading = { workspace = true }
 log = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, default-features = true }
 serde_json = { workspace = true }
 urlencoding = { workspace = true }
 zenoh = { path = "../../zenoh/", default-features = false, features = [ "unstable" ] }

--- a/plugins/zenoh-plugin-storage-manager/src/backends_mgt.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/backends_mgt.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use zenoh::prelude::r#async::*;
 use zenoh::Session;
 use zenoh_backend_traits::config::StorageConfig;
-use zenoh_core::Result as ZResult;
+use zenoh_result::ZResult;
 
 pub(crate) async fn create_and_start_storage(
     admin_key: String,

--- a/plugins/zenoh-plugin-storage-manager/src/lib.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/lib.rs
@@ -37,7 +37,8 @@ use zenoh::Session;
 use zenoh_backend_traits::CreateVolume;
 use zenoh_backend_traits::CREATE_VOLUME_FN_NAME;
 use zenoh_backend_traits::{config::*, Volume};
-use zenoh_core::{bail, zlock, Result as ZResult};
+use zenoh_core::zlock;
+use zenoh_result::{bail, ZResult};
 use zenoh_util::LibLoader;
 
 mod backends_mgt;

--- a/plugins/zenoh-plugin-storage-manager/src/memory_backend/mod.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/memory_backend/mod.rs
@@ -22,7 +22,7 @@ use zenoh::prelude::r#async::*;
 use zenoh::time::Timestamp;
 use zenoh_backend_traits::config::{StorageConfig, VolumeConfig};
 use zenoh_backend_traits::*;
-use zenoh_core::Result as ZResult;
+use zenoh_result::ZResult;
 use zenoh_util::{Timed, TimedEvent, TimedHandle, Timer};
 
 pub fn create_memory_backend(config: VolumeConfig) -> ZResult<Box<dyn Volume>> {

--- a/plugins/zenoh-plugin-storage-manager/src/storages_mgt.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/storages_mgt.rs
@@ -16,7 +16,7 @@ use log::trace;
 use zenoh::prelude::r#async::*;
 use zenoh::Session;
 use zenoh_backend_traits::config::StorageConfig;
-use zenoh_core::Result as ZResult;
+use zenoh_result::ZResult;
 
 pub use super::replica::{Replica, StorageService};
 

--- a/plugins/zenoh-plugin-trait/Cargo.toml
+++ b/plugins/zenoh-plugin-trait/Cargo.toml
@@ -34,6 +34,6 @@ no_mangle = []
 libloading = { workspace = true }
 log = { workspace = true }
 serde_json = { workspace = true }
-zenoh-core = { path = "../../commons/zenoh-core/" }
 zenoh-macros = { path = "../../commons/zenoh-macros/" }
+zenoh-result = { path = "../../commons/zenoh-result/" }
 zenoh-util = { path = "../../commons/zenoh-util/" }

--- a/plugins/zenoh-plugin-trait/src/lib.rs
+++ b/plugins/zenoh-plugin-trait/src/lib.rs
@@ -21,7 +21,7 @@
 pub mod loading;
 pub mod vtable;
 
-use zenoh_core::Result as ZResult;
+use zenoh_result::ZResult;
 
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/plugins/zenoh-plugin-trait/src/loading.rs
+++ b/plugins/zenoh-plugin-trait/src/loading.rs
@@ -17,7 +17,7 @@ use libloading::Library;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::path::PathBuf;
-use zenoh_core::{bail, zerror, Result as ZResult};
+use zenoh_result::{bail, zerror, ZResult};
 use zenoh_util::LibLoader;
 
 /// A plugins manager that handles starting and stopping plugins.

--- a/plugins/zenoh-plugin-trait/src/vtable.rs
+++ b/plugins/zenoh-plugin-trait/src/vtable.rs
@@ -13,7 +13,7 @@
 //
 use crate::*;
 pub use no_mangle::*;
-use zenoh_core::Result as ZResult;
+use zenoh_result::ZResult;
 
 pub type PluginVTableVersion = u16;
 type LoadPluginResultInner = Result<PluginVTableInner<(), ()>, PluginVTableVersion>;

--- a/zenoh-ext/Cargo.toml
+++ b/zenoh-ext/Cargo.toml
@@ -40,7 +40,7 @@ env_logger = { workspace = true }
 flume = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }
-serde = { workspace = true, default-features = true }
+serde = { workspace = true, features = ["default"] }
 zenoh = { path = "../zenoh/", default-features = false, features = ["unstable"] }
 zenoh-core = { path = "../commons/zenoh-core/" }
 zenoh-result = { path = "../commons/zenoh-result/" }

--- a/zenoh-ext/Cargo.toml
+++ b/zenoh-ext/Cargo.toml
@@ -43,6 +43,7 @@ log = { workspace = true }
 serde = { workspace = true }
 zenoh = { path = "../zenoh/", default-features = false, features = ["unstable"] }
 zenoh-core = { path = "../commons/zenoh-core/" }
+zenoh-result = { path = "../commons/zenoh-result/" }
 zenoh-sync = { path = "../commons/zenoh-sync/" }
 zenoh-util = { path = "../commons/zenoh-util/" }
 

--- a/zenoh-ext/Cargo.toml
+++ b/zenoh-ext/Cargo.toml
@@ -34,13 +34,13 @@ unstable = []
 default = []
 
 [dependencies]
-async-std = { workspace = true, default-features = false, features = ["attributes", "unstable"] }
+async-std = { workspace = true, features = ["attributes", "unstable"] }
 bincode = { workspace = true }
 env_logger = { workspace = true }
 flume = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, default-features = true }
 zenoh = { path = "../zenoh/", default-features = false, features = ["unstable"] }
 zenoh-core = { path = "../commons/zenoh-core/" }
 zenoh-result = { path = "../commons/zenoh-result/" }

--- a/zenoh-ext/src/group.rs
+++ b/zenoh-ext/src/group.rs
@@ -31,7 +31,7 @@ use zenoh::query::ConsolidationMode;
 use zenoh::Error as ZError;
 use zenoh::Result as ZResult;
 use zenoh::Session;
-use zenoh_core::bail;
+use zenoh_result::bail;
 use zenoh_sync::Condition;
 
 const GROUP_PREFIX: &str = "zenoh/ext/net/group";

--- a/zenoh-ext/src/publication_cache.rs
+++ b/zenoh-ext/src/publication_cache.rs
@@ -22,7 +22,8 @@ use zenoh::prelude::r#async::*;
 use zenoh::queryable::{Query, Queryable};
 use zenoh::subscriber::FlumeSubscriber;
 use zenoh::Session;
-use zenoh_core::{bail, AsyncResolve, Resolvable, Result as ZResult, SyncResolve};
+use zenoh_core::{AsyncResolve, Resolvable, SyncResolve};
+use zenoh_result::{bail, ZResult};
 use zenoh_util::core::ResolveFuture;
 
 /// The builder of PublicationCache, allowing to configure it.
@@ -54,7 +55,7 @@ impl<'a, 'b, 'c> PublicationCacheBuilder<'a, 'b, 'c> {
     pub fn queryable_prefix<TryIntoKeyExpr>(mut self, queryable_prefix: TryIntoKeyExpr) -> Self
     where
         TryIntoKeyExpr: TryInto<KeyExpr<'c>>,
-        <TryIntoKeyExpr as TryInto<KeyExpr<'c>>>::Error: Into<zenoh_core::Error>,
+        <TryIntoKeyExpr as TryInto<KeyExpr<'c>>>::Error: Into<zenoh_result::Error>,
     {
         self.queryable_prefix = Some(queryable_prefix.try_into().map_err(Into::into));
         self

--- a/zenoh-ext/src/querying_subscriber.rs
+++ b/zenoh-ext/src/querying_subscriber.rs
@@ -179,7 +179,7 @@ impl<'a, 'b, Handler> QueryingSubscriberBuilder<'a, 'b, Handler> {
     pub fn query_selector<IntoSelector>(mut self, query_selector: IntoSelector) -> Self
     where
         IntoSelector: TryInto<Selector<'b>>,
-        <IntoSelector as TryInto<Selector<'b>>>::Error: Into<zenoh_core::Error>,
+        <IntoSelector as TryInto<Selector<'b>>>::Error: Into<zenoh_result::Error>,
     {
         self.query_selector = Some(query_selector.try_into().map_err(Into::into));
         self

--- a/zenoh-ext/src/session_ext.rs
+++ b/zenoh-ext/src/session_ext.rs
@@ -84,7 +84,7 @@ pub trait SessionExt {
     ) -> QueryingSubscriberBuilder<'a, 'b, DefaultHandler>
     where
         TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
-        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_core::Error>;
+        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_result::Error>;
 
     fn declare_publication_cache<'a, 'b, 'c, TryIntoKeyExpr>(
         &'a self,
@@ -92,7 +92,7 @@ pub trait SessionExt {
     ) -> PublicationCacheBuilder<'a, 'b, 'c>
     where
         TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
-        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_core::Error>;
+        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_result::Error>;
 }
 
 impl SessionExt for Session {
@@ -102,7 +102,7 @@ impl SessionExt for Session {
     ) -> QueryingSubscriberBuilder<'a, 'b, DefaultHandler>
     where
         TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
-        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_core::Error>,
+        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_result::Error>,
     {
         QueryingSubscriberBuilder::new(
             SessionRef::Borrow(self),
@@ -116,7 +116,7 @@ impl SessionExt for Session {
     ) -> PublicationCacheBuilder<'a, 'b, 'c>
     where
         TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
-        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_core::Error>,
+        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_result::Error>,
     {
         PublicationCacheBuilder::new(self, pub_key_expr.try_into().map_err(Into::into))
     }
@@ -129,7 +129,7 @@ impl SessionExt for Arc<Session> {
     ) -> QueryingSubscriberBuilder<'a, 'b, DefaultHandler>
     where
         TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
-        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_core::Error>,
+        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_result::Error>,
     {
         QueryingSubscriberBuilder::new(
             SessionRef::Shared(self.clone()),
@@ -143,7 +143,7 @@ impl SessionExt for Arc<Session> {
     ) -> PublicationCacheBuilder<'a, 'b, 'c>
     where
         TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
-        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_core::Error>,
+        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_result::Error>,
     {
         PublicationCacheBuilder::new(self, pub_key_expr.try_into().map_err(Into::into))
     }

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -93,6 +93,7 @@ zenoh-crypto = { path = "../commons/zenoh-crypto/" }
 zenoh-link = { path = "../io/zenoh-link/" }
 zenoh-plugin-trait = { path = "../plugins/zenoh-plugin-trait/", default-features = false }
 zenoh-protocol = { path = "../commons/zenoh-protocol/" }
+zenoh-result = { path = "../commons/zenoh-result/" }
 zenoh-shm = { path = "../commons/zenoh-shm/", optional = true }
 zenoh-sync = { path = "../commons/zenoh-sync/" }
 zenoh-transport = { path = "../io/zenoh-transport/" }

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -60,7 +60,7 @@ default = [
 
 [dependencies]
 async-global-executor = { workspace = true }
-async-std = { workspace = true, default-features = false, features = ["attributes"] }
+async-std = { workspace = true, features = ["attributes"] }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 env_logger = { workspace = true }
@@ -69,19 +69,19 @@ flume = { workspace = true }
 form_urlencoded = { workspace = true }
 futures = { workspace = true }
 git-version = { workspace = true }
-hex = { workspace = true }
+hex = { workspace = true, default-features = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
 ordered-float = { workspace = true }
 petgraph = { workspace = true }
-rand = { workspace = true }
+rand = { workspace = true, default-features = true }
 regex = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, default-features = true }
 serde_json = { workspace = true }
 socket2 = { workspace = true }
 stop-token = { workspace = true }
-uhlc = { workspace = true }
-uuid = { workspace = true }
+uhlc = { workspace = true, default-features = true }
+uuid = { workspace = true, default-features = true }
 vec_map = { workspace = true }
 zenoh-buffers = { path = "../commons/zenoh-buffers/" }
 zenoh-cfg-properties = { path = "../commons/zenoh-cfg-properties/" }

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -69,19 +69,19 @@ flume = { workspace = true }
 form_urlencoded = { workspace = true }
 futures = { workspace = true }
 git-version = { workspace = true }
-hex = { workspace = true, default-features = true }
+hex = { workspace = true, features = ["default"] }
 lazy_static = { workspace = true }
 log = { workspace = true }
 ordered-float = { workspace = true }
 petgraph = { workspace = true }
-rand = { workspace = true, default-features = true }
+rand = { workspace = true, features = ["default"] }
 regex = { workspace = true }
-serde = { workspace = true, default-features = true }
+serde = { workspace = true, features = ["default"] }
 serde_json = { workspace = true }
 socket2 = { workspace = true }
 stop-token = { workspace = true }
-uhlc = { workspace = true, default-features = true }
-uuid = { workspace = true, default-features = true }
+uhlc = { workspace = true, features = ["default"] }
+uuid = { workspace = true, features = ["default"] }
 vec_map = { workspace = true }
 zenoh-buffers = { path = "../commons/zenoh-buffers/" }
 zenoh-cfg-properties = { path = "../commons/zenoh-cfg-properties/" }

--- a/zenoh/src/key_expr.rs
+++ b/zenoh/src/key_expr.rs
@@ -19,9 +19,10 @@ use std::{
     future::Ready,
     str::FromStr,
 };
-use zenoh_core::{AsyncResolve, Resolvable, Result as ZResult, SyncResolve};
+use zenoh_core::{AsyncResolve, Resolvable, SyncResolve};
 pub use zenoh_protocol::core::key_expr::*;
 use zenoh_protocol::core::{key_expr::canon::Canonizable, WireExpr};
+use zenoh_result::ZResult;
 use zenoh_transport::Primitives;
 
 use crate::{prelude::Selector, Session, Undeclarable};
@@ -270,7 +271,7 @@ impl<'a> KeyExpr<'a> {
 }
 
 impl FromStr for KeyExpr<'static> {
-    type Err = zenoh_core::Error;
+    type Err = zenoh_result::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Self(KeyExprInner::Owned(s.parse()?)))
     }
@@ -351,31 +352,31 @@ impl<'a> From<KeyExpr<'a>> for String {
     }
 }
 impl<'a> TryFrom<String> for KeyExpr<'a> {
-    type Error = zenoh_core::Error;
+    type Error = zenoh_result::Error;
     fn try_from(value: String) -> Result<Self, Self::Error> {
         Ok(Self(KeyExprInner::Owned(value.try_into()?)))
     }
 }
 impl<'a> TryFrom<&'a String> for KeyExpr<'a> {
-    type Error = zenoh_core::Error;
+    type Error = zenoh_result::Error;
     fn try_from(value: &'a String) -> Result<Self, Self::Error> {
         Self::try_from(value.as_str())
     }
 }
 impl<'a> TryFrom<&'a mut String> for KeyExpr<'a> {
-    type Error = zenoh_core::Error;
+    type Error = zenoh_result::Error;
     fn try_from(value: &'a mut String) -> Result<Self, Self::Error> {
         Ok(Self::from(keyexpr::new(value)?))
     }
 }
 impl<'a> TryFrom<&'a str> for KeyExpr<'a> {
-    type Error = zenoh_core::Error;
+    type Error = zenoh_result::Error;
     fn try_from(value: &'a str) -> Result<Self, Self::Error> {
         Ok(Self(KeyExprInner::Borrowed(value.try_into()?)))
     }
 }
 impl<'a> TryFrom<&'a mut str> for KeyExpr<'a> {
-    type Error = zenoh_core::Error;
+    type Error = zenoh_result::Error;
     fn try_from(value: &'a mut str) -> Result<Self, Self::Error> {
         Ok(Self(KeyExprInner::Borrowed(value.try_into()?)))
     }

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -76,6 +76,8 @@
 //! ```
 #[macro_use]
 extern crate zenoh_core;
+#[macro_use]
+extern crate zenoh_result;
 
 use git_version::git_version;
 use handlers::DefaultHandler;
@@ -85,13 +87,13 @@ use prelude::config::whatami::WhatAmIMatcher;
 use prelude::*;
 use scouting::ScoutBuilder;
 use std::future::Ready;
-use zenoh_core::{zerror, AsyncResolve, Result as ZResult};
-use zenoh_core::{Resolvable, SyncResolve};
+use zenoh_core::{AsyncResolve, Resolvable, SyncResolve};
+use zenoh_result::{zerror, ZResult};
 
 /// A zenoh error.
-pub use zenoh_core::Error;
+pub use zenoh_result::Error;
 /// A zenoh result.
-pub use zenoh_core::Result;
+pub use zenoh_result::ZResult as Result;
 
 const GIT_VERSION: &str = git_version!(prefix = "v", cargo_prefix = "v");
 
@@ -192,7 +194,8 @@ pub fn scout<I: Into<WhatAmIMatcher>, TryIntoConfig>(
 ) -> ScoutBuilder<DefaultHandler>
 where
     TryIntoConfig: std::convert::TryInto<crate::config::Config> + Send + 'static,
-    <TryIntoConfig as std::convert::TryInto<crate::config::Config>>::Error: Into<zenoh_core::Error>,
+    <TryIntoConfig as std::convert::TryInto<crate::config::Config>>::Error:
+        Into<zenoh_result::Error>,
 {
     ScoutBuilder {
         what: what.into(),

--- a/zenoh/src/net/routing/router.rs
+++ b/zenoh/src/net/routing/router.rs
@@ -32,7 +32,8 @@ use zenoh_protocol::{
 };
 use zenoh_transport::{DeMux, Mux, Primitives, TransportPeerEventHandler, TransportUnicast};
 // use zenoh_collections::Timer;
-use zenoh_core::{zconfigurable, Result as ZResult};
+use zenoh_core::zconfigurable;
+use zenoh_result::ZResult;
 use zenoh_sync::get_mut_unchecked;
 
 zconfigurable! {

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -25,7 +25,6 @@ use std::sync::Mutex;
 use zenoh_buffers::{SplitBuffer, ZBuf};
 use zenoh_config::ValidatedMap;
 use zenoh_config::WhatAmI;
-use zenoh_core::Result as ZResult;
 use zenoh_protocol::{
     core::{
         key_expr::OwnedKeyExpr, Channel, CongestionControl, ConsolidationMode, Encoding,
@@ -34,6 +33,7 @@ use zenoh_protocol::{
     },
     zenoh::{DataInfo, QueryBody, RoutingContext},
 };
+use zenoh_result::ZResult;
 use zenoh_transport::{Primitives, TransportUnicast};
 
 pub struct AdminContext {

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -35,12 +35,12 @@ use std::time::Duration;
 use stop_token::future::FutureExt;
 use stop_token::{StopSource, TimedOutError};
 use uhlc::{HLCBuilder, HLC};
-use zenoh_core::{bail, Result as ZResult};
 use zenoh_link::{EndPoint, Link};
 use zenoh_protocol::{
     core::{whatami::WhatAmIMatcher, Locator, WhatAmI, ZenohId},
     zenoh::{ZenohBody, ZenohMessage},
 };
+use zenoh_result::{bail, ZResult};
 use zenoh_sync::get_mut_unchecked;
 use zenoh_transport::{
     TransportEventHandler, TransportManager, TransportMulticast, TransportMulticastEventHandler,

--- a/zenoh/src/net/runtime/orchestrator.rs
+++ b/zenoh/src/net/runtime/orchestrator.rs
@@ -22,12 +22,12 @@ use zenoh_buffers::reader::DidntRead;
 use zenoh_buffers::{reader::HasReader, writer::HasWriter};
 use zenoh_codec::{RCodec, WCodec, Zenoh060};
 use zenoh_config::{unwrap_or_default, EndPoint, ModeDependent};
-use zenoh_core::{bail, zerror, Result as ZResult};
 use zenoh_link::Locator;
 use zenoh_protocol::{
     core::{whatami::WhatAmIMatcher, WhatAmI, ZenohId},
     scouting::{Hello, Scout, ScoutingBody, ScoutingMessage},
 };
+use zenoh_result::{bail, zerror, ZResult};
 use zenoh_transport::TransportUnicast;
 
 const RCV_BUF_SIZE: usize = u16::MAX as usize;

--- a/zenoh/src/publication.rs
+++ b/zenoh/src/publication.rs
@@ -21,8 +21,9 @@ use crate::Encoding;
 use crate::SessionRef;
 use crate::Undeclarable;
 use std::future::Ready;
-use zenoh_core::{zread, AsyncResolve, Resolvable, Resolve, Result as ZResult, SyncResolve};
+use zenoh_core::{zread, AsyncResolve, Resolvable, Resolve, SyncResolve};
 use zenoh_protocol::{core::Channel, zenoh::DataInfo};
+use zenoh_result::ZResult;
 
 /// The kind of congestion control.
 pub use zenoh_protocol::core::CongestionControl;
@@ -183,7 +184,7 @@ use std::convert::TryFrom;
 use std::convert::TryInto;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use zenoh_core::zresult::Error;
+use zenoh_result::Error;
 
 /// A publisher that allows to send data through a stream.
 ///
@@ -644,7 +645,7 @@ impl Default for Priority {
 }
 
 impl TryFrom<u8> for Priority {
-    type Error = zenoh_core::Error;
+    type Error = zenoh_result::Error;
 
     /// A Priority is identified by a numeric value.
     /// Lower the value, higher the priority.

--- a/zenoh/src/query.rs
+++ b/zenoh/src/query.rs
@@ -20,8 +20,8 @@ use crate::Session;
 use std::collections::HashMap;
 use std::future::Ready;
 use std::time::Duration;
-use zenoh_core::zresult::ZResult;
 use zenoh_core::{AsyncResolve, Resolvable, SyncResolve};
+use zenoh_result::ZResult;
 
 /// The [`Queryable`](crate::queryable::Queryable)s that should be target of a [`get`](Session::get).
 pub use zenoh_protocol::core::QueryTarget;

--- a/zenoh/src/queryable.rs
+++ b/zenoh/src/queryable.rs
@@ -28,8 +28,9 @@ use std::ops::Deref;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
-use zenoh_core::{AsyncResolve, Resolvable, Result as ZResult, SyncResolve};
+use zenoh_core::{AsyncResolve, Resolvable, SyncResolve};
 use zenoh_protocol::core::WireExpr;
+use zenoh_result::ZResult;
 
 /// Structs received by a [`Queryable`](Queryable).
 pub struct Query {
@@ -159,7 +160,9 @@ impl SyncResolve for ReplyBuilder<'_> {
 
 /// The future returned by a [`ReplyBuilder`] when using async.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct ReplyFuture<'a>(Result<flume::r#async::SendFut<'a, Sample>, Option<zenoh_core::Error>>);
+pub struct ReplyFuture<'a>(
+    Result<flume::r#async::SendFut<'a, Sample>, Option<zenoh_result::Error>>,
+);
 
 impl Future for ReplyFuture<'_> {
     type Output = ZResult<()>;

--- a/zenoh/src/sample.rs
+++ b/zenoh/src/sample.rs
@@ -138,10 +138,10 @@ impl Sample {
     pub fn try_from<TryIntoKeyExpr, IntoValue>(
         key_expr: TryIntoKeyExpr,
         value: IntoValue,
-    ) -> Result<Self, zenoh_core::Error>
+    ) -> Result<Self, zenoh_result::Error>
     where
         TryIntoKeyExpr: TryInto<KeyExpr<'static>>,
-        <TryIntoKeyExpr as TryInto<KeyExpr<'static>>>::Error: Into<zenoh_core::Error>,
+        <TryIntoKeyExpr as TryInto<KeyExpr<'static>>>::Error: Into<zenoh_result::Error>,
         IntoValue: Into<Value>,
     {
         Ok(Sample {

--- a/zenoh/src/scouting.rs
+++ b/zenoh/src/scouting.rs
@@ -21,7 +21,8 @@ use std::{fmt, ops::Deref};
 use zenoh_config::{
     whatami::WhatAmIMatcher, ZN_MULTICAST_INTERFACE_DEFAULT, ZN_MULTICAST_IPV4_ADDRESS_DEFAULT,
 };
-use zenoh_core::{AsyncResolve, Resolvable, Result as ZResult, SyncResolve};
+use zenoh_core::{AsyncResolve, Resolvable, SyncResolve};
+use zenoh_result::ZResult;
 
 /// Constants and helpers for zenoh `whatami` flags.
 pub use zenoh_protocol::core::WhatAmI;

--- a/zenoh/src/selector.rs
+++ b/zenoh/src/selector.rs
@@ -14,8 +14,8 @@
 
 //! [Selector](https://github.com/eclipse-zenoh/roadmap/tree/main/rfcs/ALL/Selectors) to issue queries
 
-use zenoh_core::Result as ZResult;
 use zenoh_protocol::core::key_expr::{keyexpr, OwnedKeyExpr};
+use zenoh_result::ZResult;
 pub use zenoh_util::time_range::{TimeBound, TimeExpr, TimeRange};
 
 use crate::{prelude::KeyExpr, queryable::Query};
@@ -458,7 +458,7 @@ impl<'a> From<&Selector<'a>> for Selector<'a> {
 }
 
 impl TryFrom<String> for Selector<'_> {
-    type Error = zenoh_core::Error;
+    type Error = zenoh_result::Error;
     fn try_from(mut s: String) -> Result<Self, Self::Error> {
         match s.find('?') {
             Some(qmark_position) => {
@@ -472,7 +472,7 @@ impl TryFrom<String> for Selector<'_> {
 }
 
 impl<'a> TryFrom<&'a str> for Selector<'a> {
-    type Error = zenoh_core::Error;
+    type Error = zenoh_result::Error;
     fn try_from(s: &'a str) -> Result<Self, Self::Error> {
         match s.find('?') {
             Some(qmark_position) => {
@@ -485,7 +485,7 @@ impl<'a> TryFrom<&'a str> for Selector<'a> {
 }
 
 impl<'a> TryFrom<&'a String> for Selector<'a> {
-    type Error = zenoh_core::Error;
+    type Error = zenoh_result::Error;
     fn try_from(s: &'a String) -> Result<Self, Self::Error> {
         Self::try_from(s.as_str())
     }

--- a/zenoh/src/session.rs
+++ b/zenoh/src/session.rs
@@ -50,9 +50,7 @@ use uhlc::HLC;
 use zenoh_buffers::ZBuf;
 use zenoh_collections::SingleOrVec;
 use zenoh_config::unwrap_or_default;
-use zenoh_core::{
-    zconfigurable, zread, Resolve, ResolveClosure, ResolveFuture, Result as ZResult, SyncResolve,
-};
+use zenoh_core::{zconfigurable, zread, Resolve, ResolveClosure, ResolveFuture, SyncResolve};
 use zenoh_protocol::{
     core::{
         key_expr::{keyexpr, OwnedKeyExpr},
@@ -61,6 +59,7 @@ use zenoh_protocol::{
     },
     zenoh::{DataInfo, QueryBody, RoutingContext},
 };
+use zenoh_result::ZResult;
 use zenoh_util::core::AsyncResolve;
 
 zconfigurable! {
@@ -513,7 +512,7 @@ impl Session {
     ) -> SubscriberBuilder<'a, 'b, PushMode, DefaultHandler>
     where
         TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
-        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_core::Error>,
+        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_result::Error>,
     {
         SubscriberBuilder {
             session: SessionRef::Borrow(self),
@@ -553,7 +552,7 @@ impl Session {
     ) -> QueryableBuilder<'a, 'b, DefaultHandler>
     where
         TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
-        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_core::Error>,
+        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_result::Error>,
     {
         QueryableBuilder {
             session: SessionRef::Borrow(self),
@@ -589,7 +588,7 @@ impl Session {
     ) -> PublisherBuilder<'a, 'b>
     where
         TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
-        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_core::Error>,
+        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_result::Error>,
     {
         PublisherBuilder {
             session: SessionRef::Borrow(self),
@@ -620,7 +619,7 @@ impl Session {
     ) -> impl Resolve<ZResult<KeyExpr<'b>>> + 'a
     where
         TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
-        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_core::Error>,
+        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_result::Error>,
     {
         let key_expr: ZResult<KeyExpr> = key_expr.try_into().map_err(Into::into);
         self._declare_keyexpr(key_expr)
@@ -686,7 +685,7 @@ impl Session {
     ) -> PutBuilder<'a, 'b>
     where
         TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
-        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_core::Error>,
+        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_result::Error>,
         IntoValue: Into<Value>,
     {
         PutBuilder {
@@ -718,7 +717,7 @@ impl Session {
     ) -> DeleteBuilder<'a, 'b>
     where
         TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
-        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_core::Error>,
+        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_result::Error>,
     {
         PutBuilder {
             publisher: self.declare_publisher(key_expr),
@@ -753,7 +752,7 @@ impl Session {
     ) -> GetBuilder<'a, 'b, DefaultHandler>
     where
         IntoSelector: TryInto<Selector<'b>>,
-        <IntoSelector as TryInto<Selector<'b>>>::Error: Into<zenoh_core::Error>,
+        <IntoSelector as TryInto<Selector<'b>>>::Error: Into<zenoh_result::Error>,
     {
         let selector = selector.try_into().map_err(Into::into);
         let conf = self.runtime.config.lock();
@@ -1529,7 +1528,7 @@ impl SessionDeclarations for Arc<Session> {
     ) -> SubscriberBuilder<'static, 'b, PushMode, DefaultHandler>
     where
         TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
-        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_core::Error>,
+        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_result::Error>,
     {
         SubscriberBuilder {
             session: SessionRef::Shared(self.clone()),
@@ -1574,7 +1573,7 @@ impl SessionDeclarations for Arc<Session> {
     ) -> QueryableBuilder<'static, 'b, DefaultHandler>
     where
         TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
-        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_core::Error>,
+        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_result::Error>,
     {
         QueryableBuilder {
             session: SessionRef::Shared(self.clone()),
@@ -1610,7 +1609,7 @@ impl SessionDeclarations for Arc<Session> {
     ) -> PublisherBuilder<'static, 'b>
     where
         TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
-        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_core::Error>,
+        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_result::Error>,
     {
         PublisherBuilder {
             session: SessionRef::Shared(self.clone()),
@@ -1963,7 +1962,7 @@ pub trait SessionDeclarations {
     ) -> SubscriberBuilder<'static, 'a, PushMode, DefaultHandler>
     where
         TryIntoKeyExpr: TryInto<KeyExpr<'a>>,
-        <TryIntoKeyExpr as TryInto<KeyExpr<'a>>>::Error: Into<zenoh_core::Error>;
+        <TryIntoKeyExpr as TryInto<KeyExpr<'a>>>::Error: Into<zenoh_result::Error>;
 
     /// Create a [`Queryable`](crate::queryable::Queryable) for the given key expression.
     ///
@@ -1998,7 +1997,7 @@ pub trait SessionDeclarations {
     ) -> QueryableBuilder<'static, 'a, DefaultHandler>
     where
         TryIntoKeyExpr: TryInto<KeyExpr<'a>>,
-        <TryIntoKeyExpr as TryInto<KeyExpr<'a>>>::Error: Into<zenoh_core::Error>;
+        <TryIntoKeyExpr as TryInto<KeyExpr<'a>>>::Error: Into<zenoh_result::Error>;
 
     /// Create a [`Publisher`](crate::publication::Publisher) for the given key expression.
     ///
@@ -2025,5 +2024,5 @@ pub trait SessionDeclarations {
     ) -> PublisherBuilder<'static, 'a>
     where
         TryIntoKeyExpr: TryInto<KeyExpr<'a>>,
-        <TryIntoKeyExpr as TryInto<KeyExpr<'a>>>::Error: Into<zenoh_core::Error>;
+        <TryIntoKeyExpr as TryInto<KeyExpr<'a>>>::Error: Into<zenoh_result::Error>;
 }

--- a/zenoh/src/session.rs
+++ b/zenoh/src/session.rs
@@ -42,7 +42,7 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fmt;
 use std::ops::Deref;
-use std::sync::atomic::{AtomicU16, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU16, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::sync::RwLock;
 use std::time::Duration;
@@ -54,13 +54,15 @@ use zenoh_core::{zconfigurable, zread, Resolve, ResolveClosure, ResolveFuture, S
 use zenoh_protocol::{
     core::{
         key_expr::{keyexpr, OwnedKeyExpr},
-        AtomicZInt, Channel, CongestionControl, ExprId, QueryTarget, QueryableInfo, SubInfo,
-        WireExpr, ZInt, ZenohId, EMPTY_EXPR_ID,
+        Channel, CongestionControl, ExprId, QueryTarget, QueryableInfo, SubInfo, WireExpr, ZInt,
+        ZenohId, EMPTY_EXPR_ID,
     },
     zenoh::{DataInfo, QueryBody, RoutingContext},
 };
 use zenoh_result::ZResult;
 use zenoh_util::core::AsyncResolve;
+
+pub type AtomicZInt = AtomicU64;
 
 zconfigurable! {
     pub(crate) static ref API_DATA_RECEPTION_CHANNEL_SIZE: usize = 256;

--- a/zenoh/src/value.rs
+++ b/zenoh/src/value.rs
@@ -21,7 +21,7 @@ use std::convert::TryFrom;
 use std::sync::Arc;
 
 use zenoh_cfg_properties::Properties;
-use zenoh_core::zresult::ZError;
+use zenoh_result::ZError;
 
 use crate::buffers::ZBuf;
 use crate::prelude::{Encoding, KnownEncoding, Sample, SplitBuffer};

--- a/zenohd/Cargo.toml
+++ b/zenohd/Cargo.toml
@@ -40,7 +40,7 @@ log = { workspace = true }
 zenoh = { path = "../zenoh/", features = ["unstable"], default-features = false }
 
 [dev-dependencies]
-rand = { workspace = true, default-features = true }
+rand = { workspace = true, features = ["default"] }
 
 [build-dependencies]
 rustc_version = { workspace = true }

--- a/zenohd/Cargo.toml
+++ b/zenohd/Cargo.toml
@@ -29,7 +29,7 @@ readme = "README.md"
 shared-memory = ["zenoh/shared-memory"]
 
 [dependencies]
-async-std = { workspace = true, default-features = false, features = ["attributes"] }
+async-std = { workspace = true, features = ["attributes"] }
 clap = { workspace = true }
 env_logger = { workspace = true }
 futures = { workspace = true }
@@ -40,7 +40,7 @@ log = { workspace = true }
 zenoh = { path = "../zenoh/", features = ["unstable"], default-features = false }
 
 [dev-dependencies]
-rand = { workspace = true }
+rand = { workspace = true, default-features = true }
 
 [build-dependencies]
 rustc_version = { workspace = true }


### PR DESCRIPTION
**In this PR:**
- fixed problem with `default-features` in workspace `Cargo.toml`;
- `zenoh-protocol` and `zenoh-codec` are made competely `no_std`:
  - `zenoh-result` was split from `zenoh-core` (`zenoh-result` supports `no_std`, while `zenoh-core` depends on stuff in `std`);
  - own `IError` in place of `std::core::Error` (until `core::error::Error` is made stable, see its [tracking issue](https://github.com/rust-lang/rust/issues/103765)) $-$ the `derive_tryfrom` macro was returning `uhlc::SizeError`s, which are now converted into a new struct `zenoh_protocol::SizeError` in order to implement `zenoh_result::IError`;
  - `AtomicZInt` (`= AtomicU64`) is not portable to `no_std` target, hence it has been moved out of `zenoh_protocol` to the only place in which it is used (namely `zenoh::session`).