### PR TITLE
Return the message length while decoding TransportMessage

### DIFF
--- a/io/zenoh-transport/src/common/batch.rs
+++ b/io/zenoh-transport/src/common/batch.rs
@@ -384,6 +384,18 @@ impl Decode<TransportMessage> for &mut RBatch {
     }
 }
 
+impl Decode<(TransportMessage, BatchSize)> for &mut RBatch {
+    type Error = DidntRead;
+
+    fn decode(self) -> Result<(TransportMessage, BatchSize), Self::Error> {
+        let len = self.buffer.len() as BatchSize;
+        let mut reader = self.buffer.reader();
+        let msg = self.codec.read(&mut reader)?;
+        let end = self.buffer.len() as BatchSize;
+        Ok((msg, len - end))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::vec;


### PR DESCRIPTION
We need the message length to properly present the info in Wireshark. Since the buffer field is private, it's better to write this function in zenoh library.