### PR TITLE
FetchingSubscriber::fetch don't need mutable reference

### DIFF
--- a/zenoh-ext/src/querying_subscriber.rs
+++ b/zenoh-ext/src/querying_subscriber.rs
@@ -778,7 +778,7 @@ impl<'a, Receiver> FetchingSubscriber<'a, Receiver> {
         Fetch: FnOnce(Box<dyn Fn(TryIntoSample) + Send + Sync>) -> ZResult<()> + Send + Sync,
         TryIntoSample,
     >(
-        &mut self,
+        &self,
         fetch: Fetch,
     ) -> impl Resolve<ZResult<()>>
     where


### PR DESCRIPTION
Method `FetchingSubscriber::fetch` works ok with shared reference, `&mut` is not needed and causes problems for zenoh-c wrapper for this method (makes zenoh-c require owned reference instead of loaned for this)