### PR TITLE
Make cargo-nextest more resilient

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,14 @@
+# By default, retry a few times until pass the test within the specified timeout
+[profile.default]
+retries = 4
+slow-timeout = { period = "60s", terminate-after = 2 }
+
+# Run the following tests exclusively with longer timeout
 [[profile.default.overrides]]
-filter = 'test(/zenoh_session_unicast/)'
+filter = """
+test(=zenoh_session_unicast) |
+test(=zenoh_session_multicast) |
+test(=three_node_combination)
+"""
 threads-required = 'num-cpus'
+slow-timeout = { period = "60s", terminate-after = 6 }


### PR DESCRIPTION
This modification has already been adopted in the tokio-porting  branch. But this also helps the CI checks at this moment.
- Kill those endlessly running tests
- The test sometimes fails on routing::gossip, match_status_*, transport_tcp_concurrent, etc. And a simple re-run can make these errors disappear.  Let's introduce "retry" to solve this problem automatically.