### PR TITLE
clippy warning fix

### DIFF
--- a/commons/zenoh-macros/build.rs
+++ b/commons/zenoh-macros/build.rs
@@ -24,6 +24,7 @@ fn main() {
     let mut version_rs = OpenOptions::new()
         .create(true)
         .write(true)
+        .truncate(true)
         .open(version_rs)
         .unwrap();
     version_rs.write_all(&output.stdout).unwrap();


### PR DESCRIPTION
Fix for new clippy warning
```
> cargo +stable clippy --all-targets -- --deny warnings

   Compiling zenoh-macros v0.11.0-dev (/home/milyin/ZS/zenoh/commons/zenoh-macros)
error: file opened with `create`, but `truncate` behavior not defined
  --> commons/zenoh-macros/build.rs:25:10
   |
25 |         .create(true)
   |          ^^^^^^^^^^^^- help: add: `.truncate(true)`
   |
   = help: if you intend to overwrite an existing file entirely, call `.truncate(true)`
   = help: if you instead know that you may want to keep some parts of the old file, call `.truncate(false)`
```