### PR TITLE
Fixes for storage replication

### DIFF
--- a/plugins/zenoh-plugin-storage-manager/src/replica/align_queryable.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/align_queryable.rs
@@ -219,21 +219,36 @@ impl AlignQueryable {
             match reply.sample {
                 Ok(sample) => {
                     log::trace!(
-                        "[ALIGN QUERYABLE] Received ('{}': '{}')",
+                        "[ALIGN QUERYABLE] Received ('{}': '{}' @ {:?})",
                         sample.key_expr.as_str(),
-                        sample.value
+                        sample.value,
+                        sample.timestamp
                     );
                     if let Some(timestamp) = sample.timestamp {
                         match timestamp.cmp(&logentry.timestamp) {
-                            Ordering::Greater => return None,
+                            Ordering::Greater => {
+                                log::error!(
+                                    "[ALIGN QUERYABLE] Data in the storage is newer than requested."
+                                );
+                                return None;
+                            }
                             Ordering::Less => {
                                 log::error!(
                                     "[ALIGN QUERYABLE] Data in the storage is older than requested."
                                 );
                                 return None;
                             }
-                            Ordering::Equal => return Some(sample),
+                            Ordering::Equal => {
+                                log::debug!(
+                                    "[ALIGN QUERYABLE] Data in the storage is has good timestamp."
+                                );
+                                return Some(sample);
+                            }
                         }
+                    } else {
+                        log::error!(
+                            "[ALIGN QUERYABLE] No timestamp on log entry sample from storage."
+                        );
                     }
                 }
                 Err(err) => {

--- a/plugins/zenoh-plugin-storage-manager/src/replica/align_queryable.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/align_queryable.rs
@@ -240,7 +240,7 @@ impl AlignQueryable {
                             }
                             Ordering::Equal => {
                                 log::debug!(
-                                    "[ALIGN QUERYABLE] Data in the storage is has good timestamp."
+                                    "[ALIGN QUERYABLE] Data in the storage has a good timestamp."
                                 );
                                 return Some(sample);
                             }

--- a/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
@@ -293,7 +293,13 @@ impl Digest {
 
         // reconstruct updated parts of the digest
         for sub in subintervals_to_update {
-            let subinterval = subintervals.get_mut(&sub).unwrap();
+            let subinterval = match subintervals.get_mut(&sub) {
+                Some(subinterval) => subinterval,
+                None => {
+                    log::error!("failed to get subinterval {sub:?}");
+                    continue;
+                }
+            };
             let content = &subinterval.content;
             if !content.is_empty() {
                 // order the content, hash them
@@ -308,7 +314,13 @@ impl Digest {
         }
 
         for int in intervals_to_update {
-            let interval = intervals.get_mut(&int).unwrap();
+            let interval = match intervals.get_mut(&int) {
+                Some(interval) => interval,
+                None => {
+                    log::error!("failed to get interval: {int:?}");
+                    continue;
+                }
+            };
             let content = &interval.content;
             if !content.is_empty() {
                 // order the content, hash them
@@ -324,7 +336,13 @@ impl Digest {
         }
 
         for era_type in eras_to_update {
-            let era = eras.get_mut(&era_type).unwrap();
+            let era = match eras.get_mut(&era_type) {
+                Some(era) => era,
+                None => {
+                    log::error!("failed to get era: {era_type:?}");
+                    continue;
+                }
+            };
             let content = &era.content;
             if !content.is_empty() {
                 // order the content, hash them
@@ -659,8 +677,22 @@ impl Digest {
     // get the intervals of a given era
     pub fn get_era_content(&self, era: &EraType) -> HashMap<u64, u64> {
         let mut result = HashMap::new();
-        for int in self.eras.get(era).unwrap().content.clone() {
-            result.insert(int, self.intervals.get(&int).unwrap().checksum);
+        let content = match self.eras.get(era) {
+            Some(era) => era.content.clone(),
+            None => {
+                log::error!("failed to get era content: {era:?}");
+                return result;
+            }
+        };
+        for int in content {
+            let checksum = match self.intervals.get(&int) {
+                Some(interval) => interval.checksum,
+                None => {
+                    log::error!("failed to get interval checksum: {int:?}");
+                    continue;
+                }
+            };
+            result.insert(int, checksum);
         }
         result
     }
@@ -670,8 +702,22 @@ impl Digest {
         //return (subintervalid, checksum) for the set of intervals
         let mut result = HashMap::new();
         for each in intervals {
-            for sub in self.intervals.get(&each).unwrap().content.clone() {
-                result.insert(sub, self.subintervals.get(&sub).unwrap().checksum);
+            let content = match self.intervals.get(&each) {
+                Some(interval) => interval.content.clone(),
+                None => {
+                    log::error!("failed to get interval content: {each:?}");
+                    continue;
+                }
+            };
+            for sub in content {
+                let checksum = match self.subintervals.get(&sub) {
+                    Some(subinterval) => subinterval.checksum,
+                    None => {
+                        log::error!("failed to get subinterval checksum: {sub:?}");
+                        continue;
+                    }
+                };
+                result.insert(sub, checksum);
             }
         }
         result
@@ -684,7 +730,14 @@ impl Digest {
     ) -> HashMap<u64, BTreeSet<LogEntry>> {
         let mut result = HashMap::new();
         for each in subintervals {
-            result.insert(each, self.subintervals.get(&each).unwrap().content.clone());
+            let content = match self.subintervals.get(&each) {
+                Some(subinterval) => subinterval.content.clone(),
+                None => {
+                    log::error!("failed to get subinterval content: {each:?}");
+                    continue;
+                }
+            };
+            result.insert(each, content);
         }
         result
     }

--- a/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
@@ -154,11 +154,9 @@ impl Digest {
             HashMap::new(),
         );
         for entry in raw_log {
-            let Some(sub) = Digest::get_subinterval(
-                config.delta,
-                entry.timestamp,
-                config.sub_intervals,
-            ) else {
+            let Some(sub) =
+                Digest::get_subinterval(config.delta, entry.timestamp, config.sub_intervals)
+            else {
                 continue;
             };
             let Some(interval) = Digest::get_interval(sub, config.sub_intervals) else {
@@ -201,8 +199,7 @@ impl Digest {
                     int_content = BTreeMap::new();
                     if era != curr_era {
                         if !era_content.is_empty() {
-                            let era_hash: Vec<u64> =
-                                era_content.values().copied().collect();
+                            let era_hash: Vec<u64> = era_content.values().copied().collect();
                             let checksum = Digest::get_content_hash(&era_hash);
                             let e = Interval {
                                 checksum,
@@ -284,18 +281,13 @@ impl Digest {
             Digest::remove_deleted_content(current, deleted_content, latest_interval);
         log::trace!("Removed deleted content: {current:?}");
         // push content in correct places
-        let (
-            current,
-            mut subintervals_to_update,
-            mut intervals_to_update,
-            mut eras_to_update,
-        ) = Digest::update_new_content(current, new_content, latest_interval);
+        let (current, mut subintervals_to_update, mut intervals_to_update, mut eras_to_update) =
+            Digest::update_new_content(current, new_content, latest_interval);
 
         // move intervals into eras if changed -- iterate through hot
         // and move them to warm/cold if needed, iterate through warm
         // and move them to cold if needed
-        let (current, realigned_eras) =
-            Digest::recalculate_era_content(current, latest_interval);
+        let (current, realigned_eras) = Digest::recalculate_era_content(current, latest_interval);
 
         subintervals_to_update.extend(further_subintervals);
         intervals_to_update.extend(further_intervals);
@@ -455,8 +447,7 @@ impl Digest {
                 continue;
             };
             subintervals_to_update.insert(subinterval);
-            let Some(interval) =
-                Digest::get_interval(subinterval, current.config.sub_intervals)
+            let Some(interval) = Digest::get_interval(subinterval, current.config.sub_intervals)
             else {
                 continue;
             };
@@ -523,8 +514,7 @@ impl Digest {
                 continue;
             };
             subintervals_to_update.insert(subinterval);
-            let Some(interval) =
-                Digest::get_interval(subinterval, current.config.sub_intervals)
+            let Some(interval) = Digest::get_interval(subinterval, current.config.sub_intervals)
             else {
                 continue;
             };
@@ -578,8 +568,7 @@ impl Digest {
         for (curr_era, interval_list) in current.eras.clone() {
             if curr_era == EraType::Hot || curr_era == EraType::Warm {
                 for interval in &interval_list.content {
-                    let new_era =
-                        Digest::get_era(&current.config, latest_interval, *interval);
+                    let new_era = Digest::get_era(&current.config, latest_interval, *interval);
                     if new_era != curr_era {
                         to_modify.insert((*interval, curr_era.clone(), new_era.clone()));
                         eras_to_update.insert(curr_era.clone());
@@ -610,11 +599,7 @@ impl Digest {
     }
 
     // compute the subinterval for a given timestamp
-    fn get_subinterval(
-        delta: Duration,
-        ts: Timestamp,
-        subintervals: usize,
-    ) -> Option<u64> {
+    fn get_subinterval(delta: Duration, ts: Timestamp, subintervals: usize) -> Option<u64> {
         let ts = ts
             .get_time()
             .to_system_time()
@@ -785,11 +770,7 @@ impl Digest {
 // functions for alignment
 impl Digest {
     // check if the other era has more content
-    pub fn era_has_diff(
-        &self,
-        era: &EraType,
-        other: &HashMap<EraType, Interval>,
-    ) -> bool {
+    pub fn era_has_diff(&self, era: &EraType, other: &HashMap<EraType, Interval>) -> bool {
         match (other.get(era), self.eras.get(era)) {
             (Some(other_era), Some(my_era)) => other_era.checksum != my_era.checksum,
             (Some(_), None) => true,
@@ -813,10 +794,7 @@ impl Digest {
     }
 
     // return mismatching subintervals in an interval
-    pub fn get_subinterval_diff(
-        &self,
-        other_subintervals: HashMap<u64, u64>,
-    ) -> HashSet<u64> {
+    pub fn get_subinterval_diff(&self, other_subintervals: HashMap<u64, u64>) -> HashSet<u64> {
         let mut mis_sub = HashSet::new();
         for (key, other_sub) in &other_subintervals {
             if let Some(sub) = self.subintervals.get(key) {
@@ -844,11 +822,7 @@ impl Digest {
     }
 
     //return missing content in a subinterval
-    pub fn get_content_diff(
-        &self,
-        subinterval: u64,
-        content: Vec<LogEntry>,
-    ) -> Vec<LogEntry> {
+    pub fn get_content_diff(&self, subinterval: u64, content: Vec<LogEntry>) -> Vec<LogEntry> {
         if let Some(sub) = self.subintervals.get(&subinterval) {
             content
                 .into_iter()
@@ -939,8 +913,7 @@ fn test_create_digest_with_initial_hot() {
             SubInterval {
                 checksum: 10827088509365589085,
                 content: BTreeSet::from([LogEntry {
-                    timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1")
-                        .unwrap(),
+                    timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
                     key: OwnedKeyExpr::from_str("demo/example/a").unwrap(),
                 }]),
             },
@@ -996,8 +969,7 @@ fn test_create_digest_with_initial_warm() {
             SubInterval {
                 checksum: 10827088509365589085,
                 content: BTreeSet::from([LogEntry {
-                    timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1")
-                        .unwrap(),
+                    timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
                     key: OwnedKeyExpr::from_str("demo/example/a").unwrap(),
                 }]),
             },
@@ -1053,8 +1025,7 @@ fn test_create_digest_with_initial_cold() {
             SubInterval {
                 checksum: 10827088509365589085,
                 content: BTreeSet::from([LogEntry {
-                    timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1")
-                        .unwrap(),
+                    timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
                     key: OwnedKeyExpr::from_str("demo/example/a").unwrap(),
                 }]),
             },
@@ -1118,8 +1089,7 @@ fn test_update_digest_add_content() {
             SubInterval {
                 checksum: 10827088509365589085,
                 content: BTreeSet::from([LogEntry {
-                    timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1")
-                        .unwrap(),
+                    timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
                     key: OwnedKeyExpr::from_str("demo/example/a").unwrap(),
                 }]),
             },
@@ -1162,10 +1132,7 @@ fn test_update_digest_remove_content() {
                 SubInterval {
                     checksum: 10007212639402189432,
                     content: BTreeSet::from([LogEntry {
-                        timestamp: Timestamp::from_str(
-                            "2022-12-21T15:00:00.000000000Z/1",
-                        )
-                        .unwrap(),
+                        timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
                         key: OwnedKeyExpr::from_str("demo/example/a").unwrap(),
                     }]),
                 },

--- a/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
@@ -534,9 +534,11 @@ impl Digest {
 
             if let Some(sub) = current.subintervals.get_mut(&subinterval) {
                 sub.content.retain(|x| {
-                    x.timestamp.get_time() != entry.timestamp.get_time()
-                        && x.timestamp.get_id() != entry.timestamp.get_id()
-                        && x.key != entry.key
+                    // Retain everything except this exact entry that
+                    // should be deleted.
+                    !(x.timestamp.get_time() == entry.timestamp.get_time()
+                        && x.timestamp.get_id() == entry.timestamp.get_id()
+                        && x.key == entry.key)
                 });
                 subintervals_to_update.insert(subinterval);
 

--- a/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
@@ -541,14 +541,23 @@ impl Digest {
                         && x.key != entry.key
                 });
                 subintervals_to_update.insert(subinterval);
-            }
-            if let Some(int) = current.intervals.get_mut(&interval) {
-                int.content.retain(|&x| x != subinterval);
-                intervals_to_update.insert(interval);
-            }
-            if let Some(e) = current.eras.get_mut(&era) {
-                e.content.retain(|&x| x != interval);
-                eras_to_update.insert(era.clone());
+
+                // Remove this subinterval from the parent interval if it's all empty
+                if sub.content.is_empty() {
+                    if let Some(int) = current.intervals.get_mut(&interval) {
+                        int.content.retain(|&x| x != subinterval);
+                        intervals_to_update.insert(interval);
+
+                        // We need to update the containing era if we've
+                        // emptied out this interval.
+                        if int.content.is_empty() {
+                            if let Some(e) = current.eras.get_mut(&era) {
+                                e.content.retain(|&x| x != interval);
+                            }
+                            eras_to_update.insert(era.clone());
+                        }
+                    }
+                }
             }
         }
         (

--- a/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
@@ -272,8 +272,8 @@ impl Digest {
     }
 
     // Updates an existing digest with new entries, also replaces removed entries
-    pub async fn update_digest(
-        mut current: Digest,
+    pub fn update_digest(
+        current: Digest,
         latest_interval: u64,
         last_snapshot_time: Timestamp,
         new_content: HashSet<LogEntry>,
@@ -1068,7 +1068,7 @@ fn test_update_digest_add_content() {
     async_std::task::block_on(async {
         zenoh_core::zasync_executor_init!();
     });
-    let created = async_std::task::block_on(Digest::update_digest(
+    let created = Digest::update_digest(
         Digest {
             timestamp: Timestamp::from_str("2022-12-21T13:00:00.000000000Z/1").unwrap(),
             config: DigestConfig {
@@ -1089,7 +1089,7 @@ fn test_update_digest_add_content() {
             key: OwnedKeyExpr::from_str("demo/example/a").unwrap(),
         }]),
         HashSet::new(),
-    ));
+    );
     let expected = Digest {
         timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
         config: DigestConfig {
@@ -1133,7 +1133,7 @@ fn test_update_digest_remove_content() {
     async_std::task::block_on(async {
         zenoh_core::zasync_executor_init!();
     });
-    let created = async_std::task::block_on(Digest::update_digest(
+    let created = Digest::update_digest(
         Digest {
             timestamp: Timestamp::from_str("2022-12-21T13:00:00.000000000Z/1").unwrap(),
             config: DigestConfig {
@@ -1178,7 +1178,7 @@ fn test_update_digest_remove_content() {
             timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
             key: OwnedKeyExpr::from_str("demo/example/a").unwrap(),
         }]),
-    ));
+    );
     let expected = Digest {
         timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
         config: DigestConfig {
@@ -1211,7 +1211,7 @@ fn test_update_remove_digest() {
         Vec::new(),
         1671612730,
     );
-    let added = async_std::task::block_on(Digest::update_digest(
+    let added = Digest::update_digest(
         created.clone(),
         1671612730,
         Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
@@ -1220,10 +1220,10 @@ fn test_update_remove_digest() {
             key: OwnedKeyExpr::from_str("a/b/c").unwrap(),
         }]),
         HashSet::new(),
-    ));
+    );
     assert_ne!(created, added);
 
-    let removed = async_std::task::block_on(Digest::update_digest(
+    let removed = Digest::update_digest(
         added.clone(),
         1671612730,
         Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
@@ -1232,10 +1232,10 @@ fn test_update_remove_digest() {
             timestamp: Timestamp::from_str("2022-12-21T12:00:00.000000000Z/1").unwrap(),
             key: OwnedKeyExpr::from_str("a/b/c").unwrap(),
         }]),
-    ));
+    );
     assert_eq!(created, removed);
 
-    let added_again = async_std::task::block_on(Digest::update_digest(
+    let added_again = Digest::update_digest(
         removed,
         1671612730,
         Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
@@ -1244,6 +1244,6 @@ fn test_update_remove_digest() {
             key: OwnedKeyExpr::from_str("a/b/c").unwrap(),
         }]),
         HashSet::new(),
-    ));
+    );
     assert_eq!(added, added_again);
 }

--- a/plugins/zenoh-plugin-storage-manager/src/replica/snapshotter.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/snapshotter.rs
@@ -258,8 +258,7 @@ impl Snapshotter {
             *last_snapshot_time,
             new_stable_content,
             deleted_content,
-        )
-        .await;
+        );
         *digest = updated_digest;
     }
 
@@ -304,8 +303,7 @@ impl Snapshotter {
             *last_snapshot_time,
             new_stable,
             deleted_stable,
-        )
-        .await;
+        );
         *digest = updated_digest;
         drop(digest);
 

--- a/plugins/zenoh-plugin-storage-manager/src/replica/snapshotter.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/snapshotter.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use super::{Digest, DigestConfig, LogEntry};
+use async_std::stream::{interval, StreamExt};
 use async_std::sync::Arc;
 use async_std::sync::RwLock;
 use async_std::task::sleep;
@@ -113,8 +114,11 @@ impl Snapshotter {
     // Periodically update parameters for snapshot
     async fn task_update_snapshot_params(&self) {
         sleep(Duration::from_secs(2)).await;
+
+        let mut interval = interval(self.replica_config.delta);
         loop {
-            sleep(self.replica_config.delta).await;
+            let _ = interval.next().await;
+
             let mut last_snapshot_time = self.content.last_snapshot_time.write().await;
             let mut last_interval = self.content.last_interval.write().await;
             let (time, interval) = Snapshotter::compute_snapshot_params(


### PR DESCRIPTION
These don't entirely fix replication but they improve a number of unnecessary `unwrap` calls and digest calculation errors.

See individual commits for rationale and the evolution of all the changes.