### PR TITLE
Automatic Generation of License Headers

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,15 @@
+# Copyright (c) 2024 ZettaScale Technology
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+#   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+
 [target.x86_64-unknown-linux-musl]
 rustflags = "-Ctarget-feature=-crt-static"
 

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,15 @@
+# Copyright (c) 2024 ZettaScale Technology
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+#   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+
 # By default, retry a few times until pass the test within the specified timeout
 [profile.default]
 retries = 1

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,3 +1,15 @@
+# Copyright (c) 2024 ZettaScale Technology
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+#   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+
 name: Bug
 description: |
   Report a bug.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,3 +1,15 @@
+# Copyright (c) 2024 ZettaScale Technology
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+#   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+
 blank_issues_enabled: false
 contact_links:
   - name: Ask a question

--- a/.github/ISSUE_TEMPLATE/new_feature.yml
+++ b/.github/ISSUE_TEMPLATE/new_feature.yml
@@ -1,3 +1,15 @@
+# Copyright (c) 2024 ZettaScale Technology
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+#   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+
 name: New feature
 description: |
   Suggest a new feature.

--- a/.github/ISSUE_TEMPLATE/release.yml
+++ b/.github/ISSUE_TEMPLATE/release.yml
@@ -1,3 +1,15 @@
+# Copyright (c) 2024 ZettaScale Technology
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+#   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+
 name: Add an issue to the next release
 description: |
   Add an issue as part of next release. 

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
 
 changelog:
   categories:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 name: CI
 
 on:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 name: Pre-Release
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 name: Release
 
 on:

