### PR TITLE
Fix examples default session mode value

### DIFF
--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -21,7 +21,7 @@ pub struct CommonArgs {
     #[arg(short, long)]
     /// A configuration file.
     config: Option<String>,
-    #[arg(short, long, default_value_t)]
+    #[arg(short, long, default_value = "peer")]
     /// The Zenoh session mode.
     mode: Wai,
     #[arg(short = 'e', long)]


### PR DESCRIPTION
Fixes the examples default session mode value missing in this commit: https://github.com/eclipse-zenoh/zenoh/commit/db235af1b45d7668ddbde4d1700e29321f5ddf9b