### PR TITLE
Set example and plugin-example crate to non-publish to reduce release build time 

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -24,6 +24,7 @@ categories = { workspace = true }
 description = "Internal crate for zenoh."
 readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [features]
 shared-memory = ["zenoh/shared-memory"]

--- a/plugins/example-plugin/Cargo.toml
+++ b/plugins/example-plugin/Cargo.toml
@@ -17,6 +17,7 @@ name = "zenoh-plugin-example"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+publish = false
 
 [lib]
 # When auto-detecting the "example" plugin, `zenohd` will look for a dynamic library named "zenoh_plugin_example"


### PR DESCRIPTION
USER STATEMENT

As a Rust developer 

I want 
to get reasonable build times when adding a new dependency 

But
Currently Zenoh just blows release build times through the roof. 

Therefore
I identified two optional crates "examples" and "plugin-example" that really slow down the release build and so I have marked them as non-publish to prevent them getting shipped and slowing down the build process.

Comment:

I actually don't have hard numbers, but it's painfully obvious that the entire release build of my project hangs for minutes just compiling zenoh code examples that shouldn't be shipped in the first place. Please accept this PR to get the already awful release build time at least a bit shorter by excluding the code examples that really are meant to reside only in the GH repo.
