### PR TITLE
Added eventual leader to zenoh-ext group (#461)

### DIFF
--- a/zenoh-ext/examples/z_member.rs
+++ b/zenoh-ext/examples/z_member.rs
@@ -38,6 +38,9 @@ async fn main() {
             v.iter()
                 .fold(String::from("\n"), |a, b| format!("\t{a} \n\t{b:?}")),
         );
+        println!(">>>>>>> Eventual Leader <<<<<<<<<");
+        let m = group.leader().await;
+        println!("Leader mid = {m:?}");
         println!(">>>>>>><<<<<<<<<");
     }
 }

--- a/zenoh-ext/src/group.rs
+++ b/zenoh-ext/src/group.rs
@@ -473,21 +473,21 @@ impl Group {
         ms.len() + 1 // with +1 being the local member
     }
 
-    /// Returns the evental leader for this group. Notice that a view change may cause 
+    /// Returns the evental leader for this group. Notice that a view change may cause
     /// a change on leader. Thus it is wise to always get the leader after a view change.
     pub async fn leader(&self) -> Member {
         use std::cmp::Ordering;
         use std::str::FromStr;
-        let group = self.view().await;        
+        let group = self.view().await;
         let mut max_id = String::from_str("").unwrap();
-        let mut leader = None;         
+        let mut leader = None;
         for m in group {
             let mid = String::from_str(m.mid.as_str()).unwrap();
             if max_id.cmp(&mid) == Ordering::Less {
-                max_id = max_id.max(mid);            
+                max_id = max_id.max(mid);
                 leader = Some(m)
-            }        
+            }
         }
-        leader.unwrap()        
+        leader.unwrap()
     }
 }

--- a/zenoh-ext/src/group.rs
+++ b/zenoh-ext/src/group.rs
@@ -472,4 +472,22 @@ impl Group {
         let ms = self.state.members.lock().await;
         ms.len() + 1 // with +1 being the local member
     }
+
+    /// Returns the evental leader for this group. Notice that a view change may cause 
+    /// a change on leader. Thus it is wise to always get the leader after a view change.
+    pub async fn leader(&self) -> Member {
+        use std::cmp::Ordering;
+        use std::str::FromStr;
+        let group = self.view().await;        
+        let mut max_id = String::from_str("").unwrap();
+        let mut leader = None;         
+        for m in group {
+            let mid = String::from_str(m.mid.as_str()).unwrap();
+            if max_id.cmp(&mid) == Ordering::Less {
+                max_id = max_id.max(mid);            
+                leader = Some(m)
+            }        
+        }
+        leader.unwrap()        
+    }
 }


### PR DESCRIPTION
The zenoh-ext group management while providing an eventual group view did not provide API to get an eventual leader. This PR adds support for that.