### PR TITLE
Squash merge sync-lockfile prs, provide zenoh HEAD hash & date

### DIFF
--- a/.github/workflows/sync-lockfiles.yml
+++ b/.github/workflows/sync-lockfiles.yml
@@ -18,12 +18,21 @@ jobs:
   fetch:
     name: Fetch Zenoh's lockfile
     runs-on: ubuntu-latest
+    outputs:
+      zenoh-head-hash: ${{ steps.info.outputs.head-hash }}
+      zenoh-head-date: ${{ steps.info.outputs.head-date }}
     steps:
       - name: Checkout Zenoh
         uses: actions/checkout@v4
         with:
           repository: eclipse-zenoh/zenoh
           ref: ${{ inputs.branch }}
+
+      - id: info
+        name: Get HEAD info
+        run: |
+          echo "head-hash=$(git log -1 --format=%h)" >> $GITHUB_OUTPUT
+          echo "head-date=$(git log -1 --format=%ad)" >> $GITHUB_OUTPUT
 
       - name: Upload lockfile
         uses: actions/upload-artifact@v3
@@ -94,8 +103,14 @@ jobs:
         # NOTE: If there is a pending PR, this action will simply update it with a forced push.
         uses: peter-evans/create-pull-request@v6
         with:
-          title: Sync lockfile with Zenoh's
-          body: Automated synchronization of the Cargo lockfile with Zenoh. This is done to ensure plugin ABI compatibility.
+          title: Sync Cargo lockfile with Zenoh's
+          body: >
+            This pull request synchronizes ${{ matrix.dependant }}'s Cargo lockfile with zenoh's.
+            This is done to ensure ABI compatibility between Zenoh applications, backends & plugins.
+
+            - **Zenoh HEAD hash**: eclipse-zenoh/zenoh@${{ needs.fetch.outputs.zenoh-head-hash }}
+            - **Zenoh HEAD date**: ${{ needs.fetch.outputs.zenoh-head-date }}
+            - **Workflow run**: [${{ github.run_id }}](https://github.com/eclipse-zenoh/zenoh/actions/runs/${{ github.run_id }})
           commit-message: "chore: Sync Cargo lockfile with Zenoh's"
           committer: eclipse-zenoh-bot <eclipse-zenoh-bot@users.noreply.github.com>
           author: eclipse-zenoh-bot <eclipse-zenoh-bot@users.noreply.github.com>
@@ -107,6 +122,11 @@ jobs:
 
       - name: Enable auto merge for the pull request
         if: steps.cpr.outputs.pull-request-operation == 'created'
-        run: gh pr merge -R "eclipse-zenoh/${{ matrix.dependant }}" --merge --auto "${{ steps.cpr.outputs.pull-request-number }}"
+        run: >
+          gh pr merge "${{ steps.cpr.outputs.pull-request-number }}"
+            --repo "eclipse-zenoh/${{ matrix.dependant }}"
+            --subject "Sync `Cargo.lock` with eclipse-zenoh/zenoh@${{ needs.fetch.outputs.zenoh-head-hash }} from ${{ needs.fetch.outputs.zenoh-head-date }} (${{ steps.cpr.outputs.pull-request-number }})"
+            --squash
+            --auto
         env:
           GH_TOKEN: ${{ secrets.BOT_TOKEN_WORKFLOW }}

--- a/.github/workflows/sync-lockfiles.yml
+++ b/.github/workflows/sync-lockfiles.yml
@@ -103,7 +103,7 @@ jobs:
         # NOTE: If there is a pending PR, this action will simply update it with a forced push.
         uses: peter-evans/create-pull-request@v6
         with:
-          title: Sync Cargo lockfile with Zenoh's
+          title: Sync `Cargo.lock` with `eclipse-zenoh/zenoh@${{ needs.fetch.outputs.zenoh-head-hash }}` from `${{ needs.fetch.outputs.zenoh-head-date }}`"
           body: >
             This pull request synchronizes ${{ matrix.dependant }}'s Cargo lockfile with zenoh's.
             This is done to ensure ABI compatibility between Zenoh applications, backends & plugins.
@@ -125,7 +125,6 @@ jobs:
         run: >
           gh pr merge "${{ steps.cpr.outputs.pull-request-number }}"
             --repo "eclipse-zenoh/${{ matrix.dependant }}"
-            --subject "Sync `Cargo.lock` with eclipse-zenoh/zenoh@${{ needs.fetch.outputs.zenoh-head-hash }} from `${{ needs.fetch.outputs.zenoh-head-date }}` (#${{ steps.cpr.outputs.pull-request-number }})"
             --squash
             --auto
         env:

--- a/.github/workflows/sync-lockfiles.yml
+++ b/.github/workflows/sync-lockfiles.yml
@@ -125,7 +125,7 @@ jobs:
         run: >
           gh pr merge "${{ steps.cpr.outputs.pull-request-number }}"
             --repo "eclipse-zenoh/${{ matrix.dependant }}"
-            --subject "Sync `Cargo.lock` with eclipse-zenoh/zenoh@${{ needs.fetch.outputs.zenoh-head-hash }} from ${{ needs.fetch.outputs.zenoh-head-date }} (${{ steps.cpr.outputs.pull-request-number }})"
+            --subject "Sync `Cargo.lock` with eclipse-zenoh/zenoh@${{ needs.fetch.outputs.zenoh-head-hash }} from `${{ needs.fetch.outputs.zenoh-head-date }}` (#${{ steps.cpr.outputs.pull-request-number }})"
             --squash
             --auto
         env:


### PR DESCRIPTION
This pull request changes the sync-lockfiles workflow to use squash commits instead of merge commits and include the sync'd zenoh HEAD hash and date in the squash commit.