### PR TITLE
fix: Disable debug information in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ on:
   schedule:
     - cron: "0 6 * * 1-5"
 
+env:
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+  CARGO_PROFILE_DEV_DEBUG: false
+
 jobs:
   check:
     name: Run checks on ${{ matrix.os }}
@@ -41,18 +45,12 @@ jobs:
 
       - name: Code format check
         run: cargo fmt --check
-        env:
-          CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
       - name: Clippy
         run: cargo clippy --all-targets -- --deny warnings
-        env:
-          CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
       - name: Clippy unstable targets
         run: cargo clippy --all-targets --features unstable -- --deny warnings
-        env:
-          CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
       - name: Clippy all features
         if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest' }}
@@ -64,8 +62,6 @@ jobs:
 
       - name: Perform no_std checks
         run: cargo check --bin nostd_check --target x86_64-unknown-none --manifest-path ci/nostd-check/Cargo.toml
-        env:
-          CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
   test:
     name: Run tests on ${{ matrix.os }}
@@ -95,14 +91,12 @@ jobs:
       - name: Run tests
         run: cargo nextest run --exclude zenoh-examples --exclude zenoh-plugin-example --workspace
         env:
-          CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
           ASYNC_STD_THREAD_COUNT: 4
 
       - name: Run tests with SHM
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: cargo nextest run -F shared-memory -F transport_unixpipe -p zenoh-transport
         env:
-          CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
           ASYNC_STD_THREAD_COUNT: 4
 
       - name: Check for feature leaks
@@ -112,7 +106,6 @@ jobs:
       - name: Run doctests
         run: cargo test --doc
         env:
-          CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
           ASYNC_STD_THREAD_COUNT: 4
 
   # NOTE: In GitHub repository settings, the "Require status checks to pass


### PR DESCRIPTION
Fixes https://github.com/eclipse-zenoh/zenoh/issues/753.

By default rustc's `split-debuginfo` is `off` on Linux and `packed` on macOS and Windows in Cargo's `dev` profile (essentially the configuration used for commands such as `cargo build`). Which means that on Linux debug information is included in the ELF binary while on macOS and Windows it's packed into a separate file. I'm not sure how this results in much larger debug information on Linux (the build size goes from > 20GB with `debuginfo=full` to < 5GB with `debuginfo=none` while it only decreases by 2-3GB for macOS and Windows).

In any case, debug information is superfluous in CI, so this pull request simply disables it. This is rustc's default setting, but Cargo overrides it for "better user experience". Which only makes sense for dev boxes where a developer might want to run a debugger at any time.