### PR TITLE
Rename zplugin-* to zenoh-plugin-*

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,7 +260,7 @@ jobs:
             *linux*)
               cd "target/${TARGET}/release/"
               echo "Packaging ${MAIN_PKG_NAME}:"
-              zip ${MAIN_PKG_NAME} zenohd libzplugin_*.so
+              zip ${MAIN_PKG_NAME} zenohd libzenoh_plugin_*.so
               cd -
               echo "MAIN_PKG_NAME=${MAIN_PKG_NAME}" >> $GITHUB_OUTPUT
 
@@ -277,14 +277,14 @@ jobs:
             *apple*)
               cd "target/${TARGET}/release/"
               echo "Packaging ${MAIN_PKG_NAME}:"
-              zip ${MAIN_PKG_NAME} zenohd libzplugin_*.dylib
+              zip ${MAIN_PKG_NAME} zenohd libzenoh_plugin_*.dylib
               cd -
               echo "MAIN_PKG_NAME=${MAIN_PKG_NAME}" >> $GITHUB_OUTPUT
               ;;
             *windows*)
               cd "target/${TARGET}/release/"
               echo "Packaging ${MAIN_PKG_NAME}:"
-              7z -y a "${MAIN_PKG_NAME}" zenohd.exe zplugin_*.dll
+              7z -y a "${MAIN_PKG_NAME}" zenohd.exe zenoh_plugin_*.dll
               cd -
               echo "MAIN_PKG_NAME=${MAIN_PKG_NAME}" >> $GITHUB_OUTPUT
               ;;
@@ -395,10 +395,10 @@ jobs:
           ls PACKAGES
           mkdir -p docker/linux/amd
           unzip PACKAGES/x86_64-unknown-linux-musl/zenoh-${{ needs.checks.outputs.PKG_VERSION }}-x86_64-unknown-linux-musl.zip -d docker/linux/amd64/
-          rm docker/linux/amd64/libzplugin_example.so
+          rm docker/linux/amd64/libzenoh_plugin_example.so
           mkdir -p docker/linux/arm64
           unzip PACKAGES/aarch64-unknown-linux-musl/zenoh-${{ needs.checks.outputs.PKG_VERSION }}-aarch64-unknown-linux-musl.zip -d docker/linux/arm64/
