### PR TITLE
Introduce rust-cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,9 @@ jobs:
       - name: Install latest Rust toolchain
         run: rustup show
 
+      - name: Setup rust-cache
+        uses: Swatinem/rust-cache@v2
+
       - name: Set rustflags
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
           rustup show
           rustup component add rustfmt clippy
 
+      - name: Setup rust-cache
+        uses: Swatinem/rust-cache@v2
+
       - name: Code format check
         run: cargo fmt --check
 


### PR DESCRIPTION
### Spending time of two consecutive runs

| Job                          | 1st Run | 2nd Run |
| -                            | -       | -       |
| Run checks on macos-13       | 5m48s   | 2m23s   |
| Run checks on macos-14       | 2m50s   | 1m23s   |
| Run checks on ubuntu-latest  | 3m28s   | 2m31s   |
| Run checks on windows-latest | 7m24s   | 5m12s   |
| Run tests on macos-13        | 15m8s   | 13m37s  |
| Run tests on macos-14        | 10m23s  | 10m21s  |
| Run tests on ubuntu-latest   | 14m54s  | 14m59s  |
| Run tests on windows-latest  | 21m26s  | 19m13s  |

P.S. This cache trick is also used in tokio.