--- a/.github/workflows/update-release-project.yml
+++ b/.github/workflows/update-release-project.yml
@@ -1,3 +1,15 @@
+# Copyright (c) 2024 ZettaScale Technology
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+#   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+
 name: Update release project
 
 on:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [workspace]
 resolver = "2"
 members = [

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,3 +1,15 @@
+# Copyright (c) 2024 ZettaScale Technology
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+#   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+
 [target.x86_64-unknown-linux-musl]
 image = "jenoch/rust-cross:x86_64-unknown-linux-musl"
 

--- a/ci/nostd-check/Cargo.toml
+++ b/ci/nostd-check/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 name = "nostd-check"
 version = "0.1.0"

--- a/ci/nostd-check/src/bin/nostd_check.rs
+++ b/ci/nostd-check/src/bin/nostd_check.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 #![no_std]
 

--- a/ci/valgrind-check/Cargo.toml
+++ b/ci/valgrind-check/Cargo.toml
@@ -1,4 +1,3 @@
-#
 # Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 name = "valgrind-check"
 version = "0.1.0"

--- a/ci/valgrind-check/run.sh
+++ b/ci/valgrind-check/run.sh
@@ -1,4 +1,16 @@
 #!/usr/bin/env bash
+# Copyright (c) 2024 ZettaScale Technology
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+#   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+
 set -e
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 

--- a/ci/valgrind-check/src/pub_sub/bin/z_pub_sub.rs
+++ b/ci/valgrind-check/src/pub_sub/bin/z_pub_sub.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::time::Duration;
 use zenoh::config::Config;
 use zenoh::prelude::r#async::*;

--- a/ci/valgrind-check/src/queryable_get/bin/z_queryable_get.rs
+++ b/ci/valgrind-check/src/queryable_get/bin/z_queryable_get.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::convert::TryFrom;
 use std::time::Duration;
 use zenoh::config::Config;

--- a/commons/zenoh-buffers/Cargo.toml
+++ b/commons/zenoh-buffers/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-buffers"

--- a/commons/zenoh-buffers/src/bbuf.rs
+++ b/commons/zenoh-buffers/src/bbuf.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{
     buffer::{Buffer, SplitBuffer},
     reader::HasReader,

--- a/commons/zenoh-buffers/src/lib.rs
+++ b/commons/zenoh-buffers/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/commons/zenoh-buffers/src/slice.rs
+++ b/commons/zenoh-buffers/src/slice.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{
     buffer::{Buffer, SplitBuffer},
     reader::{BacktrackableReader, DidntRead, DidntSiphon, HasReader, Reader, SiphonableReader},

--- a/commons/zenoh-buffers/src/vec.rs
+++ b/commons/zenoh-buffers/src/vec.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{
     buffer::{Buffer, SplitBuffer},
     reader::HasReader,

--- a/commons/zenoh-buffers/src/zbuf.rs
+++ b/commons/zenoh-buffers/src/zbuf.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 #[cfg(feature = "shared-memory")]
 use crate::ZSliceKind;
 use crate::{

--- a/commons/zenoh-buffers/src/zslice.rs
+++ b/commons/zenoh-buffers/src/zslice.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{
     buffer::{Buffer, SplitBuffer},
     reader::{BacktrackableReader, DidntRead, HasReader, Reader},

--- a/commons/zenoh-buffers/tests/readwrite.rs
+++ b/commons/zenoh-buffers/tests/readwrite.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use zenoh_buffers::{
     reader::{HasReader, Reader, SiphonableReader},
     writer::{BacktrackableWriter, HasWriter, Writer},

--- a/commons/zenoh-codec/Cargo.toml
+++ b/commons/zenoh-codec/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-codec"

--- a/commons/zenoh-codec/benches/codec.rs
+++ b/commons/zenoh-codec/benches/codec.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 #[macro_use]
 extern crate criterion;
 

--- a/commons/zenoh-codec/src/common/extension.rs
+++ b/commons/zenoh-codec/src/common/extension.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{RCodec, WCodec, Zenoh080, Zenoh080Bounded, Zenoh080Header};
 use alloc::vec::Vec;
 use zenoh_buffers::{

--- a/commons/zenoh-codec/src/common/mod.rs
+++ b/commons/zenoh-codec/src/common/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,6 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 pub mod extension;
 mod priority;

--- a/commons/zenoh-codec/src/common/priority.rs
+++ b/commons/zenoh-codec/src/common/priority.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{RCodec, WCodec, Zenoh080, Zenoh080Header};
 use core::convert::TryInto;
 use zenoh_buffers::{

--- a/commons/zenoh-codec/src/core/encoding.rs
+++ b/commons/zenoh-codec/src/core/encoding.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{LCodec, RCodec, WCodec, Zenoh080, Zenoh080Bounded};
 use alloc::string::String;
 use zenoh_buffers::{

--- a/commons/zenoh-codec/src/core/locator.rs
+++ b/commons/zenoh-codec/src/core/locator.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{RCodec, WCodec, Zenoh080, Zenoh080Bounded};
 use alloc::{string::String, vec::Vec};
 use core::convert::TryFrom;

--- a/commons/zenoh-codec/src/core/mod.rs
+++ b/commons/zenoh-codec/src/core/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 mod encoding;
 mod locator;
 mod property;

--- a/commons/zenoh-codec/src/core/property.rs
+++ b/commons/zenoh-codec/src/core/property.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{RCodec, WCodec, Zenoh080};
 use alloc::vec::Vec;
 use zenoh_buffers::{

--- a/commons/zenoh-codec/src/core/shm.rs
+++ b/commons/zenoh-codec/src/core/shm.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{RCodec, WCodec, Zenoh080};
 use zenoh_buffers::{
     reader::{DidntRead, Reader},

--- a/commons/zenoh-codec/src/core/timestamp.rs
+++ b/commons/zenoh-codec/src/core/timestamp.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{LCodec, RCodec, WCodec, Zenoh080};
 use core::convert::TryFrom;
 use zenoh_buffers::{

--- a/commons/zenoh-codec/src/core/wire_expr.rs
+++ b/commons/zenoh-codec/src/core/wire_expr.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{core::Zenoh080Bounded, RCodec, WCodec, Zenoh080, Zenoh080Condition};
 use alloc::string::String;
 use zenoh_buffers::{

--- a/commons/zenoh-codec/src/core/zbuf.rs
+++ b/commons/zenoh-codec/src/core/zbuf.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{LCodec, RCodec, WCodec, Zenoh080, Zenoh080Bounded};
 use zenoh_buffers::{
     buffer::Buffer,

--- a/commons/zenoh-codec/src/core/zenohid.rs
+++ b/commons/zenoh-codec/src/core/zenohid.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{LCodec, RCodec, WCodec, Zenoh080, Zenoh080Length};
 use core::convert::TryFrom;
 use zenoh_buffers::{

--- a/commons/zenoh-codec/src/core/zint.rs
+++ b/commons/zenoh-codec/src/core/zint.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{LCodec, RCodec, WCodec, Zenoh080, Zenoh080Bounded};
 use zenoh_buffers::{
     reader::{DidntRead, Reader},

--- a/commons/zenoh-codec/src/core/zslice.rs
+++ b/commons/zenoh-codec/src/core/zslice.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{RCodec, WCodec, Zenoh080, Zenoh080Bounded};
 use zenoh_buffers::{
     reader::{DidntRead, Reader},

--- a/commons/zenoh-codec/src/lib.rs
+++ b/commons/zenoh-codec/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/commons/zenoh-codec/src/network/declare.rs
+++ b/commons/zenoh-codec/src/network/declare.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{common::extension, RCodec, WCodec, Zenoh080, Zenoh080Condition, Zenoh080Header};
 use alloc::string::String;
 use zenoh_buffers::{

--- a/commons/zenoh-codec/src/network/mod.rs
+++ b/commons/zenoh-codec/src/network/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 mod declare;
 mod oam;
 mod push;

--- a/commons/zenoh-codec/src/network/oam.rs
+++ b/commons/zenoh-codec/src/network/oam.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{common::extension, RCodec, WCodec, Zenoh080, Zenoh080Header};
 use zenoh_buffers::{
     reader::{DidntRead, Reader},

--- a/commons/zenoh-codec/src/network/push.rs
+++ b/commons/zenoh-codec/src/network/push.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{common::extension, RCodec, WCodec, Zenoh080, Zenoh080Condition, Zenoh080Header};
 use zenoh_buffers::{
     reader::{DidntRead, Reader},

--- a/commons/zenoh-codec/src/network/request.rs
+++ b/commons/zenoh-codec/src/network/request.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{
     common::extension, RCodec, WCodec, Zenoh080, Zenoh080Bounded, Zenoh080Condition, Zenoh080Header,
 };

--- a/commons/zenoh-codec/src/network/response.rs
+++ b/commons/zenoh-codec/src/network/response.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{
     common::extension, RCodec, WCodec, Zenoh080, Zenoh080Bounded, Zenoh080Condition, Zenoh080Header,
 };

--- a/commons/zenoh-codec/src/scouting/hello.rs
+++ b/commons/zenoh-codec/src/scouting/hello.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{RCodec, WCodec, Zenoh080, Zenoh080Header, Zenoh080Length};
 use alloc::{vec, vec::Vec};
 use zenoh_buffers::{

--- a/commons/zenoh-codec/src/scouting/mod.rs
+++ b/commons/zenoh-codec/src/scouting/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 mod hello;
 mod scout;
 

--- a/commons/zenoh-codec/src/scouting/scout.rs
+++ b/commons/zenoh-codec/src/scouting/scout.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{RCodec, WCodec, Zenoh080, Zenoh080Header, Zenoh080Length};
 use core::convert::TryFrom;
 use zenoh_buffers::{

--- a/commons/zenoh-codec/src/transport/batch.rs
+++ b/commons/zenoh-codec/src/transport/batch.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{RCodec, WCodec, Zenoh080};
 use core::num::NonZeroUsize;
 use zenoh_buffers::reader::{BacktrackableReader, DidntRead, Reader, SiphonableReader};

--- a/commons/zenoh-codec/src/transport/close.rs
+++ b/commons/zenoh-codec/src/transport/close.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{common::extension, RCodec, WCodec, Zenoh080, Zenoh080Header};
 use zenoh_buffers::{
     reader::{DidntRead, Reader},

--- a/commons/zenoh-codec/src/transport/fragment.rs
+++ b/commons/zenoh-codec/src/transport/fragment.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{common::extension, RCodec, WCodec, Zenoh080, Zenoh080Header};
 use zenoh_buffers::{
     reader::{BacktrackableReader, DidntRead, Reader},

--- a/commons/zenoh-codec/src/transport/frame.rs
+++ b/commons/zenoh-codec/src/transport/frame.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{common::extension, RCodec, WCodec, Zenoh080, Zenoh080Header, Zenoh080Reliability};
 use alloc::vec::Vec;
 use zenoh_buffers::{

--- a/commons/zenoh-codec/src/transport/init.rs
+++ b/commons/zenoh-codec/src/transport/init.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{
     common::extension, RCodec, WCodec, Zenoh080, Zenoh080Bounded, Zenoh080Header, Zenoh080Length,
 };

--- a/commons/zenoh-codec/src/transport/join.rs
+++ b/commons/zenoh-codec/src/transport/join.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{common::extension, LCodec, RCodec, WCodec, Zenoh080, Zenoh080Header, Zenoh080Length};
 use alloc::boxed::Box;
 use core::time::Duration;

--- a/commons/zenoh-codec/src/transport/keepalive.rs
+++ b/commons/zenoh-codec/src/transport/keepalive.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{common::extension, RCodec, WCodec, Zenoh080, Zenoh080Header};
 use zenoh_buffers::{
     reader::{DidntRead, Reader},

--- a/commons/zenoh-codec/src/transport/mod.rs
+++ b/commons/zenoh-codec/src/transport/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 pub mod batch;
 mod close;
 mod fragment;

--- a/commons/zenoh-codec/src/transport/oam.rs
+++ b/commons/zenoh-codec/src/transport/oam.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{common::extension, RCodec, WCodec, Zenoh080, Zenoh080Header};
 use zenoh_buffers::{
     reader::{DidntRead, Reader},

--- a/commons/zenoh-codec/src/transport/open.rs
+++ b/commons/zenoh-codec/src/transport/open.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{common::extension, RCodec, WCodec, Zenoh080, Zenoh080Header};
 use core::time::Duration;
 use zenoh_buffers::{

--- a/commons/zenoh-codec/src/zenoh/ack.rs
+++ b/commons/zenoh-codec/src/zenoh/ack.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{common::extension, RCodec, WCodec, Zenoh080, Zenoh080Header};
 use alloc::vec::Vec;
 use zenoh_buffers::{

--- a/commons/zenoh-codec/src/zenoh/del.rs
+++ b/commons/zenoh-codec/src/zenoh/del.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{common::extension, RCodec, WCodec, Zenoh080, Zenoh080Header};
 use alloc::vec::Vec;
 use zenoh_buffers::{

--- a/commons/zenoh-codec/src/zenoh/err.rs
+++ b/commons/zenoh-codec/src/zenoh/err.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{common::extension, RCodec, WCodec, Zenoh080, Zenoh080Header};
 use alloc::vec::Vec;
 use zenoh_buffers::{

--- a/commons/zenoh-codec/src/zenoh/mod.rs
+++ b/commons/zenoh-codec/src/zenoh/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 pub mod ack;
 pub mod del;
 pub mod err;

--- a/commons/zenoh-codec/src/zenoh/pull.rs
+++ b/commons/zenoh-codec/src/zenoh/pull.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{common::extension, RCodec, WCodec, Zenoh080, Zenoh080Header};
 use alloc::vec::Vec;
 use zenoh_buffers::{

--- a/commons/zenoh-codec/src/zenoh/put.rs
+++ b/commons/zenoh-codec/src/zenoh/put.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 #[cfg(not(feature = "shared-memory"))]
 use crate::Zenoh080Bounded;
 #[cfg(feature = "shared-memory")]

--- a/commons/zenoh-codec/src/zenoh/query.rs
+++ b/commons/zenoh-codec/src/zenoh/query.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{common::extension, RCodec, WCodec, Zenoh080, Zenoh080Header};
 use alloc::{string::String, vec::Vec};
 use zenoh_buffers::{

--- a/commons/zenoh-codec/src/zenoh/reply.rs
+++ b/commons/zenoh-codec/src/zenoh/reply.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 #[cfg(not(feature = "shared-memory"))]
 use crate::Zenoh080Bounded;
 #[cfg(feature = "shared-memory")]

--- a/commons/zenoh-codec/tests/codec.rs
+++ b/commons/zenoh-codec/tests/codec.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use rand::{
     distributions::{Alphanumeric, DistString},
     *,

--- a/commons/zenoh-collections/Cargo.toml
+++ b/commons/zenoh-collections/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-collections"

--- a/commons/zenoh-collections/src/lib.rs
+++ b/commons/zenoh-collections/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/commons/zenoh-collections/src/properties.rs
+++ b/commons/zenoh-collections/src/properties.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::{
     collections::HashMap,
     fmt,

--- a/commons/zenoh-collections/src/ring_buffer.rs
+++ b/commons/zenoh-collections/src/ring_buffer.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::collections::VecDeque;
 
 pub struct RingBuffer<T> {

--- a/commons/zenoh-collections/src/single_or_vec.rs
+++ b/commons/zenoh-collections/src/single_or_vec.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use alloc::vec;
 use core::{

--- a/commons/zenoh-collections/src/stack_buffer.rs
+++ b/commons/zenoh-collections/src/stack_buffer.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::collections::VecDeque;
 
 pub struct StackBuffer<T> {

--- a/commons/zenoh-config/Cargo.toml
+++ b/commons/zenoh-config/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-config"

--- a/commons/zenoh-config/src/connection_retry.rs
+++ b/commons/zenoh-config/src/connection_retry.rs
@@ -1,4 +1,3 @@
-//
 // Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use crate::{
     defaults::{

--- a/commons/zenoh-config/src/defaults.rs
+++ b/commons/zenoh-config/src/defaults.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::*;
 
 pub const ENV: &str = "ZENOH_CONFIG";

--- a/commons/zenoh-config/src/include.rs
+++ b/commons/zenoh-config/src/include.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use std::{
     collections::HashSet,

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! Configuration to pass to `zenoh::open()` and `zenoh::scout()` functions and associated constants.
 pub mod defaults;

--- a/commons/zenoh-config/src/mode_dependent.rs
+++ b/commons/zenoh-config/src/mode_dependent.rs
@@ -1,4 +1,3 @@
-//
 // Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use serde::{
     de::{self, MapAccess, Visitor},

--- a/commons/zenoh-core/Cargo.toml
+++ b/commons/zenoh-core/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-core"

--- a/commons/zenoh-core/src/lib.rs
+++ b/commons/zenoh-core/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/commons/zenoh-core/src/macros.rs
+++ b/commons/zenoh-core/src/macros.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 // This macro performs a standard lock on Mutex<T>
 // For performance reasons, it first performs a try_lock() and,

--- a/commons/zenoh-crypto/Cargo.toml
+++ b/commons/zenoh-crypto/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-crypto"

--- a/commons/zenoh-crypto/src/cipher.rs
+++ b/commons/zenoh-crypto/src/cipher.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::PseudoRng;
 use aes::cipher::{generic_array::GenericArray, BlockDecrypt, BlockEncrypt, KeyInit};
 use aes::Aes128;

--- a/commons/zenoh-crypto/src/hmac.rs
+++ b/commons/zenoh-crypto/src/hmac.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use hmac::{Hmac, Mac};
 use sha3::{Digest, Sha3_256};
 use zenoh_result::ZResult;

--- a/commons/zenoh-crypto/src/lib.rs
+++ b/commons/zenoh-crypto/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/commons/zenoh-crypto/src/prng.rs
+++ b/commons/zenoh-crypto/src/prng.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use rand_chacha::ChaCha20Rng;
 
 pub type PseudoRng = ChaCha20Rng;

--- a/commons/zenoh-keyexpr/Cargo.toml
+++ b/commons/zenoh-keyexpr/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-keyexpr"

--- a/commons/zenoh-keyexpr/benches/keyexpr_tree.rs
+++ b/commons/zenoh-keyexpr/benches/keyexpr_tree.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use std::{
     collections::{HashMap, HashSet},

--- a/commons/zenoh-keyexpr/src/key_expr/borrowed.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/borrowed.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use super::{canon::Canonizable, OwnedKeyExpr, FORBIDDEN_CHARS};
 use alloc::{

--- a/commons/zenoh-keyexpr/src/key_expr/canon.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/canon.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::key_expr::{
     utils::{Split, Writer},
     DELIMITER, DOUBLE_WILD, SINGLE_WILD,

--- a/commons/zenoh-keyexpr/src/key_expr/format/mod.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/format/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! # Building and parsing Key Expressions
 //! A common issue in REST API is the association of meaning to sections of the URL, and respecting that API in a convenient manner.

--- a/commons/zenoh-keyexpr/src/key_expr/format/parsing.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/format/parsing.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use zenoh_result::{bail, ZResult};
 

--- a/commons/zenoh-keyexpr/src/key_expr/format/support.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/format/support.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use alloc::{boxed::Box, vec::Vec};
 use core::convert::{TryFrom, TryInto};

--- a/commons/zenoh-keyexpr/src/key_expr/fuzzer.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/fuzzer.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::OwnedKeyExpr;
 
 fn random_chunk(rng: &'_ mut impl rand::Rng) -> impl Iterator<Item = u8> + '_ {

--- a/commons/zenoh-keyexpr/src/key_expr/include.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/include.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::{intersect::MayHaveVerbatim, keyexpr, utils::Split, DELIMITER, DOUBLE_WILD, STAR_DSL};
 
 pub const DEFAULT_INCLUDER: LTRIncluder = LTRIncluder;

--- a/commons/zenoh-keyexpr/src/key_expr/intersect/classical.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/intersect/classical.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 #[cold]
 fn star_dsl_intersect(mut it1: &[u8], mut it2: &[u8]) -> bool {
     fn next(s: &[u8]) -> (u8, &[u8]) {

--- a/commons/zenoh-keyexpr/src/key_expr/intersect/ltr.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/intersect/ltr.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,12 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
-// use super::{
-//     restiction::{NoBigWilds, NoSubWilds},
-//     Intersector,
-// };
-// use crate::key_expr::{utils::Split, DELIMITER};
 
 // #[derive(Debug, Clone, Copy)]
 // pub struct LeftToRightIntersector<ChunkIntersector>(pub ChunkIntersector);

--- a/commons/zenoh-keyexpr/src/key_expr/intersect/ltr_chunk.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/intersect/ltr_chunk.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,8 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
-// use crate::key_expr::SINGLE_WILD;
 
 // use super::{restiction::NoBigWilds, Intersector};
 

--- a/commons/zenoh-keyexpr/src/key_expr/intersect/middle_out.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/intersect/middle_out.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,12 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
-// use super::{
-//     restiction::{NoBigWilds, NoSubWilds},
-//     Intersector,
-// };
-// use crate::key_expr::{utils::Split, DELIMITER, DOUBLE_WILD};
 
 // pub struct MiddleOutIntersector<ChunkIntersector>(pub ChunkIntersector);
 // impl<ChunkIntersector: for<'a> Intersector<NoBigWilds<&'a [u8]>, NoBigWilds<&'a [u8]>>>

--- a/commons/zenoh-keyexpr/src/key_expr/intersect/mod.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/intersect/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use crate::DELIMITER;
 

--- a/commons/zenoh-keyexpr/src/key_expr/mod.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! This module implements the Key Expression Language, as explained in details in [`keyexpr`]'s documentation.
 

--- a/commons/zenoh-keyexpr/src/key_expr/owned.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/owned.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 extern crate alloc;
 
 use super::{canon::Canonizable, keyexpr};

--- a/commons/zenoh-keyexpr/src/key_expr/tests.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/tests.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use crate::key_expr::{fuzzer, intersect::*, keyexpr};
 use std::{convert::TryInto, fmt::Debug};

--- a/commons/zenoh-keyexpr/src/key_expr/utils.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/utils.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use core::{ptr, str};
 
 pub(crate) struct Writer {

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/arc_tree.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/arc_tree.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use alloc::{
     string::String,

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/box_tree.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/box_tree.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 #[cfg(not(feature = "std"))]
 use alloc::boxed::Box;

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/impls/hashmap_impl.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/impls/hashmap_impl.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use core::hash::Hasher;
 #[cfg(not(feature = "std"))]

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/impls/keyed_set_impl.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/impls/keyed_set_impl.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use core::hash::Hasher;
 #[cfg(not(feature = "std"))]

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/impls/mod.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/impls/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use crate::keyexpr;
 pub use hashmap_impl::HashMapProvider;

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/impls/vec_set_impl.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/impls/vec_set_impl.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use alloc::vec::Vec;
 use zenoh_result::unlikely;

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/iters/includer.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/iters/includer.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use crate::keyexpr_tree::*;
 use alloc::vec::Vec;

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/iters/inclusion.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/iters/inclusion.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use crate::keyexpr_tree::*;
 use alloc::vec::Vec;

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/iters/intersection.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/iters/intersection.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use crate::keyexpr_tree::*;
 use alloc::vec::Vec;

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/iters/mod.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/iters/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 mod tree_iter;
 pub use tree_iter::{TreeIter, TreeIterMut};

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/iters/tree_iter.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/iters/tree_iter.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use core::num::NonZeroUsize;
 

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/mod.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! KeTrees are specialized data structures to work with sets of values addressed by key expressions.
 //!

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/support.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/support.rs
@@ -1,3 +1,15 @@
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+
 use alloc::boxed::Box;
 use core::ops::{Deref, DerefMut};
 

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/test.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/test.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use crate::fuzzer::KeyExprFuzzer;
 use alloc::vec::Vec;

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/traits/default_impls.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/traits/default_impls.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use alloc::{boxed::Box, sync::Arc};
 use token_cell::prelude::{TokenCell, TokenCellTrait, TokenTrait};

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/traits/mod.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/traits/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use crate::{keyexpr, OwnedKeyExpr};
 use alloc::boxed::Box;

--- a/commons/zenoh-keyexpr/src/lib.rs
+++ b/commons/zenoh-keyexpr/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! [Key expression](https://github.com/eclipse-zenoh/roadmap/blob/main/rfcs/ALL/Key%20Expressions.md) are Zenoh's address space.
 //!

--- a/commons/zenoh-macros/Cargo.toml
+++ b/commons/zenoh-macros/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-macros"

--- a/commons/zenoh-macros/build.rs
+++ b/commons/zenoh-macros/build.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::{env, ffi::OsString, fs::OpenOptions, io::Write, process::Command};
 
 fn main() {

--- a/commons/zenoh-macros/src/lib.rs
+++ b/commons/zenoh-macros/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/commons/zenoh-macros/src/zenoh_runtime_derive.rs
+++ b/commons/zenoh-macros/src/zenoh_runtime_derive.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/commons/zenoh-protocol/Cargo.toml
+++ b/commons/zenoh-protocol/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-protocol"

--- a/commons/zenoh-protocol/src/common/extension.rs
+++ b/commons/zenoh-protocol/src/common/extension.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use core::{
     convert::TryFrom,
     fmt::{self, Debug},

--- a/commons/zenoh-protocol/src/common/mod.rs
+++ b/commons/zenoh-protocol/src/common/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 pub mod extension;
 pub use extension::*;
 

--- a/commons/zenoh-protocol/src/core/cowstr.rs
+++ b/commons/zenoh-protocol/src/core/cowstr.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use alloc::{borrow::ToOwned, boxed::Box, string::String, vec::Vec};
 use core::fmt::{Debug, Display, Formatter};
 use core::num::NonZeroUsize;

--- a/commons/zenoh-protocol/src/core/encoding.rs
+++ b/commons/zenoh-protocol/src/core/encoding.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::core::CowStr;
 use alloc::{borrow::Cow, string::String};
 use core::{

--- a/commons/zenoh-protocol/src/core/endpoint.rs
+++ b/commons/zenoh-protocol/src/core/endpoint.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::locator::*;
 use alloc::{borrow::ToOwned, format, string::String, vec::Vec};
 use core::{convert::TryFrom, fmt, str::FromStr};

--- a/commons/zenoh-protocol/src/core/locator.rs
+++ b/commons/zenoh-protocol/src/core/locator.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::endpoint::*;
 use alloc::{borrow::ToOwned, string::String};
 use core::{convert::TryFrom, fmt, hash::Hash, str::FromStr};

--- a/commons/zenoh-protocol/src/core/mod.rs
+++ b/commons/zenoh-protocol/src/core/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use alloc::{
     boxed::Box,

--- a/commons/zenoh-protocol/src/core/resolution.rs
+++ b/commons/zenoh-protocol/src/core/resolution.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{network::RequestId, transport::TransportSn};
 use alloc::string::String;
 use core::{fmt, str::FromStr};

--- a/commons/zenoh-protocol/src/core/whatami.rs
+++ b/commons/zenoh-protocol/src/core/whatami.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use alloc::string::String;
 use const_format::formatcp;
 use core::{convert::TryFrom, fmt, num::NonZeroU8, ops::BitOr, str::FromStr};

--- a/commons/zenoh-protocol/src/core/wire_expr.rs
+++ b/commons/zenoh-protocol/src/core/wire_expr.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! This module defines the wire representation of Key Expressions.
 use alloc::{

--- a/commons/zenoh-protocol/src/lib.rs
+++ b/commons/zenoh-protocol/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/commons/zenoh-protocol/src/network/declare.rs
+++ b/commons/zenoh-protocol/src/network/declare.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{
     common::{imsg, ZExtZ64, ZExtZBuf},
     core::{ExprId, Reliability, WireExpr},

--- a/commons/zenoh-protocol/src/network/mod.rs
+++ b/commons/zenoh-protocol/src/network/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 pub mod declare;
 pub mod oam;
 pub mod push;

--- a/commons/zenoh-protocol/src/network/oam.rs
+++ b/commons/zenoh-protocol/src/network/oam.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::common::ZExtBody;
 
 pub type OamId = u16;

--- a/commons/zenoh-protocol/src/network/push.rs
+++ b/commons/zenoh-protocol/src/network/push.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{core::WireExpr, zenoh::PushBody};
 
 pub mod flag {

--- a/commons/zenoh-protocol/src/network/request.rs
+++ b/commons/zenoh-protocol/src/network/request.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{core::WireExpr, zenoh::RequestBody};
 use core::sync::atomic::AtomicU32;
 

--- a/commons/zenoh-protocol/src/network/response.rs
+++ b/commons/zenoh-protocol/src/network/response.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{core::WireExpr, network::RequestId, zenoh::ResponseBody};
 
 /// # Response message

--- a/commons/zenoh-protocol/src/scouting/hello.rs
+++ b/commons/zenoh-protocol/src/scouting/hello.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::core::{Locator, WhatAmI, ZenohId};
 use alloc::vec::Vec;
 use core::fmt;

--- a/commons/zenoh-protocol/src/scouting/mod.rs
+++ b/commons/zenoh-protocol/src/scouting/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 pub mod hello;
 pub mod scout;
 

--- a/commons/zenoh-protocol/src/scouting/scout.rs
+++ b/commons/zenoh-protocol/src/scouting/scout.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::core::{whatami::WhatAmIMatcher, ZenohId};
 
 /// # Scout message

--- a/commons/zenoh-protocol/src/transport/close.rs
+++ b/commons/zenoh-protocol/src/transport/close.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 /// # Close message
 ///

--- a/commons/zenoh-protocol/src/transport/fragment.rs
+++ b/commons/zenoh-protocol/src/transport/fragment.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::core::Reliability;
 pub use crate::transport::TransportSn;
 use zenoh_buffers::ZSlice;

--- a/commons/zenoh-protocol/src/transport/frame.rs
+++ b/commons/zenoh-protocol/src/transport/frame.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{core::Reliability, network::NetworkMessage, transport::TransportSn};
 use alloc::vec::Vec;
 

--- a/commons/zenoh-protocol/src/transport/init.rs
+++ b/commons/zenoh-protocol/src/transport/init.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{
     core::{Resolution, WhatAmI, ZenohId},
     transport::BatchSize,

--- a/commons/zenoh-protocol/src/transport/join.rs
+++ b/commons/zenoh-protocol/src/transport/join.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{
     core::{Priority, Resolution, WhatAmI, ZenohId},
     transport::{BatchSize, PrioritySn},

--- a/commons/zenoh-protocol/src/transport/keepalive.rs
+++ b/commons/zenoh-protocol/src/transport/keepalive.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 /// # KeepAlive message
 ///

--- a/commons/zenoh-protocol/src/transport/mod.rs
+++ b/commons/zenoh-protocol/src/transport/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 pub mod close;
 pub mod fragment;
 pub mod frame;

--- a/commons/zenoh-protocol/src/transport/oam.rs
+++ b/commons/zenoh-protocol/src/transport/oam.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::common::ZExtBody;
 
 pub type OamId = u16;

--- a/commons/zenoh-protocol/src/transport/open.rs
+++ b/commons/zenoh-protocol/src/transport/open.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::transport::TransportSn;
 use core::time::Duration;
 use zenoh_buffers::ZSlice;

--- a/commons/zenoh-protocol/src/zenoh/ack.rs
+++ b/commons/zenoh-protocol/src/zenoh/ack.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::common::ZExtUnknown;
 use alloc::vec::Vec;
 use uhlc::Timestamp;

--- a/commons/zenoh-protocol/src/zenoh/del.rs
+++ b/commons/zenoh-protocol/src/zenoh/del.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::common::ZExtUnknown;
 use alloc::vec::Vec;
 use uhlc::Timestamp;

--- a/commons/zenoh-protocol/src/zenoh/err.rs
+++ b/commons/zenoh-protocol/src/zenoh/err.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::common::ZExtUnknown;
 use alloc::vec::Vec;
 use uhlc::Timestamp;

--- a/commons/zenoh-protocol/src/zenoh/mod.rs
+++ b/commons/zenoh-protocol/src/zenoh/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 pub mod ack;
 pub mod del;
 pub mod err;

--- a/commons/zenoh-protocol/src/zenoh/pull.rs
+++ b/commons/zenoh-protocol/src/zenoh/pull.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::common::ZExtUnknown;
 use alloc::vec::Vec;
 

--- a/commons/zenoh-protocol/src/zenoh/put.rs
+++ b/commons/zenoh-protocol/src/zenoh/put.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{common::ZExtUnknown, core::Encoding};
 use alloc::vec::Vec;
 use uhlc::Timestamp;

--- a/commons/zenoh-protocol/src/zenoh/query.rs
+++ b/commons/zenoh-protocol/src/zenoh/query.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{common::ZExtUnknown, core::ConsolidationMode};
 use alloc::{string::String, vec::Vec};
 

--- a/commons/zenoh-protocol/src/zenoh/reply.rs
+++ b/commons/zenoh-protocol/src/zenoh/reply.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{common::ZExtUnknown, core::Encoding};
 use alloc::vec::Vec;
 use uhlc::Timestamp;

--- a/commons/zenoh-result/Cargo.toml
+++ b/commons/zenoh-result/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-result"

--- a/commons/zenoh-result/src/lib.rs
+++ b/commons/zenoh-result/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/commons/zenoh-runtime/Cargo.toml
+++ b/commons/zenoh-runtime/Cargo.toml
@@ -1,3 +1,15 @@
+# Copyright (c) 2024 ZettaScale Technology
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+#   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+
 [package]
 name = "zenoh-runtime"
 rust-version = { workspace = true }

--- a/commons/zenoh-runtime/src/lib.rs
+++ b/commons/zenoh-runtime/src/lib.rs
@@ -1,4 +1,3 @@
-//
 // Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use core::panic;
 use lazy_static::lazy_static;
 use serde::Deserialize;

--- a/commons/zenoh-shm/Cargo.toml
+++ b/commons/zenoh-shm/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-shm"

--- a/commons/zenoh-shm/src/lib.rs
+++ b/commons/zenoh-shm/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use shared_memory::{Shmem, ShmemConf, ShmemError};
 use std::{
     any::Any,

--- a/commons/zenoh-sync/Cargo.toml
+++ b/commons/zenoh-sync/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-sync"

--- a/commons/zenoh-sync/src/condition.rs
+++ b/commons/zenoh-sync/src/condition.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use event_listener::{Event, EventListener};
 use std::{pin::Pin, sync::MutexGuard};
 use tokio::sync::MutexGuard as AysncMutexGuard;

--- a/commons/zenoh-sync/src/fifo_queue.rs
+++ b/commons/zenoh-sync/src/fifo_queue.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::Condition;
 use tokio::sync::Mutex;
 use zenoh_collections::RingBuffer;

--- a/commons/zenoh-sync/src/lib.rs
+++ b/commons/zenoh-sync/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/commons/zenoh-sync/src/lifo_queue.rs
+++ b/commons/zenoh-sync/src/lifo_queue.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::sync::{Condvar, Mutex};
 use zenoh_collections::StackBuffer;
 use zenoh_core::zlock;

--- a/commons/zenoh-sync/src/mvar.rs
+++ b/commons/zenoh-sync/src/mvar.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::Condition;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::sync::Mutex;

--- a/commons/zenoh-sync/src/object_pool.rs
+++ b/commons/zenoh-sync/src/object_pool.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::LifoQueue;
 use std::{
     any::Any,

--- a/commons/zenoh-sync/src/signal.rs
+++ b/commons/zenoh-sync/src/signal.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::sync::atomic::{AtomicBool, Ordering::*};
 use std::sync::Arc;
 use tokio::sync::Semaphore;

--- a/commons/zenoh-task/Cargo.toml
+++ b/commons/zenoh-task/Cargo.toml
@@ -1,4 +1,3 @@
-#
 # Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-task"

--- a/commons/zenoh-task/src/lib.rs
+++ b/commons/zenoh-task/src/lib.rs
@@ -1,4 +1,3 @@
-//
 // Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/commons/zenoh-util/Cargo.toml
+++ b/commons/zenoh-util/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-util"

--- a/commons/zenoh-util/src/lib.rs
+++ b/commons/zenoh-util/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/commons/zenoh-util/src/std_only/ffi/mod.rs
+++ b/commons/zenoh-util/src/std_only/ffi/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 #[cfg(windows)]
 pub mod win;

--- a/commons/zenoh-util/src/std_only/ffi/win.rs
+++ b/commons/zenoh-util/src/std_only/ffi/win.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::io;
 use std::mem;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};

--- a/commons/zenoh-util/src/std_only/lib_loader.rs
+++ b/commons/zenoh-util/src/std_only/lib_loader.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use libloading::Library;
 use std::env::consts::{DLL_PREFIX, DLL_SUFFIX};
 use std::ffi::OsString;

--- a/commons/zenoh-util/src/std_only/log.rs
+++ b/commons/zenoh-util/src/std_only/log.rs
@@ -1,4 +1,3 @@
-//
 // Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use tracing_subscriber::EnvFilter;
 
 /// This is an utility function to enable the tracing formatting subscriber from

--- a/commons/zenoh-util/src/std_only/mod.rs
+++ b/commons/zenoh-util/src/std_only/mod.rs
@@ -1,3 +1,15 @@
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+
 pub mod ffi;
 mod lib_loader;
 pub mod net;

--- a/commons/zenoh-util/src/std_only/net/mod.rs
+++ b/commons/zenoh-util/src/std_only/net/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::net::{IpAddr, Ipv6Addr};
 use tokio::net::{TcpSocket, UdpSocket};
 use zenoh_core::zconfigurable;

--- a/commons/zenoh-util/src/std_only/time_range.rs
+++ b/commons/zenoh-util/src/std_only/time_range.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use humantime::{format_rfc3339, parse_rfc3339_weak};
 use std::{

--- a/commons/zenoh-util/src/std_only/timer.rs
+++ b/commons/zenoh-util/src/std_only/timer.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use async_std::prelude::*;
 use async_std::sync::Mutex;
 use async_std::task;

--- a/commons/zenoh-util/tests/zresult.rs
+++ b/commons/zenoh-util/tests/zresult.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use zenoh_result::{zerror, ZResult};
 
 #[test]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-examples"

--- a/examples/examples/z_delete.rs
+++ b/examples/examples/z_delete.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use clap::Parser;
 use zenoh::config::Config;
 use zenoh::prelude::r#async::*;

--- a/examples/examples/z_formats.rs
+++ b/examples/examples/z_formats.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use zenoh::prelude::keyexpr;
 

--- a/examples/examples/z_forward.rs
+++ b/examples/examples/z_forward.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use clap::Parser;
 use zenoh::config::Config;
 use zenoh::prelude::r#async::*;

--- a/examples/examples/z_get.rs
+++ b/examples/examples/z_get.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use clap::Parser;
 use std::convert::TryFrom;
 use std::time::Duration;

--- a/examples/examples/z_get_liveliness.rs
+++ b/examples/examples/z_get_liveliness.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use clap::Parser;
 use std::convert::TryFrom;
 use std::time::Duration;

--- a/examples/examples/z_info.rs
+++ b/examples/examples/z_info.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use clap::Parser;
 use zenoh::config::Config;
 use zenoh::prelude::r#async::*;

--- a/examples/examples/z_liveliness.rs
+++ b/examples/examples/z_liveliness.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use clap::Parser;
 use zenoh::config::Config;
 use zenoh::prelude::r#async::*;

--- a/examples/examples/z_ping.rs
+++ b/examples/examples/z_ping.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use clap::Parser;
 use std::time::{Duration, Instant};
 use zenoh::config::Config;

--- a/examples/examples/z_pong.rs
+++ b/examples/examples/z_pong.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use clap::Parser;
 use zenoh::config::Config;
 use zenoh::prelude::sync::*;

--- a/examples/examples/z_pub.rs
+++ b/examples/examples/z_pub.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use clap::Parser;
 use std::time::Duration;
 use zenoh::config::Config;

--- a/examples/examples/z_pub_shm.rs
+++ b/examples/examples/z_pub_shm.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use clap::Parser;
 use std::time::Duration;
 use zenoh::config::Config;

--- a/examples/examples/z_pub_shm_thr.rs
+++ b/examples/examples/z_pub_shm_thr.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use clap::Parser;
 use zenoh::config::Config;
 use zenoh::prelude::r#async::*;

--- a/examples/examples/z_pub_thr.rs
+++ b/examples/examples/z_pub_thr.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use clap::Parser;
 use std::convert::TryInto;

--- a/examples/examples/z_pull.rs
+++ b/examples/examples/z_pull.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use clap::Parser;
 use std::time::Duration;
 use zenoh::config::Config;

--- a/examples/examples/z_put.rs
+++ b/examples/examples/z_put.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use clap::Parser;
 use zenoh::config::Config;
 use zenoh::prelude::r#async::*;

--- a/examples/examples/z_put_float.rs
+++ b/examples/examples/z_put_float.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use clap::Parser;
 use zenoh::config::Config;
 use zenoh::prelude::r#async::*;

--- a/examples/examples/z_queryable.rs
+++ b/examples/examples/z_queryable.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use clap::Parser;
 use zenoh::config::Config;
 use zenoh::prelude::r#async::*;

--- a/examples/examples/z_scout.rs
+++ b/examples/examples/z_scout.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use zenoh::config::Config;
 use zenoh::prelude::r#async::*;
 use zenoh::scouting::WhatAmI;

--- a/examples/examples/z_storage.rs
+++ b/examples/examples/z_storage.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 #![recursion_limit = "256"]
 
 use clap::Parser;

--- a/examples/examples/z_sub.rs
+++ b/examples/examples/z_sub.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use clap::Parser;
 use zenoh::config::Config;
 use zenoh::prelude::r#async::*;

--- a/examples/examples/z_sub_liveliness.rs
+++ b/examples/examples/z_sub_liveliness.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use clap::Parser;
 use zenoh::config::Config;
 use zenoh::prelude::r#async::*;

--- a/examples/examples/z_sub_thr.rs
+++ b/examples/examples/z_sub_thr.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use clap::Parser;
 use std::time::Instant;
 use zenoh::config::Config;

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -1,3 +1,15 @@
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+
 //! Examples on using Zenoh.
 //! See the code in ../examples/
 //! Check ../README.md for usage.

--- a/io/zenoh-link-commons/Cargo.toml
+++ b/io/zenoh-link-commons/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-link-commons"

--- a/io/zenoh-link-commons/src/lib.rs
+++ b/io/zenoh-link-commons/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/io/zenoh-link-commons/src/listener.rs
+++ b/io/zenoh-link-commons/src/listener.rs
@@ -1,4 +1,3 @@
-//
 // Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use futures::Future;
 use std::collections::HashMap;
 use std::net::IpAddr;

--- a/io/zenoh-link-commons/src/multicast.rs
+++ b/io/zenoh-link-commons/src/multicast.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use alloc::{borrow::Cow, boxed::Box, sync::Arc, vec::Vec};
 use async_trait::async_trait;
 use core::{

--- a/io/zenoh-link-commons/src/tls.rs
+++ b/io/zenoh-link-commons/src/tls.rs
@@ -1,3 +1,15 @@
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+
 use alloc::vec::Vec;
 use rustls::{
     client::{

--- a/io/zenoh-link-commons/src/unicast.rs
+++ b/io/zenoh-link-commons/src/unicast.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
 use async_trait::async_trait;
 use core::{

--- a/io/zenoh-link/Cargo.toml
+++ b/io/zenoh-link/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-link"

--- a/io/zenoh-link/src/lib.rs
+++ b/io/zenoh-link/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/io/zenoh-links/zenoh-link-quic/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-quic/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-link-quic"

--- a/io/zenoh-links/zenoh-link-quic/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/io/zenoh-links/zenoh-link-quic/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/unicast.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use crate::base64_decode;
 use crate::{

--- a/io/zenoh-links/zenoh-link-quic/src/verify.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/verify.rs
@@ -1,3 +1,15 @@
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+
 use rustls::client::verify_server_cert_signed_by_trust_anchor;
 use rustls::server::ParsedCertificate;
 use std::time::SystemTime;

--- a/io/zenoh-links/zenoh-link-serial/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-serial/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-link-serial"

--- a/io/zenoh-links/zenoh-link-serial/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-serial/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/io/zenoh-links/zenoh-link-serial/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-serial/src/unicast.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use async_trait::async_trait;
 use std::cell::UnsafeCell;

--- a/io/zenoh-links/zenoh-link-tcp/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-tcp/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-link-tcp"

--- a/io/zenoh-links/zenoh-link-tcp/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use async_trait::async_trait;
 use std::cell::UnsafeCell;
 use std::convert::TryInto;

--- a/io/zenoh-links/zenoh-link-tls/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-tls/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-link-tls"

--- a/io/zenoh-links/zenoh-link-tls/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{
     base64_decode, config::*, get_tls_addr, get_tls_host, get_tls_server_name,
     TLS_ACCEPT_THROTTLE_TIME, TLS_DEFAULT_MTU, TLS_LINGER_TIMEOUT, TLS_LOCATOR_PREFIX,

--- a/io/zenoh-links/zenoh-link-udp/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-udp/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-link-udp"

--- a/io/zenoh-links/zenoh-link-udp/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/io/zenoh-links/zenoh-link-udp/src/multicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/multicast.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::{config::*, UDP_DEFAULT_MTU};
 use crate::{get_udp_addrs, socket_addr_to_udp_locator};
 use async_trait::async_trait;

--- a/io/zenoh-links/zenoh-link-udp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/unicast.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::{
     get_udp_addrs, socket_addr_to_udp_locator, UDP_ACCEPT_THROTTLE_TIME, UDP_DEFAULT_MTU,
     UDP_MAX_MTU,

--- a/io/zenoh-links/zenoh-link-unixpipe/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-unixpipe/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-link-unixpipe"

--- a/io/zenoh-links/zenoh-link-unixpipe/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-unixpipe/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/io/zenoh-links/zenoh-link-unixpipe/src/unix/mod.rs
+++ b/io/zenoh-links/zenoh-link-unixpipe/src/unix/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/io/zenoh-links/zenoh-link-unixpipe/src/unix/unicast.rs
+++ b/io/zenoh-links/zenoh-link-unixpipe/src/unix/unicast.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::config;
 #[cfg(not(target_os = "macos"))]
 use advisory_lock::{AdvisoryFileLock, FileLockMode};

--- a/io/zenoh-links/zenoh-link-unixsock_stream/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-unixsock_stream/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-link-unixsock_stream"

--- a/io/zenoh-links/zenoh-link-unixsock_stream/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-unixsock_stream/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/io/zenoh-links/zenoh-link-unixsock_stream/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-unixsock_stream/src/unicast.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::UNIXSOCKSTREAM_ACCEPT_THROTTLE_TIME;
 use async_trait::async_trait;
 use std::cell::UnsafeCell;

--- a/io/zenoh-links/zenoh-link-vsock/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-vsock/Cargo.toml
@@ -1,4 +1,3 @@
-#
 # Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-link-vsock"

--- a/io/zenoh-links/zenoh-link-vsock/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-vsock/src/lib.rs
@@ -1,4 +1,3 @@
-//
 // Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/io/zenoh-links/zenoh-link-vsock/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-vsock/src/unicast.rs
@@ -1,4 +1,3 @@
-//
 // Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use async_trait::async_trait;
 use libc::VMADDR_PORT_ANY;

--- a/io/zenoh-links/zenoh-link-ws/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-ws/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-link-ws"

--- a/io/zenoh-links/zenoh-link-ws/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-ws/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/io/zenoh-links/zenoh-link-ws/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-ws/src/unicast.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use async_trait::async_trait;
 use futures_util::stream::SplitSink;

--- a/io/zenoh-transport/Cargo.toml
+++ b/io/zenoh-transport/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-transport"

--- a/io/zenoh-transport/src/common/batch.rs
+++ b/io/zenoh-transport/src/common/batch.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::num::NonZeroUsize;
 use zenoh_buffers::{
     buffer::Buffer,

--- a/io/zenoh-transport/src/common/defragmentation.rs
+++ b/io/zenoh-transport/src/common/defragmentation.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::seq_num::SeqNum;
 use zenoh_buffers::{buffer::Buffer, reader::HasReader, ZBuf, ZSlice};
 use zenoh_codec::{RCodec, Zenoh080Reliability};

--- a/io/zenoh-transport/src/common/mod.rs
+++ b/io/zenoh-transport/src/common/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 pub mod batch;
 pub(crate) mod defragmentation;
 pub(crate) mod pipeline;

--- a/io/zenoh-transport/src/common/pipeline.rs
+++ b/io/zenoh-transport/src/common/pipeline.rs
@@ -1,3 +1,15 @@
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+
 use crate::common::batch::BatchConfig;
 
 //

--- a/io/zenoh-transport/src/common/priority.rs
+++ b/io/zenoh-transport/src/common/priority.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::defragmentation::DefragBuffer;
 use super::seq_num::{SeqNum, SeqNumGenerator};
 use std::sync::{Arc, Mutex};

--- a/io/zenoh-transport/src/common/seq_num.rs
+++ b/io/zenoh-transport/src/common/seq_num.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use zenoh_protocol::{core::Bits, transport::TransportSn};
 use zenoh_result::{bail, ZResult};
 

--- a/io/zenoh-transport/src/common/stats.rs
+++ b/io/zenoh-transport/src/common/stats.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 macro_rules! stats_struct {
     (@field_type ) => {AtomicUsize};
     (@field_type $field_type:ident) => {std::sync::Arc<$field_type>};

--- a/io/zenoh-transport/src/lib.rs
+++ b/io/zenoh-transport/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/io/zenoh-transport/src/manager.rs
+++ b/io/zenoh-transport/src/manager.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::unicast::manager::{
     TransportManagerBuilderUnicast, TransportManagerConfigUnicast, TransportManagerStateUnicast,
 };

--- a/io/zenoh-transport/src/multicast/establishment.rs
+++ b/io/zenoh-transport/src/multicast/establishment.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{
     common::{batch::BatchConfig, seq_num},
     multicast::{

--- a/io/zenoh-transport/src/multicast/link.rs
+++ b/io/zenoh-transport/src/multicast/link.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 #[cfg(feature = "stats")]
 use crate::stats::TransportStats;
 use crate::{

--- a/io/zenoh-transport/src/multicast/manager.rs
+++ b/io/zenoh-transport/src/multicast/manager.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 #[cfg(feature = "shared-memory")]
 use crate::multicast::shm::SharedMemoryMulticast;
 use crate::multicast::{transport::TransportMulticastInner, TransportMulticast};

--- a/io/zenoh-transport/src/multicast/mod.rs
+++ b/io/zenoh-transport/src/multicast/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,6 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+
 pub(crate) mod establishment;
 pub(crate) mod link;
 pub(crate) mod manager;

--- a/io/zenoh-transport/src/multicast/rx.rs
+++ b/io/zenoh-transport/src/multicast/rx.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::transport::{TransportMulticastInner, TransportMulticastPeer};
 use crate::common::{
     batch::{Decode, RBatch},

--- a/io/zenoh-transport/src/multicast/shm.rs
+++ b/io/zenoh-transport/src/multicast/shm.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use rand::{Rng, SeedableRng};
 use tokio::sync::RwLock;
 use zenoh_crypto::PseudoRng;

--- a/io/zenoh-transport/src/multicast/transport.rs
+++ b/io/zenoh-transport/src/multicast/transport.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::common::priority::{TransportPriorityRx, TransportPriorityTx};
 use super::link::{TransportLinkMulticastConfigUniversal, TransportLinkMulticastUniversal};
 #[cfg(feature = "stats")]

--- a/io/zenoh-transport/src/multicast/tx.rs
+++ b/io/zenoh-transport/src/multicast/tx.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::transport::TransportMulticastInner;
 use zenoh_core::zread;
 use zenoh_protocol::network::NetworkMessage;

--- a/io/zenoh-transport/src/shm.rs
+++ b/io/zenoh-transport/src/shm.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use tokio::sync::RwLock;
 use zenoh_buffers::{reader::HasReader, writer::HasWriter, ZBuf, ZSlice, ZSliceKind};
 use zenoh_codec::{RCodec, WCodec, Zenoh080};

--- a/io/zenoh-transport/src/unicast/establishment/accept.rs
+++ b/io/zenoh-transport/src/unicast/establishment/accept.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 #[cfg(feature = "shared-memory")]
 use crate::unicast::shared_memory_unicast::Challenge;
 use crate::{

--- a/io/zenoh-transport/src/unicast/establishment/cookie.rs
+++ b/io/zenoh-transport/src/unicast/establishment/cookie.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,8 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
-// use super::properties::EstablishmentProperties;
+
 use crate::unicast::establishment::ext;
 use std::convert::TryFrom;
 use zenoh_buffers::{

--- a/io/zenoh-transport/src/unicast/establishment/ext/auth/mod.rs
+++ b/io/zenoh-transport/src/unicast/establishment/ext/auth/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 #[cfg(feature = "auth_pubkey")]
 pub(crate) mod pubkey;
 #[cfg(feature = "auth_usrpwd")]

--- a/io/zenoh-transport/src/unicast/establishment/ext/auth/pubkey.rs
+++ b/io/zenoh-transport/src/unicast/establishment/ext/auth/pubkey.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::unicast::establishment::{ext::auth::id, AcceptFsm, OpenFsm};
 use async_trait::async_trait;
 use rand::Rng;

--- a/io/zenoh-transport/src/unicast/establishment/ext/auth/usrpwd.rs
+++ b/io/zenoh-transport/src/unicast/establishment/ext/auth/usrpwd.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::unicast::establishment::{ext::auth::id, AcceptFsm, OpenFsm};
 use async_trait::async_trait;
 use rand::{CryptoRng, Rng};

--- a/io/zenoh-transport/src/unicast/establishment/ext/compression.rs
+++ b/io/zenoh-transport/src/unicast/establishment/ext/compression.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::unicast::establishment::{AcceptFsm, OpenFsm};
 use async_trait::async_trait;
 use core::marker::PhantomData;

--- a/io/zenoh-transport/src/unicast/establishment/ext/lowlatency.rs
+++ b/io/zenoh-transport/src/unicast/establishment/ext/lowlatency.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::unicast::establishment::{AcceptFsm, OpenFsm};
 use async_trait::async_trait;
 use core::marker::PhantomData;

--- a/io/zenoh-transport/src/unicast/establishment/ext/mod.rs
+++ b/io/zenoh-transport/src/unicast/establishment/ext/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 #[cfg(feature = "transport_auth")]
 pub mod auth;
 #[cfg(feature = "transport_compression")]

--- a/io/zenoh-transport/src/unicast/establishment/ext/multilink.rs
+++ b/io/zenoh-transport/src/unicast/establishment/ext/multilink.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::unicast::establishment::{
     ext::auth::pubkey::{self, AuthPubKey, AuthPubKeyFsm, ZPublicKey},
     AcceptFsm, OpenFsm,

--- a/io/zenoh-transport/src/unicast/establishment/ext/qos.rs
+++ b/io/zenoh-transport/src/unicast/establishment/ext/qos.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::unicast::establishment::{AcceptFsm, OpenFsm};
 use async_trait::async_trait;
 use core::marker::PhantomData;

--- a/io/zenoh-transport/src/unicast/establishment/ext/shm.rs
+++ b/io/zenoh-transport/src/unicast/establishment/ext/shm.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::unicast::{
     establishment::{AcceptFsm, OpenFsm},
     shared_memory_unicast::{Challenge, SharedMemoryUnicast},

--- a/io/zenoh-transport/src/unicast/establishment/mod.rs
+++ b/io/zenoh-transport/src/unicast/establishment/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 pub(crate) mod accept;
 pub(super) mod cookie;
 pub mod ext;

--- a/io/zenoh-transport/src/unicast/establishment/open.rs
+++ b/io/zenoh-transport/src/unicast/establishment/open.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 #[cfg(feature = "shared-memory")]
 use crate::unicast::shared_memory_unicast::Challenge;
 use crate::{

--- a/io/zenoh-transport/src/unicast/establishment/properties.rs
+++ b/io/zenoh-transport/src/unicast/establishment/properties.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::{
     convert::TryFrom,
     ops::{Deref, DerefMut},

--- a/io/zenoh-transport/src/unicast/link.rs
+++ b/io/zenoh-transport/src/unicast/link.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::common::batch::{BatchConfig, Decode, Encode, Finalize, RBatch, WBatch};
 use std::fmt;
 use std::sync::Arc;

--- a/io/zenoh-transport/src/unicast/lowlatency/link.rs
+++ b/io/zenoh-transport/src/unicast/lowlatency/link.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::transport::TransportUnicastLowlatency;
 #[cfg(feature = "stats")]
 use crate::stats::TransportStats;

--- a/io/zenoh-transport/src/unicast/lowlatency/mod.rs
+++ b/io/zenoh-transport/src/unicast/lowlatency/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 pub(crate) mod transport;
 
 mod link;

--- a/io/zenoh-transport/src/unicast/lowlatency/rx.rs
+++ b/io/zenoh-transport/src/unicast/lowlatency/rx.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::transport::TransportUnicastLowlatency;
 use zenoh_buffers::{
     reader::{HasReader, Reader},

--- a/io/zenoh-transport/src/unicast/lowlatency/transport.rs
+++ b/io/zenoh-transport/src/unicast/lowlatency/transport.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 #[cfg(feature = "stats")]
 use crate::stats::TransportStats;
 use crate::{

--- a/io/zenoh-transport/src/unicast/lowlatency/tx.rs
+++ b/io/zenoh-transport/src/unicast/lowlatency/tx.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::transport::TransportUnicastLowlatency;
 use zenoh_protocol::{
     network::NetworkMessage,

--- a/io/zenoh-transport/src/unicast/manager.rs
+++ b/io/zenoh-transport/src/unicast/manager.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 #[cfg(feature = "shared-memory")]
 use super::shared_memory_unicast::SharedMemoryUnicast;
 use super::{link::LinkUnicastWithOpenAck, transport_unicast_inner::InitTransportResult};

--- a/io/zenoh-transport/src/unicast/mod.rs
+++ b/io/zenoh-transport/src/unicast/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 pub mod establishment;
 pub(crate) mod link;
 pub(crate) mod lowlatency;

--- a/io/zenoh-transport/src/unicast/shared_memory_unicast.rs
+++ b/io/zenoh-transport/src/unicast/shared_memory_unicast.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use rand::{Rng, SeedableRng};
 use tokio::sync::RwLock;
 use zenoh_core::zerror;

--- a/io/zenoh-transport/src/unicast/test_helpers.rs
+++ b/io/zenoh-transport/src/unicast/test_helpers.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{unicast::TransportManagerBuilderUnicast, TransportManager};
 use zenoh_core::zcondfeat;
 

--- a/io/zenoh-transport/src/unicast/transport_unicast_inner.rs
+++ b/io/zenoh-transport/src/unicast/transport_unicast_inner.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use crate::{
     unicast::{link::TransportLinkUnicast, TransportConfigUnicast},

--- a/io/zenoh-transport/src/unicast/universal/link.rs
+++ b/io/zenoh-transport/src/unicast/universal/link.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::transport::TransportUnicastUniversal;
 use crate::{
     common::{

--- a/io/zenoh-transport/src/unicast/universal/mod.rs
+++ b/io/zenoh-transport/src/unicast/universal/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 pub(crate) mod transport;
 
 mod link;

--- a/io/zenoh-transport/src/unicast/universal/reliability.rs
+++ b/io/zenoh-transport/src/unicast/universal/reliability.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::convert::TryInto;
 use std::fmt;
 

--- a/io/zenoh-transport/src/unicast/universal/rx.rs
+++ b/io/zenoh-transport/src/unicast/universal/rx.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::transport::TransportUnicastUniversal;
 use crate::{
     common::{

--- a/io/zenoh-transport/src/unicast/universal/transport.rs
+++ b/io/zenoh-transport/src/unicast/universal/transport.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 #[cfg(feature = "stats")]
 use crate::stats::TransportStats;
 use crate::{

--- a/io/zenoh-transport/src/unicast/universal/tx.rs
+++ b/io/zenoh-transport/src/unicast/universal/tx.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::transport::TransportUnicastUniversal;
 use zenoh_core::zread;
 use zenoh_protocol::network::NetworkMessage;

--- a/io/zenoh-transport/tests/endpoints.rs
+++ b/io/zenoh-transport/tests/endpoints.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::{any::Any, convert::TryFrom, sync::Arc, time::Duration};
 use zenoh_core::ztimeout;
 use zenoh_link::{EndPoint, Link};

--- a/io/zenoh-transport/tests/multicast_compression.rs
+++ b/io/zenoh-transport/tests/multicast_compression.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 // Restricting to macos by default because of no IPv6 support
 // on GitHub CI actions on Linux and Windows.

--- a/io/zenoh-transport/tests/multicast_transport.rs
+++ b/io/zenoh-transport/tests/multicast_transport.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 // Restricting to macos by default because of no IPv6 support
 // on GitHub CI actions on Linux and Windows.

--- a/io/zenoh-transport/tests/transport_whitelist.rs
+++ b/io/zenoh-transport/tests/transport_whitelist.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::{any::Any, convert::TryFrom, iter::FromIterator, sync::Arc, time::Duration};
 use zenoh_core::ztimeout;
 use zenoh_link::Link;

--- a/io/zenoh-transport/tests/unicast_authenticator.rs
+++ b/io/zenoh-transport/tests/unicast_authenticator.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::{any::Any, sync::Arc, time::Duration};
 use zenoh_core::{zasyncwrite, ztimeout};
 use zenoh_link::Link;

--- a/io/zenoh-transport/tests/unicast_compression.rs
+++ b/io/zenoh-transport/tests/unicast_compression.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 #[cfg(feature = "transport_compression")]
 mod tests {
     use std::fmt::Write as _;

--- a/io/zenoh-transport/tests/unicast_concurrent.rs
+++ b/io/zenoh-transport/tests/unicast_concurrent.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -9,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::any::Any;
 use std::convert::TryFrom;
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/io/zenoh-transport/tests/unicast_defragmentation.rs
+++ b/io/zenoh-transport/tests/unicast_defragmentation.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::{convert::TryFrom, sync::Arc, time::Duration};
 use zenoh_core::ztimeout;
 use zenoh_protocol::{

--- a/io/zenoh-transport/tests/unicast_intermittent.rs
+++ b/io/zenoh-transport/tests/unicast_intermittent.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::any::Any;
 use std::convert::TryFrom;
 use std::io::Write;

--- a/io/zenoh-transport/tests/unicast_multilink.rs
+++ b/io/zenoh-transport/tests/unicast_multilink.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 #[cfg(feature = "transport_multilink")]
 mod tests {
     use std::{convert::TryFrom, sync::Arc, time::Duration};

--- a/io/zenoh-transport/tests/unicast_openclose.rs
+++ b/io/zenoh-transport/tests/unicast_openclose.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::{convert::TryFrom, sync::Arc, time::Duration};
 use zenoh_core::ztimeout;
 use zenoh_link::EndPoint;

--- a/io/zenoh-transport/tests/unicast_priorities.rs
+++ b/io/zenoh-transport/tests/unicast_priorities.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::any::Any;
 use std::convert::TryFrom;
 use std::fmt::Write as _;

--- a/io/zenoh-transport/tests/unicast_shm.rs
+++ b/io/zenoh-transport/tests/unicast_shm.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 #[cfg(feature = "shared-memory")]
 mod tests {
     use rand::{Rng, SeedableRng};

--- a/io/zenoh-transport/tests/unicast_simultaneous.rs
+++ b/io/zenoh-transport/tests/unicast_simultaneous.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 #[cfg(target_family = "unix")]
 mod tests {
     use std::any::Any;

--- a/io/zenoh-transport/tests/unicast_transport.rs
+++ b/io/zenoh-transport/tests/unicast_transport.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::fmt::Write as _;
 use std::{
     any::Any,

--- a/license-header.txt
+++ b/license-header.txt
@@ -1,0 +1,11 @@
+Copyright (c) ${year} ZettaScale Technology
+
+This program and the accompanying materials are made available under the
+terms of the Eclipse Public License 2.0 which is available at
+http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+which is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+Contributors:
+  ZettaScale Zenoh Team, <zenoh@zettascale.tech>

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -1,0 +1,16 @@
+# Copyright (c) 2024 ZettaScale Technology
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+#   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+
+headerPath = "license-header.txt"
+
+[properties]
+year = 2024

--- a/plugins/zenoh-backend-example/Cargo.toml
+++ b/plugins/zenoh-backend-example/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-backend-example"

--- a/plugins/zenoh-backend-example/src/lib.rs
+++ b/plugins/zenoh-backend-example/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use async_std::sync::RwLock;
 use async_trait::async_trait;
 use std::{

--- a/plugins/zenoh-backend-traits/Cargo.toml
+++ b/plugins/zenoh-backend-traits/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh_backend_traits"

--- a/plugins/zenoh-backend-traits/src/config.rs
+++ b/plugins/zenoh-backend-traits/src/config.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use const_format::concatcp;
 use derive_more::{AsMut, AsRef};
 use schemars::JsonSchema;

--- a/plugins/zenoh-backend-traits/src/lib.rs
+++ b/plugins/zenoh-backend-traits/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/plugins/zenoh-plugin-example/Cargo.toml
+++ b/plugins/zenoh-plugin-example/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-plugin-example"

--- a/plugins/zenoh-plugin-example/src/lib.rs
+++ b/plugins/zenoh-plugin-example/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 #![recursion_limit = "256"]
 
 use futures::select;

--- a/plugins/zenoh-plugin-rest/Cargo.toml
+++ b/plugins/zenoh-plugin-rest/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-plugin-rest"

--- a/plugins/zenoh-plugin-rest/build.rs
+++ b/plugins/zenoh-plugin-rest/build.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use schemars::schema_for;
 
 use crate::config::Config;

--- a/plugins/zenoh-plugin-rest/examples/z_serve_sse.rs
+++ b/plugins/zenoh-plugin-rest/examples/z_serve_sse.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use clap::{arg, Command};
 use std::time::Duration;
 use zenoh::prelude::r#async::*;

--- a/plugins/zenoh-plugin-rest/src/config.rs
+++ b/plugins/zenoh-plugin-rest/src/config.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use schemars::JsonSchema;
 use serde::de::{Unexpected, Visitor};
 use serde::{de, Deserialize, Deserializer};

--- a/plugins/zenoh-plugin-rest/src/lib.rs
+++ b/plugins/zenoh-plugin-rest/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/plugins/zenoh-plugin-storage-manager/Cargo.toml
+++ b/plugins/zenoh-plugin-storage-manager/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-plugin-storage-manager"

--- a/plugins/zenoh-plugin-storage-manager/build.rs
+++ b/plugins/zenoh-plugin-storage-manager/build.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use schemars::schema_for;
 use zenoh_backend_traits::config::PluginConfig;
 

--- a/plugins/zenoh-plugin-storage-manager/src/backends_mgt.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/backends_mgt.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::storages_mgt::*;
 use flume::Sender;
 use std::sync::Arc;

--- a/plugins/zenoh-plugin-storage-manager/src/lib.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/plugins/zenoh-plugin-storage-manager/src/memory_backend/mod.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/memory_backend/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use async_std::sync::RwLock;
 use async_trait::async_trait;
 use std::collections::HashMap;

--- a/plugins/zenoh-plugin-storage-manager/src/replica/align_queryable.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/align_queryable.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::digest::*;
 use super::Snapshotter;
 use async_std::sync::Arc;

--- a/plugins/zenoh-plugin-storage-manager/src/replica/aligner.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/aligner.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use super::{Digest, EraType, LogEntry, Snapshotter};
 use super::{CONTENTS, ERA, INTERVALS, SUBINTERVALS};

--- a/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/digest.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use crc::{Crc, CRC_64_ECMA_182};
 use derive_new::new;

--- a/plugins/zenoh-plugin-storage-manager/src/replica/mod.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 // This module extends Storage with alignment protocol that aligns storages subscribing to the same key_expr
 

--- a/plugins/zenoh-plugin-storage-manager/src/replica/snapshotter.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/snapshotter.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::{Digest, DigestConfig, LogEntry};
 use async_std::sync::Arc;
 use async_std::sync::RwLock;

--- a/plugins/zenoh-plugin-storage-manager/src/replica/storage.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/storage.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::backends_mgt::StoreIntercept;
 use crate::storages_mgt::StorageMessage;
 use async_std::sync::Arc;

--- a/plugins/zenoh-plugin-storage-manager/src/storages_mgt.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/storages_mgt.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use async_std::sync::Arc;
 use zenoh::Session;
 use zenoh_backend_traits::config::StorageConfig;

--- a/plugins/zenoh-plugin-storage-manager/tests/operations.rs
+++ b/plugins/zenoh-plugin-storage-manager/tests/operations.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 // Test wild card updates -
 // 1. normal case, just some wild card puts and deletes on existing keys and ensure it works

--- a/plugins/zenoh-plugin-storage-manager/tests/wildcard.rs
+++ b/plugins/zenoh-plugin-storage-manager/tests/wildcard.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 // Test wild card updates -
 // 1. normal case, just some wild card puts and deletes on existing keys and ensure it works

--- a/plugins/zenoh-plugin-trait/Cargo.toml
+++ b/plugins/zenoh-plugin-trait/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-plugin-trait"

--- a/plugins/zenoh-plugin-trait/src/compatibility.rs
+++ b/plugins/zenoh-plugin-trait/src/compatibility.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use std::fmt::Display;
 

--- a/plugins/zenoh-plugin-trait/src/lib.rs
+++ b/plugins/zenoh-plugin-trait/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! # The plugin infrastructure for Zenoh.
 //!

--- a/plugins/zenoh-plugin-trait/src/manager.rs
+++ b/plugins/zenoh-plugin-trait/src/manager.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -9,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 mod dynamic_plugin;
 mod static_plugin;
 

--- a/plugins/zenoh-plugin-trait/src/manager/dynamic_plugin.rs
+++ b/plugins/zenoh-plugin-trait/src/manager/dynamic_plugin.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -9,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::*;
 use std::path::{Path, PathBuf};
 

--- a/plugins/zenoh-plugin-trait/src/manager/static_plugin.rs
+++ b/plugins/zenoh-plugin-trait/src/manager/static_plugin.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::*;
 use std::marker::PhantomData;
 use zenoh_result::ZResult;

--- a/plugins/zenoh-plugin-trait/src/plugin.rs
+++ b/plugins/zenoh-plugin-trait/src/plugin.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::StructVersion;
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, ops::BitOrAssign};

--- a/plugins/zenoh-plugin-trait/src/vtable.rs
+++ b/plugins/zenoh-plugin-trait/src/vtable.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use zenoh_result::ZResult;
 
 use crate::{Plugin, StructVersion, FEATURES};

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,14 @@
+# Copyright (c) 2024 ZettaScale Technology
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+#   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+
 [toolchain]
 channel = "1.72.0"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,15 @@
+# Copyright (c) 2024 ZettaScale Technology
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+#   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+
 edition = "2021"
 use_try_shorthand = true
 use_field_init_shorthand = true

--- a/zenoh-ext/Cargo.toml
+++ b/zenoh-ext/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-ext"

--- a/zenoh-ext/examples/Cargo.toml
+++ b/zenoh-ext/examples/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh-ext-examples"

--- a/zenoh-ext/examples/examples/z_member.rs
+++ b/zenoh-ext/examples/examples/z_member.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use futures::StreamExt;
 use std::sync::Arc;
 use std::time::Duration;

--- a/zenoh-ext/examples/examples/z_pub_cache.rs
+++ b/zenoh-ext/examples/examples/z_pub_cache.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use clap::{arg, Parser};
 use std::time::Duration;
 use zenoh::config::{Config, ModeDependentValue};

--- a/zenoh-ext/examples/examples/z_query_sub.rs
+++ b/zenoh-ext/examples/examples/z_query_sub.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use clap::arg;
 use clap::Parser;
 use zenoh::config::Config;

--- a/zenoh-ext/examples/examples/z_view_size.rs
+++ b/zenoh-ext/examples/examples/z_view_size.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use clap::{arg, Parser};
 use std::sync::Arc;
 use std::time::Duration;

--- a/zenoh-ext/examples/src/lib.rs
+++ b/zenoh-ext/examples/src/lib.rs
@@ -1,3 +1,15 @@
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+
 //! Examples on using Zenoh.
 //! See the code in ../examples/
 //! Check ../README.md for usage.

--- a/zenoh-ext/src/group.rs
+++ b/zenoh-ext/src/group.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! To manage groups and group memeberships
 

--- a/zenoh-ext/src/lib.rs
+++ b/zenoh-ext/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 pub mod group;
 mod publication_cache;
 mod querying_subscriber;

--- a/zenoh-ext/src/publication_cache.rs
+++ b/zenoh-ext/src/publication_cache.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::collections::{HashMap, VecDeque};
 use std::convert::TryInto;
 use std::future::Ready;

--- a/zenoh-ext/src/querying_subscriber.rs
+++ b/zenoh-ext/src/querying_subscriber.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::collections::{btree_map, BTreeMap, VecDeque};
 use std::convert::TryInto;
 use std::future::Ready;

--- a/zenoh-ext/src/session_ext.rs
+++ b/zenoh-ext/src/session_ext.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::PublicationCacheBuilder;
 use std::convert::TryInto;
 use std::sync::Arc;

--- a/zenoh-ext/src/subscriber_ext.rs
+++ b/zenoh-ext/src/subscriber_ext.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use flume::r#async::RecvStream;
 use futures::stream::{Forward, Map};
 use std::{convert::TryInto, time::Duration};

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenoh"

--- a/zenoh/build.rs
+++ b/zenoh/build.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -9,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 fn main() {
     // Add rustc version to zenohd
     let version_meta = rustc_version::version_meta().unwrap();

--- a/zenoh/src/admin.rs
+++ b/zenoh/src/admin.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::{
     keyexpr,
     prelude::sync::{KeyExpr, Locality, SampleKind},

--- a/zenoh/src/handlers.rs
+++ b/zenoh/src/handlers.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! Callback handler trait.
 use crate::API_DATA_RECEPTION_CHANNEL_SIZE;

--- a/zenoh/src/info.rs
+++ b/zenoh/src/info.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! Tools to access information about the current zenoh [`Session`](crate::Session).
 use crate::SessionRef;

--- a/zenoh/src/key_expr.rs
+++ b/zenoh/src/key_expr.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! [Key expression](https://github.com/eclipse-zenoh/roadmap/blob/main/rfcs/ALL/Key%20Expressions.md) are Zenoh's address space.
 //!

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! [Zenoh](https://zenoh.io) /zeno/ is a stack that unifies data in motion, data at
 //! rest and computations. It elegantly blends traditional pub/sub with geo distributed

--- a/zenoh/src/liveliness.rs
+++ b/zenoh/src/liveliness.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! Liveliness primitives.
 //!

--- a/zenoh/src/net/codec/linkstate.rs
+++ b/zenoh/src/net/codec/linkstate.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::Zenoh080Routing;
 use crate::net::protocol::{
     linkstate,

--- a/zenoh/src/net/codec/mod.rs
+++ b/zenoh/src/net/codec/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 pub(crate) mod linkstate;
 
 #[derive(Clone, Copy)]

--- a/zenoh/src/net/mod.rs
+++ b/zenoh/src/net/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/zenoh/src/net/primitives/demux.rs
+++ b/zenoh/src/net/primitives/demux.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::Primitives;
 use crate::net::routing::{
     dispatcher::face::Face,

--- a/zenoh/src/net/primitives/mod.rs
+++ b/zenoh/src/net/primitives/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 mod demux;
 mod mux;
 

--- a/zenoh/src/net/primitives/mux.rs
+++ b/zenoh/src/net/primitives/mux.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::{EPrimitives, Primitives};
 use crate::net::routing::{
     dispatcher::face::{Face, WeakFace},

--- a/zenoh/src/net/protocol/linkstate.rs
+++ b/zenoh/src/net/protocol/linkstate.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use zenoh_protocol::core::{Locator, WhatAmI, ZenohId};
 
 pub const PID: u64 = 1; // 0x01

--- a/zenoh/src/net/protocol/mod.rs
+++ b/zenoh/src/net/protocol/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,5 +9,5 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 pub(crate) mod linkstate;

--- a/zenoh/src/net/routing/dispatcher/face.rs
+++ b/zenoh/src/net/routing/dispatcher/face.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::super::router::*;
 use super::tables::TablesLock;
 use super::{resource::*, tables};

--- a/zenoh/src/net/routing/dispatcher/mod.rs
+++ b/zenoh/src/net/routing/dispatcher/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/zenoh/src/net/routing/dispatcher/pubsub.rs
+++ b/zenoh/src/net/routing/dispatcher/pubsub.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::face::FaceState;
 use super::resource::{DataRoutes, Direction, PullCaches, Resource};
 use super::tables::{NodeId, Route, RoutingExpr, Tables, TablesLock};

--- a/zenoh/src/net/routing/dispatcher/queries.rs
+++ b/zenoh/src/net/routing/dispatcher/queries.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::face::FaceState;
 use super::resource::{QueryRoute, QueryRoutes, QueryTargetQablSet, Resource};
 use super::tables::NodeId;

--- a/zenoh/src/net/routing/dispatcher/resource.rs
+++ b/zenoh/src/net/routing/dispatcher/resource.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::face::FaceState;
 use super::tables::{Tables, TablesLock};
 use crate::net::routing::dispatcher::face::Face;

--- a/zenoh/src/net/routing/dispatcher/tables.rs
+++ b/zenoh/src/net/routing/dispatcher/tables.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::face::FaceState;
 pub use super::pubsub::*;
 pub use super::queries::*;

--- a/zenoh/src/net/routing/hat/client/mod.rs
+++ b/zenoh/src/net/routing/hat/client/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/zenoh/src/net/routing/hat/client/pubsub.rs
+++ b/zenoh/src/net/routing/hat/client/pubsub.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::{face_hat, face_hat_mut, get_routes_entries};
 use super::{HatCode, HatFace};
 use crate::net::routing::dispatcher::face::FaceState;

--- a/zenoh/src/net/routing/hat/client/queries.rs
+++ b/zenoh/src/net/routing/hat/client/queries.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::{face_hat, face_hat_mut, get_routes_entries};
 use super::{HatCode, HatFace};
 use crate::net::routing::dispatcher::face::FaceState;

--- a/zenoh/src/net/routing/hat/linkstate_peer/mod.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/zenoh/src/net/routing/hat/linkstate_peer/network.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/network.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::net::codec::Zenoh080Routing;
 use crate::net::protocol::linkstate::{LinkState, LinkStateList};
 use crate::net::routing::dispatcher::tables::NodeId;

--- a/zenoh/src/net/routing/hat/linkstate_peer/pubsub.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/pubsub.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::network::Network;
 use super::{face_hat, face_hat_mut, get_routes_entries, hat, hat_mut, res_hat, res_hat_mut};
 use super::{get_peer, HatCode, HatContext, HatFace, HatTables};

--- a/zenoh/src/net/routing/hat/linkstate_peer/queries.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/queries.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::network::Network;
 use super::{face_hat, face_hat_mut, get_routes_entries, hat, hat_mut, res_hat, res_hat_mut};
 use super::{get_peer, HatCode, HatContext, HatFace, HatTables};

--- a/zenoh/src/net/routing/hat/mod.rs
+++ b/zenoh/src/net/routing/hat/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/zenoh/src/net/routing/hat/p2p_peer/gossip.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/gossip.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::net::codec::Zenoh080Routing;
 use crate::net::protocol::linkstate::{LinkState, LinkStateList};
 use crate::net::runtime::Runtime;

--- a/zenoh/src/net/routing/hat/p2p_peer/mod.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/zenoh/src/net/routing/hat/p2p_peer/pubsub.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/pubsub.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::{face_hat, face_hat_mut, get_routes_entries};
 use super::{HatCode, HatFace};
 use crate::net::routing::dispatcher::face::FaceState;

--- a/zenoh/src/net/routing/hat/p2p_peer/queries.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/queries.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::{face_hat, face_hat_mut, get_routes_entries};
 use super::{HatCode, HatFace};
 use crate::net::routing::dispatcher::face::FaceState;

--- a/zenoh/src/net/routing/hat/router/mod.rs
+++ b/zenoh/src/net/routing/hat/router/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/zenoh/src/net/routing/hat/router/network.rs
+++ b/zenoh/src/net/routing/hat/router/network.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::net::codec::Zenoh080Routing;
 use crate::net::protocol::linkstate::{LinkState, LinkStateList};
 use crate::net::routing::dispatcher::tables::NodeId;

--- a/zenoh/src/net/routing/hat/router/pubsub.rs
+++ b/zenoh/src/net/routing/hat/router/pubsub.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::network::Network;
 use super::{face_hat, face_hat_mut, get_routes_entries, hat, hat_mut, res_hat, res_hat_mut};
 use super::{get_peer, get_router, HatCode, HatContext, HatFace, HatTables};

--- a/zenoh/src/net/routing/hat/router/queries.rs
+++ b/zenoh/src/net/routing/hat/router/queries.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::network::Network;
 use super::{face_hat, face_hat_mut, get_routes_entries, hat, hat_mut, res_hat, res_hat_mut};
 use super::{get_peer, get_router, HatCode, HatContext, HatFace, HatTables};

--- a/zenoh/src/net/routing/interceptor/access_control.rs
+++ b/zenoh/src/net/routing/interceptor/access_control.rs
@@ -1,4 +1,3 @@
-//
 // Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/zenoh/src/net/routing/interceptor/authorization.rs
+++ b/zenoh/src/net/routing/interceptor/authorization.rs
@@ -1,4 +1,3 @@
-//
 // Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/zenoh/src/net/routing/interceptor/downsampling.rs
+++ b/zenoh/src/net/routing/interceptor/downsampling.rs
@@ -1,4 +1,3 @@
-//
 // Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/zenoh/src/net/routing/interceptor/mod.rs
+++ b/zenoh/src/net/routing/interceptor/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/zenoh/src/net/routing/mod.rs
+++ b/zenoh/src/net/routing/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/zenoh/src/net/routing/router.rs
+++ b/zenoh/src/net/routing/router.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::dispatcher::face::{Face, FaceState};
 pub use super::dispatcher::pubsub::*;
 pub use super::dispatcher::queries::*;

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,6 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+
 use super::routing::dispatcher::face::Face;
 use super::Runtime;
 use crate::key_expr::KeyExpr;

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/zenoh/src/net/runtime/orchestrator.rs
+++ b/zenoh/src/net/runtime/orchestrator.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use super::{Runtime, RuntimeSession};
 use futures::prelude::*;
 use socket2::{Domain, Socket, Type};

--- a/zenoh/src/net/tests/mod.rs
+++ b/zenoh/src/net/tests/mod.rs
@@ -1,1 +1,13 @@
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+
 pub(crate) mod tables;

--- a/zenoh/src/net/tests/tables.rs
+++ b/zenoh/src/net/tests/tables.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::net::primitives::{DummyPrimitives, EPrimitives, Primitives};
 use crate::net::routing::dispatcher::tables::{self, Tables};
 use crate::net::routing::router::*;

--- a/zenoh/src/plugins/mod.rs
+++ b/zenoh/src/plugins/mod.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! ⚠️ WARNING ⚠️
 //!

--- a/zenoh/src/plugins/sealed.rs
+++ b/zenoh/src/plugins/sealed.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! `zenohd`'s plugin system. For more details, consult the [detailed documentation](https://github.com/eclipse-zenoh/roadmap/blob/main/rfcs/ALL/Plugins/Zenoh%20Plugins.md).
 

--- a/zenoh/src/prelude.rs
+++ b/zenoh/src/prelude.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! A "prelude" for crates using the `zenoh` crate.
 //!

--- a/zenoh/src/publication.rs
+++ b/zenoh/src/publication.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! Publishing primitives.
 #[zenoh_macros::unstable]

--- a/zenoh/src/query.rs
+++ b/zenoh/src/query.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! Query primitives.
 

--- a/zenoh/src/queryable.rs
+++ b/zenoh/src/queryable.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! Queryable primitives.
 

--- a/zenoh/src/sample.rs
+++ b/zenoh/src/sample.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! Sample primitives
 use crate::buffers::ZBuf;

--- a/zenoh/src/scouting.rs
+++ b/zenoh/src/scouting.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use crate::handlers::{locked, Callback, DefaultHandler};
 use crate::net::runtime::{orchestrator::Loop, Runtime};
 

--- a/zenoh/src/selector.rs
+++ b/zenoh/src/selector.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! [Selector](https://github.com/eclipse-zenoh/roadmap/tree/main/rfcs/ALL/Selectors) to issue queries
 

--- a/zenoh/src/session.rs
+++ b/zenoh/src/session.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 use crate::admin;
 use crate::config::Config;

--- a/zenoh/src/subscriber.rs
+++ b/zenoh/src/subscriber.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! Subscribing primitives.
 use crate::handlers::{locked, Callback, DefaultHandler};

--- a/zenoh/src/value.rs
+++ b/zenoh/src/value.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,6 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 
 //! Value primitives.
 

--- a/zenoh/tests/acl.rs
+++ b/zenoh/tests/acl.rs
@@ -1,4 +1,3 @@
-//
 // Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 #![cfg(target_family = "unix")]
 mod test {
     use std::sync::{Arc, Mutex};

--- a/zenoh/tests/attachments.rs
+++ b/zenoh/tests/attachments.rs
@@ -1,4 +1,3 @@
-//
 // Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 #[cfg(feature = "unstable")]
 #[test]
 fn pubsub() {

--- a/zenoh/tests/connection_retry.rs
+++ b/zenoh/tests/connection_retry.rs
@@ -1,4 +1,3 @@
-//
 // Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use config::ConnectionRetryConf;
 use zenoh::prelude::sync::*;
 

--- a/zenoh/tests/events.rs
+++ b/zenoh/tests/events.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::time::Duration;
 use zenoh::prelude::r#async::*;
 use zenoh::query::Reply;

--- a/zenoh/tests/formatters.rs
+++ b/zenoh/tests/formatters.rs
@@ -1,4 +1,3 @@
-//
 // Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 #[test]
 fn kedefine_reuse() {
     zenoh::kedefine!(

--- a/zenoh/tests/interceptors.rs
+++ b/zenoh/tests/interceptors.rs
@@ -1,4 +1,3 @@
-//
 // Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::sync::{Arc, Mutex};
 use zenoh_core::zlock;
 

--- a/zenoh/tests/liveliness.rs
+++ b/zenoh/tests/liveliness.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::time::Duration;
 use zenoh::prelude::r#async::*;
 use zenoh_core::ztimeout;

--- a/zenoh/tests/matching.rs
+++ b/zenoh/tests/matching.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::str::FromStr;
 use std::time::Duration;
 use zenoh::prelude::r#async::*;

--- a/zenoh/tests/qos.rs
+++ b/zenoh/tests/qos.rs
@@ -1,4 +1,3 @@
-//
 // Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::time::Duration;
 use zenoh::prelude::r#async::*;
 use zenoh::{publication::Priority, SessionDeclarations};

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::{
     str::FromStr,
     sync::{atomic::AtomicUsize, atomic::Ordering, Arc},

--- a/zenoh/tests/session.rs
+++ b/zenoh/tests/session.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;

--- a/zenoh/tests/unicity.rs
+++ b/zenoh/tests/unicity.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;

--- a/zenohd/Cargo.toml
+++ b/zenohd/Cargo.toml
@@ -1,5 +1,4 @@
-#
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2024 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 #
 # Contributors:
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
+
 [package]
 rust-version = { workspace = true }
 name = "zenohd"

--- a/zenohd/build.rs
+++ b/zenohd/build.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -9,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 fn main() {
     // Add rustc version to zenohd
     let version_meta = rustc_version::version_meta().unwrap();

--- a/zenohd/src/main.rs
+++ b/zenohd/src/main.rs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2024 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -10,7 +9,7 @@
 //
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
+
 use clap::Parser;
 use futures::future;
 use git_version::git_version;


### PR DESCRIPTION
At first, I've tried with [skywalking-eyes](https://github.com/apache/skywalking-eyes) developed by Apache. But it turns out to be too slow to generate the header. Then [hawkeye](https://github.com/korandoru/hawkeye) from the [greptime](https://github.com/GreptimeTeam/greptimedb) was tested and ran fluently. It's quite slim and extensible to use. And the check is fast enough to be integrated into CI.