### PR TITLE
feat: use GitHub's markdown alerts for warnings in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ Then you can start run `zenohd`.
 -------------------------------
 ## How to build it
 
-> :warning: **WARNING** :warning: : Zenoh and its ecosystem are under active development. When you build from git, make sure you also build from git any other Zenoh repository you plan to use (e.g. binding, plugin, backend, etc.). It may happen that some changes in git are not compatible with the most recent packaged Zenoh release (e.g. deb, docker, pip). We put particular effort in mantaining compatibility between the various git repositories in the Zenoh project.
+> [!WARNING]
+> Zenoh and its ecosystem are under active development. When you build from git, make sure you also build from git any other Zenoh repository you plan to use (e.g. binding, plugin, backend, etc.). It may happen that some changes in git are not compatible with the most recent packaged Zenoh release (e.g. deb, docker, pip). We put particular effort in mantaining compatibility between the various git repositories in the Zenoh project.
 
 Install [Cargo and Rust](https://doc.rust-lang.org/cargo/getting-started/installation.html). Zenoh can be succesfully compiled with Rust stable (>= 1.71.0), so no special configuration is required from your side. If you already have the Rust toolchain installed, make sure it is up-to-date with:
 
@@ -94,6 +95,7 @@ Zenoh's router is built as `target/release/zenohd`. All the examples are built i
 
 **Routed tests:**
 
+> [!NOTE]
 > **Windows users**: to properly execute the commands below in PowerShell you need to escape `"` characters as `\"`.
 
  - **put/store/get**
@@ -168,19 +170,22 @@ See other examples of Zenoh usage in [examples/](examples)
 
     If not specified, the REST plugin will be active on any interface (`[::]`) and port `8000`.
 
-> :warning: **WARNING** :warning: : The following documentation pertains to the v0.6+ API, which comes many changes to the behaviour and configuration of Zenoh.
+> [!WARNING]
+> The following documentation pertains to the v0.6+ API, which comes many changes to the behaviour and configuration of Zenoh.
 To access the v0.5 version of the code and matching README, please go to the [0.5.0-beta.9](https://github.com/eclipse-zenoh/zenoh/tree/0.5.0-beta.9) tagged version.
 
 -------------------------------
 ## Plugins
 
-> :warning: **WARNING** :warning: : As Rust doesn't have a stable ABI, the plugins should be
+> [!WARNING]
+> As Rust doesn't have a stable ABI, the plugins should be
 built with the exact same Rust version than `zenohd`, and using for `zenoh` dependency the same version (or commit number) than 'zenohd'.
 Otherwise, incompatibilities in memory mapping of shared types between `zenohd` and the library can lead to a `"SIGSEV"` crash.
 
 By default the Zenoh router is delivered or built with 2 plugins. These may be configured through a configuration file, or through individual changes to the configuration via the `--cfg` CLI option or via zenoh puts on individual parts of the configuration.
 
-> :warning: **WARNING** :warning: : since `v0.6`, `zenohd` no longer loads every available plugin at startup. Instead, only configured plugins are loaded (after processing `--cfg` and `--plugin` options). Once `zenohd` is running, plugins can be hot-loaded and, if they support it, reconfigured at runtime by editing their configuration through the adminspace.  
+> [!WARNING] 
+> Since `v0.6`, `zenohd` no longer loads every available plugin at startup. Instead, only configured plugins are loaded (after processing `--cfg` and `--plugin` options). Once `zenohd` is running, plugins can be hot-loaded and, if they support it, reconfigured at runtime by editing their configuration through the adminspace.  
 
 Note that the REST plugin is added to the configuration by the default value of the `--rest-http-port` CLI argument.
 


### PR DESCRIPTION
Relatively recently GitHub has added support for adding a "callout" element in markdown files ([source](https://github.com/orgs/community/discussions/16925)). I was reading the README and thought it could be something the project might be interested in using, since it has a couple of warnings in the README.


Instead of 

> :warning: Warning! :warning: : Critical content demanding immediate user attention due to potential risks.

it is shown like

> [!WARNING]
> Critical content demanding immediate user attention due to potential risks.

which in my opinion stands out more, which is why I thought you might find it interesting.

This is achieved with the following markdown

```
> [!WARNING]
> Critical content demanding immediate user attention due to potential risks.
```