### PR TITLE
Fix potential panic when Stats drops

### DIFF
--- a/examples/examples/z_sub_thr.rs
+++ b/examples/examples/z_sub_thr.rs
@@ -58,7 +58,10 @@ impl Stats {
 }
 impl Drop for Stats {
     fn drop(&mut self) {
-        let elapsed = self.global_start.unwrap().elapsed().as_secs_f64();
+        let Some(global_start) = self.global_start else {
+            return;
+        };
+        let elapsed = global_start.elapsed().as_secs_f64();
         let total = self.round_size * self.finished_rounds + self.round_count;
         let throughtput = total as f64 / elapsed;
         println!("Received {total} messages over {elapsed:.2}s: {throughtput}msg/s");


### PR DESCRIPTION
It fixes this line of code that may panic on unwrap in `Stats::drop()`.

```rust
let elapsed = self.global_start.unwrap().elapsed().as_secs_f64();
```

A check is added before the offending line.

```rust
let Some(global_start) = self.global_start else { return; };
```