### PR TITLE
Able to unwrap while using reply with attachment.

### DIFF
--- a/zenoh/src/info.rs
+++ b/zenoh/src/info.rs
@@ -32,6 +32,7 @@ use zenoh_protocol::core::{WhatAmI, ZenohId};
 /// # })
 /// ```
 #[must_use = "Resolvables do nothing unless you resolve them using the `res` method from either `SyncResolve` or `AsyncResolve`"]
+#[derive(Debug)]
 pub struct ZidBuilder<'a> {
     pub(crate) session: SessionRef<'a>,
 }
@@ -69,6 +70,7 @@ impl<'a> AsyncResolve for ZidBuilder<'a> {
 /// # })
 /// ```
 #[must_use = "Resolvables do nothing unless you resolve them using the `res` method from either `SyncResolve` or `AsyncResolve`"]
+#[derive(Debug)]
 pub struct RoutersZidBuilder<'a> {
     pub(crate) session: SessionRef<'a>,
 }
@@ -115,6 +117,7 @@ impl<'a> AsyncResolve for RoutersZidBuilder<'a> {
 /// # })
 /// ```
 #[must_use = "Resolvables do nothing unless you resolve them using the `res` method from either `SyncResolve` or `AsyncResolve`"]
+#[derive(Debug)]
 pub struct PeersZidBuilder<'a> {
     pub(crate) session: SessionRef<'a>,
 }

--- a/zenoh/src/queryable.rs
+++ b/zenoh/src/queryable.rs
@@ -155,6 +155,7 @@ impl fmt::Display for Query {
 
 /// A builder returned by [`Query::reply()`](Query::reply).
 #[must_use = "Resolvables do nothing unless you resolve them using the `res` method from either `SyncResolve` or `AsyncResolve`"]
+#[derive(Debug)]
 pub struct ReplyBuilder<'a> {
     query: &'a Query,
     result: Result<Sample, Value>,

--- a/zenoh/src/sample.rs
+++ b/zenoh/src/sample.rs
@@ -112,6 +112,7 @@ mod attachment {
 
     /// A builder for [`Attachment`]
     #[zenoh_macros::unstable]
+    #[derive(Debug)]
     pub struct AttachmentBuilder {
         pub(crate) inner: Vec<u8>,
     }


### PR DESCRIPTION
While we add with_attachment after the reply, it returns `Result` and it's intuitive for users to use `unwrap()`
https://github.com/eclipse-zenoh/zenoh/blob/main/zenoh/src/queryable.rs#L166
However, `ReplyBuilder` doesn't implement Debug, so we can't use `unwrap()`

```rust
let replybuilder = query
            .reply(reply)
            .with_attachment(attachment.build())
            .unwrap();  //<----- Error here
```

Although there are other ways to handle the error (like `map_err`), I'm just wondering whether it's possible to support Debug for `ReplyBuilder`.