### PR TITLE
Replace webpki with rustls-webpki and bump webpki-roots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2977,9 +2977,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.2"
+version = "0.101.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513722fd73ad80a71f72b61009ea1b584bcfa1483ca93949c8f290298837fa59"
+checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
 dependencies = [
  "ring",
  "untrusted",
@@ -4179,23 +4179,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "webpki-roots"
-version = "0.22.6"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
-]
+checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "win-sys"
@@ -4607,7 +4594,6 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-pemfile",
- "webpki",
  "zenoh-cfg-properties",
  "zenoh-config",
  "zenoh-core",
@@ -4666,7 +4652,7 @@ dependencies = [
  "log",
  "rustls",
  "rustls-pemfile",
- "webpki",
+ "rustls-webpki",
  "webpki-roots",
  "zenoh-cfg-properties",
  "zenoh-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,8 +151,8 @@ uuid = { version = "1.3.0", default-features = false, features = [
 ] } # Default features are disabled due to usage in no_std crates
 validated_struct = "2.1.0"
 vec_map = "0.8.2"
-webpki = "0.22.0"
-webpki-roots = "0.22.6"
+rustls-webpki = "0.101.4"
+webpki-roots = "0.25"
 winapi = { version = "0.3.9", features = ["iphlpapi"] }
 z-serial = "0.2.1"
 zenoh-ext = { version = "0.10.0-dev", path = "zenoh-ext" }

--- a/io/zenoh-links/zenoh-link-quic/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-quic/Cargo.toml
@@ -34,7 +34,6 @@ quinn = { workspace = true }
 rustls = { workspace = true }
 rustls-native-certs = { workspace = true }
 rustls-pemfile = { workspace = true }
-webpki = { workspace = true }
 zenoh-cfg-properties = { workspace = true }
 zenoh-config = { workspace = true }
 zenoh-core = { workspace = true }

--- a/io/zenoh-links/zenoh-link-tls/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-tls/Cargo.toml
@@ -32,7 +32,7 @@ async-trait = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }
 rustls-pemfile = { workspace = true }
-webpki = { workspace = true }
+rustls-webpki = { workspace = true }
 webpki-roots = { workspace = true }
 zenoh-cfg-properties = { workspace = true }
 zenoh-config = { workspace = true }

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -776,7 +776,7 @@ fn load_trust_anchors(config: &Config<'_>) -> ZResult<Option<RootCertStore>> {
 
 fn load_default_webpki_certs() -> RootCertStore {
     let mut root_cert_store = RootCertStore::empty();
-    root_cert_store.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
+    root_cert_store.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| {
         OwnedTrustAnchor::from_subject_spki_name_constraints(
             ta.subject,
             ta.spki,


### PR DESCRIPTION
Dependabot reports a security issue with [webpki](https://crates.io/crates/webpki):
https://github.com/eclipse-zenoh/zenoh/security/dependabot/11

This webpki crate is no longer maintained and has to be replaced by its fork in rustls project:
[rustls-webpki](https://crates.io/crates/rustls-webpki).

At the same time, this PR upgrades [webpki-roots](https://crates.io/crates/webpki-roots) to the latest (0.25.2)