### PR TITLE
fix(replication): do not reply an error when a key is not found

### DIFF
--- a/plugins/zenoh-plugin-storage-manager/src/replica/storage.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/storage.rs
@@ -567,16 +567,7 @@ impl StorageService {
                     }
                 }
                 Err(e) => {
-                    let err_message =
-                        format!("Storage '{}' raised an error on query: {}", self.name, e);
-                    log::warn!("{}", err_message);
-                    if let Err(e) = q.reply(Err(err_message.into())).res().await {
-                        log::warn!(
-                            "Storage '{}' raised an error replying a query: {}",
-                            self.name,
-                            e
-                        )
-                    }
+                    log::warn!("Storage '{}' raised an error on query: {e}", self.name);
                 }
             };
         }


### PR DESCRIPTION
As discussed internally, a reply to a query should not return an error when a key does not exist — this is a perfectly valid situation.

In addition, this prevented the replication from correctly functioning: as an error was always returned by the storage that was actually looking for the data, other replies were not processed and that storage would thus never receive anything.

* plugins/zenoh-plugin-storage-manager/src/replica/storage.rs: deleted the code replying an error to a query looking for a key the storage does not have.