### PR TITLE
Sample api rework update

### DIFF
--- a/zenoh/src/prelude.rs
+++ b/zenoh/src/prelude.rs
@@ -61,9 +61,7 @@ pub(crate) mod common {
     pub use crate::publication::PublisherDeclarations;
     pub use zenoh_protocol::core::{CongestionControl, Reliability, WhatAmI};
 
-    pub use crate::sample::builder::{
-        QoSBuilderTrait,  TimestampBuilderTrait, ValueBuilderTrait,
-    };
+    pub use crate::sample::builder::{QoSBuilderTrait, TimestampBuilderTrait, ValueBuilderTrait};
 
     #[zenoh_macros::unstable]
     pub use crate::sample::builder::SampleBuilderTrait;

--- a/zenoh/src/prelude.rs
+++ b/zenoh/src/prelude.rs
@@ -62,8 +62,11 @@ pub(crate) mod common {
     pub use zenoh_protocol::core::{CongestionControl, Reliability, WhatAmI};
 
     pub use crate::sample::builder::{
-        QoSBuilderTrait, SampleBuilderTrait, TimestampBuilderTrait, ValueBuilderTrait,
+        QoSBuilderTrait,  TimestampBuilderTrait, ValueBuilderTrait,
     };
+
+    #[zenoh_macros::unstable]
+    pub use crate::sample::builder::SampleBuilderTrait;
 }
 
 /// Prelude to import when using Zenoh's sync API.

--- a/zenoh/src/queryable.rs
+++ b/zenoh/src/queryable.rs
@@ -18,13 +18,12 @@ use crate::encoding::Encoding;
 use crate::handlers::{locked, DefaultHandler};
 use crate::net::primitives::Primitives;
 use crate::prelude::*;
-use crate::sample::builder::SampleBuilder;
 use crate::sample::{QoSBuilder, SourceInfo};
 use crate::Id;
 use crate::SessionRef;
 use crate::Undeclarable;
 #[cfg(feature = "unstable")]
-use crate::{query::ReplyKeyExpr, sample::Attachment};
+use crate::{query::ReplyKeyExpr, sample::Attachment, sample::builder::SampleBuilder};
 use std::fmt;
 use std::future::Ready;
 use std::ops::Deref;

--- a/zenoh/src/queryable.rs
+++ b/zenoh/src/queryable.rs
@@ -23,7 +23,7 @@ use crate::Id;
 use crate::SessionRef;
 use crate::Undeclarable;
 #[cfg(feature = "unstable")]
-use crate::{query::ReplyKeyExpr, sample::Attachment, sample::builder::SampleBuilder};
+use crate::{query::ReplyKeyExpr, sample::builder::SampleBuilder, sample::Attachment};
 use std::fmt;
 use std::future::Ready;
 use std::ops::Deref;
@@ -95,6 +95,18 @@ impl Query {
     #[inline(always)]
     pub fn value(&self) -> Option<&Value> {
         self.inner.value.as_ref()
+    }
+
+    /// This Query's payload.
+    #[inline(always)]
+    pub fn payload(&self) -> Option<&Payload> {
+        self.inner.value.as_ref().map(|v| &v.payload)
+    }
+
+    /// This Query's encoding.
+    #[inline(always)]
+    pub fn encoding(&self) -> Option<&Encoding> {
+        self.inner.value.as_ref().map(|v| &v.encoding)
     }
 
     #[zenoh_macros::unstable]

--- a/zenoh/src/sample/builder.rs
+++ b/zenoh/src/sample/builder.rs
@@ -15,11 +15,8 @@
 use std::marker::PhantomData;
 
 #[cfg(feature = "unstable")]
-use crate::sample::Attachment;
-use crate::sample::QoS;
-use crate::sample::QoSBuilder;
-#[cfg(feature = "unstable")]
-use crate::sample::SourceInfo;
+use crate::sample::{Attachment, SourceInfo};
+use crate::sample::{QoS, QoSBuilder};
 use crate::Encoding;
 use crate::KeyExpr;
 use crate::Payload;
@@ -47,6 +44,7 @@ pub trait TimestampBuilderTrait {
     fn timestamp<T: Into<Option<Timestamp>>>(self, timestamp: T) -> Self;
 }
 
+#[zenoh_macros::unstable]
 pub trait SampleBuilderTrait {
     /// Attach source information
     #[zenoh_macros::unstable]

--- a/zenoh/src/session.rs
+++ b/zenoh/src/session.rs
@@ -41,6 +41,7 @@ use crate::Priority;
 use crate::Sample;
 use crate::SampleKind;
 use crate::Selector;
+#[cfg(feature = "unstable")]
 use crate::SourceInfo;
 use crate::Value;
 use log::{error, trace, warn};

--- a/zenoh/tests/qos.rs
+++ b/zenoh/tests/qos.rs
@@ -13,7 +13,6 @@
 //
 use std::time::Duration;
 use zenoh::prelude::r#async::*;
-use zenoh::sample::builder::QoSBuilderTrait;
 use zenoh::{publication::Priority, SessionDeclarations};
 use zenoh_core::ztimeout;
 

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -18,7 +18,6 @@ use std::time::Duration;
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use zenoh::config::{Config, ModeDependentValue};
 use zenoh::prelude::r#async::*;
-use zenoh::sample::builder::QoSBuilderTrait;
 use zenoh::Result;
 use zenoh_core::ztimeout;
 use zenoh_protocol::core::{WhatAmI, WhatAmIMatcher};


### PR DESCRIPTION
- Remove unnecessary `use`
- Properly mark `SampleBuilder` as `unstable` 
- Add `payload()` and `encoding()` accessors to `Query`