### PR TITLE
fix: Replace macos-latest with macos-13 and macos-14 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-12, macos-13, macos-14]
 
     steps:
       - name: Clone this repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-12, macos-13, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
 
     steps:
       - name: Clone this repository
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
 
     steps:
       - name: Clone this repository


### PR DESCRIPTION
Clippy from Rust 1.77.2 has been failing on maco-latest for a while. I suspect it might have something to do with https://github.com/rust-lang/rust/issues/92173. Except in our case the failure happens 100% of the time and is not sporadic.

What I know so far:

1. Even though we specify macos-latest, GitHub simply uses macos-12 images, for some reason I'm not too keen on knowing.
2. The command that fails is `cargo +stable clippy --all-targets` and not `cargo +stable build --all-targets` and not `cargo +stable clippy`.
3. Every time clippy fails out of a SIGABRT, it's because of failure to compile some zenoh crate, often for test targets. It seems that this can be any crate, which helps the hypothesis that this is a sporadic failure made worse by zenoh having 34 crates.
3. I cannot reproduces this on macOS 13, neither on AArch64 nor on x86_64.

This pull request tries to force GitHub to give us macOS 13/14 to see what happens. The idea is that Rust 1.77.2 doesn't play too nicely with the C runtime in macOS 12, which would explain why it doesn't fail on macOS 13 or 14 for me (locally).
