### PR TITLE
Adding the ability to return an error from the interceptors factory

### DIFF
--- a/zenoh/src/net/routing/dispatcher/tables.rs
+++ b/zenoh/src/net/routing/dispatcher/tables.rs
@@ -28,6 +28,7 @@ use zenoh_config::unwrap_or_default;
 use zenoh_config::Config;
 use zenoh_protocol::core::{ExprId, WhatAmI, ZenohId};
 use zenoh_protocol::network::Mapping;
+use zenoh_result::ZResult;
 // use zenoh_collections::Timer;
 use zenoh_sync::get_mut_unchecked;
 
@@ -76,7 +77,12 @@ pub struct Tables {
 }
 
 impl Tables {
-    pub fn new(zid: ZenohId, whatami: WhatAmI, hlc: Option<Arc<HLC>>, config: &Config) -> Self {
+    pub fn new(
+        zid: ZenohId,
+        whatami: WhatAmI,
+        hlc: Option<Arc<HLC>>,
+        config: &Config,
+    ) -> ZResult<Self> {
         let drop_future_timestamp =
             unwrap_or_default!(config.timestamping().drop_future_timestamp());
         let router_peers_failover_brokering =
@@ -84,7 +90,7 @@ impl Tables {
         // let queries_default_timeout =
         //     Duration::from_millis(unwrap_or_default!(config.queries_default_timeout()));
         let hat_code = hat::new_hat(whatami, config);
-        Tables {
+        Ok(Tables {
             zid,
             whatami,
             face_counter: 0,
@@ -96,11 +102,11 @@ impl Tables {
             faces: HashMap::new(),
             mcast_groups: vec![],
             mcast_faces: vec![],
-            interceptors: interceptor_factories(config),
+            interceptors: interceptor_factories(config)?,
             pull_caches_lock: Mutex::new(()),
             hat: hat_code.new_tables(router_peers_failover_brokering),
             hat_code: hat_code.into(),
-        }
+        })
     }
 
     #[doc(hidden)]

--- a/zenoh/src/net/routing/interceptor/mod.rs
+++ b/zenoh/src/net/routing/interceptor/mod.rs
@@ -20,6 +20,7 @@
 use super::RoutingContext;
 use zenoh_config::Config;
 use zenoh_protocol::network::NetworkMessage;
+use zenoh_result::ZResult;
 use zenoh_transport::{multicast::TransportMulticast, unicast::TransportUnicast};
 
 pub(crate) trait InterceptorTrait {
@@ -44,11 +45,11 @@ pub(crate) trait InterceptorFactoryTrait {
 
 pub(crate) type InterceptorFactory = Box<dyn InterceptorFactoryTrait + Send + Sync>;
 
-pub(crate) fn interceptor_factories(_config: &Config) -> Vec<InterceptorFactory> {
+pub(crate) fn interceptor_factories(_config: &Config) -> ZResult<Vec<InterceptorFactory>> {
     // Add interceptors here
     // @TODO build the list of intercetors with the correct order from the config
     // vec![Box::new(LoggerInterceptor {})]
-    vec![]
+    Ok(vec![])
 }
 
 pub(crate) struct InterceptorsChain {

--- a/zenoh/src/net/routing/router.rs
+++ b/zenoh/src/net/routing/router.rs
@@ -45,15 +45,20 @@ pub struct Router {
 }
 
 impl Router {
-    pub fn new(zid: ZenohId, whatami: WhatAmI, hlc: Option<Arc<HLC>>, config: &Config) -> Self {
-        Router {
+    pub fn new(
+        zid: ZenohId,
+        whatami: WhatAmI,
+        hlc: Option<Arc<HLC>>,
+        config: &Config,
+    ) -> ZResult<Self> {
+        Ok(Router {
             // whatami,
             tables: Arc::new(TablesLock {
-                tables: RwLock::new(Tables::new(zid, whatami, hlc, config)),
+                tables: RwLock::new(Tables::new(zid, whatami, hlc, config)?),
                 ctrl_lock: Mutex::new(hat::new_hat(whatami, config)),
                 queries_lock: RwLock::new(()),
             }),
-        }
+        })
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -95,7 +95,7 @@ impl Runtime {
         let hlc = (*unwrap_or_default!(config.timestamping().enabled().get(whatami)))
             .then(|| Arc::new(HLCBuilder::new().with_id(uhlc::ID::from(&zid)).build()));
 
-        let router = Arc::new(Router::new(zid, whatami, hlc.clone(), &config));
+        let router = Arc::new(Router::new(zid, whatami, hlc.clone(), &config)?);
 
         let handler = Arc::new(RuntimeTransportEventHandler {
             runtime: std::sync::RwLock::new(None),

--- a/zenoh/src/net/tests/tables.rs
+++ b/zenoh/src/net/tests/tables.rs
@@ -38,7 +38,8 @@ fn base_test() {
         WhatAmI::Client,
         Some(Arc::new(HLC::default())),
         &config,
-    );
+    )
+    .unwrap();
     let tables = router.tables.clone();
 
     let primitives = Arc::new(DummyPrimitives {});
@@ -133,7 +134,8 @@ fn match_test() {
         WhatAmI::Client,
         Some(Arc::new(HLC::default())),
         &config,
-    );
+    )
+    .unwrap();
     let tables = router.tables.clone();
 
     let primitives = Arc::new(DummyPrimitives {});
@@ -172,7 +174,8 @@ fn clean_test() {
         WhatAmI::Client,
         Some(Arc::new(HLC::default())),
         &config,
-    );
+    )
+    .unwrap();
     let tables = router.tables.clone();
 
     let primitives = Arc::new(DummyPrimitives {});
@@ -478,7 +481,8 @@ fn client_test() {
         WhatAmI::Client,
         Some(Arc::new(HLC::default())),
         &config,
-    );
+    )
+    .unwrap();
     let tables = router.tables.clone();
 
     let sub_info = SubscriberInfo {


### PR DESCRIPTION
Adding the ability to return an error from the interceptors factory it will allows return interceptor configuration or other errors during creation time.