### PR TITLE
Implement get_interface_names for serial link

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4549,9 +4549,9 @@ dependencies = [
 
 [[package]]
 name = "z-serial"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a74ab200b318928231fa62809ca06397f2790d29ffb58d9cbbc7d517e93a6b17"
+checksum = "f113597c6b880587004169f14bc010e4b440981ab2ad669779d3654f9b1c4af1"
 dependencies = [
  "cobs",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,7 +160,7 @@ validated_struct = "2.1.0"
 vec_map = "0.8.2"
 webpki-roots = "0.26.0"
 winapi = { version = "0.3.9", features = ["iphlpapi"] }
-z-serial = "0.2.1"
+z-serial = "0.2.3"
 zenoh-ext = { version = "0.11.0-dev", path = "zenoh-ext" }
 zenoh-shm = { version = "0.11.0-dev", path = "commons/zenoh-shm" }
 zenoh-result = { version = "0.11.0-dev", path = "commons/zenoh-result", default-features = false }

--- a/io/zenoh-links/zenoh-link-serial/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-serial/src/unicast.rs
@@ -183,9 +183,18 @@ impl LinkUnicastTrait for LinkUnicastSerial {
 
     #[inline(always)]
     fn get_interface_names(&self) -> Vec<String> {
-        // @TODO: Not supported for now
-        log::debug!("The get_interface_names for LinkUnicastSerial is not supported");
-        vec![]
+        // For POSIX systems, the interface name refers to the file name without the path
+        // e.g. for serial port "/dev/ttyUSB0" interface name will be "ttyUSB0"
+        match z_serial::get_available_port_names() {
+            Ok(interfaces) => {
+                log::trace!("get_interface_names for serial: {:?}", interfaces);
+                interfaces
+            }
+            Err(e) => {
+                log::debug!("get_interface_names for serial failed: {:?}", e);
+                vec![]
+            }
+        }
     }
 
     #[inline(always)]


### PR DESCRIPTION
Implement get_interface_names for serial link, it will allow correctly use downsampling for serial interface

get_available_port_names implemented there https://github.com/ZettaScaleLabs/z-serial/pull/5