### PR TITLE
metadata support

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -11,6 +11,12 @@
   /// The node's mode (router, peer or client)
   mode: "peer",
 
+  /// The node's metadata (name, location, DNS name, etc.) Arbitrary JSON data not interpreted by zenohd and available in admin space @/router/<id>
+  metadata: {
+    name: "strawberry",
+    location: "Penny Lane"
+  },
+
   /// Which endpoints to connect to. E.g. tcp/localhost:7447.
   /// By configuring the endpoints, it is possible to tell zenoh which router/peer to connect to at startup.
   connect: {

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -110,6 +110,8 @@ validated_struct::validator! {
     Config {
         /// The Zenoh ID of the instance. This ID MUST be unique throughout your Zenoh infrastructure and cannot exceed 16 bytes of length. If left unset, a random u128 will be generated.
         id: ZenohId,
+        /// The metadata of the instance. Arbitrary json data available from the admin space
+        metadata: Value,
         /// The node's mode ("router" (default value in `zenohd`), "peer" or "client").
         mode: Option<whatami::WhatAmI>,
         /// Which zenoh nodes to connect to.

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -44,6 +44,7 @@ pub struct AdminContext {
     plugins_mgr: Mutex<plugins::PluginsManager>,
     zid_str: String,
     version: String,
+    metadata: String,
 }
 
 type Handler = Arc<dyn Fn(&AdminContext, Query) + Send + Sync>;
@@ -65,6 +66,7 @@ enum PluginDiff {
 impl AdminSpace {
     pub async fn start(runtime: &Runtime, plugins_mgr: plugins::PluginsManager, version: String) {
         let zid_str = runtime.zid.to_string();
+        let metadata = runtime.metadata.to_string();
         let root_key: OwnedKeyExpr = format!("@/router/{zid_str}").try_into().unwrap();
 
         let mut handlers: HashMap<_, Handler> = HashMap::new();
@@ -111,6 +113,7 @@ impl AdminSpace {
             plugins_mgr: Mutex::new(plugins_mgr),
             zid_str,
             version,
+            metadata,
         });
         let admin = Arc::new(AdminSpace {
             zid: runtime.zid,
@@ -530,6 +533,7 @@ fn router_data(context: &AdminContext, query: Query) {
     let json = json!({
         "zid": context.zid_str,
         "version": context.version,
+        "metadata": context.metadata,
         "locators": locators,
         "sessions": transports,
         "plugins": plugins,

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -51,6 +51,7 @@ use zenoh_transport::{
 pub struct RuntimeState {
     pub zid: ZenohId,
     pub whatami: WhatAmI,
+    pub metadata: serde_json::Value,
     pub router: Arc<Router>,
     pub config: Notifier<Config>,
     pub manager: TransportManager,
@@ -92,6 +93,7 @@ impl Runtime {
         log::info!("Using PID: {}", zid);
 
         let whatami = unwrap_or_default!(config.mode());
+        let metadata = config.metadata().clone();
         let hlc = (*unwrap_or_default!(config.timestamping().enabled().get(whatami)))
             .then(|| Arc::new(HLCBuilder::new().with_id(uhlc::ID::from(&zid)).build()));
         let drop_future_timestamp =
@@ -139,6 +141,7 @@ impl Runtime {
             state: Arc::new(RuntimeState {
                 zid,
                 whatami,
+                metadata,
                 router,
                 config: config.clone(),
                 manager: transport_manager,


### PR DESCRIPTION
The zenoh configuration file should be able to accomodate a generic metadata field (i.e. JSON). Those metadata should be able to be retrieved via the admin space. 
Examples of metadata:
- name
- location
- DNS name
- etc.
Zenoh is NOT supposed to interpret those metadata, just to parse them and make them available.

config.json5:
```
...
  metadata: {
    name: "strawberry",
    location: "Penny Lane"
  },
...
```
access to metadata:
```
z_get -s "@/router/**"
```
result:

> Received ('@/router/f210c0a762f796e1356d52516b2de011': '{"locators":["tcp/[2001:861:428f:460:2585:b567:f4af:af7a]:7447","tcp/[2001:861:428f:460:f106:10e3:dec5:7926]:7447","tcp/[fe80::5bd0:7343:3d80:3d6]:7447","tcp/[fe80::d3a7:eefe:603d:14c3]:7447","tcp/[fe80::bfe1:d5e6:ba5d:43b8]:7447","tcp/[fe80::ebaa:1021:d966:cce6]:7447","tcp/[fe80::9318:29e0:eed5:6b36]:7447","tcp/[fe80::ea8a:48ec:320f:6462]:7447","tcp/[fe80::f559:6549:471f:74cb]:7447","tcp/[fe80::243f:3535:8b2c:97a4]:7447","tcp/192.168.1.44:7447","tcp/172.20.128.1:7447"],"**metadata":"{\"location\":\"Penny Lane\",\"name\":\"strawberry\"}"**,"plugins":{},"sessions":[{"links":["tcp/[2001:861:428f:460:2585:b567:f4af:af7a]:57412"],"peer":"125c38cfd6a17e690bfd790b7edmetadata":"{\"location\":\"Penny Lane\",\"name\":\"strawberry\"}"8936f","whatami":"peer"}],"version":"v0.10.0-dev-18-g2a08f1ab-modified built with rustc 1.71.0 (8ede3aae2 2023-07-12)","zid":"f210c0a762f796e1356d52516b2de011"}')
