### PR TITLE
fix(828): ensuring valid JSON response from REST API

### DIFF
--- a/plugins/zenoh-plugin-rest/src/lib.rs
+++ b/plugins/zenoh-plugin-rest/src/lib.rs
@@ -61,10 +61,6 @@ pub fn base64_encode(data: &[u8]) -> String {
     general_purpose::STANDARD.encode(data)
 }
 
-// fn payload_to_string(payload: &Payload) -> String {
-//     String::from_utf8(payload.contiguous().to_vec()).unwrap_or(base64_encode(&payload.contiguous()))
-// }
-
 fn payload_to_json(payload: Payload, encoding: &Encoding) -> serde_json::Value {
     match payload.len() {
         // If the value is empty return a JSON null
@@ -75,11 +71,11 @@ fn payload_to_json(payload: Payload, encoding: &Encoding) -> serde_json::Value {
                 // If it is a JSON try to deserialize as json, if it fails fallback to base64
                 &Encoding::APPLICATION_JSON | &Encoding::TEXT_JSON | &Encoding::TEXT_JSON5 => {
                     serde_json::from_slice::<serde_json::Value>(&payload.contiguous()).unwrap_or(
-                        serde_json::Value::String((*StringOrBase64::from(payload)).clone()),
+                        serde_json::Value::String(StringOrBase64::from(payload).into_string()),
                     )
                 }
                 // otherwise convert to JSON string
-                _ => serde_json::Value::String((*StringOrBase64::from(payload)).clone()),
+                _ => serde_json::Value::String(StringOrBase64::from(payload).into_string()),
             }
         }
     }

--- a/plugins/zenoh-plugin-rest/src/lib.rs
+++ b/plugins/zenoh-plugin-rest/src/lib.rs
@@ -18,9 +18,10 @@
 //!
 //! [Click here for Zenoh's documentation](../zenoh/index.html)
 use async_std::prelude::FutureExt;
-use base64::{engine::general_purpose::STANDARD as b64_std_engine, Engine};
+use base64::Engine;
 use futures::StreamExt;
 use http_types::Method;
+use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::str::FromStr;
@@ -46,36 +47,57 @@ lazy_static::lazy_static! {
 }
 const RAW_KEY: &str = "_raw";
 
