### PR TITLE
Add a CallbackPair handler implementing Drop and IntoCallbackReceiverPair

### DIFF
--- a/zenoh/src/handlers.rs
+++ b/zenoh/src/handlers.rs
@@ -86,3 +86,41 @@ pub fn locked<T>(fnmut: impl FnMut(T)) -> impl Fn(T) {
     let lock = std::sync::Mutex::new(fnmut);
     move |x| zlock!(lock)(x)
 }
+
+/// A handler containing 2 callback functions:
+///  - `callback`: the typical callback function. `context` will be passed as its last argument.
+///  - `drop``: a callback called when this handler is dropped.
+///
+/// It is guaranteed that:
+///
+///   - `callback` will never be called once `drop` has started.
+///   - `drop` will only be called **once**, and **after every** `callback` has ended.
+///   - The two previous guarantees imply that `call` and `drop` are never called concurrently.
+pub struct CallbackPair<Callback, DropFn>
+where
+    DropFn: FnMut() + Send + Sync + 'static,
+{
+    pub callback: Callback,
+    pub drop: DropFn,
+}
+
+impl<Callback, DropFn> Drop for CallbackPair<Callback, DropFn>
+where
+    DropFn: FnMut() + Send + Sync + 'static,
+{
+    fn drop(&mut self) {
+        (self.drop)()
+    }
+}
+
+impl<'a, OnEvent, Event, DropFn> IntoCallbackReceiverPair<'a, Event>
+    for CallbackPair<OnEvent, DropFn>
+where
+    OnEvent: Fn(Event) + Send + Sync + 'a,
+    DropFn: FnMut() + Send + Sync + 'static,
+{
+    type Receiver = ();
+    fn into_cb_receiver_pair(self) -> (Callback<'a, Event>, Self::Receiver) {
+        (Dyn::from(move |evt| (self.callback)(evt)), ())
+    }
+}

--- a/zenoh/src/handlers.rs
+++ b/zenoh/src/handlers.rs
@@ -89,7 +89,7 @@ pub fn locked<T>(fnmut: impl FnMut(T)) -> impl Fn(T) {
 
 /// A handler containing 2 callback functions:
 ///  - `callback`: the typical callback function. `context` will be passed as its last argument.
-///  - `drop``: a callback called when this handler is dropped.
+///  - `drop`: a callback called when this handler is dropped.
 ///
 /// It is guaranteed that:
 ///


### PR DESCRIPTION
This struct holds 2 callbacks functions:
  - `callback`: the typical callback function. `context` will be passed as its last argument.
  - `drop`: a callback called when this handler is dropped.

It can be passed to any subscriber or getter function accepting a callback.
E.g.:
 - [`GetBuilder::with(Handler)`](https://github.com/eclipse-zenoh/zenoh/blob/b669489bc814a758741f09c671ecc3a0683697a0/zenoh/src/query.rs#L236)
 - [`SubscriberBuilder::with(Handler)`](https://github.com/eclipse-zenoh/zenoh/blob/b669489bc814a758741f09c671ecc3a0683697a0/zenoh/src/subscriber.rs#L426)
