### PR TITLE
Reduce status checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,15 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest' }}
         run: cargo clippy --all-targets --all-features -- --deny warnings
 
+      - name: Install nightly Rust toolchain
+        # Generic no_std target architecture is x86_64-unknown-none
+        run: rustup target add x86_64-unknown-none
+
+      - name: Perform no_std checks
+        run: cargo check --bin nostd_check --target x86_64-unknown-none --manifest-path ci/nostd-check/Cargo.toml
+        env:
+          CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+
   test:
     name: Run tests on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -106,28 +115,6 @@ jobs:
           CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
           ASYNC_STD_THREAD_COUNT: 4
 
-  nostd:
-    name: Run no_std checks
-    runs-on: ubuntu-latest
-    needs: check
-    strategy:
-      fail-fast: false
-
-    steps:
-      - name: Clone this repository
-        uses: actions/checkout@v4
-
-      - name: Install nightly Rust toolchain
-        # Generic no_std target architecture is x86_64-unknown-none
-        run: |
-          rustup override set nightly
-          rustup target add --toolchain nightly x86_64-unknown-none
-
-      - name: Perform no_std checks
-        run: cargo check --bin nostd_check --target x86_64-unknown-none --manifest-path ci/nostd-check/Cargo.toml
-        env:
-          CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
-
   # NOTE: In GitHub repository settings, the "Require status checks to pass
   # before merging" branch protection rule ensures that commits are only merged
   # from branches where specific status checks have passed. These checks are
@@ -136,7 +123,7 @@ jobs:
   ci:
     name: CI status checks
     runs-on: ubuntu-latest
-    needs: [check, test, nostd]
+    needs: [check, test]
     if: always()
     steps:
       - name: Check whether all jobs pass

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,3 +127,16 @@ jobs:
         run: cargo check --bin nostd_check --target x86_64-unknown-none --manifest-path ci/nostd-check/Cargo.toml
         env:
           CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+
+  # NOTE: In GitHub repository settings, the "Require status checks to pass
+  # before merging" branch protection rule ensures that commits are only merged
+  # from branches where specific status checks have passed. These checks are
+  # specified manually as a list of workflow job names. Thus we use this extra
+  # job to signal whether all CI checks have passed.
+  ci:
+    runs-on: ubuntu-latest
+    needs: [check, test, nostd]
+    if: always()
+    steps:
+      - name: Check whether all jobs pass
+        run: echo '${{ toJson(needs) }}' | jq -e 'all(.result == "success")'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,8 +80,8 @@ jobs:
             *windows*) echo "RUSTFLAGS=-Clink-arg=/DEBUG:NONE" >> $GITHUB_ENV ;;
           esac
 
-      - name: Install nextest
-        run: cargo install cargo-nextest --locked
+      - name: Install latest nextest
+        uses: taiki-e/install-action@nextest
 
       - name: Run tests
         run: cargo nextest run --exclude zenoh-examples --exclude zenoh-plugin-example --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest' }}
         run: cargo clippy --all-targets --all-features -- --deny warnings
 
-      - name: Install nightly Rust toolchain
+      - name: Install generic no_std target
         # Generic no_std target architecture is x86_64-unknown-none
         run: rustup target add x86_64-unknown-none
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,7 @@ jobs:
   # specified manually as a list of workflow job names. Thus we use this extra
   # job to signal whether all CI checks have passed.
   ci:
+    name: CI status checks
     runs-on: ubuntu-latest
     needs: [check, test, nostd]
     if: always()

--- a/ci/nostd-check/Cargo.toml
+++ b/ci/nostd-check/Cargo.toml
@@ -16,9 +16,7 @@ name = "nostd-check"
 version = "0.1.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"
 homepage = "http://zenoh.io"
-authors = [
-  "Davide Della Giustina <davide.dellagiustina@zettascale.tech>",
-]
+authors = ["Davide Della Giustina <davide.dellagiustina@zettascale.tech>"]
 edition = "2021"
 license = "EPL-2.0 OR Apache-2.0"
 categories = ["network-programming"]
@@ -26,7 +24,7 @@ description = "Internal crate for zenoh."
 
 [dependencies]
 getrandom = { version = "0.2.8", features = ["custom"] }
-linked_list_allocator = "0.10.5" # Needs nightly toolchain
+linked_list_allocator = "0.10.5"
 zenoh-buffers = { path = "../../commons/zenoh-buffers/", default-features = false }
 zenoh-codec = { path = "../../commons/zenoh-codec/", default-features = false }
 zenoh-protocol = { path = "../../commons/zenoh-protocol/", default-features = false }

--- a/ci/nostd-check/rust-toolchain.toml
+++ b/ci/nostd-check/rust-toolchain.toml
@@ -1,2 +1,1 @@
-[toolchain]
-channel = "nightly"
+../../rust-toolchain.toml

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/impls/hashmap_impl.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/impls/hashmap_impl.rs
@@ -30,6 +30,7 @@ use std::collections::{
 
 use crate::keyexpr_tree::*;
 
+#[cfg_attr(not(feature = "std"), allow(deprecated))]
 pub struct HashMapProvider<Hash: Hasher + Default + 'static = DefaultHasher>(
     core::marker::PhantomData<Hash>,
 );

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/impls/keyed_set_impl.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/impls/keyed_set_impl.rs
@@ -23,6 +23,7 @@ use std::collections::hash_map::DefaultHasher;
 use crate::keyexpr_tree::*;
 use keyed_set::{KeyExtractor, KeyedSet};
 
+#[cfg_attr(not(feature = "std"), allow(deprecated))]
 pub struct KeyedSetProvider<Hash: Hasher + Default + 'static = DefaultHasher>(
     core::marker::PhantomData<Hash>,
 );


### PR DESCRIPTION
In GitHub repository settings, the "Require status checks to pass before merging" branch protection rule ensures that commits are only merged from branches where specific status checks have passed. These checks are specified manually as a list of workflow job names.

To properly use the branch protection rule, we need this additional 'all encompassing' status check. Without this, GitHub won't wait for status checks when auto-merging pull requests.

Further context and a more feature-full implementation is available at: https://github.com/re-actors/alls-green. Although we don't (currently) need an 'allow skips' or 'allow failures' option so the value of adding yet another dependency is questionable.

Needless to say, this change needs to be propagated to all other `eclipse-zenoh/zenoh-*` repositories. We could add this logic in an action under `.github/actions/reduce-status-checks.yml` and use that from the other repositories. However, all we would factor out is the `jq` command (and maybe the comment/documentation). This makes for a good argument for using the existing re-actors/alls-green action.