### PR TITLE
ZenohID are handled as NonZeroU128

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,7 +358,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -404,9 +404,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1e31e207a6b8fb791a38ea3105e6cb541f55e4d029902d3039a4ad07cc4105"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "base64ct"
@@ -1115,7 +1115,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -1457,9 +1457,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
@@ -1900,7 +1900,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -1941,7 +1941,7 @@ checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -2144,9 +2144,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
+checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
 dependencies = [
  "unicode-ident",
 ]
@@ -2201,9 +2201,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -2335,9 +2335,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a59b5d8e97dee33696bf13c5ba8ab85341c002922fba050069326b9c498974"
+checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2469,7 +2469,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64 0.21.1",
+ "base64 0.21.2",
 ]
 
 [[package]]
@@ -2583,7 +2583,7 @@ checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -2949,9 +2949,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
+checksum = "45b6ddbb36c5b969c182aec3c4a0bce7df3fbad4b77114706a49aacc80567388"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2990,7 +2990,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -3140,7 +3140,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -3189,7 +3189,7 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.17",
 ]
 
 [[package]]
@@ -3235,15 +3235,15 @@ checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 [[package]]
 name = "uhlc"
 version = "0.5.2"
-source = "git+https://github.com/atolab/uhlc-rs.git?branch=u128#0f3029ecb472e1d57481610d6c3526fe790800c9"
+source = "git+https://github.com/atolab/uhlc-rs.git?branch=u128#34348734fdf631c4bf57ba9229b50ca840ad5cad"
 dependencies = [
  "hex",
  "humantime",
  "lazy_static",
  "log",
+ "rand 0.8.5",
  "serde",
  "spin 0.9.8",
- "uuid",
 ]
 
 [[package]]
@@ -3254,9 +3254,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "unicode-normalization"
@@ -3440,7 +3440,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.17",
  "wasm-bindgen-shared",
 ]
 
@@ -3474,7 +3474,7 @@ checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.17",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3782,7 +3782,7 @@ dependencies = [
  "async-global-executor",
  "async-std",
  "async-trait",
- "base64 0.21.1",
+ "base64 0.21.2",
  "env_logger",
  "event-listener",
  "flume",
