### PR TITLE
Enhancement to Valgrind test in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,13 +102,23 @@ jobs:
       - name: Run doctests
         run: cargo test --doc
 
+  valgrind:
+    name: Memory leak checks
+    runs-on: ubuntu-latest
+    needs: check
+    steps:
+      - name: Clone this repository
+        uses: actions/checkout@v4
+
+      - name: Install latest Rust toolchain
+        run: rustup show
+
       - name: Install valgrind
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: sudo apt-get install -y valgrind
-        shell: bash
+        uses: taiki-e/install-action@valgrind
+
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run memory leaks check
-        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: ci/valgrind-check/run.sh
         shell: bash
 
@@ -120,7 +130,7 @@ jobs:
   ci:
     name: CI status checks
     runs-on: ubuntu-latest
-    needs: [check, test]
+    needs: [check, test, valgrind]
     if: always()
     steps:
       - name: Check whether all jobs pass


### PR DESCRIPTION
Closes #955 .

- Use [taiki-e/action](https://github.com/taiki-e/install-action) to install Valgrind.
- CI Speedup
  - Relocate the Valgrind test from the step test to following the step check.
  - Use rust-cache 