### PR TITLE
Speed up cargo-nextest by excluding the compilation on unneeded examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: nextest
-          args: run
+          args: run --exclude zenoh-examples --exclude zenoh-plugin-example --workspace
         env:
           ASYNC_STD_THREAD_COUNT: 4
 


### PR DESCRIPTION
### Effect on my laptop (Intel i5-10300H (8) @ 4.500GHz)

* Original
    ```bash
    cargo nextest list
    ```
    Time: 3m01s
    Number of compiled targets: 574
    Size of target folder: 14.57 GiB

* Examples excluded
    ```bash
    cargo nextest list --exclude zenoh-examples --exclude zenoh-plugin-example --workspace
    ```
    Time: 1m36s
    Number of compiled targets: 553
    Size of target folder: 9.75 GiB

### Effect on  Github runners (taking Ubuntu runner as an example)

It can shrink the compiling time on CI from 9m47s to 5m57s
