### PR TITLE
Add interfaces to the Link

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -8,6 +8,8 @@ slow-timeout = { period = "60s", terminate-after = 2 }
 filter = """
 test(=zenoh_session_unicast) |
 test(=zenoh_session_multicast) |
+test(=transport_tcp_intermittent) |
+test(=transport_tcp_intermittent_for_lowlatency_transport) |
 test(=three_node_combination)
 """
 threads-required = 'num-cpus'

--- a/commons/zenoh-util/src/std_only/net/mod.rs
+++ b/commons/zenoh-util/src/std_only/net/mod.rs
@@ -91,6 +91,39 @@ pub fn set_linger(socket: &TcpStream, dur: Option<Duration>) -> ZResult<()> {
     }
 }
 
+#[cfg(windows)]
+unsafe fn get_adapters_adresses(af_spec: i32) -> ZResult<Vec<u8>> {
+    use winapi::um::iptypes::IP_ADAPTER_ADDRESSES_LH;
+
+    let mut ret;
+    let mut retries = 0;
+    let mut size: u32 = *WINDOWS_GET_ADAPTERS_ADDRESSES_BUF_SIZE;
+    let mut buffer: Vec<u8>;
+    loop {
+        buffer = Vec::with_capacity(size as usize);
+        ret = winapi::um::iphlpapi::GetAdaptersAddresses(
+            af_spec.try_into().unwrap(),
+            0,
+            std::ptr::null_mut(),
+            buffer.as_mut_ptr() as *mut IP_ADAPTER_ADDRESSES_LH,
+            &mut size,
+        );
+        if ret != winapi::shared::winerror::ERROR_BUFFER_OVERFLOW {
+            break;
+        }
+        if retries >= *WINDOWS_GET_ADAPTERS_ADDRESSES_MAX_RETRIES {
+            break;
+        }
+        retries += 1;
+    }
+
+    if ret != 0 {
+        bail!("GetAdaptersAddresses returned {}", ret)
+    }
+
+    Ok(buffer)
+}
+
 pub fn get_interface(name: &str) -> ZResult<Option<IpAddr>> {
     #[cfg(unix)]
     {
@@ -117,31 +150,7 @@ pub fn get_interface(name: &str) -> ZResult<Option<IpAddr>> {
             use crate::ffi;
             use winapi::um::iptypes::IP_ADAPTER_ADDRESSES_LH;
 
-            let mut ret;
-            let mut retries = 0;
-            let mut size: u32 = *WINDOWS_GET_ADAPTERS_ADDRESSES_BUF_SIZE;
-            let mut buffer: Vec<u8>;
-            loop {
-                buffer = Vec::with_capacity(size as usize);
-                ret = winapi::um::iphlpapi::GetAdaptersAddresses(
-                    winapi::shared::ws2def::AF_INET.try_into().unwrap(),
-                    0,
-                    std::ptr::null_mut(),
-                    buffer.as_mut_ptr() as *mut IP_ADAPTER_ADDRESSES_LH,
-                    &mut size,
-                );
-                if ret != winapi::shared::winerror::ERROR_BUFFER_OVERFLOW {
-                    break;
-                }
-                if retries >= *WINDOWS_GET_ADAPTERS_ADDRESSES_MAX_RETRIES {
-                    break;
-                }
-                retries += 1;
-            }
-
-            if ret != 0 {
-                bail!("GetAdaptersAddresses returned {}", ret)
-            }
+            let buffer = get_adapters_adresses(winapi::shared::ws2def::AF_INET)?;
 
             let mut next_iface = (buffer.as_ptr() as *mut IP_ADAPTER_ADDRESSES_LH).as_ref();
             while let Some(iface) = next_iface {
@@ -218,33 +227,9 @@ pub fn get_local_addresses() -> ZResult<Vec<IpAddr>> {
             use crate::ffi;
             use winapi::um::iptypes::IP_ADAPTER_ADDRESSES_LH;
 
+            let buffer = get_adapters_adresses(winapi::shared::ws2def::AF_UNSPEC)?;
+
             let mut result = vec![];
-            let mut ret;
-            let mut retries = 0;
-            let mut size: u32 = *WINDOWS_GET_ADAPTERS_ADDRESSES_BUF_SIZE;
-            let mut buffer: Vec<u8>;
-            loop {
-                buffer = Vec::with_capacity(size as usize);
-                ret = winapi::um::iphlpapi::GetAdaptersAddresses(
-                    winapi::shared::ws2def::AF_UNSPEC.try_into().unwrap(),
-                    0,
-                    std::ptr::null_mut(),
-                    buffer.as_mut_ptr() as *mut IP_ADAPTER_ADDRESSES_LH,
-                    &mut size,
-                );
-                if ret != winapi::shared::winerror::ERROR_BUFFER_OVERFLOW {
-                    break;
-                }
-                if retries >= *WINDOWS_GET_ADAPTERS_ADDRESSES_MAX_RETRIES {
-                    break;
-                }
-                retries += 1;
-            }
-
-            if ret != 0 {
-                bail!("GetAdaptersAddresses returned {}", ret)
-            }
-
             let mut next_iface = (buffer.as_ptr() as *mut IP_ADAPTER_ADDRESSES_LH).as_ref();
             while let Some(iface) = next_iface {
                 let mut next_ucast_addr = iface.FirstUnicastAddress.as_ref();
@@ -317,33 +302,9 @@ pub fn get_unicast_addresses_of_interface(name: &str) -> ZResult<Vec<IpAddr>> {
             use crate::ffi;
             use winapi::um::iptypes::IP_ADAPTER_ADDRESSES_LH;
 
+            let buffer = get_adapters_adresses(winapi::shared::ws2def::AF_INET)?;
+
             let mut addrs = vec![];
-            let mut ret;
-            let mut retries = 0;
-            let mut size: u32 = *WINDOWS_GET_ADAPTERS_ADDRESSES_BUF_SIZE;
-            let mut buffer: Vec<u8>;
-            loop {
-                buffer = Vec::with_capacity(size as usize);
-                ret = winapi::um::iphlpapi::GetAdaptersAddresses(
-                    winapi::shared::ws2def::AF_INET.try_into().unwrap(),
-                    0,
-                    std::ptr::null_mut(),
-                    buffer.as_mut_ptr() as *mut IP_ADAPTER_ADDRESSES_LH,
-                    &mut size,
-                );
-                if ret != winapi::shared::winerror::ERROR_BUFFER_OVERFLOW {
-                    break;
-                }
-                if retries >= *WINDOWS_GET_ADAPTERS_ADDRESSES_MAX_RETRIES {
-                    break;
-                }
-                retries += 1;
-            }
-
-            if ret != 0 {
-                bail!("GetAdaptersAddresses returned {}", ret);
-            }
-
             let mut next_iface = (buffer.as_ptr() as *mut IP_ADAPTER_ADDRESSES_LH).as_ref();
             while let Some(iface) = next_iface {
                 if name == ffi::pstr_to_string(iface.AdapterName)
@@ -380,31 +341,7 @@ pub fn get_index_of_interface(addr: IpAddr) -> ZResult<u32> {
             use crate::ffi;
             use winapi::um::iptypes::IP_ADAPTER_ADDRESSES_LH;
 
-            let mut ret;
-            let mut retries = 0;
-            let mut size: u32 = *WINDOWS_GET_ADAPTERS_ADDRESSES_BUF_SIZE;
-            let mut buffer: Vec<u8>;
-            loop {
-                buffer = Vec::with_capacity(size as usize);
-                ret = winapi::um::iphlpapi::GetAdaptersAddresses(
-                    winapi::shared::ws2def::AF_INET.try_into().unwrap(),
-                    0,
-                    std::ptr::null_mut(),
-                    buffer.as_mut_ptr() as *mut IP_ADAPTER_ADDRESSES_LH,
-                    &mut size,
-                );
-                if ret != winapi::shared::winerror::ERROR_BUFFER_OVERFLOW {
-                    break;
-                }
-                if retries >= *WINDOWS_GET_ADAPTERS_ADDRESSES_MAX_RETRIES {
-                    break;
-                }
-                retries += 1;
-            }
-
-            if ret != 0 {
-                bail!("GetAdaptersAddresses returned {}", ret)
-            }
+            let buffer = get_adapters_adresses(winapi::shared::ws2def::AF_INET)?;
 
             let mut next_iface = (buffer.as_ptr() as *mut IP_ADAPTER_ADDRESSES_LH).as_ref();
             while let Some(iface) = next_iface {
@@ -421,6 +358,57 @@ pub fn get_index_of_interface(addr: IpAddr) -> ZResult<u32> {
             }
             bail!("No interface found with address {addr}")
         }
+    }
+}
+
+pub fn get_interface_names_by_addr(addr: IpAddr) -> ZResult<Vec<String>> {
+    #[cfg(unix)]
+    {
+        if addr.is_unspecified() {
+            Ok(pnet_datalink::interfaces()
+                .iter()
+                .map(|iface| iface.name.clone())
+                .collect::<Vec<String>>())
+        } else {
+            Ok(pnet_datalink::interfaces()
+                .iter()
+                .filter(|iface| iface.ips.iter().any(|ipnet| ipnet.ip() == addr))
+                .map(|iface| iface.name.clone())
+                .collect::<Vec<String>>())
+        }
+    }
+    #[cfg(windows)]
+    {
+        let mut result = vec![];
+        unsafe {
+            use crate::ffi;
+            use winapi::um::iptypes::IP_ADAPTER_ADDRESSES_LH;
+
+            let buffer = get_adapters_adresses(winapi::shared::ws2def::AF_UNSPEC)?;
+
+            if addr.is_unspecified() {
+                let mut next_iface = (buffer.as_ptr() as *mut IP_ADAPTER_ADDRESSES_LH).as_ref();
+                while let Some(iface) = next_iface {
+                    result.push(ffi::pstr_to_string(iface.AdapterName));
+                    next_iface = iface.Next.as_ref();
+                }
+            } else {
+                let mut next_iface = (buffer.as_ptr() as *mut IP_ADAPTER_ADDRESSES_LH).as_ref();
+                while let Some(iface) = next_iface {
+                    let mut next_ucast_addr = iface.FirstUnicastAddress.as_ref();
+                    while let Some(ucast_addr) = next_ucast_addr {
+                        if let Ok(ifaddr) = ffi::win::sockaddr_to_addr(ucast_addr.Address) {
+                            if ifaddr.ip() == addr {
+                                result.push(ffi::pstr_to_string(iface.AdapterName));
+                            }
+                        }
+                        next_ucast_addr = ucast_addr.Next.as_ref();
+                    }
+                    next_iface = iface.Next.as_ref();
+                }
+            }
+        }
+        Ok(result)
     }
 }
 

--- a/io/zenoh-link-commons/src/lib.rs
+++ b/io/zenoh-link-commons/src/lib.rs
@@ -23,7 +23,7 @@ extern crate alloc;
 mod multicast;
 mod unicast;
 
-use alloc::{borrow::ToOwned, boxed::Box, string::String};
+use alloc::{borrow::ToOwned, boxed::Box, string::String, vec, vec::Vec};
 use async_trait::async_trait;
 use core::{cmp::PartialEq, fmt, hash::Hash};
 pub use multicast::*;
@@ -43,6 +43,7 @@ pub struct Link {
     pub mtu: u16,
     pub is_reliable: bool,
     pub is_streamed: bool,
+    pub interfaces: Vec<String>,
 }
 
 #[async_trait]
@@ -71,6 +72,7 @@ impl From<&LinkUnicast> for Link {
             mtu: link.get_mtu(),
             is_reliable: link.is_reliable(),
             is_streamed: link.is_streamed(),
+            interfaces: link.get_interface_names(),
         }
     }
 }
@@ -90,6 +92,7 @@ impl From<&LinkMulticast> for Link {
             mtu: link.get_mtu(),
             is_reliable: link.is_reliable(),
             is_streamed: false,
+            interfaces: vec![],
         }
     }
 }

--- a/io/zenoh-link-commons/src/unicast.rs
+++ b/io/zenoh-link-commons/src/unicast.rs
@@ -11,7 +11,7 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
 use async_trait::async_trait;
 use core::{
     fmt,
@@ -45,6 +45,7 @@ pub trait LinkUnicastTrait: Send + Sync {
     fn get_dst(&self) -> &Locator;
     fn is_reliable(&self) -> bool;
     fn is_streamed(&self) -> bool;
+    fn get_interface_names(&self) -> Vec<String>;
     async fn write(&self, buffer: &[u8]) -> ZResult<usize>;
     async fn write_all(&self, buffer: &[u8]) -> ZResult<()>;
     async fn read(&self, buffer: &mut [u8]) -> ZResult<usize>;

--- a/io/zenoh-links/zenoh-link-quic/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/unicast.rs
@@ -144,6 +144,13 @@ impl LinkUnicastTrait for LinkUnicastQuic {
     }
 
     #[inline(always)]
+    fn get_interface_names(&self) -> Vec<String> {
+        // @TODO: Not supported for now
+        log::debug!("The get_interface_names for LinkUnicastQuic is not supported");
+        vec![]
+    }
+
+    #[inline(always)]
     fn is_reliable(&self) -> bool {
         true
     }

--- a/io/zenoh-links/zenoh-link-serial/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-serial/src/unicast.rs
@@ -182,6 +182,13 @@ impl LinkUnicastTrait for LinkUnicastSerial {
     }
 
     #[inline(always)]
+    fn get_interface_names(&self) -> Vec<String> {
+        // @TODO: Not supported for now
+        log::debug!("The get_interface_names for LinkUnicastSerial is not supported");
+        vec![]
+    }
+
+    #[inline(always)]
     fn is_reliable(&self) -> bool {
         false
     }

--- a/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
@@ -145,6 +145,28 @@ impl LinkUnicastTrait for LinkUnicastTcp {
     }
 
     #[inline(always)]
+    fn get_interface_names(&self) -> Vec<String> {
+        match zenoh_util::net::get_interface_names_by_addr(self.src_addr.ip()) {
+            Ok(interfaces) => {
+                log::trace!(
+                    "get_interface_names for {:?}: {:?}",
+                    self.src_addr.ip(),
+                    interfaces
+                );
+                interfaces
+            }
+            Err(e) => {
+                log::debug!(
+                    "get_interface_names for {:?} failed: {:?}",
+                    self.src_addr.ip(),
+                    e
+                );
+                vec![]
+            }
+        }
+    }
+
+    #[inline(always)]
     fn is_reliable(&self) -> bool {
         true
     }

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -196,6 +196,13 @@ impl LinkUnicastTrait for LinkUnicastTls {
     }
 
     #[inline(always)]
+    fn get_interface_names(&self) -> Vec<String> {
+        // @TODO: Not supported for now
+        log::debug!("The get_interface_names for LinkUnicastTls is not supported");
+        vec![]
+    }
+
+    #[inline(always)]
     fn is_reliable(&self) -> bool {
         true
     }

--- a/io/zenoh-links/zenoh-link-udp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/unicast.rs
@@ -209,6 +209,28 @@ impl LinkUnicastTrait for LinkUnicastUdp {
     }
 
     #[inline(always)]
+    fn get_interface_names(&self) -> Vec<String> {
+        match zenoh_util::net::get_interface_names_by_addr(self.src_addr.ip()) {
+            Ok(interfaces) => {
+                log::trace!(
+                    "get_interface_names for {:?}: {:?}",
+                    self.src_addr.ip(),
+                    interfaces
+                );
+                interfaces
+            }
+            Err(e) => {
+                log::debug!(
+                    "get_interface_names for {:?} failed: {:?}",
+                    self.src_addr.ip(),
+                    e
+                );
+                vec![]
+            }
+        }
+    }
+
+    #[inline(always)]
     fn is_reliable(&self) -> bool {
         false
     }

--- a/io/zenoh-links/zenoh-link-unixpipe/src/unix/unicast.rs
+++ b/io/zenoh-links/zenoh-link-unixpipe/src/unix/unicast.rs
@@ -493,6 +493,13 @@ impl LinkUnicastTrait for UnicastPipe {
     }
 
     #[inline(always)]
+    fn get_interface_names(&self) -> Vec<String> {
+        // @TODO: Not supported for now
+        log::debug!("The get_interface_names for UnicastPipe is not supported");
+        vec![]
+    }
+
+    #[inline(always)]
     fn is_reliable(&self) -> bool {
         true
     }

--- a/io/zenoh-links/zenoh-link-unixsock_stream/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-unixsock_stream/src/unicast.rs
@@ -116,6 +116,13 @@ impl LinkUnicastTrait for LinkUnicastUnixSocketStream {
     }
 
     #[inline(always)]
+    fn get_interface_names(&self) -> Vec<String> {
+        // @TODO: Not supported for now
+        log::debug!("The get_interface_names for LinkUnicastUnixSocketStream is not supported");
+        vec![]
+    }
+
+    #[inline(always)]
     fn is_reliable(&self) -> bool {
         true
     }

--- a/io/zenoh-links/zenoh-link-ws/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-ws/src/unicast.rs
@@ -208,6 +208,13 @@ impl LinkUnicastTrait for LinkUnicastWs {
     }
 
     #[inline(always)]
+    fn get_interface_names(&self) -> Vec<String> {
+        // @TODO: Not supported for now
+        log::debug!("The get_interface_names for LinkUnicastWs is not supported");
+        vec![]
+    }
+
+    #[inline(always)]
     fn is_reliable(&self) -> bool {
         true
     }


### PR DESCRIPTION
Add interfaces, which correspond to the address, to the Link.
This will allow interceptors to obtain information about the interface with which the message is associated.
Additionally, a small refactoring of the module std_only/net was made.