### PR TITLE
Fix new Clippy 1.67.0 warnings

### DIFF
--- a/commons/zenoh-buffers/tests/readwrite.rs
+++ b/commons/zenoh-buffers/tests/readwrite.rs
@@ -194,28 +194,28 @@ fn buffer_zslice() {
 fn buffer_siphon() {
     let capacity = 1 + u8::MAX as usize;
 
-    println!("Buffer Siphon BBuf({}) -> BBuf({})", capacity, capacity);
+    println!("Buffer Siphon BBuf({capacity}) -> BBuf({capacity})");
     let mut bbuf1 = BBuf::with_capacity(capacity);
     let mut bbuf2 = BBuf::with_capacity(capacity);
     run_siphon!(bbuf1, capacity, bbuf2, capacity);
 
-    println!("Buffer Siphon ZBuf({}) -> ZBuf({})", capacity, capacity);
+    println!("Buffer Siphon ZBuf({capacity}) -> ZBuf({capacity})");
     let mut zbuf1 = ZBuf::default();
     let mut zbuf2 = ZBuf::default();
     run_siphon!(zbuf1, capacity, zbuf2, capacity);
 
-    println!("Buffer Siphon ZBuf({}) -> BBuf({})", capacity, capacity);
+    println!("Buffer Siphon ZBuf({capacity}) -> BBuf({capacity})");
     let mut zbuf1 = ZBuf::default();
     let mut bbuf1 = BBuf::with_capacity(capacity);
     run_siphon!(zbuf1, capacity, bbuf1, capacity);
 
     let capacity2 = 1 + capacity / 2;
-    println!("Buffer Siphon BBuf({}) -> BBuf({})", capacity, capacity2);
+    println!("Buffer Siphon BBuf({capacity}) -> BBuf({capacity2})");
     let mut bbuf1 = BBuf::with_capacity(capacity);
     let mut bbuf2 = BBuf::with_capacity(capacity2);
     run_siphon!(bbuf1, capacity, bbuf2, capacity2);
 
-    println!("Buffer Siphon ZBuf({}) -> BBuf({})", capacity, capacity2);
+    println!("Buffer Siphon ZBuf({capacity}) -> BBuf({capacity2})");
     let mut zbuf1 = ZBuf::default();
     let mut bbuf1 = BBuf::with_capacity(capacity2);
     run_siphon!(zbuf1, capacity, bbuf1, capacity2);

--- a/commons/zenoh-cfg-properties/src/lib.rs
+++ b/commons/zenoh-cfg-properties/src/lib.rs
@@ -190,13 +190,13 @@ impl fmt::Display for Properties {
         let mut it = self.0.iter();
         if let Some((k, v)) = it.next() {
             if v.is_empty() {
-                write!(f, "{}", k)?
+                write!(f, "{k}")?
             } else {
                 write!(f, "{}{}{}", k, KV_SEP[0], v)?
             }
             for (k, v) in it {
                 if v.is_empty() {
-                    write!(f, "{}{}", DEFAULT_PROP_SEP, k)?
+                    write!(f, "{DEFAULT_PROP_SEP}{k}")?
                 } else {
                     write!(f, "{}{}{}{}", DEFAULT_PROP_SEP, k, KV_SEP[0], v)?
                 }
@@ -216,7 +216,7 @@ impl fmt::Debug for Properties {
         let mut it = self.0.iter();
         if let Some((k, v)) = it.next() {
             if v.is_empty() {
-                write!(f, "{}", k)?
+                write!(f, "{k}")?
             } else if k.contains("password") {
                 write!(f, "{}{}*****", k, KV_SEP[0])?
             } else {
@@ -224,7 +224,7 @@ impl fmt::Debug for Properties {
             }
             for (k, v) in it {
                 if v.is_empty() {
-                    write!(f, "{}{}", DEFAULT_PROP_SEP, k)?
+                    write!(f, "{DEFAULT_PROP_SEP}{k}")?
                 } else if k.contains("password") {
                     write!(f, "{}{}{}*****", DEFAULT_PROP_SEP, k, KV_SEP[0])?
                 } else {

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -488,8 +488,8 @@ pub enum ConfigOpenErr {
 impl std::fmt::Display for ConfigOpenErr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ConfigOpenErr::IoError(e) => write!(f, "Couldn't open file: {}", e),
-            ConfigOpenErr::JsonParseErr(e) => write!(f, "JSON5 parsing error {}", e),
+            ConfigOpenErr::IoError(e) => write!(f, "Couldn't open file: {e}"),
+            ConfigOpenErr::JsonParseErr(e) => write!(f, "JSON5 parsing error {e}"),
             ConfigOpenErr::InvalidConfiguration(c) => write!(
                 f,
                 "Invalid configuration {}",
@@ -947,8 +947,7 @@ impl PartialMerge for serde_json::Value {
         let mut key = path;
         let key_not_found = || {
             Err(validated_struct::InsertionError::String(format!(
-                "{} not found",
-                path
+                "{path} not found"
             )))
         };
         while !key.is_empty() {
@@ -1027,7 +1026,7 @@ impl validated_struct::ValidatedMap for PluginsConfig {
             ) {
                 Ok(Some(val)) => new_value = Value::Object(val),
                 Ok(None) => {}
-                Err(e) => return Err(format!("{}", e).into()),
+                Err(e) => return Err(format!("{e}").into()),
             }
         }
         *value = new_value;

--- a/commons/zenoh-crypto/src/cipher.rs
+++ b/commons/zenoh-crypto/src/cipher.rs
@@ -74,38 +74,38 @@ mod tests {
         fn encrypt_decrypt(cipher: &BlockCipher, prng: &mut PseudoRng) {
             println!("\n[1]");
             let t1 = "A".as_bytes().to_vec();
-            println!("Clear: {:?}", t1);
+            println!("Clear: {t1:?}");
             let encrypted = cipher.encrypt(t1.clone(), prng);
-            println!("Encrypted: {:?}", encrypted);
+            println!("Encrypted: {encrypted:?}");
             let decrypted = cipher.decrypt(encrypted).unwrap();
-            println!("Decrypted: {:?}", decrypted);
+            println!("Decrypted: {decrypted:?}");
             assert_eq!(&t1[..], &decrypted[..t1.len()]);
 
             println!("\n[2]");
             let t2 = "Short string".as_bytes().to_vec();
-            println!("Clear: {:?}", t2);
+            println!("Clear: {t2:?}");
             let encrypted = cipher.encrypt(t2.clone(), prng);
-            println!("Encrypted: {:?}", encrypted);
+            println!("Encrypted: {encrypted:?}");
             let decrypted = cipher.decrypt(encrypted).unwrap();
-            println!("Decrypted: {:?}", decrypted);
+            println!("Decrypted: {decrypted:?}");
             assert_eq!(&t2[..], &decrypted[..t2.len()]);
 
             println!("\n[3]");
             let t3 = "This is a medium string with some text".as_bytes().to_vec();
-            println!("Clear: {:?}", t3);
+            println!("Clear: {t3:?}");
             let encrypted = cipher.encrypt(t3.clone(), prng);
-            println!("Encrypted: {:?}", encrypted);
+            println!("Encrypted: {encrypted:?}");
             let decrypted = cipher.decrypt(encrypted).unwrap();
-            println!("Decrypted: {:?}", decrypted);
+            println!("Decrypted: {decrypted:?}");
             assert_eq!(&t3[..], &decrypted[..t3.len()]);
 
             println!("\n[4]");
             let t4 = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.".as_bytes().to_vec();
-            println!("Clear: {:?}", t4);
+            println!("Clear: {t4:?}");
             let encrypted = cipher.encrypt(t4.clone(), prng);
-            println!("Encrypted: {:?}", encrypted);
+            println!("Encrypted: {encrypted:?}");
             let decrypted = cipher.decrypt(encrypted).unwrap();
-            println!("Decrypted: {:?}", decrypted);
+            println!("Decrypted: {decrypted:?}");
             assert_eq!(&t4[..], &decrypted[..t4.len()]);
         }
 

--- a/commons/zenoh-protocol/src/core/endpoint.rs
+++ b/commons/zenoh-protocol/src/core/endpoint.rs
@@ -442,13 +442,12 @@ impl EndPoint {
         let c: &str = config.as_ref();
 
         let s = match (m.is_empty(), c.is_empty()) {
-            (true, true) => format!("{}{}{}", p, PROTO_SEPARATOR, a),
-            (false, true) => format!("{}{}{}{}{}", p, PROTO_SEPARATOR, a, METADATA_SEPARATOR, m),
-            (true, false) => format!("{}{}{}{}{}", p, PROTO_SEPARATOR, a, CONFIG_SEPARATOR, c),
-            (false, false) => format!(
-                "{}{}{}{}{}{}{}",
-                p, PROTO_SEPARATOR, a, METADATA_SEPARATOR, m, CONFIG_SEPARATOR, c
-            ),
+            (true, true) => format!("{p}{PROTO_SEPARATOR}{a}"),
+            (false, true) => format!("{p}{PROTO_SEPARATOR}{a}{METADATA_SEPARATOR}{m}"),
+            (true, false) => format!("{p}{PROTO_SEPARATOR}{a}{CONFIG_SEPARATOR}{c}"),
+            (false, false) => {
+                format!("{p}{PROTO_SEPARATOR}{a}{METADATA_SEPARATOR}{m}{CONFIG_SEPARATOR}{c}")
+            }
         };
 
         Self::try_from(s)

--- a/commons/zenoh-shm/src/lib.rs
+++ b/commons/zenoh-shm/src/lib.rs
@@ -319,7 +319,7 @@ impl SharedMemoryManager {
     /// given size.
     pub fn make(id: String, size: usize) -> ZResult<SharedMemoryManager> {
         let mut temp_dir = std::env::temp_dir();
-        let file_name: String = format!("{}_{}", ZENOH_SHM_PREFIX, id);
+        let file_name: String = format!("{ZENOH_SHM_PREFIX}_{id}");
         temp_dir.push(file_name);
         let path: String = temp_dir
             .to_str()

--- a/commons/zenoh-sync/src/mvar.rs
+++ b/commons/zenoh-sync/src/mvar.rs
@@ -108,14 +108,14 @@ mod tests {
         let ch = task::spawn(async move {
             for _ in 0..count {
                 let n = c_mvar.take().await;
-                print!("-{} ", n);
+                print!("-{n} ");
             }
         });
 
         let ph = task::spawn(async move {
             for i in 0..count {
                 mvar.put(i).await;
-                print!("+{} ", i);
+                print!("+{i} ");
             }
         });
 

--- a/commons/zenoh-util/src/time_range.rs
+++ b/commons/zenoh-util/src/time_range.rs
@@ -110,13 +110,13 @@ impl TryFrom<TimeRange<TimeExpr>> for TimeRange<SystemTime> {
 impl Display for TimeRange<TimeExpr> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.0 {
-            TimeBound::Inclusive(t) => write!(f, "[{}..", t)?,
-            TimeBound::Exclusive(t) => write!(f, "]{}..", t)?,
+            TimeBound::Inclusive(t) => write!(f, "[{t}..")?,
+            TimeBound::Exclusive(t) => write!(f, "]{t}..")?,
             TimeBound::Unbounded => f.write_str("[..")?,
         }
         match &self.1 {
-            TimeBound::Inclusive(t) => write!(f, "{}]", t),
-            TimeBound::Exclusive(t) => write!(f, "{}[", t),
+            TimeBound::Inclusive(t) => write!(f, "{t}]"),
+            TimeBound::Exclusive(t) => write!(f, "{t}["),
             TimeBound::Unbounded => f.write_str("]"),
         }
     }
@@ -262,7 +262,7 @@ impl Display for TimeExpr {
                 if *offset_secs == 0.0 {
                     f.write_str("now()")
                 } else {
-                    write!(f, "now({}s)", offset_secs)
+                    write!(f, "now({offset_secs}s)")
                 }
             }
         }

--- a/commons/zenoh-util/tests/zresult.rs
+++ b/commons/zenoh-util/tests/zresult.rs
@@ -18,8 +18,8 @@ fn error_simple() {
     let err: ZResult<()> = Err(zerror!("TEST").into());
     if let Err(e) = err {
         let s = e.to_string();
-        println!("{}", e);
-        println!("{:?}", e);
+        println!("{e}");
+        println!("{e:?}");
         assert!(s.contains("TEST"));
         assert!(s.contains(file!()));
     // assert!(e.source().is_none());
@@ -34,8 +34,8 @@ fn error_with_source() {
     if let Err(e) = err1 {
         let e = zerror!(e => "ERR2");
         let s = e.to_string();
-        println!("{}", e);
-        println!("{:?}", e);
+        println!("{e}");
+        println!("{e:?}");
 
         assert!(s.contains(file!()));
         // assert!(e.source().is_some());
@@ -48,8 +48,8 @@ fn error_with_source() {
     let ioerr = std::io::Error::new(std::io::ErrorKind::Other, "IOERR");
     let e = zerror!( ioerr =>"ERR2");
     let s = e.to_string();
-    println!("{}", e);
-    println!("{:?}", e);
+    println!("{e}");
+    println!("{e:?}");
 
     assert!(s.contains(file!()));
     // assert!(e.source().is_some());

--- a/examples/examples/z_delete.rs
+++ b/examples/examples/z_delete.rs
@@ -25,7 +25,7 @@ async fn main() {
     println!("Opening session...");
     let session = zenoh::open(config).res().await.unwrap();
 
-    println!("Deleting resources matching '{}'...", key_expr);
+    println!("Deleting resources matching '{key_expr}'...");
     session.delete(&key_expr).res().await.unwrap();
 
     session.close().res().await.unwrap();

--- a/examples/examples/z_forward.rs
+++ b/examples/examples/z_forward.rs
@@ -26,11 +26,11 @@ async fn main() {
     println!("Opening session...");
     let session = zenoh::open(config).res().await.unwrap();
 
-    println!("Declaring Subscriber on '{}'...", key_expr);
+    println!("Declaring Subscriber on '{key_expr}'...");
     let mut subscriber = session.declare_subscriber(&key_expr).res().await.unwrap();
-    println!("Declaring Publisher on '{}'...", forward);
+    println!("Declaring Publisher on '{forward}'...");
     let publisher = session.declare_publisher(&forward).res().await.unwrap();
-    println!("Forwarding data from '{}' to '{}'...", key_expr, forward);
+    println!("Forwarding data from '{key_expr}' to '{forward}'...");
     subscriber.forward(publisher).await.unwrap();
 }
 

--- a/examples/examples/z_get.rs
+++ b/examples/examples/z_get.rs
@@ -27,7 +27,7 @@ async fn main() {
     println!("Opening session...");
     let session = zenoh::open(config).res().await.unwrap();
 
-    println!("Sending Query '{}'...", selector);
+    println!("Sending Query '{selector}'...");
     let replies = match value {
         Some(value) => session.get(&selector).with_value(value),
         None => session.get(&selector),

--- a/examples/examples/z_ping.rs
+++ b/examples/examples/z_ping.rs
@@ -45,7 +45,7 @@ fn main() {
     let mut samples = Vec::with_capacity(n);
 
     // -- warmup --
-    println!("Warming up for {:?}...", warmup);
+    println!("Warming up for {warmup:?}...");
     let now = Instant::now();
     while now.elapsed() < warmup {
         let data = data.clone();

--- a/examples/examples/z_pub.rs
+++ b/examples/examples/z_pub.rs
@@ -27,12 +27,12 @@ async fn main() {
     println!("Opening session...");
     let session = zenoh::open(config).res().await.unwrap();
 
-    println!("Declaring Publisher on '{}'...", key_expr);
+    println!("Declaring Publisher on '{key_expr}'...");
     let publisher = session.declare_publisher(&key_expr).res().await.unwrap();
 
     for idx in 0..u32::MAX {
         sleep(Duration::from_secs(1)).await;
-        let buf = format!("[{:4}] {}", idx, value);
+        let buf = format!("[{idx:4}] {value}");
         println!("Putting Data ('{}': '{}')...", &key_expr, buf);
         publisher.put(buf).res().await.unwrap();
     }

--- a/examples/examples/z_pub_thr.rs
+++ b/examples/examples/z_pub_thr.rs
@@ -46,7 +46,7 @@ fn main() {
                 count += 1;
             } else {
                 let thpt = count as f64 / start.elapsed().as_secs_f64();
-                println!("{} msg/s", thpt);
+                println!("{thpt} msg/s");
                 count = 0;
                 start = std::time::Instant::now();
             }

--- a/examples/examples/z_pull.rs
+++ b/examples/examples/z_pull.rs
@@ -29,7 +29,7 @@ async fn main() {
     println!("Opening session...");
     let session = zenoh::open(config).res().await.unwrap();
 
-    println!("Declaring Subscriber on '{}'...", key_expr);
+    println!("Declaring Subscriber on '{key_expr}'...");
 
     let subscriber = session
         .declare_subscriber(&key_expr)

--- a/examples/examples/z_put.rs
+++ b/examples/examples/z_put.rs
@@ -25,7 +25,7 @@ async fn main() {
     println!("Opening session...");
     let session = zenoh::open(config).res().await.unwrap();
 
-    println!("Putting Data ('{}': '{}')...", key_expr, value);
+    println!("Putting Data ('{key_expr}': '{value}')...");
     session.put(&key_expr, value).res().await.unwrap();
 }
 

--- a/examples/examples/z_put_float.rs
+++ b/examples/examples/z_put_float.rs
@@ -25,7 +25,7 @@ async fn main() {
     println!("Opening session...");
     let session = zenoh::open(config).res().await.unwrap();
 
-    println!("Putting Float ('{}': '{}')...", key_expr, value);
+    println!("Putting Float ('{key_expr}': '{value}')...");
     session.put(&key_expr, value).res().await.unwrap();
 
     session.close().res().await.unwrap();

--- a/examples/examples/z_queryable.rs
+++ b/examples/examples/z_queryable.rs
@@ -31,7 +31,7 @@ async fn main() {
     println!("Opening session...");
     let session = zenoh::open(config).res().await.unwrap();
 
-    println!("Declaring Queryable on '{}'...", key_expr);
+    println!("Declaring Queryable on '{key_expr}'...");
     let queryable = session
         .declare_queryable(&key_expr)
         .complete(complete)
@@ -54,7 +54,7 @@ async fn main() {
                     .reply(Ok(Sample::new(key_expr.clone(), value.clone())))
                     .res()
                     .await
-                    .unwrap_or_else(|e| println!(">> [Queryable ] Error sending reply: {}", e));
+                    .unwrap_or_else(|e| println!(">> [Queryable ] Error sending reply: {e}"));
             },
 
             _ = stdin.read_exact(&mut input).fuse() => {

--- a/examples/examples/z_scout.rs
+++ b/examples/examples/z_scout.rs
@@ -29,7 +29,7 @@ async fn main() {
 
     let _ = async {
         while let Ok(hello) = receiver.recv_async().await {
-            println!("{}", hello);
+            println!("{hello}");
         }
     }
     .timeout(std::time::Duration::from_secs(1))

--- a/examples/examples/z_storage.rs
+++ b/examples/examples/z_storage.rs
@@ -34,10 +34,10 @@ async fn main() {
     println!("Opening session...");
     let session = zenoh::open(config).res().await.unwrap();
 
-    println!("Declaring Subscriber on '{}'...", key_expr);
+    println!("Declaring Subscriber on '{key_expr}'...");
     let subscriber = session.declare_subscriber(&key_expr).res().await.unwrap();
 
-    println!("Declaring Queryable on '{}'...", key_expr);
+    println!("Declaring Queryable on '{key_expr}'...");
     let queryable = session
         .declare_queryable(&key_expr)
         .complete(complete)

--- a/examples/examples/z_sub_thr.rs
+++ b/examples/examples/z_sub_thr.rs
@@ -52,7 +52,7 @@ impl Stats {
     fn print_round(&self) {
         let elapsed = self.round_start.elapsed().as_secs_f64();
         let throughtput = (self.round_size as f64) / elapsed;
-        println!("{} msg/s", throughtput);
+        println!("{throughtput} msg/s");
     }
 }
 impl Drop for Stats {
@@ -60,10 +60,7 @@ impl Drop for Stats {
         let elapsed = self.global_start.unwrap().elapsed().as_secs_f64();
         let total = self.round_size * self.finished_rounds + self.round_count;
         let throughtput = total as f64 / elapsed;
-        println!(
-            "Received {} messages over {:.2}s: {}msg/s",
-            total, elapsed, throughtput
-        );
+        println!("Received {total} messages over {elapsed:.2}s: {throughtput}msg/s");
     }
 }
 

--- a/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
@@ -291,7 +291,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastTcp {
                     // Update the endpoint locator address
                     endpoint = EndPoint::new(
                         endpoint.protocol(),
-                        &format!("{}", local_addr),
+                        &format!("{local_addr}"),
                         endpoint.metadata(),
                         endpoint.config(),
                     )?;

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -366,7 +366,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastTls {
         // Update the endpoint locator address
         let locator = Locator::new(
             endpoint.protocol(),
-            format!("{}:{}", host, local_port),
+            format!("{host}:{local_port}"),
             endpoint.metadata(),
         )?;
 
@@ -488,7 +488,7 @@ async fn accept_task(
         let tls_stream = match acceptor.accept(tcp_stream).await {
             Ok(stream) => TlsStream::Server(stream),
             Err(e) => {
-                let e = format!("Can not accept TLS connection: {}", e);
+                let e = format!("Can not accept TLS connection: {e}");
                 log::warn!("{}", e);
                 continue;
             }

--- a/io/zenoh-links/zenoh-link-unixsock_stream/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-unixsock_stream/src/unicast.rs
@@ -232,10 +232,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastUnixSocketStream {
         let local_path = match src_addr.as_pathname() {
             Some(path) => PathBuf::from(path),
             None => {
-                let e = format!(
-                    "Can not create a new UnixSocketStream link bound to {:?}",
-                    path
-                );
+                let e = format!("Can not create a new UnixSocketStream link bound to {path:?}");
                 log::warn!("{}", e);
                 PathBuf::from(format!("{}", Uuid::new_v4()))
             }
@@ -278,7 +275,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastUnixSocketStream {
 
         // We generate the path for the lock file, by adding .lock
         // to the socket file
-        let lock_file_path = format!("{}.lock", path);
+        let lock_file_path = format!("{path}.lock");
 
         // We try to open the lock file, with O_RDONLY | O_CREAT
         // and mode S_IRUSR | S_IWUSR, user read-write permissions
@@ -409,7 +406,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastUnixSocketStream {
         let _ = remove_file(path.clone());
 
         // Remove the Unix Domain Socket file
-        let lock_file_path = format!("{}.lock", path);
+        let lock_file_path = format!("{path}.lock");
         let tmp = remove_file(lock_file_path);
         log::trace!("UnixSocketStream Domain Socket removal result: {:?}", tmp);
         res

--- a/io/zenoh-transport/src/common/pipeline.rs
+++ b/io/zenoh-transport/src/common/pipeline.rs
@@ -742,8 +742,7 @@ mod tests {
             );
 
             println!(
-                "Pipeline Flow [>>>]: Sending {} messages with payload size of {} bytes",
-                num_msg, payload_size
+                "Pipeline Flow [>>>]: Sending {num_msg} messages with payload size of {payload_size} bytes"
             );
             for i in 0..num_msg {
                 println!("Pipeline Flow [>>>]: Pushed {} msgs", i + 1);
@@ -798,8 +797,7 @@ mod tests {
             }
 
             println!(
-                "Pipeline Flow [<<<]: Received {} messages, {} bytes, {} batches, {} fragments",
-                msgs, bytes, batches, fragments
+                "Pipeline Flow [<<<]: Received {msgs} messages, {bytes} bytes, {batches} batches, {fragments} fragments"
             );
         }
 
@@ -879,9 +877,7 @@ mod tests {
             let num_msg = 1 + CONFIG.queue_size[0];
             for i in 0..num_msg {
                 println!(
-                    "Pipeline Blocking [>>>]: ({}) Scheduling message #{} with payload size of {} bytes",
-                    id, i,
-                    payload_size
+                    "Pipeline Blocking [>>>]: ({id}) Scheduling message #{i} with payload size of {payload_size} bytes"
                 );
                 queue.push_zenoh_message(message.clone());
                 let c = counter.fetch_add(1, Ordering::AcqRel);

--- a/io/zenoh-transport/src/manager.rs
+++ b/io/zenoh-transport/src/manager.rs
@@ -222,7 +222,7 @@ impl TransportManagerBuilder {
             use std::fmt::Write;
             let mut formatter = String::from("Some protocols reported configuration errors:\r\n");
             for (proto, err) in errors {
-                write!(&mut formatter, "\t{}: {}\r\n", proto, err)?;
+                write!(&mut formatter, "\t{proto}: {err}\r\n")?;
             }
             bail!("{}", formatter);
         }

--- a/io/zenoh-transport/src/multicast/link.rs
+++ b/io/zenoh-transport/src/multicast/link.rs
@@ -224,7 +224,7 @@ async fn tx_task(
     }
 
     let keep_alive = config.join_interval / config.keep_alive as u32;
-    let mut last_join = Instant::now() - config.join_interval;
+    let mut last_join = Instant::now().checked_sub(config.join_interval).unwrap();
     loop {
         match pull(&mut pipeline, keep_alive)
             .race(join(last_join, config.join_interval))

--- a/io/zenoh-transport/src/multicast/mod.rs
+++ b/io/zenoh-transport/src/multicast/mod.rs
@@ -184,7 +184,7 @@ impl fmt::Debug for TransportMulticast {
                     .finish()
             }
             Err(e) => {
-                write!(f, "{}", e)
+                write!(f, "{e}")
             }
         }
     }

--- a/io/zenoh-transport/src/unicast/establishment/authenticator/shm.rs
+++ b/io/zenoh-transport/src/unicast/establishment/authenticator/shm.rs
@@ -182,8 +182,7 @@ impl SharedMemoryAuthenticator {
         let mut prng = PseudoRng::from_entropy();
         let challenge = prng.gen::<ZInt>();
 
-        let mut _manager =
-            SharedMemoryManager::make(format!("{}.{}", SHM_NAME, challenge), SHM_SIZE)?;
+        let mut _manager = SharedMemoryManager::make(format!("{SHM_NAME}.{challenge}"), SHM_SIZE)?;
 
         let mut buffer = _manager.alloc(SHM_SIZE).unwrap();
         let slice = unsafe { buffer.as_mut_slice() };
@@ -204,7 +203,7 @@ impl SharedMemoryAuthenticator {
             let challenge = prng.gen::<ZInt>();
 
             let mut _manager =
-                SharedMemoryManager::make(format!("{}.{}", SHM_NAME, challenge), SHM_SIZE)?;
+                SharedMemoryManager::make(format!("{SHM_NAME}.{challenge}"), SHM_SIZE)?;
 
             let mut buffer = _manager.alloc(SHM_SIZE)?;
             let slice = unsafe { buffer.as_mut_slice() };

--- a/io/zenoh-transport/src/unicast/mod.rs
+++ b/io/zenoh-transport/src/unicast/mod.rs
@@ -231,7 +231,7 @@ impl fmt::Debug for TransportUnicast {
                 .field("links", &transport.get_links())
                 .finish(),
             Err(e) => {
-                write!(f, "{}", e)
+                write!(f, "{e}")
             }
         }
     }

--- a/io/zenoh-transport/tests/endpoints.rs
+++ b/io/zenoh-transport/tests/endpoints.rs
@@ -87,7 +87,7 @@ async fn run(endpoints: &[EndPoint]) {
     for _ in 0..RUNS {
         // Create the listeners
         for e in endpoints.iter() {
-            println!("Add {}", e);
+            println!("Add {e}");
             ztimeout!(sm.add_listener(e.clone())).unwrap();
         }
 
@@ -95,7 +95,7 @@ async fn run(endpoints: &[EndPoint]) {
 
         // Delete the listeners
         for e in endpoints.iter() {
-            println!("Del {}", e);
+            println!("Del {e}");
             ztimeout!(sm.del_listener(e)).unwrap();
         }
 
@@ -152,14 +152,14 @@ fn endpoint_unix() {
     let _ = std::fs::remove_file(f2);
     // Define the locators
     let endpoints: Vec<EndPoint> = vec![
-        format!("unixsock-stream/{}", f1).parse().unwrap(),
-        format!("unixsock-stream/{}", f2).parse().unwrap(),
+        format!("unixsock-stream/{f1}").parse().unwrap(),
+        format!("unixsock-stream/{f2}").parse().unwrap(),
     ];
     task::block_on(run(&endpoints));
     let _ = std::fs::remove_file(f1);
     let _ = std::fs::remove_file(f2);
-    let _ = std::fs::remove_file(format!("{}.lock", f1));
-    let _ = std::fs::remove_file(format!("{}.lock", f2));
+    let _ = std::fs::remove_file(format!("{f1}.lock"));
+    let _ = std::fs::remove_file(format!("{f2}.lock"));
 }
 
 #[cfg(feature = "transport_ws")]
@@ -219,11 +219,11 @@ fn endpoint_tcp_udp_unix() {
         format!("udp/127.0.0.1:{}", 7041).parse().unwrap(),
         format!("tcp/[::1]:{}", 7042).parse().unwrap(),
         format!("udp/[::1]:{}", 7043).parse().unwrap(),
-        format!("unixsock-stream/{}", f1).parse().unwrap(),
+        format!("unixsock-stream/{f1}").parse().unwrap(),
     ];
     task::block_on(run(&endpoints));
     let _ = std::fs::remove_file(f1);
-    let _ = std::fs::remove_file(format!("{}.lock", f1));
+    let _ = std::fs::remove_file(format!("{f1}.lock"));
 }
 
 #[cfg(all(
@@ -245,11 +245,11 @@ fn endpoint_tcp_unix() {
     let endpoints: Vec<EndPoint> = vec![
         format!("tcp/127.0.0.1:{}", 7050).parse().unwrap(),
         format!("tcp/[::1]:{}", 7051).parse().unwrap(),
-        format!("unixsock-stream/{}", f1).parse().unwrap(),
+        format!("unixsock-stream/{f1}").parse().unwrap(),
     ];
     task::block_on(run(&endpoints));
     let _ = std::fs::remove_file(f1);
-    let _ = std::fs::remove_file(format!("{}.lock", f1));
+    let _ = std::fs::remove_file(format!("{f1}.lock"));
 }
 
 #[cfg(all(
@@ -270,11 +270,11 @@ fn endpoint_udp_unix() {
     let endpoints: Vec<EndPoint> = vec![
         format!("udp/127.0.0.1:{}", 7060).parse().unwrap(),
         format!("udp/[::1]:{}", 7061).parse().unwrap(),
-        format!("unixsock-stream/{}", f1).parse().unwrap(),
+        format!("unixsock-stream/{f1}").parse().unwrap(),
     ];
     task::block_on(run(&endpoints));
     let _ = std::fs::remove_file(f1);
-    let _ = std::fs::remove_file(format!("{}.lock", f1));
+    let _ = std::fs::remove_file(format!("{f1}.lock"));
 }
 
 #[cfg(feature = "transport_tls")]

--- a/io/zenoh-transport/tests/multicast_transport.rs
+++ b/io/zenoh-transport/tests/multicast_transport.rs
@@ -159,14 +159,14 @@ mod tests {
 
         // Create an empty transport with the peer01
         // Open transport -> This should be accepted
-        println!("Opening transport with {}", endpoint);
+        println!("Opening transport with {endpoint}");
         let _ = ztimeout!(peer01_manager.open_transport_multicast(endpoint.clone())).unwrap();
         assert!(peer01_manager
             .get_transport_multicast(&endpoint.to_locator())
             .is_some());
         println!("\t{:?}", peer01_manager.get_transports_multicast());
 
-        println!("Opening transport with {}", endpoint);
+        println!("Opening transport with {endpoint}");
         let _ = ztimeout!(peer02_manager.open_transport_multicast(endpoint.clone())).unwrap();
         assert!(peer02_manager
             .get_transport_multicast(&endpoint.to_locator())
@@ -212,13 +212,13 @@ mod tests {
         endpoint: &EndPoint,
     ) {
         // Close the peer01 transport
-        println!("Closing transport with {}", endpoint);
+        println!("Closing transport with {endpoint}");
         ztimeout!(peer01.transport.close()).unwrap();
         assert!(peer01.manager.get_transports_multicast().is_empty());
         assert!(peer02.transport.get_peers().unwrap().is_empty());
 
         // Close the peer02 transport
-        println!("Closing transport with {}", endpoint);
+        println!("Closing transport with {endpoint}");
         ztimeout!(peer02.transport.close()).unwrap();
         assert!(peer02.manager.get_transports_multicast().is_empty());
 
@@ -250,10 +250,7 @@ mod tests {
             attachment,
         );
 
-        println!(
-            "Sending {} messages... {:?} {}",
-            MSG_COUNT, channel, msg_size
-        );
+        println!("Sending {MSG_COUNT} messages... {channel:?} {msg_size}");
         for _ in 0..MSG_COUNT {
             peer01.transport.schedule(message.clone()).unwrap();
         }
@@ -315,7 +312,7 @@ mod tests {
 
         // Define the locator
         let endpoints: Vec<EndPoint> = vec![
-            format!("udp/{}", ZN_MULTICAST_IPV4_ADDRESS_DEFAULT)
+            format!("udp/{ZN_MULTICAST_IPV4_ADDRESS_DEFAULT}")
                 .parse()
                 .unwrap(),
             // Disabling by default because of no IPv6 support

--- a/io/zenoh-transport/tests/unicast_authenticator.rs
+++ b/io/zenoh-transport/tests/unicast_authenticator.rs
@@ -335,7 +335,7 @@ async fn authenticator_multilink(endpoint: &EndPoint) {
     ztimeout!(router_manager.add_listener(endpoint.clone())).unwrap();
     println!("Transport Authenticator PubKey [1a2]");
     let locators = router_manager.get_listeners();
-    println!("Transport Authenticator PubKey [1a2]: {:?}", locators);
+    println!("Transport Authenticator PubKey [1a2]: {locators:?}");
     assert_eq!(locators.len(), 1);
 
     /* [2a] */
@@ -358,7 +358,7 @@ async fn authenticator_multilink(endpoint: &EndPoint) {
     // -> This should be rejected
     println!("Transport Authenticator PubKey [2c1]");
     let res = ztimeout!(client01_manager.open_transport(endpoint.clone()));
-    println!("Transport Authenticator PubKey [2c2]: {:?}", res);
+    println!("Transport Authenticator PubKey [2c2]: {res:?}");
     assert!(res.is_err());
     assert_eq!(c_ses1.get_links().unwrap().len(), 2);
 
@@ -393,7 +393,7 @@ async fn authenticator_multilink(endpoint: &EndPoint) {
     // -> This should be rejected
     println!("Transport Authenticator PubKey [3c1]");
     let res = ztimeout!(client02_manager.open_transport(endpoint.clone()));
-    println!("Transport Authenticator PubKey [3c2]: {:?}", res);
+    println!("Transport Authenticator PubKey [3c2]: {res:?}");
     assert!(res.is_err());
     assert_eq!(c_ses2.get_links().unwrap().len(), 2);
 
@@ -401,7 +401,7 @@ async fn authenticator_multilink(endpoint: &EndPoint) {
     // Close the session
     println!("Transport Authenticator PubKey [3d1]");
     let res = ztimeout!(c_ses2.close());
-    println!("Transport Authenticator PubKey [3d2]: {:?}", res);
+    println!("Transport Authenticator PubKey [3d2]: {res:?}");
     assert!(res.is_ok());
 
     ztimeout!(async {
@@ -415,7 +415,7 @@ async fn authenticator_multilink(endpoint: &EndPoint) {
     // -> This should be accepted
     println!("Transport Authenticator PubKey [4a1]");
     let res = ztimeout!(client01_spoof_manager.open_transport(endpoint.clone()));
-    println!("Transport Authenticator PubKey [4a2]: {:?}", res);
+    println!("Transport Authenticator PubKey [4a2]: {res:?}");
     assert!(res.is_ok());
     let c_ses1_spoof = res.unwrap();
     assert_eq!(c_ses1_spoof.get_links().unwrap().len(), 1);
@@ -425,7 +425,7 @@ async fn authenticator_multilink(endpoint: &EndPoint) {
     // -> This should be accepted
     println!("Transport Authenticator PubKey [4b1]");
     let res = ztimeout!(client01_spoof_manager.open_transport(endpoint.clone()));
-    println!("Transport Authenticator PubKey [4b2]: {:?}", res);
+    println!("Transport Authenticator PubKey [4b2]: {res:?}");
     assert!(res.is_ok());
     assert_eq!(c_ses1_spoof.get_links().unwrap().len(), 2);
 
@@ -434,7 +434,7 @@ async fn authenticator_multilink(endpoint: &EndPoint) {
     // -> This should be rejected
     println!("Transport Authenticator PubKey [41]");
     let res = ztimeout!(client01_spoof_manager.open_transport(endpoint.clone()));
-    println!("Transport Authenticator PubKey [4c2]: {:?}", res);
+    println!("Transport Authenticator PubKey [4c2]: {res:?}");
     assert!(res.is_err());
     assert_eq!(c_ses1_spoof.get_links().unwrap().len(), 2);
 
@@ -442,7 +442,7 @@ async fn authenticator_multilink(endpoint: &EndPoint) {
     // Close the session
     println!("Transport Authenticator PubKey [4d1]");
     let res = ztimeout!(c_ses1_spoof.close());
-    println!("Transport Authenticator PubKey [4d2]: {:?}", res);
+    println!("Transport Authenticator PubKey [4d2]: {res:?}");
     assert!(res.is_ok());
 
     ztimeout!(async {
@@ -456,7 +456,7 @@ async fn authenticator_multilink(endpoint: &EndPoint) {
     // -> This should be accepted
     println!("Transport Authenticator PubKey [5a1]");
     let res = ztimeout!(client01_manager.open_transport(endpoint.clone()));
-    println!("Transport Authenticator PubKey [5a2]: {:?}", res);
+    println!("Transport Authenticator PubKey [5a2]: {res:?}");
     assert!(res.is_ok());
     let c_ses1 = res.unwrap();
     assert_eq!(c_ses1.get_links().unwrap().len(), 1);
@@ -466,7 +466,7 @@ async fn authenticator_multilink(endpoint: &EndPoint) {
     // -> This should be rejected. Spoofing detected.
     println!("Transport Authenticator PubKey [5b1]");
     let res = ztimeout!(client01_spoof_manager.open_transport(endpoint.clone()));
-    println!("Transport Authenticator PubKey [5b2]: {:?}", res);
+    println!("Transport Authenticator PubKey [5b2]: {res:?}");
     assert!(res.is_err());
 
     /* [5c] */
@@ -474,7 +474,7 @@ async fn authenticator_multilink(endpoint: &EndPoint) {
     // -> This should be accepted
     println!("Transport Authenticator PubKey [5a1]");
     let res = ztimeout!(client01_manager.open_transport(endpoint.clone()));
-    println!("Transport Authenticator PubKey [5a2]: {:?}", res);
+    println!("Transport Authenticator PubKey [5a2]: {res:?}");
     assert!(res.is_ok());
     let c_ses1 = res.unwrap();
     assert_eq!(c_ses1.get_links().unwrap().len(), 2);
@@ -483,7 +483,7 @@ async fn authenticator_multilink(endpoint: &EndPoint) {
     // Close the session
     println!("Transport Authenticator PubKey [5d1]");
     let res = ztimeout!(c_ses1.close());
-    println!("Transport Authenticator PubKey [5d2]: {:?}", res);
+    println!("Transport Authenticator PubKey [5d2]: {res:?}");
     assert!(res.is_ok());
 
     ztimeout!(async {
@@ -496,7 +496,7 @@ async fn authenticator_multilink(endpoint: &EndPoint) {
     // Perform clean up of the open locators
     println!("Transport Authenticator UserPassword [6a1]");
     let res = ztimeout!(router_manager.del_listener(endpoint));
-    println!("Transport Authenticator UserPassword [6a2]: {:?}", res);
+    println!("Transport Authenticator UserPassword [6a2]: {res:?}");
     assert!(res.is_ok());
 
     ztimeout!(async {
@@ -598,11 +598,11 @@ async fn authenticator_user_password(endpoint: &EndPoint) {
     println!("\nTransport Authenticator UserPassword [1a1]");
     // Add the locator on the router
     let res = ztimeout!(router_manager.add_listener(endpoint.clone()));
-    println!("Transport Authenticator UserPassword [1a1]: {:?}", res);
+    println!("Transport Authenticator UserPassword [1a1]: {res:?}");
     assert!(res.is_ok());
     println!("Transport Authenticator UserPassword [1a2]");
     let locators = router_manager.get_listeners();
-    println!("Transport Authenticator UserPassword [1a2]: {:?}", locators);
+    println!("Transport Authenticator UserPassword [1a2]: {locators:?}");
     assert_eq!(locators.len(), 1);
 
     /* [2] */
@@ -610,14 +610,14 @@ async fn authenticator_user_password(endpoint: &EndPoint) {
     // -> This should be accepted
     println!("Transport Authenticator UserPassword [2a1]");
     let res = ztimeout!(client01_manager.open_transport(endpoint.clone()));
-    println!("Transport Authenticator UserPassword [2a1]: {:?}", res);
+    println!("Transport Authenticator UserPassword [2a1]: {res:?}");
     assert!(res.is_ok());
     let c_ses1 = res.unwrap();
 
     /* [3] */
     println!("Transport Authenticator UserPassword [3a1]");
     let res = ztimeout!(c_ses1.close());
-    println!("Transport Authenticator UserPassword [3a1]: {:?}", res);
+    println!("Transport Authenticator UserPassword [3a1]: {res:?}");
     assert!(res.is_ok());
 
     ztimeout!(async {
@@ -631,7 +631,7 @@ async fn authenticator_user_password(endpoint: &EndPoint) {
     // -> This should be rejected
     println!("Transport Authenticator UserPassword [4a1]");
     let res = ztimeout!(client02_manager.open_transport(endpoint.clone()));
-    println!("Transport Authenticator UserPassword [4a1]: {:?}", res);
+    println!("Transport Authenticator UserPassword [4a1]: {res:?}");
     assert!(res.is_err());
 
     /* [5] */
@@ -639,7 +639,7 @@ async fn authenticator_user_password(endpoint: &EndPoint) {
     // -> This should be accepted
     println!("Transport Authenticator UserPassword [5a1]");
     let res = ztimeout!(client01_manager.open_transport(endpoint.clone()));
-    println!("Transport Authenticator UserPassword [5a1]: {:?}", res);
+    println!("Transport Authenticator UserPassword [5a1]: {res:?}");
     assert!(res.is_ok());
     let c_ses1 = res.unwrap();
 
@@ -651,7 +651,7 @@ async fn authenticator_user_password(endpoint: &EndPoint) {
     // -> This should be accepted
     println!("Transport Authenticator UserPassword [6a1]");
     let res = ztimeout!(client02_manager.open_transport(endpoint.clone()));
-    println!("Transport Authenticator UserPassword [6a1]: {:?}", res);
+    println!("Transport Authenticator UserPassword [6a1]: {res:?}");
     assert!(res.is_ok());
     let c_ses2 = res.unwrap();
 
@@ -660,17 +660,17 @@ async fn authenticator_user_password(endpoint: &EndPoint) {
     // -> This should be rejected
     println!("Transport Authenticator UserPassword [7a1]");
     let res = ztimeout!(client03_manager.open_transport(endpoint.clone()));
-    println!("Transport Authenticator UserPassword [7a1]: {:?}", res);
+    println!("Transport Authenticator UserPassword [7a1]: {res:?}");
     assert!(res.is_err());
 
     /* [8] */
     println!("Transport Authenticator UserPassword [8a1]");
     let res = ztimeout!(c_ses1.close());
-    println!("Transport Authenticator UserPassword [8a1]: {:?}", res);
+    println!("Transport Authenticator UserPassword [8a1]: {res:?}");
     assert!(res.is_ok());
     println!("Transport Authenticator UserPassword [8a2]");
     let res = ztimeout!(c_ses2.close());
-    println!("Transport Authenticator UserPassword [8a2]: {:?}", res);
+    println!("Transport Authenticator UserPassword [8a2]: {res:?}");
     assert!(res.is_ok());
 
     ztimeout!(async {
@@ -683,7 +683,7 @@ async fn authenticator_user_password(endpoint: &EndPoint) {
     // Perform clean up of the open locators
     println!("Transport Authenticator UserPassword [9a1]");
     let res = ztimeout!(router_manager.del_listener(endpoint));
-    println!("Transport Authenticator UserPassword [9a2]: {:?}", res);
+    println!("Transport Authenticator UserPassword [9a2]: {res:?}");
     assert!(res.is_ok());
 
     ztimeout!(async {
@@ -733,11 +733,11 @@ async fn authenticator_shared_memory(endpoint: &EndPoint) {
     println!("\nTransport Authenticator SharedMemory [1a1]");
     // Add the locator on the router
     let res = ztimeout!(router_manager.add_listener(endpoint.clone()));
-    println!("Transport Authenticator SharedMemory [1a1]: {:?}", res);
+    println!("Transport Authenticator SharedMemory [1a1]: {res:?}");
     assert!(res.is_ok());
     println!("Transport Authenticator SharedMemory [1a2]");
     let locators = router_manager.get_listeners();
-    println!("Transport Authenticator SharedMemory 1a2]: {:?}", locators);
+    println!("Transport Authenticator SharedMemory 1a2]: {locators:?}");
     assert_eq!(locators.len(), 1);
 
     /* [2] */
@@ -745,7 +745,7 @@ async fn authenticator_shared_memory(endpoint: &EndPoint) {
     // -> This should be accepted
     println!("Transport Authenticator SharedMemory [2a1]");
     let res = ztimeout!(client_manager.open_transport(endpoint.clone()));
-    println!("Transport Authenticator SharedMemory [2a1]: {:?}", res);
+    println!("Transport Authenticator SharedMemory [2a1]: {res:?}");
     assert!(res.is_ok());
     let c_ses1 = res.unwrap();
     assert!(c_ses1.is_shm().unwrap());
@@ -753,7 +753,7 @@ async fn authenticator_shared_memory(endpoint: &EndPoint) {
     /* [3] */
     println!("Transport Authenticator SharedMemory [3a1]");
     let res = ztimeout!(c_ses1.close());
-    println!("Transport Authenticator SharedMemory [3a1]: {:?}", res);
+    println!("Transport Authenticator SharedMemory [3a1]: {res:?}");
     assert!(res.is_ok());
 
     ztimeout!(async {
@@ -766,7 +766,7 @@ async fn authenticator_shared_memory(endpoint: &EndPoint) {
     // Perform clean up of the open locators
     println!("Transport Authenticator SharedMemory [4a1]");
     let res = ztimeout!(router_manager.del_listener(endpoint));
-    println!("Transport Authenticator SharedMemory [4a2]: {:?}", res);
+    println!("Transport Authenticator SharedMemory [4a2]: {res:?}");
     assert!(res.is_ok());
 
     ztimeout!(async {
@@ -833,10 +833,10 @@ fn authenticator_unix() {
 
     let f1 = "zenoh-test-unix-socket-10.sock";
     let _ = std::fs::remove_file(f1);
-    let endpoint: EndPoint = format!("unixsock-stream/{}", f1).parse().unwrap();
+    let endpoint: EndPoint = format!("unixsock-stream/{f1}").parse().unwrap();
     task::block_on(run(&endpoint));
     let _ = std::fs::remove_file(f1);
-    let _ = std::fs::remove_file(format!("{}.lock", f1));
+    let _ = std::fs::remove_file(format!("{f1}.lock"));
 }
 
 #[cfg(feature = "transport_tls")]

--- a/io/zenoh-transport/tests/unicast_concurrent.rs
+++ b/io/zenoh-transport/tests/unicast_concurrent.rs
@@ -145,14 +145,11 @@ async fn transport_concurrent(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPoin
         // Add the endpoints on the first peer
         for e in c_end01.iter() {
             let res = ztimeout!(peer01_manager.add_listener(e.clone()));
-            println!("[Transport Peer 01a] => Adding endpoint {:?}: {:?}", e, res);
+            println!("[Transport Peer 01a] => Adding endpoint {e:?}: {res:?}");
             assert!(res.is_ok());
         }
         let locs = peer01_manager.get_listeners();
-        println!(
-            "[Transport Peer 01b] => Getting endpoints: {:?} {:?}",
-            c_end01, locs
-        );
+        println!("[Transport Peer 01b] => Getting endpoints: {c_end01:?} {locs:?}");
         assert_eq!(c_end01.len(), locs.len());
 
         // Open the transport with the second peer
@@ -166,10 +163,7 @@ async fn transport_concurrent(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPoin
                 // Syncrhonize before opening the transports
                 ztimeout!(cc_barow.wait());
                 let res = ztimeout!(c_p01m.open_transport(c_end.clone()));
-                println!(
-                    "[Transport Peer 01d] => Opening transport with {:?}: {:?}",
-                    c_end, res
-                );
+                println!("[Transport Peer 01d] => Opening transport with {c_end:?}: {res:?}");
                 assert!(res.is_ok());
 
                 // Syncrhonize after opening the transports
@@ -218,7 +212,7 @@ async fn transport_concurrent(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPoin
         println!("[Transport Peer 01f] => Waiting... OK");
 
         for i in 0..MSG_COUNT {
-            println!("[Transport Peer 01g] Scheduling message {}", i);
+            println!("[Transport Peer 01g] Scheduling message {i}");
             s02.schedule(message.clone()).unwrap();
         }
         println!("[Transport Peer 01g] => Scheduling OK");
@@ -233,9 +227,9 @@ async fn transport_concurrent(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPoin
         // Synchronize wit the peer
         ztimeout!(c_barp.wait());
 
-        println!("[Transport Peer 01h] => Closing {:?}...", s02);
+        println!("[Transport Peer 01h] => Closing {s02:?}...");
         let res = ztimeout!(s02.close());
-        println!("[Transport Peer 01l] => Closing {:?}: {:?}", s02, res);
+        println!("[Transport Peer 01l] => Closing {s02:?}: {res:?}");
         assert!(res.is_ok());
 
         // Close the transport
@@ -253,14 +247,11 @@ async fn transport_concurrent(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPoin
         // Add the endpoints on the first peer
         for e in c_end02.iter() {
             let res = ztimeout!(peer02_manager.add_listener(e.clone()));
-            println!("[Transport Peer 02a] => Adding endpoint {:?}: {:?}", e, res);
+            println!("[Transport Peer 02a] => Adding endpoint {e:?}: {res:?}");
             assert!(res.is_ok());
         }
         let locs = peer02_manager.get_listeners();
-        println!(
-            "[Transport Peer 02b] => Getting endpoints: {:?} {:?}",
-            c_end02, locs
-        );
+        println!("[Transport Peer 02b] => Getting endpoints: {c_end02:?} {locs:?}");
         assert_eq!(c_end02.len(), locs.len());
 
         // Open the transport with the first peer
@@ -275,10 +266,7 @@ async fn transport_concurrent(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPoin
                 ztimeout!(cc_barow.wait());
 
                 let res = ztimeout!(c_p02m.open_transport(c_end.clone()));
-                println!(
-                    "[Transport Peer 02d] => Opening transport with {:?}: {:?}",
-                    c_end, res
-                );
+                println!("[Transport Peer 02d] => Opening transport with {c_end:?}: {res:?}");
                 assert!(res.is_ok());
 
                 // Syncrhonize after opening the transports
@@ -330,7 +318,7 @@ async fn transport_concurrent(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPoin
         println!("[Transport Peer 02f] => Waiting... OK");
 
         for i in 0..MSG_COUNT {
-            println!("[Transport Peer 02g] Scheduling message {}", i);
+            println!("[Transport Peer 02g] Scheduling message {i}");
             s01.schedule(message.clone()).unwrap();
         }
         println!("[Transport Peer 02g] => Scheduling OK");
@@ -345,9 +333,9 @@ async fn transport_concurrent(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPoin
         // Synchronize wit the peer
         ztimeout!(c_barp.wait());
 
-        println!("[Transport Peer 02h] => Closing {:?}...", s01);
+        println!("[Transport Peer 02h] => Closing {s01:?}...");
         let res = ztimeout!(s01.close());
-        println!("[Transport Peer 02l] => Closing {:?}: {:?}", s01, res);
+        println!("[Transport Peer 02l] => Closing {s01:?}: {res:?}");
         assert!(res.is_ok());
 
         // Close the transport

--- a/io/zenoh-transport/tests/unicast_conduits.rs
+++ b/io/zenoh-transport/tests/unicast_conduits.rs
@@ -202,14 +202,14 @@ async fn open_transport(
 
     // Create the listener on the router
     for e in endpoints.iter() {
-        println!("Add locator: {}", e);
+        println!("Add locator: {e}");
         let _ = ztimeout!(router_manager.add_listener(e.clone())).unwrap();
     }
 
     // Create an empty transport with the client
     // Open transport -> This should be accepted
     for e in endpoints.iter() {
-        println!("Opening transport with {}", e);
+        println!("Opening transport with {e}");
         let _ = ztimeout!(client_manager.open_transport(e.clone())).unwrap();
     }
 
@@ -233,9 +233,9 @@ async fn close_transport(
     // Close the client transport
     let mut ee = String::new();
     for e in endpoints.iter() {
-        let _ = write!(ee, "{} ", e);
+        let _ = write!(ee, "{e} ");
     }
-    println!("Closing transport with {}", ee);
+    println!("Closing transport with {ee}");
     ztimeout!(client_transport.close()).unwrap();
 
     ztimeout!(async {
@@ -246,7 +246,7 @@ async fn close_transport(
 
     // Stop the locators on the manager
     for e in endpoints.iter() {
-        println!("Del locator: {}", e);
+        println!("Del locator: {e}");
         ztimeout!(router_manager.del_listener(e)).unwrap();
     }
 
@@ -284,10 +284,7 @@ async fn single_run(
         attachment,
     );
 
-    println!(
-        "Sending {} messages... {:?} {}",
-        MSG_COUNT, channel, msg_size
-    );
+    println!("Sending {MSG_COUNT} messages... {channel:?} {msg_size}");
     for _ in 0..MSG_COUNT {
         client_transport.schedule(message.clone()).unwrap();
     }

--- a/io/zenoh-transport/tests/unicast_defragmentation.rs
+++ b/io/zenoh-transport/tests/unicast_defragmentation.rs
@@ -55,12 +55,12 @@ async fn run(endpoint: &EndPoint, channel: Channel, msg_size: usize) {
         .unwrap();
 
     // Create the listener on the router
-    println!("Add locator: {}", endpoint);
+    println!("Add locator: {endpoint}");
     let _ = ztimeout!(router_manager.add_listener(endpoint.clone())).unwrap();
 
     // Create an empty transport with the client
     // Open transport -> This should be accepted
-    println!("Opening transport with {}", endpoint);
+    println!("Opening transport with {endpoint}");
     let _ = ztimeout!(client_manager.open_transport(endpoint.clone())).unwrap();
 
     let client_transport = client_manager.get_transport(&router_id).unwrap();
@@ -84,8 +84,7 @@ async fn run(endpoint: &EndPoint, channel: Channel, msg_size: usize) {
     );
 
     println!(
-        "Sending message of {} bytes while defragmentation buffer size is {} bytes",
-        msg_size, MSG_DEFRAG_BUF
+        "Sending message of {msg_size} bytes while defragmentation buffer size is {MSG_DEFRAG_BUF} bytes"
     );
     client_transport.schedule(message.clone()).unwrap();
 
@@ -104,7 +103,7 @@ async fn run(endpoint: &EndPoint, channel: Channel, msg_size: usize) {
     });
 
     // Stop the locators on the manager
-    println!("Del locator: {}", endpoint);
+    println!("Del locator: {endpoint}");
     ztimeout!(router_manager.del_listener(endpoint)).unwrap();
 
     // Wait a little bit

--- a/io/zenoh-transport/tests/unicast_intermittent.rs
+++ b/io/zenoh-transport/tests/unicast_intermittent.rs
@@ -201,7 +201,7 @@ async fn transport_intermittent(endpoint: &EndPoint) {
     println!("\nTransport Intermittent [1a1]");
     let _ = ztimeout!(router_manager.add_listener(endpoint.clone())).unwrap();
     let locators = router_manager.get_listeners();
-    println!("Transport Intermittent [1a2]: {:?}", locators);
+    println!("Transport Intermittent [1a2]: {locators:?}");
     assert_eq!(locators.len(), 1);
 
     /* [2] */
@@ -295,7 +295,7 @@ async fn transport_intermittent(endpoint: &EndPoint) {
         let mut count = 0;
         while count < MSG_COUNT {
             if count == ticks[0] {
-                println!("\nScheduled {}", count);
+                println!("\nScheduled {count}");
                 ticks.remove(0);
             }
             let transports = c_router_manager.get_transports();
@@ -334,7 +334,7 @@ async fn transport_intermittent(endpoint: &EndPoint) {
             if c == MSG_COUNT {
                 break;
             }
-            println!("Transport Intermittent [4b2]: Received {}/{}", c, MSG_COUNT);
+            println!("Transport Intermittent [4b2]: Received {c}/{MSG_COUNT}");
             task::sleep(SLEEP).await;
         }
     });

--- a/io/zenoh-transport/tests/unicast_openclose.rs
+++ b/io/zenoh-transport/tests/unicast_openclose.rs
@@ -124,11 +124,11 @@ async fn openclose_transport(endpoint: &EndPoint) {
     println!("\nTransport Open Close [1a1]");
     // Add the locator on the router
     let res = ztimeout!(router_manager.add_listener(endpoint.clone()));
-    println!("Transport Open Close [1a1]: {:?}", res);
+    println!("Transport Open Close [1a1]: {res:?}");
     assert!(res.is_ok());
     println!("Transport Open Close [1a2]");
     let locators = router_manager.get_listeners();
-    println!("Transport Open Close [1a2]: {:?}", locators);
+    println!("Transport Open Close [1a2]: {locators:?}");
     assert_eq!(locators.len(), 1);
 
     // Open a first transport from the client to the router
@@ -137,17 +137,17 @@ async fn openclose_transport(endpoint: &EndPoint) {
 
     println!("Transport Open Close [1c1]");
     let res = ztimeout!(client01_manager.open_transport(endpoint.clone()));
-    println!("Transport Open Close [1c2]: {:?}", res);
+    println!("Transport Open Close [1c2]: {res:?}");
     assert!(res.is_ok());
     let c_ses1 = res.unwrap();
     println!("Transport Open Close [1d1]");
     let transports = client01_manager.get_transports();
-    println!("Transport Open Close [1d2]: {:?}", transports);
+    println!("Transport Open Close [1d2]: {transports:?}");
     assert_eq!(transports.len(), 1);
     assert_eq!(c_ses1.get_zid().unwrap(), router_id);
     println!("Transport Open Close [1e1]");
     let links = c_ses1.get_links().unwrap();
-    println!("Transport Open Close [1e2]: {:?}", links);
+    println!("Transport Open Close [1e2]: {links:?}");
     assert_eq!(links.len(), links_num);
 
     // Verify that the transport has been open on the router
@@ -177,17 +177,17 @@ async fn openclose_transport(endpoint: &EndPoint) {
 
     println!("\nTransport Open Close [2a1]");
     let res = ztimeout!(client01_manager.open_transport(endpoint.clone()));
-    println!("Transport Open Close [2a2]: {:?}", res);
+    println!("Transport Open Close [2a2]: {res:?}");
     assert!(res.is_ok());
     let c_ses2 = res.unwrap();
     println!("Transport Open Close [2b1]");
     let transports = client01_manager.get_transports();
-    println!("Transport Open Close [2b2]: {:?}", transports);
+    println!("Transport Open Close [2b2]: {transports:?}");
     assert_eq!(transports.len(), 1);
     assert_eq!(c_ses2.get_zid().unwrap(), router_id);
     println!("Transport Open Close [2c1]");
     let links = c_ses2.get_links().unwrap();
-    println!("Transport Open Close [2c2]: {:?}", links);
+    println!("Transport Open Close [2c2]: {links:?}");
     assert_eq!(links.len(), links_num);
     assert_eq!(c_ses2, c_ses1);
 
@@ -214,16 +214,16 @@ async fn openclose_transport(endpoint: &EndPoint) {
     // of the maximum limit of links per transport
     println!("\nTransport Open Close [3a1]");
     let res = ztimeout!(client01_manager.open_transport(endpoint.clone()));
-    println!("Transport Open Close [3a2]: {:?}", res);
+    println!("Transport Open Close [3a2]: {res:?}");
     assert!(res.is_err());
     println!("Transport Open Close [3b1]");
     let transports = client01_manager.get_transports();
-    println!("Transport Open Close [3b2]: {:?}", transports);
+    println!("Transport Open Close [3b2]: {transports:?}");
     assert_eq!(transports.len(), 1);
     assert_eq!(c_ses1.get_zid().unwrap(), router_id);
     println!("Transport Open Close [3c1]");
     let links = c_ses1.get_links().unwrap();
-    println!("Transport Open Close [3c2]: {:?}", links);
+    println!("Transport Open Close [3c2]: {links:?}");
     assert_eq!(links.len(), links_num);
 
     // Verify that the transport has not been open on the router
@@ -244,11 +244,11 @@ async fn openclose_transport(endpoint: &EndPoint) {
     // Close the open transport on the client
     println!("\nTransport Open Close [4a1]");
     let res = ztimeout!(c_ses1.close());
-    println!("Transport Open Close [4a2]: {:?}", res);
+    println!("Transport Open Close [4a2]: {res:?}");
     assert!(res.is_ok());
     println!("Transport Open Close [4b1]");
     let transports = client01_manager.get_transports();
-    println!("Transport Open Close [4b2]: {:?}", transports);
+    println!("Transport Open Close [4b2]: {transports:?}");
     assert_eq!(transports.len(), 0);
 
     // Verify that the transport has been closed also on the router
@@ -273,17 +273,17 @@ async fn openclose_transport(endpoint: &EndPoint) {
 
     println!("\nTransport Open Close [5a1]");
     let res = ztimeout!(client01_manager.open_transport(endpoint.clone()));
-    println!("Transport Open Close [5a2]: {:?}", res);
+    println!("Transport Open Close [5a2]: {res:?}");
     assert!(res.is_ok());
     let c_ses3 = res.unwrap();
     println!("Transport Open Close [5b1]");
     let transports = client01_manager.get_transports();
-    println!("Transport Open Close [5b2]: {:?}", transports);
+    println!("Transport Open Close [5b2]: {transports:?}");
     assert_eq!(transports.len(), 1);
     assert_eq!(c_ses3.get_zid().unwrap(), router_id);
     println!("Transport Open Close [5c1]");
     let links = c_ses3.get_links().unwrap();
-    println!("Transport Open Close [5c2]: {:?}", links);
+    println!("Transport Open Close [5c2]: {links:?}");
     assert_eq!(links.len(), links_num);
 
     // Verify that the transport has been open on the router
@@ -305,11 +305,11 @@ async fn openclose_transport(endpoint: &EndPoint) {
     // of the maximum limit of transports
     println!("\nTransport Open Close [6a1]");
     let res = ztimeout!(client02_manager.open_transport(endpoint.clone()));
-    println!("Transport Open Close [6a2]: {:?}", res);
+    println!("Transport Open Close [6a2]: {res:?}");
     assert!(res.is_err());
     println!("Transport Open Close [6b1]");
     let transports = client02_manager.get_transports();
-    println!("Transport Open Close [6b2]: {:?}", transports);
+    println!("Transport Open Close [6b2]: {transports:?}");
     assert_eq!(transports.len(), 0);
 
     // Verify that the transport has not been open on the router
@@ -330,11 +330,11 @@ async fn openclose_transport(endpoint: &EndPoint) {
     // Close the open transport on the client
     println!("\nTransport Open Close [7a1]");
     let res = ztimeout!(c_ses3.close());
-    println!("Transport Open Close [7a2]: {:?}", res);
+    println!("Transport Open Close [7a2]: {res:?}");
     assert!(res.is_ok());
     println!("Transport Open Close [7b1]");
     let transports = client01_manager.get_transports();
-    println!("Transport Open Close [7b2]: {:?}", transports);
+    println!("Transport Open Close [7b2]: {transports:?}");
     assert_eq!(transports.len(), 0);
 
     // Verify that the transport has been closed also on the router
@@ -356,16 +356,16 @@ async fn openclose_transport(endpoint: &EndPoint) {
 
     println!("\nTransport Open Close [8a1]");
     let res = ztimeout!(client02_manager.open_transport(endpoint.clone()));
-    println!("Transport Open Close [8a2]: {:?}", res);
+    println!("Transport Open Close [8a2]: {res:?}");
     assert!(res.is_ok());
     let c_ses4 = res.unwrap();
     println!("Transport Open Close [8b1]");
     let transports = client02_manager.get_transports();
-    println!("Transport Open Close [8b2]: {:?}", transports);
+    println!("Transport Open Close [8b2]: {transports:?}");
     assert_eq!(transports.len(), 1);
     println!("Transport Open Close [8c1]");
     let links = c_ses4.get_links().unwrap();
-    println!("Transport Open Close [8c2]: {:?}", links);
+    println!("Transport Open Close [8c2]: {links:?}");
     assert_eq!(links.len(), links_num);
 
     // Verify that the transport has been open on the router
@@ -391,11 +391,11 @@ async fn openclose_transport(endpoint: &EndPoint) {
     // Close the open transport on the client
     println!("Transport Open Close [9a1]");
     let res = ztimeout!(c_ses4.close());
-    println!("Transport Open Close [9a2]: {:?}", res);
+    println!("Transport Open Close [9a2]: {res:?}");
     assert!(res.is_ok());
     println!("Transport Open Close [9b1]");
     let transports = client02_manager.get_transports();
-    println!("Transport Open Close [9b2]: {:?}", transports);
+    println!("Transport Open Close [9b2]: {transports:?}");
     assert_eq!(transports.len(), 0);
 
     // Verify that the transport has been closed also on the router
@@ -414,7 +414,7 @@ async fn openclose_transport(endpoint: &EndPoint) {
     // Perform clean up of the open locators
     println!("\nTransport Open Close [10a1]");
     let res = ztimeout!(router_manager.del_listener(endpoint));
-    println!("Transport Open Close [10a2]: {:?}", res);
+    println!("Transport Open Close [10a2]: {res:?}");
     assert!(res.is_ok());
 
     ztimeout!(async {
@@ -480,10 +480,10 @@ fn openclose_unix_only() {
 
     let f1 = "zenoh-test-unix-socket-9.sock";
     let _ = std::fs::remove_file(f1);
-    let endpoint: EndPoint = format!("unixsock-stream/{}", f1).parse().unwrap();
+    let endpoint: EndPoint = format!("unixsock-stream/{f1}").parse().unwrap();
     task::block_on(openclose_transport(&endpoint));
     let _ = std::fs::remove_file(f1);
-    let _ = std::fs::remove_file(format!("{}.lock", f1));
+    let _ = std::fs::remove_file(format!("{f1}.lock"));
 }
 
 #[cfg(feature = "transport_tls")]

--- a/io/zenoh-transport/tests/unicast_shm.rs
+++ b/io/zenoh-transport/tests/unicast_shm.rs
@@ -120,7 +120,7 @@ mod tests {
             let msg_count = u64::from_le_bytes(count_bytes) as usize;
             let sex_count = self.count.fetch_add(1, Ordering::SeqCst);
             assert_eq!(msg_count, sex_count);
-            print!("{} ", msg_count);
+            print!("{msg_count} ");
 
             Ok(())
         }
@@ -136,7 +136,7 @@ mod tests {
     }
 
     async fn run(endpoint: &EndPoint) {
-        println!("Transport SHM [0a]: {:?}", endpoint);
+        println!("Transport SHM [0a]: {endpoint:?}");
 
         // Define client and router IDs
         let peer_shm01 = ZenohId::try_from([1]).unwrap();

--- a/io/zenoh-transport/tests/unicast_simultaneous.rs
+++ b/io/zenoh-transport/tests/unicast_simultaneous.rs
@@ -166,27 +166,21 @@ mod tests {
         // Add the endpoints on the peer01
         for e in endpoint01.iter() {
             let res = ztimeout!(peer01_manager.add_listener(e.clone()));
-            println!("[Simultaneous 01a] => Adding endpoint {:?}: {:?}", e, res);
+            println!("[Simultaneous 01a] => Adding endpoint {e:?}: {res:?}");
             assert!(res.is_ok());
         }
         let locs = peer01_manager.get_listeners();
-        println!(
-            "[Simultaneous 01b] => Getting endpoints: {:?} {:?}",
-            endpoint01, locs
-        );
+        println!("[Simultaneous 01b] => Getting endpoints: {endpoint01:?} {locs:?}");
         assert_eq!(endpoint01.len(), locs.len());
 
         // Add the endpoints on peer02
         for e in endpoint02.iter() {
             let res = ztimeout!(peer02_manager.add_listener(e.clone()));
-            println!("[Simultaneous 02a] => Adding endpoint {:?}: {:?}", e, res);
+            println!("[Simultaneous 02a] => Adding endpoint {e:?}: {res:?}");
             assert!(res.is_ok());
         }
         let locs = peer02_manager.get_listeners();
-        println!(
-            "[Simultaneous 02b] => Getting endpoints: {:?} {:?}",
-            endpoint02, locs
-        );
+        println!("[Simultaneous 02b] => Getting endpoints: {endpoint02:?} {locs:?}");
         assert_eq!(endpoint02.len(), locs.len());
 
         // Endpoints
@@ -199,13 +193,13 @@ mod tests {
             // Open the transport with the second peer
             // These open should succeed
             for e in c_ep02.iter() {
-                println!("[Simultaneous 01c] => Opening transport with {:?}...", e);
+                println!("[Simultaneous 01c] => Opening transport with {e:?}...");
                 let _ = ztimeout!(c_p01m.open_transport(e.clone())).unwrap();
             }
 
             // These open should fails
             for e in c_ep02.iter() {
-                println!("[Simultaneous 01d] => Exceeding transport with {:?}...", e);
+                println!("[Simultaneous 01d] => Exceeding transport with {e:?}...");
                 let res = ztimeout!(c_p01m.open_transport(e.clone()));
                 assert!(res.is_err());
             }
@@ -243,7 +237,7 @@ mod tests {
                 while check != MSG_COUNT {
                     task::sleep(SLEEP).await;
                     check = peer_sh01.get_count();
-                    println!("[Simultaneous 01g] => Received {:?}/{:?}", check, MSG_COUNT);
+                    println!("[Simultaneous 01g] => Received {check:?}/{MSG_COUNT:?}");
                 }
             });
         });
@@ -254,13 +248,13 @@ mod tests {
             // Open the transport with the first peer
             // These open should succeed
             for e in c_ep01.iter() {
-                println!("[Simultaneous 02c] => Opening transport with {:?}...", e);
+                println!("[Simultaneous 02c] => Opening transport with {e:?}...");
                 let _ = ztimeout!(c_p02m.open_transport(e.clone())).unwrap();
             }
 
             // These open should fails
             for e in c_ep01.iter() {
-                println!("[Simultaneous 02d] => Exceeding transport with {:?}...", e);
+                println!("[Simultaneous 02d] => Exceeding transport with {e:?}...");
                 let res = ztimeout!(c_p02m.open_transport(e.clone()));
                 assert!(res.is_err());
             }
@@ -298,7 +292,7 @@ mod tests {
                 while check != MSG_COUNT {
                     task::sleep(SLEEP).await;
                     check = peer_sh02.get_count();
-                    println!("[Simultaneous 02g] => Received {:?}/{:?}", check, MSG_COUNT);
+                    println!("[Simultaneous 02g] => Received {check:?}/{MSG_COUNT:?}");
                 }
             });
         });

--- a/io/zenoh-transport/tests/unicast_transport.rs
+++ b/io/zenoh-transport/tests/unicast_transport.rs
@@ -351,7 +351,7 @@ async fn open_transport(
 
     // Create the listener on the router
     for e in server_endpoints.iter() {
-        println!("Add endpoint: {}\n", e);
+        println!("Add endpoint: {e}\n");
         let _ = ztimeout!(router_manager.add_listener(e.clone())).unwrap();
     }
 
@@ -367,7 +367,7 @@ async fn open_transport(
     // Create an empty transport with the client
     // Open transport -> This should be accepted
     for e in client_endpoints.iter() {
-        println!("Opening transport with {}", e);
+        println!("Opening transport with {e}");
         let _ = ztimeout!(client_manager.open_transport(e.clone())).unwrap();
     }
 
@@ -391,9 +391,9 @@ async fn close_transport(
     // Close the client transport
     let mut ee = String::new();
     for e in endpoints.iter() {
-        let _ = write!(ee, "{} ", e);
+        let _ = write!(ee, "{e} ");
     }
-    println!("Closing transport with {}", ee);
+    println!("Closing transport with {ee}");
     ztimeout!(client_transport.close()).unwrap();
 
     ztimeout!(async {
@@ -404,7 +404,7 @@ async fn close_transport(
 
     // Stop the locators on the manager
     for e in endpoints.iter() {
-        println!("Del locator: {}", e);
+        println!("Del locator: {e}");
         ztimeout!(router_manager.del_listener(e)).unwrap();
     }
 
@@ -448,10 +448,7 @@ async fn test_transport(
         attachment,
     );
 
-    println!(
-        "Sending {} messages... {:?} {}",
-        MSG_COUNT, channel, msg_size
-    );
+    println!("Sending {MSG_COUNT} messages... {channel:?} {msg_size}");
     for _ in 0..MSG_COUNT {
         client_transport.schedule(message.clone()).unwrap();
     }
@@ -604,7 +601,7 @@ fn transport_unicast_unix_only() {
     let f1 = "zenoh-test-unix-socket-5.sock";
     let _ = std::fs::remove_file(f1);
     // Define the locator
-    let endpoints: Vec<EndPoint> = vec![format!("unixsock-stream/{}", f1).parse().unwrap()];
+    let endpoints: Vec<EndPoint> = vec![format!("unixsock-stream/{f1}").parse().unwrap()];
     // Define the reliability and congestion control
     let channel = [
         Channel {
@@ -619,7 +616,7 @@ fn transport_unicast_unix_only() {
     // Run
     task::block_on(run(&endpoints, &endpoints, &channel, &MSG_SIZE_ALL));
     let _ = std::fs::remove_file(f1);
-    let _ = std::fs::remove_file(format!("{}.lock", f1));
+    let _ = std::fs::remove_file(format!("{f1}.lock"));
 }
 
 #[cfg(feature = "transport_ws")]
@@ -706,7 +703,7 @@ fn transport_unicast_tcp_unix() {
     let endpoints: Vec<EndPoint> = vec![
         format!("tcp/127.0.0.1:{}", 16040).parse().unwrap(),
         format!("tcp/[::1]:{}", 16041).parse().unwrap(),
-        format!("unixsock-stream/{}", f1).parse().unwrap(),
+        format!("unixsock-stream/{f1}").parse().unwrap(),
     ];
     // Define the reliability and congestion control
     let channel = [
@@ -722,7 +719,7 @@ fn transport_unicast_tcp_unix() {
     // Run
     task::block_on(run(&endpoints, &endpoints, &channel, &MSG_SIZE_ALL));
     let _ = std::fs::remove_file(f1);
-    let _ = std::fs::remove_file(format!("{}.lock", f1));
+    let _ = std::fs::remove_file(format!("{f1}.lock"));
 }
 
 #[cfg(all(
@@ -743,7 +740,7 @@ fn transport_unicast_udp_unix() {
     let endpoints: Vec<EndPoint> = vec![
         format!("udp/127.0.0.1:{}", 16050).parse().unwrap(),
         format!("udp/[::1]:{}", 16051).parse().unwrap(),
-        format!("unixsock-stream/{}", f1).parse().unwrap(),
+        format!("unixsock-stream/{f1}").parse().unwrap(),
     ];
     // Define the reliability and congestion control
     let channel = [
@@ -759,7 +756,7 @@ fn transport_unicast_udp_unix() {
     // Run
     task::block_on(run(&endpoints, &endpoints, &channel, &MSG_SIZE_NOFRAG));
     let _ = std::fs::remove_file(f1);
-    let _ = std::fs::remove_file(format!("{}.lock", f1));
+    let _ = std::fs::remove_file(format!("{f1}.lock"));
 }
 
 #[cfg(all(
@@ -783,7 +780,7 @@ fn transport_unicast_tcp_udp_unix() {
         format!("udp/127.0.0.1:{}", 16061).parse().unwrap(),
         format!("tcp/[::1]:{}", 16062).parse().unwrap(),
         format!("udp/[::1]:{}", 16063).parse().unwrap(),
-        format!("unixsock-stream/{}", f1).parse().unwrap(),
+        format!("unixsock-stream/{f1}").parse().unwrap(),
     ];
     // Define the reliability and congestion control
     let channel = [
@@ -799,7 +796,7 @@ fn transport_unicast_tcp_udp_unix() {
     // Run
     task::block_on(run(&endpoints, &endpoints, &channel, &MSG_SIZE_NOFRAG));
     let _ = std::fs::remove_file(f1);
-    let _ = std::fs::remove_file(format!("{}.lock", f1));
+    let _ = std::fs::remove_file(format!("{f1}.lock"));
 }
 
 #[cfg(all(feature = "transport_tls", target_family = "unix"))]

--- a/plugins/zenoh-plugin-rest/examples/z_serve_sse.rs
+++ b/plugins/zenoh-plugin-rest/examples/z_serve_sse.rs
@@ -42,7 +42,7 @@ async fn main() {
     println!("Opening session...");
     let session = zenoh::open(config).res().await.unwrap();
 
-    println!("Declaring Queryable on '{}'...", key);
+    println!("Declaring Queryable on '{key}'...");
     let queryable = session.declare_queryable(key).res().await.unwrap();
 
     async_std::task::spawn({
@@ -60,7 +60,7 @@ async fn main() {
 
     let event_key = [key, "/event"].concat();
 
-    println!("Declaring Publisher on '{}'...", event_key);
+    println!("Declaring Publisher on '{event_key}'...");
     let publisher = session
         .declare_publisher(&event_key)
         .congestion_control(CongestionControl::Block)
@@ -73,10 +73,7 @@ async fn main() {
         &event_key, value
     );
 
-    println!(
-        "Data updates are accessible through HTML5 SSE at http://<hostname>:8000/{}",
-        key
-    );
+    println!("Data updates are accessible through HTML5 SSE at http://<hostname>:8000/{key}");
     loop {
         publisher
             .put(Value::from(value).encoding(KnownEncoding::TextPlain.into()))

--- a/plugins/zenoh-plugin-rest/src/config.rs
+++ b/plugins/zenoh-plugin-rest/src/config.rs
@@ -52,7 +52,7 @@ impl<'de> Visitor<'de> for HttpPortVisitor {
     where
         E: de::Error,
     {
-        Ok(format!("{}:{}", DEFAULT_HTTP_INTERFACE, value))
+        Ok(format!("{DEFAULT_HTTP_INTERFACE}:{value}"))
     }
 
     fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
@@ -71,6 +71,6 @@ impl<'de> Visitor<'de> for HttpPortVisitor {
         if port.parse::<u32>().is_err() {
             return Err(E::invalid_value(Unexpected::Str(port), &self));
         }
-        Ok(format!("{}:{}", interface, port))
+        Ok(format!("{interface}:{port}"))
     }
 }

--- a/plugins/zenoh-plugin-rest/src/lib.rs
+++ b/plugins/zenoh-plugin-rest/src/lib.rs
@@ -99,7 +99,7 @@ async fn to_json(results: flume::Receiver<Reply>) -> String {
         .collect::<Vec<String>>()
         .await
         .join(",\n");
-    format!("[\n{}\n]\n", values)
+    format!("[\n{values}\n]\n")
 }
 
 fn sample_to_html(sample: Sample) -> String {
@@ -129,7 +129,7 @@ async fn to_html(results: flume::Receiver<Reply>) -> String {
         .collect::<Vec<String>>()
         .await
         .join("\n");
-    format!("<dl>\n{}\n</dl>\n", values)
+    format!("<dl>\n{values}\n</dl>\n")
 }
 
 fn method_to_kind(method: Method) -> SampleKind {
@@ -462,9 +462,9 @@ pub async fn run(runtime: Runtime, conf: Config) {
 fn path_to_key_expr<'a>(path: &'a str, zid: &str) -> ZResult<KeyExpr<'a>> {
     let path = path.strip_prefix('/').unwrap_or(path);
     if path == "@/router/local" {
-        KeyExpr::try_from(format!("@/router/{}", zid))
+        KeyExpr::try_from(format!("@/router/{zid}"))
     } else if let Some(suffix) = path.strip_prefix("@/router/local/") {
-        KeyExpr::try_from(format!("@/router/{}/{}", zid, suffix))
+        KeyExpr::try_from(format!("@/router/{zid}/{suffix}"))
     } else {
         KeyExpr::try_from(path)
     }

--- a/plugins/zenoh-plugin-storage-manager/src/storages_mgt.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/storages_mgt.rs
@@ -43,7 +43,7 @@ pub(crate) async fn start_storage(
     let parts: Vec<&str> = admin_key.split('/').collect();
     let uuid = parts[2];
     let storage_name = parts[7];
-    let name = format!("{}/{}", uuid, storage_name);
+    let name = format!("{uuid}/{storage_name}");
 
     trace!("Start storage {} on {}", name, config.key_expr);
 

--- a/zenoh-ext/examples/z_member.rs
+++ b/zenoh-ext/examples/z_member.rs
@@ -36,7 +36,7 @@ async fn main() {
         println!(
             "{}",
             v.iter()
-                .fold(String::from("\n"), |a, b| format!("\t{} \n\t{:?}", a, b)),
+                .fold(String::from("\n"), |a, b| format!("\t{a} \n\t{b:?}")),
         );
         println!(">>>>>>><<<<<<<<<");
     }

--- a/zenoh-ext/examples/z_pub_cache.rs
+++ b/zenoh-ext/examples/z_pub_cache.rs
@@ -39,7 +39,7 @@ async fn main() {
 
     for idx in 0..u32::MAX {
         sleep(Duration::from_secs(1)).await;
-        let buf = format!("[{:4}] {}", idx, value);
+        let buf = format!("[{idx:4}] {value}");
         println!("Put Data ('{}': '{}')", &key_expr, buf);
         session.put(&key_expr, buf).res().await.unwrap();
     }

--- a/zenoh-ext/examples/z_view_size.rs
+++ b/zenoh-ext/examples/z_view_size.rs
@@ -34,19 +34,18 @@ async fn main() {
         .await
         .unwrap();
     println!(
-        "Member {} waiting for {} members in group {} for {} seconds...",
-        member_id, size, group_name, timeout
+        "Member {member_id} waiting for {size} members in group {group_name} for {timeout} seconds..."
     );
     if group
         .wait_for_view_size(size, Duration::from_secs(timeout))
         .await
     {
-        println!("Established view size of {} with members:", size);
+        println!("Established view size of {size} with members:");
         for m in group.view().await {
             println!(" - {}", m.id());
         }
     } else {
-        println!("Failed to establish view size of {}", size);
+        println!("Failed to establish view size of {size}");
     }
 }
 

--- a/zenoh-ext/src/group.rs
+++ b/zenoh-ext/src/group.rs
@@ -163,6 +163,18 @@ struct GroupState {
 
 pub struct Group {
     state: Arc<GroupState>,
+    tasks: Vec<JoinHandle<()>>,
+}
+
+impl Drop for Group {
+    fn drop(&mut self) {
+        // cancel background tasks
+        async_std::task::block_on(async {
+            while let Some(handle) = self.tasks.pop() {
+                let _ = handle.cancel().await;
+            }
+        });
+    }
 }
 
 async fn keep_alive_task(state: Arc<GroupState>) {
@@ -360,7 +372,7 @@ impl Group {
             bail!("Group ID is not allowed to contain wildcards: {}", group);
         }
 
-        let event_expr = format!("{}/{}/{}", GROUP_PREFIX, group, EVENT_POSTFIX);
+        let event_expr = format!("{GROUP_PREFIX}/{group}/{EVENT_POSTFIX}");
         let publisher = z
             .declare_publisher(event_expr)
             .priority(with.priority)
@@ -387,10 +399,13 @@ impl Group {
         if is_auto_liveliness {
             async_std::task::spawn(keep_alive_task(state.clone()));
         }
-        let _ = async_std::task::spawn(net_event_handler(z.clone(), state.clone()));
-        let _ = async_std::task::spawn(query_handler(z.clone(), state.clone()));
-        let _ = spawn_watchdog(state.clone(), Duration::from_secs(1));
-        Ok(Group { state })
+        let events_task = async_std::task::spawn(net_event_handler(z.clone(), state.clone()));
+        let queries_task = async_std::task::spawn(query_handler(z.clone(), state.clone()));
+        let watchdog_task = spawn_watchdog(state.clone(), Duration::from_secs(1));
+        Ok(Group {
+            state,
+            tasks: Vec::from([events_task, queries_task, watchdog_task]),
+        })
     }
 
     /// Returns a receivers that will allow to receive notifications for group events.

--- a/zenoh/src/key_expr.rs
+++ b/zenoh/src/key_expr.rs
@@ -230,7 +230,7 @@ impl<'a> KeyExpr<'a> {
         if self.ends_with('*') && s.starts_with('*') {
             bail!("Tried to concatenate {} (ends with *) and {} (starts with *), which would likely have caused bugs. If you're sure you want to do this, concatenate these into a string and then try to convert.", self, s)
         }
-        let r = OwnedKeyExpr::try_from(format!("{}{}", self, s))?;
+        let r = OwnedKeyExpr::try_from(format!("{self}{s}"))?;
         if let KeyExprInner::Wire {
             expr_id,
             prefix_len,

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -66,7 +66,7 @@ enum PluginDiff {
 impl AdminSpace {
     pub async fn start(runtime: &Runtime, plugins_mgr: plugins::PluginsManager, version: String) {
         let zid_str = runtime.zid.to_string();
-        let root_key: OwnedKeyExpr = format!("@/router/{}", zid_str).try_into().unwrap();
+        let root_key: OwnedKeyExpr = format!("@/router/{zid_str}").try_into().unwrap();
 
         let mut handlers: HashMap<_, Arc<Handler>> = HashMap::new();
         handlers.insert(

--- a/zenoh/src/selector.rs
+++ b/zenoh/src/selector.rs
@@ -160,7 +160,7 @@ impl<'a> Selector<'a> {
             selector.push('&')
         }
         use std::fmt::Write;
-        write!(selector, "{}={}", TIME_RANGE_KEY, time_range).unwrap(); // This unwrap is safe because `String: Write` should be infallibe.
+        write!(selector, "{TIME_RANGE_KEY}={time_range}").unwrap(); // This unwrap is safe because `String: Write` should be infallibe.
     }
 
     pub fn remove_time_range(&mut self) {
@@ -437,7 +437,7 @@ impl<'a, K: Borrow<str> + Hash + Eq + 'a, V: Borrow<str> + 'a> Parameters<'a> fo
 
 impl std::fmt::Debug for Selector<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "sel\"{}\"", self)
+        write!(f, "sel\"{self}\"")
     }
 }
 

--- a/zenoh/tests/events.rs
+++ b/zenoh/tests/events.rs
@@ -54,12 +54,12 @@ fn zenoh_events() {
         let session = open_session(&["tcp/127.0.0.1:18447"], &[]).await;
         let zid = session.zid();
         let sub1 = session
-            .declare_subscriber(format!("@/session/{}/transport/unicast/*", zid))
+            .declare_subscriber(format!("@/session/{zid}/transport/unicast/*"))
             .res()
             .await
             .unwrap();
         let sub2 = session
-            .declare_subscriber(format!("@/session/{}/transport/unicast/*/link/*", zid))
+            .declare_subscriber(format!("@/session/{zid}/transport/unicast/*/link/*"))
             .res()
             .await
             .unwrap();
@@ -70,20 +70,17 @@ fn zenoh_events() {
         let sample = ztimeout!(sub1.recv_async());
         assert!(sample.is_ok());
         let key_expr = sample.as_ref().unwrap().key_expr.as_str();
-        assert!(key_expr.eq(&format!("@/session/{}/transport/unicast/{}", zid, zid2)));
+        assert!(key_expr.eq(&format!("@/session/{zid}/transport/unicast/{zid2}")));
         assert!(sample.as_ref().unwrap().kind == SampleKind::Put);
 
         let sample = ztimeout!(sub2.recv_async());
         assert!(sample.is_ok());
         let key_expr = sample.as_ref().unwrap().key_expr.as_str();
-        assert!(key_expr.starts_with(&format!(
-            "@/session/{}/transport/unicast/{}/link/",
-            zid, zid2
-        )));
+        assert!(key_expr.starts_with(&format!("@/session/{zid}/transport/unicast/{zid2}/link/")));
         assert!(sample.as_ref().unwrap().kind == SampleKind::Put);
 
         let replies: Vec<Reply> = ztimeout!(session
-            .get(format!("@/session/{}/transport/unicast/*", zid))
+            .get(format!("@/session/{zid}/transport/unicast/*"))
             .res_async())
         .unwrap()
         .into_iter()
@@ -91,10 +88,10 @@ fn zenoh_events() {
         assert!(replies.len() == 1);
         assert!(replies[0].sample.is_ok());
         let key_expr = replies[0].sample.as_ref().unwrap().key_expr.as_str();
-        assert!(key_expr.eq(&format!("@/session/{}/transport/unicast/{}", zid, zid2)));
+        assert!(key_expr.eq(&format!("@/session/{zid}/transport/unicast/{zid2}")));
 
         let replies: Vec<Reply> = ztimeout!(session
-            .get(format!("@/session/{}/transport/unicast/*/link/*", zid))
+            .get(format!("@/session/{zid}/transport/unicast/*/link/*"))
             .res_async())
         .unwrap()
         .into_iter()
@@ -102,26 +99,20 @@ fn zenoh_events() {
         assert!(replies.len() == 1);
         assert!(replies[0].sample.is_ok());
         let key_expr = replies[0].sample.as_ref().unwrap().key_expr.as_str();
-        assert!(key_expr.starts_with(&format!(
-            "@/session/{}/transport/unicast/{}/link/",
-            zid, zid2
-        )));
+        assert!(key_expr.starts_with(&format!("@/session/{zid}/transport/unicast/{zid2}/link/")));
 
         close_session(session2).await;
 
         let sample = ztimeout!(sub1.recv_async());
         assert!(sample.is_ok());
         let key_expr = sample.as_ref().unwrap().key_expr.as_str();
-        assert!(key_expr.eq(&format!("@/session/{}/transport/unicast/{}", zid, zid2)));
+        assert!(key_expr.eq(&format!("@/session/{zid}/transport/unicast/{zid2}")));
         assert!(sample.as_ref().unwrap().kind == SampleKind::Delete);
 
         let sample = ztimeout!(sub2.recv_async());
         assert!(sample.is_ok());
         let key_expr = sample.as_ref().unwrap().key_expr.as_str();
-        assert!(key_expr.starts_with(&format!(
-            "@/session/{}/transport/unicast/{}/link/",
-            zid, zid2
-        )));
+        assert!(key_expr.starts_with(&format!("@/session/{zid}/transport/unicast/{zid2}/link/")));
         assert!(sample.as_ref().unwrap().kind == SampleKind::Delete);
 
         sub2.undeclare().res().await.unwrap();

--- a/zenoh/tests/session.rs
+++ b/zenoh/tests/session.rs
@@ -85,10 +85,7 @@ async fn test_session_pubsub(peer01: &Session, peer02: &Session) {
         task::sleep(SLEEP).await;
 
         // Put data
-        println!(
-            "[PS][02b] Putting on peer02 session. {} msgs of {} bytes.",
-            MSG_COUNT, size
-        );
+        println!("[PS][02b] Putting on peer02 session. {MSG_COUNT} msgs of {size} bytes.");
         for _ in 0..MSG_COUNT {
             ztimeout!(peer02
                 .put(key_expr, vec![0u8; size])
@@ -100,7 +97,7 @@ async fn test_session_pubsub(peer01: &Session, peer02: &Session) {
         ztimeout!(async {
             loop {
                 let cnt = msgs.load(Ordering::SeqCst);
-                println!("[PS][03b] Received {}/{}.", cnt, MSG_COUNT);
+                println!("[PS][03b] Received {cnt}/{MSG_COUNT}.");
                 if cnt < MSG_COUNT {
                     task::sleep(SLEEP).await;
                 } else {
@@ -142,7 +139,7 @@ async fn test_session_qryrep(peer01: &Session, peer02: &Session) {
         task::sleep(SLEEP).await;
 
         // Get data
-        println!("[QR][02c] Getting on peer02 session. {} msgs.", MSG_COUNT);
+        println!("[QR][02c] Getting on peer02 session. {MSG_COUNT} msgs.");
         let mut cnt = 0;
         for _ in 0..MSG_COUNT {
             let rs = ztimeout!(peer02.get(key_expr).res_async()).unwrap();
@@ -151,10 +148,7 @@ async fn test_session_qryrep(peer01: &Session, peer02: &Session) {
                 cnt += 1;
             }
         }
-        println!(
-            "[QR][02c] Got on peer02 session. {}/{} msgs.",
-            cnt, MSG_COUNT
-        );
+        println!("[QR][02c] Got on peer02 session. {cnt}/{MSG_COUNT} msgs.");
         assert_eq!(msgs.load(Ordering::SeqCst), MSG_COUNT);
         assert_eq!(cnt, MSG_COUNT);
 

--- a/zenohd/src/main.rs
+++ b/zenohd/src/main.rs
@@ -99,7 +99,7 @@ clap::Arg::new("adminspace-permissions").long("adminspace-permissions").value_na
         let runtime = match Runtime::new(config).await {
             Ok(runtime) => runtime,
             Err(e) => {
-                println!("{}. Exiting...", e);
+                println!("{e}. Exiting...");
                 std::process::exit(-1);
             }
         };
@@ -155,7 +155,7 @@ fn config_from_args(args: &ArgMatches) -> Config {
         let value = args.value_of("rest-http-port").unwrap();
         if !value.eq_ignore_ascii_case("none") {
             config
-                .insert_json5("plugins/rest/http_port", &format!(r#""{}""#, value))
+                .insert_json5("plugins/rest/http_port", &format!(r#""{value}""#))
                 .unwrap();
         }
     }
@@ -169,17 +169,14 @@ fn config_from_args(args: &ArgMatches) -> Config {
             match plugin.split_once(':') {
                 Some((name, path)) => {
                     config
-                        .insert_json5(&format!("plugins/{}/__required__", name), "true")
+                        .insert_json5(&format!("plugins/{name}/__required__"), "true")
                         .unwrap();
                     config
-                        .insert_json5(
-                            &format!("plugins/{}/__path__", name),
-                            &format!("\"{}\"", path),
-                        )
+                        .insert_json5(&format!("plugins/{name}/__path__"), &format!("\"{path}\""))
                         .unwrap();
                 }
                 None => config
-                    .insert_json5(&format!("plugins/{}/__required__", plugin), "true")
+                    .insert_json5(&format!("plugins/{plugin}/__required__"), "true")
                     .unwrap(),
             }
         }


### PR DESCRIPTION
Trivial (automatic) fixes about `format!("{}")` usage.
Plus a less trivial one in `zenoh-ext/src/group.rs`.