### PR TITLE
Add homebrew lib search path for Apple Silicon systems

### DIFF
--- a/commons/zenoh-util/src/std_only/lib_loader.rs
+++ b/commons/zenoh-util/src/std_only/lib_loader.rs
@@ -26,7 +26,7 @@ zconfigurable! {
     /// The libraries suffix for the current platform (`".dll"` or `".so"` or `".dylib"`...)
     pub static ref LIB_SUFFIX: String = DLL_SUFFIX.to_string();
     /// The default list of paths where to search for libraries to load
-    pub static ref LIB_DEFAULT_SEARCH_PATHS: String = "/usr/local/lib:/usr/lib:~/.zenoh/lib:.".to_string();
+    pub static ref LIB_DEFAULT_SEARCH_PATHS: String = "/usr/local/lib:/usr/lib:/opt/homebrew/lib:~/.zenoh/lib:.".to_string();
 }
 
 /// LibLoader allows search for librairies and to load them.


### PR DESCRIPTION
Fixes https://github.com/eclipse-zenoh/homebrew-zenoh/issues/2.

This adds `/opt/homebrew/lib` to the default list of plugin search paths. This is because macOS systems running Apple Silicon no longer use `/usr/local/lib`. Of course, there is always an argument against hard-coding values like this, and there has been [much](https://github.com/Homebrew/brew/issues/13481) [discussion](https://github.com/orgs/Homebrew/discussions/1600) about this.

At the end of the day, little changes the fact that Apple has made it so `/opt/homebrew/lib` is the new `/usr/local/lib` on macOS. Ruby's [ffi](https://github.com/ffi/ffi/blob/82e20928319e499b2e60679205733cb5f088c363/lib/ffi/library.rb#L129) for instance also hard-codes the search path.