### PR TITLE
Protocol batchsize

### DIFF
--- a/commons/zenoh-protocol/src/transport/init.rs
+++ b/commons/zenoh-protocol/src/transport/init.rs
@@ -165,7 +165,7 @@ impl InitSyn {
         let whatami = WhatAmI::rand();
         let zid = ZenohId::default();
         let resolution = Resolution::rand();
-        let batch_size: u16 = rng.gen();
+        let batch_size: BatchSize = rng.gen();
         let ext_qos = rng.gen_bool(0.5).then_some(ZExtUnit::rand());
         let ext_shm = rng.gen_bool(0.5).then_some(ZExtZBuf::rand());
         let ext_auth = rng.gen_bool(0.5).then_some(ZExtZBuf::rand());
@@ -221,7 +221,7 @@ impl InitAck {
         } else {
             Resolution::rand()
         };
-        let batch_size: u16 = rng.gen();
+        let batch_size: BatchSize = rng.gen();
         let cookie = ZSlice::rand(64);
         let ext_qos = rng.gen_bool(0.5).then_some(ZExtUnit::rand());
         let ext_shm = rng.gen_bool(0.5).then_some(ZExtZBuf::rand());

--- a/commons/zenoh-protocol/src/transport/join.rs
+++ b/commons/zenoh-protocol/src/transport/join.rs
@@ -141,7 +141,7 @@ impl Join {
         let whatami = WhatAmI::rand();
         let zid = ZenohId::default();
         let resolution = Resolution::rand();
-        let batch_size: u16 = rng.gen();
+        let batch_size: BatchSize = rng.gen();
         let lease = if rng.gen_bool(0.5) {
             Duration::from_secs(rng.gen())
         } else {

--- a/commons/zenoh-protocol/src/transport/mod.rs
+++ b/commons/zenoh-protocol/src/transport/mod.rs
@@ -39,6 +39,7 @@ use crate::network::NetworkMessage;
 ///       the boundary of the serialized messages. The length is encoded as little-endian.
 ///       In any case, the length of a message must not exceed 65_535 bytes.
 pub type BatchSize = u16;
+pub type AtomicBatchSize = core::sync::atomic::AtomicU16;
 
 pub mod batch_size {
     use super::BatchSize;

--- a/io/zenoh-link-commons/src/lib.rs
+++ b/io/zenoh-link-commons/src/lib.rs
@@ -32,6 +32,7 @@ pub use multicast::*;
 use serde::Serialize;
 pub use unicast::*;
 use zenoh_protocol::core::Locator;
+use zenoh_protocol::transport::BatchSize;
 use zenoh_result::ZResult;
 
 /*************************************/
@@ -45,7 +46,7 @@ pub struct Link {
     pub src: Locator,
     pub dst: Locator,
     pub group: Option<Locator>,
-    pub mtu: u16,
+    pub mtu: BatchSize,
     pub is_reliable: bool,
     pub is_streamed: bool,
     pub interfaces: Vec<String>,

--- a/io/zenoh-link-commons/src/multicast.rs
+++ b/io/zenoh-link-commons/src/multicast.rs
@@ -22,7 +22,7 @@ use zenoh_buffers::{reader::HasReader, writer::HasWriter};
 use zenoh_codec::{RCodec, WCodec, Zenoh080};
 use zenoh_protocol::{
     core::{EndPoint, Locator},
-    transport::TransportMessage,
+    transport::{BatchSize, TransportMessage},
 };
 use zenoh_result::{zerror, ZResult};
 
@@ -44,7 +44,7 @@ pub struct LinkMulticast(pub Arc<dyn LinkMulticastTrait>);
 
 #[async_trait]
 pub trait LinkMulticastTrait: Send + Sync {
-    fn get_mtu(&self) -> u16;
+    fn get_mtu(&self) -> BatchSize;
     fn get_src(&self) -> &Locator;
     fn get_dst(&self) -> &Locator;
     fn is_reliable(&self) -> bool;

--- a/io/zenoh-link-commons/src/unicast.rs
+++ b/io/zenoh-link-commons/src/unicast.rs
@@ -19,7 +19,10 @@ use core::{
     ops::Deref,
 };
 use std::net::SocketAddr;
-use zenoh_protocol::core::{EndPoint, Locator};
+use zenoh_protocol::{
+    core::{EndPoint, Locator},
+    transport::BatchSize,
+};
 use zenoh_result::ZResult;
 
 pub type LinkManagerUnicast = Arc<dyn LinkManagerUnicastTrait>;
@@ -41,7 +44,7 @@ pub struct LinkUnicast(pub Arc<dyn LinkUnicastTrait>);
 
 #[async_trait]
 pub trait LinkUnicastTrait: Send + Sync {
-    fn get_mtu(&self) -> u16;
+    fn get_mtu(&self) -> BatchSize;
     fn get_src(&self) -> &Locator;
     fn get_dst(&self) -> &Locator;
     fn is_reliable(&self) -> bool;

--- a/io/zenoh-links/zenoh-link-quic/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/lib.rs
@@ -28,9 +28,12 @@ use std::net::SocketAddr;
 use zenoh_config::Config;
 use zenoh_core::zconfigurable;
 use zenoh_link_commons::{ConfigurationInspector, LocatorInspector};
-use zenoh_protocol::core::{
-    endpoint::{Address, Parameters},
-    Locator,
+use zenoh_protocol::{
+    core::{
+        endpoint::{Address, Parameters},
+        Locator,
+    },
+    transport::BatchSize,
 };
 use zenoh_result::{bail, zerror, ZResult};
 
@@ -47,7 +50,7 @@ pub const ALPN_QUIC_HTTP: &[&[u8]] = &[b"hq-29"];
 //       adopted in Zenoh and the usage of 16 bits in Zenoh to encode the
 //       payload length in byte-streamed, the QUIC MTU is constrained to
 //       2^16 - 1 bytes (i.e., 65535).
-const QUIC_MAX_MTU: u16 = u16::MAX;
+const QUIC_MAX_MTU: BatchSize = BatchSize::MAX;
 pub const QUIC_LOCATOR_PREFIX: &str = "quic";
 
 #[derive(Default, Clone, Copy, Debug)]
@@ -137,7 +140,7 @@ impl ConfigurationInspector<Config> for QuicConfigurator {
 
 zconfigurable! {
     // Default MTU (QUIC PDU) in bytes.
-    static ref QUIC_DEFAULT_MTU: u16 = QUIC_MAX_MTU;
+    static ref QUIC_DEFAULT_MTU: BatchSize = QUIC_MAX_MTU;
     // The LINGER option causes the shutdown() call to block until (1) all application data is delivered
     // to the remote end or (2) a timeout expires. The timeout is expressed in seconds.
     // More info on the LINGER option and its dynamics can be found at:

--- a/io/zenoh-links/zenoh-link-quic/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/unicast.rs
@@ -34,6 +34,7 @@ use zenoh_link_commons::{
     ListenersUnicastIP, NewLinkChannelSender,
 };
 use zenoh_protocol::core::{EndPoint, Locator};
+use zenoh_protocol::transport::BatchSize;
 use zenoh_result::{bail, zerror, ZError, ZResult};
 
 pub struct LinkUnicastQuic {
@@ -135,7 +136,7 @@ impl LinkUnicastTrait for LinkUnicastQuic {
     }
 
     #[inline(always)]
-    fn get_mtu(&self) -> u16 {
+    fn get_mtu(&self) -> BatchSize {
         *QUIC_DEFAULT_MTU
     }
 

--- a/io/zenoh-links/zenoh-link-serial/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-serial/src/lib.rs
@@ -25,10 +25,11 @@ pub use unicast::*;
 use zenoh_core::zconfigurable;
 use zenoh_link_commons::LocatorInspector;
 use zenoh_protocol::core::{endpoint::Address, EndPoint, Locator};
+use zenoh_protocol::transport::BatchSize;
 use zenoh_result::ZResult;
 
 // Maximum MTU (Serial PDU) in bytes.
-const SERIAL_MAX_MTU: u16 = z_serial::MAX_MTU as u16;
+const SERIAL_MAX_MTU: BatchSize = z_serial::MAX_MTU as BatchSize;
 
 const DEFAULT_BAUDRATE: u32 = 9_600;
 
@@ -36,11 +37,11 @@ const DEFAULT_EXCLUSIVE: bool = true;
 
 pub const SERIAL_LOCATOR_PREFIX: &str = "serial";
 
-const SERIAL_MTU_LIMIT: u16 = SERIAL_MAX_MTU;
+const SERIAL_MTU_LIMIT: BatchSize = SERIAL_MAX_MTU;
 
 zconfigurable! {
     // Default MTU (UDP PDU) in bytes.
-    static ref SERIAL_DEFAULT_MTU: u16 = SERIAL_MTU_LIMIT;
+    static ref SERIAL_DEFAULT_MTU: BatchSize = SERIAL_MTU_LIMIT;
     // Amount of time in microseconds to throttle the accept loop upon an error.
     // Default set to 100 ms.
     static ref SERIAL_ACCEPT_THROTTLE_TIME: u64 = 100_000;

--- a/io/zenoh-links/zenoh-link-serial/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-serial/src/unicast.rs
@@ -30,6 +30,7 @@ use zenoh_link_commons::{
     NewLinkChannelSender,
 };
 use zenoh_protocol::core::{EndPoint, Locator};
+use zenoh_protocol::transport::BatchSize;
 use zenoh_result::{zerror, ZResult};
 
 use z_serial::ZSerial;
@@ -177,7 +178,7 @@ impl LinkUnicastTrait for LinkUnicastSerial {
     }
 
     #[inline(always)]
-    fn get_mtu(&self) -> u16 {
+    fn get_mtu(&self) -> BatchSize {
         *SERIAL_DEFAULT_MTU
     }
 

--- a/io/zenoh-links/zenoh-link-tcp/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/lib.rs
@@ -22,6 +22,7 @@ use std::net::SocketAddr;
 use zenoh_core::zconfigurable;
 use zenoh_link_commons::LocatorInspector;
 use zenoh_protocol::core::{endpoint::Address, Locator};
+use zenoh_protocol::transport::BatchSize;
 use zenoh_result::{zerror, ZResult};
 
 mod unicast;
@@ -33,7 +34,7 @@ pub use unicast::*;
 //       adopted in Zenoh and the usage of 16 bits in Zenoh to encode the
 //       payload length in byte-streamed, the TCP MTU is constrained to
 //       2^16 - 1 bytes (i.e., 65535).
-const TCP_MAX_MTU: u16 = u16::MAX;
+const TCP_MAX_MTU: BatchSize = BatchSize::MAX;
 
 pub const TCP_LOCATOR_PREFIX: &str = "tcp";
 
@@ -52,7 +53,7 @@ impl LocatorInspector for TcpLocatorInspector {
 
 zconfigurable! {
     // Default MTU (TCP PDU) in bytes.
-    static ref TCP_DEFAULT_MTU: u16 = TCP_MAX_MTU;
+    static ref TCP_DEFAULT_MTU: BatchSize = TCP_MAX_MTU;
     // The LINGER option causes the shutdown() call to block until (1) all application data is delivered
     // to the remote end or (2) a timeout expires. The timeout is expressed in seconds.
     // More info on the LINGER option and its dynamics can be found at:

--- a/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
@@ -25,6 +25,7 @@ use zenoh_link_commons::{
     ListenersUnicastIP, NewLinkChannelSender, BIND_INTERFACE,
 };
 use zenoh_protocol::core::{EndPoint, Locator};
+use zenoh_protocol::transport::BatchSize;
 use zenoh_result::{bail, zerror, Error as ZError, ZResult};
 
 use super::{
@@ -145,7 +146,7 @@ impl LinkUnicastTrait for LinkUnicastTcp {
     }
 
     #[inline(always)]
-    fn get_mtu(&self) -> u16 {
+    fn get_mtu(&self) -> BatchSize {
         *TCP_DEFAULT_MTU
     }
 

--- a/io/zenoh-links/zenoh-link-tls/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/lib.rs
@@ -30,9 +30,12 @@ use std::{convert::TryFrom, net::SocketAddr};
 use zenoh_config::Config;
 use zenoh_core::zconfigurable;
 use zenoh_link_commons::{ConfigurationInspector, LocatorInspector};
-use zenoh_protocol::core::{
-    endpoint::{self, Address},
-    Locator,
+use zenoh_protocol::{
+    core::{
+        endpoint::{self, Address},
+        Locator,
+    },
+    transport::BatchSize,
 };
 use zenoh_result::{bail, zerror, ZResult};
 
@@ -45,7 +48,7 @@ pub use unicast::*;
 //       adopted in Zenoh and the usage of 16 bits in Zenoh to encode the
 //       payload length in byte-streamed, the TLS MTU is constrained to
 //       2^16 - 1 bytes (i.e., 65535).
-const TLS_MAX_MTU: u16 = u16::MAX;
+const TLS_MAX_MTU: BatchSize = BatchSize::MAX;
 pub const TLS_LOCATOR_PREFIX: &str = "tls";
 
 #[derive(Default, Clone, Copy)]
@@ -172,7 +175,7 @@ impl ConfigurationInspector<Config> for TlsConfigurator {
 
 zconfigurable! {
     // Default MTU (TLS PDU) in bytes.
-    static ref TLS_DEFAULT_MTU: u16 = TLS_MAX_MTU;
+    static ref TLS_DEFAULT_MTU: BatchSize = TLS_MAX_MTU;
     // The LINGER option causes the shutdown() call to block until (1) all application data is delivered
     // to the remote end or (2) a timeout expires. The timeout is expressed in seconds.
     // More info on the LINGER option and its dynamics can be found at:

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -42,8 +42,8 @@ use zenoh_link_commons::{
     get_ip_interface_names, LinkManagerUnicastTrait, LinkUnicast, LinkUnicastTrait,
     ListenersUnicastIP, NewLinkChannelSender,
 };
-use zenoh_protocol::core::endpoint::Config;
 use zenoh_protocol::core::{EndPoint, Locator};
+use zenoh_protocol::{core::endpoint::Config, transport::BatchSize};
 use zenoh_result::{bail, zerror, ZError, ZResult};
 
 pub struct LinkUnicastTls {
@@ -180,7 +180,7 @@ impl LinkUnicastTrait for LinkUnicastTls {
     }
 
     #[inline(always)]
-    fn get_mtu(&self) -> u16 {
+    fn get_mtu(&self) -> BatchSize {
         *TLS_DEFAULT_MTU
     }
 

--- a/io/zenoh-links/zenoh-link-udp/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/lib.rs
@@ -27,6 +27,7 @@ pub use unicast::*;
 use zenoh_core::zconfigurable;
 use zenoh_link_commons::LocatorInspector;
 use zenoh_protocol::core::{endpoint::Address, Locator};
+use zenoh_protocol::transport::BatchSize;
 use zenoh_result::{zerror, ZResult};
 
 // NOTE: In case of using UDP in high-throughput scenarios, it is recommended to set the
@@ -44,24 +45,24 @@ use zenoh_result::{zerror, ZResult};
 //       Although in IPv6 it is possible to have UDP datagrams of size greater than 65,535 bytes via
 //       IPv6 Jumbograms, its usage in Zenoh is discouraged unless the consequences are very well
 //       understood.
-const UDP_MAX_MTU: u16 = 65_507;
+const UDP_MAX_MTU: BatchSize = 65_507;
 
 pub const UDP_LOCATOR_PREFIX: &str = "udp";
 
 #[cfg(any(target_os = "linux", target_os = "windows"))]
 // Linux default value of a maximum datagram size is set to UDP MAX MTU.
-const UDP_MTU_LIMIT: u16 = UDP_MAX_MTU;
+const UDP_MTU_LIMIT: BatchSize = UDP_MAX_MTU;
 
 #[cfg(target_os = "macos")]
 // Mac OS X default value of a maximum datagram size is set to 9216 bytes.
-const UDP_MTU_LIMIT: u16 = 9_216;
+const UDP_MTU_LIMIT: BatchSize = 9_216;
 
 #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
-const UDP_MTU_LIMIT: u16 = 8_192;
+const UDP_MTU_LIMIT: BatchSize = 8_192;
 
 zconfigurable! {
     // Default MTU (UDP PDU) in bytes.
-    static ref UDP_DEFAULT_MTU: u16 = UDP_MTU_LIMIT;
+    static ref UDP_DEFAULT_MTU: BatchSize = UDP_MTU_LIMIT;
     // Amount of time in microseconds to throttle the accept loop upon an error.
     // Default set to 100 ms.
     static ref UDP_ACCEPT_THROTTLE_TIME: u64 = 100_000;

--- a/io/zenoh-links/zenoh-link-udp/src/multicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/multicast.rs
@@ -21,6 +21,7 @@ use std::{borrow::Cow, fmt};
 use tokio::net::UdpSocket;
 use zenoh_link_commons::{LinkManagerMulticastTrait, LinkMulticast, LinkMulticastTrait};
 use zenoh_protocol::core::{Config, EndPoint, Locator};
+use zenoh_protocol::transport::BatchSize;
 use zenoh_result::{bail, zerror, Error as ZError, ZResult};
 
 pub struct LinkMulticastUdp {
@@ -119,7 +120,7 @@ impl LinkMulticastTrait for LinkMulticastUdp {
     }
 
     #[inline(always)]
-    fn get_mtu(&self) -> u16 {
+    fn get_mtu(&self) -> BatchSize {
         *UDP_DEFAULT_MTU
     }
 

--- a/io/zenoh-links/zenoh-link-udp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/unicast.rs
@@ -30,6 +30,7 @@ use zenoh_link_commons::{
     LinkUnicastTrait, ListenersUnicastIP, NewLinkChannelSender, BIND_INTERFACE,
 };
 use zenoh_protocol::core::{EndPoint, Locator};
+use zenoh_protocol::transport::BatchSize;
 use zenoh_result::{bail, zerror, Error as ZError, ZResult};
 use zenoh_sync::Mvar;
 
@@ -200,7 +201,7 @@ impl LinkUnicastTrait for LinkUnicastUdp {
     }
 
     #[inline(always)]
-    fn get_mtu(&self) -> u16 {
+    fn get_mtu(&self) -> BatchSize {
         *UDP_DEFAULT_MTU
     }
 

--- a/io/zenoh-links/zenoh-link-unixpipe/src/unix/unicast.rs
+++ b/io/zenoh-links/zenoh-link-unixpipe/src/unix/unicast.rs
@@ -33,6 +33,7 @@ use tokio::io::Interest;
 use tokio_util::sync::CancellationToken;
 use zenoh_core::{zasyncread, zasyncwrite};
 use zenoh_protocol::core::{EndPoint, Locator};
+use zenoh_protocol::transport::BatchSize;
 use zenoh_runtime::ZRuntime;
 
 use unix_named_pipe::{create, open_write};
@@ -45,7 +46,7 @@ use zenoh_result::{bail, ZResult};
 
 use super::FILE_ACCESS_MASK;
 
-const LINUX_PIPE_MAX_MTU: u16 = 65_535;
+const LINUX_PIPE_MAX_MTU: BatchSize = BatchSize::MAX;
 const LINUX_PIPE_DEDICATE_TRIES: usize = 100;
 
 static PIPE_INVITATION: &[u8] = &[0xDE, 0xAD, 0xBE, 0xEF];
@@ -498,7 +499,7 @@ impl LinkUnicastTrait for UnicastPipe {
     }
 
     #[inline(always)]
-    fn get_mtu(&self) -> u16 {
+    fn get_mtu(&self) -> BatchSize {
         LINUX_PIPE_MAX_MTU
     }
 

--- a/io/zenoh-links/zenoh-link-unixsock_stream/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-unixsock_stream/src/lib.rs
@@ -21,6 +21,7 @@ use async_trait::async_trait;
 use zenoh_core::zconfigurable;
 use zenoh_link_commons::LocatorInspector;
 use zenoh_protocol::core::{endpoint::Address, Locator};
+use zenoh_protocol::transport::BatchSize;
 use zenoh_result::ZResult;
 #[cfg(target_family = "unix")]
 mod unicast;
@@ -33,13 +34,13 @@ pub use unicast::*;
 //       adopted in Zenoh and the usage of 16 bits in Zenoh to encode the
 //       payload length in byte-streamed, the UNIXSOCKSTREAM MTU is constrained to
 //       2^16 - 1 bytes (i.e., 65535).
-const UNIXSOCKSTREAM_MAX_MTU: u16 = u16::MAX;
+const UNIXSOCKSTREAM_MAX_MTU: BatchSize = BatchSize::MAX;
 
 pub const UNIXSOCKSTREAM_LOCATOR_PREFIX: &str = "unixsock-stream";
 
 zconfigurable! {
     // Default MTU (UNIXSOCKSTREAM PDU) in bytes.
-    static ref UNIXSOCKSTREAM_DEFAULT_MTU: u16 = UNIXSOCKSTREAM_MAX_MTU;
+    static ref UNIXSOCKSTREAM_DEFAULT_MTU: BatchSize = UNIXSOCKSTREAM_MAX_MTU;
     // Amount of time in microseconds to throttle the accept loop upon an error.
     // Default set to 100 ms.
     static ref UNIXSOCKSTREAM_ACCEPT_THROTTLE_TIME: u64 = 100_000;

--- a/io/zenoh-links/zenoh-link-unixsock_stream/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-unixsock_stream/src/unicast.rs
@@ -32,6 +32,7 @@ use zenoh_link_commons::{
     LinkManagerUnicastTrait, LinkUnicast, LinkUnicastTrait, NewLinkChannelSender,
 };
 use zenoh_protocol::core::{EndPoint, Locator};
+use zenoh_protocol::transport::BatchSize;
 use zenoh_result::{zerror, ZResult};
 
 use super::{get_unix_path_as_string, UNIXSOCKSTREAM_DEFAULT_MTU, UNIXSOCKSTREAM_LOCATOR_PREFIX};
@@ -119,7 +120,7 @@ impl LinkUnicastTrait for LinkUnicastUnixSocketStream {
     }
 
     #[inline(always)]
-    fn get_mtu(&self) -> u16 {
+    fn get_mtu(&self) -> BatchSize {
         *UNIXSOCKSTREAM_DEFAULT_MTU
     }
 

--- a/io/zenoh-links/zenoh-link-vsock/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-vsock/src/lib.rs
@@ -22,7 +22,7 @@
 use async_trait::async_trait;
 use zenoh_core::zconfigurable;
 use zenoh_link_commons::LocatorInspector;
-use zenoh_protocol::core::Locator;
+use zenoh_protocol::{core::Locator, transport::BatchSize};
 use zenoh_result::ZResult;
 
 #[cfg(target_os = "linux")]
@@ -47,7 +47,7 @@ impl LocatorInspector for VsockLocatorInspector {
 
 zconfigurable! {
     // Default MTU in bytes.
-    static ref VSOCK_DEFAULT_MTU: u16 = u16::MAX;
+    static ref VSOCK_DEFAULT_MTU: BatchSize = BatchSize::MAX;
     // Amount of time in microseconds to throttle the accept loop upon an error.
     // Default set to 100 ms.
     static ref VSOCK_ACCEPT_THROTTLE_TIME: u64 = 100_000;

--- a/io/zenoh-links/zenoh-link-vsock/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-vsock/src/unicast.rs
@@ -27,8 +27,10 @@ use zenoh_core::{zasyncread, zasyncwrite};
 use zenoh_link_commons::{
     LinkManagerUnicastTrait, LinkUnicast, LinkUnicastTrait, NewLinkChannelSender,
 };
-use zenoh_protocol::core::endpoint::Address;
-use zenoh_protocol::core::{EndPoint, Locator};
+use zenoh_protocol::{
+    core::{endpoint::Address, EndPoint, Locator},
+    transport::BatchSize,
+};
 use zenoh_result::{bail, zerror, ZResult};
 
 use super::{VSOCK_ACCEPT_THROTTLE_TIME, VSOCK_DEFAULT_MTU, VSOCK_LOCATOR_PREFIX};
@@ -170,7 +172,7 @@ impl LinkUnicastTrait for LinkUnicastVsock {
     }
 
     #[inline(always)]
-    fn get_mtu(&self) -> u16 {
+    fn get_mtu(&self) -> BatchSize {
         *VSOCK_DEFAULT_MTU
     }
 

--- a/io/zenoh-links/zenoh-link-ws/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-ws/src/lib.rs
@@ -23,6 +23,7 @@ use url::Url;
 use zenoh_core::zconfigurable;
 use zenoh_link_commons::LocatorInspector;
 use zenoh_protocol::core::{endpoint::Address, Locator};
+use zenoh_protocol::transport::BatchSize;
 use zenoh_result::{bail, ZResult};
 mod unicast;
 pub use unicast::*;
@@ -33,7 +34,7 @@ pub use unicast::*;
 //       adopted in Zenoh and the usage of 16 bits in Zenoh to encode the
 //       payload length in byte-streamed, the TCP MTU is constrained to
 //       2^16 - 1 bytes (i.e., 65535).
-const WS_MAX_MTU: u16 = u16::MAX;
+const WS_MAX_MTU: BatchSize = BatchSize::MAX;
 
 pub const WS_LOCATOR_PREFIX: &str = "ws";
 
@@ -51,7 +52,7 @@ impl LocatorInspector for WsLocatorInspector {
 
 zconfigurable! {
     // Default MTU (TCP PDU) in bytes.
-    static ref WS_DEFAULT_MTU: u16 = WS_MAX_MTU;
+    static ref WS_DEFAULT_MTU: BatchSize = WS_MAX_MTU;
     // Amount of time in microseconds to throttle the accept loop upon an error.
     // Default set to 100 ms.
     static ref TCP_ACCEPT_THROTTLE_TIME: u64 = 100_000;

--- a/io/zenoh-links/zenoh-link-ws/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-ws/src/unicast.rs
@@ -34,6 +34,7 @@ use zenoh_link_commons::{
     LinkManagerUnicastTrait, LinkUnicast, LinkUnicastTrait, NewLinkChannelSender,
 };
 use zenoh_protocol::core::{EndPoint, Locator};
+use zenoh_protocol::transport::BatchSize;
 use zenoh_result::{bail, zerror, ZResult};
 
 use super::{get_ws_addr, get_ws_url, TCP_ACCEPT_THROTTLE_TIME, WS_DEFAULT_MTU, WS_LOCATOR_PREFIX};
@@ -200,7 +201,7 @@ impl LinkUnicastTrait for LinkUnicastWs {
     }
 
     #[inline(always)]
-    fn get_mtu(&self) -> u16 {
+    fn get_mtu(&self) -> BatchSize {
         *WS_DEFAULT_MTU
     }
 

--- a/io/zenoh-transport/src/manager.rs
+++ b/io/zenoh-transport/src/manager.rs
@@ -93,7 +93,7 @@ pub struct TransportManagerConfig {
     pub zid: ZenohId,
     pub whatami: WhatAmI,
     pub resolution: Resolution,
-    pub batch_size: u16,
+    pub batch_size: BatchSize,
     pub wait_before_drop: Duration,
     pub queue_size: [usize; Priority::NUM],
     pub queue_backoff: Duration,
@@ -122,7 +122,7 @@ pub struct TransportManagerBuilder {
     zid: ZenohId,
     whatami: WhatAmI,
     resolution: Resolution,
-    batch_size: u16,
+    batch_size: BatchSize,
     wait_before_drop: Duration,
     queue_size: QueueSizeConf,
     queue_backoff: Duration,
@@ -151,7 +151,7 @@ impl TransportManagerBuilder {
         self
     }
 
-    pub fn batch_size(mut self, batch_size: u16) -> Self {
+    pub fn batch_size(mut self, batch_size: BatchSize) -> Self {
         self.batch_size = batch_size;
         self
     }

--- a/io/zenoh-transport/src/unicast/establishment/cookie.rs
+++ b/io/zenoh-transport/src/unicast/establishment/cookie.rs
@@ -19,14 +19,17 @@ use zenoh_buffers::{
 };
 use zenoh_codec::{RCodec, WCodec, Zenoh080};
 use zenoh_crypto::{BlockCipher, PseudoRng};
-use zenoh_protocol::core::{Resolution, WhatAmI, ZenohId};
+use zenoh_protocol::{
+    core::{Resolution, WhatAmI, ZenohId},
+    transport::BatchSize,
+};
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct Cookie {
     pub(crate) zid: ZenohId,
     pub(crate) whatami: WhatAmI,
     pub(crate) resolution: Resolution,
-    pub(crate) batch_size: u16,
+    pub(crate) batch_size: BatchSize,
     pub(crate) nonce: u64,
     // Extensions
     pub(crate) ext_qos: ext::qos::StateAccept,
@@ -82,7 +85,7 @@ where
         let whatami = WhatAmI::try_from(wai).map_err(|_| DidntRead)?;
         let resolution: u8 = self.read(&mut *reader)?;
         let resolution = Resolution::from(resolution);
-        let batch_size: u16 = self.read(&mut *reader)?;
+        let batch_size: BatchSize = self.read(&mut *reader)?;
         let nonce: u64 = self.read(&mut *reader)?;
         // Extensions
         let ext_qos: ext::qos::StateAccept = self.read(&mut *reader)?;


### PR DESCRIPTION
Use already existing `BatchSize` typedef instead of `u16` to abstract the actual type.