### PR TITLE
Ketree boundfix

### DIFF
--- a/commons/zenoh-keyexpr/src/keyexpr_tree/traits/mod.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/traits/mod.rs
@@ -13,7 +13,7 @@
 //
 
 use crate::{keyexpr, OwnedKeyExpr};
-
+use alloc::boxed::Box;
 pub mod default_impls;
 
 /// The basic immutable methods of all all KeTrees

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/traits/mod.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/traits/mod.rs
@@ -277,7 +277,7 @@ pub trait IKeyExprTreeExt<'a, Weight>: IKeyExprTree<'a, Weight> {
         fn(Self::TreeIterItem) -> Option<(OwnedKeyExpr, &'a Weight)>,
     >
     where
-        Self::TreeIterItem: AsNode<Self::Node>,
+        Self::TreeIterItem: AsNode<Box<Self::Node>>,
     {
         self.tree_iter().filter_map(|node| {
             unsafe { core::mem::transmute::<_, Option<&Weight>>(node.as_node().weight()) }


### PR DESCRIPTION
Sreeja spotted that `key_value_pairs` was unusable on KeBoxTree due to bounds, this PR fixes it.