### PR TITLE
Add missing options of z_pub_shm_thr.rs

### DIFF
--- a/examples/examples/z_pub_shm_thr.rs
+++ b/examples/examples/z_pub_shm_thr.rs
@@ -47,8 +47,15 @@ fn parse_args() -> (Config, usize, usize) {
             Arg::from_usage("-s, --shared-memory=[MB]  'shared memory size in MBytes'")
                 .default_value("32"),
         )
+        .arg(
+            Arg::from_usage("-m, --mode=[MODE] 'The zenoh session mode (peer by default).")
+                .possible_values(["peer", "client"]),
+        )
         .arg(Arg::from_usage(
             "-e, --connect=[ENDPOINT]...  'Endpoints to connect to.'",
+        ))
+        .arg(Arg::from_usage(
+            "-l, --listen=[ENDPOINT]...   'Endpoints to listen on.'",
         ))
         .arg(Arg::from_usage(
             "-c, --config=[FILE]      'A configuration file.'",
@@ -56,9 +63,28 @@ fn parse_args() -> (Config, usize, usize) {
         .arg(Arg::from_usage(
             "<PAYLOAD_SIZE>           'Sets the size of the payload to publish'",
         ))
+        .arg(Arg::from_usage(
+            "--no-multicast-scouting 'Disable the multicast-based scouting mechanism.'",
+        ))
         .get_matches();
 
-    let config = Config::default();
+    let mut config = if let Some(conf_file) = args.value_of("config") {
+        Config::from_file(conf_file).unwrap()
+    } else {
+        Config::default()
+    };
+    if let Some(Ok(mode)) = args.value_of("mode").map(|mode| mode.parse()) {
+        config.set_mode(Some(mode)).unwrap();
+    }
+    if let Some(values) = args.values_of("connect") {
+        config.connect.endpoints = values.map(|v| v.parse().unwrap()).collect();
+    }
+    if let Some(values) = args.values_of("listen") {
+        config.listen.endpoints = values.map(|v| v.parse().unwrap()).collect();
+    }
+    if args.is_present("no-multicast-scouting") {
+        config.scouting.multicast.set_enabled(Some(false)).unwrap();
+    }
     let sm_size = args
         .value_of("shared-memory")
         .unwrap()


### PR DESCRIPTION
The option of the config file is needed to change the global setting, like shared_memory transport.