### PR TITLE
allow to build zenoh without 'unstable' feature

### DIFF
--- a/zenoh/src/publication.rs
+++ b/zenoh/src/publication.rs
@@ -157,6 +157,7 @@ impl<P> ValueBuilderTrait for PublicationBuilder<P, PublicationBuilderPut> {
     }
 }
 
+#[zenoh_macros::unstable]
 impl<P, T> SampleBuilderTrait for PublicationBuilder<P, T> {
     #[cfg(feature = "unstable")]
     fn source_info(self, source_info: SourceInfo) -> Self {

--- a/zenoh/src/query.rs
+++ b/zenoh/src/query.rs
@@ -133,6 +133,7 @@ pub struct GetBuilder<'a, 'b, Handler> {
     pub(crate) source_info: SourceInfo,
 }
 
+#[zenoh_macros::unstable]
 impl<Handler> SampleBuilderTrait for GetBuilder<'_, '_, Handler> {
     #[cfg(feature = "unstable")]
     fn source_info(self, source_info: SourceInfo) -> Self {
@@ -430,6 +431,7 @@ where
                 self.value,
                 #[cfg(feature = "unstable")]
                 self.attachment,
+                #[cfg(feature = "unstable")]
                 self.source_info,
                 callback,
             )

--- a/zenoh/src/queryable.rs
+++ b/zenoh/src/queryable.rs
@@ -18,12 +18,15 @@ use crate::encoding::Encoding;
 use crate::handlers::{locked, DefaultHandler};
 use crate::net::primitives::Primitives;
 use crate::prelude::*;
-use crate::sample::{QoSBuilder, SourceInfo};
+use crate::sample::builder::SampleBuilder;
+use crate::sample::QoSBuilder;
+#[cfg(feature = "unstable")]
+use crate::sample::SourceInfo;
 use crate::Id;
 use crate::SessionRef;
 use crate::Undeclarable;
 #[cfg(feature = "unstable")]
-use crate::{query::ReplyKeyExpr, sample::builder::SampleBuilder, sample::Attachment};
+use crate::{query::ReplyKeyExpr, sample::Attachment};
 use std::fmt;
 use std::future::Ready;
 use std::ops::Deref;
@@ -155,7 +158,9 @@ impl Query {
                 encoding: Encoding::default(),
             },
             timestamp: None,
+            #[cfg(feature = "unstable")]
             source_info: SourceInfo::empty(),
+            #[cfg(feature = "unstable")]
             attachment: None,
         }
     }
@@ -193,7 +198,9 @@ impl Query {
             qos: response::ext::QoSType::RESPONSE.into(),
             kind: ReplyBuilderDelete,
             timestamp: None,
+            #[cfg(feature = "unstable")]
             source_info: SourceInfo::empty(),
+            #[cfg(feature = "unstable")]
             attachment: None,
         }
     }
@@ -298,6 +305,7 @@ impl<T> TimestampBuilderTrait for ReplyBuilder<'_, '_, T> {
     }
 }
 
+#[cfg(feature = "unstable")]
 impl<T> SampleBuilderTrait for ReplyBuilder<'_, '_, T> {
     #[cfg(feature = "unstable")]
     fn attachment<U: Into<Option<Attachment>>>(self, attachment: U) -> Self {

--- a/zenoh/src/sample/builder.rs
+++ b/zenoh/src/sample/builder.rs
@@ -163,6 +163,7 @@ impl<T> TimestampBuilderTrait for SampleBuilder<T> {
     }
 }
 
+#[cfg(feature = "unstable")]
 impl<T> SampleBuilderTrait for SampleBuilder<T> {
     #[zenoh_macros::unstable]
     fn source_info(self, source_info: SourceInfo) -> Self {

--- a/zenoh/src/sample/mod.rs
+++ b/zenoh/src/sample/mod.rs
@@ -22,9 +22,9 @@ use crate::Priority;
 #[zenoh_macros::unstable]
 use serde::Serialize;
 use std::{convert::TryFrom, fmt};
+use zenoh_protocol::core::CongestionControl;
 use zenoh_protocol::core::EntityGlobalId;
 use zenoh_protocol::network::declare::ext::QoSType;
-use zenoh_protocol::{core::CongestionControl, zenoh};
 
 pub mod builder;
 
@@ -178,12 +178,12 @@ impl SourceInfo {
 }
 
 #[zenoh_macros::unstable]
-impl From<SourceInfo> for Option<zenoh::put::ext::SourceInfoType> {
-    fn from(source_info: SourceInfo) -> Option<zenoh::put::ext::SourceInfoType> {
+impl From<SourceInfo> for Option<zenoh_protocol::zenoh::put::ext::SourceInfoType> {
+    fn from(source_info: SourceInfo) -> Option<zenoh_protocol::zenoh::put::ext::SourceInfoType> {
         if source_info.is_empty() {
             None
         } else {
-            Some(zenoh::put::ext::SourceInfoType {
+            Some(zenoh_protocol::zenoh::put::ext::SourceInfoType {
                 id: source_info.source_id.unwrap_or_default(),
                 sn: source_info.source_sn.unwrap_or_default() as u32,
             })

--- a/zenoh/src/session.rs
+++ b/zenoh/src/session.rs
@@ -61,6 +61,8 @@ use zenoh_config::unwrap_or_default;
 use zenoh_core::{zconfigurable, zread, Resolve, ResolveClosure, ResolveFuture, SyncResolve};
 #[cfg(feature = "unstable")]
 use zenoh_protocol::network::declare::SubscriberId;
+#[cfg(feature = "unstable")]
+use zenoh_protocol::network::ext;
 use zenoh_protocol::network::AtomicRequestId;
 use zenoh_protocol::network::RequestId;
 use zenoh_protocol::zenoh::reply::ReplyBody;
@@ -77,7 +79,6 @@ use zenoh_protocol::{
             subscriber::ext::SubscriberInfo, Declare, DeclareBody, DeclareKeyExpr, DeclareMode,
             DeclareQueryable, DeclareSubscriber, UndeclareQueryable, UndeclareSubscriber,
         },
-        ext,
         request::{self, ext::TargetType, Request},
         Mapping, Push, Response, ResponseFinal,
     },
@@ -1687,7 +1688,10 @@ impl Session {
                 payload: RequestBody::Query(zenoh_protocol::zenoh::Query {
                     consolidation,
                     parameters: selector.parameters().to_string(),
+                    #[cfg(feature = "unstable")]
                     ext_sinfo: source.into(),
+                    #[cfg(not(feature = "unstable"))]
+                    ext_sinfo: None,
                     ext_body: value.as_ref().map(|v| query::ext::QueryBodyType {
                         #[cfg(feature = "shared-memory")]
                         ext_shm: None,

--- a/zenoh/src/subscriber.rs
+++ b/zenoh/src/subscriber.rs
@@ -202,9 +202,6 @@ pub struct SubscriberBuilder<'a, 'b, Handler> {
     #[cfg(not(feature = "unstable"))]
     pub(crate) reliability: Reliability,
 
-    #[cfg(not(feature = "unstable"))]
-    pub(crate) mode: Mode,
-
     #[cfg(feature = "unstable")]
     pub origin: Locality,
     #[cfg(not(feature = "unstable"))]


### PR DESCRIPTION
both
```
cargo check --package zenoh
```
and
```
cargo check --package zenoh --all-features
```
works after this update. Before the update the `cargo check --package zenoh` didn't work