### PR TITLE
Stabilize query with_value

### DIFF
--- a/zenoh/src/query.rs
+++ b/zenoh/src/query.rs
@@ -284,7 +284,6 @@ impl<'a, 'b, Handler> GetBuilder<'a, 'b, Handler> {
     }
 
     /// Set query value.
-    #[zenoh_macros::unstable]
     #[inline]
     pub fn with_value<IntoValue>(mut self, value: IntoValue) -> Self
     where

--- a/zenoh/src/queryable.rs
+++ b/zenoh/src/queryable.rs
@@ -39,8 +39,6 @@ pub struct Query {
     /// This Query's selector parameters.
     pub(crate) parameters: String,
     /// This Query's body.
-    #[allow(unused_variables)]
-    #[allow(dead_code)]
     pub(crate) value: Option<Value>,
     /// The sender to use to send replies to this query.
     /// When this sender is dropped, the reply is finalized.
@@ -70,7 +68,6 @@ impl Query {
     }
 
     /// This Query's value.
-    #[zenoh_macros::unstable]
     #[inline(always)]
     pub fn value(&self) -> Option<&Value> {
         self.value.as_ref()


### PR DESCRIPTION
This PR stabilizes `with_value` option in the `get` builder.