### PR TITLE
Fix liveliness bug

### DIFF
--- a/zenoh/src/net/routing/hat/client/pubsub.rs
+++ b/zenoh/src/net/routing/hat/client/pubsub.rs
@@ -41,7 +41,8 @@ fn propagate_simple_subscription_to(
     sub_info: &SubscriberInfo,
     src_face: &mut Arc<FaceState>,
 ) {
-    if (src_face.id != dst_face.id || res.expr().starts_with(PREFIX_LIVELINESS))
+    if (src_face.id != dst_face.id
+        || (dst_face.whatami == WhatAmI::Client && res.expr().starts_with(PREFIX_LIVELINESS)))
         && !face_hat!(dst_face).local_subs.contains(res)
         && (src_face.whatami == WhatAmI::Client || dst_face.whatami == WhatAmI::Client)
     {

--- a/zenoh/src/net/routing/hat/p2p_peer/pubsub.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/pubsub.rs
@@ -41,7 +41,8 @@ fn propagate_simple_subscription_to(
     sub_info: &SubscriberInfo,
     src_face: &mut Arc<FaceState>,
 ) {
-    if (src_face.id != dst_face.id || res.expr().starts_with(PREFIX_LIVELINESS))
+    if (src_face.id != dst_face.id
+        || (dst_face.whatami == WhatAmI::Client && res.expr().starts_with(PREFIX_LIVELINESS)))
         && !face_hat!(dst_face).local_subs.contains(res)
         && (src_face.whatami == WhatAmI::Client || dst_face.whatami == WhatAmI::Client)
     {

--- a/zenoh/src/net/routing/hat/router/pubsub.rs
+++ b/zenoh/src/net/routing/hat/router/pubsub.rs
@@ -87,7 +87,8 @@ fn propagate_simple_subscription_to(
     src_face: &mut Arc<FaceState>,
     full_peer_net: bool,
 ) {
-    if (src_face.id != dst_face.id || res.expr().starts_with(PREFIX_LIVELINESS))
+    if (src_face.id != dst_face.id
+        || (dst_face.whatami == WhatAmI::Client && res.expr().starts_with(PREFIX_LIVELINESS)))
         && !face_hat!(dst_face).local_subs.contains(res)
         && if full_peer_net {
             dst_face.whatami == WhatAmI::Client


### PR DESCRIPTION
This fixes a bug that could only be reproduced in `rmw_zenoh` and that was causing a dropped liveliness token to be wrongly relived: https://gist.github.com/Yadunund/63befdc4ef80eb10e2114b1bf2132708 .