### PR TITLE
Fix issue #835

### DIFF
--- a/commons/zenoh-runtime/src/lib.rs
+++ b/commons/zenoh-runtime/src/lib.rs
@@ -110,8 +110,10 @@ impl ZRuntime {
     where
         F: Future<Output = R>,
     {
-        if Handle::current().runtime_flavor() == RuntimeFlavor::CurrentThread {
-            panic!("Zenoh runtime doesn't support Tokio's current thread scheduler. Please use multi thread scheduler instead, e.g. a multi thread scheduler with one worker thread: `#[tokio::main(flavor = \"multi_thread\", worker_threads = 1)]`");
+        if let Ok(handle) = Handle::try_current() {
+            if handle.runtime_flavor() == RuntimeFlavor::CurrentThread {
+                panic!("Zenoh runtime doesn't support Tokio's current thread scheduler. Please use multi thread scheduler instead, e.g. a multi thread scheduler with one worker thread: `#[tokio::main(flavor = \"multi_thread\", worker_threads = 1)]`");
+            }
         }
         tokio::task::block_in_place(move || self.block_on(f))
     }


### PR DESCRIPTION
Closes #835 . 

- Panic if zenoh runtime is called from a context of tokio's current thread scheduler.
- Inform the user to use multi thread scheduler instead. 