### PR TITLE
Fix sync-lockfiles workflow (3)

### DIFF
--- a/.github/workflows/sync-lockfiles.yml
+++ b/.github/workflows/sync-lockfiles.yml
@@ -96,12 +96,6 @@ jobs:
           labels: dependencies
           token: ${{ secrets.BOT_TOKEN_WORKFLOW }}
 
-      - name: Auto approve the pull request
-        if: ${{ steps.cpr.outputs.pull-request-operation == 'created' }}
-        run: gh pr review -R "eclipse-zenoh/${{ matrix.dependant }}" --approve "${{ steps.cpr.outputs.pull-request-number }}"
-        env:
-          GH_TOKEN: ${{ secrets.BOT_TOKEN_WORKFLOW }}
-
       - name: Enable auto merge for the pull request
         if: steps.cpr.outputs.pull-request-operation == 'created'
         run: gh pr merge -R "eclipse-zenoh/${{ matrix.dependant }}" --merge --auto "${{ steps.cpr.outputs.pull-request-number }}"


### PR DESCRIPTION
I overlooked the fact that eclipse-zenoh-bot can't approve its own pull requests. Since eclipse-zenoh repos don't require approvals for merging pull requests, this is the simplest solution for now. If approvals are needed in the future, workflows on the dependant repos will be needed.