### PR TITLE
'complete' option in PublicationCache, refactoring

### DIFF
--- a/zenoh-ext/examples/z_pub_cache.rs
+++ b/zenoh-ext/examples/z_pub_cache.rs
@@ -60,12 +60,12 @@ fn parse_args() -> (Config, String, String, usize, Option<String>, bool) {
         )
         .arg(arg!(-v --value [VALUE]      "The value to publish.").default_value("Pub from Rust!"))
         .arg(
-            arg!(-h --history [SIZE] "The number of publications to keep in cache")
+            arg!(-i --history [SIZE] "The number of publications to keep in cache")
                 .default_value("1"),
         )
         .arg(arg!(-x --prefix [STRING] "An optional queryable prefix"))
         .arg(arg!(-c --config [FILE]      "A configuration file."))
-        // .arg(arg!(-o --complete  "Set `complete` option to true. This means that this queryable is ulitmate data source, no need to scan other queryables."))
+        .arg(arg!(-o --complete  "Set `complete` option to true. This means that this queryable is ulitmate data source, no need to scan other queryables."))
         .arg(arg!(--"no-multicast-scouting" "Disable the multicast-based scouting mechanism."))
         .get_matches();
 

--- a/zenoh-ext/examples/z_pub_cache.rs
+++ b/zenoh-ext/examples/z_pub_cache.rs
@@ -23,7 +23,7 @@ async fn main() {
     // Initiate logging
     env_logger::init();
 
-    let (config, key_expr, value, history, prefix) = parse_args();
+    let (config, key_expr, value, history, prefix, complete) = parse_args();
 
     println!("Opening session...");
     let session = zenoh::open(config).res().await.unwrap();
@@ -31,7 +31,8 @@ async fn main() {
     println!("Declaring PublicationCache on {}", &key_expr);
     let mut publication_cache_builder = session
         .declare_publication_cache(&key_expr)
-        .history(history);
+        .history(history)
+        .queryable_complete(complete);
     if let Some(prefix) = prefix {
         publication_cache_builder = publication_cache_builder.queryable_prefix(prefix);
     }
@@ -45,7 +46,7 @@ async fn main() {
     }
 }
 
-fn parse_args() -> (Config, String, String, usize, Option<String>) {
+fn parse_args() -> (Config, String, String, usize, Option<String>, bool) {
     let args = Command::new("zenoh-ext pub cache example")
         .arg(
             arg!(-m --mode [MODE] "The zenoh session mode (peer by default)")
@@ -64,6 +65,7 @@ fn parse_args() -> (Config, String, String, usize, Option<String>) {
         )
         .arg(arg!(-x --prefix [STRING] "An optional queryable prefix"))
         .arg(arg!(-c --config [FILE]      "A configuration file."))
+        // .arg(arg!(-o --complete  "Set `complete` option to true. This means that this queryable is ulitmate data source, no need to scan other queryables."))
         .arg(arg!(--"no-multicast-scouting" "Disable the multicast-based scouting mechanism."))
         .get_matches();
 
@@ -101,6 +103,7 @@ fn parse_args() -> (Config, String, String, usize, Option<String>) {
     let value = args.get_one::<String>("value").unwrap().to_string();
     let history: usize = args.get_one::<String>("history").unwrap().parse().unwrap();
     let prefix = args.get_one::<String>("prefix").map(|s| (*s).to_owned());
+    let complete = args.get_flag("complete");
 
-    (config, key_expr, value, history, prefix)
+    (config, key_expr, value, history, prefix, complete)
 }

--- a/zenoh-ext/src/lib.rs
+++ b/zenoh-ext/src/lib.rs
@@ -20,7 +20,7 @@ pub use publication_cache::{PublicationCache, PublicationCacheBuilder};
 pub use querying_subscriber::{
     FetchingSubscriber, FetchingSubscriberBuilder, QueryingSubscriberBuilder,
 };
-pub use session_ext::{ArcSessionExt, SessionExt};
+pub use session_ext::SessionExt;
 pub use subscriber_ext::SubscriberBuilderExt;
 pub use subscriber_ext::SubscriberForward;
 

--- a/zenoh-ext/src/querying_subscriber.rs
+++ b/zenoh-ext/src/querying_subscriber.rs
@@ -680,33 +680,20 @@ impl<'a, Receiver> FetchingSubscriber<'a, Receiver> {
         // register fetch handler
         let handler = register_handler(state.clone(), callback.clone());
         // declare subscriber
-        let subscriber = match conf.session.clone() {
-            SessionRef::Borrow(session) => match conf.key_space.into() {
-                crate::KeySpace::User => session
-                    .declare_subscriber(&key_expr)
-                    .callback(sub_callback)
-                    .reliability(conf.reliability)
-                    .allowed_origin(conf.origin)
-                    .res_sync()?,
-                crate::KeySpace::Liveliness => session
-                    .liveliness()
-                    .declare_subscriber(&key_expr)
-                    .callback(sub_callback)
-                    .res_sync()?,
-            },
-            SessionRef::Shared(session) => match conf.key_space.into() {
-                crate::KeySpace::User => session
-                    .declare_subscriber(&key_expr)
-                    .callback(sub_callback)
-                    .reliability(conf.reliability)
-                    .allowed_origin(conf.origin)
-                    .res_sync()?,
-                crate::KeySpace::Liveliness => session
-                    .liveliness()
-                    .declare_subscriber(&key_expr)
-                    .callback(sub_callback)
-                    .res_sync()?,
-            },
+        let subscriber = match conf.key_space.into() {
+            crate::KeySpace::User => conf
+                .session
+                .declare_subscriber(&key_expr)
+                .callback(sub_callback)
+                .reliability(conf.reliability)
+                .allowed_origin(conf.origin)
+                .res_sync()?,
+            crate::KeySpace::Liveliness => conf
+                .session
+                .liveliness()
+                .declare_subscriber(&key_expr)
+                .callback(sub_callback)
+                .res_sync()?,
         };
 
         let fetch_subscriber = FetchingSubscriber {

--- a/zenoh/src/session.rs
+++ b/zenoh/src/session.rs
@@ -278,158 +278,6 @@ impl Resource {
     }
 }
 
-/// Functions to create zenoh entities
-///
-/// This trait contains functions to create zenoh entities like
-/// [`Subscriber`](crate::subscriber::Subscriber), and
-/// [`Queryable`](crate::queryable::Queryable)
-///
-/// This trait is implemented by [`Session`](crate::session::Session) itself and
-/// by wrappers [`SessionRef`](crate::session::SessionRef) and [`Arc<Session>`](crate::session::Arc<Session>)
-///
-/// # Examples
-/// ```no_run
-/// # async_std::task::block_on(async {
-/// use zenoh::prelude::r#async::*;
-///
-/// let session = zenoh::open(config::peer()).res().await.unwrap().into_arc();
-/// let subscriber = session.declare_subscriber("key/expression")
-///     .res()
-///     .await
-///     .unwrap();
-/// async_std::task::spawn(async move {
-///     while let Ok(sample) = subscriber.recv_async().await {
-///         println!("Received: {:?}", sample);
-///     }
-/// }).await;
-/// # })
-/// ```
-pub trait SessionDeclarations<'s, 'a> {
-    /// Create a [`Subscriber`](crate::subscriber::Subscriber) for the given key expression.
-    ///
-    /// # Arguments
-    ///
-    /// * `key_expr` - The resourkey expression to subscribe to
-    ///
-    /// # Examples
-    /// ```no_run
-    /// # async_std::task::block_on(async {
-    /// use zenoh::prelude::r#async::*;
-    ///
-    /// let session = zenoh::open(config::peer()).res().await.unwrap().into_arc();
-    /// let subscriber = session.declare_subscriber("key/expression")
-    ///     .res()
-    ///     .await
-    ///     .unwrap();
-    /// async_std::task::spawn(async move {
-    ///     while let Ok(sample) = subscriber.recv_async().await {
-    ///         println!("Received: {:?}", sample);
-    ///     }
-    /// }).await;
-    /// # })
-    /// ```
-    fn declare_subscriber<'b, TryIntoKeyExpr>(
-        &'s self,
-        key_expr: TryIntoKeyExpr,
-    ) -> SubscriberBuilder<'a, 'b, PushMode, DefaultHandler>
-    where
-        TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
-        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_result::Error>;
-
-    /// Create a [`Queryable`](crate::queryable::Queryable) for the given key expression.
-    ///
-    /// # Arguments
-    ///
-    /// * `key_expr` - The key expression matching the queries the
-    /// [`Queryable`](crate::queryable::Queryable) will reply to
-    ///
-    /// # Examples
-    /// ```no_run
-    /// # async_std::task::block_on(async {
-    /// use zenoh::prelude::r#async::*;
-    ///
-    /// let session = zenoh::open(config::peer()).res().await.unwrap().into_arc();
-    /// let queryable = session.declare_queryable("key/expression")
-    ///     .res()
-    ///     .await
-    ///     .unwrap();
-    /// async_std::task::spawn(async move {
-    ///     while let Ok(query) = queryable.recv_async().await {
-    ///         query.reply(Ok(Sample::try_from(
-    ///             "key/expression",
-    ///             "value",
-    ///         ).unwrap())).res().await.unwrap();
-    ///     }
-    /// }).await;
-    /// # })
-    /// ```
-    fn declare_queryable<'b, TryIntoKeyExpr>(
-        &'s self,
-        key_expr: TryIntoKeyExpr,
-    ) -> QueryableBuilder<'a, 'b, DefaultHandler>
-    where
-        TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
-        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_result::Error>;
-
-    /// Create a [`Publisher`](crate::publication::Publisher) for the given key expression.
-    ///
-    /// # Arguments
-    ///
-    /// * `key_expr` - The key expression matching resources to write
-    ///
-    /// # Examples
-    /// ```
-    /// # async_std::task::block_on(async {
-    /// use zenoh::prelude::r#async::*;
-    ///
-    /// let session = zenoh::open(config::peer()).res().await.unwrap().into_arc();
-    /// let publisher = session.declare_publisher("key/expression")
-    ///     .res()
-    ///     .await
-    ///     .unwrap();
-    /// publisher.put("value").res().await.unwrap();
-    /// # })
-    /// ```
-    fn declare_publisher<'b, TryIntoKeyExpr>(
-        &'s self,
-        key_expr: TryIntoKeyExpr,
-    ) -> PublisherBuilder<'a, 'b>
-    where
-        TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
-        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_result::Error>;
-
-    /// Obtain a [`Liveliness`] struct tied to this Zenoh [`Session`].
-    ///
-    /// # Examples
-    /// ```
-    /// # async_std::task::block_on(async {
-    /// use zenoh::prelude::r#async::*;
-    ///
-    /// let session = zenoh::open(config::peer()).res().await.unwrap().into_arc();
-    /// let liveliness = session
-    ///     .liveliness()
-    ///     .declare_token("key/expression")
-    ///     .res()
-    ///     .await
-    ///     .unwrap();
-    /// # })
-    /// ```
-    #[zenoh_macros::unstable]
-    fn liveliness(&'s self) -> Liveliness<'a>;
-    /// Get informations about the zenoh [`Session`](Session).
-    ///
-    /// # Examples
-    /// ```
-    /// # async_std::task::block_on(async {
-    /// use zenoh::prelude::r#async::*;
-    ///
-    /// let session = zenoh::open(config::peer()).res().await.unwrap();
-    /// let info = session.info();
-    /// # })
-    /// ```
-    fn info(&'s self) -> SessionInfo<'a>;
-}
-
 #[derive(Clone)]
 pub enum SessionRef<'a> {
     Borrow(&'a Session),
@@ -2646,4 +2494,156 @@ impl fmt::Debug for Session {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Session").field("id", &self.zid()).finish()
     }
+}
+
+/// Functions to create zenoh entities
+///
+/// This trait contains functions to create zenoh entities like
+/// [`Subscriber`](crate::subscriber::Subscriber), and
+/// [`Queryable`](crate::queryable::Queryable)
+///
+/// This trait is implemented by [`Session`](crate::session::Session) itself and
+/// by wrappers [`SessionRef`](crate::session::SessionRef) and [`Arc<Session>`](crate::session::Arc<Session>)
+///
+/// # Examples
+/// ```no_run
+/// # async_std::task::block_on(async {
+/// use zenoh::prelude::r#async::*;
+///
+/// let session = zenoh::open(config::peer()).res().await.unwrap().into_arc();
+/// let subscriber = session.declare_subscriber("key/expression")
+///     .res()
+///     .await
+///     .unwrap();
+/// async_std::task::spawn(async move {
+///     while let Ok(sample) = subscriber.recv_async().await {
+///         println!("Received: {:?}", sample);
+///     }
+/// }).await;
+/// # })
+/// ```
+pub trait SessionDeclarations<'s, 'a> {
+    /// Create a [`Subscriber`](crate::subscriber::Subscriber) for the given key expression.
+    ///
+    /// # Arguments
+    ///
+    /// * `key_expr` - The resourkey expression to subscribe to
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # async_std::task::block_on(async {
+    /// use zenoh::prelude::r#async::*;
+    ///
+    /// let session = zenoh::open(config::peer()).res().await.unwrap().into_arc();
+    /// let subscriber = session.declare_subscriber("key/expression")
+    ///     .res()
+    ///     .await
+    ///     .unwrap();
+    /// async_std::task::spawn(async move {
+    ///     while let Ok(sample) = subscriber.recv_async().await {
+    ///         println!("Received: {:?}", sample);
+    ///     }
+    /// }).await;
+    /// # })
+    /// ```
+    fn declare_subscriber<'b, TryIntoKeyExpr>(
+        &'s self,
+        key_expr: TryIntoKeyExpr,
+    ) -> SubscriberBuilder<'a, 'b, PushMode, DefaultHandler>
+    where
+        TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
+        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_result::Error>;
+
+    /// Create a [`Queryable`](crate::queryable::Queryable) for the given key expression.
+    ///
+    /// # Arguments
+    ///
+    /// * `key_expr` - The key expression matching the queries the
+    /// [`Queryable`](crate::queryable::Queryable) will reply to
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # async_std::task::block_on(async {
+    /// use zenoh::prelude::r#async::*;
+    ///
+    /// let session = zenoh::open(config::peer()).res().await.unwrap().into_arc();
+    /// let queryable = session.declare_queryable("key/expression")
+    ///     .res()
+    ///     .await
+    ///     .unwrap();
+    /// async_std::task::spawn(async move {
+    ///     while let Ok(query) = queryable.recv_async().await {
+    ///         query.reply(Ok(Sample::try_from(
+    ///             "key/expression",
+    ///             "value",
+    ///         ).unwrap())).res().await.unwrap();
+    ///     }
+    /// }).await;
+    /// # })
+    /// ```
+    fn declare_queryable<'b, TryIntoKeyExpr>(
+        &'s self,
+        key_expr: TryIntoKeyExpr,
+    ) -> QueryableBuilder<'a, 'b, DefaultHandler>
+    where
+        TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
+        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_result::Error>;
+
+    /// Create a [`Publisher`](crate::publication::Publisher) for the given key expression.
+    ///
+    /// # Arguments
+    ///
+    /// * `key_expr` - The key expression matching resources to write
+    ///
+    /// # Examples
+    /// ```
+    /// # async_std::task::block_on(async {
+    /// use zenoh::prelude::r#async::*;
+    ///
+    /// let session = zenoh::open(config::peer()).res().await.unwrap().into_arc();
+    /// let publisher = session.declare_publisher("key/expression")
+    ///     .res()
+    ///     .await
+    ///     .unwrap();
+    /// publisher.put("value").res().await.unwrap();
+    /// # })
+    /// ```
+    fn declare_publisher<'b, TryIntoKeyExpr>(
+        &'s self,
+        key_expr: TryIntoKeyExpr,
+    ) -> PublisherBuilder<'a, 'b>
+    where
+        TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
+        <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_result::Error>;
+
+    /// Obtain a [`Liveliness`] struct tied to this Zenoh [`Session`].
+    ///
+    /// # Examples
+    /// ```
+    /// # async_std::task::block_on(async {
+    /// use zenoh::prelude::r#async::*;
+    ///
+    /// let session = zenoh::open(config::peer()).res().await.unwrap().into_arc();
+    /// let liveliness = session
+    ///     .liveliness()
+    ///     .declare_token("key/expression")
+    ///     .res()
+    ///     .await
+    ///     .unwrap();
+    /// # })
+    /// ```
+    #[zenoh_macros::unstable]
+    fn liveliness(&'s self) -> Liveliness<'a>;
+    /// Get informations about the zenoh [`Session`](Session).
+    ///
+    /// # Examples
+    /// ```
+    /// # async_std::task::block_on(async {
+    /// use zenoh::prelude::r#async::*;
+    ///
+    /// let session = zenoh::open(config::peer()).res().await.unwrap();
+    /// let info = session.info();
+    /// # })
+    /// ```
+    fn info(&'s self) -> SessionInfo<'a>;
 }


### PR DESCRIPTION
- added 'complete' option to query of `PublicationCache`
- refactored access to `SessionRef` object: added mthods for creating publisher, queryable, etc to it. This allowed to access the `SessionRef` without code duplication just to satisfy borrow checker
- Simplified `SessionExt` trait

Closes 'rust' checkbox of https://github.com/eclipse-zenoh/zenoh/issues/668