### PR TITLE
Verbatim chunks for Key Expressions

### DIFF
--- a/commons/zenoh-keyexpr/src/key_expr/include.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/include.rs
@@ -38,7 +38,7 @@ impl Includer<&[u8], &[u8]> for LTRIncluder {
             let (lchunk, lrest) = left.split_once(&DELIMITER);
             let lempty = lrest.is_empty();
             if lchunk == DOUBLE_WILD {
-                if (lempty && !right.has_verbatim()) || self.includes(lrest, right) {
+                if (lempty && !right.has_verbatim()) || (!lempty && self.includes(lrest, right)) {
                     return true;
                 }
                 if unsafe { right.has_direct_verbatim_non_empty() } {

--- a/commons/zenoh-keyexpr/src/key_expr/tests.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/tests.rs
@@ -94,6 +94,16 @@ fn intersections() {
     assert!(intersect("@a", "@a/**"));
     assert!(!intersect("**/xyz$*xyz", "@a/b/xyzdefxyz"));
     assert!(intersect("@a/**/c/**/e", "@a/b/b/b/c/d/d/d/e"));
+    assert!(!intersect("@a/**/c/**/e", "@a/@b/b/b/c/d/d/d/e"));
+    assert!(intersect("@a/**/@c/**/e", "@a/b/b/b/@c/d/d/d/e"));
+    assert!(intersect("@a/**/e", "@a/b/b/d/d/d/e"));
+    assert!(intersect("@a/**/e", "@a/b/b/b/d/d/d/e"));
+    assert!(intersect("@a/**/e", "@a/b/b/c/d/d/d/e"));
+    assert!(!intersect("@a/**/e", "@a/b/b/@c/b/d/d/d/e"));
+    assert!(!intersect("@a/*", "@a/@b"));
+    assert!(!intersect("@a/**", "@a/@b"));
+    assert!(intersect("@a/**/@b", "@a/@b"));
+    assert!(intersect("@a/@b/**", "@a/@b"));
 }
 
 fn includes<
@@ -167,6 +177,10 @@ fn inclusions() {
     assert!(includes("@a/**", "@a"));
     assert!(!includes("**/xyz$*xyz", "@a/b/xyzdefxyz"));
     assert!(includes("@a/**/c/**/e", "@a/b/b/b/c/d/d/d/e"));
+    assert!(!includes("@a/*", "@a/@b"));
+    assert!(!includes("@a/**", "@a/@b"));
+    assert!(includes("@a/**/@b", "@a/@b"));
+    assert!(includes("@a/@b/**", "@a/@b"));
 }
 
 #[test]

--- a/commons/zenoh-keyexpr/src/key_expr/tests.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/tests.rs
@@ -84,6 +84,16 @@ fn intersections() {
     assert!(intersect("x/a$*d$*e", "x/ade"));
     assert!(!intersect("x/c$*", "x/abc$*"));
     assert!(!intersect("x/$*d", "x/$*e"));
+
+    assert!(intersect("@a", "@a"));
+    assert!(!intersect("@a", "@ab"));
+    assert!(!intersect("@a", "@a/b"));
+    assert!(!intersect("@a", "@a/*"));
+    assert!(!intersect("@a", "@a/*/**"));
+    assert!(!intersect("@a", "@a$*/**"));
+    assert!(intersect("@a", "@a/**"));
+    assert!(!intersect("**/xyz$*xyz", "@a/b/xyzdefxyz"));
+    assert!(intersect("@a/**/c/**/e", "@a/b/b/b/c/d/d/d/e"));
 }
 
 fn includes<
@@ -146,6 +156,17 @@ fn inclusions() {
     assert!(!includes("x/c$*", "x/abc$*"));
     assert!(includes("x/$*c$*", "x/abc$*"));
     assert!(!includes("x/$*d", "x/$*e"));
+
+    assert!(includes("@a", "@a"));
+    assert!(!includes("@a", "@ab"));
+    assert!(!includes("@a", "@a/b"));
+    assert!(!includes("@a", "@a/*"));
+    assert!(!includes("@a", "@a/*/**"));
+    assert!(!includes("@a$*/**", "@a"));
+    assert!(!includes("@a", "@a/**"));
+    assert!(includes("@a/**", "@a"));
+    assert!(!includes("**/xyz$*xyz", "@a/b/xyzdefxyz"));
+    assert!(includes("@a/**/c/**/e", "@a/b/b/b/c/d/d/d/e"));
 }
 
 #[test]

--- a/commons/zenoh-keyexpr/src/key_expr/tests.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/tests.rs
@@ -104,6 +104,10 @@ fn intersections() {
     assert!(!intersect("@a/**", "@a/@b"));
     assert!(intersect("@a/**/@b", "@a/@b"));
     assert!(intersect("@a/@b/**", "@a/@b"));
+    assert!(intersect("@a/**/@c/**/@b", "@a/**/@c/@b"));
+    assert!(intersect("@a/**/@c/**/@b", "@a/@c/**/@b"));
+    assert!(intersect("@a/**/@c/@b", "@a/@c/**/@b"));
+    assert!(!intersect("@a/**/@b", "@a/**/@c/**/@b"));
 }
 
 fn includes<


### PR DESCRIPTION
This PR implements the proposed changes to KEs, introducing verbatim chunks that can only match themselves (any chunk starting with `@`)

Additional expressions to test for intersection and inclusion are welcome