### PR TITLE
Remove `defmt` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,35 +897,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "defmt"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a0ae7494d9bff013d7b89471f4c424356a71e9752e0c78abe7e6c608a16bb3"
-dependencies = [
- "bitflags",
- "defmt-macros",
-]
-
-[[package]]
-name = "defmt-macros"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8500cbe4cca056412efce4215a63d0bc20492942aeee695f23b624a53e0a6854"
-dependencies = [
- "defmt-parser",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "defmt-parser"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0db23d29972d99baa3de2ee2ae3f104c10564a6d05a346eb3f4c4f2c0525a06e"
-
-[[package]]
 name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2209,30 +2180,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro-hack"
 version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3311,7 +3258,6 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d291a7454d390b753ef68df8145da18367e32883ec2fa863959f0aefb915cdb"
 dependencies = [
- "defmt",
  "hex",
  "humantime",
  "lazy_static",
@@ -3817,7 +3763,6 @@ dependencies = [
 name = "zenoh-buffers"
 version = "0.7.0-rc"
 dependencies = [
- "defmt",
  "rand 0.8.5",
  "zenoh-collections",
 ]
@@ -3846,9 +3791,6 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "0.7.0-rc"
-dependencies = [
- "defmt",
-]
 
 [[package]]
 name = "zenoh-config"
@@ -4183,7 +4125,6 @@ dependencies = [
 name = "zenoh-protocol"
 version = "0.7.0-rc"
 dependencies = [
- "defmt",
  "hex",
  "lazy_static",
  "rand 0.8.5",
@@ -4200,7 +4141,6 @@ name = "zenoh-result"
 version = "0.7.0-rc"
 dependencies = [
  "anyhow",
- "defmt",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,6 @@ bincode = "1.3.3"
 clap = "3.2.23"
 crc = "3.0.0"
 criterion = "0.4.0"
-defmt = { version = "0.3.2", features = ["alloc"] }
 derive_more = "0.99.17"
 derive-new = "0.5.9"
 env_logger = "0.10.0"

--- a/commons/zenoh-buffers/Cargo.toml
+++ b/commons/zenoh-buffers/Cargo.toml
@@ -26,9 +26,7 @@ description = "Internal crate for zenoh."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 test = ["rand"]
-defmt = ["dep:defmt", "zenoh-collections/defmt"]
 
 [dependencies]
-defmt = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 zenoh-collections = { path = "../zenoh-collections/", default-features = false }

--- a/commons/zenoh-buffers/src/bbuf.rs
+++ b/commons/zenoh-buffers/src/bbuf.rs
@@ -20,7 +20,6 @@ use alloc::boxed::Box;
 use core::num::NonZeroUsize;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct BBuf {
     buffer: Box<[u8]>,
     len: usize,

--- a/commons/zenoh-buffers/src/lib.rs
+++ b/commons/zenoh-buffers/src/lib.rs
@@ -32,7 +32,6 @@ pub mod writer {
     use core::num::NonZeroUsize;
 
     #[derive(Debug, Clone, Copy)]
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct DidntWrite;
 
     pub trait Writer {
@@ -75,7 +74,6 @@ pub mod reader {
     use core::num::NonZeroUsize;
 
     #[derive(Debug, Clone, Copy)]
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct DidntRead;
 
     pub trait Reader {
@@ -116,7 +114,6 @@ pub mod reader {
     }
 
     #[derive(Debug, Clone, Copy)]
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct DidntSiphon;
 
     pub trait SiphonableReader: Reader {

--- a/commons/zenoh-buffers/src/zbuf.rs
+++ b/commons/zenoh-buffers/src/zbuf.rs
@@ -25,7 +25,6 @@ fn get_mut_unchecked<T>(arc: &mut Arc<T>) -> &mut T {
 }
 
 #[derive(Debug, Clone, Default, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ZBuf {
     slices: SingleOrVec<ZSlice>,
 }
@@ -124,14 +123,12 @@ where
 
 // Reader
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ZBufPos {
     slice: usize,
     byte: usize,
 }
 
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ZBufReader<'a> {
     inner: &'a ZBuf,
     cursor: ZBufPos,
@@ -349,7 +346,6 @@ impl Iterator for ZBufSliceIterator<'_, '_> {
 
 // Writer
 #[derive(Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ZBufWriter<'a> {
     inner: &'a mut ZBuf,
     cache: Arc<Vec<u8>>,

--- a/commons/zenoh-buffers/src/zslice.rs
+++ b/commons/zenoh-buffers/src/zslice.rs
@@ -213,13 +213,6 @@ impl fmt::Debug for ZSlice {
     }
 }
 
-#[cfg(feature = "defmt")]
-impl defmt::Format for ZSlice {
-    fn format(&self, f: defmt::Formatter) {
-        defmt::write!(f, "{:02x}", self.as_slice());
-    }
-}
-
 // From impls
 impl<T> From<Arc<T>> for ZSlice
 where

--- a/commons/zenoh-codec/Cargo.toml
+++ b/commons/zenoh-codec/Cargo.toml
@@ -40,10 +40,6 @@ shared-memory = [
     "zenoh-protocol/shared-memory"
 ]
 complete_n = ["zenoh-protocol/complete_n"]
-defmt = [
-    "zenoh-buffers/defmt",
-    "zenoh-protocol/defmt"
-]
 
 [dependencies]
 uhlc = { workspace = true }

--- a/commons/zenoh-collections/Cargo.toml
+++ b/commons/zenoh-collections/Cargo.toml
@@ -31,7 +31,5 @@ description = "Internal crate for zenoh."
 [features]
 default = ["std"]
 std = []
-defmt = ["dep:defmt"]
 
 [dependencies]
-defmt = { workspace = true, optional = true }

--- a/commons/zenoh-collections/src/single_or_vec.rs
+++ b/commons/zenoh-collections/src/single_or_vec.rs
@@ -20,7 +20,6 @@ use core::{
 };
 
 #[derive(Clone, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 enum SingleOrVecInner<T> {
     Single(T),
     Vec(Vec<T>),
@@ -82,7 +81,6 @@ where
 }
 
 #[derive(Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SingleOrVec<T>(SingleOrVecInner<T>);
 
 impl<T> SingleOrVec<T> {

--- a/commons/zenoh-protocol/Cargo.toml
+++ b/commons/zenoh-protocol/Cargo.toml
@@ -37,10 +37,8 @@ std = [
 test = ["rand", "zenoh-buffers/test"]
 shared-memory = ["std"]
 complete_n = []
-defmt = ["dep:defmt", "uhlc/defmt", "zenoh-buffers/defmt"]
 
 [dependencies]
-defmt = { workspace = true, optional = true }
 hex = { workspace = true, features = ["alloc"] }
 rand = { workspace = true, features = ["alloc", "getrandom"], optional = true }
 serde = { workspace = true, features = ["alloc"] }

--- a/commons/zenoh-protocol/src/common/attachment.rs
+++ b/commons/zenoh-protocol/src/common/attachment.rs
@@ -36,7 +36,6 @@ use zenoh_buffers::ZBuf;
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Attachment {
     pub buffer: ZBuf,
 }

--- a/commons/zenoh-protocol/src/core/cowstr.rs
+++ b/commons/zenoh-protocol/src/core/cowstr.rs
@@ -75,12 +75,6 @@ impl PartialEq for CowStr<'_> {
     }
 }
 impl Eq for CowStr<'_> {}
-#[cfg(feature = "defmt")]
-impl defmt::Format for CowStr<'_> {
-    fn format(&self, fmt: defmt::Formatter) {
-        self.as_str().format(fmt)
-    }
-}
 impl core::ops::Add<&str> for CowStr<'_> {
     type Output = String;
     fn add(self, rhs: &str) -> Self::Output {

--- a/commons/zenoh-protocol/src/core/encoding.rs
+++ b/commons/zenoh-protocol/src/core/encoding.rs
@@ -48,7 +48,6 @@ mod consts {
 
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum KnownEncoding {
     Empty = 0,
     AppOctetStream = 1,
@@ -124,7 +123,6 @@ impl AsRef<str> for KnownEncoding {
 /// A zenoh encoding is a HTTP Mime type represented, for wire efficiency,
 /// as an integer prefix (that maps to a string) and a string suffix.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Encoding {
     Exact(KnownEncoding),
     WithSuffix(KnownEncoding, CowStr<'static>),

--- a/commons/zenoh-protocol/src/core/endpoint.rs
+++ b/commons/zenoh-protocol/src/core/endpoint.rs
@@ -109,7 +109,6 @@ where
 // Protocol
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Protocol<'a>(pub(super) &'a str);
 
 impl<'a> Protocol<'a> {
@@ -132,7 +131,6 @@ impl fmt::Display for Protocol<'_> {
 
 #[repr(transparent)]
 #[derive(Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ProtocolMut<'a>(&'a mut EndPoint);
 
 impl<'a> ProtocolMut<'a> {
@@ -163,7 +161,6 @@ impl fmt::Display for ProtocolMut<'_> {
 // Address
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Address<'a>(pub(super) &'a str);
 
 impl<'a> Address<'a> {
@@ -186,7 +183,6 @@ impl fmt::Display for Address<'_> {
 
 #[repr(transparent)]
 #[derive(Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AddressMut<'a>(&'a mut EndPoint);
 
 impl<'a> AddressMut<'a> {
@@ -217,7 +213,6 @@ impl fmt::Display for AddressMut<'_> {
 // Metadata
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Metadata<'a>(pub(super) &'a str);
 
 impl<'a> Metadata<'a> {
@@ -252,7 +247,6 @@ impl fmt::Display for Metadata<'_> {
 
 #[repr(transparent)]
 #[derive(Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct MetadataMut<'a>(&'a mut EndPoint);
 
 impl<'a> MetadataMut<'a> {
@@ -320,7 +314,6 @@ impl fmt::Display for MetadataMut<'_> {
 // Config
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Config<'a>(pub(super) &'a str);
 
 impl<'a> Config<'a> {
@@ -355,7 +348,6 @@ impl fmt::Display for Config<'_> {
 
 #[repr(transparent)]
 #[derive(Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ConfigMut<'a>(&'a mut EndPoint);
 
 impl<'a> ConfigMut<'a> {
@@ -421,7 +413,6 @@ impl fmt::Display for ConfigMut<'_> {
 }
 /// A `String` that respects the [`EndPoint`] canon form: `<locator>#<config>`, such that `<locator>` is a valid [`Locator`] `<config>` is of the form `<key1>=<value1>;...;<keyN>=<valueN>` where keys are alphabetically sorted.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[serde(into = "String")]
 #[serde(try_from = "String")]
 pub struct EndPoint {

--- a/commons/zenoh-protocol/src/core/key_expr/borrowed.rs
+++ b/commons/zenoh-protocol/src/core/key_expr/borrowed.rs
@@ -45,7 +45,6 @@ use zenoh_result::{bail, Error as ZError, ZResult};
 #[allow(non_camel_case_types)]
 #[repr(transparent)]
 #[derive(PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct keyexpr(str);
 
 impl keyexpr {
@@ -308,7 +307,6 @@ impl Div for &keyexpr {
 ///
 /// You can check for intersection with `level >= SetIntersecionLevel::Intersection` and for inclusion with `level >= SetIntersectionLevel::Includes`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SetIntersectionLevel {
     Disjoint,
     Intersects,

--- a/commons/zenoh-protocol/src/core/key_expr/intersect/mod.rs
+++ b/commons/zenoh-protocol/src/core/key_expr/intersect/mod.rs
@@ -41,11 +41,9 @@ pub(crate) mod restiction {
 
     #[repr(transparent)]
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct NoBigWilds<T>(pub T);
     #[repr(transparent)]
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct NoSubWilds<T>(pub T);
 
     impl<T> Deref for NoBigWilds<T> {

--- a/commons/zenoh-protocol/src/core/key_expr/owned.rs
+++ b/commons/zenoh-protocol/src/core/key_expr/owned.rs
@@ -32,7 +32,6 @@ use core::{
 ///
 /// See [`keyexpr`](super::borrowed::keyexpr).
 #[derive(Clone, PartialEq, Eq, Hash, serde::Deserialize)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[serde(try_from = "String")]
 pub struct OwnedKeyExpr(pub(crate) Arc<str>);
 impl serde::Serialize for OwnedKeyExpr {

--- a/commons/zenoh-protocol/src/core/key_expr/utils.rs
+++ b/commons/zenoh-protocol/src/core/key_expr/utils.rs
@@ -31,7 +31,6 @@ impl Writer {
 }
 
 #[derive(Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Splitter<'a, S: ?Sized, D: ?Sized> {
     s: Option<&'a S>,
     d: &'a D,

--- a/commons/zenoh-protocol/src/core/locator.rs
+++ b/commons/zenoh-protocol/src/core/locator.rs
@@ -20,7 +20,6 @@ use zenoh_result::{Error as ZError, ZResult};
 /// A `String` that respects the [`Locator`] canon form: `<proto>/<address>[?<metadata>]`,
 /// such that `<metadata>` is of the form `<key1>=<value1>;...;<keyN>=<valueN>` where keys are alphabetically sorted.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[serde(into = "String")]
 #[serde(try_from = "String")]
 pub struct Locator(pub(super) EndPoint);

--- a/commons/zenoh-protocol/src/core/mod.rs
+++ b/commons/zenoh-protocol/src/core/mod.rs
@@ -65,7 +65,6 @@ pub mod endpoint;
 pub use endpoint::EndPoint;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Property {
     pub key: ZInt,
     pub value: Vec<u8>,
@@ -74,7 +73,6 @@ pub struct Property {
 /// The kind of a `Sample`.
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SampleKind {
     /// if the `Sample` was issued by a `put` operation.
     Put = 0,
@@ -110,7 +108,6 @@ impl TryFrom<ZInt> for SampleKind {
 
 /// The global unique id of a zenoh peer.
 #[derive(Clone, Copy, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ZenohId(uhlc::ID);
 
 impl ZenohId {
@@ -150,7 +147,6 @@ impl From<uuid::Uuid> for ZenohId {
 
 // Mimics uhlc::SizeError,
 #[derive(Debug, Clone, Copy)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SizeError(usize);
 
 #[cfg(feature = "std")]
@@ -332,7 +328,6 @@ impl<'de> serde::Deserialize<'de> for ZenohId {
 }
 
 #[derive(Debug, Copy, Clone, Eq, Hash, PartialEq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum Priority {
     Control = 0,
@@ -384,7 +379,6 @@ impl TryFrom<u8> for Priority {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum Reliability {
     BestEffort,
@@ -398,14 +392,12 @@ impl Default for Reliability {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Channel {
     pub priority: Priority,
     pub reliability: Reliability,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ConduitSnList {
     Plain(ConduitSn),
     QoS(Box<[ConduitSn; Priority::NUM]>),
@@ -444,7 +436,6 @@ impl fmt::Display for ConduitSnList {
 
 /// The kind of reliability.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ConduitSn {
     pub reliable: ZInt,
     pub best_effort: ZInt,
@@ -452,7 +443,6 @@ pub struct ConduitSn {
 
 /// The kind of congestion control.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum CongestionControl {
     Block,
@@ -467,7 +457,6 @@ impl Default for CongestionControl {
 
 /// The subscription mode.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum SubMode {
     Push,
@@ -482,14 +471,12 @@ impl Default for SubMode {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SubInfo {
     pub reliability: Reliability,
     pub mode: SubMode,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct QueryableInfo {
     pub complete: ZInt, // Default 0: incomplete
     pub distance: ZInt, // Default 0: no distance
@@ -497,7 +484,6 @@ pub struct QueryableInfo {
 
 /// The kind of consolidation.
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ConsolidationMode {
     /// No consolidation applied: multiple samples may be received for the same key-timestamp.
     None,
@@ -515,7 +501,6 @@ pub enum ConsolidationMode {
 
 /// The `zenoh::queryable::Queryable`s that should be target of a `zenoh::Session::get()`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum QueryTarget {
     BestMatching,
     All,

--- a/commons/zenoh-protocol/src/core/whatami.rs
+++ b/commons/zenoh-protocol/src/core/whatami.rs
@@ -18,7 +18,6 @@ use zenoh_result::{bail, ZError};
 
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum WhatAmI {
     Router = 1,
     Peer = 1 << 1,
@@ -131,7 +130,6 @@ impl From<WhatAmI> for ZInt {
 
 #[repr(transparent)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct WhatAmIMatcher(pub NonZeroU8);
 
 impl WhatAmIMatcher {

--- a/commons/zenoh-protocol/src/core/wire_expr.rs
+++ b/commons/zenoh-protocol/src/core/wire_expr.rs
@@ -47,7 +47,6 @@ use zenoh_result::{bail, ZResult};
 // +---------------+
 //
 #[derive(PartialEq, Eq, Hash, Clone)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct WireExpr<'a> {
     pub scope: ExprId, // 0 marks global scope
     pub suffix: Cow<'a, str>,

--- a/commons/zenoh-protocol/src/scouting/hello.rs
+++ b/commons/zenoh-protocol/src/scouting/hello.rs
@@ -48,7 +48,6 @@ use core::fmt;
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Hello {
     pub zid: Option<ZenohId>,
     pub whatami: WhatAmI,

--- a/commons/zenoh-protocol/src/scouting/mod.rs
+++ b/commons/zenoh-protocol/src/scouting/mod.rs
@@ -24,14 +24,12 @@ pub use scout::*;
 
 // Zenoh messages at scouting level
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ScoutingBody {
     Scout(Scout),
     Hello(Hello),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ScoutingMessage {
     pub body: ScoutingBody,
     pub attachment: Option<Attachment>,

--- a/commons/zenoh-protocol/src/scouting/scout.rs
+++ b/commons/zenoh-protocol/src/scouting/scout.rs
@@ -32,7 +32,6 @@ use crate::core::whatami::WhatAmIMatcher;
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Scout {
     pub what: Option<WhatAmIMatcher>,
     pub zid_request: bool,

--- a/commons/zenoh-protocol/src/transport/close.rs
+++ b/commons/zenoh-protocol/src/transport/close.rs
@@ -41,7 +41,6 @@ use crate::core::ZenohId;
 ///           the transport's lease period expires.
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Close {
     pub zid: Option<ZenohId>,
     pub reason: u8,

--- a/commons/zenoh-protocol/src/transport/frame.rs
+++ b/commons/zenoh-protocol/src/transport/frame.rs
@@ -52,7 +52,6 @@ use zenoh_buffers::ZSlice;
 ///       place at this stage. Then, the F bit is used to detect the last fragment during re-ordering.
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Frame {
     pub channel: Channel,
     pub sn: ZInt,
@@ -60,7 +59,6 @@ pub struct Frame {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum FramePayload {
     /// ```text
     /// The Payload of a fragmented Frame.
@@ -141,7 +139,6 @@ impl Frame {
 
 // FrameHeader
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum FrameKind {
     Messages,
@@ -150,7 +147,6 @@ pub enum FrameKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct FrameHeader {
     pub channel: Channel,
     pub sn: ZInt,

--- a/commons/zenoh-protocol/src/transport/init.rs
+++ b/commons/zenoh-protocol/src/transport/init.rs
@@ -51,7 +51,6 @@ use zenoh_buffers::ZSlice;
 /// - if Q==1 then the initiator/responder support QoS.
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct InitSyn {
     pub version: u8,
     pub whatami: WhatAmI,
@@ -89,7 +88,6 @@ impl InitSyn {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct InitAck {
     pub whatami: WhatAmI,
     pub zid: ZenohId,

--- a/commons/zenoh-protocol/src/transport/join.rs
+++ b/commons/zenoh-protocol/src/transport/join.rs
@@ -53,7 +53,6 @@ use core::time::Duration;
 ///
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Join {
     pub version: u8,
     pub whatami: WhatAmI,

--- a/commons/zenoh-protocol/src/transport/keepalive.rs
+++ b/commons/zenoh-protocol/src/transport/keepalive.rs
@@ -33,7 +33,6 @@ use crate::core::ZenohId;
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct KeepAlive {
     pub zid: Option<ZenohId>,
 }

--- a/commons/zenoh-protocol/src/transport/mod.rs
+++ b/commons/zenoh-protocol/src/transport/mod.rs
@@ -129,7 +129,6 @@ pub mod tmsg {
 
 // Zenoh messages at zenoh-transport level
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TransportBody {
     InitSyn(InitSyn),
     InitAck(InitAck),
@@ -142,7 +141,6 @@ pub enum TransportBody {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct TransportMessage {
     pub body: TransportBody,
     pub attachment: Option<Attachment>,

--- a/commons/zenoh-protocol/src/transport/open.rs
+++ b/commons/zenoh-protocol/src/transport/open.rs
@@ -43,7 +43,6 @@ use zenoh_buffers::ZSlice;
 /// (***) the cookie MUST be the same received in the INIT message with A==1 from the corresponding peer
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct OpenSyn {
     pub lease: Duration,
     pub initial_sn: ZInt,
@@ -77,7 +76,6 @@ impl OpenSyn {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct OpenAck {
     pub lease: Duration,
     pub initial_sn: ZInt,

--- a/commons/zenoh-protocol/src/zenoh/data.rs
+++ b/commons/zenoh-protocol/src/zenoh/data.rs
@@ -35,12 +35,10 @@ use zenoh_buffers::ZBuf;
 /// - if F==1 then the message is a REPLY_FINAL
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ReplierInfo {
     pub id: ZenohId,
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ReplyContext {
     pub qid: ZInt,
     pub replier: Option<ReplierInfo>,
@@ -114,7 +112,6 @@ impl ReplyContext {
 ///
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct DataInfo {
     #[cfg(feature = "shared-memory")]
     pub sliced: bool,
@@ -173,7 +170,6 @@ impl DataInfo {
 ///
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Data {
     pub key: WireExpr<'static>,
     pub data_info: Option<DataInfo>,

--- a/commons/zenoh-protocol/src/zenoh/declare.rs
+++ b/commons/zenoh-protocol/src/zenoh/declare.rs
@@ -25,7 +25,6 @@ use alloc::vec::Vec;
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Declare {
     pub declarations: Vec<Declaration>,
 }
@@ -47,7 +46,6 @@ impl Declare {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Declaration {
     Resource(Resource),
     ForgetResource(ForgetResource),
@@ -91,7 +89,6 @@ impl Declaration {
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Resource {
     pub expr_id: ZInt,
     pub key: WireExpr<'static>,
@@ -120,7 +117,6 @@ impl Resource {
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ForgetResource {
     pub expr_id: ZInt,
 }
@@ -147,7 +143,6 @@ impl ForgetResource {
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Publisher {
     pub key: WireExpr<'static>,
 }
@@ -170,7 +165,6 @@ impl Publisher {
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ForgetPublisher {
     pub key: WireExpr<'static>,
 }
@@ -195,7 +189,6 @@ impl ForgetPublisher {
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Subscriber {
     pub key: WireExpr<'static>,
     pub info: SubInfo,
@@ -235,7 +228,6 @@ impl Subscriber {
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ForgetSubscriber {
     pub key: WireExpr<'static>,
 }
@@ -260,7 +252,6 @@ impl ForgetSubscriber {
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Queryable {
     pub key: WireExpr<'static>,
     pub info: QueryableInfo,
@@ -291,7 +282,6 @@ impl Queryable {
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ForgetQueryable {
     pub key: WireExpr<'static>,
 }

--- a/commons/zenoh-protocol/src/zenoh/linkstate.rs
+++ b/commons/zenoh-protocol/src/zenoh/linkstate.rs
@@ -31,7 +31,6 @@ use alloc::vec::Vec;
 // ~    [links]    ~
 // +---------------+
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct LinkState {
     pub psid: ZInt,
     pub sn: ZInt,
@@ -91,7 +90,6 @@ impl LinkState {
 // ~ [link_states] ~
 // +---------------+
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct LinkStateList {
     pub link_states: Vec<LinkState>,
 }

--- a/commons/zenoh-protocol/src/zenoh/mod.rs
+++ b/commons/zenoh-protocol/src/zenoh/mod.rs
@@ -194,7 +194,6 @@ pub mod zmsg {
 // Zenoh messages at zenoh level
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ZenohBody {
     Data(Data),
     Unit(Unit),
@@ -205,7 +204,6 @@ pub enum ZenohBody {
 }
 
 #[derive(Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ZenohMessage {
     pub body: ZenohBody,
     pub channel: Channel,

--- a/commons/zenoh-protocol/src/zenoh/pull.rs
+++ b/commons/zenoh-protocol/src/zenoh/pull.rs
@@ -28,7 +28,6 @@ use crate::core::{WireExpr, ZInt};
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Pull {
     pub key: WireExpr<'static>,
     pub pull_id: ZInt,

--- a/commons/zenoh-protocol/src/zenoh/query.rs
+++ b/commons/zenoh-protocol/src/zenoh/query.rs
@@ -31,7 +31,6 @@ use zenoh_buffers::ZBuf;
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct QueryBody {
     pub data_info: DataInfo,
     pub payload: ZBuf,
@@ -74,7 +73,6 @@ impl QueryBody {
 /// ~   QueryBody   ~ if B==1
 /// +---------------+
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Query {
     pub key: WireExpr<'static>,
     pub parameters: String,

--- a/commons/zenoh-protocol/src/zenoh/routing.rs
+++ b/commons/zenoh-protocol/src/zenoh/routing.rs
@@ -27,7 +27,6 @@ use crate::core::ZInt;
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct RoutingContext {
     pub tree_id: ZInt,
 }

--- a/commons/zenoh-protocol/src/zenoh/unit.rs
+++ b/commons/zenoh-protocol/src/zenoh/unit.rs
@@ -24,7 +24,6 @@ use crate::core::CongestionControl;
 ///
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Unit {
     pub congestion_control: CongestionControl,
     pub reply_context: Option<ReplyContext>,

--- a/commons/zenoh-result/Cargo.toml
+++ b/commons/zenoh-result/Cargo.toml
@@ -27,8 +27,6 @@ description = "Internal crate for zenoh."
 [features]
 default = ["std"]
 std = ["anyhow/std"]
-defmt = ["dep:defmt"]
 
 [dependencies]
 anyhow = { workspace = true }
-defmt = { workspace = true, optional = true }

--- a/commons/zenoh-result/src/lib.rs
+++ b/commons/zenoh-result/src/lib.rs
@@ -86,7 +86,6 @@ pub type ZResult<T> = core::result::Result<T, Error>;
 
 #[repr(transparent)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct NegativeI8(i8);
 
 impl NegativeI8 {
@@ -102,14 +101,11 @@ impl NegativeI8 {
     pub const MIN: Self = Self::new(i8::MIN);
 }
 
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ZError {
-    #[cfg_attr(feature = "defmt", defmt(Debug2Format))]
     error: AnyError,
     file: &'static str,
     line: u32,
     errno: NegativeI8,
-    #[cfg_attr(feature = "defmt", defmt(Debug2Format))]
     source: Option<Error>,
 }
 
@@ -177,7 +173,6 @@ impl From<ZError> for Error {
 // +----------+
 
 #[derive(Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ShmError(pub ZError);
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
Removed defmt dependency because:
- we are not using it anymore in `no_std`;
- it was causing problems with `keformatter` (@p-avital).