### PR TITLE
Add 'shared_memory' config in shm examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -139,13 +139,14 @@
       z_storage -k demo/**
    ```
 
-### z_pub_shm & z_sub_shm
+### z_pub_shm & z_sub
 
    A pub/sub example involving the shared-memory feature.
+   Note that on subscriber side, the same `z_sub` example than for non-shared-memory example is used.
 
    Typical Subscriber usage:
    ```bash
-      z_sub_shm
+      z_sub
    ```
 
    Typical Publisher usage:
@@ -188,16 +189,17 @@
       z_ping 1024
    ```
 
-### z_pub_shm_thr & z_sub_shm_thr
+### z_pub_shm_thr & z_sub_thr
 
    Pub/Sub throughput test involving the shared-memory feature.
    This example allows performing throughput measurements between a publisher performing
    put operations with the shared-memory feature and a subscriber receiving notifications
    of those puts.
+   Note that on subscriber side, the same `z_sub_thr` example than for non-shared-memory example is used.
 
    Typical Subscriber usage:
    ```bash
-      z_sub_shm_thr
+      z_sub_thr
    ```
 
    Typical Publisher usage:

--- a/examples/examples/z_pub_shm_thr.rs
+++ b/examples/examples/z_pub_shm_thr.rs
@@ -21,7 +21,12 @@ use zenoh::shm::SharedMemoryManager;
 async fn main() {
     // initiate logging
     env_logger::init();
-    let (config, sm_size, size) = parse_args();
+    let (mut config, sm_size, size) = parse_args();
+
+    // A probing procedure for shared memory is performed upon session opening. To enable `z_pub_shm_thr` to operate
+    // over shared memory (and to not fallback on network mode), shared memory needs to be enabled also on the
+    // subscriber side. By doing so, the probing procedure will succeed and shared memory will operate as expected.
+    config.transport.shared_memory.set_enabled(true).unwrap();
 
     let z = zenoh::open(config).res().await.unwrap();
     let id = z.zid();

--- a/examples/examples/z_sub.rs
+++ b/examples/examples/z_sub.rs
@@ -25,7 +25,12 @@ async fn main() {
     // Initiate logging
     env_logger::init();
 
-    let (config, key_expr) = parse_args();
+    let (mut config, key_expr) = parse_args();
+
+    // A probing procedure for shared memory is performed upon session opening. To enable `z_pub_shm` to operate
+    // over shared memory (and to not fallback on network mode), shared memory needs to be enabled also on the
+    // subscriber side. By doing so, the probing procedure will succeed and shared memory will operate as expected.
+    config.transport.shared_memory.set_enabled(true).unwrap();
 
     println!("Opening session...");
     let session = zenoh::open(config).res().await.unwrap();

--- a/examples/examples/z_sub_thr.rs
+++ b/examples/examples/z_sub_thr.rs
@@ -70,7 +70,12 @@ fn main() {
     // initiate logging
     env_logger::init();
 
-    let (config, m, n) = parse_args();
+    let (mut config, m, n) = parse_args();
+
+    // A probing procedure for shared memory is performed upon session opening. To enable `z_pub_shm_thr` to operate
+    // over shared memory (and to not fallback on network mode), shared memory needs to be enabled also on the
+    // subscriber side. By doing so, the probing procedure will succeed and shared memory will operate as expected.
+    config.transport.shared_memory.set_enabled(true).unwrap();
 
     let session = zenoh::open(config).res().unwrap();
 


### PR DESCRIPTION
The `z_pub_shm` and `z_pub_shm_thr` examples, as well as their `z_sub`/`z_sub_thr` counterparts were missing the config enabling shared memory transport.