### PR TITLE
Fixing hypothetic race in zenoh-links

### DIFF
--- a/io/zenoh-links/zenoh-link-quic/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/unicast.rs
@@ -386,6 +386,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastQuic {
         // Spawn the accept loop for the listener
         let active = Arc::new(AtomicBool::new(true));
         let signal = Signal::new();
+        let mut listeners = zwrite!(self.listeners);
 
         let c_active = active.clone();
         let c_signal = signal.clone();
@@ -403,7 +404,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastQuic {
         let locator = endpoint.to_locator();
         let listener = ListenerUnicastQuic::new(endpoint, active, signal, handle);
         // Update the list of active listeners on the manager
-        zwrite!(self.listeners).insert(local_addr, listener);
+        listeners.insert(local_addr, listener);
 
         Ok(locator)
     }

--- a/io/zenoh-links/zenoh-link-serial/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-serial/src/unicast.rs
@@ -309,6 +309,8 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastSerial {
         // Spawn the accept loop for the listener
         let active = Arc::new(AtomicBool::new(true));
         let signal = Signal::new();
+        let mut listeners = zwrite!(self.listeners);
+
         let c_path = path.clone();
         let c_active = active.clone();
         let c_signal = signal.clone();
@@ -332,7 +334,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastSerial {
         let locator = endpoint.to_locator();
         let listener = ListenerUnicastSerial::new(endpoint, active, signal, handle);
         // Update the list of active listeners on the manager
-        zwrite!(self.listeners).insert(path, listener);
+        listeners.insert(path, listener);
 
         Ok(locator)
     }

--- a/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
@@ -299,6 +299,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastTcp {
                     // Spawn the accept loop for the listener
                     let active = Arc::new(AtomicBool::new(true));
                     let signal = Signal::new();
+                    let mut listeners = zwrite!(self.listeners);
 
                     let c_active = active.clone();
                     let c_signal = signal.clone();
@@ -315,7 +316,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastTcp {
                     let locator = endpoint.to_locator();
                     let listener = ListenerUnicastTcp::new(endpoint, active, signal, handle);
                     // Update the list of active listeners on the manager
-                    zwrite!(self.listeners).insert(local_addr, listener);
+                    listeners.insert(local_addr, listener);
 
                     return Ok(locator);
                 }

--- a/io/zenoh-links/zenoh-link-udp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/unicast.rs
@@ -401,6 +401,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastUdp {
                     // Spawn the accept loop for the listener
                     let active = Arc::new(AtomicBool::new(true));
                     let signal = Signal::new();
+                    let mut listeners = zwrite!(self.listeners);
 
                     let c_active = active.clone();
                     let c_signal = signal.clone();
@@ -417,7 +418,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastUdp {
                     let locator = endpoint.to_locator();
                     let listener = ListenerUnicastUdp::new(endpoint, active, signal, handle);
                     // Update the list of active listeners on the manager
-                    zwrite!(self.listeners).insert(local_addr, listener);
+                    listeners.insert(local_addr, listener);
 
                     return Ok(locator);
                 }

--- a/io/zenoh-links/zenoh-link-unixsock_stream/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-unixsock_stream/src/unicast.rs
@@ -362,6 +362,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastUnixSocketStream {
         // Spawn the accept loop for the listener
         let active = Arc::new(AtomicBool::new(true));
         let signal = Signal::new();
+        let mut listeners = zwrite!(self.listeners);
 
         let c_active = active.clone();
         let c_signal = signal.clone();
@@ -377,7 +378,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastUnixSocketStream {
 
         let locator = endpoint.to_locator();
         let listener = ListenerUnixSocketStream::new(endpoint, active, signal, handle, lock_fd);
-        zwrite!(self.listeners).insert(local_path_str.to_owned(), listener);
+        listeners.insert(local_path_str.to_owned(), listener);
 
         Ok(locator)
     }


### PR DESCRIPTION
I discovered some repeated code that I don't like: the concurrent listening task may (theoretically) finish earlier than the spawning task, leaving `listener` unremoved and thus leaving obsolete data in `self.listeners`. Obviously, 99.9(9)% of time that does not happen, but in some corner cases \ platforms that theoretically could.