### PR TITLE
Add support for pubsub multicast

### DIFF
--- a/io/zenoh-links/zenoh-link-udp/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/lib.rs
@@ -85,7 +85,7 @@ impl LocatorInspector for UdpLocatorInspector {
 }
 
 pub mod config {
-    pub const UDP_MULTICAST_SRC_IFACE: &str = "src_iface";
+    pub const UDP_MULTICAST_IFACE: &str = "iface";
 }
 
 pub async fn get_udp_addrs(address: Address<'_>) -> ZResult<impl Iterator<Item = SocketAddr>> {

--- a/io/zenoh-transport/src/manager.rs
+++ b/io/zenoh-transport/src/manager.rs
@@ -15,6 +15,7 @@ use super::multicast::manager::{
     TransportManagerBuilderMulticast, TransportManagerConfigMulticast,
     TransportManagerStateMulticast,
 };
+use super::multicast::TransportMulticast;
 use super::unicast::manager::{
     TransportManagerBuilderUnicast, TransportManagerConfigUnicast, TransportManagerStateUnicast,
 };
@@ -499,15 +500,24 @@ impl TransportManager {
             );
         }
 
-        if self
-            .locator_inspector
-            .is_multicast(&endpoint.to_locator())
-            .await?
+        self.open_transport_unicast(endpoint).await
+    }
+
+    pub async fn open_transport_mcast(&self, endpoint: EndPoint) -> ZResult<TransportMulticast> {
+        let p = endpoint.protocol();
+        if !self
+            .config
+            .protocols
+            .iter()
+            .any(|x| x.as_str() == p.as_str())
         {
-            // @TODO: multicast
-            bail!("Unimplemented");
-        } else {
-            self.open_transport_unicast(endpoint).await
+            bail!(
+                "Unsupported protocol: {}. Supported protocols are: {:?}",
+                p,
+                self.config.protocols
+            );
         }
+
+        self.open_transport_multicast(endpoint).await
     }
 }