@@ -4155,7 +4155,7 @@ version = "0.7.0-rc"
 dependencies = [
  "anyhow",
  "async-std",
- "base64 0.21.1",
+ "base64 0.21.2",
  "clap",
  "env_logger",
  "flume",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0e9889e6db118d49d88d84728d0e964d973a5680befb5f85f55141beea5c20b"
 dependencies = [
  "libc",
- "mach 0.1.2",
+ "mach",
 ]
 
 [[package]]
@@ -20,7 +20,7 @@ checksum = "99696c398cbaf669d2368076bdb3d627fb0ce51a26899d7c61228c5c0af3bf4a"
 dependencies = [
  "CoreFoundation-sys",
  "libc",
- "mach 0.1.2",
+ "mach",
 ]
 
 [[package]]
@@ -125,9 +125,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anyhow"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "array-init"
@@ -278,7 +278,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29479d362e242e320fa8f5c831940a5b83c1679af014068196cd20d4bf497b6b"
 dependencies = [
  "futures-io",
- "rustls 0.21.0",
+ "rustls",
 ]
 
 [[package]]
@@ -358,7 +358,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -404,9 +404,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "3f1e31e207a6b8fb791a38ea3105e6cb541f55e4d029902d3039a4ad07cc4105"
 
 [[package]]
 name = "base64ct"
@@ -428,6 +428,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487f1e0fcbe47deb8b0574e646def1c903389d95241dd1bbcc6ce4a715dfc0c1"
 
 [[package]]
 name = "blake3"
@@ -479,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.1"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "byteorder"
@@ -497,9 +503,9 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cache-padded"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
+checksum = "981520c98f422fcc584dc1a95c334e6953900b9106bc47a9839b81790009eb21"
 
 [[package]]
 name = "cast"
@@ -543,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "ciborium"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -554,15 +560,15 @@ dependencies = [
 
 [[package]]
 name = "ciborium-io"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
 
 [[package]]
 name = "ciborium-ll"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
 dependencies = [
  "ciborium-io",
  "half",
@@ -589,12 +595,12 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.24"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef2b3ded6a26dfaec672a742c93c8cf6b689220324da509ec5caa20de55dc83"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex",
  "indexmap",
  "strsim",
@@ -616,16 +622,6 @@ name = "cobs"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
-
-[[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
-]
 
 [[package]]
 name = "concurrent-queue"
@@ -824,9 +820,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.10.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
+checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
 dependencies = [
  "generic-array",
  "subtle",
@@ -849,50 +845,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb4a30d54f7443bf3d6191dcd486aca19e67cb3c49fa7a06a319966346707e7f"
 dependencies = [
  "cipher 0.2.5",
-]
-
-[[package]]
-name = "cxx"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn 2.0.15",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.15",
 ]
 
 [[package]]
@@ -941,9 +893,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid",
@@ -953,22 +905,23 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "5.0.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dece029acd3353e3a58ac2e3eb3c8d6c35827a892edc6cc4138ef9c33df46ecd"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04414300db88f70d74c5ff54e50f9e1d1737d9a5b90f53fcf2e95ca2a9ab554b"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
+ "option-ext",
  "redox_users",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1162,7 +1115,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -1356,7 +1309,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
- "crypto-mac 0.10.1",
+ "crypto-mac 0.10.0",
  "digest 0.9.0",
 ]
 
@@ -1366,7 +1319,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1451,12 +1404,11 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone-haiku"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
- "cxx",
- "cxx-build",
+ "cc",
 ]
 
 [[package]]
@@ -1552,9 +1504,9 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1572,9 +1524,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
 dependencies = [
  "cpufeatures",
 ]
@@ -1608,9 +1560,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libloading"
@@ -1624,24 +1576,15 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
-
-[[package]]
-name = "link-cplusplus"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
-dependencies = [
- "cc",
-]
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.4"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eb31c1778188ae1e64398743890d0877fef36d11521ac60406b42016e8c2cf"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
@@ -1674,10 +1617,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "mach"
-version = "0.3.2"
+name = "mach2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
 dependencies = [
  "libc",
 ]
@@ -1755,7 +1698,7 @@ version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cc",
  "cfg-if 1.0.0",
  "libc",
@@ -1764,22 +1707,11 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
-dependencies = [
- "bitflags",
- "cfg-if 1.0.0",
- "libc",
-]
-
-[[package]]
-name = "nix"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "libc",
  "memoffset 0.7.1",
@@ -1876,6 +1808,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ordered-float"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1962,7 +1900,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -1988,22 +1926,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -2172,7 +2110,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
 dependencies = [
  "autocfg",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "concurrent-queue",
  "libc",
@@ -2206,68 +2144,66 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quinn"
-version = "0.9.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445cbfe2382fa023c4f2f3c7e1c95c03dcc1df2bf23cebcb2b13e1402c4394d1"
+checksum = "21252f1c0fc131f1b69182db8f34837e8a69737b8251dff75636a9be0518c324"
 dependencies = [
  "bytes",
  "pin-project-lite 0.2.9",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.20.8",
+ "rustls",
  "thiserror",
  "tokio",
  "tracing",
- "webpki",
 ]
 
 [[package]]
 name = "quinn-proto"
-version = "0.9.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c10f662eee9c94ddd7135043e544f3c82fa839a1e7b865911331961b53186c"
+checksum = "85af4ed6ee5a89f26a26086e9089a6643650544c025158449a3626ebf72884b3"
 dependencies = [
  "bytes",
  "rand 0.8.5",
  "ring",
  "rustc-hash",
- "rustls 0.20.8",
+ "rustls",
  "rustls-native-certs",
  "slab",
  "thiserror",
  "tinyvec",
  "tracing",
- "webpki",
 ]
 
 [[package]]
 name = "quinn-udp"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "641538578b21f5e5c8ea733b736895576d0fe329bb883b937db6f4d163dbaaf4"
+checksum = "6df19e284d93757a9fb91d63672f7741b129246a669db09d1c0063071debc0c0"
 dependencies = [
+ "bytes",
  "libc",
- "quinn-proto",
- "socket2 0.4.9",
+ "socket2 0.5.3",
  "tracing",
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
 ]
@@ -2373,7 +2309,7 @@ checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.20",
+ "time 0.3.21",
  "yasna",
 ]
 
@@ -2383,7 +2319,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2399,9 +2335,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+checksum = "d1a59b5d8e97dee33696bf13c5ba8ab85341c002922fba050069326b9c498974"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2410,9 +2346,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "ring"
@@ -2452,7 +2388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55a77d189da1fee555ad95b7e50e7457d91c0e089ec68ca69ad2989413bbdab4"
 dependencies = [
  "byteorder",
- "digest 0.10.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-iter",
@@ -2491,11 +2427,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.15"
+version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0661814f891c57c930a610266415528da53c4933e6dea5fb350cbfe048a9ece"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -2505,21 +2441,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.8"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
-dependencies = [
- "log",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07180898a28ed6a7f7ba2311594308f595e3dd2e3c3812fa0a80a47b45f17e5d"
+checksum = "c911ba11bc8433e811ce56fde130ccf32f5127cab0e0194e9c68c5a5b671791e"
 dependencies = [
  "log",
  "ring",
@@ -2545,7 +2469,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.1",
 ]
 
 [[package]]
@@ -2589,12 +2513,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "scratch"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
-
-[[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2606,11 +2524,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.8.2"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
+checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2619,9 +2537,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
+checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2650,29 +2568,29 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "serde_fmt"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6180def5ddda7565fea64b0fba33b99192d86d669f23b5019598e0b7e846b407"
+checksum = "e1d4ddca14104cd60529e8c7f7ba71a2c8acd8f7f5cfcdc2faf97eeb7c3010a4"
 dependencies = [
  "serde",
 ]
@@ -2726,17 +2644,18 @@ dependencies = [
 
 [[package]]
 name = "serialport"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aab92efb5cf60ad310548bc3f16fa6b0d950019cb7ed8ff41968c3d03721cf12"
+checksum = "353dc2cbfc67c9a14a89a1292a9d8e819bd51066b083e08c1974ba08e3f48c62"
 dependencies = [
  "CoreFoundation-sys",
  "IOKit-sys",
- "bitflags",
+ "bitflags 2.0.2",
  "cfg-if 1.0.0",
- "mach 0.3.2",
- "nix 0.24.3",
+ "mach2",
+ "nix 0.26.2",
  "regex",
+ "scopeguard",
  "winapi",
 ]
 
@@ -2757,7 +2676,7 @@ checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2787,16 +2706,16 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c2bb1a323307527314a36bfb73f24febb08ce2b8a554bf4ffd6f51ad15198c"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -2847,7 +2766,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -2887,9 +2806,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d283f86695ae989d1e18440a943880967156325ba025f05049946bff47bcc2b"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
@@ -3004,9 +2923,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "sval"
@@ -3030,9 +2949,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3071,7 +2990,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -3125,9 +3044,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
 dependencies = [
  "serde",
  "time-core",
@@ -3135,9 +3054,9 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
@@ -3198,9 +3117,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.28.0"
+version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c786bf8134e5a3a166db9b29ab8f48134739014a3eca7bc6bfa95d673b136f"
+checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3221,7 +3140,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -3251,10 +3170,12 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.38"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9cf6a813d3f40c88b0b6b6f29a5c95c6cdbf97c1f9cc53fb820200f5ad814d"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
+ "cfg-if 1.0.0",
+ "log",
  "pin-project-lite 0.2.9",
  "tracing-attributes",
  "tracing-core",
@@ -3268,14 +3189,14 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
 ]
@@ -3314,8 +3235,7 @@ checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 [[package]]
 name = "uhlc"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d291a7454d390b753ef68df8145da18367e32883ec2fa863959f0aefb915cdb"
+source = "git+https://github.com/atolab/uhlc-rs.git?branch=u128#0f3029ecb472e1d57481610d6c3526fe790800c9"
 dependencies = [
  "hex",
  "humantime",
@@ -3348,16 +3268,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
 name = "universal-hash"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
+checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
 dependencies = [
  "generic-array",
  "subtle",
@@ -3412,9 +3326,9 @@ checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "uuid"
-version = "1.3.1"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b55a3fef2a1e3b3a00ce878640918820d3c51081576ac657d23af9fc7928fdb"
+checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
 dependencies = [
  "getrandom 0.2.9",
 ]
@@ -3505,9 +3419,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -3517,24 +3431,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.16",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.34"
+version = "0.4.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
+checksum = "2d1985d03709c53167ce907ff394f5316aa22cb4e12761295c5dc57dacb6297e"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3544,9 +3458,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3554,28 +3468,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.16",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3845,7 +3759,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
- "time 0.3.20",
+ "time 0.3.21",
 ]
 
 [[package]]
@@ -3868,7 +3782,7 @@ dependencies = [
  "async-global-executor",
  "async-std",
  "async-trait",
- "base64 0.21.0",
+ "base64 0.21.1",
  "env_logger",
  "event-listener",
  "flume",
@@ -3885,7 +3799,7 @@ dependencies = [
  "rustc_version 0.4.0",
  "serde",
  "serde_json",
- "socket2 0.5.2",
+ "socket2 0.5.3",
  "stop-token",
  "uhlc",
  "uuid",
@@ -4079,7 +3993,7 @@ dependencies = [
  "futures",
  "log",
  "quinn",
- "rustls 0.20.8",
+ "rustls",
  "rustls-native-certs",
  "rustls-pemfile",
  "webpki",
@@ -4159,7 +4073,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "log",
- "socket2 0.5.2",
+ "socket2 0.5.3",
  "zenoh-buffers",
  "zenoh-collections",
  "zenoh-core",
@@ -4241,7 +4155,7 @@ version = "0.7.0-rc"
 dependencies = [
  "anyhow",
  "async-std",
- "base64 0.21.0",
+ "base64 0.21.1",
  "clap",
  "env_logger",
  "flume",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,7 +364,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.17",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -533,13 +539,13 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "fdbc37d37da9e5bce8173f3a41b71d9bf3c674deebbaceacd0ebdabde76efb03"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-integer",
  "num-traits",
  "serde",
  "time 0.1.45",
@@ -829,16 +835,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "ctr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,7 +1111,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.17",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1598,11 +1594,10 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
 dependencies = [
- "cfg-if 1.0.0",
  "serde",
  "value-bag",
 ]
@@ -1660,14 +1655,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "eebffdb73fe72e917997fad08bdbf31ac50b0fa91cec93e69a0662e4264d454c"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1785,9 +1780,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
 
 [[package]]
 name = "oorandom"
@@ -1900,7 +1895,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.17",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1941,7 +1936,7 @@ checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.17",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2583,7 +2578,7 @@ checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.17",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2929,11 +2924,70 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "sval"
-version = "1.0.0-alpha.5"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45f6ee7c7b87caf59549e9fe45d6a69c75c8019e79e212a835c5da0e92f0ba08"
+checksum = "0e6aa16ce8d9e472e21a528a52c875a76a49190f3968f2ec7e9b550ccc28b410"
+
+[[package]]
+name = "sval_buffer"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "905c4373621186ee9637464b0aaa026389ea9e7f841f2225f160a32ba5d5bac4"
+dependencies = [
+ "sval",
+ "sval_ref",
+]
+
+[[package]]
+name = "sval_dynamic"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad6b4988322c5f22859a6a7649fa1249aa3dd01514caf8ed57d83735f997bb8b"
+dependencies = [
+ "sval",
+]
+
+[[package]]
+name = "sval_fmt"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d3ccd10346f925c2fbd97b75e8573b38e34431bfba04cc531cd23aad0fbabb8"
+dependencies = [
+ "itoa",
+ "ryu",
+ "sval",
+]
+
+[[package]]
+name = "sval_json"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a12e1488defd6344e23243c17ea4a1b185c547968749e8a281373fde0bde2d5"
+dependencies = [
+ "itoa",
+ "ryu",
+ "sval",
+]
+
+[[package]]
+name = "sval_ref"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b797fc4b284dd0e45f7ec424479e604ea5be9bb191a1ef4e96c20c7685649938"
+dependencies = [
+ "sval",
+]
+
+[[package]]
+name = "sval_serde"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "810fa9a837e67a23e0efa7536250fc4d24043306cc1efd076f1943ba2fc2e62d"
 dependencies = [
  "serde",
+ "sval",
+ "sval_buffer",
+ "sval_fmt",
 ]
 
 [[package]]
@@ -2949,9 +3003,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45b6ddbb36c5b969c182aec3c4a0bce7df3fbad4b77114706a49aacc80567388"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2990,7 +3044,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.17",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -3117,9 +3171,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.28.1"
+version = "1.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
+checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3140,7 +3194,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.17",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -3189,7 +3243,7 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.17",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -3234,8 +3288,9 @@ checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "uhlc"
-version = "0.5.2"
-source = "git+https://github.com/atolab/uhlc-rs.git?branch=u128#34348734fdf631c4bf57ba9229b50ca840ad5cad"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1438496174a601a35fb41bf9bc408e47384b1df52ddc1252e75ef0ab811322"
 dependencies = [
  "hex",
  "humantime",
@@ -3359,16 +3414,38 @@ dependencies = [
 
 [[package]]
 name = "value-bag"
-version = "1.0.0-alpha.9"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
+checksum = "a4d330786735ea358f3bc09eea4caa098569c1c93f342d9aca0514915022fe7e"
 dependencies = [
- "ctor",
+ "value-bag-serde1",
+ "value-bag-sval2",
+]
+
+[[package]]
+name = "value-bag-serde1"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4735c95b4cca1447b448e2e2e87e98d7e7498f4da27e355cf7af02204521001d"
+dependencies = [
  "erased-serde",
  "serde",
  "serde_fmt",
+]
+
+[[package]]
+name = "value-bag-sval2"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859cb4f0ce7da6a118b559ba74b0e63bf569bea867c20ba457a6b1c886a04e97"
+dependencies = [
  "sval",
- "version_check",
+ "sval_buffer",
+ "sval_dynamic",
+ "sval_fmt",
+ "sval_json",
+ "sval_ref",
+ "sval_serde",
 ]
 
 [[package]]
@@ -3440,7 +3517,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.17",
+ "syn 2.0.18",
  "wasm-bindgen-shared",
 ]
 
@@ -3474,7 +3551,7 @@ checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.17",
+ "syn 2.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3573,7 +3650,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3593,35 +3670,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,7 @@ token-cell = { version = "1.4.2", default-features = false }
 tokio = { version = "1.26.0", default-features = false } # Default features are disabled due to some crates' requirements
 tokio-tungstenite = "0.18.0"
 typenum = "1.16.0"
-uhlc = { version = "0.5.2", default-features = false } # Default features are disabled due to usage in no_std crates
+uhlc = { git = "https://github.com/atolab/uhlc-rs.git", branch = "u128", default-features = false } # Default features are disabled due to usage in no_std crates
 unzip-n = "0.1.2"
 url = "2.3.1"
 urlencoding = "2.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,7 @@ token-cell = { version = "1.4.2", default-features = false }
 tokio = { version = "1.26.0", default-features = false } # Default features are disabled due to some crates' requirements
 tokio-tungstenite = "0.18.0"
 typenum = "1.16.0"
-uhlc = { git = "https://github.com/atolab/uhlc-rs.git", branch = "u128", default-features = false } # Default features are disabled due to usage in no_std crates
+uhlc = { version = "0.6.0", default-features = false } # Default features are disabled due to usage in no_std crates
 unzip-n = "0.1.2"
 url = "2.3.1"
 urlencoding = "2.1.2"

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -2,10 +2,10 @@
 /// For a more complete view of the configuration's structure, check out `zenoh/src/config.rs`'s `Config` structure.
 /// Note that the values here are correctly typed, but may not be sensible, so copying this file to change only the parts that matter to you is not good practice.
 {
-  /// The identifier (as hex-string) that zenohd must use.
+  /// The identifier (as UUID) that zenoh runtime will use.
   /// If not set, a random UUIDv4 will be used.
   /// WARNING: this id must be unique in your zenoh network.
-  // id: "5975702c206974277320415343494921",
+  // id: "00000000-0000-0000-0000-000000000001",
 
   /// The node's mode (router, peer or client)
   mode: "peer",

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -2,10 +2,10 @@
 /// For a more complete view of the configuration's structure, check out `zenoh/src/config.rs`'s `Config` structure.
 /// Note that the values here are correctly typed, but may not be sensible, so copying this file to change only the parts that matter to you is not good practice.
 {
-  /// The identifier (as UUID) that zenoh runtime will use.
-  /// If not set, a random UUIDv4 will be used.
+  /// The identifier (as unsigned 128bit integer) that zenoh runtime will use.
+  /// If not set, a random unsigned 128bit integer will be used.
   /// WARNING: this id must be unique in your zenoh network.
-  // id: "00000000-0000-0000-0000-000000000001",
+  // id: "1234567890abcdef",
 
   /// The node's mode (router, peer or client)
   mode: "peer",

--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ See other examples of Zenoh usage in [examples/](examples)
   * `-e, --connect <ENDPOINT>...`: An endpoint this router will try to connect to. Repeat this option to connect to several peers or routers.
   * `--no-multicast-scouting`: By default zenohd replies to multicast scouting messages for being discovered by peers and clients.
     This option disables this feature.
-  * `-i, --id <hex_string>`: The identifier (as an hexadecimal string - e.g.: 0A0B23...) that zenohd must use.
-     **WARNING**: this identifier must be unique in the system! If not set, a random UUIDv4 will be used.
+  * `-i, --id <hex_string>`: The identifier (as an hexadecimal string - e.g.: A0B23...) that zenohd must use.
+     **WARNING**: this identifier must be unique in the system! If not set, a random unsigned 128bit integer will be used.
   * `--no-timestamp`: By default zenohd adds a HLC-generated Timestamp to each routed Data if there isn't already one.
     This option disables this feature.
   * `-P, --plugin [<PLUGIN_NAME> | <PLUGIN_NAME>:<LIBRARY_PATH>]...`: A [plugin](https://zenoh.io/docs/manual/plugins/) that must be loaded. Accepted values:

--- a/commons/zenoh-cfg-properties/src/config.rs
+++ b/commons/zenoh-cfg-properties/src/config.rs
@@ -222,7 +222,7 @@ pub const ZN_OPEN_INCOMING_PENDING_DEFAULT: &str = "100";
 
 /// Configures the peer ID.
 /// String key: `"peer_id"`.
-/// Accepted values: `<UUID>`.
+/// Accepted values: `<hex u128>`.
 pub const ZN_PEER_ID_KEY: u64 = 0x68;
 pub const ZN_PEER_ID_STR: &str = "peer_id";
 

--- a/commons/zenoh-codec/src/core/timestamp.rs
+++ b/commons/zenoh-codec/src/core/timestamp.rs
@@ -27,7 +27,8 @@ where
 
     fn write(self, writer: &mut W, x: &Timestamp) -> Self::Output {
         self.write(&mut *writer, x.get_time().as_u64())?;
-        self.write(&mut *writer, x.get_id().as_slice())?;
+        let id = x.get_id();
+        self.write(&mut *writer, &id.to_le_bytes()[..id.size()])?;
         Ok(())
     }
 }

--- a/commons/zenoh-codec/src/core/zenohid.rs
+++ b/commons/zenoh-codec/src/core/zenohid.rs
@@ -26,7 +26,7 @@ where
     type Output = Result<(), DidntWrite>;
 
     fn write(self, writer: &mut W, x: &ZenohId) -> Self::Output {
-        self.write(&mut *writer, x.as_slice())
+        self.write(&mut *writer, &x.to_le_bytes()[..x.size()])
     }
 }
 

--- a/commons/zenoh-codec/tests/codec.rs
+++ b/commons/zenoh-codec/tests/codec.rs
@@ -157,7 +157,7 @@ fn codec_locator() {
 fn codec_timestamp() {
     run!(Timestamp, {
         let time = uhlc::NTP64(thread_rng().gen());
-        let id = uhlc::ID::try_from(ZenohId::rand().as_slice()).unwrap();
+        let id = uhlc::ID::try_from(ZenohId::rand().to_le_bytes()).unwrap();
         Timestamp::new(time, id)
     });
 }

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -108,7 +108,7 @@ validated_struct::validator! {
     #[serde(default)]
     #[serde(deny_unknown_fields)]
     Config {
-        /// The Zenoh ID of the instance. This ID MUST be unique throughout your Zenoh infrastructure and cannot exceed 16 bytes of length. If left unset, a random UUIDv4 will be generated.
+        /// The Zenoh ID of the instance. This ID MUST be unique throughout your Zenoh infrastructure and cannot exceed 16 bytes of length. If left unset, a random u128 will be generated.
         id: ZenohId,
         /// The node's mode ("router" (default value in `zenohd`), "peer" or "client").
         mode: Option<whatami::WhatAmI>,

--- a/commons/zenoh-protocol/src/core/mod.rs
+++ b/commons/zenoh-protocol/src/core/mod.rs
@@ -226,22 +226,10 @@ impl FromStr for ZenohId {
     type Err = zenoh_result::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // filter-out '-' characters (in case s has UUID format)
-        match s.parse::<Uuid>() {
-            Ok(u) => Ok(ZenohId::from(u)),
-            Err(_) => {
-                // Handle odd-length string for the hex decode
-                let i = if s.len() % 2 != 0 {
-                    let mut t = String::from("0");
-                    t.push_str(s);
-                    hex::decode(t)
-                } else {
-                    hex::decode(s)
-                }
-                .map_err(|e| zerror!("Invalid id: {} - {}", s, e))?;
-                i.as_slice().try_into()
-            }
-        }
+        let u: Uuid = s
+            .parse()
+            .map_err(|e| zerror!("Invalid id: {} - {}", s, e))?;
+        Ok(ZenohId::from(u))
     }
 }
 

--- a/commons/zenoh-protocol/src/core/mod.rs
+++ b/commons/zenoh-protocol/src/core/mod.rs
@@ -21,12 +21,11 @@ use alloc::{
 use core::{
     convert::{From, TryFrom, TryInto},
     fmt,
-    hash::{Hash, Hasher},
+    hash::Hash,
     num::NonZeroU64,
     str::FromStr,
 };
 pub use uhlc::{Timestamp, NTP64};
-use uuid::Uuid;
 use zenoh_keyexpr::OwnedKeyExpr;
 use zenoh_result::{bail, zerror};
 
@@ -103,7 +102,8 @@ impl TryFrom<ZInt> for SampleKind {
 }
 
 /// The global unique id of a zenoh peer.
-#[derive(Clone, Copy, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
 pub struct ZenohId(uhlc::ID);
 
 impl ZenohId {
@@ -115,12 +115,12 @@ impl ZenohId {
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &[u8] {
-        self.0.as_slice()
+    pub fn to_le_bytes(&self) -> [u8; uhlc::ID::MAX_SIZE] {
+        self.0.to_le_bytes()
     }
 
     pub fn rand() -> ZenohId {
-        ZenohId::from(Uuid::new_v4())
+        ZenohId(uhlc::ID::rand())
     }
 
     pub fn into_keyexpr(self) -> OwnedKeyExpr {
@@ -131,20 +131,6 @@ impl ZenohId {
 impl Default for ZenohId {
     fn default() -> Self {
         Self::rand()
-    }
-}
-
-impl From<uuid::Uuid> for ZenohId {
-    #[inline]
-    fn from(uuid: uuid::Uuid) -> Self {
-        ZenohId(uuid.into())
-    }
-}
-
-impl From<ZenohId> for uuid::Uuid {
-    #[inline]
-    fn from(zid: ZenohId) -> Self {
-        zid.into()
     }
 }
 
@@ -180,10 +166,10 @@ macro_rules! derive_tryfrom {
         impl TryFrom<$T> for ZenohId {
             type Error = zenoh_result::Error;
             fn try_from(val: $T) -> Result<Self, Self::Error> {
-                return match val.try_into() {
+                match val.try_into() {
                     Ok(ok) => Ok(Self(ok)),
                     Err(err) => Err(Box::<SizeError>::new(err.into())),
-                };
+                }
             }
         }
     };
@@ -226,30 +212,16 @@ impl FromStr for ZenohId {
     type Err = zenoh_result::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let u: Uuid = s
+        let u: uhlc::ID = s
             .parse()
-            .map_err(|e| zerror!("Invalid id: {} - {}", s, e))?;
-        Ok(ZenohId::from(u))
-    }
-}
-
-impl PartialEq for ZenohId {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        self.0.eq(&other.0)
-    }
-}
-
-impl Hash for ZenohId {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.as_slice().hash(state);
+            .map_err(|e: uhlc::ParseIDError| zerror!("Invalid id: {} - {}", s, e.cause))?;
+        Ok(ZenohId(u))
     }
 }
 
 impl fmt::Debug for ZenohId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let uuid = Uuid::from(self.0);
-        write!(f, "{}", uuid)
+        write!(f, "{}", self.0)
     }
 }
 

--- a/commons/zenoh-protocol/src/zenoh/data.rs
+++ b/commons/zenoh-protocol/src/zenoh/data.rs
@@ -135,7 +135,7 @@ impl DataInfo {
         let encoding = rng.gen_bool(0.5).then(Encoding::rand);
         let timestamp = rng.gen_bool(0.5).then(|| {
             let time = uhlc::NTP64(rng.gen());
-            let id = uhlc::ID::try_from(ZenohId::rand().as_slice()).unwrap();
+            let id = uhlc::ID::try_from(ZenohId::rand().to_le_bytes()).unwrap();
             Timestamp::new(time, id)
         });
         let source_id = rng.gen_bool(0.5).then(ZenohId::rand);

--- a/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
@@ -773,7 +773,7 @@ fn test_create_digest_empty_initial() {
         zenoh_core::zasync_executor_init!();
     });
     let created = Digest::create_digest(
-        Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+        Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
         DigestConfig {
             delta: Duration::from_millis(1000),
             sub_intervals: 10,
@@ -784,7 +784,7 @@ fn test_create_digest_empty_initial() {
         1671612730,
     );
     let expected = Digest {
-        timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+        timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
         config: DigestConfig {
             delta: Duration::from_millis(1000),
             sub_intervals: 10,
@@ -805,7 +805,7 @@ fn test_create_digest_with_initial_hot() {
         zenoh_core::zasync_executor_init!();
     });
     let created = Digest::create_digest(
-        Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+        Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
         DigestConfig {
             delta: Duration::from_millis(1000),
             sub_intervals: 10,
@@ -813,40 +813,40 @@ fn test_create_digest_with_initial_hot() {
             warm: 30,
         },
         vec![LogEntry {
-            timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+            timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
             key: OwnedKeyExpr::from_str("demo/example/a").unwrap(),
         }],
         1671634800,
     );
     let expected = Digest {
-        timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+        timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
         config: DigestConfig {
             delta: Duration::from_millis(1000),
             sub_intervals: 10,
             hot: 6,
             warm: 30,
         },
-        checksum: 3304302629246049840,
+        checksum: 6001159706341373391,
         eras: HashMap::from([(
             EraType::Hot,
             Interval {
-                checksum: 8238986480495191270,
+                checksum: 4598971083408074426,
                 content: BTreeSet::from([1671634800]),
             },
         )]),
         intervals: HashMap::from([(
             1671634800,
             Interval {
-                checksum: 12344398372324783476,
+                checksum: 8436018757196527319,
                 content: BTreeSet::from([16716348000]),
             },
         )]),
         subintervals: HashMap::from([(
             16716348000,
             SubInterval {
-                checksum: 10007212639402189432,
+                checksum: 10827088509365589085,
                 content: BTreeSet::from([LogEntry {
-                    timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+                    timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
                     key: OwnedKeyExpr::from_str("demo/example/a").unwrap(),
                 }]),
             },
@@ -861,7 +861,7 @@ fn test_create_digest_with_initial_warm() {
         zenoh_core::zasync_executor_init!();
     });
     let created = Digest::create_digest(
-        Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+        Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
         DigestConfig {
             delta: Duration::from_millis(1000),
             sub_intervals: 10,
@@ -869,40 +869,40 @@ fn test_create_digest_with_initial_warm() {
             warm: 30,
         },
         vec![LogEntry {
-            timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+            timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
             key: OwnedKeyExpr::from_str("demo/example/a").unwrap(),
         }],
         1671634810,
     );
     let expected = Digest {
-        timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+        timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
         config: DigestConfig {
             delta: Duration::from_millis(1000),
             sub_intervals: 10,
             hot: 6,
             warm: 30,
         },
-        checksum: 3304302629246049840,
+        checksum: 6001159706341373391,
         eras: HashMap::from([(
             EraType::Warm,
             Interval {
-                checksum: 8238986480495191270,
+                checksum: 4598971083408074426,
                 content: BTreeSet::from([1671634800]),
             },
         )]),
         intervals: HashMap::from([(
             1671634800,
             Interval {
-                checksum: 12344398372324783476,
+                checksum: 8436018757196527319,
                 content: BTreeSet::from([16716348000]),
             },
         )]),
         subintervals: HashMap::from([(
             16716348000,
             SubInterval {
-                checksum: 10007212639402189432,
+                checksum: 10827088509365589085,
                 content: BTreeSet::from([LogEntry {
-                    timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+                    timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
                     key: OwnedKeyExpr::from_str("demo/example/a").unwrap(),
                 }]),
             },
@@ -917,7 +917,7 @@ fn test_create_digest_with_initial_cold() {
         zenoh_core::zasync_executor_init!();
     });
     let created = Digest::create_digest(
-        Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+        Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
         DigestConfig {
             delta: Duration::from_millis(1000),
             sub_intervals: 10,
@@ -925,40 +925,40 @@ fn test_create_digest_with_initial_cold() {
             warm: 30,
         },
         vec![LogEntry {
-            timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+            timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
             key: OwnedKeyExpr::from_str("demo/example/a").unwrap(),
         }],
         1671634910,
     );
     let expected = Digest {
-        timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+        timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
         config: DigestConfig {
             delta: Duration::from_millis(1000),
             sub_intervals: 10,
             hot: 6,
             warm: 30,
         },
-        checksum: 3304302629246049840,
+        checksum: 6001159706341373391,
         eras: HashMap::from([(
             EraType::Cold,
             Interval {
-                checksum: 8238986480495191270,
+                checksum: 4598971083408074426,
                 content: BTreeSet::from([1671634800]),
             },
         )]),
         intervals: HashMap::from([(
             1671634800,
             Interval {
-                checksum: 12344398372324783476,
+                checksum: 8436018757196527319,
                 content: BTreeSet::from([16716348000]),
             },
         )]),
         subintervals: HashMap::from([(
             16716348000,
             SubInterval {
-                checksum: 10007212639402189432,
+                checksum: 10827088509365589085,
                 content: BTreeSet::from([LogEntry {
-                    timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+                    timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
                     key: OwnedKeyExpr::from_str("demo/example/a").unwrap(),
                 }]),
             },
@@ -974,7 +974,7 @@ fn test_update_digest_add_content() {
     });
     let created = async_std::task::block_on(Digest::update_digest(
         Digest {
-            timestamp: Timestamp::from_str("2022-12-21T13:00:00.000000000Z/01").unwrap(),
+            timestamp: Timestamp::from_str("2022-12-21T13:00:00.000000000Z/1").unwrap(),
             config: DigestConfig {
                 delta: Duration::from_millis(1000),
                 sub_intervals: 10,
@@ -987,42 +987,42 @@ fn test_update_digest_add_content() {
             subintervals: HashMap::new(),
         },
         1671634910,
-        Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+        Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
         HashSet::from([LogEntry {
-            timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+            timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
             key: OwnedKeyExpr::from_str("demo/example/a").unwrap(),
         }]),
         HashSet::new(),
     ));
     let expected = Digest {
-        timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+        timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
         config: DigestConfig {
             delta: Duration::from_millis(1000),
             sub_intervals: 10,
             hot: 6,
             warm: 30,
         },
-        checksum: 3304302629246049840,
+        checksum: 6001159706341373391,
         eras: HashMap::from([(
             EraType::Cold,
             Interval {
-                checksum: 8238986480495191270,
+                checksum: 4598971083408074426,
                 content: BTreeSet::from([1671634800]),
             },
         )]),
         intervals: HashMap::from([(
             1671634800,
             Interval {
-                checksum: 12344398372324783476,
+                checksum: 8436018757196527319,
                 content: BTreeSet::from([16716348000]),
             },
         )]),
         subintervals: HashMap::from([(
             16716348000,
             SubInterval {
-                checksum: 10007212639402189432,
+                checksum: 10827088509365589085,
                 content: BTreeSet::from([LogEntry {
-                    timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+                    timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
                     key: OwnedKeyExpr::from_str("demo/example/a").unwrap(),
                 }]),
             },
@@ -1038,7 +1038,7 @@ fn test_update_digest_remove_content() {
     });
     let created = async_std::task::block_on(Digest::update_digest(
         Digest {
-            timestamp: Timestamp::from_str("2022-12-21T13:00:00.000000000Z/01").unwrap(),
+            timestamp: Timestamp::from_str("2022-12-21T13:00:00.000000000Z/1").unwrap(),
             config: DigestConfig {
                 delta: Duration::from_millis(1000),
                 sub_intervals: 10,
@@ -1065,23 +1065,22 @@ fn test_update_digest_remove_content() {
                 SubInterval {
                     checksum: 10007212639402189432,
                     content: BTreeSet::from([LogEntry {
-                        timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01")
-                            .unwrap(),
+                        timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
                         key: OwnedKeyExpr::from_str("demo/example/a").unwrap(),
                     }]),
                 },
             )]),
         },
         1671634910,
-        Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+        Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
         HashSet::new(),
         HashSet::from([LogEntry {
-            timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+            timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
             key: OwnedKeyExpr::from_str("demo/example/a").unwrap(),
         }]),
     ));
     let expected = Digest {
-        timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+        timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
         config: DigestConfig {
             delta: Duration::from_millis(1000),
             sub_intervals: 10,
@@ -1102,7 +1101,7 @@ fn test_update_remove_digest() {
         zenoh_core::zasync_executor_init!();
     });
     let created = Digest::create_digest(
-        Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+        Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
         DigestConfig {
             delta: Duration::from_millis(1000),
             sub_intervals: 10,
@@ -1115,9 +1114,9 @@ fn test_update_remove_digest() {
     let added = async_std::task::block_on(Digest::update_digest(
         created.clone(),
         1671612730,
-        Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+        Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
         HashSet::from([LogEntry {
-            timestamp: Timestamp::from_str("2022-12-21T12:00:00.000000000Z/01").unwrap(),
+            timestamp: Timestamp::from_str("2022-12-21T12:00:00.000000000Z/1").unwrap(),
             key: OwnedKeyExpr::from_str("a/b/c").unwrap(),
         }]),
         HashSet::new(),
@@ -1127,10 +1126,10 @@ fn test_update_remove_digest() {
     let removed = async_std::task::block_on(Digest::update_digest(
         added.clone(),
         1671612730,
-        Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+        Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
         HashSet::new(),
         HashSet::from([LogEntry {
-            timestamp: Timestamp::from_str("2022-12-21T12:00:00.000000000Z/01").unwrap(),
+            timestamp: Timestamp::from_str("2022-12-21T12:00:00.000000000Z/1").unwrap(),
             key: OwnedKeyExpr::from_str("a/b/c").unwrap(),
         }]),
     ));
@@ -1139,9 +1138,9 @@ fn test_update_remove_digest() {
     let added_again = async_std::task::block_on(Digest::update_digest(
         removed,
         1671612730,
-        Timestamp::from_str("2022-12-21T15:00:00.000000000Z/01").unwrap(),
+        Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
         HashSet::from([LogEntry {
-            timestamp: Timestamp::from_str("2022-12-21T12:00:00.000000000Z/01").unwrap(),
+            timestamp: Timestamp::from_str("2022-12-21T12:00:00.000000000Z/1").unwrap(),
             key: OwnedKeyExpr::from_str("a/b/c").unwrap(),
         }]),
         HashSet::new(),

--- a/plugins/zenoh-plugin-storage-manager/src/replica/mod.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/mod.rs
@@ -64,7 +64,7 @@ pub const SUBINTERVAL_CHUNKS: usize = 10;
 
 pub struct Replica {
     // TODO: Discuss if we need to add -<storage_type> for uniqueness
-    name: String, // name of replica  -- UUID(zenoh)-<storage_name>
+    name: String, // name of replica  -- ID(zenoh)-<storage_name>
     session: Arc<Session>,
     key_expr: OwnedKeyExpr,
     replica_config: ReplicaConfig,

--- a/zenoh-ext/examples/z_view_size.rs
+++ b/zenoh-ext/examples/z_view_size.rs
@@ -68,7 +68,7 @@ fn parse_args() -> (Config, String, Option<String>, usize, u64) {
             "-g, --group=[STRING] 'The group name'",
         ).default_value("zgroup"))
         .arg(Arg::from_usage(
-            "-i, --id=[STRING] 'The group member id (default is the zenoh UUID)'",
+            "-i, --id=[STRING] 'The group member id (default is the zenoh ID)'",
         ))
         .arg(Arg::from_usage(
             "-s, --size=[INT] 'The expected group size. The example will wait for the group to reach this size'",

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -228,7 +228,7 @@ where
 /// use zenoh::prelude::r#async::*;
 ///
 /// let mut config = config::peer();
-/// config.set_id(ZenohId::from_str("F000").unwrap());
+/// config.set_id(ZenohId::from_str("221B72DF-2092-4C15-B879-4C6BDB471150").unwrap());
 /// config.connect.endpoints.extend("tcp/10.10.10.10:7447,tcp/11.11.11.11:7447".split(',').map(|s|s.parse().unwrap()));
 ///
 /// let session = zenoh::open(config).res().await.unwrap();

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -228,7 +228,7 @@ where
 /// use zenoh::prelude::r#async::*;
 ///
 /// let mut config = config::peer();
-/// config.set_id(ZenohId::from_str("221B72DF-2092-4C15-B879-4C6BDB471150").unwrap());
+/// config.set_id(ZenohId::from_str("221B72DF20924C15B8794C6BDB471150").unwrap());
 /// config.connect.endpoints.extend("tcp/10.10.10.10:7447,tcp/11.11.11.11:7447".split(',').map(|s|s.parse().unwrap()));
 ///
 /// let session = zenoh::open(config).res().await.unwrap();

--- a/zenoh/src/net/routing/network.rs
+++ b/zenoh/src/net/routing/network.rs
@@ -310,12 +310,12 @@ impl Network {
     fn update_edge(&mut self, idx1: NodeIndex, idx2: NodeIndex) {
         use std::hash::Hasher;
         let mut hasher = std::collections::hash_map::DefaultHasher::default();
-        if self.graph[idx1].zid.as_slice() > self.graph[idx2].zid.as_slice() {
-            hasher.write(self.graph[idx2].zid.as_slice());
-            hasher.write(self.graph[idx1].zid.as_slice());
+        if self.graph[idx1].zid > self.graph[idx2].zid {
+            hasher.write(&self.graph[idx2].zid.to_le_bytes());
+            hasher.write(&self.graph[idx1].zid.to_le_bytes());
         } else {
-            hasher.write(self.graph[idx1].zid.as_slice());
-            hasher.write(self.graph[idx2].zid.as_slice());
+            hasher.write(&self.graph[idx1].zid.to_le_bytes());
+            hasher.write(&self.graph[idx2].zid.to_le_bytes());
         }
         let weight = 100.0 + ((hasher.finish() as u32) as f64) / u32::MAX as f64;
         self.graph.update_edge(idx1, idx2, weight);

--- a/zenoh/src/net/routing/router.rs
+++ b/zenoh/src/net/routing/router.rs
@@ -207,7 +207,7 @@ impl Tables {
                     for b in key_expr.as_bytes() {
                         hasher.write_u8(*b);
                     }
-                    for b in r.as_slice() {
+                    for b in &r.to_le_bytes()[..r.size()] {
                         hasher.write_u8(*b);
                     }
                     hasher.finish()

--- a/zenohd/.service/zenohd.json5
+++ b/zenohd/.service/zenohd.json5
@@ -7,10 +7,10 @@
 {
   /**
    * The identifier (as hex-string) that zenohd must use.
-   * If not set, a random UUIDv4 will be used.
+   * If not set, a random unsigned 128bit integer will be used.
    * WARNING: this id must be unique in your zenoh network.
    */
-  // id: "0123456789ABCDEF",
+  // id: "123456789ABCDEF",
 
   /**
    * Which endpoints to listen on. E.g. tcp/localhost:7447.

--- a/zenohd/src/main.rs
+++ b/zenohd/src/main.rs
@@ -49,7 +49,7 @@ clap::Arg::new("listen").short('l').long("listen").value_name("ENDPOINT").help(r
 Repeat this option to open several listeners.").takes_value(true).multiple_occurrences(true),
 clap::Arg::new("connect").short('e').long("connect").value_name("ENDPOINT").help(r"A peer locator this router will try to connect to.
 Repeat this option to connect to several peers.").takes_value(true).multiple_occurrences(true),
-clap::Arg::new("id").short('i').long("id").value_name("HEX_STRING").help(r"The identifier (as an hexadecimal string, with odd number of chars - e.g.: 0A0B23...) that zenohd must use. If not set, a random UUIDv4 will be used.
+clap::Arg::new("id").short('i').long("id").value_name("HEX_STRING").help(r"The identifier (as an hexadecimal string, with odd number of chars - e.g.: A0B23...) that zenohd must use. If not set, a random unsigned 128bit integer will be used.
 WARNING: this identifier must be unique in the system and must be 16 bytes maximum (32 chars)!").multiple_values(false).multiple_occurrences(false),
 clap::Arg::new("plugin").short('P').long("plugin").value_name("PLUGIN").takes_value(true).multiple_occurrences(true).help(r#"A plugin that MUST be loaded. You can give just the name of the plugin, zenohd will search for a library named 'libzenoh_plugin_<name>.so' (exact name depending the OS). Or you can give such a string: "<plugin_name>:<library_path>".
 Repeat this option to load several plugins. If loading failed, zenohd will exit."#),


### PR DESCRIPTION
This PR displays ZenohID as u128. 

This is to fix an inconsistency that may be encountered when configuring the ZenohID via config and retrieve it from the adminspace.

Depends on: https://github.com/atolab/uhlc-rs/pull/9

Verify breaking changes:

- [x] zenoh-backend-filesystem
- [x] zenoh-backend-influxdb
- [x] zenoh-backend-rocksdb
- [x] zenoh-backend-s3
- [ ] zenoh-c https://github.com/eclipse-zenoh/zenoh-c/pull/163
- [ ] zenoh-cpp https://github.com/eclipse-zenoh/zenoh-cpp/pull/48
- [x] zenoh-pico https://github.com/eclipse-zenoh/zenoh-pico/pull/216
- [x] zenoh-plugin-dds
- [x] zenoh-plugin-mqtt
- [x] zenoh-plugin-ros1
- [x] zenoh-plugin-webserver
- [ ] zenoh-python https://github.com/eclipse-zenoh/zenoh-python/pull/105