### PR TITLE
Revert "Fix issue #887"

### DIFF
--- a/zenoh-ext/Cargo.toml
+++ b/zenoh-ext/Cargo.toml
@@ -38,7 +38,7 @@ flume = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true, features = ["default"] }
-zenoh = { workspace = true, features = ["unstable"], default-features = true }
+zenoh = { workspace = true, features = ["unstable"], default-features = false }
 zenoh-core = { workspace = true }
 zenoh-macros = { workspace = true }
 zenoh-result = { workspace = true }


### PR DESCRIPTION
Reverts eclipse-zenoh/zenoh#888 because it makes zenoh-c CI fail: https://github.com/eclipse-zenoh/zenoh-c/actions/runs/8562959546/job/23467191384