--- a/io/zenoh-transport/src/multicast/link.rs
+++ b/io/zenoh-transport/src/multicast/link.rs
@@ -87,8 +87,22 @@ impl TransportLinkMulticast {
         let initial_sns: Vec<ConduitSn> = conduit_tx
             .iter()
             .map(|x| ConduitSn {
-                reliable: zlock!(x.reliable).sn.now(),
-                best_effort: zlock!(x.best_effort).sn.now(),
+                reliable: {
+                    let sn = zlock!(x.reliable).sn.now();
+                    if sn == 0 {
+                        config.sn_resolution - 1
+                    } else {
+                        sn - 1
+                    }
+                },
+                best_effort: {
+                    let sn = zlock!(x.best_effort).sn.now();
+                    if sn == 0 {
+                        config.sn_resolution - 1
+                    } else {
+                        sn - 1
+                    }
+                },
             })
             .collect();
 

--- a/io/zenoh-transport/src/multicast/manager.rs
+++ b/io/zenoh-transport/src/multicast/manager.rs
@@ -41,9 +41,9 @@ pub struct TransportManagerBuilderMulticast {
 
 pub struct TransportManagerStateMulticast {
     // Established listeners
-    pub(super) protocols: Arc<Mutex<HashMap<String, LinkManagerMulticast>>>,
+    pub(crate) protocols: Arc<Mutex<HashMap<String, LinkManagerMulticast>>>,
     // Established transports
-    pub(super) transports: Arc<Mutex<HashMap<Locator, Arc<TransportMulticastInner>>>>,
+    pub(crate) transports: Arc<Mutex<HashMap<Locator, Arc<TransportMulticastInner>>>>,
 }
 
 pub struct TransportManagerParamsMulticast {
@@ -89,7 +89,9 @@ impl TransportManagerBuilderMulticast {
             config.transport().multicast().join_interval().unwrap(),
         ));
         self = self.max_sessions(config.transport().multicast().max_sessions().unwrap());
-        self = self.qos(*config.transport().qos().enabled());
+        // Force QoS deactivation in multicast
+        // self = self.qos(*config.transport().qos().enabled());
+        self = self.qos(false);
 
         Ok(self)
     }

--- a/io/zenoh-transport/src/multicast/rx.rs
+++ b/io/zenoh-transport/src/multicast/rx.rs
@@ -83,7 +83,7 @@ impl TransportMulticastInner {
                 "Transport: {}. Frame with invalid SN dropped: {}. Expected: {}.",
                 self.manager.config.zid,
                 sn,
-                guard.sn.get()
+                guard.sn.get() + 1,
             );
             // Drop the fragments if needed
             if !guard.defrag.is_empty() {

--- a/io/zenoh-transport/src/primitives/mux.rs
+++ b/io/zenoh-transport/src/primitives/mux.rs
@@ -1,3 +1,5 @@
+use crate::TransportMulticast;
+
 //
 // Copyright (c) 2023 ZettaScale Technology
 //
@@ -37,6 +39,206 @@ impl Mux {
 }
 
 impl Primitives for Mux {
+    fn decl_resource(&self, expr_id: ZInt, key_expr: &WireExpr) {
+        let d = Declaration::Resource(Resource {
+            expr_id,
+            key: key_expr.to_owned(),
+        });
+        let decls = vec![d];
+        let _ = self
+            .handler
+            .handle_message(ZenohMessage::make_declare(decls, None, None));
+    }
+
+    fn forget_resource(&self, expr_id: ZInt) {
+        let d = Declaration::ForgetResource(ForgetResource { expr_id });
+        let decls = vec![d];
+        let _ = self
+            .handler
+            .handle_message(ZenohMessage::make_declare(decls, None, None));
+    }
+
+    fn decl_subscriber(
+        &self,
+        key_expr: &WireExpr,
+        sub_info: &SubInfo,
+        routing_context: Option<RoutingContext>,
+    ) {
+        let d = Declaration::Subscriber(Subscriber {
+            key: key_expr.to_owned(),
+            info: sub_info.clone(),
+        });
+        let decls = vec![d];
+        let _ =
+            self.handler
+                .handle_message(ZenohMessage::make_declare(decls, routing_context, None));
+    }
+
+    fn forget_subscriber(&self, key_expr: &WireExpr, routing_context: Option<RoutingContext>) {
+        let d = Declaration::ForgetSubscriber(ForgetSubscriber {
+            key: key_expr.to_owned(),
+        });
+        let decls = vec![d];
+        let _ =
+            self.handler
+                .handle_message(ZenohMessage::make_declare(decls, routing_context, None));
+    }
+
+    fn decl_publisher(&self, key_expr: &WireExpr, routing_context: Option<RoutingContext>) {
+        let d = Declaration::Publisher(Publisher {
+            key: key_expr.to_owned(),
+        });
+        let decls = vec![d];
+        let _ =
+            self.handler
+                .handle_message(ZenohMessage::make_declare(decls, routing_context, None));
+    }
+
+    fn forget_publisher(&self, key_expr: &WireExpr, routing_context: Option<RoutingContext>) {
+        let d = Declaration::ForgetPublisher(ForgetPublisher {
+            key: key_expr.to_owned(),
+        });
+        let decls = vec![d];
+        let _ =
+            self.handler
+                .handle_message(ZenohMessage::make_declare(decls, routing_context, None));
+    }
+
+    fn decl_queryable(
+        &self,
+        key_expr: &WireExpr,
+        qabl_info: &QueryableInfo,
+        routing_context: Option<RoutingContext>,
+    ) {
+        let d = Declaration::Queryable(Queryable {
+            key: key_expr.to_owned(),
+            info: qabl_info.clone(),
+        });
+        let decls = vec![d];
+        let _ =
+            self.handler
+                .handle_message(ZenohMessage::make_declare(decls, routing_context, None));
+    }
+
+    fn forget_queryable(&self, key_expr: &WireExpr, routing_context: Option<RoutingContext>) {
+        let d = Declaration::ForgetQueryable(ForgetQueryable {
+            key: key_expr.to_owned(),
+        });
+        let decls = vec![d];
+        let _ =
+            self.handler
+                .handle_message(ZenohMessage::make_declare(decls, routing_context, None));
+    }
+
+    fn send_data(
+        &self,
+        key_expr: &WireExpr,
+        payload: ZBuf,
+        channel: Channel,
+        cogestion_control: CongestionControl,
+        data_info: Option<DataInfo>,
+        routing_context: Option<RoutingContext>,
+    ) {
+        let _ = self.handler.handle_message(ZenohMessage::make_data(
+            key_expr.to_owned(),
+            payload,
+            channel,
+            cogestion_control,
+            data_info,
+            routing_context,
+            None,
+            None,
+        ));
+    }
+
+    fn send_query(
+        &self,
+        key_expr: &WireExpr,
+        parameters: &str,
+        qid: ZInt,
+        target: QueryTarget,
+        consolidation: ConsolidationMode,
+        body: Option<QueryBody>,
+        routing_context: Option<RoutingContext>,
+    ) {
+        let target_opt = if target == QueryTarget::default() {
+            None
+        } else {
+            Some(target)
+        };
+        let _ = self.handler.handle_message(ZenohMessage::make_query(
+            key_expr.to_owned(),
+            parameters.to_owned(),
+            qid,
+            target_opt,
+            consolidation,
+            body,
+            routing_context,
+            None,
+        ));
+    }
+
+    fn send_reply_data(
+        &self,
+        qid: ZInt,
+        replier_id: ZenohId,
+        key_expr: WireExpr,
+        data_info: Option<DataInfo>,
+        payload: ZBuf,
+    ) {
+        let _ = self.handler.handle_message(ZenohMessage::make_data(
+            key_expr.to_owned(),
+            payload,
+            zmsg::default_channel::REPLY,
+            zmsg::default_congestion_control::REPLY,
+            data_info,
+            None,
+            Some(ReplyContext::new(qid, Some(ReplierInfo { id: replier_id }))),
+            None,
+        ));
+    }
+
+    fn send_reply_final(&self, qid: ZInt) {
+        let _ = self.handler.handle_message(ZenohMessage::make_unit(
+            zmsg::default_channel::REPLY,
+            zmsg::default_congestion_control::REPLY,
+            Some(ReplyContext::new(qid, None)),
+            None,
+        ));
+    }
+
+    fn send_pull(
+        &self,
+        is_final: bool,
+        key_expr: &WireExpr,
+        pull_id: ZInt,
+        max_samples: &Option<ZInt>,
+    ) {
+        let _ = self.handler.handle_message(ZenohMessage::make_pull(
+            is_final,
+            key_expr.to_owned(),
+            pull_id,
+            *max_samples,
+            None,
+        ));
+    }
+
+    fn send_close(&self) {
+        // self.handler.closing().await;
+    }
+}
+
+pub struct McastMux {
+    handler: TransportMulticast,
+}
+
+impl McastMux {
+    pub fn new(handler: TransportMulticast) -> McastMux {
+        McastMux { handler }
+    }
+}
+
+impl Primitives for McastMux {
     fn decl_resource(&self, expr_id: ZInt, key_expr: &WireExpr) {
         let d = Declaration::Resource(Resource {
             expr_id,

--- a/zenoh/src/admin.rs
+++ b/zenoh/src/admin.rs
@@ -28,7 +28,9 @@ use zenoh_protocol::{
     core::{Encoding, KnownEncoding, SampleKind, WireExpr},
     zenoh::{DataInfo, ZenohMessage},
 };
-use zenoh_transport::{TransportEventHandler, TransportPeerEventHandler};
+use zenoh_transport::{
+    TransportEventHandler, TransportMulticastEventHandler, TransportPeer, TransportPeerEventHandler,
+};
 
 macro_rules! ke_for_sure {
     ($val:expr) => {
@@ -62,41 +64,47 @@ pub(crate) fn init(session: &Session) {
 }
 
 pub(crate) fn on_admin_query(session: &Session, query: Query) {
-    if let Ok(own_zid) = keyexpr::new(&session.zid().to_string()) {
-        for transport in session.runtime.manager().get_transports() {
-            if let Ok(zid) = transport.get_zid().map(|zid| zid.to_string()) {
-                if let Ok(zid) = keyexpr::new(&zid) {
-                    let key_expr = *KE_PREFIX / own_zid / *KE_TRANSPORT_UNICAST / zid;
-                    if query.key_expr().intersects(&key_expr) {
-                        if let Ok(value) = transport
-                            .get_peer()
-                            .map_err(|_| ())
-                            .and_then(|p| serde_json::value::to_value(p).map_err(|_| ()))
-                        {
-                            let _ = query.reply(Ok(Sample::new(key_expr, value))).res_sync();
-                        }
-                    }
+    fn reply_peer(own_zid: &keyexpr, query: &Query, peer: TransportPeer) {
+        let zid = peer.zid.to_string();
+        if let Ok(zid) = keyexpr::new(&zid) {
+            let key_expr = *KE_PREFIX / own_zid / *KE_TRANSPORT_UNICAST / zid;
+            if query.key_expr().intersects(&key_expr) {
+                if let Ok(value) = serde_json::value::to_value(peer.clone()) {
+                    let _ = query.reply(Ok(Sample::new(key_expr, value))).res_sync();
+                }
+            }
 
-                    for link in transport.get_links().unwrap_or_else(|_| vec![]) {
-                        let mut s = DefaultHasher::new();
-                        link.hash(&mut s);
-                        if let Ok(lid) = keyexpr::new(&s.finish().to_string()) {
-                            let key_expr =
-                                *KE_PREFIX / own_zid / *KE_TRANSPORT_UNICAST / zid / *KE_LINK / lid;
-                            if query.key_expr().intersects(&key_expr) {
-                                if let Ok(value) = serde_json::value::to_value(link) {
-                                    let _ =
-                                        query.reply(Ok(Sample::new(key_expr, value))).res_sync();
-                                }
-                            }
+            for link in peer.links {
+                let mut s = DefaultHasher::new();
+                link.hash(&mut s);
+                if let Ok(lid) = keyexpr::new(&s.finish().to_string()) {
+                    let key_expr =
+                        *KE_PREFIX / own_zid / *KE_TRANSPORT_UNICAST / zid / *KE_LINK / lid;
+                    if query.key_expr().intersects(&key_expr) {
+                        if let Ok(value) = serde_json::value::to_value(link) {
+                            let _ = query.reply(Ok(Sample::new(key_expr, value))).res_sync();
                         }
                     }
                 }
             }
         }
     }
+
+    if let Ok(own_zid) = keyexpr::new(&session.zid().to_string()) {
+        for transport in session.runtime.manager().get_transports() {
+            if let Ok(peer) = transport.get_peer() {
+                reply_peer(own_zid, &query, peer);
+            }
+        }
+        for transport in session.runtime.manager().get_transports_multicast() {
+            for peer in transport.get_peers().unwrap_or_default() {
+                reply_peer(own_zid, &query, peer);
+            }
+        }
+    }
 }
 
+#[derive(Clone)]
 pub(crate) struct Handler {
     pub(crate) session: Arc<Session>,
 }
@@ -115,6 +123,22 @@ impl TransportEventHandler for Handler {
         peer: zenoh_transport::TransportPeer,
         _transport: zenoh_transport::TransportUnicast,
     ) -> ZResult<Arc<dyn zenoh_transport::TransportPeerEventHandler>> {
+        self.new_peer(peer)
+    }
+
+    fn new_multicast(
+        &self,
+        _transport: zenoh_transport::TransportMulticast,
+    ) -> ZResult<Arc<dyn zenoh_transport::TransportMulticastEventHandler>> {
+        Ok(Arc::new(self.clone()))
+    }
+}
+
+impl TransportMulticastEventHandler for Handler {
+    fn new_peer(
+        &self,
+        peer: zenoh_transport::TransportPeer,
+    ) -> ZResult<Arc<dyn TransportPeerEventHandler>> {
         if let Ok(own_zid) = keyexpr::new(&self.session.zid().to_string()) {
             if let Ok(zid) = keyexpr::new(&peer.zid.to_string()) {
                 let expr = WireExpr::from(&(*KE_PREFIX / own_zid / *KE_TRANSPORT_UNICAST / zid))
@@ -141,11 +165,12 @@ impl TransportEventHandler for Handler {
         }
     }
 
-    fn new_multicast(
-        &self,
-        _transport: zenoh_transport::TransportMulticast,
-    ) -> ZResult<Arc<dyn zenoh_transport::TransportMulticastEventHandler>> {
-        bail!("unimplemented")
+    fn closing(&self) {}
+
+    fn closed(&self) {}
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }
 

--- a/zenoh/src/net/routing/face.rs
+++ b/zenoh/src/net/routing/face.rs
@@ -23,7 +23,7 @@ use zenoh_protocol::{
     },
     zenoh::{DataInfo, QueryBody, RoutingContext},
 };
-use zenoh_transport::Primitives;
+use zenoh_transport::{Primitives, TransportMulticast};
 
 pub struct FaceState {
     pub(super) id: usize,
@@ -39,6 +39,7 @@ pub struct FaceState {
     pub(super) remote_qabls: HashSet<Arc<Resource>>,
     pub(super) next_qid: ZInt,
     pub(super) pending_queries: HashMap<ZInt, Arc<Query>>,
+    pub(super) mcast_group: Option<TransportMulticast>,
 }
 
 impl FaceState {
@@ -48,6 +49,7 @@ impl FaceState {
         whatami: WhatAmI,
         primitives: Arc<dyn Primitives + Send + Sync>,
         link_id: usize,
+        mcast_group: Option<TransportMulticast>,
     ) -> Arc<FaceState> {
         Arc::new(FaceState {
             id,
@@ -63,6 +65,7 @@ impl FaceState {
             remote_qabls: HashSet::new(),
             next_qid: 0,
             pending_queries: HashMap::new(),
+            mcast_group,
         })
     }
 

--- a/zenoh/src/net/routing/router.rs
+++ b/zenoh/src/net/routing/router.rs
@@ -22,6 +22,7 @@ use std::any::Any;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{HashMap, HashSet};
 use std::hash::Hasher;
+use std::str::FromStr;
 use std::sync::{Arc, Weak};
 use std::sync::{Mutex, RwLock};
 use std::time::Duration;
@@ -32,7 +33,10 @@ use zenoh_protocol::{
     core::{WhatAmI, ZInt, ZenohId},
     zenoh::{ZenohBody, ZenohMessage},
 };
-use zenoh_transport::{DeMux, Mux, Primitives, TransportPeerEventHandler, TransportUnicast};
+use zenoh_transport::{
+    DeMux, DummyPrimitives, McastMux, Mux, Primitives, TransportMulticast, TransportPeer,
+    TransportPeerEventHandler, TransportUnicast,
+};
 // use zenoh_collections::Timer;
 use zenoh_core::zconfigurable;
 use zenoh_result::ZResult;
@@ -79,6 +83,8 @@ pub struct Tables {
     // pub(crate) queries_default_timeout: Duration,
     pub(crate) root_res: Arc<Resource>,
     pub(crate) faces: HashMap<usize, Arc<FaceState>>,
+    pub(crate) mcast_groups: Vec<Arc<FaceState>>,
+    pub(crate) mcast_faces: Vec<Arc<FaceState>>,
     pub(crate) pull_caches_lock: Mutex<()>,
     pub(crate) router_subs: HashSet<Arc<Resource>>,
     pub(crate) peer_subs: HashSet<Arc<Resource>>,
@@ -111,6 +117,8 @@ impl Tables {
             // queries_default_timeout,
             root_res: Resource::root(),
             faces: HashMap::new(),
+            mcast_groups: vec![],
+            mcast_faces: vec![],
             pull_caches_lock: Mutex::new(()),
             router_subs: HashSet::new(),
             peer_subs: HashSet::new(),
@@ -254,7 +262,7 @@ impl Tables {
         let mut newface = self
             .faces
             .entry(fid)
-            .or_insert_with(|| FaceState::new(fid, zid, whatami, primitives.clone(), link_id))
+            .or_insert_with(|| FaceState::new(fid, zid, whatami, primitives.clone(), link_id, None))
             .clone();
         log::debug!("New {}", newface);
 
@@ -590,6 +598,52 @@ impl Router {
         drop(tables);
         drop(ctrl_lock);
         Ok(handler)
+    }
+
+    pub fn new_transport_multicast(&self, transport: TransportMulticast) -> ZResult<()> {
+        let mut tables = zwrite!(self.tables.tables);
+        let fid = tables.face_counter;
+        tables.face_counter += 1;
+        tables.mcast_groups.push(FaceState::new(
+            fid,
+            ZenohId::from_str("1").unwrap(),
+            WhatAmI::Peer,
+            Arc::new(McastMux::new(transport.clone())),
+            0,
+            Some(transport),
+        ));
+
+        // recompute routes
+        let mut root_res = tables.root_res.clone();
+        compute_data_routes_from(&mut tables, &mut root_res);
+        Ok(())
+    }
+
+    pub fn new_peer_multicast(
+        &self,
+        transport: TransportMulticast,
+        peer: TransportPeer,
+    ) -> ZResult<Arc<DeMux<Face>>> {
+        let mut tables = zwrite!(self.tables.tables);
+        let fid = tables.face_counter;
+        tables.face_counter += 1;
+        let face_state = FaceState::new(
+            fid,
+            peer.zid,
+            WhatAmI::Client, // Quick hack
+            Arc::new(DummyPrimitives),
+            0,
+            Some(transport),
+        );
+        tables.mcast_faces.push(face_state.clone());
+
+        // recompute routes
+        let mut root_res = tables.root_res.clone();
+        compute_data_routes_from(&mut tables, &mut root_res);
+        Ok(Arc::new(DeMux::new(Face {
+            tables: self.tables.clone(),
+            state: face_state,
+        })))
     }
 }
 

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -21,6 +21,7 @@ mod adminspace;
 pub mod orchestrator;
 
 use super::routing;
+use super::routing::face::Face;
 use super::routing::pubsub::full_reentrant_route_data;
 use super::routing::router::{LinkStateInterceptor, Router};
 use crate::config::{unwrap_or_default, Config, ModeDependent, Notifier};
@@ -43,8 +44,8 @@ use zenoh_protocol::{
 use zenoh_result::{bail, ZResult};
 use zenoh_sync::get_mut_unchecked;
 use zenoh_transport::{
-    TransportEventHandler, TransportManager, TransportMulticast, TransportMulticastEventHandler,
-    TransportPeer, TransportPeerEventHandler, TransportUnicast,
+    DeMux, TransportEventHandler, TransportManager, TransportMulticast,
+    TransportMulticastEventHandler, TransportPeer, TransportPeerEventHandler, TransportUnicast,
 };
 
 pub struct RuntimeState {
@@ -245,10 +246,24 @@ impl TransportEventHandler for RuntimeTransportEventHandler {
 
     fn new_multicast(
         &self,
-        _transport: TransportMulticast,
+        transport: TransportMulticast,
     ) -> ZResult<Arc<dyn TransportMulticastEventHandler>> {
-        // @TODO
-        unimplemented!();
+        match zread!(self.runtime).as_ref() {
+            Some(runtime) => {
+                let slave_handlers: Vec<Arc<dyn TransportMulticastEventHandler>> =
+                    zread!(runtime.transport_handlers)
+                        .iter()
+                        .filter_map(|handler| handler.new_multicast(transport.clone()).ok())
+                        .collect();
+                runtime.router.new_transport_multicast(transport.clone())?;
+                Ok(Arc::new(RuntimeMuticastGroup {
+                    runtime: runtime.clone(),
+                    transport,
+                    slave_handlers,
+                }))
+            }
+            None => bail!("Runtime not yet ready!"),
+        }
     }
 }
 
@@ -301,6 +316,88 @@ impl TransportPeerEventHandler for RuntimeSession {
     fn closing(&self) {
         self.main_handler.closing();
         Runtime::closing_session(self);
+        for handler in &self.slave_handlers {
+            handler.closing();
+        }
+    }
+
+    fn closed(&self) {
+        self.main_handler.closed();
+        for handler in &self.slave_handlers {
+            handler.closed();
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+pub(super) struct RuntimeMuticastGroup {
+    pub(super) runtime: Runtime,
+    pub(super) transport: TransportMulticast,
+    pub(super) slave_handlers: Vec<Arc<dyn TransportMulticastEventHandler>>,
+}
+
+impl TransportMulticastEventHandler for RuntimeMuticastGroup {
+    fn new_peer(&self, peer: TransportPeer) -> ZResult<Arc<dyn TransportPeerEventHandler>> {
+        let slave_handlers: Vec<Arc<dyn TransportPeerEventHandler>> = self
+            .slave_handlers
+            .iter()
+            .filter_map(|handler| handler.new_peer(peer.clone()).ok())
+            .collect();
+        Ok(Arc::new(RuntimeMuticastSession {
+            main_handler: self
+                .runtime
+                .router
+                .new_peer_multicast(self.transport.clone(), peer)?,
+            slave_handlers,
+        }))
+    }
+
+    fn closing(&self) {
+        for handler in &self.slave_handlers {
+            handler.closed();
+        }
+    }
+
+    fn closed(&self) {
+        for handler in &self.slave_handlers {
+            handler.closed();
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+pub(super) struct RuntimeMuticastSession {
+    pub(super) main_handler: Arc<DeMux<Face>>,
+    pub(super) slave_handlers: Vec<Arc<dyn TransportPeerEventHandler>>,
+}
+
+impl TransportPeerEventHandler for RuntimeMuticastSession {
+    fn handle_message(&self, msg: ZenohMessage) -> ZResult<()> {
+        self.main_handler.handle_message(msg)
+    }
+
+    fn new_link(&self, link: Link) {
+        self.main_handler.new_link(link.clone());
+        for handler in &self.slave_handlers {
+            handler.new_link(link.clone());
+        }
+    }
+
+    fn del_link(&self, link: Link) {
+        self.main_handler.del_link(link.clone());
+        for handler in &self.slave_handlers {
+            handler.del_link(link.clone());
+        }
+    }
+
+    fn closing(&self) {
+        self.main_handler.closing();
         for handler in &self.slave_handlers {
             handler.closing();
         }


### PR DESCRIPTION
Performed checks:
- Interoperability with pico
- Routing (TCP_client <-> Router <-> UDPMulticast_peer)
- No perf regression in P2P TCP throughput

Current limitations :
- No support for queries
- The `multicast_if` socket option is not set on the sending socket when IpV6 (https://github.com/eclipse-zenoh/zenoh/blob/102baaee2c34078f75701a85ecdb057cc029ee5d/io/zenoh-links/zenoh-link-udp/src/multicast.rs#L225)
- The TransportManager API has not been improved (Transport Enum, etc ...)