### PR TITLE
fix package-scale compilation for subcrates, make ketrees generic over their hasher

### DIFF
--- a/commons/zenoh-keyexpr/Cargo.toml
+++ b/commons/zenoh-keyexpr/Cargo.toml
@@ -42,6 +42,7 @@ hashbrown = { workspace = true }
 [dev-dependencies]
 criterion = { workspace = true }
 lazy_static = { workspace = true }
+rand = { workspace = true, features = ["default"] }
 
 [[bench]]
 name = "keyexpr_tree"

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/impls/hashmap_impl.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/impls/hashmap_impl.rs
@@ -14,8 +14,12 @@
 
 use core::hash::Hasher;
 #[cfg(not(feature = "std"))]
+// `SipHasher` is deprecated in favour of a symbol that only exists in `std`
+#[allow(deprecated)]
+use core::hash::SipHasher as DefaultHasher;
+#[cfg(not(feature = "std"))]
 use hashbrown::{
-    hash_map::{DefaultHasher, Entry, Iter, IterMut, Values, ValuesMut},
+    hash_map::{Entry, Iter, IterMut, Values, ValuesMut},
     HashMap,
 };
 #[cfg(feature = "std")]

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/impls/hashmap_impl.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/impls/hashmap_impl.rs
@@ -12,22 +12,25 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
+use core::hash::Hasher;
 #[cfg(not(feature = "std"))]
 use hashbrown::{
-    hash_map::{Entry, Iter, IterMut, Values, ValuesMut},
+    hash_map::{DefaultHasher, Entry, Iter, IterMut, Values, ValuesMut},
     HashMap,
 };
 #[cfg(feature = "std")]
 use std::collections::{
-    hash_map::{Entry, Iter, IterMut, Values, ValuesMut},
+    hash_map::{DefaultHasher, Entry, Iter, IterMut, Values, ValuesMut},
     HashMap,
 };
 
 use crate::keyexpr_tree::*;
 
-pub struct HashMapProvider;
-impl<T: 'static> IChildrenProvider<T> for HashMapProvider {
-    type Assoc = HashMap<OwnedKeyExpr, T>;
+pub struct HashMapProvider<Hash: Hasher + Default + 'static = DefaultHasher>(
+    core::marker::PhantomData<Hash>,
+);
+impl<T: 'static, Hash: Hasher + Default + 'static> IChildrenProvider<T> for HashMapProvider<Hash> {
+    type Assoc = HashMap<OwnedKeyExpr, T, core::hash::BuildHasherDefault<Hash>>;
 }
 
 #[cfg(not(feature = "std"))]

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/impls/keyed_set_impl.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/impls/keyed_set_impl.rs
@@ -12,11 +12,19 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
+use core::hash::Hasher;
+#[cfg(not(feature = "std"))]
+use hashbrown::hash_map::DefaultHasher;
+#[cfg(feature = "std")]
+use std::collections::hash_map::DefaultHasher;
+
 use crate::keyexpr_tree::*;
 use keyed_set::{KeyExtractor, KeyedSet};
 
-pub struct KeyedSetProvider;
-impl<T: 'static> IChildrenProvider<T> for KeyedSetProvider {
+pub struct KeyedSetProvider<Hash: Hasher + Default + 'static = DefaultHasher>(
+    core::marker::PhantomData<Hash>,
+);
+impl<T: 'static, Hash: Hasher + Default + 'static> IChildrenProvider<T> for KeyedSetProvider<Hash> {
     type Assoc = KeyedSet<T, ChunkExtractor>;
 }
 #[derive(Debug, Default, Clone, Copy)]

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/impls/keyed_set_impl.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/impls/keyed_set_impl.rs
@@ -14,7 +14,9 @@
 
 use core::hash::Hasher;
 #[cfg(not(feature = "std"))]