-          rm docker/linux/arm64/libzplugin_example.so
+          rm docker/linux/arm64/libzenoh_plugin_example.so
           tree docker
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4288,6 +4288,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "zenoh_plugin-example"
+version = "0.7.0-rc"
+dependencies = [
+ "async-std",
+ "clap",
+ "env_logger",
+ "futures",
+ "log",
+ "serde_json",
+ "zenoh",
+ "zenoh-core",
+ "zenoh-plugin-trait",
+ "zenoh-result",
+ "zenoh-util",
+]
+
+[[package]]
 name = "zenohd"
 version = "0.7.0-rc"
 dependencies = [
@@ -4309,20 +4326,3 @@ name = "zeroize"
 version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
-
-[[package]]
-name = "zplugin-example"
-version = "0.7.0-rc"
-dependencies = [
- "async-std",
- "clap",
- "env_logger",
- "futures",
- "log",
- "serde_json",
- "zenoh",
- "zenoh-core",
- "zenoh-plugin-trait",
- "zenoh-result",
- "zenoh-util",
-]

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -245,7 +245,7 @@
 //  /// Plugins are only loaded if present in the configuration. When starting
 //  /// Once loaded, they may react to changes in the configuration made through the zenoh instance's adminspace.
 //  plugins: {
-//    /// If no `__path__` is given to a plugin, zenohd will automatically search for a shared library matching the plugin's name (here, `libzplugin_rest.so` would be searched for on linux)
+//    /// If no `__path__` is given to a plugin, zenohd will automatically search for a shared library matching the plugin's name (here, `libzenoh_plugin_rest.so` would be searched for on linux)
 //
 //    /// Configure the REST API plugin
 //    rest: {
@@ -258,8 +258,8 @@
 //    storage_manager: {
 //      /// When a path is present, automatic search is disabled, and zenohd will instead select the first path which manages to load.
 //      __path__: [
-//        "./target/release/libzplugin_storage_manager.so",
-//        "./target/release/libzplugin_storage_manager.dylib",
+//        "./target/release/libzenoh_plugin_storage_manager.so",
+//        "./target/release/libzenoh_plugin_storage_manager.dylib",
 //      ],
 //      /// The "memory" volume is always available, but you may create other volumes here, with various backends to support the actual storing.
 //      volumes: {

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ See other examples of Zenoh usage in [examples/](examples)
   * `--no-timestamp`: By default zenohd adds a HLC-generated Timestamp to each routed Data if there isn't already one.
     This option disables this feature.
   * `-P, --plugin [<PLUGIN_NAME> | <PLUGIN_NAME>:<LIBRARY_PATH>]...`: A [plugin](https://zenoh.io/docs/manual/plugins/) that must be loaded. Accepted values:
-     - a plugin name; zenohd will search for a library named `libzplugin_<name>.so` on Unix, `libzplugin_<PLUGIN_NAME>.dylib` on MacOS or `zplugin_<PLUGIN_NAME>.dll` on Windows.
+     - a plugin name; zenohd will search for a library named `libzenoh_plugin_<name>.so` on Unix, `libzenoh_plugin_<PLUGIN_NAME>.dylib` on MacOS or `zenoh_plugin_<PLUGIN_NAME>.dll` on Windows.
      - `"<PLUGIN_NAME>:<LIBRARY_PATH>"`; the plugin will be loaded from library file at `<LIBRARY_PATH>`.
 
     Repeat this option to load several plugins.

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -780,7 +780,7 @@ fn user_conf_validator(u: &UserConf) -> bool {
 ///         //   simply log them otherwise
 ///         __required__: bool,
 ///         // The path(s) where the plugin is expected to be located.
-///         // If none is specified, `zenohd` will search for a `<dylib_prefix>zplugin_<plugin_name>.<dylib_suffix>` file in the search directories.
+///         // If none is specified, `zenohd` will search for a `<dylib_prefix>zenoh_plugin_<plugin_name>.<dylib_suffix>` file in the search directories.
 ///         // If any path is specified, file-search will be disabled, and the first path leading to
 ///         // an existing file will be used
 ///         __path__: string | [string],

--- a/plugins/example-plugin/Cargo.toml
+++ b/plugins/example-plugin/Cargo.toml
@@ -13,18 +13,18 @@
 #
 [package]
 rust-version = { workspace = true }
-name = "zplugin-example"
+name = "zenoh_plugin-example"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
 
 [lib]
-# When auto-detecting the "example" plugin, `zenohd` will look for a dynamic library named "zplugin_example"
+# When auto-detecting the "example" plugin, `zenohd` will look for a dynamic library named "zenoh_plugin_example"
 # `zenohd` will expect the file to be named according to OS conventions:
-#   - libzplugin_example.so on linux
-#   - libzplugin_example.dylib on macOS
-#   - zplugin_example.dll on Windows
-name = "zplugin_example"
+#   - libzenoh_plugin_example.so on linux
+#   - libzenoh_plugin_example.dylib on macOS
+#   - zenoh_plugin_example.dll on Windows
+name = "zenoh_plugin_example"
 # This crate type will make `cargo` output a dynamic library instead of a rust static library
 crate-type = ["cdylib"]
 

--- a/plugins/zenoh-plugin-rest/Cargo.toml
+++ b/plugins/zenoh-plugin-rest/Cargo.toml
@@ -28,7 +28,7 @@ default = ["no_mangle"]
 no_mangle = ["zenoh-plugin-trait/no_mangle"]
 
 [lib]
-name = "zplugin_rest"
+name = "zenoh_plugin_rest"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]

--- a/plugins/zenoh-plugin-storage-manager/Cargo.toml
+++ b/plugins/zenoh-plugin-storage-manager/Cargo.toml
@@ -34,7 +34,7 @@ default = ["no_mangle"]
 no_mangle = ["zenoh-plugin-trait/no_mangle"]
 
 [lib]
-name = "zplugin_storage_manager"
+name = "zenoh_plugin_storage_manager"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]

--- a/plugins/zenoh-plugin-storage-manager/tests/operations.rs
+++ b/plugins/zenoh-plugin-storage-manager/tests/operations.rs
@@ -80,7 +80,7 @@ async fn test_updates_in_order() {
 
     let runtime = zenoh::runtime::Runtime::new(config).await.unwrap();
     let storage =
-        zplugin_storage_manager::StoragesPlugin::start("storage-manager", &runtime).unwrap();
+        zenoh_plugin_storage_manager::StoragesPlugin::start("storage-manager", &runtime).unwrap();
 
     let session = zenoh::init(runtime).res().await.unwrap();
 

--- a/plugins/zenoh-plugin-storage-manager/tests/wildcard.rs
+++ b/plugins/zenoh-plugin-storage-manager/tests/wildcard.rs
@@ -81,7 +81,7 @@ async fn test_wild_card_in_order() {
 
     let runtime = zenoh::runtime::Runtime::new(config).await.unwrap();
     let storage =
-        zplugin_storage_manager::StoragesPlugin::start("storage-manager", &runtime).unwrap();
+        zenoh_plugin_storage_manager::StoragesPlugin::start("storage-manager", &runtime).unwrap();
 
     let session = zenoh::init(runtime).res().await.unwrap();
     sleep(std::time::Duration::from_secs(1));

--- a/plugins/zenoh-plugin-trait/src/loading.rs
+++ b/plugins/zenoh-plugin-trait/src/loading.rs
@@ -182,7 +182,7 @@ impl<StartArgs: 'static, RunningPlugin: 'static> PluginsManager<StartArgs, Runni
 
     pub fn load_plugin_by_name(&mut self, name: String) -> ZResult<String> {
         let (lib, p) = match &mut self.loader {
-            Some(l) => unsafe { l.search_and_load(&format!("zplugin_{}", &name))? },
+            Some(l) => unsafe { l.search_and_load(&format!("zenoh_plugin_{}", &name))? },
             None => bail!("Can't load dynamic plugin ` {}`, as dynamic loading is not enabled for this plugin manager.", name),
         };
         let plugin = match Self::load_plugin(&name, lib, p.clone()) {

--- a/zenoh/src/plugins/sealed.rs
+++ b/zenoh/src/plugins/sealed.rs
@@ -20,7 +20,7 @@ pub use crate::Result as ZResult;
 use zenoh_core::zconfigurable;
 
 zconfigurable! {
-    pub static ref PLUGIN_PREFIX: String = "zplugin_".to_string();
+    pub static ref PLUGIN_PREFIX: String = "zenoh_plugin_".to_string();
 }
 
 /// Zenoh plugins should implement this trait to ensure type-safety, even if the starting arguments and expected plugin types change in a future release.

--- a/zenohd/src/main.rs
+++ b/zenohd/src/main.rs
@@ -51,7 +51,7 @@ clap::Arg::new("connect").short('e').long("connect").value_name("ENDPOINT").help
 Repeat this option to connect to several peers.").takes_value(true).multiple_occurrences(true),
 clap::Arg::new("id").short('i').long("id").value_name("HEX_STRING").help(r"The identifier (as an hexadecimal string, with odd number of chars - e.g.: 0A0B23...) that zenohd must use. If not set, a random UUIDv4 will be used.
 WARNING: this identifier must be unique in the system and must be 16 bytes maximum (32 chars)!").multiple_values(false).multiple_occurrences(false),
-clap::Arg::new("plugin").short('P').long("plugin").value_name("PLUGIN").takes_value(true).multiple_occurrences(true).help(r#"A plugin that MUST be loaded. You can give just the name of the plugin, zenohd will search for a library named 'libzplugin_<name>.so' (exact name depending the OS). Or you can give such a string: "<plugin_name>:<library_path>".
+clap::Arg::new("plugin").short('P').long("plugin").value_name("PLUGIN").takes_value(true).multiple_occurrences(true).help(r#"A plugin that MUST be loaded. You can give just the name of the plugin, zenohd will search for a library named 'libzenoh_plugin_<name>.so' (exact name depending the OS). Or you can give such a string: "<plugin_name>:<library_path>".
 Repeat this option to load several plugins. If loading failed, zenohd will exit."#),
 clap::Arg::new("plugin-search-dir").long("plugin-search-dir").takes_value(true).multiple_occurrences(true).value_name("DIRECTORY").help(r"A directory where to search for plugins libraries to load.
 Repeat this option to specify several search directories."),


### PR DESCRIPTION
Rename zplugin-* to zenoh-plugin-* to harmonize naming and streamline CI for plugins.