### PR TITLE
Improve project mangement (follow-up) 

### DIFF
--- a/.github/workflows/enforce-linking-issues.yml
+++ b/.github/workflows/enforce-linking-issues.yml
@@ -1,7 +1,7 @@
 name: Enforce linking issues to pull requests
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, labeled]
   workflow_call:
 

--- a/.github/workflows/update-release-project.yml
+++ b/.github/workflows/update-release-project.yml
@@ -60,7 +60,6 @@ jobs:
             const login = "${{ github.event.issue.user.login }}";
 
             const result = contributors
-              .data
               .map(c => c.login)
               .includes(login);
 


### PR DESCRIPTION
There should be no `.data` in the Octokit query in https://github.com/eclipse-zenoh/zenoh/pull/674. Moreover, the `enforce-linking-issues.yml` workflow should run in the context of base and not the fork head.