### PR TITLE
Update README documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Note that the REST plugin is added to the configuration by the default value of 
 **[REST plugin](https://zenoh.io/docs/manual/plugin-http/)** (exposing a REST API):
 This plugin converts GET and PUT REST requests into Zenoh gets and puts respectively.
 
-**[Storages plugin](https://zenoh.io/docs/manual/plugin-storages/)** (managing [backends and storages](https://zenoh.io/docs/manual/backends/))
+**[Storages plugin](https://zenoh.io/docs/manual/plugin-storage-manager/)** (managing [backends and storages](https://zenoh.io/docs/manual/plugin-storage-manager/#backends-and-volumes))
 This plugin allows you to easily define storages. These will store key-value pairs they subscribed to, and send the most recent ones when queried. Check out [DEFAULT_CONFIG.json5](DEFAULT_CONFIG.json5) for info on how to configure them.
 
 -------------------------------


### PR DESCRIPTION
I noticed that two of the links at the bottom of the page are out of date and return a 404, so I did this PR to overcome this problem.