### PR TITLE
name the threads spawned to service the TX queue

### DIFF
--- a/io/zenoh-transport/src/manager.rs
+++ b/io/zenoh-transport/src/manager.rs
@@ -333,7 +333,9 @@ impl TransportExecutor {
         for _ in 0..num_threads {
             let exec = executor.clone();
             let recv = receiver.clone();
-            std::thread::spawn(move || async_std::task::block_on(exec.run(recv.recv())));
+            std::thread::Builder::new()
+                .name(format!("zenoh-tx-{}", thread_idx))
+                .spawn(move || async_std::task::block_on(exec.run(recv.recv())));
         }
         Self { executor, sender }
     }

--- a/io/zenoh-transport/src/manager.rs
+++ b/io/zenoh-transport/src/manager.rs
@@ -330,12 +330,13 @@ impl TransportExecutor {
     fn new(num_threads: usize) -> Self {
         let (sender, receiver) = async_std::channel::bounded(1);
         let executor = Arc::new(async_executor::Executor::new());
-        for _ in 0..num_threads {
+        for i in 0..num_threads {
             let exec = executor.clone();
             let recv = receiver.clone();
             std::thread::Builder::new()
-                .name(format!("zenoh-tx-{}", thread_idx))
-                .spawn(move || async_std::task::block_on(exec.run(recv.recv())));
+                .name(format!("zenoh-tx-{}", i))
+                .spawn(move || async_std::task::block_on(exec.run(recv.recv())))
+                .unwrap();
         }
         Self { executor, sender }
     }


### PR DESCRIPTION
Currently the TX queue threads are unnamed. This is a tiny PR to name them, so it's easier to understand the CPU usage. I'm not attached to the name scheme at all, feel free to edit it :slightly_smiling_face: 