### PR TITLE
Added multiple root CA support

### DIFF
--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -605,13 +605,15 @@ impl TlsClientConfig {
 
         // Allows mixed user-generated CA and webPKI CA
         log::debug!("Loading default Web PKI certificates.");
-        let mut root_cert_store: RootCertStore = RootCertStore { roots: load_default_webpki_certs().roots };
-        
-        if let Some(custom_root_cert) = load_trust_anchors(config)?{
+        let mut root_cert_store: RootCertStore = RootCertStore {
+            roots: load_default_webpki_certs().roots,
+        };
+
+        if let Some(custom_root_cert) = load_trust_anchors(config)? {
             log::debug!("Loading user-generated certificates.");
             root_cert_store.add_server_trust_anchors(custom_root_cert.roots.into_iter());
         }
-            
+
         let cc = if client_auth {
             log::debug!("Loading client authentication key and certificate...");
             let tls_client_private_key = TlsClientConfig::load_tls_private_key(config).await?;

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -603,11 +603,15 @@ impl TlsClientConfig {
             client_auth = value.parse()?
         }
 
-        let root_cert_store =
-            load_trust_anchors(config)?.map_or_else(|| {
-                log::debug!("Field 'root_ca_certificate' not specified. Loading default Web PKI certificates instead.");
-                load_default_webpki_certs()
-            }, |certs| certs);
+        // Allows mixed user-generated CA and webPKI CA
+        log::debug!("Loading default Web PKI certificates.");
+        let mut root_cert_store: RootCertStore = RootCertStore { roots: load_default_webpki_certs().roots };
+        
+        if let Some(custom_root_cert) = load_trust_anchors(config)?{
+            log::debug!("Loading user-generated certificates.");
+            root_cert_store.add_server_trust_anchors(custom_root_cert.roots.into_iter());
+        }
+            
         let cc = if client_auth {
             log::debug!("Loading client authentication key and certificate...");
             let tls_client_private_key = TlsClientConfig::load_tls_private_key(config).await?;


### PR DESCRIPTION
Makes it possible to have user-generated and webki TLS CA in the same network.

Tested with the following setup:
1. A local (peer) subscriber with user-generated CA using miniCA
2. A default router in the cloud deployed via the PaaS
3. A local (client) subscriber connected to the cloud router
4. A local (peer) publisher connected to two endpoints: one for the local peer (1.) with user-generated CA, another for the PaaS router (3.) with webkpi configured.

Both 1. and 3. are able to establish a session with 4. simultaneously.