### PR TITLE
Fixes for storage replication

### DIFF
--- a/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
@@ -276,26 +276,27 @@ impl Digest {
         new_content: HashSet<LogEntry>,
         deleted_content: HashSet<LogEntry>,
     ) -> Digest {
-        // push content in correct places
-        let (mut current, mut subintervals_to_update, mut intervals_to_update, mut eras_to_update) =
-            Digest::update_new_content(&mut current, new_content, latest_interval);
-
         // remove deleted content from proper places
-        let (mut current, further_subintervals, further_intervals, further_eras) =
-            Digest::remove_deleted_content(&mut current, deleted_content, latest_interval);
+        let (current, further_subintervals, further_intervals, further_eras) =
+            Digest::remove_deleted_content(current, deleted_content, latest_interval);
+        tracing::trace!("Removed deleted content: {current:?}");
+        // push content in correct places
+        let (current, mut subintervals_to_update, mut intervals_to_update, mut eras_to_update) =
+            Digest::update_new_content(current, new_content, latest_interval);
 
-        // move intervals into eras if changed -- iterate through hot and move them to warm/cold if needed, iterate through warm and move them to cold if needed
-        let (current, realigned_eras) =
-            Digest::recalculate_era_content(&mut current, latest_interval);
+        // move intervals into eras if changed -- iterate through hot
+        // and move them to warm/cold if needed, iterate through warm
+        // and move them to cold if needed
+        let (current, realigned_eras) = Digest::recalculate_era_content(current, latest_interval);
 
         subintervals_to_update.extend(further_subintervals);
         intervals_to_update.extend(further_intervals);
         eras_to_update.extend(further_eras);
         eras_to_update.extend(realigned_eras);
 
-        let mut subintervals = current.subintervals.clone();
-        let mut intervals = current.intervals.clone();
-        let mut eras = current.eras.clone();
+        let mut subintervals = current.subintervals;
+        let mut intervals = current.intervals;
+        let mut eras = current.eras;
 
         // reconstruct updated parts of the digest
         for sub in subintervals_to_update {
@@ -432,7 +433,7 @@ impl Digest {
 
     // update the digest with new content
     fn update_new_content(
-        current: &mut Digest,
+        mut current: Digest,
         content: HashSet<LogEntry>,
         latest_interval: u64,
     ) -> (Digest, HashSet<u64>, HashSet<u64>, HashSet<EraType>) {
@@ -490,7 +491,7 @@ impl Digest {
         }
 
         (
-            current.clone(),
+            current,
             subintervals_to_update,
             intervals_to_update,
             eras_to_update,
@@ -499,7 +500,7 @@ impl Digest {
 
     // remove deleted content from the digest
     fn remove_deleted_content(
-        current: &mut Digest,
+        mut current: Digest,
         deleted_content: HashSet<LogEntry>,
         latest_interval: u64,
     ) -> (Digest, HashSet<u64>, HashSet<u64>, HashSet<EraType>) {
@@ -548,7 +549,7 @@ impl Digest {
             }
         }
         (
-            current.clone(),
+            current,
             subintervals_to_update,
             intervals_to_update,
             eras_to_update,
@@ -557,7 +558,7 @@ impl Digest {
 
     // re-assign intervals into eras as time moves on
     fn recalculate_era_content(
-        current: &mut Digest,
+        mut current: Digest,
         latest_interval: u64,
     ) -> (Digest, HashSet<EraType>) {
         let mut eras_to_update = HashSet::new();
@@ -588,11 +589,11 @@ impl Digest {
                 })
                 .or_insert(Interval {
                     checksum: 0,
-                    content: [interval].iter().cloned().collect(),
+                    content: [interval].into(),
                 });
         }
 
-        (current.clone(), eras_to_update)
+        (current, eras_to_update)
     }
 
     // compute the subinterval for a given timestamp

--- a/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
@@ -269,8 +269,8 @@ impl Digest {
     }
 
     // Updates an existing digest with new entries, also replaces removed entries
-    pub async fn update_digest(
-        mut current: Digest,
+    pub fn update_digest(
+        current: Digest,
         latest_interval: u64,
         last_snapshot_time: Timestamp,
         new_content: HashSet<LogEntry>,
@@ -1036,7 +1036,7 @@ fn test_update_digest_add_content() {
     async_std::task::block_on(async {
         zenoh_core::zasync_executor_init!();
     });
-    let created = async_std::task::block_on(Digest::update_digest(
+    let created = Digest::update_digest(
         Digest {
             timestamp: Timestamp::from_str("2022-12-21T13:00:00.000000000Z/1").unwrap(),
             config: DigestConfig {
@@ -1057,7 +1057,7 @@ fn test_update_digest_add_content() {
             key: OwnedKeyExpr::from_str("demo/example/a").unwrap(),
         }]),
         HashSet::new(),
-    ));
+    );
     let expected = Digest {
         timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
         config: DigestConfig {
@@ -1100,7 +1100,7 @@ fn test_update_digest_remove_content() {
     async_std::task::block_on(async {
         zenoh_core::zasync_executor_init!();
     });
-    let created = async_std::task::block_on(Digest::update_digest(
+    let created = Digest::update_digest(
         Digest {
             timestamp: Timestamp::from_str("2022-12-21T13:00:00.000000000Z/1").unwrap(),
             config: DigestConfig {
@@ -1142,7 +1142,7 @@ fn test_update_digest_remove_content() {
             timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
             key: OwnedKeyExpr::from_str("demo/example/a").unwrap(),
         }]),
-    ));
+    );
     let expected = Digest {
         timestamp: Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
         config: DigestConfig {
@@ -1175,7 +1175,7 @@ fn test_update_remove_digest() {
         Vec::new(),
         1671612730,
     );
-    let added = async_std::task::block_on(Digest::update_digest(
+    let added = Digest::update_digest(
         created.clone(),
         1671612730,
         Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
@@ -1184,10 +1184,10 @@ fn test_update_remove_digest() {
             key: OwnedKeyExpr::from_str("a/b/c").unwrap(),
         }]),
         HashSet::new(),
-    ));
+    );
     assert_ne!(created, added);
 
-    let removed = async_std::task::block_on(Digest::update_digest(
+    let removed = Digest::update_digest(
         added.clone(),
         1671612730,
         Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
@@ -1196,10 +1196,10 @@ fn test_update_remove_digest() {
             timestamp: Timestamp::from_str("2022-12-21T12:00:00.000000000Z/1").unwrap(),
             key: OwnedKeyExpr::from_str("a/b/c").unwrap(),
         }]),
-    ));
+    );
     assert_eq!(created, removed);
 
-    let added_again = async_std::task::block_on(Digest::update_digest(
+    let added_again = Digest::update_digest(
         removed,
         1671612730,
         Timestamp::from_str("2022-12-21T15:00:00.000000000Z/1").unwrap(),
@@ -1208,6 +1208,6 @@ fn test_update_remove_digest() {
             key: OwnedKeyExpr::from_str("a/b/c").unwrap(),
         }]),
         HashSet::new(),
-    ));
+    );
     assert_eq!(added, added_again);
 }

--- a/plugins/zenoh-plugin-storage-manager/src/replica/mod.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/mod.rs
@@ -16,9 +16,9 @@
 
 use crate::backends_mgt::StoreIntercept;
 use crate::storages_mgt::StorageMessage;
+use async_std::stream::{interval, StreamExt};
 use async_std::sync::Arc;
 use async_std::sync::RwLock;
-use async_std::task::sleep;
 use flume::{Receiver, Sender};
 use futures::{pin_mut, select, FutureExt};
 use std::collections::{HashMap, HashSet};
@@ -273,8 +273,11 @@ impl Replica {
             .await
             .unwrap();
 
+        // Ensure digest gets published every interval, accounting for
+        // time it takes to publish.
+        let mut interval = interval(self.replica_config.publication_interval);
         loop {
-            sleep(self.replica_config.publication_interval).await;
+            let _ = interval.next().await;
 
             let digest = snapshotter.get_digest().await;
             let digest = digest.compress();

--- a/plugins/zenoh-plugin-storage-manager/src/replica/snapshotter.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/snapshotter.rs
@@ -258,8 +258,7 @@ impl Snapshotter {
             *last_snapshot_time,
             new_stable_content,
             deleted_content,
-        )
-        .await;
+        );
         *digest = updated_digest;
     }
 
@@ -304,8 +303,7 @@ impl Snapshotter {
             *last_snapshot_time,
             new_stable,
             deleted_stable,
-        )
-        .await;
+        );
         *digest = updated_digest;
         drop(digest);
 

--- a/plugins/zenoh-plugin-storage-manager/src/replica/snapshotter.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/snapshotter.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use super::{Digest, DigestConfig, LogEntry};
+use async_std::stream::{interval, StreamExt};
 use async_std::sync::Arc;
 use async_std::sync::RwLock;
 use async_std::task::sleep;
@@ -113,8 +114,11 @@ impl Snapshotter {
     // Periodically update parameters for snapshot
     async fn task_update_snapshot_params(&self) {
         sleep(Duration::from_secs(2)).await;
+
+        let mut interval = interval(self.replica_config.delta);
         loop {
-            sleep(self.replica_config.delta).await;
+            let _ = interval.next().await;
+
             let mut last_snapshot_time = self.content.last_snapshot_time.write().await;
             let mut last_interval = self.content.last_interval.write().await;
             let (time, interval) = Snapshotter::compute_snapshot_params(


### PR DESCRIPTION
This is a rebase of #884 as the previous branch `main` was mistakenly corrupted.

>  These don't entirely fix replication but they improve a number of unnecessary unwrap calls and digest calculation errors.
> See individual commits for rationale and the evolution of all the changes.


