### PR TITLE
Zenoh: Fix badly behaved build.rs scripts.

### DIFF
--- a/plugins/zenoh-plugin-rest/build.rs
+++ b/plugins/zenoh-plugin-rest/build.rs
@@ -27,13 +27,13 @@ fn main() {
     );
     // Generate config schema
     let schema = schema_for!(Config);
-    std::fs::write(
-        "config_schema.json5",
-        serde_json::to_string_pretty(&schema).unwrap(),
-    )
-    .unwrap();
+
+    let schema_file = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap())
+        .join("config_schema.json5");
+    std::fs::write(&schema_file, serde_json::to_string_pretty(&schema).unwrap()).unwrap();
+
     // Check that the example config matches the schema
-    let schema = std::fs::read_to_string("config_schema.json5").unwrap();
+    let schema = std::fs::read_to_string(schema_file).unwrap();
     let schema: serde_json::Value = serde_json::from_str(&schema).unwrap();
     let schema = jsonschema::JSONSchema::compile(&schema).unwrap();
     let config = std::fs::read_to_string("config.json5").unwrap();

--- a/plugins/zenoh-plugin-rest/build.rs
+++ b/plugins/zenoh-plugin-rest/build.rs
@@ -28,8 +28,8 @@ fn main() {
     // Generate config schema
     let schema = schema_for!(Config);
 
-    let schema_file = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap())
-        .join("config_schema.json5");
+    let schema_file =
+        std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap()).join("config_schema.json5");
     std::fs::write(&schema_file, serde_json::to_string_pretty(&schema).unwrap()).unwrap();
 
     // Check that the example config matches the schema

--- a/plugins/zenoh-plugin-storage-manager/build.rs
+++ b/plugins/zenoh-plugin-storage-manager/build.rs
@@ -23,13 +23,12 @@ fn main() {
     );
     // Generate default config schema
     let schema = schema_for!(PluginConfig);
-    std::fs::write(
-        "config_schema.json5",
-        serde_json::to_string_pretty(&schema).unwrap(),
-    )
-    .unwrap();
+    let schema_file = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap())
+        .join("config_schema.json5");
+    std::fs::write(&schema_file, serde_json::to_string_pretty(&schema).unwrap()).unwrap();
+
     // Check that the example config matches the schema
-    let schema = std::fs::read_to_string("config_schema.json5").unwrap();
+    let schema = std::fs::read_to_string(schema_file).unwrap();
     let schema: serde_json::Value = serde_json::from_str(&schema).unwrap();
     let schema = jsonschema::JSONSchema::compile(&schema).unwrap();
     let config = std::fs::read_to_string("config.json5").unwrap();

--- a/plugins/zenoh-plugin-storage-manager/build.rs
+++ b/plugins/zenoh-plugin-storage-manager/build.rs
@@ -23,8 +23,8 @@ fn main() {
     );
     // Generate default config schema
     let schema = schema_for!(PluginConfig);
-    let schema_file = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap())
-        .join("config_schema.json5");
+    let schema_file =
+        std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap()).join("config_schema.json5");
     std::fs::write(&schema_file, serde_json::to_string_pretty(&schema).unwrap()).unwrap();
 
     // Check that the example config matches the schema


### PR DESCRIPTION
build.rs should only ever modify OUT_DIR. These scripts were modifying local files which caused a git index update which caused them to rebuild due to the git-version appearing out of date.