### PR TITLE
Fix formatter reuse and and issue with ** sometimes being considered as included into *

### DIFF
--- a/commons/zenoh-keyexpr/src/key_expr/include.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/include.rs
@@ -47,7 +47,10 @@ impl Includer<&[u8], &[u8]> for LTRIncluder {
                 }
             } else {
                 let (rchunk, rrest) = right.split_once(&DELIMITER);
-                if rchunk.is_empty() || !self.non_double_wild_chunk_includes(lchunk, rchunk) {
+                if rchunk.is_empty()
+                    || rchunk == DOUBLE_WILD
+                    || !self.non_double_wild_chunk_includes(lchunk, rchunk)
+                {
                     return false;
                 }
                 let rempty = rrest.is_empty();

--- a/zenoh/tests/formatters.rs
+++ b/zenoh/tests/formatters.rs
@@ -1,0 +1,23 @@
+#[test]
+fn reuse() {
+    zenoh::kedefine!(
+        pub gkeys: "zenoh/${group:*}/${member:*}",
+    );
+    let mut formatter = gkeys::formatter();
+    let k1 = zenoh::keformat!(formatter, group = "foo", member = "bar").unwrap();
+    assert_eq!(dbg!(k1).as_str(), "zenoh/foo/bar");
+
+    formatter.set("member", "*").unwrap();
+    let k2 = formatter.build().unwrap();
+    assert_eq!(dbg!(k2).as_str(), "zenoh/foo/*");
+
+    dbg!(&mut formatter).group("foo").unwrap();
+    dbg!(&mut formatter).member("*").unwrap();
+    let k2 = dbg!(&mut formatter).build().unwrap();
+    assert_eq!(dbg!(k2).as_str(), "zenoh/foo/*");
+
+    let k3 = zenoh::keformat!(formatter, group = "foo", member = "*").unwrap();
+    assert_eq!(dbg!(k3).as_str(), "zenoh/foo/*");
+
+    zenoh::keformat!(formatter, group = "**", member = "**").unwrap_err();
+}


### PR DESCRIPTION
- Formatter reuse would fail due to some chunks not being readdressed properly when a chunk before them would be reset (closes #636 )
- A bug in `keyexpr::includes` was detected due to formatters allowing a pattern that they then couldn't parse.