### PR TITLE
Issue a diagnostic whenever `Publication` is not used

### DIFF
--- a/zenoh/src/publication.rs
+++ b/zenoh/src/publication.rs
@@ -404,6 +404,7 @@ impl Drop for Publisher<'_> {
 
 /// A [`Resolvable`] returned by [`Publisher::put()`](Publisher::put),
 /// [`Publisher::delete()`](Publisher::delete) and [`Publisher::write()`](Publisher::write).
+#[must_use]
 pub struct Publication<'a> {
     publisher: &'a Publisher<'a>,
     value: Value,


### PR DESCRIPTION
Resolves #581.

I opted to put `#[must_use]` on `Publication` itself instead of `Publisher::put`. This way we cover `Publisher::delete` and `Publisher::write` too, and any method that returns `Publication`.