### PR TITLE
Ensure that the clap version is set to a version no newer than 4.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ async-std = { version = "=1.12.0", default-features = false } # Default features
 async-trait = "0.1.60"
 base64 = "0.21.4"
 bincode = "1.3.3"
-clap = { version = "4.4.11", features = ["derive"] }
+clap = { version = "4.4.*", features = ["derive"] }
 const_format = "0.2.30"
 crc = "3.0.1"
 criterion = "0.5"


### PR DESCRIPTION
Ensure that the clap version is set to a version no newer than 4.5.0 to fix #740 .
Closes #740 .