### PR TITLE
Prevent session from closing external runtime on drop

### DIFF
--- a/zenoh/tests/session.rs
+++ b/zenoh/tests/session.rs
@@ -200,7 +200,6 @@ async fn zenoh_session_multicast() {
     close_session(peer01, peer02).await;
 }
 
-
 async fn open_session_unicast_runtime(endpoints: &[&str]) -> (Runtime, Runtime) {
     // Open the sessions
     let mut config = config::peer();

--- a/zenoh/tests/session.rs
+++ b/zenoh/tests/session.rs
@@ -225,7 +225,7 @@ async fn open_session_unicast_runtime(endpoints: &[&str]) -> (Runtime, Runtime) 
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn zenoh_2sessions_1runtime_init() {
-    let (r1, r2) = open_session_unicast_runtime(&["tcp/127.0.1:17449"]).await;
+    let (r1, r2) = open_session_unicast_runtime(&["tcp/127.0.0.1:17449"]).await;
     println!("[RI][02a] Creating peer01 session from runtime 1");
     let peer01 = zenoh::init(r1.clone()).res_async().await.unwrap();
     println!("[RI][02b] Creating peer02 session from runtime 2");


### PR DESCRIPTION
Make session only close its runtime on drop, if it was created from config (and thus "owns" this runtime).
Closes #612.