### PR TITLE
Fix broken Debian package

### DIFF
--- a/gen_zenoh_deb.sh
+++ b/gen_zenoh_deb.sh
@@ -21,7 +21,9 @@ if [ -z "$1" -o -z "$2" ]; then
     exit 1
 fi
 
-VERSION=`echo $1`
+# NOTE: cargo-deb v2.0.0 and later will add a "-1" suffix to the version for
+# compliance with Debian's packaging standard.
+VERSION="$1-1"
 ARCH=$2
 
 PACKAGE_NAME="zenoh_${VERSION}_${ARCH}"


### PR DESCRIPTION
From cargo-deb's README:

> **Note** Since v2.0.0 the deb package version will have a "-1" suffix. You can disable this by adding --deb-revision="" flag or revision = "" in Cargo metadata. The default suffix is for compliance with Debian's packaging standard.

We use cargo-deb in the CI/Release workflows to generate Debian packages. This change should've gone without any disturbances. Except that the Zenoh top-level Debian package (i.e an empty package which pulls the router and plugins) is generated manually at `./gen_zenoh_deb.sh` without the "-1" suffix.

Needless to say, the Debian package is broken because `zenoh`'s version is 0.10.1-rc but it tries to pull, `zenohd` & friends at 0.10.1-rc-1.

Why we got here:
1. cargo-deb's version is not pinned in the workflows.
2. We generate the top-level package in an ad-hoc way. cargo-deb doesn't seem to support creating such a thing. We could use a dummy empty crate for this however.

Instead of disabling cargo-deb's new behavior, it's less work (16 times less to be precise) to simply change the `gen_zenoh_deb.sh`. Also, who doesn't want to comply with Debian's packaging standard? :)

Let's cherry-pick this into `release-0.10.1-rc` and partially re-run the release.