### PR TITLE
Add protocol extensions for user attachment

### DIFF
--- a/commons/zenoh-buffers/src/zbuf.rs
+++ b/commons/zenoh-buffers/src/zbuf.rs
@@ -89,7 +89,7 @@ impl PartialEq for ZBuf {
                 (None, _) | (_, None) => return false,
                 (Some(l), Some(r)) => {
                     let cmp_len = l.len().min(r.len());
-                    // SAFETY: cmp_len is the minimum lenght between l and r slices.
+                    // SAFETY: cmp_len is the minimum length between l and r slices.
                     let lhs = crate::unsafe_slice!(l, ..cmp_len);
                     let rhs = crate::unsafe_slice!(r, ..cmp_len);
                     if lhs != rhs {
@@ -98,14 +98,14 @@ impl PartialEq for ZBuf {
                     if cmp_len == l.len() {
                         current_self = self_slices.next();
                     } else {
-                        // SAFETY: cmp_len is the minimum lenght between l and r slices.
+                        // SAFETY: cmp_len is the minimum length between l and r slices.
                         let lhs = crate::unsafe_slice!(l, cmp_len..);
                         current_self = Some(lhs);
                     }
                     if cmp_len == r.len() {
                         current_other = other_slices.next();
                     } else {
-                        // SAFETY: cmp_len is the minimum lenght between l and r slices.
+                        // SAFETY: cmp_len is the minimum length between l and r slices.
                         let rhs = crate::unsafe_slice!(r, cmp_len..);
                         current_other = Some(rhs);
                     }
@@ -161,12 +161,12 @@ impl<'a> Reader for ZBufReader<'a> {
             // Take the minimum length among read and write slices
             let len = from.len().min(into.len());
             // Copy the slice content
-            // SAFETY: len is the minimum lenght between from and into slices.
+            // SAFETY: len is the minimum length between from and into slices.
             let lhs = crate::unsafe_slice_mut!(into, ..len);
             let rhs = crate::unsafe_slice!(from, ..len);
             lhs.copy_from_slice(rhs);
             // Advance the write slice
-            // SAFETY: len is the minimum lenght between from and into slices.
+            // SAFETY: len is the minimum length between from and into slices.
             into = crate::unsafe_slice_mut!(into, len..);
             // Update the counter
             read += len;

--- a/commons/zenoh-codec/benches/codec.rs
+++ b/commons/zenoh-codec/benches/codec.rs
@@ -91,6 +91,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             ext_sinfo: None,
             #[cfg(feature = "shared-memory")]
             ext_shm: None,
+            ext_attachment: None,
             ext_unknown: vec![],
             payload: ZBuf::from(vec![0u8; 8]),
         }),
@@ -136,6 +137,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             ext_sinfo: None,
             #[cfg(feature = "shared-memory")]
             ext_shm: None,
+            ext_attachment: None,
             ext_unknown: vec![],
             payload: ZBuf::from(vec![0u8; 8]),
         }),
@@ -176,6 +178,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             ext_sinfo: None,
             #[cfg(feature = "shared-memory")]
             ext_shm: None,
+            ext_attachment: None,
             ext_unknown: vec![],
             payload: ZBuf::from(vec![0u8; 8]),
         }),
@@ -216,6 +219,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             ext_sinfo: None,
             #[cfg(feature = "shared-memory")]
             ext_shm: None,
+            ext_attachment: None,
             ext_unknown: vec![],
             payload: ZBuf::from(vec![0u8; 1_000_000]),
         }),
@@ -243,6 +247,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             ext_sinfo: None,
             #[cfg(feature = "shared-memory")]
             ext_shm: None,
+            ext_attachment: None,
             ext_unknown: vec![],
             payload: ZBuf::from(vec![0u8; 1_000_000]),
         }),
@@ -281,6 +286,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             ext_sinfo: None,
             #[cfg(feature = "shared-memory")]
             ext_shm: None,
+            ext_attachment: None,
             ext_unknown: vec![],
             payload: ZBuf::from(vec![0u8; 1_000_000]),
         }),

--- a/commons/zenoh-codec/src/common/extension.rs
+++ b/commons/zenoh-codec/src/common/extension.rs
@@ -88,7 +88,9 @@ where
     type Output = Result<(), DidntWrite>;
 
     fn write(self, writer: &mut W, x: (&ZExtUnit<{ ID }>, bool)) -> Self::Output {
-        let (_x, more) = x;
+        let (x, more) = x;
+        let ZExtUnit = x;
+
         let mut header: u8 = ID;
         if more {
             header |= iext::FLAG_Z;
@@ -134,12 +136,14 @@ where
 
     fn write(self, writer: &mut W, x: (&ZExtZ64<{ ID }>, bool)) -> Self::Output {
         let (x, more) = x;
+        let ZExtZ64 { value } = x;
+
         let mut header: u8 = ID;
         if more {
             header |= iext::FLAG_Z;
         }
         self.write(&mut *writer, header)?;
-        self.write(&mut *writer, x.value)?;
+        self.write(&mut *writer, value)?;
         Ok(())
     }
 }
@@ -182,13 +186,15 @@ where
 
     fn write(self, writer: &mut W, x: (&ZExtZBuf<{ ID }>, bool)) -> Self::Output {
         let (x, more) = x;
+        let ZExtZBuf { value } = x;
+
         let mut header: u8 = ID;
         if more {
             header |= iext::FLAG_Z;
         }
         self.write(&mut *writer, header)?;
         let bodec = Zenoh080Bounded::<u32>::new();
-        bodec.write(&mut *writer, &x.value)?;
+        bodec.write(&mut *writer, value)?;
         Ok(())
     }
 }
@@ -231,13 +237,15 @@ where
 
     fn write(self, writer: &mut W, x: (&ZExtZBufHeader<{ ID }>, bool)) -> Self::Output {
         let (x, more) = x;
+        let ZExtZBufHeader { len } = x;
+
         let mut header: u8 = ID;
         if more {
             header |= iext::FLAG_Z;
         }
         self.write(&mut *writer, header)?;
         let bodec = Zenoh080Bounded::<u32>::new();
-        bodec.write(&mut *writer, x.len)?;
+        bodec.write(&mut *writer, *len)?;
         Ok(())
     }
 }