-use hashbrown::hash_map::DefaultHasher;
+// `SipHasher` is deprecated in favour of a symbol that only exists in `std`
+#[allow(deprecated)]
+use core::hash::SipHasher as DefaultHasher;
 #[cfg(feature = "std")]
 use std::collections::hash_map::DefaultHasher;
 

--- a/commons/zenoh-protocol/Cargo.toml
+++ b/commons/zenoh-protocol/Cargo.toml
@@ -47,10 +47,11 @@ rand = { workspace = true, features = ["alloc", "getrandom"], optional = true }
 serde = { workspace = true, features = ["alloc"] }
 uhlc = { workspace = true, default-features = false }
 uuid = { workspace = true }                                                     # Needs a getrandom::getrandom() custom implementation on embedded (in root crate)
-zenoh-buffers = { workspace = true, default-features = false  }
+zenoh-buffers = { workspace = true, default-features = false }
 zenoh-keyexpr = { workspace = true }
 zenoh-result = { workspace = true }
 
 # NOTE: May cause problems when testing no_std stuff. Check this tool: https://docs.rs/crate/cargo-no-dev-deps/0.1.0
 [dev-dependencies]
 lazy_static = { workspace = true }
+rand = { workspace = true, features = ["default"] }

--- a/commons/zenoh-protocol/src/network/request.rs
+++ b/commons/zenoh-protocol/src/network/request.rs
@@ -93,7 +93,7 @@ pub mod ext {
     impl TargetType {
         #[cfg(feature = "test")]
         pub fn rand() -> Self {
-            use rand::prelude::SliceRandom;
+            use rand::prelude::*;
             let mut rng = rand::thread_rng();
 
             *[

--- a/io/zenoh-transport/src/unicast/manager.rs
+++ b/io/zenoh-transport/src/unicast/manager.rs
@@ -96,6 +96,8 @@ pub struct TransportManagerBuilderUnicast {
     pub(super) max_links: usize,
     #[cfg(feature = "shared-memory")]
     pub(super) is_shm: bool,
+    #[cfg(feature = "transport_compression")]
+    pub(super) is_compressed: bool,
     #[cfg(feature = "transport_auth")]
     pub(super) authenticator: Auth,
     pub(super) is_lowlatency: bool,
@@ -251,6 +253,8 @@ impl Default for TransportManagerBuilderUnicast {
             max_links: *transport.max_links(),
             #[cfg(feature = "shared-memory")]
             is_shm: *shm.enabled(),
+            #[cfg(feature = "transport_compression")]
+            is_compressed: false,
             #[cfg(feature = "transport_auth")]
             authenticator: Auth::default(),
             is_lowlatency: *transport.lowlatency(),

--- a/io/zenoh-transport/src/unicast/universal/link.rs
+++ b/io/zenoh-transport/src/unicast/universal/link.rs
@@ -106,7 +106,7 @@ impl TransportLinkUnicast {
             };
 
             #[cfg(all(feature = "unstable", feature = "transport_compression"))]
-            let is_compressed = self.transport.config.manager.config.unicast.is_compressed;
+            let is_compressed = self.transport.manager.config.unicast.is_compressed;
 
             // The pipeline
             let (producer, consumer) = TransmissionPipeline::make(config, priority_tx);

--- a/zenoh/src/net/routing/queries.rs
+++ b/zenoh/src/net/routing/queries.rs
@@ -2178,7 +2178,7 @@ pub fn route_query(
                                 ext_qos: ext::QoSType::request_default(), // TODO
                                 ext_tstamp: None,
                                 ext_nodeid: ext::NodeIdType {
-                                    node_id: context.map(|c| c.tree_id).unwrap_or(0) as u16,
+                                    node_id: context.unwrap_or(0),
                                 },
                                 ext_target: *t,
                                 ext_budget: None,


### PR DESCRIPTION
Noticed some subcrates didn't compile individually because of missing feature flags.

Made Hashmap-based KeTrees generic over their hashers, since this could have a large influence on performance