### PR TITLE
Implement a Pull subscriber with a PullCache

### DIFF
--- a/commons/zenoh-collections/src/ring_buffer.rs
+++ b/commons/zenoh-collections/src/ring_buffer.rs
@@ -41,6 +41,14 @@ impl<T> RingBuffer<T> {
     }
 
     #[inline]
+    pub fn push_force(&mut self, elem: T) -> Option<T> {
+        self.push(elem).and_then(|elem| {
+            self.buffer.push_back(elem);
+            self.buffer.pop_front()
+        })
+    }
+
+    #[inline]
     pub fn pull(&mut self) -> Option<T> {
         let x = self.buffer.pop_front();
         if x.is_some() {


### PR DESCRIPTION
This PR is a PoC to showcase how the current `pull()` behaviour of a subscriber could be replaced.

To test its behaviour:
```sh
./target/debug/z_pub
```
```sh
./target/debug/z_pull --cache 3
```