### PR TITLE
fix: Set `fail-fast = false` in sync-lockfiles workflow

### DIFF
--- a/.github/workflows/sync-lockfiles.yml
+++ b/.github/workflows/sync-lockfiles.yml
@@ -30,6 +30,7 @@ jobs:
     needs: fetch
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         dependant:
           - zenoh-c


### PR DESCRIPTION
Resolves https://github.com/eclipse-zenoh/zenoh/issues/779.

Currently we neither ensure all lockfiles are synced or otherwise cancel, nor do we sync as much of them as possible; a sort of awkward middle-ground. Let's sync as much of them as possible for now.