### PR TITLE
Add routing test draft

### DIFF
--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -88,7 +88,8 @@ impl Task {
             Self::Get(ke, expected_size) => {
                 let mut counter = 0;
                 while counter < MSG_COUNT {
-                    let replies = ztimeout!(session.get(ke).res_async())?;
+                    let replies =
+                        ztimeout!(session.get(ke).timeout(Duration::from_secs(10)).res_async())?;
                     while let Ok(reply) = replies.recv_async().await {
                         match reply.sample {
                             Ok(sample) => {

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -26,7 +26,7 @@ use zenoh_config::ModeDependentValue;
 use zenoh_core::zasync_executor_init;
 use zenoh_result::bail;
 
-const TIMEOUT: Duration = Duration::from_secs(60);
+const TIMEOUT: Duration = Duration::from_secs(120);
 const MSG_COUNT: usize = 1_000;
 const MSG_SIZE: [usize; 2] = [1_024, 131_072];
 

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -288,7 +288,7 @@ impl Recipe {
                 });
 
                 // All tasks of the node run together
-                try_join_all(node_tasks)
+                try_join_all(node_tasks.into_iter().map(async_std::task::spawn))
                     .await
                     .map_err(|e| zerror!("The recipe {} failed due to {}", receipe_name, &e))?;
 

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -477,7 +477,7 @@ fn three_node_combination() -> Result<()> {
             .map(
                 |(node1_mode, node2_mode, msg_size, (delay1, delay2, delay3))| {
                     idx += 1;
-                    let ke_pubsub = format!("three_node_combination_keyexpr_pubsub_{idx}");
+                    // let ke_pubsub = format!("three_node_combination_keyexpr_pubsub_{idx}");
                     let ke_getqueryable =
                         format!("three_node_combination_keyexpr_getqueryable_{idx}");
                     let locator = format!("tcp/127.0.0.1:{}", base_port + idx);
@@ -496,7 +496,7 @@ fn three_node_combination() -> Result<()> {
                             mode: node1_mode,
                             connect: vec![locator.clone()],
                             con_task: ConcurrentTask::from([
-                                SequentialTask::from([Task::Pub(ke_pubsub.clone(), msg_size)]),
+                                // SequentialTask::from([Task::Pub(ke_pubsub.clone(), msg_size)]),
                                 SequentialTask::from([Task::Queryable(
                                     ke_getqueryable.clone(),
                                     msg_size,
@@ -510,10 +510,10 @@ fn three_node_combination() -> Result<()> {
                             mode: node2_mode,
                             connect: vec![locator],
                             con_task: ConcurrentTask::from([
-                                SequentialTask::from([
-                                    Task::Sub(ke_pubsub, msg_size),
-                                    Task::Checkpoint,
-                                ]),
+                                // SequentialTask::from([
+                                //     Task::Sub(ke_pubsub, msg_size),
+                                //     Task::Checkpoint,
+                                // ]),
                                 SequentialTask::from([
                                     Task::Get(ke_getqueryable, msg_size),
                                     Task::Checkpoint,
@@ -562,7 +562,7 @@ fn two_node_combination() -> Result<()> {
             .flat_map(|(n1, n2, who)| MSG_SIZE.map(|s| (n1, n2, who, s)))
             .map(|(node1_mode, node2_mode, who, msg_size)| {
                 idx += 1;
-                let ke_pubsub = format!("two_node_combination_keyexpr_pubsub_{idx}");
+                // let ke_pubsub = format!("two_node_combination_keyexpr_pubsub_{idx}");
                 let ke_getqueryable = format!("two_node_combination_keyexpr_getqueryable_{idx}");
 
                 let (node1_listen_connect, node2_listen_connect) = {
@@ -584,7 +584,7 @@ fn two_node_combination() -> Result<()> {
                         listen: node1_listen_connect.0,
                         connect: node1_listen_connect.1,
                         con_task: ConcurrentTask::from([
-                            SequentialTask::from([Task::Pub(ke_pubsub.clone(), msg_size)]),
+                            // SequentialTask::from([Task::Pub(ke_pubsub.clone(), msg_size)]),
                             SequentialTask::from([Task::Queryable(
                                 ke_getqueryable.clone(),
                                 msg_size,
@@ -598,10 +598,10 @@ fn two_node_combination() -> Result<()> {
                         listen: node2_listen_connect.0,
                         connect: node2_listen_connect.1,
                         con_task: ConcurrentTask::from([
-                            SequentialTask::from([
-                                Task::Sub(ke_pubsub, msg_size),
-                                Task::Checkpoint,
-                            ]),
+                            // SequentialTask::from([
+                            //     Task::Sub(ke_pubsub, msg_size),
+                            //     Task::Checkpoint,
+                            // ]),
                             SequentialTask::from([
                                 Task::Get(ke_getqueryable, msg_size),
                                 Task::Checkpoint,

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -146,7 +146,7 @@ async fn run_recipe(receipe: impl IntoIterator<Item = Node>) -> Result<()> {
 #[test]
 fn gossip() -> Result<()> {
     async_std::task::block_on(async {
-        let locator = String::from("tcp/127.0.0.1:17447");
+        let locator = String::from("tcp/127.0.0.1:17448");
         let topic = String::from("testTopic");
 
         // Gossip test

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -89,7 +89,8 @@ async fn run_recipe(receipe: impl IntoIterator<Item = Node>) -> Result<()> {
 
             // Each session spawns several given task(s)
             let c_session = session.clone();
-            let fut = match task {
+
+            match task {
 
                 // Subscription task
                 Task::Sub(topic, expected_size) => {
@@ -130,9 +131,8 @@ async fn run_recipe(receipe: impl IntoIterator<Item = Node>) -> Result<()> {
                 Task::Sleep(dur) => async_std::task::spawn(async move {
                     async_std::task::sleep(dur).await;
                     Ok(())
-                }),
-            };
-            fut
+                })
+            }
         });
 
         let (state, _, _) = select_all(futs).await;
@@ -140,9 +140,8 @@ async fn run_recipe(receipe: impl IntoIterator<Item = Node>) -> Result<()> {
     }.boxed());
 
     let (state, _, _) = select_all(futures).timeout(TIMEOUT).await?;
-    Ok(state?)
+    state
 }
-
 
 #[test]
 fn gossip() -> Result<()> {

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -444,6 +444,7 @@ fn three_node_combination() -> Result<()> {
         let modes = [WhatAmI::Peer, WhatAmI::Client];
 
         let mut idx = 0;
+        // Ports going to be used: 17451 to 17474
         let base_port = 17450;
         let recipe_list = modes
             .map(|n1| modes.map(|n2| (n1, n2)))
@@ -532,7 +533,8 @@ fn two_node_combination() -> Result<()> {
         ];
 
         let mut idx = 0;
-        let base_port = 17470;
+        // Ports going to be used: 17481 to 17488
+        let base_port = 17480;
         let recipe_list = modes
             .into_iter()
             .flat_map(|(n1, n2, who)| MSG_SIZE.map(|s| (n1, n2, who, s)))

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -462,7 +462,7 @@ fn three_node_combination() -> Result<()> {
         ];
 
         let mut idx = 0;
-        // Ports going to be used: 17451 to 17474
+        // Ports going to be used: 17451 to 17498
         let base_port = 17450;
         let recipe_list = modes
             .map(|n1| modes.map(|n2| (n1, n2)))
@@ -545,8 +545,8 @@ fn two_node_combination() -> Result<()> {
         ];
 
         let mut idx = 0;
-        // Ports going to be used: 17481 to 17488
-        let base_port = 17480;
+        // Ports going to be used: 17500 to 17508
+        let base_port = 17500;
         let recipe_list = modes
             .into_iter()
             .flat_map(|(n1, n2, who)| MSG_SIZE.map(|s| (n1, n2, who, s)))

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -13,6 +13,7 @@
 //
 use futures::future::try_join_all;
 use futures::FutureExt as _;
+use std::str::FromStr;
 use std::sync::atomic::Ordering;
 use std::sync::{atomic::AtomicUsize, Arc};
 use std::time::Duration;
@@ -386,9 +387,9 @@ fn static_failover_brokering() -> Result<()> {
             config
                 .scouting
                 .gossip
-                .set_autoconnect(Some(ModeDependentValue::Unique(WhatAmIMatcher::try_from(
-                    128,
-                )?)))
+                .set_autoconnect(Some(ModeDependentValue::Unique(
+                    WhatAmIMatcher::from_str("").unwrap(),
+                )))
                 .unwrap();
             Some(config)
         };
@@ -402,7 +403,7 @@ fn static_failover_brokering() -> Result<()> {
                 ..Default::default()
             },
             Node {
-                name: format!("Pub {}", WhatAmI::Peer),
+                name: format!("Pub & Queryable {}", WhatAmI::Peer),
                 mode: WhatAmI::Peer,
                 connect: vec![locator.clone()],
                 config: disable_autoconnect_config(),
@@ -413,7 +414,7 @@ fn static_failover_brokering() -> Result<()> {
                 ..Default::default()
             },
             Node {
-                name: format!("Sub {}", WhatAmI::Peer),
+                name: format!("Sub & Get {}", WhatAmI::Peer),
                 mode: WhatAmI::Peer,
                 connect: vec![locator.clone()],
                 config: disable_autoconnect_config(),

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -303,11 +303,9 @@ impl Recipe {
 // And the message transmission should work even if the common node disappears after a while.
 #[test]
 fn gossip() -> Result<()> {
+    env_logger::try_init().unwrap_or_default();
     async_std::task::block_on(async {
         zasync_executor_init!();
-
-        // env_logger should be activated only once across all the tests. Otherwise, it fails the tests below.
-        env_logger::try_init()?;
 
         let locator = String::from("tcp/127.0.0.1:17448");
         let ke = String::from("testKeyExprGossip");
@@ -375,6 +373,7 @@ fn gossip() -> Result<()> {
 // Simulate two peers connecting to a router but not directly reachable to each other can exchange messages via the brokering by the router.
 #[test]
 fn static_failover_brokering() -> Result<()> {
+    env_logger::try_init().unwrap_or_default();
     async_std::task::block_on(async {
         zasync_executor_init!();
 
@@ -438,6 +437,7 @@ fn static_failover_brokering() -> Result<()> {
 // 3. Spawning order
 #[test]
 fn three_node_combination() -> Result<()> {
+    env_logger::try_init().unwrap_or_default();
     async_std::task::block_on(async {
         zasync_executor_init!();
 

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -100,7 +100,12 @@ impl Task {
                             }
 
                             Err(err) => {
-                                bail!("Sample got from {ke} failed to unwrap! Error: {err}.");
+                                log::warn!(
+                                    "Sample got from {} failed to unwrap! Error: {}.",
+                                    ke,
+                                    err
+                                );
+                                continue;
                             }
                         }
                         counter += 1;

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -308,7 +308,6 @@ impl Recipe {
 
         // All tasks of the recipe run together
         try_join_all(futures)
-            .timeout(TIMEOUT)
             .await
             .map_err(|e| format!("The recipe: {} failed due to {}", &self, e))??;
         Ok(())

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -477,7 +477,9 @@ fn three_node_combination() -> Result<()> {
             .map(
                 |(node1_mode, node2_mode, msg_size, (delay1, delay2, delay3))| {
                     idx += 1;
-                    let ke = format!("three_node_combination_keyexpr_{idx}");
+                    let ke_pubsub = format!("three_node_combination_keyexpr_pubsub_{idx}");
+                    let ke_getqueryable =
+                        format!("three_node_combination_keyexpr_getqueryable_{idx}");
                     let locator = format!("tcp/127.0.0.1:{}", base_port + idx);
 
                     Recipe::new([
@@ -494,8 +496,11 @@ fn three_node_combination() -> Result<()> {
                             mode: node1_mode,
                             connect: vec![locator.clone()],
                             con_task: ConcurrentTask::from([
-                                SequentialTask::from([Task::Pub(ke.clone(), msg_size)]),
-                                SequentialTask::from([Task::Queryable(ke.clone(), msg_size)]),
+                                SequentialTask::from([Task::Pub(ke_pubsub.clone(), msg_size)]),
+                                SequentialTask::from([Task::Queryable(
+                                    ke_getqueryable.clone(),
+                                    msg_size,
+                                )]),
                             ]),
                             warmup: Duration::from_secs(delay2),
                             ..Default::default()
@@ -506,10 +511,13 @@ fn three_node_combination() -> Result<()> {
                             connect: vec![locator],
                             con_task: ConcurrentTask::from([
                                 SequentialTask::from([
-                                    Task::Sub(ke.clone(), msg_size),
+                                    Task::Sub(ke_pubsub, msg_size),
                                     Task::Checkpoint,
                                 ]),
-                                SequentialTask::from([Task::Get(ke, msg_size), Task::Checkpoint]),
+                                SequentialTask::from([
+                                    Task::Get(ke_getqueryable, msg_size),
+                                    Task::Checkpoint,
+                                ]),
                             ]),
                             warmup: Duration::from_secs(delay3),
                             ..Default::default()
@@ -554,7 +562,8 @@ fn two_node_combination() -> Result<()> {
             .flat_map(|(n1, n2, who)| MSG_SIZE.map(|s| (n1, n2, who, s)))
             .map(|(node1_mode, node2_mode, who, msg_size)| {
                 idx += 1;
-                let ke = format!("two_node_combination_keyexpr_{idx}");
+                let ke_pubsub = format!("two_node_combination_keyexpr_pubsub_{idx}");
+                let ke_getqueryable = format!("two_node_combination_keyexpr_getqueryable_{idx}");
 
                 let (node1_listen_connect, node2_listen_connect) = {
                     let locator = format!("tcp/127.0.0.1:{}", base_port + idx);
@@ -575,8 +584,11 @@ fn two_node_combination() -> Result<()> {
                         listen: node1_listen_connect.0,
                         connect: node1_listen_connect.1,
                         con_task: ConcurrentTask::from([
-                            SequentialTask::from([Task::Pub(ke.clone(), msg_size)]),
-                            SequentialTask::from([Task::Queryable(ke.clone(), msg_size)]),
+                            SequentialTask::from([Task::Pub(ke_pubsub.clone(), msg_size)]),
+                            SequentialTask::from([Task::Queryable(
+                                ke_getqueryable.clone(),
+                                msg_size,
+                            )]),
                         ]),
                         ..Default::default()
                     },
@@ -587,10 +599,13 @@ fn two_node_combination() -> Result<()> {
                         connect: node2_listen_connect.1,
                         con_task: ConcurrentTask::from([
                             SequentialTask::from([
-                                Task::Sub(ke.clone(), msg_size),
+                                Task::Sub(ke_pubsub, msg_size),
                                 Task::Checkpoint,
                             ]),
-                            SequentialTask::from([Task::Get(ke, msg_size), Task::Checkpoint]),
+                            SequentialTask::from([
+                                Task::Get(ke_getqueryable, msg_size),
+                                Task::Checkpoint,
+                            ]),
                         ]),
                         ..Default::default()
                     },

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -25,7 +25,6 @@ use zenoh_result::bail;
 const TIMEOUT: Duration = Duration::from_secs(10);
 const MSG_COUNT: usize = 1_000;
 const MSG_SIZE: [usize; 2] = [1_024, 131_072];
-// const MSG_SIZE: [usize; 1] = [1_024];
 
 macro_rules! ztimeout {
     ($f:expr) => {
@@ -47,6 +46,7 @@ struct Node {
     listen: Vec<String>,
     connect: Vec<String>,
     task: Vec<Task>,
+    config: Option<Config>,
 }
 
 impl Default for Node {
@@ -57,16 +57,18 @@ impl Default for Node {
             listen: vec![],
             connect: vec![],
             task: vec![],
+            config: None,
         }
     }
 }
 
 async fn run_recipe(receipe: impl IntoIterator<Item = Node>) -> Result<()> {
-    let futures = receipe.into_iter().map(|node| async move {
+    let futures = receipe.into_iter().map(|node|
+        async move {
         dbg!(node.name);
 
         // Load the config and build up a session
-        let mut config = Config::default();
+        let mut config = node.config.unwrap_or_else(Config::default);
         config.set_mode(Some(node.mode)).unwrap();
         config.scouting.multicast.set_enabled(Some(false)).unwrap();
         config
@@ -90,8 +92,8 @@ async fn run_recipe(receipe: impl IntoIterator<Item = Node>) -> Result<()> {
         // Each node consists of a specified session associated with tasks to run
         let futs = node.task.into_iter().map(|task| {
 
-            // Each session spawns several given task(s)
-            let c_session = session.clone();
+            // Multiple tasks share the session
+            let session = session.clone();
 
             match task {
 
@@ -99,7 +101,7 @@ async fn run_recipe(receipe: impl IntoIterator<Item = Node>) -> Result<()> {
                 Task::Sub(topic, expected_size) => {
                     async_std::task::spawn(async move {
                         let sub =
-                            ztimeout!(c_session.declare_subscriber(&topic).res_async())?;
+                            ztimeout!(session.declare_subscriber(&topic).res_async())?;
                         let mut counter = 0;
                         while let Ok(sample) = sub.recv_async().await {
                             let recv_size = sample.value.payload.len();
@@ -121,7 +123,7 @@ async fn run_recipe(receipe: impl IntoIterator<Item = Node>) -> Result<()> {
                     async_std::task::spawn(async move {
                         loop {
                             // async_std::task::sleep(Duration::from_millis(300)).await;
-                            ztimeout!(c_session
+                            ztimeout!(session
                                 .put(&topic, vec![0u8; payload_size])
                                 .congestion_control(CongestionControl::Block)
                                 .res_async())?;
@@ -147,6 +149,44 @@ async fn run_recipe(receipe: impl IntoIterator<Item = Node>) -> Result<()> {
 
 #[test]
 fn gossip() -> Result<()> {
+    async_std::task::block_on(async {
+        zasync_executor_init!();
+        let locator = String::from("tcp/127.0.0.1:17448");
+        let topic = String::from("testTopic");
+
+        // Gossip test
+        let recipe = [
+            Node {
+                name: "Peer0".into(),
+                mode: WhatAmI::Peer,
+                listen: vec![locator.clone()],
+                task: vec![Task::Sleep(Duration::from_secs(2))],
+                ..Default::default()
+            },
+            Node {
+                name: "Peer1".into(),
+                connect: vec![locator.clone()],
+                mode: WhatAmI::Peer,
+                task: vec![Task::Pub(topic.clone(), 8)],
+                ..Default::default()
+            },
+            Node {
+                name: "Peer2".into(),
+                mode: WhatAmI::Peer,
+                connect: vec![locator.clone()],
+                task: vec![Task::Sub(topic.clone(), 8)],
+                ..Default::default()
+            },
+        ];
+        run_recipe(recipe).await?;
+        println!("Gossip test passed.");
+        Result::Ok(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn failover_brokering() -> Result<()> {
     async_std::task::block_on(async {
         zasync_executor_init!();
         let locator = String::from("tcp/127.0.0.1:17448");

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -47,8 +47,8 @@ enum Task {
 impl Task {
     async fn run(&self, session: Arc<Session>, terminated: Arc<AtomicBool>) -> Result<()> {
         match self {
-            Self::Sub(topic, expected_size) => {
-                let sub = ztimeout!(session.declare_subscriber(topic).res_async())?;
+            Self::Sub(ke, expected_size) => {
+                let sub = ztimeout!(session.declare_subscriber(ke).res_async())?;
                 let mut counter = 0;
                 while let Ok(sample) = sub.recv_async().await {
                     let recv_size = sample.value.payload.len();
@@ -63,11 +63,11 @@ impl Task {
                 }
             }
 
-            Self::Pub(topic, payload_size) => {
+            Self::Pub(ke, payload_size) => {
                 while !terminated.load(Ordering::Relaxed) {
                     // async_std::task::sleep(Duration::from_millis(300)).await;
                     ztimeout!(session
-                        .put(topic, vec![0u8; *payload_size])
+                        .put(ke, vec![0u8; *payload_size])
                         .congestion_control(CongestionControl::Block)
                         .res_async())?;
                 }
@@ -102,6 +102,7 @@ struct Node {
     connect: Vec<String>,
     task: ConcurrentTask,
     config: Option<Config>,
+    warmup: Duration,
 }
 
 impl Default for Node {
@@ -113,78 +114,100 @@ impl Default for Node {
             connect: vec![],
             task: vec![],
             config: None,
+            warmup: Duration::from_secs(0),
         }
     }
 }
 
-async fn run_recipe(receipe: impl IntoIterator<Item = Node>) -> Result<()> {
-    let terminated = Arc::new(AtomicBool::default());
+#[derive(Debug, Clone)]
+struct Recipe {
+    nodes: Vec<Node>,
+}
 
-    let futures = receipe.into_iter().map(|node| {
-        log::info!("Node: {} started.", &node.name);
+impl std::fmt::Display for Recipe {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let names: Vec<_> = self.nodes.iter().map(|node| node.name.clone()).collect();
+        write!(f, "[{}]", names.join(", "))
+    }
+}
 
-        // Multiple nodes share the same terminated flag
-        let terminated = terminated.clone();
+impl Recipe {
+    fn new(nodes: impl IntoIterator<Item = Node>) -> Self {
+        let nodes = nodes.into_iter().collect();
+        Self { nodes }
+    }
 
-        async move {
-            dbg!(&node.name);
+    async fn run(&self) -> Result<()> {
+        let terminated = Arc::new(AtomicBool::default());
 
-            // Load the config and build up a session
-            let config = {
-                let mut config = node.config.unwrap_or_default();
-                config.set_mode(Some(node.mode)).unwrap();
-                config.scouting.multicast.set_enabled(Some(false)).unwrap();
-                config
-                    .listen
-                    .set_endpoints(node.listen.iter().map(|x| x.parse().unwrap()).collect())
-                    .unwrap();
-                config
-                    .connect
-                    .set_endpoints(node.connect.iter().map(|x| x.parse().unwrap()).collect())
-                    .unwrap();
-                config
-            };
+        let futures = self.nodes.clone().into_iter().map(|node| {
+            log::info!("Node: {} started.", &node.name);
 
-            // In case of client can't connect to some peers/routers
-            let session = if let Ok(session) = zenoh::open(config.clone()).res_async().await {
-                session.into_arc()
-            } else {
-                log::info!("Sleep and retry to connect to the endpoint...");
-                async_std::task::sleep(Duration::from_secs(1)).await;
-                zenoh::open(config).res_async().await?.into_arc()
-            };
+            // Multiple nodes share the same terminated flag
+            let terminated = terminated.clone();
 
-            // Each node consists of a specified session associated with tasks to run
-            let futs = node.task.into_iter().map(|seq_tasks| {
-                // Multiple tasks share the session
-                let session = session.clone();
-                let terminated = terminated.clone();
+            async move {
+                dbg!(&node.name);
 
-                async_std::task::spawn(async move {
-                    for t in seq_tasks {
-                        t.run(session.clone(), terminated.clone()).await?;
-                    }
-                    Result::Ok(())
-                })
-            });
+                // Load the config and build up a session
+                let config = {
+                    let mut config = node.config.unwrap_or_default();
+                    config.set_mode(Some(node.mode)).unwrap();
+                    config.scouting.multicast.set_enabled(Some(false)).unwrap();
+                    config
+                        .listen
+                        .set_endpoints(node.listen.iter().map(|x| x.parse().unwrap()).collect())
+                        .unwrap();
+                    config
+                        .connect
+                        .set_endpoints(node.connect.iter().map(|x| x.parse().unwrap()).collect())
+                        .unwrap();
+                    config
+                };
 
-            // let (state, _, _) = select_all(futs).await;
-            // state
-            try_join_all(futs).await?;
-            Arc::try_unwrap(session)
-                .unwrap()
-                .close()
-                .res_async()
-                .await?;
-            log::info!("Node: {} is closed.", &node.name);
-            Result::Ok(())
-        }
-    });
+                async_std::task::sleep(node.warmup).await;
 
-    // let (state, _, _) = select_all(futures).timeout(TIMEOUT).await?;
-    // state
-    try_join_all(futures).timeout(TIMEOUT).await??;
-    Ok(())
+                // In case of client can't connect to some peers/routers
+                let session = if let Ok(session) = zenoh::open(config.clone()).res_async().await {
+                    session.into_arc()
+                } else {
+                    log::info!("Sleep and retry to connect to the endpoint...");
+                    async_std::task::sleep(Duration::from_secs(1)).await;
+                    zenoh::open(config).res_async().await?.into_arc()
+                };
+
+                // Each node consists of a specified session associated with tasks to run
+                let futs = node.task.into_iter().map(|seq_tasks| {
+                    // Multiple tasks share the session
+                    let session = session.clone();
+                    let terminated = terminated.clone();
+
+                    async_std::task::spawn(async move {
+                        for t in seq_tasks {
+                            t.run(session.clone(), terminated.clone()).await?;
+                        }
+                        Result::Ok(())
+                    })
+                });
+
+                // let (state, _, _) = select_all(futs).await;
+                // state
+                try_join_all(futs).await?;
+                Arc::try_unwrap(session)
+                    .unwrap()
+                    .close()
+                    .res_async()
+                    .await?;
+                log::info!("Node: {} is closed.", &node.name);
+                Result::Ok(())
+            }
+        });
+
+        // let (state, _, _) = select_all(futures).timeout(TIMEOUT).await?;
+        // state
+        try_join_all(futures).timeout(TIMEOUT).await??;
+        Ok(())
+    }
 }
 
 #[test]
@@ -194,13 +217,13 @@ fn gossip() -> Result<()> {
         env_logger::try_init()?;
 
         let locator = String::from("tcp/127.0.0.1:17448");
-        let topic = String::from("testTopicGossip");
+        let ke = String::from("testKeyExprGossip");
         let msg_size = 8;
 
         // Gossip test
-        let recipe = [
+        let recipe = Recipe::new([
             Node {
-                name: "Peer0".into(),
+                name: format!("RTR {}", WhatAmI::Peer),
                 mode: WhatAmI::Peer,
                 listen: vec![locator.clone()],
                 task: ConcurrentTask::from([SequentialTask::from([Task::Sleep(
@@ -209,28 +232,30 @@ fn gossip() -> Result<()> {
                 ..Default::default()
             },
             Node {
-                name: "Peer1".into(),
+                name: format!("Pub {}", WhatAmI::Peer),
                 connect: vec![locator.clone()],
                 mode: WhatAmI::Peer,
                 task: ConcurrentTask::from([SequentialTask::from([
                     Task::Sleep(Duration::from_millis(2000)),
-                    Task::Pub(topic.clone(), msg_size),
+                    Task::Pub(ke.clone(), msg_size),
                 ])]),
                 ..Default::default()
             },
             Node {
-                name: "Peer2".into(),
+                name: format!("Sub {}", WhatAmI::Peer),
                 mode: WhatAmI::Peer,
                 connect: vec![locator.clone()],
                 task: ConcurrentTask::from([SequentialTask::from([
                     Task::Sleep(Duration::from_millis(2000)),
-                    Task::Sub(topic, msg_size),
+                    Task::Sub(ke, msg_size),
                     Task::Terminate,
                 ])]),
                 ..Default::default()
             },
-        ];
-        run_recipe(recipe).await?;
+        ]);
+
+        log::info!("[Recipe]: {}", &recipe);
+        recipe.run().await?;
         println!("Gossip test passed.");
         Result::Ok(())
     })?;
@@ -244,7 +269,7 @@ fn static_failover_brokering() -> Result<()> {
         // env_logger::try_init()?;
 
         let locator = String::from("tcp/127.0.0.1:17449");
-        let topic = String::from("testTopicStaticFailoverBrokering");
+        let ke = String::from("testKeyExprStaticFailoverBrokering");
         let msg_size = 8;
 
         let disable_autoconnect_config = || {
@@ -259,38 +284,39 @@ fn static_failover_brokering() -> Result<()> {
             Some(config)
         };
 
-        let recipe = [
+        let recipe = Recipe::new([
             Node {
-                name: "Router".into(),
+                name: format!("RTR {}", WhatAmI::Router),
                 mode: WhatAmI::Router,
                 listen: vec![locator.clone()],
                 task: ConcurrentTask::from([SequentialTask::from([Task::Wait])]),
                 ..Default::default()
             },
             Node {
-                name: "Peer1".into(),
+                name: format!("Pub {}", WhatAmI::Peer),
                 mode: WhatAmI::Peer,
                 connect: vec![locator.clone()],
                 config: disable_autoconnect_config(),
                 task: ConcurrentTask::from([SequentialTask::from([Task::Pub(
-                    topic.clone(),
+                    ke.clone(),
                     msg_size,
                 )])]),
                 ..Default::default()
             },
             Node {
-                name: "Peer2".into(),
+                name: format!("Sub {}", WhatAmI::Peer),
                 mode: WhatAmI::Peer,
                 connect: vec![locator.clone()],
                 config: disable_autoconnect_config(),
                 task: ConcurrentTask::from([SequentialTask::from([
-                    Task::Sub(topic.clone(), msg_size),
+                    Task::Sub(ke.clone(), msg_size),
                     Task::Terminate,
                 ])]),
                 ..Default::default()
             },
-        ];
-        run_recipe(recipe).await?;
+        ]);
+        log::info!("[Recipe]: {}", &recipe);
+        recipe.run().await?;
         println!("Static failover brokering test passed.");
         Result::Ok(())
     })?;
@@ -314,33 +340,33 @@ fn pubsub_combination() -> Result<()> {
             .flat_map(|(n1, n2)| MSG_SIZE.map(|s| (n1, n2, s)))
             .flat_map(|(node1_mode, node2_mode, msg_size)| {
                 idx += 1;
-                let topic = format!("pubsub_combination_topic_{idx}");
+                let ke = format!("pubsub_combination_keyexpr_{idx}");
                 let locator = format!("tcp/127.0.0.1:{}", base_port + idx);
 
                 let recipe = vec![
                     Node {
-                        name: "Router".into(),
+                        name: format!("RTR {}", WhatAmI::Router),
                         mode: WhatAmI::Router,
                         listen: vec![locator.clone()],
                         task: ConcurrentTask::from([SequentialTask::from([Task::Wait])]),
                         ..Default::default()
                     },
                     Node {
-                        name: "Node1".into(),
-                        connect: vec![locator.clone()],
+                        name: format!("Pub {node1_mode}"),
                         mode: node1_mode,
+                        connect: vec![locator.clone()],
                         task: ConcurrentTask::from([SequentialTask::from([Task::Pub(
-                            topic.clone(),
+                            ke.clone(),
                             msg_size,
                         )])]),
                         ..Default::default()
                     },
                     Node {
-                        name: "Node2".into(),
+                        name: format!("Sub {node2_mode}"),
                         mode: node2_mode,
                         connect: vec![locator],
                         task: ConcurrentTask::from([SequentialTask::from([
-                            Task::Sub(topic, msg_size),
+                            Task::Sub(ke, msg_size),
                             Task::Terminate,
                         ])]),
                         ..Default::default()
@@ -349,22 +375,97 @@ fn pubsub_combination() -> Result<()> {
 
                 // All permuations
                 vec![
-                    vec![recipe[0].clone(), recipe[1].clone(), recipe[2].clone()],
-                    vec![recipe[0].clone(), recipe[2].clone(), recipe[1].clone()],
-                    vec![recipe[1].clone(), recipe[0].clone(), recipe[2].clone()],
-                    vec![recipe[1].clone(), recipe[2].clone(), recipe[0].clone()],
-                    vec![recipe[2].clone(), recipe[0].clone(), recipe[1].clone()],
-                    vec![recipe[2].clone(), recipe[1].clone(), recipe[0].clone()],
+                    Recipe::new([recipe[0].clone(), recipe[1].clone(), recipe[2].clone()]),
+                    Recipe::new([recipe[0].clone(), recipe[2].clone(), recipe[1].clone()]),
+                    Recipe::new([recipe[1].clone(), recipe[0].clone(), recipe[2].clone()]),
+                    Recipe::new([recipe[1].clone(), recipe[2].clone(), recipe[0].clone()]),
+                    Recipe::new([recipe[2].clone(), recipe[0].clone(), recipe[1].clone()]),
+                    Recipe::new([recipe[2].clone(), recipe[1].clone(), recipe[0].clone()]),
                 ]
             });
 
         for recipe in recipe_list {
-            run_recipe(recipe).await?;
+            log::info!("[Recipe]: {}", &recipe);
+            recipe.run().await?;
         }
 
         // try_join_all(recipe_list.map(|r| run_recipe(r))).await?;
 
         println!("Pub/sub combination test passed.");
+        Result::Ok(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn p2p_combination() -> Result<()> {
+    async_std::task::block_on(async {
+        zasync_executor_init!();
+        // env_logger::try_init()?;
+
+        #[derive(Clone, Copy)]
+        struct IsFirstListen(bool);
+
+        let modes = [
+            (WhatAmI::Client, WhatAmI::Peer, IsFirstListen(false)),
+            (WhatAmI::Peer, WhatAmI::Client, IsFirstListen(true)),
+            (WhatAmI::Peer, WhatAmI::Peer, IsFirstListen(true)),
+            (WhatAmI::Peer, WhatAmI::Peer, IsFirstListen(false)),
+        ];
+
+        let mut idx = 0;
+        let base_port = 17470;
+        let recipe_list = modes
+            .into_iter()
+            .flat_map(|(n1, n2, who)| MSG_SIZE.map(|s| (n1, n2, who, s)))
+            .map(|(node1_mode, node2_mode, who, msg_size)| {
+                idx += 1;
+                let ke = format!("p2p_combination_keyexpr_{idx}");
+
+                let (node1_listen_connect, node2_listen_connect) = {
+                    let locator = format!("tcp/127.0.0.1:{}", base_port + idx);
+                    let listen = vec![locator];
+                    let connect = vec![];
+
+                    if let IsFirstListen(true) = who {
+                        ((listen.clone(), connect.clone()), (connect, listen))
+                    } else {
+                        ((connect.clone(), listen.clone()), (listen, connect))
+                    }
+                };
+
+                Recipe::new([
+                    Node {
+                        name: format!("Pub {node1_mode}"),
+                        mode: node1_mode,
+                        listen: node1_listen_connect.0,
+                        connect: node1_listen_connect.1,
+                        task: ConcurrentTask::from([SequentialTask::from([Task::Pub(
+                            ke.clone(),
+                            msg_size,
+                        )])]),
+                        ..Default::default()
+                    },
+                    Node {
+                        name: format!("Sub {node2_mode}"),
+                        mode: node2_mode,
+                        listen: node2_listen_connect.0,
+                        connect: node2_listen_connect.1,
+                        task: ConcurrentTask::from([SequentialTask::from([
+                            Task::Sub(ke, msg_size),
+                            Task::Terminate,
+                        ])]),
+                        ..Default::default()
+                    },
+                ])
+            });
+
+        for recipe in recipe_list {
+            log::info!("[Recipe]: {}", &recipe);
+            recipe.run().await?;
+        }
+
+        println!("P2P pub/sub combination test passed.");
         Result::Ok(())
     })?;
     Ok(())

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -309,7 +309,7 @@ impl Recipe {
         // All tasks of the recipe run together
         try_join_all(futures)
             .await
-            .map_err(|e| format!("The recipe: {} failed due to {}", &self, e))??;
+            .map_err(|e| format!("The recipe: {} failed due to {}", &self, e))?;
         Ok(())
     }
 }

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -308,8 +308,9 @@ impl Recipe {
 
         // All tasks of the recipe run together
         try_join_all(futures)
+            .timeout(TIMEOUT)
             .await
-            .map_err(|e| format!("The recipe: {} failed due to {}", &self, e))?;
+            .map_err(|e| format!("The recipe: {} failed due to {}", &self, e))??;
         Ok(())
     }
 }

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -27,8 +27,8 @@ use zenoh_config::ModeDependentValue;
 use zenoh_core::zasync_executor_init;
 use zenoh_result::{bail, zerror};
 
-const TIMEOUT: Duration = Duration::from_secs(240);
-const MSG_COUNT: usize = 1_000;
+const TIMEOUT: Duration = Duration::from_secs(360);
+const MSG_COUNT: usize = 50;
 const MSG_SIZE: [usize; 2] = [1_024, 131_072];
 
 macro_rules! ztimeout {

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -27,7 +27,7 @@ use zenoh_config::ModeDependentValue;
 use zenoh_core::zasync_executor_init;
 use zenoh_result::{bail, zerror};
 
-const TIMEOUT: Duration = Duration::from_secs(120);
+const TIMEOUT: Duration = Duration::from_secs(240);
 const MSG_COUNT: usize = 1_000;
 const MSG_SIZE: [usize; 2] = [1_024, 131_072];
 

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -1,0 +1,182 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+use futures::future::select_all;
+use futures::FutureExt as _;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_std::prelude::FutureExt;
+use zenoh::config::{whatami::WhatAmI, Config};
+use zenoh::prelude::r#async::*;
+use zenoh::Result;
+use zenoh_result::bail;
+
+const TIMEOUT: Duration = Duration::from_secs(10);
+
+macro_rules! ztimeout {
+    ($f:expr) => {
+        $f.timeout(TIMEOUT).await?
+    };
+}
+
+#[derive(Debug)]
+enum Task {
+    Pub(String, usize),
+    Sub(String, usize),
+    Sleep(Duration),
+}
+
+#[derive(Debug)]
+struct Node {
+    name: String,
+    mode: WhatAmI,
+    listen: Vec<String>,
+    connect: Vec<String>,
+    task: Vec<Task>,
+}
+
+impl Default for Node {
+    fn default() -> Self {
+        Self {
+            name: "TestNode".into(),
+            mode: WhatAmI::Peer,
+            listen: vec![],
+            connect: vec![],
+            task: vec![],
+        }
+    }
+}
+
+async fn run_recipe(receipe: impl IntoIterator<Item = Node>) -> Result<()> {
+    let futures = receipe.into_iter().map(|node| async move {
+        dbg!(node.name);
+
+        // Load the config and build up a session
+        let mut config = Config::default();
+        config.set_mode(Some(node.mode)).unwrap();
+        config.scouting.multicast.set_enabled(Some(false)).unwrap();
+        config
+            .listen
+            .set_endpoints(node.listen.iter().map(|x| x.parse().unwrap()).collect())
+            .unwrap();
+        config
+            .connect
+            .set_endpoints(node.connect.iter().map(|x| x.parse().unwrap()).collect())
+            .unwrap();
+
+        // In case of client can't connect to some peers/routers
+        let session = if let Ok(session) = zenoh::open(config.clone()).res_async().await {
+            Arc::new(session)
+        } else {
+            // Sleep one second and retry
+            async_std::task::sleep(Duration::from_secs(1)).await;
+            Arc::new(zenoh::open(config).res_async().await?)
+        };
+
+        // Each node consists of a specified session associated with tasks to run
+        let futs = node.task.into_iter().map(|task| {
+
+            // Each session spawns several given task(s)
+            let c_session = session.clone();
+            let fut = match task {
+
+                // Subscription task
+                Task::Sub(topic, expected_size) => {
+                    async_std::task::spawn(async move {
+                        let sub =
+                            ztimeout!(c_session.declare_subscriber(&topic).res_async())?;
+
+                        let mut counter = 0;
+                        while let Ok(sample) = sub.recv_async().await {
+                            let recv_size = sample.value.payload.len();
+                            if recv_size != expected_size {
+                                bail!("Received payload size {recv_size} mismatches the expected {expected_size}");
+                            }
+                            counter += 1;
+                            println!("Received : {:?}", sample);
+                            if counter >= 5 {
+                                break;
+                            }
+                        }
+                        Result::Ok(())
+                    })
+                }
+
+                // Publishment task
+                Task::Pub(topic, payload_size) => {
+                    async_std::task::spawn(async move {
+                        loop {
+                            async_std::task::sleep(Duration::from_millis(300)).await;
+                            ztimeout!(c_session
+                                .put(&topic, vec![0u8; payload_size])
+                                .congestion_control(CongestionControl::Block)
+                                .res_async())?;
+                        }
+                    })
+                }
+
+                // Sleep a while according to the given duration
+                Task::Sleep(dur) => async_std::task::spawn(async move {
+                    async_std::task::sleep(dur).await;
+                    Ok(())
+                }),
+            };
+            fut
+        });
+
+        let (state, _, _) = select_all(futs).await;
+        state
+    }.boxed());
+
+    let (state, _, _) = select_all(futures).timeout(TIMEOUT).await?;
+    Ok(state?)
+}
+
+
+#[test]
+fn gossip() -> Result<()> {
+    async_std::task::block_on(async {
+        let locator = String::from("tcp/127.0.0.1:17447");
+        let topic = String::from("testTopic");
+
+        // Gossip test
+        let recipe = [
+            Node {
+                name: "C".into(),
+                mode: WhatAmI::Peer,
+                listen: vec![locator.clone()],
+                task: vec![Task::Sleep(Duration::from_secs(30))],
+                ..Default::default()
+            },
+            Node {
+                name: "A".into(),
+                connect: vec![locator.clone()],
+                mode: WhatAmI::Peer,
+                task: vec![Task::Pub(topic.clone(), 8)],
+                ..Default::default()
+            },
+            Node {
+                name: "B".into(),
+                mode: WhatAmI::Peer,
+                connect: vec![locator.clone()],
+                task: vec![Task::Sub(topic.clone(), 8)],
+                ..Default::default()
+            },
+        ];
+        run_recipe(recipe).await?;
+        println!("Gossip test passed.");
+        Result::Ok(())
+    })?;
+    Ok(())
+}

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -454,10 +454,7 @@ fn pubsub_combination() -> Result<()> {
                                 Task::Sub(ke.clone(), msg_size),
                                 Task::CheckPoint,
                             ]),
-                            SequentialTask::from([
-                                Task::Get(ke, msg_size),
-                                Task::CheckPoint,
-                            ]),
+                            SequentialTask::from([Task::Get(ke, msg_size), Task::CheckPoint]),
                         ]),
                         ..Default::default()
                     },
@@ -547,10 +544,7 @@ fn p2p_combination() -> Result<()> {
                                 Task::Sub(ke.clone(), msg_size),
                                 Task::CheckPoint,
                             ]),
-                            SequentialTask::from([
-                                Task::Get(ke, msg_size),
-                                Task::CheckPoint,
-                            ]),
+                            SequentialTask::from([Task::Get(ke, msg_size), Task::CheckPoint]),
                         ]),
                         ..Default::default()
                     },

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -362,7 +362,7 @@ fn gossip() -> Result<()> {
         for mode in [WhatAmI::Peer, WhatAmI::Router] {
             Recipe::new([
                 Node {
-                    name: format!("RTR {}", mode),
+                    name: format!("Router {}", mode),
                     mode: WhatAmI::Peer,
                     listen: vec![locator.clone()],
                     con_task: ConcurrentTask::from([SequentialTask::from([Task::Sleep(
@@ -408,7 +408,7 @@ fn static_failover_brokering() -> Result<()> {
 
         let recipe = Recipe::new([
             Node {
-                name: format!("RTR {}", WhatAmI::Router),
+                name: format!("Router {}", WhatAmI::Router),
                 mode: WhatAmI::Router,
                 listen: vec![locator.clone()],
                 con_task: ConcurrentTask::from([SequentialTask::from([Task::Wait])]),
@@ -477,119 +477,82 @@ fn three_node_combination() -> Result<()> {
             .map(
                 |(node1_mode, node2_mode, msg_size, (delay1, delay2, delay3))| {
                     idx += 1;
-                    // let ke_pubsub = format!("three_node_combination_keyexpr_pubsub_{idx}");
+                    let locator = format!("tcp/127.0.0.1:{}", base_port + idx);
+
+                    let ke_pubsub = format!("three_node_combination_keyexpr_pubsub_{idx}");
                     let ke_getqueryable =
                         format!("three_node_combination_keyexpr_getqueryable_{idx}");
-                    let locator = format!("tcp/127.0.0.1:{}", base_port + idx);
 
-                    Recipe::new([
-                        Node {
-                            name: format!("RTR {}", WhatAmI::Router),
-                            mode: WhatAmI::Router,
-                            listen: vec![locator.clone()],
-                            con_task: ConcurrentTask::from([SequentialTask::from([Task::Wait])]),
-                            warmup: Duration::from_secs(delay1),
-                            ..Default::default()
-                        },
-                        Node {
-                            name: format!("Pub & Queryable {node1_mode}"),
-                            mode: node1_mode,
-                            connect: vec![locator.clone()],
-                            con_task: ConcurrentTask::from([
-                                // SequentialTask::from([Task::Pub(ke_pubsub.clone(), msg_size)]),
-                                SequentialTask::from([Task::Queryable(
-                                    ke_getqueryable.clone(),
+                    let router_node = Node {
+                        name: format!("Router {}", WhatAmI::Router),
+                        mode: WhatAmI::Router,
+                        listen: vec![locator.clone()],
+                        con_task: ConcurrentTask::from([SequentialTask::from([Task::Wait])]),
+                        warmup: Duration::from_secs(delay1),
+                        ..Default::default()
+                    };
+
+                    let (pub_node, queryable_node) =
+                        {
+                            let base = Node {
+                                mode: node1_mode,
+                                connect: vec![locator.clone()],
+                                warmup: Duration::from_secs(delay2),
+                                ..Default::default()
+                            };
+
+                            let mut pub_node = base.clone();
+                            pub_node.name = format!("Pub {node1_mode}");
+                            pub_node.con_task =
+                                ConcurrentTask::from([SequentialTask::from([Task::Pub(
+                                    ke_pubsub.clone(),
                                     msg_size,
-                                )]),
-                            ]),
-                            warmup: Duration::from_secs(delay2),
-                            ..Default::default()
-                        },
-                        Node {
-                            name: format!("Sub & Get {node2_mode}"),
+                                )])]);
+
+                            let mut queryable_node = base;
+                            queryable_node.name = format!("Queryable {node1_mode}");
+                            queryable_node.con_task = ConcurrentTask::from([SequentialTask::from(
+                                [Task::Queryable(ke_getqueryable.clone(), msg_size)],
+                            )]);
+
+                            (pub_node, queryable_node)
+                        };
+
+                    let (sub_node, get_node) = {
+                        let base = Node {
                             mode: node2_mode,
                             connect: vec![locator],
-                            con_task: ConcurrentTask::from([
-                                // SequentialTask::from([
-                                //     Task::Sub(ke_pubsub, msg_size),
-                                //     Task::Checkpoint,
-                                // ]),
-                                SequentialTask::from([
-                                    Task::Get(ke_getqueryable, msg_size),
-                                    Task::Checkpoint,
-                                ]),
-                            ]),
                             warmup: Duration::from_secs(delay3),
                             ..Default::default()
-                        },
-                    ])
+                        };
+
+                        let mut sub_node = base.clone();
+                        sub_node.name = format!("Sub {node2_mode}");
+                        sub_node.con_task = ConcurrentTask::from([SequentialTask::from([
+                            Task::Sub(ke_pubsub, msg_size),
+                            Task::Checkpoint,
+                        ])]);
+
+                        let mut get_node = base;
+                        get_node.name = format!("Get {node2_mode}");
+                        get_node.con_task = ConcurrentTask::from([SequentialTask::from([
+                            Task::Get(ke_getqueryable, msg_size),
+                            Task::Checkpoint,
+                        ])]);
+
+                        (sub_node, get_node)
+                    };
+
+                    (
+                        Recipe::new([router_node.clone(), pub_node, sub_node]),
+                        Recipe::new([router_node, queryable_node, get_node]),
+                    )
                 },
             );
 
-        for recipe in recipe_list {
-            recipe.run().await?;
-        }
-
-        let recipe_list = modes
-            .map(|n1| modes.map(|n2| (n1, n2)))
-            .concat()
-            .into_iter()
-            .flat_map(|(n1, n2)| MSG_SIZE.map(|s| (n1, n2, s)))
-            .flat_map(|(n1, n2, s)| delay_in_secs.map(|d| (n1, n2, s, d)))
-            .map(
-                |(node1_mode, node2_mode, msg_size, (delay1, delay2, delay3))| {
-                    idx += 1;
-                    let ke_pubsub = format!("three_node_combination_keyexpr_pubsub_{idx}");
-                    // let ke_getqueryable =
-                    //     format!("three_node_combination_keyexpr_getqueryable_{idx}");
-                    let locator = format!("tcp/127.0.0.1:{}", base_port + idx);
-
-                    Recipe::new([
-                        Node {
-                            name: format!("RTR {}", WhatAmI::Router),
-                            mode: WhatAmI::Router,
-                            listen: vec![locator.clone()],
-                            con_task: ConcurrentTask::from([SequentialTask::from([Task::Wait])]),
-                            warmup: Duration::from_secs(delay1),
-                            ..Default::default()
-                        },
-                        Node {
-                            name: format!("Pub & Queryable {node1_mode}"),
-                            mode: node1_mode,
-                            connect: vec![locator.clone()],
-                            con_task: ConcurrentTask::from([
-                                SequentialTask::from([Task::Pub(ke_pubsub.clone(), msg_size)]),
-                                // SequentialTask::from([Task::Queryable(
-                                //     ke_getqueryable.clone(),
-                                //     msg_size,
-                                // )]),
-                            ]),
-                            warmup: Duration::from_secs(delay2),
-                            ..Default::default()
-                        },
-                        Node {
-                            name: format!("Sub & Get {node2_mode}"),
-                            mode: node2_mode,
-                            connect: vec![locator],
-                            con_task: ConcurrentTask::from([
-                                SequentialTask::from([
-                                    Task::Sub(ke_pubsub, msg_size),
-                                    Task::Checkpoint,
-                                ]),
-                                // SequentialTask::from([
-                                //     Task::Get(ke_getqueryable, msg_size),
-                                //     Task::Checkpoint,
-                                // ]),
-                            ]),
-                            warmup: Duration::from_secs(delay3),
-                            ..Default::default()
-                        },
-                    ])
-                },
-            );
-
-        for recipe in recipe_list {
-            recipe.run().await?;
+        for (pubsub, getqueryable) in recipe_list {
+            pubsub.run().await?;
+            getqueryable.run().await?;
         }
 
         println!("Three-node combination test passed.");
@@ -624,7 +587,7 @@ fn two_node_combination() -> Result<()> {
             .flat_map(|(n1, n2, who)| MSG_SIZE.map(|s| (n1, n2, who, s)))
             .map(|(node1_mode, node2_mode, who, msg_size)| {
                 idx += 1;
-                // let ke_pubsub = format!("two_node_combination_keyexpr_pubsub_{idx}");
+                let ke_pubsub = format!("two_node_combination_keyexpr_pubsub_{idx}");
                 let ke_getqueryable = format!("two_node_combination_keyexpr_getqueryable_{idx}");
 
                 let (node1_listen_connect, node2_listen_connect) = {
@@ -639,102 +602,66 @@ fn two_node_combination() -> Result<()> {
                     }
                 };
 
-                Recipe::new([
-                    Node {
-                        name: format!("Pub & Queryable {node1_mode}"),
+                let (pub_node, queryable_node) = {
+                    let base = Node {
                         mode: node1_mode,
                         listen: node1_listen_connect.0,
                         connect: node1_listen_connect.1,
-                        con_task: ConcurrentTask::from([
-                            // SequentialTask::from([Task::Pub(ke_pubsub.clone(), msg_size)]),
-                            SequentialTask::from([Task::Queryable(
-                                ke_getqueryable.clone(),
-                                msg_size,
-                            )]),
-                        ]),
                         ..Default::default()
-                    },
-                    Node {
-                        name: format!("Sub & Get {node2_mode}"),
-                        mode: node2_mode,
-                        listen: node2_listen_connect.0,
-                        connect: node2_listen_connect.1,
-                        con_task: ConcurrentTask::from([
-                            // SequentialTask::from([
-                            //     Task::Sub(ke_pubsub, msg_size),
-                            //     Task::Checkpoint,
-                            // ]),
-                            SequentialTask::from([
-                                Task::Get(ke_getqueryable, msg_size),
-                                Task::Checkpoint,
-                            ]),
-                        ]),
-                        ..Default::default()
-                    },
-                ])
-            });
+                    };
 
-        for recipe in recipe_list {
-            recipe.run().await?;
-        }
+                    let mut pub_node = base.clone();
+                    pub_node.name = format!("Pub {node1_mode}");
+                    pub_node.con_task = ConcurrentTask::from([SequentialTask::from([Task::Pub(
+                        ke_pubsub.clone(),
+                        msg_size,
+                    )])]);
 
-        let recipe_list = modes
-            .into_iter()
-            .flat_map(|(n1, n2, who)| MSG_SIZE.map(|s| (n1, n2, who, s)))
-            .map(|(node1_mode, node2_mode, who, msg_size)| {
-                idx += 1;
-                let ke_pubsub = format!("two_node_combination_keyexpr_pubsub_{idx}");
-                // let ke_getqueryable = format!("two_node_combination_keyexpr_getqueryable_{idx}");
+                    let mut queryable_node = base;
+                    queryable_node.name = format!("Queryable {node1_mode}");
+                    queryable_node.con_task =
+                        ConcurrentTask::from([SequentialTask::from([Task::Queryable(
+                            ke_getqueryable.clone(),
+                            msg_size,
+                        )])]);
 
-                let (node1_listen_connect, node2_listen_connect) = {
-                    let locator = format!("tcp/127.0.0.1:{}", base_port + idx);
-                    let listen = vec![locator];
-                    let connect = vec![];
-
-                    if let IsFirstListen(true) = who {
-                        ((listen.clone(), connect.clone()), (connect, listen))
-                    } else {
-                        ((connect.clone(), listen.clone()), (listen, connect))
-                    }
+                    (pub_node, queryable_node)
                 };
 
-                Recipe::new([
-                    Node {
-                        name: format!("Pub & Queryable {node1_mode}"),
-                        mode: node1_mode,
-                        listen: node1_listen_connect.0,
-                        connect: node1_listen_connect.1,
-                        con_task: ConcurrentTask::from([
-                            SequentialTask::from([Task::Pub(ke_pubsub.clone(), msg_size)]),
-                            // SequentialTask::from([Task::Queryable(
-                            //     ke_getqueryable.clone(),
-                            //     msg_size,
-                            // )]),
-                        ]),
-                        ..Default::default()
-                    },
-                    Node {
-                        name: format!("Sub & Get {node2_mode}"),
+                let (sub_node, get_node) = {
+                    let base = Node {
                         mode: node2_mode,
                         listen: node2_listen_connect.0,
                         connect: node2_listen_connect.1,
-                        con_task: ConcurrentTask::from([
-                            SequentialTask::from([
-                                Task::Sub(ke_pubsub, msg_size),
-                                Task::Checkpoint,
-                            ]),
-                            // SequentialTask::from([
-                            //     Task::Get(ke_getqueryable, msg_size),
-                            //     Task::Checkpoint,
-                            // ]),
-                        ]),
                         ..Default::default()
-                    },
-                ])
+                    };
+
+                    let mut sub_node = base.clone();
+                    sub_node.name = format!("Sub {node2_mode}");
+                    sub_node.con_task = ConcurrentTask::from([SequentialTask::from([
+                        Task::Sub(ke_pubsub, msg_size),
+                        Task::Checkpoint,
+                    ])]);
+
+                    let mut get_node = base;
+                    get_node.name = format!("Get {node2_mode}");
+                    get_node.con_task = ConcurrentTask::from([SequentialTask::from([
+                        Task::Get(ke_getqueryable, msg_size),
+                        Task::Checkpoint,
+                    ])]);
+
+                    (sub_node, get_node)
+                };
+
+                (
+                    Recipe::new([pub_node, sub_node]),
+                    Recipe::new([queryable_node, get_node]),
+                )
             });
 
-        for recipe in recipe_list {
-            recipe.run().await?;
+        for (pubsub, getqueryable) in recipe_list {
+            pubsub.run().await?;
+            getqueryable.run().await?;
         }
 
         println!("Two-node combination test passed.");

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -11,14 +11,13 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
+use async_std::prelude::FutureExt;
 use futures::future::try_join_all;
 use futures::FutureExt as _;
 use std::str::FromStr;
 use std::sync::atomic::Ordering;
 use std::sync::{atomic::AtomicUsize, Arc};
 use std::time::Duration;
-
-use async_std::prelude::FutureExt;
 use zenoh::config::{whatami::WhatAmI, Config};
 use zenoh::prelude::r#async::*;
 use zenoh::{value::Value, Result};


### PR DESCRIPTION
- [x] Cover gossip test. (The bug was fixed last week. 185e630f4215512616969aa45f3036aa0b94e3ab)
- [x] Combinations of router/client/peer
    - [x] Basic cases
    - [x] Add options for spawning order
- [x] Failover brokering test
    - [x] ~Dynamic: disconnection in runtime is not supported yet. See #498 .~ (on hold)
    - [x] Static: Simulate the case of two peers that are connecting to one router but unable to reach each other.
- [x] Combinations of p2p pub/sub
- [x] Same tests for queryable and get