### PR TITLE
Fix #461. Remove unnecessary unwraps in leader selection

### DIFF
--- a/zenoh-ext/src/group.rs
+++ b/zenoh-ext/src/group.rs
@@ -477,17 +477,13 @@ impl Group {
     /// a change on leader. Thus it is wise to always get the leader after a view change.
     pub async fn leader(&self) -> Member {
         use std::cmp::Ordering;
-        use std::str::FromStr;
         let group = self.view().await;
-        let mut max_id = String::from_str("").unwrap();
-        let mut leader = None;
+        let mut leader = self.state.local_member.clone();
         for m in group {
-            let mid = String::from_str(m.mid.as_str()).unwrap();
-            if max_id.cmp(&mid) == Ordering::Less {
-                max_id = max_id.max(mid);
-                leader = Some(m)
+            if leader.id().as_str().cmp(m.id().as_str()) == Ordering::Less {
+                leader = m
             }
         }
-        leader.unwrap()
+        leader
     }
 }


### PR DESCRIPTION
Tracking comment on https://github.com/eclipse-zenoh/zenoh/pull/463.