@@ -284,11 +292,13 @@ where
 
     fn write(self, writer: &mut W, x: (&ZExtUnknown, bool)) -> Self::Output {
         let (x, more) = x;
-        let mut header: u8 = x.id;
+        let ZExtUnknown { id, body } = x;
+
+        let mut header: u8 = *id;
         if more {
             header |= iext::FLAG_Z;
         }
-        match &x.body {
+        match body {
             ZExtBody::Unit => self.write(&mut *writer, header)?,
             ZExtBody::Z64(u64) => {
                 self.write(&mut *writer, header)?;

--- a/commons/zenoh-codec/src/core/property.rs
+++ b/commons/zenoh-codec/src/core/property.rs
@@ -26,8 +26,10 @@ where
     type Output = Result<(), DidntWrite>;
 
     fn write(self, writer: &mut W, x: &Property) -> Self::Output {
-        self.write(&mut *writer, x.key)?;
-        self.write(&mut *writer, x.value.as_slice())?;
+        let Property { key, value } = x;
+
+        self.write(&mut *writer, key)?;
+        self.write(&mut *writer, value.as_slice())?;
         Ok(())
     }
 }

--- a/commons/zenoh-codec/src/core/shm.rs
+++ b/commons/zenoh-codec/src/core/shm.rs
@@ -25,10 +25,17 @@ where
     type Output = Result<(), DidntWrite>;
 
     fn write(self, writer: &mut W, x: &SharedMemoryBufInfo) -> Self::Output {
-        self.write(&mut *writer, x.offset)?;
-        self.write(&mut *writer, x.length)?;
-        self.write(&mut *writer, x.shm_manager.as_str())?;
-        self.write(&mut *writer, x.kind)?;
+        let SharedMemoryBufInfo {
+            offset,
+            length,
+            shm_manager,
+            kind,
+        } = x;
+
+        self.write(&mut *writer, offset)?;
+        self.write(&mut *writer, length)?;
+        self.write(&mut *writer, shm_manager.as_str())?;
+        self.write(&mut *writer, kind)?;
         Ok(())
     }
 }

--- a/commons/zenoh-codec/src/core/wire_expr.rs
+++ b/commons/zenoh-codec/src/core/wire_expr.rs
@@ -29,12 +29,18 @@ where
     type Output = Result<(), DidntWrite>;
 
     fn write(self, writer: &mut W, x: &WireExpr<'_>) -> Self::Output {
+        let WireExpr {
+            scope,
+            suffix,
+            mapping: _,
+        } = x;
+
         let zodec = Zenoh080Bounded::<ExprId>::new();
-        zodec.write(&mut *writer, x.scope)?;
+        zodec.write(&mut *writer, *scope)?;
 
         if x.has_suffix() {
             let zodec = Zenoh080Bounded::<ExprLen>::new();
-            zodec.write(&mut *writer, x.suffix.as_ref())?;
+            zodec.write(&mut *writer, suffix.as_ref())?;
         }
         Ok(())
     }

--- a/commons/zenoh-codec/src/network/mod.rs
+++ b/commons/zenoh-codec/src/network/mod.rs
@@ -27,7 +27,7 @@ use zenoh_buffers::{
 use zenoh_protocol::{
     common::{imsg, ZExtZ64, ZExtZBufHeader},
     core::{Reliability, ZenohId},
-    network::*,
+    network::{ext::EntityIdType, *},
 };
 
 // NetworkMessage
@@ -38,7 +38,9 @@ where
     type Output = Result<(), DidntWrite>;
 
     fn write(self, writer: &mut W, x: &NetworkMessage) -> Self::Output {
-        match &x.body {
+        let NetworkMessage { body } = x;
+
+        match body {
             NetworkBody::Push(b) => self.write(&mut *writer, b),
             NetworkBody::Request(b) => self.write(&mut *writer, b),
             NetworkBody::Response(b) => self.write(&mut *writer, b),
@@ -218,7 +220,9 @@ where
 // Extension: EntityId
 impl<const ID: u8> LCodec<&ext::EntityIdType<{ ID }>> for Zenoh080 {
     fn w_len(self, x: &ext::EntityIdType<{ ID }>) -> usize {
-        1 + self.w_len(&x.zid) + self.w_len(x.eid)
+        let EntityIdType { zid, eid } = x;
+
+        1 + self.w_len(zid) + self.w_len(*eid)
     }
 }
 

--- a/commons/zenoh-codec/src/scouting/hello.rs
+++ b/commons/zenoh-codec/src/scouting/hello.rs
@@ -33,31 +33,38 @@ where
     type Output = Result<(), DidntWrite>;
 
     fn write(self, writer: &mut W, x: &Hello) -> Self::Output {
+        let Hello {
+            version,
+            whatami,
+            zid,
+            locators,
+        } = x;
+
         // Header
         let mut header = id::HELLO;
-        if !x.locators.is_empty() {
+        if !locators.is_empty() {
             header |= flag::L;
         }
         self.write(&mut *writer, header)?;
 
         // Body
-        self.write(&mut *writer, x.version)?;
+        self.write(&mut *writer, version)?;
 
         let mut flags: u8 = 0;
-        let whatami: u8 = match x.whatami {
+        let whatami: u8 = match whatami {
             WhatAmI::Router => 0b00,
             WhatAmI::Peer => 0b01,
             WhatAmI::Client => 0b10,
         };
         flags |= whatami & 0b11;
-        flags |= ((x.zid.size() - 1) as u8) << 4;
+        flags |= ((zid.size() - 1) as u8) << 4;
         self.write(&mut *writer, flags)?;
 
-        let lodec = Zenoh080Length::new(x.zid.size());
-        lodec.write(&mut *writer, &x.zid)?;
+        let lodec = Zenoh080Length::new(zid.size());
+        lodec.write(&mut *writer, zid)?;
 
-        if !x.locators.is_empty() {
-            self.write(&mut *writer, x.locators.as_slice())?;
+        if !locators.is_empty() {
+            self.write(&mut *writer, locators.as_slice())?;
         }
 
         Ok(())

--- a/commons/zenoh-codec/src/scouting/mod.rs
+++ b/commons/zenoh-codec/src/scouting/mod.rs
@@ -31,7 +31,9 @@ where
     type Output = Result<(), DidntWrite>;
 
     fn write(self, writer: &mut W, x: &ScoutingMessage) -> Self::Output {
-        match &x.body {
+        let ScoutingMessage { body } = x;
+
+        match body {
             ScoutingBody::Scout(s) => self.write(&mut *writer, s),
             ScoutingBody::Hello(h) => self.write(&mut *writer, h),
         }

--- a/commons/zenoh-codec/src/scouting/scout.rs
+++ b/commons/zenoh-codec/src/scouting/scout.rs
@@ -33,22 +33,24 @@ where
     type Output = Result<(), DidntWrite>;
 
     fn write(self, writer: &mut W, x: &Scout) -> Self::Output {
+        let Scout { version, what, zid } = x;
+
         // Header
         let header = id::SCOUT;
         self.write(&mut *writer, header)?;
 
         // Body
-        self.write(&mut *writer, x.version)?;
+        self.write(&mut *writer, version)?;
 
         let mut flags: u8 = 0;
-        let what: u8 = x.what.into();
+        let what: u8 = (*what).into();
         flags |= what & 0b111;
-        if let Some(zid) = x.zid.as_ref() {
+        if let Some(zid) = zid.as_ref() {
             flags |= (((zid.size() - 1) as u8) << 4) | flag::I;
         };
         self.write(&mut *writer, flags)?;
 
-        if let Some(zid) = x.zid.as_ref() {
+        if let Some(zid) = zid.as_ref() {
             let lodec = Zenoh080Length::new(zid.size());
             lodec.write(&mut *writer, zid)?;
         }

--- a/commons/zenoh-codec/src/transport/close.rs
+++ b/commons/zenoh-codec/src/transport/close.rs
@@ -31,15 +31,17 @@ where
     type Output = Result<(), DidntWrite>;
 
     fn write(self, writer: &mut W, x: &Close) -> Self::Output {
+        let Close { reason, session } = x;
+
         // Header
         let mut header = id::CLOSE;
-        if x.session {
+        if *session {
             header |= flag::S;
         }
         self.write(&mut *writer, header)?;
 
         // Body
-        self.write(&mut *writer, x.reason)?;
+        self.write(&mut *writer, reason)?;
 
         Ok(())
     }

--- a/commons/zenoh-codec/src/transport/init.rs
+++ b/commons/zenoh-codec/src/transport/init.rs
@@ -37,58 +37,71 @@ where
     type Output = Result<(), DidntWrite>;
 
     fn write(self, writer: &mut W, x: &InitSyn) -> Self::Output {
+        let InitSyn {
+            version,
+            whatami,
+            zid,
+            resolution,
+            batch_size,
+            ext_qos,
+            ext_shm,
+            ext_auth,
+            ext_mlink,
+            ext_lowlatency,
+        } = x;
+
         // Header
         let mut header = id::INIT;
-        if x.resolution != Resolution::default() || x.batch_size != batch_size::UNICAST {
+        if resolution != &Resolution::default() || batch_size != &batch_size::UNICAST {
             header |= flag::S;
         }
-        let mut n_exts = (x.ext_qos.is_some() as u8)
-            + (x.ext_shm.is_some() as u8)
-            + (x.ext_auth.is_some() as u8)
-            + (x.ext_mlink.is_some() as u8)
-            + (x.ext_lowlatency.is_some() as u8);
+        let mut n_exts = (ext_qos.is_some() as u8)
+            + (ext_shm.is_some() as u8)
+            + (ext_auth.is_some() as u8)
+            + (ext_mlink.is_some() as u8)
+            + (ext_lowlatency.is_some() as u8);
         if n_exts != 0 {
             header |= flag::Z;
         }
         self.write(&mut *writer, header)?;
 
         // Body
-        self.write(&mut *writer, x.version)?;
+        self.write(&mut *writer, version)?;
 
-        let whatami: u8 = match x.whatami {
+        let whatami: u8 = match whatami {
             WhatAmI::Router => 0b00,
             WhatAmI::Peer => 0b01,
             WhatAmI::Client => 0b10,
         };
-        let flags: u8 = ((x.zid.size() as u8 - 1) << 4) | whatami;
+        let flags: u8 = ((zid.size() as u8 - 1) << 4) | whatami;
         self.write(&mut *writer, flags)?;
 
-        let lodec = Zenoh080Length::new(x.zid.size());
-        lodec.write(&mut *writer, &x.zid)?;
+        let lodec = Zenoh080Length::new(zid.size());
+        lodec.write(&mut *writer, zid)?;
 
         if imsg::has_flag(header, flag::S) {
-            self.write(&mut *writer, x.resolution.as_u8())?;
-            self.write(&mut *writer, x.batch_size.to_le_bytes())?;
+            self.write(&mut *writer, resolution.as_u8())?;
+            self.write(&mut *writer, batch_size.to_le_bytes())?;
         }
 
         // Extensions
-        if let Some(qos) = x.ext_qos.as_ref() {
+        if let Some(qos) = ext_qos.as_ref() {
             n_exts -= 1;
             self.write(&mut *writer, (qos, n_exts != 0))?;
         }
-        if let Some(shm) = x.ext_shm.as_ref() {
+        if let Some(shm) = ext_shm.as_ref() {
             n_exts -= 1;
             self.write(&mut *writer, (shm, n_exts != 0))?;
         }
-        if let Some(auth) = x.ext_auth.as_ref() {
+        if let Some(auth) = ext_auth.as_ref() {
             n_exts -= 1;
             self.write(&mut *writer, (auth, n_exts != 0))?;
         }
-        if let Some(mlink) = x.ext_mlink.as_ref() {
+        if let Some(mlink) = ext_mlink.as_ref() {
             n_exts -= 1;
             self.write(&mut *writer, (mlink, n_exts != 0))?;
         }
-        if let Some(lowlatency) = x.ext_lowlatency.as_ref() {
+        if let Some(lowlatency) = ext_lowlatency.as_ref() {
             n_exts -= 1;
             self.write(&mut *writer, (lowlatency, n_exts != 0))?;
         }
@@ -210,61 +223,75 @@ where
     type Output = Result<(), DidntWrite>;
 
     fn write(self, writer: &mut W, x: &InitAck) -> Self::Output {
+        let InitAck {
+            version,
+            whatami,
+            zid,
+            resolution,
+            batch_size,
+            cookie,
+            ext_qos,
+            ext_shm,
+            ext_auth,
+            ext_mlink,
+            ext_lowlatency,
+        } = x;
+
         // Header
         let mut header = id::INIT | flag::A;
-        if x.resolution != Resolution::default() || x.batch_size != batch_size::UNICAST {
+        if resolution != &Resolution::default() || batch_size != &batch_size::UNICAST {
             header |= flag::S;
         }
-        let mut n_exts = (x.ext_qos.is_some() as u8)
-            + (x.ext_shm.is_some() as u8)
-            + (x.ext_auth.is_some() as u8)
-            + (x.ext_mlink.is_some() as u8)
-            + (x.ext_lowlatency.is_some() as u8);
+        let mut n_exts = (ext_qos.is_some() as u8)
+            + (ext_shm.is_some() as u8)
+            + (ext_auth.is_some() as u8)
+            + (ext_mlink.is_some() as u8)
+            + (ext_lowlatency.is_some() as u8);
         if n_exts != 0 {
             header |= flag::Z;
         }
         self.write(&mut *writer, header)?;
 
         // Body
-        self.write(&mut *writer, x.version)?;
+        self.write(&mut *writer, version)?;
 
-        let whatami: u8 = match x.whatami {
+        let whatami: u8 = match whatami {
             WhatAmI::Router => 0b00,
             WhatAmI::Peer => 0b01,
             WhatAmI::Client => 0b10,
         };
-        let flags: u8 = ((x.zid.size() as u8 - 1) << 4) | whatami;
+        let flags: u8 = ((zid.size() as u8 - 1) << 4) | whatami;
         self.write(&mut *writer, flags)?;
 
-        let lodec = Zenoh080Length::new(x.zid.size());
-        lodec.write(&mut *writer, &x.zid)?;
+        let lodec = Zenoh080Length::new(zid.size());
+        lodec.write(&mut *writer, zid)?;
 
         if imsg::has_flag(header, flag::S) {
-            self.write(&mut *writer, x.resolution.as_u8())?;
-            self.write(&mut *writer, x.batch_size.to_le_bytes())?;
+            self.write(&mut *writer, resolution.as_u8())?;
+            self.write(&mut *writer, batch_size.to_le_bytes())?;
         }
 
         let zodec = Zenoh080Bounded::<BatchSize>::new();
-        zodec.write(&mut *writer, &x.cookie)?;
+        zodec.write(&mut *writer, cookie)?;
 
         // Extensions
-        if let Some(qos) = x.ext_qos.as_ref() {
+        if let Some(qos) = ext_qos.as_ref() {
             n_exts -= 1;
             self.write(&mut *writer, (qos, n_exts != 0))?;
         }
-        if let Some(shm) = x.ext_shm.as_ref() {
+        if let Some(shm) = ext_shm.as_ref() {
             n_exts -= 1;
             self.write(&mut *writer, (shm, n_exts != 0))?;
         }
-        if let Some(auth) = x.ext_auth.as_ref() {
+        if let Some(auth) = ext_auth.as_ref() {
             n_exts -= 1;
             self.write(&mut *writer, (auth, n_exts != 0))?;
         }
-        if let Some(mlink) = x.ext_mlink.as_ref() {
+        if let Some(mlink) = ext_mlink.as_ref() {
             n_exts -= 1;
             self.write(&mut *writer, (mlink, n_exts != 0))?;
         }
-        if let Some(lowlatency) = x.ext_lowlatency.as_ref() {
+        if let Some(lowlatency) = ext_lowlatency.as_ref() {
             n_exts -= 1;
             self.write(&mut *writer, (lowlatency, n_exts != 0))?;
         }

--- a/commons/zenoh-codec/src/transport/keepalive.rs
+++ b/commons/zenoh-codec/src/transport/keepalive.rs
@@ -30,7 +30,9 @@ where
 {
     type Output = Result<(), DidntWrite>;
 
-    fn write(self, writer: &mut W, _x: &KeepAlive) -> Self::Output {
+    fn write(self, writer: &mut W, x: &KeepAlive) -> Self::Output {
+        let KeepAlive = x;
+
         // Header
         let header = id::KEEP_ALIVE;
         self.write(&mut *writer, header)?;

--- a/commons/zenoh-codec/src/transport/mod.rs
+++ b/commons/zenoh-codec/src/transport/mod.rs
@@ -39,7 +39,9 @@ where
     type Output = Result<(), DidntWrite>;
 
     fn write(self, writer: &mut W, x: &TransportMessageLowLatency) -> Self::Output {
-        match &x.body {
+        let TransportMessageLowLatency { body } = x;
+
+        match body {
             TransportBodyLowLatency::Network(b) => self.write(&mut *writer, b),
             TransportBodyLowLatency::KeepAlive(b) => self.write(&mut *writer, b),
             TransportBodyLowLatency::Close(b) => self.write(&mut *writer, b),
@@ -78,7 +80,9 @@ where
     type Output = Result<(), DidntWrite>;
 
     fn write(self, writer: &mut W, x: &TransportMessage) -> Self::Output {
-        match &x.body {
+        let TransportMessage { body } = x;
+
+        match body {
             TransportBody::Frame(b) => self.write(&mut *writer, b),
             TransportBody::Fragment(b) => self.write(&mut *writer, b),
             TransportBody::KeepAlive(b) => self.write(&mut *writer, b),
@@ -141,6 +145,7 @@ where
     fn write(self, writer: &mut W, x: (ext::QoSType<{ ID }>, bool)) -> Self::Output {
         let (x, more) = x;
         let ext: ZExtZ64<{ ID }> = x.into();
+
         self.write(&mut *writer, (&ext, more))
     }
 }

--- a/commons/zenoh-codec/src/transport/open.rs
+++ b/commons/zenoh-codec/src/transport/open.rs
@@ -35,16 +35,27 @@ where
     type Output = Result<(), DidntWrite>;
 
     fn write(self, writer: &mut W, x: &OpenSyn) -> Self::Output {
+        let OpenSyn {
+            lease,
+            initial_sn,
+            cookie,
+            ext_qos,
+            ext_shm,
+            ext_auth,
+            ext_mlink,
+            ext_lowlatency,
+        } = x;
+
         // Header
         let mut header = id::OPEN;
-        if x.lease.as_millis() % 1_000 == 0 {
+        if lease.as_millis() % 1_000 == 0 {
             header |= flag::T;
         }
-        let mut n_exts = (x.ext_qos.is_some() as u8)
-            + (x.ext_shm.is_some() as u8)
-            + (x.ext_auth.is_some() as u8)
-            + (x.ext_mlink.is_some() as u8)
-            + (x.ext_lowlatency.is_some() as u8);
+        let mut n_exts = (ext_qos.is_some() as u8)
+            + (ext_shm.is_some() as u8)
+            + (ext_auth.is_some() as u8)
+            + (ext_mlink.is_some() as u8)
+            + (ext_lowlatency.is_some() as u8);
         if n_exts != 0 {
             header |= flag::Z;
         }
@@ -52,31 +63,31 @@ where
 
         // Body
         if imsg::has_flag(header, flag::T) {
-            self.write(&mut *writer, x.lease.as_secs())?;
+            self.write(&mut *writer, lease.as_secs())?;
         } else {
-            self.write(&mut *writer, x.lease.as_millis() as u64)?;
+            self.write(&mut *writer, lease.as_millis() as u64)?;
         }
-        self.write(&mut *writer, x.initial_sn)?;
-        self.write(&mut *writer, &x.cookie)?;
+        self.write(&mut *writer, initial_sn)?;
+        self.write(&mut *writer, cookie)?;
 
         // Extensions
-        if let Some(qos) = x.ext_qos.as_ref() {
+        if let Some(qos) = ext_qos.as_ref() {
             n_exts -= 1;
             self.write(&mut *writer, (qos, n_exts != 0))?;
         }
-        if let Some(shm) = x.ext_shm.as_ref() {
+        if let Some(shm) = ext_shm.as_ref() {
             n_exts -= 1;
             self.write(&mut *writer, (shm, n_exts != 0))?;
         }
-        if let Some(auth) = x.ext_auth.as_ref() {
+        if let Some(auth) = ext_auth.as_ref() {
             n_exts -= 1;
             self.write(&mut *writer, (auth, n_exts != 0))?;
         }
-        if let Some(mlink) = x.ext_mlink.as_ref() {
+        if let Some(mlink) = ext_mlink.as_ref() {
             n_exts -= 1;
             self.write(&mut *writer, (mlink, n_exts != 0))?;
         }
-        if let Some(lowlatency) = x.ext_lowlatency.as_ref() {
+        if let Some(lowlatency) = ext_lowlatency.as_ref() {
             n_exts -= 1;
             self.write(&mut *writer, (lowlatency, n_exts != 0))?;
         }
@@ -183,18 +194,28 @@ where
     type Output = Result<(), DidntWrite>;
 
     fn write(self, writer: &mut W, x: &OpenAck) -> Self::Output {
+        let OpenAck {
+            lease,
+            initial_sn,
+            ext_qos,
+            ext_shm,
+            ext_auth,
+            ext_mlink,
+            ext_lowlatency,
+        } = x;
+
         // Header
         let mut header = id::OPEN;
         header |= flag::A;
         // Verify that the timeout is expressed in seconds, i.e. subsec part is 0.
-        if x.lease.subsec_nanos() == 0 {
+        if lease.subsec_nanos() == 0 {
             header |= flag::T;
         }
-        let mut n_exts = (x.ext_qos.is_some() as u8)
-            + (x.ext_shm.is_some() as u8)
-            + (x.ext_auth.is_some() as u8)
-            + (x.ext_mlink.is_some() as u8)
-            + (x.ext_lowlatency.is_some() as u8);
+        let mut n_exts = (ext_qos.is_some() as u8)
+            + (ext_shm.is_some() as u8)
+            + (ext_auth.is_some() as u8)
+            + (ext_mlink.is_some() as u8)
+            + (ext_lowlatency.is_some() as u8);
         if n_exts != 0 {
             header |= flag::Z;
         }
@@ -202,30 +223,30 @@ where
 
         // Body
         if imsg::has_flag(header, flag::T) {
-            self.write(&mut *writer, x.lease.as_secs())?;
+            self.write(&mut *writer, lease.as_secs())?;
         } else {
-            self.write(&mut *writer, x.lease.as_millis() as u64)?;
+            self.write(&mut *writer, lease.as_millis() as u64)?;
         }
-        self.write(&mut *writer, x.initial_sn)?;
+        self.write(&mut *writer, initial_sn)?;
 
         // Extensions
-        if let Some(qos) = x.ext_qos.as_ref() {
+        if let Some(qos) = ext_qos.as_ref() {
             n_exts -= 1;
             self.write(&mut *writer, (qos, n_exts != 0))?;
         }
-        if let Some(shm) = x.ext_shm.as_ref() {
+        if let Some(shm) = ext_shm.as_ref() {
             n_exts -= 1;
             self.write(&mut *writer, (shm, n_exts != 0))?;
         }
-        if let Some(auth) = x.ext_auth.as_ref() {
+        if let Some(auth) = ext_auth.as_ref() {
             n_exts -= 1;
             self.write(&mut *writer, (auth, n_exts != 0))?;
         }
-        if let Some(mlink) = x.ext_mlink.as_ref() {
+        if let Some(mlink) = ext_mlink.as_ref() {
             n_exts -= 1;
             self.write(&mut *writer, (mlink, n_exts != 0))?;
         }
-        if let Some(lowlatency) = x.ext_lowlatency.as_ref() {
+        if let Some(lowlatency) = ext_lowlatency.as_ref() {
             n_exts -= 1;
             self.write(&mut *writer, (lowlatency, n_exts != 0))?;
         }

--- a/commons/zenoh-codec/src/zenoh/del.rs
+++ b/commons/zenoh-codec/src/zenoh/del.rs
@@ -32,28 +32,34 @@ where
     type Output = Result<(), DidntWrite>;
 
     fn write(self, writer: &mut W, x: &Del) -> Self::Output {
+        let Del {
+            timestamp,
+            ext_sinfo,
+            ext_unknown,
+        } = x;
+
         // Header
         let mut header = id::DEL;
-        if x.timestamp.is_some() {
+        if timestamp.is_some() {
             header |= flag::T;
         }
-        let mut n_exts = (x.ext_sinfo.is_some()) as u8 + (x.ext_unknown.len() as u8);
+        let mut n_exts = (ext_sinfo.is_some()) as u8 + (ext_unknown.len() as u8);
         if n_exts != 0 {
             header |= flag::Z;
         }
         self.write(&mut *writer, header)?;
 
         // Body
-        if let Some(ts) = x.timestamp.as_ref() {
+        if let Some(ts) = timestamp.as_ref() {
             self.write(&mut *writer, ts)?;
         }
 
         // Extensions
-        if let Some(sinfo) = x.ext_sinfo.as_ref() {
+        if let Some(sinfo) = ext_sinfo.as_ref() {
             n_exts -= 1;
             self.write(&mut *writer, (sinfo, n_exts != 0))?;
         }
-        for u in x.ext_unknown.iter() {
+        for u in ext_unknown.iter() {
             n_exts -= 1;
             self.write(&mut *writer, (u, n_exts != 0))?;
         }

--- a/commons/zenoh-codec/src/zenoh/err.rs
+++ b/commons/zenoh-codec/src/zenoh/err.rs
@@ -32,38 +32,46 @@ where
     type Output = Result<(), DidntWrite>;
 
     fn write(self, writer: &mut W, x: &Err) -> Self::Output {
+        let Err {
+            code,
+            is_infrastructure,
+            timestamp,
+            ext_sinfo,
+            ext_body,
+            ext_unknown,
+        } = x;
+
         // Header
         let mut header = id::ERR;
-        if x.timestamp.is_some() {
+        if timestamp.is_some() {
             header |= flag::T;
         }
-        if x.is_infrastructure {
+        if *is_infrastructure {
             header |= flag::I;
         }
-        let mut n_exts = (x.ext_sinfo.is_some() as u8)
-            + (x.ext_body.is_some() as u8)
-            + (x.ext_unknown.len() as u8);
+        let mut n_exts =
+            (ext_sinfo.is_some() as u8) + (ext_body.is_some() as u8) + (ext_unknown.len() as u8);
         if n_exts != 0 {
             header |= flag::Z;
         }
         self.write(&mut *writer, header)?;
 
         // Body
-        self.write(&mut *writer, x.code)?;
-        if let Some(ts) = x.timestamp.as_ref() {
+        self.write(&mut *writer, code)?;
+        if let Some(ts) = timestamp.as_ref() {
             self.write(&mut *writer, ts)?;
         }
 
         // Extensions
-        if let Some(sinfo) = x.ext_sinfo.as_ref() {
+        if let Some(sinfo) = ext_sinfo.as_ref() {
             n_exts -= 1;
             self.write(&mut *writer, (sinfo, n_exts != 0))?;
         }
-        if let Some(body) = x.ext_body.as_ref() {
+        if let Some(body) = ext_body.as_ref() {
             n_exts -= 1;
             self.write(&mut *writer, (body, n_exts != 0))?;
         }
-        for u in x.ext_unknown.iter() {
+        for u in ext_unknown.iter() {
             n_exts -= 1;
             self.write(&mut *writer, (u, n_exts != 0))?;
         }

--- a/commons/zenoh-codec/src/zenoh/mod.rs
+++ b/commons/zenoh-codec/src/zenoh/mod.rs
@@ -153,7 +153,9 @@ where
 // Extension: SourceInfo
 impl<const ID: u8> LCodec<&ext::SourceInfoType<{ ID }>> for Zenoh080 {
     fn w_len(self, x: &ext::SourceInfoType<{ ID }>) -> usize {
-        1 + self.w_len(&x.zid) + self.w_len(x.eid) + self.w_len(x.sn)
+        let ext::SourceInfoType { zid, eid, sn } = x;
+
+        1 + self.w_len(zid) + self.w_len(*eid) + self.w_len(*sn)
     }
 }
 
@@ -165,17 +167,19 @@ where
 
     fn write(self, writer: &mut W, x: (&ext::SourceInfoType<{ ID }>, bool)) -> Self::Output {
         let (x, more) = x;
+        let ext::SourceInfoType { zid, eid, sn } = x;
+
         let header: ZExtZBufHeader<{ ID }> = ZExtZBufHeader::new(self.w_len(x));
         self.write(&mut *writer, (&header, more))?;
 
-        let flags: u8 = (x.zid.size() as u8 - 1) << 4;
+        let flags: u8 = (zid.size() as u8 - 1) << 4;
         self.write(&mut *writer, flags)?;
 
-        let lodec = Zenoh080Length::new(x.zid.size());
-        lodec.write(&mut *writer, &x.zid)?;
+        let lodec = Zenoh080Length::new(zid.size());
+        lodec.write(&mut *writer, zid)?;
 
-        self.write(&mut *writer, x.eid)?;
-        self.write(&mut *writer, x.sn)?;
+        self.write(&mut *writer, eid)?;
+        self.write(&mut *writer, sn)?;
         Ok(())
     }
 }
@@ -211,7 +215,9 @@ where
     type Output = Result<(), DidntWrite>;
 
     fn write(self, writer: &mut W, x: (&ext::ShmType<{ ID }>, bool)) -> Self::Output {
-        let (_, more) = x;
+        let (x, more) = x;
+        let ext::ShmType = x;
+
         let header: ZExtUnit<{ ID }> = ZExtUnit::new();
         self.write(&mut *writer, (&header, more))?;
         Ok(())
@@ -241,25 +247,31 @@ where
 
     fn write(self, writer: &mut W, x: (&ext::ValueType<{ VID }, { SID }>, bool)) -> Self::Output {
         let (x, more) = x;
+        let ext::ValueType {
+            encoding,
+            payload,
+            #[cfg(feature = "shared-memory")]
+            ext_shm,
+        } = x;
 
         #[cfg(feature = "shared-memory")] // Write Shm extension if present
-        if let Some(eshm) = x.ext_shm.as_ref() {
+        if let Some(eshm) = ext_shm.as_ref() {
             self.write(&mut *writer, (eshm, true))?;
         }
 
         // Compute extension length
-        let mut len = self.w_len(&x.encoding);
+        let mut len = self.w_len(encoding);
 
         #[cfg(feature = "shared-memory")]
         {
-            let codec = Zenoh080Sliced::<u32>::new(x.ext_shm.is_some());
-            len += codec.w_len(&x.payload);
+            let codec = Zenoh080Sliced::<u32>::new(ext_shm.is_some());
+            len += codec.w_len(&payload);
         }
 
         #[cfg(not(feature = "shared-memory"))]
         {
             let codec = Zenoh080Bounded::<u32>::new();
-            len += codec.w_len(&x.payload);
+            len += codec.w_len(payload);
         }
 
         // Write ZExtBuf header
@@ -267,7 +279,7 @@ where
         self.write(&mut *writer, (&header, more))?;
 
         // Write encoding
-        self.write(&mut *writer, &x.encoding)?;
+        self.write(&mut *writer, encoding)?;
 
         // Write payload
         fn write<W>(writer: &mut W, payload: &ZBuf) -> Result<(), DidntWrite>
@@ -283,17 +295,17 @@ where
 
         #[cfg(feature = "shared-memory")]
         {
-            if x.ext_shm.is_some() {
+            if ext_shm.is_some() {
                 let codec = Zenoh080Sliced::<u32>::new(true);
-                codec.write(&mut *writer, &x.payload)?;
+                codec.write(&mut *writer, payload)?;
             } else {
-                write(&mut *writer, &x.payload)?;
+                write(&mut *writer, payload)?;
             }
         }
 
         #[cfg(not(feature = "shared-memory"))]
         {
-            write(&mut *writer, &x.payload)?;
+            write(&mut *writer, payload)?;
         }
 
         Ok(())
@@ -365,5 +377,41 @@ where
             },
             more,
         ))
+    }
+}
+
+// Extension: Attachment
+impl<W, const ID: u8> WCodec<(&ext::AttachmentType<{ ID }>, bool), &mut W> for Zenoh080
+where
+    W: Writer,
+{
+    type Output = Result<(), DidntWrite>;
+
+    fn write(self, writer: &mut W, x: (&ext::AttachmentType<{ ID }>, bool)) -> Self::Output {
+        let (x, more) = x;
+        let ext::AttachmentType { buffer } = x;
+
+        let header: ZExtZBufHeader<{ ID }> = ZExtZBufHeader::new(self.w_len(buffer));
+        self.write(&mut *writer, (&header, more))?;
+        for s in buffer.zslices() {
+            writer.write_zslice(s)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<R, const ID: u8> RCodec<(ext::AttachmentType<{ ID }>, bool), &mut R> for Zenoh080Header
+where
+    R: Reader,
+{
+    type Error = DidntRead;
+
+    fn read(self, reader: &mut R) -> Result<(ext::AttachmentType<{ ID }>, bool), Self::Error> {
+        let (h, more): (ZExtZBufHeader<{ ID }>, bool) = self.read(&mut *reader)?;
+        let mut buffer = ZBuf::empty();
+        reader.read_zslices(h.len, |s| buffer.push_zslice(s))?;
+
+        Ok((ext::AttachmentType { buffer }, more))
     }
 }

--- a/commons/zenoh-codec/src/zenoh/pull.rs
+++ b/commons/zenoh-codec/src/zenoh/pull.rs
@@ -33,16 +33,18 @@ where
     type Output = Result<(), DidntWrite>;
 
     fn write(self, writer: &mut W, x: &Pull) -> Self::Output {
+        let Pull { ext_unknown } = x;
+
         // Header
         let mut header = id::PULL;
-        let mut n_exts = x.ext_unknown.len() as u8;
+        let mut n_exts = ext_unknown.len() as u8;
         if n_exts != 0 {
             header |= flag::Z;
         }
         self.write(&mut *writer, header)?;
 
         // Extensions
-        for u in x.ext_unknown.iter() {
+        for u in ext_unknown.iter() {
             n_exts -= 1;
             self.write(&mut *writer, (u, n_exts != 0))?;
         }

--- a/commons/zenoh-codec/src/zenoh/query.rs
+++ b/commons/zenoh-codec/src/zenoh/query.rs
@@ -79,6 +79,7 @@ where
             ext_sinfo,
             ext_consolidation,
             ext_body,
+            ext_attachment,
             ext_unknown,
         } = x;
 
@@ -90,6 +91,7 @@ where
         let mut n_exts = (ext_sinfo.is_some() as u8)
             + ((ext_consolidation != &ext::ConsolidationType::default()) as u8)
             + (ext_body.is_some() as u8)
+            + (ext_attachment.is_some() as u8)
             + (ext_unknown.len() as u8);
         if n_exts != 0 {
             header |= flag::Z;
@@ -113,6 +115,10 @@ where
         if let Some(body) = ext_body.as_ref() {
             n_exts -= 1;
             self.write(&mut *writer, (body, n_exts != 0))?;
+        }
+        if let Some(att) = ext_attachment.as_ref() {
+            n_exts -= 1;
+            self.write(&mut *writer, (att, n_exts != 0))?;
         }
         for u in ext_unknown.iter() {
             n_exts -= 1;
@@ -157,6 +163,7 @@ where
         let mut ext_sinfo: Option<ext::SourceInfoType> = None;
         let mut ext_consolidation = ext::ConsolidationType::default();
         let mut ext_body: Option<ext::QueryBodyType> = None;
+        let mut ext_attachment: Option<ext::AttachmentType> = None;
         let mut ext_unknown = Vec::new();
 
         let mut has_ext = imsg::has_flag(self.header, flag::Z);
@@ -179,6 +186,11 @@ where
                     ext_body = Some(s);
                     has_ext = ext;
                 }
+                ext::Attachment::ID => {
+                    let (a, ext): (ext::AttachmentType, bool) = eodec.read(&mut *reader)?;
+                    ext_attachment = Some(a);
+                    has_ext = ext;
+                }
                 _ => {
                     let (u, ext) = extension::read(reader, "Query", ext)?;
                     ext_unknown.push(u);
@@ -192,6 +204,7 @@ where
             ext_sinfo,
             ext_consolidation,
             ext_body,
+            ext_attachment,
             ext_unknown,
         })
     }

--- a/commons/zenoh-codec/src/zenoh/reply.rs
+++ b/commons/zenoh-codec/src/zenoh/reply.rs
@@ -38,20 +38,31 @@ where
     type Output = Result<(), DidntWrite>;
 
     fn write(self, writer: &mut W, x: &Reply) -> Self::Output {
+        let Reply {
+            timestamp,
+            encoding,
+            ext_sinfo,
+            ext_consolidation,
+            #[cfg(feature = "shared-memory")]
+            ext_shm,
+            ext_unknown,
+            payload,
+        } = x;
+
         // Header
         let mut header = id::REPLY;
-        if x.timestamp.is_some() {
+        if timestamp.is_some() {
             header |= flag::T;
         }
-        if x.encoding != Encoding::default() {
+        if encoding != &Encoding::default() {
             header |= flag::E;
         }
-        let mut n_exts = (x.ext_sinfo.is_some()) as u8
-            + ((x.ext_consolidation != ext::ConsolidationType::default()) as u8)
-            + (x.ext_unknown.len() as u8);
+        let mut n_exts = (ext_sinfo.is_some()) as u8
+            + ((ext_consolidation != &ext::ConsolidationType::default()) as u8)
+            + (ext_unknown.len() as u8);
         #[cfg(feature = "shared-memory")]
         {
-            n_exts += x.ext_shm.is_some() as u8;
+            n_exts += ext_shm.is_some() as u8;
         }
         if n_exts != 0 {
             header |= flag::Z;
@@ -59,28 +70,28 @@ where
         self.write(&mut *writer, header)?;
 
         // Body
-        if let Some(ts) = x.timestamp.as_ref() {
+        if let Some(ts) = timestamp.as_ref() {
             self.write(&mut *writer, ts)?;
         }
-        if x.encoding != Encoding::default() {
-            self.write(&mut *writer, &x.encoding)?;
+        if encoding != &Encoding::default() {
+            self.write(&mut *writer, encoding)?;
         }
 
         // Extensions
-        if let Some(sinfo) = x.ext_sinfo.as_ref() {
+        if let Some(sinfo) = ext_sinfo.as_ref() {
             n_exts -= 1;
             self.write(&mut *writer, (sinfo, n_exts != 0))?;
         }
-        if x.ext_consolidation != ext::ConsolidationType::default() {
+        if ext_consolidation != &ext::ConsolidationType::default() {
             n_exts -= 1;
-            self.write(&mut *writer, (x.ext_consolidation, n_exts != 0))?;
+            self.write(&mut *writer, (*ext_consolidation, n_exts != 0))?;
         }
         #[cfg(feature = "shared-memory")]
-        if let Some(eshm) = x.ext_shm.as_ref() {
+        if let Some(eshm) = ext_shm.as_ref() {
             n_exts -= 1;
             self.write(&mut *writer, (eshm, n_exts != 0))?;
         }
-        for u in x.ext_unknown.iter() {
+        for u in ext_unknown.iter() {
             n_exts -= 1;
             self.write(&mut *writer, (u, n_exts != 0))?;
         }
@@ -88,14 +99,14 @@ where
         // Payload
         #[cfg(feature = "shared-memory")]
         {
-            let codec = Zenoh080Sliced::<u32>::new(x.ext_shm.is_some());
-            codec.write(&mut *writer, &x.payload)?;
+            let codec = Zenoh080Sliced::<u32>::new(ext_shm.is_some());
+            codec.write(&mut *writer, &payload)?;
         }
 
         #[cfg(not(feature = "shared-memory"))]
         {
             let bodec = Zenoh080Bounded::<u32>::new();
-            bodec.write(&mut *writer, &x.payload)?;
+            bodec.write(&mut *writer, payload)?;
         }
 
         Ok(())

--- a/commons/zenoh-crypto/src/cipher.rs
+++ b/commons/zenoh-crypto/src/cipher.rs
@@ -50,7 +50,7 @@ impl BlockCipher {
 
     pub fn decrypt(&self, mut bytes: Vec<u8>) -> ZResult<Vec<u8>> {
         if bytes.len() % Self::BLOCK_SIZE != 0 {
-            bail!("Invalid bytes lenght to decode: {}", bytes.len());
+            bail!("Invalid bytes length to decode: {}", bytes.len());
         }
 
         let mut start: usize = 0;

--- a/commons/zenoh-protocol/src/lib.rs
+++ b/commons/zenoh-protocol/src/lib.rs
@@ -48,7 +48,7 @@ pub const VERSION: u8 = 0x08;
 // # Variable length field
 //
 // The field size depends on the element definition and/or actual encoding. An example of variable
-// lenght element is an array of bytes (e.g., a payload or a string).
+// length element is an array of bytes (e.g., a payload or a string).
 //
 // ```text
 //  7 6 5 4 3 2 1 0
@@ -60,7 +60,7 @@ pub const VERSION: u8 = 0x08;
 //
 // # u64 field
 //
-// A u64 is a specialized variable lenght field that is used to encode an unsigned integer.
+// A u64 is a specialized variable length field that is used to encode an unsigned integer.
 //
 // ```text
 //  7 6 5 4 3 2 1 0

--- a/commons/zenoh-protocol/src/scouting/scout.rs
+++ b/commons/zenoh-protocol/src/scouting/scout.rs
@@ -56,7 +56,7 @@ use crate::core::{whatami::WhatAmIMatcher, ZenohId};
 /// +---------------+
 ///
 /// (#) ZID length. If Flag(I)==1 it indicates how many bytes are used for the ZenohID bytes.
-///     A ZenohID is minimum 1 byte and maximum 16 bytes. Therefore, the actual lenght is computed as:
+///     A ZenohID is minimum 1 byte and maximum 16 bytes. Therefore, the actual length is computed as:
 ///         real_zid_len := 1 + zid_len
 ///
 /// (*) What. It indicates a bitmap of WhatAmI interests.

--- a/commons/zenoh-protocol/src/transport/init.rs
+++ b/commons/zenoh-protocol/src/transport/init.rs
@@ -76,7 +76,7 @@ use zenoh_buffers::ZSlice;
 ///    - 0b11: Reserved
 ///
 /// (#) ZID length. It indicates how many bytes are used for the ZenohID bytes.
-///     A ZenohID is minimum 1 byte and maximum 16 bytes. Therefore, the actual lenght is computed as:
+///     A ZenohID is minimum 1 byte and maximum 16 bytes. Therefore, the actual length is computed as:
 ///         real_zid_len := 1 + zid_len
 ///
 /// (+) Sequence Number/ID resolution. It indicates the resolution and consequently the wire overhead

--- a/commons/zenoh-protocol/src/transport/join.rs
+++ b/commons/zenoh-protocol/src/transport/join.rs
@@ -74,7 +74,7 @@ use core::time::Duration;
 ///    - 0b11: Reserved
 ///
 /// (#) ZID length. It indicates how many bytes are used for the ZenohID bytes.
-///     A ZenohID is minimum 1 byte and maximum 16 bytes. Therefore, the actual lenght is computed as:
+///     A ZenohID is minimum 1 byte and maximum 16 bytes. Therefore, the actual length is computed as:
 ///         real_zid_len := 1 + zid_len
 ///
 /// (+) Sequence Number/ID resolution. It indicates the resolution and consequently the wire overhead

--- a/commons/zenoh-protocol/src/zenoh/del.rs
+++ b/commons/zenoh-protocol/src/zenoh/del.rs
@@ -42,6 +42,7 @@ pub mod flag {
 pub struct Del {
     pub timestamp: Option<Timestamp>,
     pub ext_sinfo: Option<ext::SourceInfoType>,
+    pub ext_attachment: Option<ext::AttachmentType>,
     pub ext_unknown: Vec<ZExtUnknown>,
 }
 
@@ -52,6 +53,10 @@ pub mod ext {
     /// Used to carry additional information about the source of data
     pub type SourceInfo = zextzbuf!(0x1, false);
     pub type SourceInfoType = crate::zenoh::ext::SourceInfoType<{ SourceInfo::ID }>;
+
+    /// # User attachment
+    pub type Attachment = zextzbuf!(0x2, false);
+    pub type AttachmentType = crate::zenoh::ext::AttachmentType<{ Attachment::ID }>;
 }
 
 impl Del {
@@ -67,10 +72,11 @@ impl Del {
             Timestamp::new(time, id)
         });
         let ext_sinfo = rng.gen_bool(0.5).then_some(ext::SourceInfoType::rand());
+        let ext_attachment = rng.gen_bool(0.5).then_some(ext::AttachmentType::rand());
         let mut ext_unknown = Vec::new();
         for _ in 0..rng.gen_range(0..4) {
             ext_unknown.push(ZExtUnknown::rand2(
-                iext::mid(ext::SourceInfo::ID) + 1,
+                iext::mid(ext::Attachment::ID) + 1,
                 false,
             ));
         }
@@ -78,6 +84,7 @@ impl Del {
         Self {
             timestamp,
             ext_sinfo,
+            ext_attachment,
             ext_unknown,
         }
     }

--- a/commons/zenoh-protocol/src/zenoh/mod.rs
+++ b/commons/zenoh-protocol/src/zenoh/mod.rs
@@ -256,4 +256,30 @@ pub mod ext {
             }
         }
     }
+
+    ///  7 6 5 4 3 2 1 0
+    /// +-+-+-+-+-+-+-+-+
+    /// %   num elems   %
+    /// +-------+-+-+---+
+    /// ~ key: <u8;z16> ~
+    /// +---------------+
+    /// ~ val: <u8;z32> ~
+    /// +---------------+
+    ///       ...         -- N times (key, value) tuples
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct AttachmentType<const ID: u8> {
+        pub buffer: ZBuf,
+    }
+
+    impl<const ID: u8> AttachmentType<{ ID }> {
+        #[cfg(feature = "test")]
+        pub fn rand() -> Self {
+            use rand::Rng;
+            let mut rng = rand::thread_rng();
+
+            Self {
+                buffer: ZBuf::rand(rng.gen_range(3..=1_024)),
+            }
+        }
+    }
 }

--- a/commons/zenoh-protocol/src/zenoh/put.rs
+++ b/commons/zenoh-protocol/src/zenoh/put.rs
@@ -48,6 +48,7 @@ pub struct Put {
     pub timestamp: Option<Timestamp>,
     pub encoding: Encoding,
     pub ext_sinfo: Option<ext::SourceInfoType>,
+    pub ext_attachment: Option<ext::AttachmentType>,
     #[cfg(feature = "shared-memory")]
     pub ext_shm: Option<ext::ShmType>,
     pub ext_unknown: Vec<ZExtUnknown>,
@@ -70,6 +71,10 @@ pub mod ext {
     pub type Shm = zextunit!(0x2, true);
     #[cfg(feature = "shared-memory")]
     pub type ShmType = crate::zenoh::ext::ShmType<{ Shm::ID }>;
+
+    /// # User attachment
+    pub type Attachment = zextzbuf!(0x3, false);
+    pub type AttachmentType = crate::zenoh::ext::AttachmentType<{ Attachment::ID }>;
 }
 
 impl Put {
@@ -88,10 +93,11 @@ impl Put {
         let ext_sinfo = rng.gen_bool(0.5).then_some(ext::SourceInfoType::rand());
         #[cfg(feature = "shared-memory")]
         let ext_shm = rng.gen_bool(0.5).then_some(ext::ShmType::rand());
+        let ext_attachment = rng.gen_bool(0.5).then_some(ext::AttachmentType::rand());
         let mut ext_unknown = Vec::new();
         for _ in 0..rng.gen_range(0..4) {
             ext_unknown.push(ZExtUnknown::rand2(
-                iext::mid(ext::SourceInfo::ID) + 1,
+                iext::mid(ext::Attachment::ID) + 1,
                 false,
             ));
         }
@@ -103,6 +109,7 @@ impl Put {
             ext_sinfo,
             #[cfg(feature = "shared-memory")]
             ext_shm,
+            ext_attachment,
             ext_unknown,
             payload,
         }

--- a/commons/zenoh-protocol/src/zenoh/query.rs
+++ b/commons/zenoh-protocol/src/zenoh/query.rs
@@ -94,6 +94,7 @@ pub struct Query {
     pub ext_sinfo: Option<ext::SourceInfoType>,
     pub ext_consolidation: Consolidation,
     pub ext_body: Option<ext::QueryBodyType>,
+    pub ext_attachment: Option<ext::AttachmentType>,
     pub ext_unknown: Vec<ZExtUnknown>,
 }
 
@@ -117,6 +118,10 @@ pub mod ext {
     /// Shared Memory extension is automatically defined by ValueType extension if
     /// #[cfg(feature = "shared-memory")] is defined.
     pub type QueryBodyType = crate::zenoh::ext::ValueType<{ ZExtZBuf::<0x03>::id(false) }, 0x04>;
+
+    /// # User attachment
+    pub type Attachment = zextzbuf!(0x5, false);
+    pub type AttachmentType = crate::zenoh::ext::AttachmentType<{ Attachment::ID }>;
 }
 
 impl Query {
@@ -141,10 +146,11 @@ impl Query {
         let ext_sinfo = rng.gen_bool(0.5).then_some(ext::SourceInfoType::rand());
         let ext_consolidation = Consolidation::rand();
         let ext_body = rng.gen_bool(0.5).then_some(ext::QueryBodyType::rand());
+        let ext_attachment = rng.gen_bool(0.5).then_some(ext::AttachmentType::rand());
         let mut ext_unknown = Vec::new();
         for _ in 0..rng.gen_range(0..4) {
             ext_unknown.push(ZExtUnknown::rand2(
-                iext::mid(ext::QueryBodyType::SID) + 1,
+                iext::mid(ext::Attachment::ID) + 1,
                 false,
             ));
         }
@@ -154,6 +160,7 @@ impl Query {
             ext_sinfo,
             ext_consolidation,
             ext_body,
+            ext_attachment,
             ext_unknown,
         }
     }

--- a/commons/zenoh-protocol/src/zenoh/reply.rs
+++ b/commons/zenoh-protocol/src/zenoh/reply.rs
@@ -51,6 +51,7 @@ pub struct Reply {
     pub ext_consolidation: ext::ConsolidationType,
     #[cfg(feature = "shared-memory")]
     pub ext_shm: Option<ext::ShmType>,
+    pub ext_attachment: Option<ext::AttachmentType>,
     pub ext_unknown: Vec<ZExtUnknown>,
     pub payload: ZBuf,
 }
@@ -78,6 +79,10 @@ pub mod ext {
     pub type Shm = zextunit!(0x3, true);
     #[cfg(feature = "shared-memory")]
     pub type ShmType = crate::zenoh::ext::ShmType<{ Shm::ID }>;
+
+    /// # User attachment
+    pub type Attachment = zextzbuf!(0x4, false);
+    pub type AttachmentType = crate::zenoh::ext::AttachmentType<{ Attachment::ID }>;
 }
 
 impl Reply {
@@ -97,10 +102,11 @@ impl Reply {
         let ext_consolidation = Consolidation::rand();
         #[cfg(feature = "shared-memory")]
         let ext_shm = rng.gen_bool(0.5).then_some(ext::ShmType::rand());
+        let ext_attachment = rng.gen_bool(0.5).then_some(ext::AttachmentType::rand());
         let mut ext_unknown = Vec::new();
         for _ in 0..rng.gen_range(0..4) {
             ext_unknown.push(ZExtUnknown::rand2(
-                iext::mid(ext::Consolidation::ID) + 1,
+                iext::mid(ext::Attachment::ID) + 1,
                 false,
             ));
         }
@@ -113,6 +119,7 @@ impl Reply {
             ext_consolidation,
             #[cfg(feature = "shared-memory")]
             ext_shm,
+            ext_attachment,
             ext_unknown,
             payload,
         }

--- a/commons/zenoh-shm/src/lib.rs
+++ b/commons/zenoh-shm/src/lib.rs
@@ -65,7 +65,6 @@ impl PartialEq for Chunk {
 /// Informations about a [`SharedMemoryBuf`].
 ///
 /// This that can be serialized and can be used to retrieve the [`SharedMemoryBuf`] in a remote process.
-#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SharedMemoryBufInfo {
     /// The index of the beginning of the buffer in the shm segment.

--- a/io/zenoh-transport/src/common/batch.rs
+++ b/io/zenoh-transport/src/common/batch.rs
@@ -370,6 +370,7 @@ mod tests {
                 ext_sinfo: None,
                 #[cfg(feature = "shared-memory")]
                 ext_shm: None,
+                ext_attachment: None,
                 ext_unknown: vec![],
                 payload: ZBuf::from(vec![0u8; 8]),
             }),

--- a/io/zenoh-transport/src/common/pipeline.rs
+++ b/io/zenoh-transport/src/common/pipeline.rs
@@ -753,6 +753,7 @@ mod tests {
                     ext_sinfo: None,
                     #[cfg(feature = "shared-memory")]
                     ext_shm: None,
+                    ext_attachment: None,
                     ext_unknown: vec![],
                     payload,
                 }),
@@ -882,6 +883,7 @@ mod tests {
                     ext_sinfo: None,
                     #[cfg(feature = "shared-memory")]
                     ext_shm: None,
+                    ext_attachment: None,
                     ext_unknown: vec![],
                     payload,
                 }),
@@ -993,6 +995,7 @@ mod tests {
                             ext_sinfo: None,
                             #[cfg(feature = "shared-memory")]
                             ext_shm: None,
+                            ext_attachment: None,
                             ext_unknown: vec![],
                             payload,
                         }),

--- a/io/zenoh-transport/tests/multicast_transport.rs
+++ b/io/zenoh-transport/tests/multicast_transport.rs
@@ -273,6 +273,7 @@ mod tests {
                 ext_sinfo: None,
                 #[cfg(feature = "shared-memory")]
                 ext_shm: None,
+                ext_attachment: None,
                 ext_unknown: vec![],
             }
             .into(),

--- a/io/zenoh-transport/tests/unicast_concurrent.rs
+++ b/io/zenoh-transport/tests/unicast_concurrent.rs
@@ -204,6 +204,7 @@ async fn transport_concurrent(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPoin
                 ext_sinfo: None,
                 #[cfg(feature = "shared-memory")]
                 ext_shm: None,
+                ext_attachment: None,
                 ext_unknown: vec![],
             }
             .into(),
@@ -308,6 +309,7 @@ async fn transport_concurrent(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPoin
                 ext_sinfo: None,
                 #[cfg(feature = "shared-memory")]
                 ext_shm: None,
+                ext_attachment: None,
                 ext_unknown: vec![],
             }
             .into(),

--- a/io/zenoh-transport/tests/unicast_defragmentation.rs
+++ b/io/zenoh-transport/tests/unicast_defragmentation.rs
@@ -89,6 +89,7 @@ async fn run(endpoint: &EndPoint, channel: Channel, msg_size: usize) {
             ext_sinfo: None,
             #[cfg(feature = "shared-memory")]
             ext_shm: None,
+            ext_attachment: None,
             ext_unknown: vec![],
         }
         .into(),

--- a/io/zenoh-transport/tests/unicast_intermittent.rs
+++ b/io/zenoh-transport/tests/unicast_intermittent.rs
@@ -306,6 +306,7 @@ async fn transport_intermittent(endpoint: &EndPoint, lowlatency_transport: bool)
                 ext_sinfo: None,
                 #[cfg(feature = "shared-memory")]
                 ext_shm: None,
+                ext_attachment: None,
                 ext_unknown: vec![],
             }
             .into(),

--- a/io/zenoh-transport/tests/unicast_priorities.rs
+++ b/io/zenoh-transport/tests/unicast_priorities.rs
@@ -305,6 +305,7 @@ async fn single_run(router_handler: Arc<SHRouter>, client_transport: TransportUn
                     ext_sinfo: None,
                     #[cfg(feature = "shared-memory")]
                     ext_shm: None,
+                    ext_attachment: None,
                     ext_unknown: vec![],
                 }
                 .into(),

--- a/io/zenoh-transport/tests/unicast_simultaneous.rs
+++ b/io/zenoh-transport/tests/unicast_simultaneous.rs
@@ -86,6 +86,7 @@ mod tests {
                     ext_sinfo: None,
                     #[cfg(feature = "shared-memory")]
                     ext_shm: None,
+                    ext_attachment: None,
                     ext_unknown: vec![],
                 }
                 .into(),

--- a/io/zenoh-transport/tests/unicast_transport.rs
+++ b/io/zenoh-transport/tests/unicast_transport.rs
@@ -475,6 +475,7 @@ async fn test_transport(
             ext_sinfo: None,
             #[cfg(feature = "shared-memory")]
             ext_shm: None,
+            ext_attachment: None,
             ext_unknown: vec![],
         }
         .into(),

--- a/zenoh/src/net/routing/queries.rs
+++ b/zenoh/src/net/routing/queries.rs
@@ -2116,6 +2116,7 @@ pub fn route_query(
                         ext_consolidation: ConsolidationType::default(),
                         #[cfg(feature = "shared-memory")]
                         ext_shm: None,
+                        ext_attachment: None, // @TODO: expose it in the API
                         ext_unknown: vec![],
                         payload,
                     });

--- a/zenoh/src/net/tests/tables.rs
+++ b/zenoh/src/net/tests/tables.rs
@@ -604,6 +604,7 @@ fn client_test() {
             ext_sinfo: None,
             #[cfg(feature = "shared-memory")]
             ext_shm: None,
+            ext_attachment: None,
             ext_unknown: vec![],
             payload: ZBuf::empty(),
         }),
@@ -636,6 +637,7 @@ fn client_test() {
             ext_sinfo: None,
             #[cfg(feature = "shared-memory")]
             ext_shm: None,
+            ext_attachment: None,
             ext_unknown: vec![],
             payload: ZBuf::empty(),
         }),
@@ -668,6 +670,7 @@ fn client_test() {
             ext_sinfo: None,
             #[cfg(feature = "shared-memory")]
             ext_shm: None,
+            ext_attachment: None,
             ext_unknown: vec![],
             payload: ZBuf::empty(),
         }),
@@ -700,6 +703,7 @@ fn client_test() {
             ext_sinfo: None,
             #[cfg(feature = "shared-memory")]
             ext_shm: None,
+            ext_attachment: None,
             ext_unknown: vec![],
             payload: ZBuf::empty(),
         }),
@@ -732,6 +736,7 @@ fn client_test() {
             ext_sinfo: None,
             #[cfg(feature = "shared-memory")]
             ext_shm: None,
+            ext_attachment: None,
             ext_unknown: vec![],
             payload: ZBuf::empty(),
         }),

--- a/zenoh/src/publication.rs
+++ b/zenoh/src/publication.rs
@@ -154,12 +154,14 @@ impl SyncResolve for PutBuilder<'_, '_> {
                         ext_sinfo: None,
                         #[cfg(feature = "shared-memory")]
                         ext_shm: None,
+                        ext_attachment: None, // @TODO: expose it in the API
                         ext_unknown: vec![],
                         payload: value.payload.clone(),
                     }),
                     SampleKind::Delete => PushBody::Del(Del {
                         timestamp,
                         ext_sinfo: None,
+                        ext_attachment: None, // @TODO: expose it in the API
                         ext_unknown: vec![],
                     }),
                 },
@@ -448,6 +450,7 @@ impl SyncResolve for Publication<'_> {
                     ext_sinfo: None,
                     #[cfg(feature = "shared-memory")]
                     ext_shm: None,
+                    ext_attachment: None, // @TODO: expose it in the API
                     ext_unknown: vec![],
                     payload: value.payload.clone(),
                 }),

--- a/zenoh/src/queryable.rs
+++ b/zenoh/src/queryable.rs
@@ -187,6 +187,7 @@ impl SyncResolve for ReplyBuilder<'_> {
                         ext_consolidation: ConsolidationType::default(),
                         #[cfg(feature = "shared-memory")]
                         ext_shm: None,
+                        ext_attachment: None, // @TODO: expose it in the API
                         ext_unknown: vec![],
                         payload,
                     }),

--- a/zenoh/src/session.rs
+++ b/zenoh/src/session.rs
@@ -1655,6 +1655,7 @@ impl Session {
                         encoding: v.encoding.clone(),
                         payload: v.payload.clone(),
                     }),
+                    ext_attachment: None, // @TODO: expose it in the API
                     ext_unknown: vec![],
                 }),
             });


### PR DESCRIPTION
This PR adds an `attachment` extension to `Put`, `Del`, `Query`, and `Reply` Zenoh messages.
This is a necessary step to allow the user to attach any arbitrary metadata to `put`, `del`, `query`, and `reply` operations.

An example of some on-going effort of such API in zenoh-c can be found here: https://github.com/eclipse-zenoh/zenoh-c/pull/190

Although I believe this PR will not evolve any further, I'll keep it in Draft for the time being since a validation with a full attachment API is desirable before merging.