### PR TITLE
Bugfix: sh (dash) dose not support `&> /dev/null`.

### DIFF
--- a/zenohd/.deb/postinst
+++ b/zenohd/.deb/postinst
@@ -20,12 +20,12 @@ set -e
 
 case "$1" in
     configure)
-        if ! command -v systemctl &> /dev/null
+        if ! command -v systemctl > /dev/null 2>&1
         then
             echo "WARNING: 'systemctl' not found - cannot install zenohd as a service."
             exit 0
         fi
-        id -u zenohd  &> /dev/null || useradd -r -s /bin/false zenohd
+        id -u zenohd > /dev/null 2>&1 || useradd -r -s /bin/false zenohd
         mkdir -p /var/zenohd
         chown zenohd:zenohd /var/zenohd
         systemctl daemon-reload


### PR DESCRIPTION
Since sh (link to dash in Ubuntu) does not support `&> /dev/null`, the if-condition will always fail and won't create zenohd users.
I believe this is why systemd fails to run zenohd while bootup.

Is there any way to build the deb file locally? I don't know how to create the deb file easily for testing.
