### PR TITLE
Allow to join multiple multicast groups on UDP

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,7 @@ serde_yaml = "0.9.19"
 sha3 = "0.10.6"
 shared_memory = "0.12.4"
 shellexpand = "3.0.0"
-socket2 = "0.5.1"
+socket2 = { version ="0.5.1", features = [ "all" ] }
 stop-token = "0.7.0"
 syn = "1.0.109"
 tide = "0.16.0"

--- a/io/zenoh-links/zenoh-link-udp/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/lib.rs
@@ -86,6 +86,7 @@ impl LocatorInspector for UdpLocatorInspector {
 
 pub mod config {
     pub const UDP_MULTICAST_IFACE: &str = "iface";
+    pub const UDP_MULTICAST_JOIN: &str = "join";
 }
 
 pub async fn get_udp_addrs(address: Address<'_>) -> ZResult<impl Iterator<Item = SocketAddr>> {

--- a/io/zenoh-links/zenoh-link-udp/src/multicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/multicast.rs
@@ -236,9 +236,12 @@ impl LinkManagerMulticastUdp {
         mcast_sock
             .set_reuse_address(true)
             .map_err(|e| zerror!("{}: {}", mcast_addr, e))?;
-        mcast_sock
-            .set_reuse_port(true)
-            .map_err(|e| zerror!("{}: {}", mcast_addr, e))?;
+        #[cfg(target_family = "unix")]
+        {
+            mcast_sock
+                .set_reuse_port(true)
+                .map_err(|e| zerror!("{}: {}", mcast_addr, e))?;
+        }
 
         // Bind the socket: let's bing to the unspecified address so we can join and read
         // from multiple multicast groups.

--- a/io/zenoh-links/zenoh-link-udp/src/multicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/multicast.rs
@@ -19,7 +19,7 @@ use socket2::{Domain, Protocol, Socket, Type};
 use std::sync::Arc;
 use std::{borrow::Cow, fmt};
 use zenoh_link_commons::{LinkManagerMulticastTrait, LinkMulticast, LinkMulticastTrait};
-use zenoh_protocol::core::{EndPoint, Locator};
+use zenoh_protocol::core::{Config, EndPoint, Locator};
 use zenoh_result::{bail, zerror, Error as ZError, ZResult};
 
 pub struct LinkMulticastUdp {
@@ -154,22 +154,16 @@ impl LinkManagerMulticastUdp {
     async fn new_link_inner(
         &self,
         mcast_addr: &SocketAddr,
-        iface: Option<&str>,
+        config: Config<'_>,
     ) -> ZResult<(UdpSocket, UdpSocket, SocketAddr)> {
         let domain = match mcast_addr.ip() {
             IpAddr::V4(_) => Domain::IPV4,
             IpAddr::V6(_) => Domain::IPV6,
         };
 
-        // Defaults
-        let _default_ipv4_iface = Ipv4Addr::UNSPECIFIED;
-        let default_ipv6_iface = 0;
-        let default_ipv4_addr = Ipv4Addr::UNSPECIFIED;
-        let default_ipv6_addr = Ipv6Addr::UNSPECIFIED;
-
         // Get default iface address to bind the socket on if provided
         let mut iface_addr: Option<IpAddr> = None;
-        if let Some(iface) = iface {
+        if let Some(iface) = config.get(UDP_MULTICAST_IFACE) {
             iface_addr = match iface.parse() {
                 Ok(addr) => Some(addr),
                 Err(_) => zenoh_util::net::get_unicast_addresses_of_interface(iface)?
@@ -206,8 +200,8 @@ impl LinkManagerMulticastUdp {
                 match iface {
                     Some(iface) => iface,
                     None => match mcast_addr.ip() {
-                        IpAddr::V4(_) => IpAddr::V4(default_ipv4_addr),
-                        IpAddr::V6(_) => IpAddr::V6(default_ipv6_addr),
+                        IpAddr::V4(_) => IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+                        IpAddr::V6(_) => IpAddr::V6(Ipv6Addr::UNSPECIFIED),
                     },
                 }
             }
@@ -242,37 +236,54 @@ impl LinkManagerMulticastUdp {
         mcast_sock
             .set_reuse_address(true)
             .map_err(|e| zerror!("{}: {}", mcast_addr, e))?;
+        mcast_sock
+            .set_reuse_port(true)
+            .map_err(|e| zerror!("{}: {}", mcast_addr, e))?;
 
-        // Bind the socket
-        let default_mcast_addr = {
-            #[cfg(unix)]
-            {
-                match mcast_addr.ip() {
-                    IpAddr::V4(ip4) => IpAddr::V4(ip4),
-                    IpAddr::V6(_) => local_addr,
-                }
-            } // See UNIX Network Programmping p.212
-            #[cfg(windows)]
-            {
-                match mcast_addr.ip() {
-                    IpAddr::V4(_) => IpAddr::V4(default_ipv4_addr),
-                    IpAddr::V6(_) => IpAddr::V6(default_ipv6_addr),
-                }
-            }
+        // Bind the socket: let's bing to the unspecified address so we can join and read
+        // from multiple multicast groups.
+        let bind_mcast_addr = match mcast_addr.ip() {
+            IpAddr::V4(_) => IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            IpAddr::V6(_) => IpAddr::V6(Ipv6Addr::UNSPECIFIED),
         };
         mcast_sock
-            .bind(&SocketAddr::new(default_mcast_addr, mcast_addr.port()).into())
+            .bind(&SocketAddr::new(bind_mcast_addr, mcast_addr.port()).into())
             .map_err(|e| zerror!("{}: {}", mcast_addr, e))?;
 
         // Join the multicast group
+        let join = config.values(UDP_MULTICAST_JOIN);
         match mcast_addr.ip() {
             IpAddr::V4(dst_ip4) => match local_addr {
-                IpAddr::V4(src_ip4) => mcast_sock.join_multicast_v4(&dst_ip4, &src_ip4),
-                IpAddr::V6(_) => panic!(),
+                IpAddr::V4(src_ip4) => {
+                    // Join default multicast group
+                    mcast_sock
+                        .join_multicast_v4(&dst_ip4, &src_ip4)
+                        .map_err(|e| zerror!("{}: {}", mcast_addr, e))?;
+                    // Join any additional multicast group
+                    for g in join {
+                        let g: Ipv4Addr =
+                            g.parse().map_err(|e| zerror!("{}: {}", mcast_addr, e))?;
+                        mcast_sock
+                            .join_multicast_v4(&g, &src_ip4)
+                            .map_err(|e| zerror!("{}: {}", mcast_addr, e))?;
+                    }
+                }
+                IpAddr::V6(src_ip6) => bail!("{}: unexepcted IPv6 source address", src_ip6),
             },
-            IpAddr::V6(dst_ip6) => mcast_sock.join_multicast_v6(&dst_ip6, default_ipv6_iface),
-        }
-        .map_err(|e| zerror!("{}: {}", mcast_addr, e))?;
+            IpAddr::V6(dst_ip6) => {
+                // Join default multicast group
+                mcast_sock
+                    .join_multicast_v6(&dst_ip6, 0)
+                    .map_err(|e| zerror!("{}: {}", mcast_addr, e))?;
+                // Join any additional multicast group
+                for g in join {
+                    let g: Ipv6Addr = g.parse().map_err(|e| zerror!("{}: {}", mcast_addr, e))?;
+                    mcast_sock
+                        .join_multicast_v6(&g, 0)
+                        .map_err(|e| zerror!("{}: {}", mcast_addr, e))?;
+                }
+            }
+        };
 
         // Build the async_std multicast UdpSocket
         let mcast_sock: UdpSocket = std::net::UdpSocket::from(mcast_sock).into();
@@ -296,10 +307,7 @@ impl LinkManagerMulticastTrait for LinkManagerMulticastUdp {
 
         let mut errs: Vec<ZError> = vec![];
         for maddr in mcast_addrs {
-            match self
-                .new_link_inner(&maddr, endpoint.config().get(UDP_MULTICAST_IFACE))
-                .await
-            {
+            match self.new_link_inner(&maddr, endpoint.config()).await {
                 Ok((mcast_sock, ucast_sock, ucast_addr)) => {
                     let link = Arc::new(LinkMulticastUdp::new(
                         ucast_addr, ucast_sock, maddr, mcast_sock,

--- a/io/zenoh-transport/src/multicast/transport.rs
+++ b/io/zenoh-transport/src/multicast/transport.rs
@@ -248,7 +248,6 @@ impl TransportMulticastInner {
                     zid: self.manager.config.zid,
                     whatami: self.manager.config.whatami,
                     lease: self.manager.config.multicast.lease,
-                    keep_alive: self.manager.config.multicast.keep_alive,
                     join_interval: self.manager.config.multicast.join_interval,
                     sn_resolution: self.manager.config.resolution.get(Field::FrameSN),
                     batch_size,


### PR DESCRIPTION
In case of using UDP multicast, an endpoint configuration option is added to support the reading from multiple multicast groups. E.g.: `udp/224.0.0.1#iface=en0;join=224.0.0.2|224.0.0.3` will operate as follows:
- write will be done on `iface=en0` and on the `224.0.0.1` multicast group
- read  will be done from the following multicast groups: `224.0.0.1`, `224.0.0.2`, `224.0.0.3`