### PR TITLE
fix: build script should not write outside of OUT_DIR

### DIFF
--- a/plugins/zenoh-plugin-rest/build.rs
+++ b/plugins/zenoh-plugin-rest/build.rs
@@ -25,16 +25,8 @@ fn main() {
         "cargo:rustc-env=RUSTC_VERSION={}",
         version_meta.short_version_string
     );
-    // Generate config schema
-    let schema = schema_for!(Config);
-    std::fs::write(
-        "config_schema.json5",
-        serde_json::to_string_pretty(&schema).unwrap(),
-    )
-    .unwrap();
-    // Check that the example config matches the schema
-    let schema = std::fs::read_to_string("config_schema.json5").unwrap();
-    let schema: serde_json::Value = serde_json::from_str(&schema).unwrap();
+
+    let schema = serde_json::to_value(schema_for!(Config)).unwrap();
     let schema = jsonschema::JSONSchema::compile(&schema).unwrap();
     let config = std::fs::read_to_string("config.json5").unwrap();
     let config: serde_json::Value = serde_json::from_str(&config).unwrap();

--- a/plugins/zenoh-plugin-storage-manager/build.rs
+++ b/plugins/zenoh-plugin-storage-manager/build.rs
@@ -21,16 +21,8 @@ fn main() {
         "cargo:rustc-env=RUSTC_VERSION={}",
         version_meta.short_version_string
     );
-    // Generate default config schema
-    let schema = schema_for!(PluginConfig);
-    std::fs::write(
-        "config_schema.json5",
-        serde_json::to_string_pretty(&schema).unwrap(),
-    )
-    .unwrap();
-    // Check that the example config matches the schema
-    let schema = std::fs::read_to_string("config_schema.json5").unwrap();
-    let schema: serde_json::Value = serde_json::from_str(&schema).unwrap();
+
+    let schema = serde_json::to_value(schema_for!(PluginConfig)).unwrap();
     let schema = jsonschema::JSONSchema::compile(&schema).unwrap();
     let config = std::fs::read_to_string("config.json5").unwrap();
     let config: serde_json::Value = serde_json::from_str(&config).unwrap();


### PR DESCRIPTION
See #885

Instead of writing out the result of the parsing of the schema, after this change the build of the plugins will simply fail.

* plugins/zenoh-plugin-rest/build.rs:
  - don't write out the result of the parsing of the schema in zenoh-plugin-rest/config_schema.json5,
  - if the schema does not match the default config.json5, panic.
* plugins/zenoh-plugin-storage-manager/build.rs:
  - don't write out the result of the parsing of the schema in zenoh-plugin-storage-manager/config_schema.json5,
  - if the schema does not match the default config.json5, panic.