### PR TITLE
Support RingBuffer to get the latest sample.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -80,7 +80,7 @@
 ### z_pull
 
    Declares a key expression and a pull subscriber.  
-   On each pull, the pull subscriber will be notified of the last `put` or `delete` made on each key expression matching the subscriber key expression, and will print this notification.
+   On each pull, the pull subscriber will be notified of the last N `put` or `delete` made on each key expression matching the subscriber key expression, and will print this notification.
 
 
    Typical usage:
@@ -89,7 +89,7 @@
    ```
    or
    ```bash
-      z_pull -k demo/**
+      z_pull -k demo/** --size 3
    ```
 
 ### z_get

--- a/examples/examples/z_pull.rs
+++ b/examples/examples/z_pull.rs
@@ -14,7 +14,7 @@
 use async_std::task::sleep;
 use clap::Parser;
 use std::time::Duration;
-use zenoh::handlers::RingQueue;
+use zenoh::handlers::RingBuffer;
 use zenoh::{config::Config, prelude::r#async::*};
 use zenoh_examples::CommonArgs;
 
@@ -31,7 +31,7 @@ async fn main() {
     println!("Declaring Subscriber on '{key_expr}'...");
     let subscriber = session
         .declare_subscriber(&key_expr)
-        .with(RingQueue::new(cache))
+        .with(RingBuffer::new(cache))
         .res()
         .await
         .unwrap();

--- a/examples/examples/z_pull.rs
+++ b/examples/examples/z_pull.rs
@@ -22,7 +22,7 @@ async fn main() {
     // initiate logging
     env_logger::init();
 
-    let (config, key_expr, cache, interval) = parse_args();
+    let (config, key_expr, size, interval) = parse_args();
 
     println!("Opening session...");
     let session = zenoh::open(config).res().await.unwrap();
@@ -30,7 +30,7 @@ async fn main() {
     println!("Declaring Subscriber on '{key_expr}'...");
     let subscriber = session
         .declare_subscriber(&key_expr)
-        .with(RingBuffer::new(cache))
+        .with(RingBuffer::new(size))
         .res()
         .await
         .unwrap();
@@ -67,10 +67,10 @@ struct SubArgs {
     #[arg(short, long, default_value = "demo/example/**")]
     /// The Key Expression to subscribe to.
     key: KeyExpr<'static>,
-    /// The size of the cache.
+    /// The size of the ringbuffer.
     #[arg(long, default_value = "3")]
-    cache: usize,
-    /// The interval for pulling the cache.
+    size: usize,
+    /// The interval for pulling the ringbuffer.
     #[arg(long, default_value = "5.0")]
     interval: f32,
     #[command(flatten)]
@@ -80,5 +80,5 @@ struct SubArgs {
 fn parse_args() -> (Config, KeyExpr<'static>, usize, Duration) {
     let args = SubArgs::parse();
     let interval = Duration::from_secs_f32(args.interval);
-    (args.common.into(), args.key, args.cache, interval)
+    (args.common.into(), args.key, args.size, interval)
 }

--- a/examples/examples/z_pull.rs
+++ b/examples/examples/z_pull.rs
@@ -14,8 +14,7 @@
 use async_std::task::sleep;
 use clap::Parser;
 use std::time::Duration;
-use zenoh::handlers::RingBuffer;
-use zenoh::{config::Config, prelude::r#async::*};
+use zenoh::{config::Config, handlers::RingBuffer, prelude::r#async::*};
 use zenoh_examples::CommonArgs;
 
 #[async_std::main]
@@ -53,11 +52,11 @@ async fn main() {
                 );
             }
             Ok(None) => {
-                println!(">> [Subscriber] nothing... sleep for {:#?}", interval);
+                println!("nothing... sleep for {:#?}", interval);
                 sleep(interval).await;
             }
             Err(e) => {
-                println!(">> [Subscriber] Pull error: {e}")
+                println!("Pull error: {e}");
             }
         }
     }

--- a/zenoh/src/handlers.rs
+++ b/zenoh/src/handlers.rs
@@ -16,7 +16,7 @@
 use crate::API_DATA_RECEPTION_CHANNEL_SIZE;
 
 use std::sync::{Arc, Mutex, Weak};
-use zenoh_collections::RingBuffer as RingBuffer_inner;
+use zenoh_collections::RingBuffer as RingBufferInner;
 use zenoh_result::ZResult;
 
 /// An alias for `Arc<T>`.
@@ -94,20 +94,20 @@ impl<T: Send + Sync + 'static> IntoHandler<'static, T>
 
 /// Ring buffer with a limited queue size, which allows users to keep the last N data.
 pub struct RingBuffer<T> {
-    cache: Arc<Mutex<RingBuffer_inner<T>>>,
+    cache: Arc<Mutex<RingBufferInner<T>>>,
 }
 
 impl<T> RingBuffer<T> {
     /// Initialize the RingBuffer with the capacity size.
     pub fn new(capacity: usize) -> Self {
         RingBuffer {
-            cache: Arc::new(Mutex::new(RingBuffer_inner::new(capacity))),
+            cache: Arc::new(Mutex::new(RingBufferInner::new(capacity))),
         }
     }
 }
 
 pub struct RingBufferHandler<T> {
-    cache: Weak<Mutex<RingBuffer_inner<T>>>,
+    cache: Weak<Mutex<RingBufferInner<T>>>,
 }
 
 impl<T> RingBufferHandler<T> {

--- a/zenoh/src/handlers.rs
+++ b/zenoh/src/handlers.rs
@@ -92,11 +92,13 @@ impl<T: Send + Sync + 'static> IntoHandler<'static, T>
     }
 }
 
+/// Ring buffer with a limited queue size, which allows users to keep the last N data.
 pub struct RingBuffer<T> {
     cache: Arc<Mutex<RingBuffer_inner<T>>>,
 }
 
 impl<T> RingBuffer<T> {
+    /// Initialize the RingBuffer with the capacity size.
     pub fn new(capacity: usize) -> Self {
         RingBuffer {
             cache: Arc::new(Mutex::new(RingBuffer_inner::new(capacity))),

--- a/zenoh/tests/attachments.rs
+++ b/zenoh/tests/attachments.rs
@@ -1,3 +1,16 @@
+//
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
 #[cfg(feature = "unstable")]
 #[test]
 fn pubsub() {

--- a/zenoh/tests/formatters.rs
+++ b/zenoh/tests/formatters.rs
@@ -1,3 +1,16 @@
+//
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
 #[test]
 fn reuse() {
     zenoh::kedefine!(

--- a/zenoh/tests/handler.rs
+++ b/zenoh/tests/handler.rs
@@ -13,6 +13,7 @@
 //
 #[test]
 fn pubsub_with_ringbuffer() {
+    use std::{thread, time::Duration};
     use zenoh::{handlers::RingBuffer, prelude::sync::*};
 
     let zenoh = zenoh::open(Config::default()).res().unwrap();
@@ -39,6 +40,8 @@ fn pubsub_with_ringbuffer() {
             format!("put{i}")
         );
     }
+    // Wait for the subscriber to get the value
+    thread::sleep(Duration::from_millis(1000));
 }
 
 #[test]

--- a/zenoh/tests/handler.rs
+++ b/zenoh/tests/handler.rs
@@ -1,3 +1,16 @@
+//
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
 #[test]
 fn pubsub_with_ringbuffer() {
     use zenoh::{handlers::RingBuffer, prelude::sync::*};

--- a/zenoh/tests/handler.rs
+++ b/zenoh/tests/handler.rs
@@ -1,0 +1,64 @@
+#[test]
+fn pubsub_with_ringbuffer() {
+    use zenoh::{handlers::RingBuffer, prelude::sync::*};
+
+    let zenoh = zenoh::open(Config::default()).res().unwrap();
+    let sub = zenoh
+        .declare_subscriber("test/ringbuffer")
+        .with(RingBuffer::new(3))
+        .res()
+        .unwrap();
+    for i in 0..10 {
+        zenoh
+            .put("test/ringbuffer", format!("put{i}"))
+            .res()
+            .unwrap();
+    }
+    // Should only receive the last three samples ("put7", "put8", "put9")
+    for i in 7..10 {
+        assert_eq!(
+            sub.recv()
+                .unwrap()
+                .unwrap()
+                .payload()
+                .deserialize::<String>()
+                .unwrap(),
+            format!("put{i}")
+        );
+    }
+}
+
+#[test]
+fn query_with_ringbuffer() {
+    use zenoh::{handlers::RingBuffer, prelude::sync::*};
+
+    let zenoh = zenoh::open(Config::default()).res().unwrap();
+    let queryable = zenoh
+        .declare_queryable("test/ringbuffer_query")
+        .with(RingBuffer::new(1))
+        .res()
+        .unwrap();
+
+    let _reply1 = zenoh
+        .get("test/ringbuffer_query")
+        .with_value("query1")
+        .res()
+        .unwrap();
+    let _reply2 = zenoh
+        .get("test/ringbuffer_query")
+        .with_value("query2")
+        .res()
+        .unwrap();
+
+    let query = queryable.recv().unwrap().unwrap();
+    // Only receive the latest query
+    assert_eq!(
+        query
+            .value()
+            .unwrap()
+            .payload
+            .deserialize::<String>()
+            .unwrap(),
+        "query2"
+    );
+}

--- a/zenoh/tests/interceptors.rs
+++ b/zenoh/tests/interceptors.rs
@@ -1,3 +1,16 @@
+//
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
 use std::sync::{Arc, Mutex};
 use zenoh_core::zlock;
 


### PR DESCRIPTION
As a successor of https://github.com/eclipse-zenoh/zenoh/pull/782, create a RingBuffer for users to get the latest data easily.

Closes https://github.com/eclipse-zenoh/zenoh/issues/809