### PR TITLE
Explicitly specify the default features in the examples.

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -49,7 +49,7 @@ futures = { workspace = true }
 git-version = { workspace = true }
 json5 = { workspace = true }
 log = { workspace = true }
-zenoh = { workspace = true }
+zenoh = { workspace = true, default-features = true }
 zenoh-ext = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
To resolve the issue in https://github.com/eclipse-zenoh/roadmap/discussions/128#discussioncomment-8860499. Users obtain an example built without default features if they run `cargo build --example EXAMPLE` in the examples folder. Although adding `--workspace` can solve this problem, it's still better to avoid this confusion completely.