### PR TITLE
Add interface bound tcp link

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4718,6 +4718,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "log",
+ "socket2 0.5.4",
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",

--- a/io/zenoh-links/zenoh-link-tcp/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-tcp/Cargo.toml
@@ -34,3 +34,4 @@ zenoh-protocol = { workspace = true }
 zenoh-result = { workspace = true }
 zenoh-sync = { workspace = true }
 zenoh-util = { workspace = true }
+socket2 = {workspace = true}

--- a/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
@@ -310,6 +310,9 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastTcp {
 
         let mut errs: Vec<ZError> = vec![];
         for da in addrs {
+            // bind_device is only supported on Android, Fushia, and Linux
+            // https://docs.rs/socket2/latest/x86_64-unknown-linux-gnu/socket2/struct.Socket.html#method.bind_device
+            #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
             let connection = {
                 // Since the building of async_std::net::TcpListener from socket2 is synchronous, let's separate the cases
                 // for the sake of the performance
@@ -331,6 +334,9 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastTcp {
                     self.new_listener_inner(&da).await
                 }
             };
+            #[cfg(not(any(target_os = "android", target_os = "fuchsia", target_os = "linux")))]
+            let connection = self.new_listener_inner(&da).await?;
+
             match connection {
                 Ok((socket, local_addr)) => {
                     // Update the endpoint locator address

--- a/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
@@ -335,7 +335,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastTcp {
                 }
             };
             #[cfg(not(any(target_os = "android", target_os = "fuchsia", target_os = "linux")))]
-            let connection = self.new_listener_inner(&da).await?;
+            let connection = self.new_listener_inner(&da).await;
 
             match connection {
                 Ok((socket, local_addr)) => {

--- a/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
@@ -262,6 +262,9 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastTcp {
         let mut errs: Vec<ZError> = vec![];
 
         for da in dst_addrs {
+            // bind_device is only supported on Android, Fushia, and Linux
+            // https://docs.rs/socket2/latest/x86_64-unknown-linux-gnu/socket2/struct.Socket.html#method.bind_device
+            #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
             let connection = {
                 // Since the building of async_std::net::TcpStream from socket2 is synchronous, let's separate the cases
                 // for the sake of the performance
@@ -281,6 +284,9 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastTcp {
                     self.new_link_inner(&da).await
                 }
             };
+            #[cfg(not(any(target_os = "android", target_os = "fuchsia", target_os = "linux")))]
+            let connection = self.new_link_inner(&da).await;
+
             match connection {
                 Ok((stream, src_addr, dst_addr)) => {
                     let link = Arc::new(LinkUnicastTcp::new(stream, src_addr, dst_addr));

--- a/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
@@ -257,6 +257,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastTcp {
     async fn new_link(&self, endpoint: EndPoint) -> ZResult<LinkUnicast> {
         let dst_addrs = get_tcp_addrs(endpoint.address()).await?;
         let config = endpoint.config();
+        #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
         let iface = config.get("iface").map(|s| s.as_bytes());
 
         let mut errs: Vec<ZError> = vec![];
@@ -312,6 +313,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastTcp {
     async fn new_listener(&self, mut endpoint: EndPoint) -> ZResult<Locator> {
         let addrs = get_tcp_addrs(endpoint.address()).await?;
         let config = endpoint.config();
+        #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
         let iface = config.get("iface").map(|s| s.as_bytes());
 
         let mut errs: Vec<ZError> = vec![];


### PR DESCRIPTION
- socket2 -> async-std tcp stream/listener is synchronous only.
- socket2 has different APIs on different platforms. 

![image](https://github.com/eclipse-zenoh/zenoh/assets/10692887/cd1b27a7-68fd-41d3-9bac-d179968c5ccf)

