### PR TITLE
Fix missing batch length check

### DIFF
--- a/io/zenoh-transport/src/unicast/establishment/accept.rs
+++ b/io/zenoh-transport/src/unicast/establishment/accept.rs
@@ -658,10 +658,11 @@ pub(crate) async fn accept_link(link: &LinkUnicast, manager: &TransportManager) 
         .map_err(|e| (e, Some(close::reason::INVALID))));
 
     log::debug!(
-        "New transport link accepted from {} to {}: {}",
+        "New transport link accepted from {} to {}: {}. Batch size: {}.",
         osyn_out.other_zid,
         manager.config.zid,
-        link
+        link,
+        state.zenoh.batch_size,
     );
 
     Ok(())

--- a/io/zenoh-transport/src/unicast/establishment/open.rs
+++ b/io/zenoh-transport/src/unicast/establishment/open.rs
@@ -573,10 +573,11 @@ pub(crate) async fn open_link(
     }
 
     log::debug!(
-        "New transport link opened from {} to {}: {}",
+        "New transport link opened from {} to {}: {}. Batch size: {}.",
         manager.config.zid,
         iack_out.other_zid,
-        link
+        link,
+        state.zenoh.batch_size,
     );
 
     Ok(transport)

--- a/io/zenoh-transport/src/unicast/lowlatency/link.rs
+++ b/io/zenoh-transport/src/unicast/lowlatency/link.rs
@@ -212,8 +212,11 @@ async fn rx_task_stream(
         let mut length = [0_u8, 0_u8, 0_u8, 0_u8];
         link.read_exact(&mut length).await?;
         let n = u32::from_le_bytes(length) as usize;
-
-        link.read_exact(&mut buffer[0..n]).await?;
+        let len = buffer.len();
+        let b = buffer.get_mut(0..n).ok_or_else(|| {
+            zerror!("Batch len is invalid. Received {n} but negotiated max len is {len}.")
+        })?;
+        link.read_exact(b).await?;
         Ok(n)
     }
 

--- a/io/zenoh-transport/src/unicast/universal/link.rs
+++ b/io/zenoh-transport/src/unicast/universal/link.rs
@@ -294,7 +294,11 @@ async fn rx_task_stream(
         let mut length = [0_u8, 0_u8];
         link.read_exact(&mut length).await?;
         let n = BatchSize::from_le_bytes(length) as usize;
-        link.read_exact(&mut buffer[0..n]).await?;
+        let len = buffer.len();
+        let b = buffer.get_mut(0..n).ok_or_else(|| {
+            zerror!("Batch len is invalid. Received {n} but negotiated max len is {len}.")
+        })?;
+        link.read_exact(b).await?;
         Ok(Action::Read(n))
     }
 


### PR DESCRIPTION
When reading from a streamed link, the advertised batch length could exceed the allocated buffer.
This PR introduces a validation check instead of directly subslice the receiving buffer to read from the link.