### PR TITLE
Align examples and remove reading from stdin

### DIFF
--- a/examples/examples/z_liveliness.rs
+++ b/examples/examples/z_liveliness.rs
@@ -27,7 +27,7 @@ async fn main() {
     let session = zenoh::open(config).res().await.unwrap();
 
     println!("Declaring LivelinessToken on '{}'...", &key_expr);
-    let _token = Some(
+    let mut token = Some(
         session
             .liveliness()
             .declare_token(&key_expr)
@@ -40,11 +40,10 @@ async fn main() {
     std::thread::park();
     // LivelinessTokens are automatically closed when dropped
     // Use the code below to manually undeclare it if needed
-    //
-    // if let Some(token) = token.take() {
-    //     println!("Undeclaring LivelinessToken...");
-    //     token.undeclare().res().await.unwrap();
-    // }
+    if let Some(token) = token.take() {
+        println!("Undeclaring LivelinessToken...");
+        token.undeclare().res().await.unwrap();
+    };
 }
 
 #[derive(clap::Parser, Clone, PartialEq, Eq, Hash, Debug)]

--- a/examples/examples/z_liveliness.rs
+++ b/examples/examples/z_liveliness.rs
@@ -11,9 +11,7 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use async_std::task::sleep;
 use clap::Parser;
-use std::time::Duration;
 use zenoh::config::Config;
 use zenoh::prelude::r#async::*;
 use zenoh_examples::CommonArgs;
@@ -39,9 +37,7 @@ async fn main() {
     );
 
     println!("Press CTRL-C to undeclare LivelinessToken and quit...");
-    loop {
-        sleep(Duration::from_secs(1)).await;
-    }
+    std::thread::park();
     // LivelinessTokens are automatically closed when dropped
     // Use the code below to manually undeclare it if needed
     //

--- a/examples/examples/z_liveliness.rs
+++ b/examples/examples/z_liveliness.rs
@@ -13,7 +13,6 @@
 //
 use async_std::task::sleep;
 use clap::Parser;
-use futures::prelude::*;
 use std::time::Duration;
 use zenoh::config::Config;
 use zenoh::prelude::r#async::*;
@@ -30,7 +29,7 @@ async fn main() {
     let session = zenoh::open(config).res().await.unwrap();
 
     println!("Declaring LivelinessToken on '{}'...", &key_expr);
-    let mut token = Some(
+    let _token = Some(
         session
             .liveliness()
             .declare_token(&key_expr)
@@ -39,23 +38,17 @@ async fn main() {
             .unwrap(),
     );
 
-    println!("Enter 'd' to undeclare LivelinessToken, 'q' to quit...");
-    let mut stdin = async_std::io::stdin();
-    let mut input = [0_u8];
+    println!("Press CTRL-C to undeclare LivelinessToken and quit...");
     loop {
-        let _ = stdin.read_exact(&mut input).await;
-        match input[0] {
-            b'q' => break,
-            b'd' => {
-                if let Some(token) = token.take() {
-                    println!("Undeclaring LivelinessToken...");
-                    token.undeclare().res().await.unwrap();
-                }
-            }
-            0 => sleep(Duration::from_secs(1)).await,
-            _ => (),
-        }
+        sleep(Duration::from_secs(1)).await;
     }
+    // LivelinessTokens are automatically closed when dropped
+    // Use the code below to manually undeclare it if needed
+    //
+    // if let Some(token) = token.take() {
+    //     println!("Undeclaring LivelinessToken...");
+    //     token.undeclare().res().await.unwrap();
+    // }
 }
 
 #[derive(clap::Parser, Clone, PartialEq, Eq, Hash, Debug)]

--- a/examples/examples/z_pong.rs
+++ b/examples/examples/z_pong.rs
@@ -1,5 +1,3 @@
-use std::io::{stdin, Read};
-
 //
 // Copyright (c) 2023 ZettaScale Technology
 //
@@ -44,7 +42,7 @@ fn main() {
         .callback(move |sample| publisher.put(sample.value).res().unwrap())
         .res()
         .unwrap();
-    for _ in stdin().bytes().take_while(|b| !matches!(b, Ok(b'q'))) {}
+    std::thread::park();
 }
 
 #[derive(clap::Parser, Clone, PartialEq, Eq, Hash, Debug)]

--- a/examples/examples/z_pub.rs
+++ b/examples/examples/z_pub.rs
@@ -31,6 +31,7 @@ async fn main() {
     println!("Declaring Publisher on '{key_expr}'...");
     let publisher = session.declare_publisher(&key_expr).res().await.unwrap();
 
+    println!("Press CTRL-C to quit...");
     for idx in 0..u32::MAX {
         sleep(Duration::from_secs(1)).await;
         let buf = format!("[{idx:4}] {value}");

--- a/examples/examples/z_pub_shm.rs
+++ b/examples/examples/z_pub_shm.rs
@@ -44,6 +44,7 @@ async fn main() -> Result<(), zenoh::Error> {
     println!("Allocating Shared Memory Buffer...");
     let publisher = session.declare_publisher(&path).res().await.unwrap();
 
+    println!("Press CTRL-C to quit...");
     for idx in 0..(K * N as u32) {
         sleep(Duration::from_secs(1)).await;
         let mut sbuf = match shm.alloc(1024) {

--- a/examples/examples/z_pub_shm_thr.rs
+++ b/examples/examples/z_pub_shm_thr.rs
@@ -42,6 +42,7 @@ async fn main() {
     // Make sure to not drop messages because of congestion control
     .congestion_control(CongestionControl::Block).res().await.unwrap();
 
+    println!("Press CTRL-C to quit...");
     loop {
         publisher.put(buf.clone()).res().await.unwrap();
     }

--- a/examples/examples/z_pub_thr.rs
+++ b/examples/examples/z_pub_thr.rs
@@ -44,6 +44,7 @@ fn main() {
         .res()
         .unwrap();
 
+    println!("Press CTRL-C to quit...");
     let mut count: usize = 0;
     let mut start = std::time::Instant::now();
     loop {

--- a/examples/examples/z_pull.rs
+++ b/examples/examples/z_pull.rs
@@ -11,10 +11,8 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use async_std::prelude::FutureExt;
 use async_std::task::sleep;
 use clap::Parser;
-use futures::prelude::*;
 use std::time::Duration;
 use zenoh::config::Config;
 use zenoh::prelude::r#async::*;
@@ -35,40 +33,24 @@ async fn main() {
     let subscriber = session
         .declare_subscriber(&key_expr)
         .pull_mode()
-        .res()
-        .await
-        .unwrap();
-
-    println!("Press <enter> to pull data...");
-
-    // Define the future to handle incoming samples of the subscription.
-    let subs = async {
-        while let Ok(sample) = subscriber.recv_async().await {
+        .callback(|sample| {
             println!(
                 ">> [Subscriber] Received {} ('{}': '{}')",
                 sample.kind,
                 sample.key_expr.as_str(),
                 sample.value,
             );
-        }
-    };
+        })
+        .res()
+        .await
+        .unwrap();
 
-    // Define the future to handle keyboard's input.
-    let keyb = async {
-        let mut stdin = async_std::io::stdin();
-        let mut input = [0_u8];
-        loop {
-            stdin.read_exact(&mut input).await.unwrap();
-            match input[0] {
-                b'q' => break,
-                0 => sleep(Duration::from_secs(1)).await,
-                _ => subscriber.pull().res().await.unwrap(),
-            }
-        }
-    };
-
-    // Execute both futures concurrently until one of them returns.
-    subs.race(keyb).await;
+    println!("Press CTRL-C to quit...");
+    for idx in 0..u32::MAX {
+        sleep(Duration::from_secs(1)).await;
+        println!("[{idx:4}] Pulling...");
+        subscriber.pull().res().await.unwrap();
+    }
 }
 
 #[derive(clap::Parser, Clone, PartialEq, Eq, Hash, Debug)]

--- a/examples/examples/z_storage.rs
+++ b/examples/examples/z_storage.rs
@@ -13,12 +13,9 @@
 //
 #![recursion_limit = "256"]
 
-use async_std::task::sleep;
 use clap::Parser;
-use futures::prelude::*;
 use futures::select;
 use std::collections::HashMap;
-use std::time::Duration;
 use zenoh::config::Config;
 use zenoh::prelude::r#async::*;
 use zenoh_examples::CommonArgs;
@@ -46,9 +43,7 @@ async fn main() {
         .await
         .unwrap();
 
-    println!("Enter 'q' to quit...");
-    let mut stdin = async_std::io::stdin();
-    let mut input = [0u8];
+    println!("Press CTRL-C to quit...");
     loop {
         select!(
             sample = subscriber.recv_async() => {
@@ -69,14 +64,6 @@ async fn main() {
                     if query.selector().key_expr.intersects(unsafe {keyexpr::from_str_unchecked(stored_name)}) {
                         query.reply(Ok(sample.clone())).res().await.unwrap();
                     }
-                }
-            },
-
-            _ = stdin.read_exact(&mut input).fuse() => {
-                match input[0] {
-                    b'q' => break,
-                    0 => sleep(Duration::from_secs(1)).await,
-                    _ => (),
                 }
             }
         );

--- a/examples/examples/z_sub.rs
+++ b/examples/examples/z_sub.rs
@@ -12,7 +12,6 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use clap::Parser;
-use futures::select;
 use zenoh::config::Config;
 use zenoh::prelude::r#async::*;
 use zenoh_examples::CommonArgs;
@@ -37,13 +36,12 @@ async fn main() {
     let subscriber = session.declare_subscriber(&key_expr).res().await.unwrap();
 
     println!("Press CTRL-C to quit...");
-    loop {
-        select!(
-            sample = subscriber.recv_async() => {
-                let sample = sample.unwrap();
-                println!(">> [Subscriber] Received {} ('{}': '{}')",
-                    sample.kind, sample.key_expr.as_str(), sample.value);
-            }
+    while let Ok(sample) = subscriber.recv_async().await {
+        println!(
+            ">> [Subscriber] Received {} ('{}': '{}')",
+            sample.kind,
+            sample.key_expr.as_str(),
+            sample.value
         );
     }
 }

--- a/examples/examples/z_sub.rs
+++ b/examples/examples/z_sub.rs
@@ -11,11 +11,8 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use async_std::task::sleep;
 use clap::Parser;
-use futures::prelude::*;
 use futures::select;
-use std::time::Duration;
 use zenoh::config::Config;
 use zenoh::prelude::r#async::*;
 use zenoh_examples::CommonArgs;
@@ -39,23 +36,13 @@ async fn main() {
 
     let subscriber = session.declare_subscriber(&key_expr).res().await.unwrap();
 
-    println!("Enter 'q' to quit...");
-    let mut stdin = async_std::io::stdin();
-    let mut input = [0_u8];
+    println!("Press CTRL-C to quit...");
     loop {
         select!(
             sample = subscriber.recv_async() => {
                 let sample = sample.unwrap();
                 println!(">> [Subscriber] Received {} ('{}': '{}')",
                     sample.kind, sample.key_expr.as_str(), sample.value);
-            },
-
-            _ = stdin.read_exact(&mut input).fuse() => {
-                match input[0] {
-                    b'q' => break,
-                    0 => sleep(Duration::from_secs(1)).await,
-                    _ => (),
-                }
             }
         );
     }

--- a/examples/examples/z_sub_liveliness.rs
+++ b/examples/examples/z_sub_liveliness.rs
@@ -12,7 +12,6 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use clap::Parser;
-use futures::select;
 use zenoh::config::Config;
 use zenoh::prelude::r#async::*;
 use zenoh_examples::CommonArgs;
@@ -37,20 +36,17 @@ async fn main() {
         .unwrap();
 
     println!("Press CTRL-C to quit...");
-    loop {
-        select!(
-            sample = subscriber.recv_async() => {
-                let sample = sample.unwrap();
-                match sample.kind {
-                    SampleKind::Put => println!(
-                        ">> [LivelinessSubscriber] New alive token ('{}')",
-                        sample.key_expr.as_str()),
-                    SampleKind::Delete => println!(
-                        ">> [LivelinessSubscriber] Dropped token ('{}')",
-                        sample.key_expr.as_str()),
-                }
-            }
-        );
+    while let Ok(sample) = subscriber.recv_async().await {
+        match sample.kind {
+            SampleKind::Put => println!(
+                ">> [LivelinessSubscriber] New alive token ('{}')",
+                sample.key_expr.as_str()
+            ),
+            SampleKind::Delete => println!(
+                ">> [LivelinessSubscriber] Dropped token ('{}')",
+                sample.key_expr.as_str()
+            ),
+        }
     }
 }
 

--- a/examples/examples/z_sub_liveliness.rs
+++ b/examples/examples/z_sub_liveliness.rs
@@ -11,11 +11,8 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use async_std::task::sleep;
 use clap::Parser;
-use futures::prelude::*;
 use futures::select;
-use std::time::Duration;
 use zenoh::config::Config;
 use zenoh::prelude::r#async::*;
 use zenoh_examples::CommonArgs;
@@ -39,9 +36,7 @@ async fn main() {
         .await
         .unwrap();
 
-    println!("Enter 'q' to quit...");
-    let mut stdin = async_std::io::stdin();
-    let mut input = [0_u8];
+    println!("Press CTRL-C to quit...");
     loop {
         select!(
             sample = subscriber.recv_async() => {
@@ -53,14 +48,6 @@ async fn main() {
                     SampleKind::Delete => println!(
                         ">> [LivelinessSubscriber] Dropped token ('{}')",
                         sample.key_expr.as_str()),
-                }
-            },
-
-            _ = stdin.read_exact(&mut input).fuse() => {
-                match input[0] {
-                    b'q' => break,
-                    0 => sleep(Duration::from_secs(1)).await,
-                    _ => (),
                 }
             }
         );

--- a/examples/examples/z_sub_thr.rs
+++ b/examples/examples/z_sub_thr.rs
@@ -12,8 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use clap::Parser;
-use std::thread::sleep;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 use zenoh::config::Config;
 use zenoh::prelude::sync::*;
 use zenoh_examples::CommonArgs;
@@ -96,9 +95,7 @@ fn main() {
         .unwrap();
 
     println!("Press CTRL-C to quit...");
-    loop {
-        sleep(Duration::from_secs(1));
-    }
+    std::thread::park();
 }
 
 #[derive(clap::Parser, Clone, PartialEq, Eq, Hash, Debug)]

--- a/examples/examples/z_sub_thr.rs
+++ b/examples/examples/z_sub_thr.rs
@@ -12,8 +12,8 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use clap::Parser;
-use std::io::{stdin, Read};
-use std::time::Instant;
+use std::thread::sleep;
+use std::time::{Duration, Instant};
 use zenoh::config::Config;
 use zenoh::prelude::sync::*;
 use zenoh_examples::CommonArgs;
@@ -95,11 +95,9 @@ fn main() {
         .res()
         .unwrap();
 
-    for byte in stdin().bytes() {
-        match byte {
-            Ok(b'q') => break,
-            _ => std::thread::yield_now(),
-        }
+    println!("Press CTRL-C to quit...");
+    loop {
+        sleep(Duration::from_secs(1));
     }
 }
 

--- a/zenoh-ext/examples/z_pub_cache.rs
+++ b/zenoh-ext/examples/z_pub_cache.rs
@@ -38,7 +38,8 @@ async fn main() {
     }
     let _publication_cache = publication_cache_builder.res().await.unwrap();
 
-    for idx in 0..u32::MAX {
+    println!("Press CTRL-C to quit...");
+    for idx in 1..u32::MAX {
         sleep(Duration::from_secs(1)).await;
         let buf = format!("[{idx:4}] {value}");
         println!("Put Data ('{}': '{}')", &key_expr, buf);

--- a/zenoh-ext/examples/z_pub_cache.rs
+++ b/zenoh-ext/examples/z_pub_cache.rs
@@ -39,7 +39,7 @@ async fn main() {
     let _publication_cache = publication_cache_builder.res().await.unwrap();
 
     println!("Press CTRL-C to quit...");
-    for idx in 1..u32::MAX {
+    for idx in 0..u32::MAX {
         sleep(Duration::from_secs(1)).await;
         let buf = format!("[{idx:4}] {value}");
         println!("Put Data ('{}': '{}')", &key_expr, buf);

--- a/zenoh-ext/examples/z_query_sub.rs
+++ b/zenoh-ext/examples/z_query_sub.rs
@@ -13,7 +13,6 @@
 //
 use clap::arg;
 use clap::Command;
-use futures::select;
 use zenoh::config::Config;
 use zenoh::prelude::r#async::*;
 use zenoh::query::ReplyKeyExpr;
@@ -53,13 +52,12 @@ async fn main() {
     };
 
     println!("Press CTRL-C to quit...");
-    loop {
-        select!(
-            sample = subscriber.recv_async() => {
-                let sample = sample.unwrap();
-                println!(">> [Subscriber] Received {} ('{}': '{}')",
-                    sample.kind, sample.key_expr.as_str(), sample.value);
-            },
+    while let Ok(sample) = subscriber.recv_async().await {
+        println!(
+            ">> [Subscriber] Received {} ('{}': '{}')",
+            sample.kind,
+            sample.key_expr.as_str(),
+            sample.value
         );
     }
 }

--- a/zenoh-ext/examples/z_query_sub.rs
+++ b/zenoh-ext/examples/z_query_sub.rs
@@ -11,12 +11,9 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use async_std::task::sleep;
 use clap::arg;
 use clap::Command;
-use futures::prelude::*;
 use futures::select;
-use std::time::Duration;
 use zenoh::config::Config;
 use zenoh::prelude::r#async::*;
 use zenoh::query::ReplyKeyExpr;
@@ -55,9 +52,7 @@ async fn main() {
             .unwrap()
     };
 
-    println!("Enter 'q' to quit...");
-    let mut stdin = async_std::io::stdin();
-    let mut input = [0_u8];
+    println!("Press CTRL-C to quit...");
     loop {
         select!(
             sample = subscriber.recv_async() => {
@@ -65,14 +60,6 @@ async fn main() {
                 println!(">> [Subscriber] Received {} ('{}': '{}')",
                     sample.kind, sample.key_expr.as_str(), sample.value);
             },
-
-            _ = stdin.read_exact(&mut input).fuse() => {
-                match input[0] {
-                    b'q' => break,
-                    0 => sleep(Duration::from_secs(1)).await,
-                    _ => (),
-                }
-            }
         );
     }
 }


### PR DESCRIPTION
These changes remove reading from stdin for all examples, and align their behaviors and outputs across projects.

This PR is part of an effort across currently active Zenoh projects. To maintain examples' implementations as close to each other as possible, any changes identified in other projects will be replicated in this PR. As such, **please do not merge these changes until all PRs are ready for merging**.

Related PRs:
- https://github.com/eclipse-zenoh/zenoh-c/pull/255
- https://github.com/eclipse-zenoh/zenoh-cpp/pull/103
- https://github.com/eclipse-zenoh/zenoh-java/pull/45
- https://github.com/eclipse-zenoh/zenoh-kotlin/pull/47
- https://github.com/eclipse-zenoh/zenoh-pico/pull/359
- https://github.com/eclipse-zenoh/zenoh-python/pull/150