### PR TITLE
Payload API

### DIFF
--- a/commons/zenoh-macros/build.rs
+++ b/commons/zenoh-macros/build.rs
@@ -23,6 +23,7 @@ fn main() {
     let version_rs = std::path::PathBuf::from(env::var_os("OUT_DIR").unwrap()).join("version.rs");
     let mut version_rs = OpenOptions::new()
         .create(true)
+        .truncate(true)
         .write(true)
         .open(version_rs)
         .unwrap();

--- a/plugins/zenoh-plugin-example/src/lib.rs
+++ b/plugins/zenoh-plugin-example/src/lib.rs
@@ -15,6 +15,7 @@
 
 use futures::select;
 use log::{debug, info};
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::sync::{
@@ -164,7 +165,7 @@ async fn run(runtime: Runtime, selector: KeyExpr<'_>, flag: Arc<AtomicBool>) {
             // on sample received by the Subscriber
             sample = sub.recv_async() => {
                 let sample = sample.unwrap();
-                let payload = sample.payload().deserialize::<String>().unwrap_or_else(|e| format!("{}", e));
+                let payload = sample.payload().deserialize::<Cow<str>>().unwrap_or_else(|e| Cow::from(e.to_string()));
                 info!("Received data ('{}': '{}')", sample.key_expr(), payload);
                 stored.insert(sample.key_expr().to_string(), sample);
             },

--- a/plugins/zenoh-plugin-rest/src/lib.rs
+++ b/plugins/zenoh-plugin-rest/src/lib.rs
@@ -70,9 +70,11 @@ fn payload_to_json(payload: &Payload, encoding: &Encoding) -> serde_json::Value 
             match encoding {
                 // If it is a JSON try to deserialize as json, if it fails fallback to base64
                 &Encoding::APPLICATION_JSON | &Encoding::TEXT_JSON | &Encoding::TEXT_JSON5 => {
-                    serde_json::from_slice::<serde_json::Value>(&payload.contiguous()).unwrap_or(
-                        serde_json::Value::String(StringOrBase64::from(payload).into_string()),
-                    )
+                    payload
+                        .deserialize::<serde_json::Value>()
+                        .unwrap_or_else(|_| {
+                            serde_json::Value::String(StringOrBase64::from(payload).into_string())
+                        })
                 }
                 // otherwise convert to JSON string
                 _ => serde_json::Value::String(StringOrBase64::from(payload).into_string()),
@@ -124,7 +126,7 @@ fn sample_to_html(sample: Sample) -> String {
     format!(
         "<dt>{}</dt>\n<dd>{}</dd>\n",
         sample.key_expr().as_str(),
-        String::from_utf8_lossy(&sample.payload().contiguous())
+        sample.payload().deserialize::<String>().unwrap_or_default()
     )
 }
 
@@ -134,7 +136,7 @@ fn result_to_html(sample: Result<Sample, Value>) -> String {
         Err(err) => {
             format!(
                 "<dt>ERROR</dt>\n<dd>{}</dd>\n",
-                String::from_utf8_lossy(&err.payload.contiguous())
+                err.payload.deserialize::<String>().unwrap_or_default()
             )
         }
     }
@@ -160,12 +162,12 @@ async fn to_raw_response(results: flume::Receiver<Reply>) -> Response {
             Ok(sample) => response(
                 StatusCode::Ok,
                 Cow::from(sample.encoding()).as_ref(),
-                String::from_utf8_lossy(&sample.payload().contiguous()).as_ref(),
+                &sample.payload().deserialize::<String>().unwrap_or_default(),
             ),
             Err(value) => response(
                 StatusCode::Ok,
                 Cow::from(&value.encoding).as_ref(),
-                String::from_utf8_lossy(&value.payload.contiguous()).as_ref(),
+                &value.payload.deserialize::<String>().unwrap_or_default(),
             ),
         },
         Err(_) => response(StatusCode::Ok, "", ""),

--- a/plugins/zenoh-plugin-rest/src/lib.rs
+++ b/plugins/zenoh-plugin-rest/src/lib.rs
@@ -126,7 +126,10 @@ fn sample_to_html(sample: Sample) -> String {
     format!(
         "<dt>{}</dt>\n<dd>{}</dd>\n",
         sample.key_expr().as_str(),
-        sample.payload().deserialize::<String>().unwrap_or_default()
+        sample
+            .payload()
+            .deserialize::<Cow<'_, str>>()
+            .unwrap_or_default()
     )
 }
 
@@ -136,7 +139,9 @@ fn result_to_html(sample: Result<Sample, Value>) -> String {
         Err(err) => {
             format!(
                 "<dt>ERROR</dt>\n<dd>{}</dd>\n",
-                err.payload.deserialize::<String>().unwrap_or_default()
+                err.payload
+                    .deserialize::<Cow<'_, str>>()
+                    .unwrap_or_default()
             )
         }
     }
@@ -162,12 +167,15 @@ async fn to_raw_response(results: flume::Receiver<Reply>) -> Response {
             Ok(sample) => response(
                 StatusCode::Ok,
                 Cow::from(sample.encoding()).as_ref(),
-                &sample.payload().deserialize::<String>().unwrap_or_default(),
+                &sample
+                    .payload()
+                    .deserialize::<Cow<str>>()
+                    .unwrap_or_default(),
             ),
             Err(value) => response(
                 StatusCode::Ok,
                 Cow::from(&value.encoding).as_ref(),
-                &value.payload.deserialize::<String>().unwrap_or_default(),
+                &value.payload.deserialize::<Cow<str>>().unwrap_or_default(),
             ),
         },
         Err(_) => response(StatusCode::Ok, "", ""),

--- a/plugins/zenoh-plugin-rest/src/lib.rs
+++ b/plugins/zenoh-plugin-rest/src/lib.rs
@@ -128,7 +128,7 @@ fn sample_to_html(sample: Sample) -> String {
         sample.key_expr().as_str(),
         sample
             .payload()
-            .deserialize::<Cow<'_, str>>()
+            .deserialize::<Cow<str>>()
             .unwrap_or_default()
     )
 }
@@ -139,9 +139,7 @@ fn result_to_html(sample: Result<Sample, Value>) -> String {
         Err(err) => {
             format!(
                 "<dt>ERROR</dt>\n<dd>{}</dd>\n",
-                err.payload
-                    .deserialize::<Cow<'_, str>>()
-                    .unwrap_or_default()
+                err.payload.deserialize::<Cow<str>>().unwrap_or_default()
             )
         }
     }

--- a/plugins/zenoh-plugin-storage-manager/src/replica/storage.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/storage.rs
@@ -676,6 +676,7 @@ fn serialize_update(update: &Update) -> String {
             },
     } = update;
     let zbuf: ZBuf = payload.into();
+
     let result = (
         kind.to_string(),
         timestamp.to_string(),

--- a/plugins/zenoh-plugin-storage-manager/src/replica/storage.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/storage.rs
@@ -665,11 +665,22 @@ impl StorageService {
 }
 
 fn serialize_update(update: &Update) -> String {
+    let Update {
+        kind,
+        data:
+            StoredData {
+                value: Value {
+                    payload, encoding, ..
+                },
+                timestamp,
+            },
+    } = update;
+    let zbuf: ZBuf = payload.into();
     let result = (
-        update.kind.to_string(),
-        update.data.timestamp.to_string(),
-        update.data.value.encoding.to_string(),
-        update.data.value.payload.slices().collect::<Vec<&[u8]>>(),
+        kind.to_string(),
+        timestamp.to_string(),
+        encoding.to_string(),
+        zbuf.slices().collect::<Vec<&[u8]>>(),
     );
     serde_json::to_string_pretty(&result).unwrap()
 }

--- a/zenoh-ext/src/group.rs
+++ b/zenoh-ext/src/group.rs
@@ -25,6 +25,7 @@ use std::convert::TryInto;
 use std::ops::Add;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use zenoh::payload::PayloadReader;
 use zenoh::prelude::r#async::*;
 use zenoh::publication::Publisher;
 use zenoh::query::ConsolidationMode;
@@ -248,7 +249,7 @@ async fn net_event_handler(z: Arc<Session>, state: Arc<GroupState>) {
         .await
         .unwrap();
     while let Ok(s) = sub.recv_async().await {
-        match bincode::deserialize::<GroupNetEvent>(&(s.payload().contiguous())) {
+        match bincode::deserialize_from::<PayloadReader, GroupNetEvent>(s.payload().reader()) {
             Ok(evt) => match evt {
                 GroupNetEvent::Join(je) => {
                     log::debug!("Member join: {:?}", &je.member);
@@ -307,8 +308,8 @@ async fn net_event_handler(z: Arc<Session>, state: Arc<GroupState>) {
                                 while let Ok(reply) = receiver.recv_async().await {
                                     match reply.sample {
                                         Ok(sample) => {
-                                            match bincode::deserialize::<Member>(
-                                                &sample.payload().contiguous(),
+                                            match bincode::deserialize_from::<PayloadReader, Member>(
+                                                sample.payload().reader(),
                                             ) {
                                                 Ok(m) => {
                                                     let mut expiry = Instant::now();

--- a/zenoh/src/payload.rs
+++ b/zenoh/src/payload.rs
@@ -19,7 +19,7 @@ use std::{
 };
 use zenoh_buffers::buffer::Buffer;
 use zenoh_buffers::{
-    buffer::SplitBuffer, reader::HasReader, writer::HasWriter, ZBufReader, ZBufWriter, ZSlice,
+    buffer::SplitBuffer, reader::HasReader, writer::HasWriter, ZBufReader, ZSlice,
 };
 use zenoh_result::ZResult;
 #[cfg(feature = "shared-memory")]
@@ -57,11 +57,6 @@ impl Payload {
     pub fn reader(&self) -> PayloadReader<'_> {
         PayloadReader(self.0.reader())
     }
-
-    /// Get a [`PayloadWriter`] implementing [`std::io::Write`] trait.
-    pub fn writer(&mut self) -> PayloadWriter<'_> {
-        PayloadWriter(self.0.writer())
-    }
 }
 
 /// A reader that implements [`std::io::Read`] trait to read from a [`Payload`].
@@ -70,19 +65,6 @@ pub struct PayloadReader<'a>(ZBufReader<'a>);
 impl std::io::Read for PayloadReader<'_> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         self.0.read(buf)
-    }
-}
-
-/// A writer that implements [`std::io::Write`] trait to read from a [`Payload`].
-pub struct PayloadWriter<'a>(ZBufWriter<'a>);
-
-impl std::io::Write for PayloadWriter<'_> {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.0.write(buf)
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.0.flush()
     }
 }
 
@@ -404,7 +386,7 @@ impl Serialize<&serde_json::Value> for ZSerde {
 
     fn serialize(self, t: &serde_json::Value) -> Self::Output {
         let mut payload = Payload::empty();
-        serde_json::to_writer(payload.writer(), t)?;
+        serde_json::to_writer(payload.0.writer(), t)?;
         Ok(payload)
     }
 }
@@ -439,7 +421,7 @@ impl Serialize<&serde_yaml::Value> for ZSerde {
 
     fn serialize(self, t: &serde_yaml::Value) -> Self::Output {
         let mut payload = Payload::empty();
-        serde_yaml::to_writer(payload.writer(), t)?;
+        serde_yaml::to_writer(payload.0.writer(), t)?;
         Ok(payload)
     }
 }
@@ -474,7 +456,7 @@ impl Serialize<&serde_cbor::Value> for ZSerde {
 
     fn serialize(self, t: &serde_cbor::Value) -> Self::Output {
         let mut payload = Payload::empty();
-        serde_cbor::to_writer(payload.writer(), t)?;
+        serde_cbor::to_writer(payload.0.writer(), t)?;
         Ok(payload)
     }
 }
@@ -510,7 +492,7 @@ impl Serialize<&serde_pickle::Value> for ZSerde {
     fn serialize(self, t: &serde_pickle::Value) -> Self::Output {
         let mut payload = Payload::empty();
         serde_pickle::value_to_writer(
-            &mut payload.writer(),
+            &mut payload.0.writer(),
             t,
             serde_pickle::SerOptions::default(),
         )?;

--- a/zenoh/src/payload.rs
+++ b/zenoh/src/payload.rs
@@ -596,8 +596,8 @@ impl std::fmt::Display for StringOrBase64 {
 impl From<&Payload> for StringOrBase64 {
     fn from(v: &Payload) -> Self {
         use base64::{engine::general_purpose::STANDARD as b64_std_engine, Engine};
-        match v.deserialize::<String>() {
-            Ok(s) => StringOrBase64::String(s),
+        match v.deserialize::<Cow<str>>() {
+            Ok(s) => StringOrBase64::String(s.into_owned()),
             Err(_) => {
                 let cow: Cow<'_, [u8]> = Cow::from(v);
                 StringOrBase64::Base64(b64_std_engine.encode(cow))

--- a/zenoh/tests/attachments.rs
+++ b/zenoh/tests/attachments.rs
@@ -7,10 +7,7 @@ fn pubsub() {
     let _sub = zenoh
         .declare_subscriber("test/attachment")
         .callback(|sample| {
-            println!(
-                "{}",
-                std::str::from_utf8(&sample.payload().contiguous()).unwrap()
-            );
+            println!("{}", sample.payload().deserialize::<String>().unwrap());
             for (k, v) in sample.attachment().unwrap() {
                 assert!(k.iter().rev().zip(v.as_slice()).all(|(k, v)| k == v))
             }
@@ -59,13 +56,10 @@ fn queries() {
         .callback(|query| {
             println!(
                 "{}",
-                std::str::from_utf8(
-                    &query
-                        .value()
-                        .map(|q| q.payload.contiguous())
-                        .unwrap_or_default()
-                )
-                .unwrap()
+                query
+                    .value()
+                    .map(|q| q.payload.deserialize::<String>().unwrap())
+                    .unwrap_or_default()
             );
             let mut attachment = Attachment::new();
             for (k, v) in query.attachment().unwrap() {


### PR DESCRIPTION
This PR removes the `Deref`/`DerefMut` of `Payload` to `ZBuf`.
It adds explicit `len()` and `reader()` operations.
It also improves some serialization/deserialization.