-fn payload_to_json(payload: Payload) -> String {
-    payload
-        .deserialize::<String>()
-        .unwrap_or_else(|_| format!(r#""{}""#, b64_std_engine.encode(payload.contiguous())))
+#[derive(Serialize, Deserialize)]
+struct JSONSample {
+    key: String,
+    value: serde_json::Value,
+    encoding: String,
+    time: Option<String>,
 }
 
-fn sample_to_json(sample: Sample) -> String {
-    format!(
-        r#"{{ "key": "{}", "value": {}, "encoding": "{}", "time": "{}" }}"#,
-        sample.key_expr.as_str(),
-        payload_to_json(sample.payload),
-        sample.encoding,
-        if let Some(ts) = sample.timestamp {
-            ts.to_string()
-        } else {
-            "None".to_string()
+pub fn base64_encode(data: &[u8]) -> String {
+    use base64::engine::general_purpose;
+    general_purpose::STANDARD.encode(data)
+}
+
+fn payload_to_json(payload: Payload, encoding: &Encoding) -> serde_json::Value {
+    match payload.len() {
+        // If the value is empty return a JSON null
+        0 => serde_json::Value::Null,
+        // if it is not check the encoding
+        _ => {
+            match encoding {
+                // If it is a JSON try to deserialize as json, if it fails fallback to base64
+                &Encoding::APPLICATION_JSON | &Encoding::TEXT_JSON | &Encoding::TEXT_JSON5 => {
+                    serde_json::from_slice::<serde_json::Value>(&payload.contiguous()).unwrap_or(
+                        serde_json::Value::String(base64_encode(&payload.contiguous())),
+                    )
+                }
+                // otherwise convert to base64 and JSON String
+                _ => serde_json::Value::String(base64_encode(&payload.contiguous())),
+            }
         }
-    )
+    }
 }
 
-fn result_to_json(sample: Result<Sample, Value>) -> String {
+fn sample_to_json(sample: Sample) -> JSONSample {
+    JSONSample {
+        key: sample.key_expr.as_str().to_string(),
+        value: payload_to_json(sample.payload, &sample.encoding),
+        encoding: sample.encoding.to_string(),
+        time: sample.timestamp.map(|ts| ts.to_string()),
+    }
+}
+
+fn result_to_json(sample: Result<Sample, Value>) -> JSONSample {
     match sample {
         Ok(sample) => sample_to_json(sample),
-        Err(err) => {
-            format!(
-                r#"{{ "key": "ERROR", "value": {}, "encoding": "{}"}}"#,
-                payload_to_json(err.payload),
-                err.encoding,
-            )
-        }
+        Err(err) => JSONSample {
+            key: "ERROR".into(),
+            value: payload_to_json(err.payload, &err.encoding),
+            encoding: err.encoding.to_string(),
+            time: None,
+        },
     }
 }
 
@@ -83,10 +105,10 @@ async fn to_json(results: flume::Receiver<Reply>) -> String {
     let values = results
         .stream()
         .filter_map(move |reply| async move { Some(result_to_json(reply.sample)) })
-        .collect::<Vec<String>>()
-        .await
-        .join(",\n");
-    format!("[\n{values}\n]\n")
+        .collect::<Vec<JSONSample>>()
+        .await;
+
+    serde_json::to_string(&values).unwrap_or("[]".into())
 }
 
 async fn to_json_response(results: flume::Receiver<Reply>) -> Response {
@@ -321,8 +343,12 @@ async fn query(mut req: Request<(Arc<Session>, String)>) -> tide::Result<Respons
                         .unwrap();
                     loop {
                         let sample = sub.recv_async().await.unwrap();
+                        let kind = sample.kind.clone();
+                        let json_sample =
+                            serde_json::to_string(&sample_to_json(sample)).unwrap_or("{}".into());
+
                         match sender
-                            .send(&sample.kind.to_string(), sample_to_json(sample), None)
+                            .send(&kind.to_string(), json_sample, None)
                             .timeout(std::time::Duration::new(10, 0))
                             .await
                         {

--- a/plugins/zenoh-plugin-rest/src/lib.rs
+++ b/plugins/zenoh-plugin-rest/src/lib.rs
@@ -62,11 +62,11 @@ pub fn base64_encode(data: &[u8]) -> String {
 }
 
 fn payload_to_json(payload: Payload, encoding: &Encoding) -> serde_json::Value {
-    match payload.len() {
+    match payload.is_empty() {
         // If the value is empty return a JSON null
-        0 => serde_json::Value::Null,
+        true => serde_json::Value::Null,
         // if it is not check the encoding
-        _ => {
+        false => {
             match encoding {
                 // If it is a JSON try to deserialize as json, if it fails fallback to base64
                 &Encoding::APPLICATION_JSON | &Encoding::TEXT_JSON | &Encoding::TEXT_JSON5 => {

--- a/zenoh/src/payload.rs
+++ b/zenoh/src/payload.rs
@@ -563,6 +563,14 @@ pub enum StringOrBase64 {
     Base64(String),
 }
 
+impl StringOrBase64 {
+    pub fn into_string(self) -> String {
+        match self {
+            StringOrBase64::String(s) | StringOrBase64::Base64(s) => s,
+        }
+    }
+}
+
 impl Deref for StringOrBase64 {
     type Target = String;
 


### PR DESCRIPTION
This PR ensures that the response of the REST plugin is a valid JSON, Closes #828 

If a sample has `application/json` or `text/json` or `text/json5` encoding then we try to convert it to a `serde_json::Value` if we fail then can be converted to a string via the `from_utf8` function then we return its payload as JSON string, otherwise  it is encoded as base64 and return as JSON string.
If the sample has a different encoding and can be converted to a string via the `from_utf8` function then we return its payload as JSON string , otherwise it is encoded as base64 and return as JSON string.


This is an example of a get with the different cases:

```
[
    // real json
    {
        "key": "demo/temp/json",
        "value": {
            "hello": "world",
            "this": {
                "is-a": "json"
            }
        },
        "encoding": "application/json",
        "time": "2024-03-14T13:36:57.440128661Z/ff29c02c6c1044c6a1b565c24566b760"
    },
    // empty json
    {
        "key": "demo/temp/empty",
        "value": null,
        "encoding": "application/json",
        "time": "2024-03-14T13:35:31.929630711Z/ff29c02c6c1044c6a1b565c24566b760"
    },
    // text that was inserted as it was a json
    {
        "key": "demo/temp/text",
        "value": "this is a text, but i said it is a json",
        "encoding": "application/json",
        "time": "2024-03-14T13:35:49.283543717Z/ff29c02c6c1044c6a1b565c24566b760"
    },
    // binary, image in this case, that was inserted as json
    {
        "key": "demo/temp/binary",
        "value": "/9j/4AAQSkZJRgABAQAAAAAAAAD/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/wAALCAAgACABAREA/8QAFQABAQAAAAAAAAAAAAAAAAAAAAn/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAA/AKpgAAAAP//Z",
        "encoding": "application/json",
        "time": "2024-03-14T13:41:08.952893450Z/ff29c02c6c1044c6a1b565c24566b760"
    },
    // image inserted as image
        {
        "key": "demo/temp/image2",
        "value": "/9j/4AAQSkZJRgABAQAAAAAAAAD/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/wAALCAAgACABAREA/8QAFQABAQAAAAAAAAAAAAAAAAAAAAn/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAA/AKpgAAAAP//Z",
        "encoding": "image/jpeg",
        "time": "2024-03-14T13:46:20.142042767Z/ff29c02c6c1044c6a1b565c24566b760"
    }
]
```