### PR TITLE
Admin space: Show known origins of Subscribers and Queryables.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,6 +531,9 @@ name = "bitflags"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "blake3"
@@ -3005,6 +3008,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ron"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+dependencies = [
+ "base64 0.21.4",
+ "bitflags 2.4.2",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "route-recognizer"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5430,8 +5445,12 @@ version = "0.11.0-dev"
 dependencies = [
  "futures",
  "lazy_static",
+ "libc",
+ "ron",
+ "serde",
  "tokio",
  "zenoh-collections",
+ "zenoh-macros",
  "zenoh-result",
 ]
 

--- a/zenoh/src/net/routing/hat/client/pubsub.rs
+++ b/zenoh/src/net/routing/hat/client/pubsub.rs
@@ -275,10 +275,13 @@ impl HatPubSubTrait for HatCode {
     }
 
     fn get_subscriptions(&self, tables: &Tables) -> Vec<(Arc<Resource>, Sources)> {
+        // Compute the list of known suscriptions (keys)
         let mut subs = HashMap::new();
         for src_face in tables.faces.values() {
             for sub in &face_hat!(src_face).remote_subs {
+                // Insert the key in the list of known suscriptions
                 let srcs = subs.entry(sub.clone()).or_insert_with(Sources::empty);
+                // Append src_face as a suscription source in the proper list
                 match src_face.whatami {
                     WhatAmI::Router => srcs.routers.push(src_face.zid),
                     WhatAmI::Peer => srcs.peers.push(src_face.zid),

--- a/zenoh/src/net/routing/hat/client/pubsub.rs
+++ b/zenoh/src/net/routing/hat/client/pubsub.rs
@@ -17,11 +17,11 @@ use crate::net::routing::dispatcher::face::FaceState;
 use crate::net::routing::dispatcher::resource::{NodeId, Resource, SessionContext};
 use crate::net::routing::dispatcher::tables::Tables;
 use crate::net::routing::dispatcher::tables::{Route, RoutingExpr};
-use crate::net::routing::hat::HatPubSubTrait;
+use crate::net::routing::hat::{HatPubSubTrait, Sources};
 use crate::net::routing::router::RoutesIndexes;
 use crate::net::routing::{RoutingContext, PREFIX_LIVELINESS};
 use std::borrow::Cow;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 use zenoh_protocol::core::key_expr::OwnedKeyExpr;
 use zenoh_protocol::{
@@ -274,11 +274,16 @@ impl HatPubSubTrait for HatCode {
         forget_client_subscription(tables, face, res);
     }
 
-    fn get_subscriptions(&self, tables: &Tables) -> Vec<Arc<Resource>> {
-        let mut subs = HashSet::new();
+    fn get_subscriptions(&self, tables: &Tables) -> Vec<(Arc<Resource>, Sources)> {
+        let mut subs = HashMap::new();
         for src_face in tables.faces.values() {
             for sub in &face_hat!(src_face).remote_subs {
-                subs.insert(sub.clone());
+                let srcs = subs.entry(sub.clone()).or_insert_with(Sources::empty);
+                match src_face.whatami {
+                    WhatAmI::Router => srcs.routers.push(src_face.zid),
+                    WhatAmI::Peer => srcs.peers.push(src_face.zid),
+                    WhatAmI::Client => srcs.clients.push(src_face.zid),
+                }
             }
         }
         Vec::from_iter(subs)

--- a/zenoh/src/net/routing/hat/client/queries.rs
+++ b/zenoh/src/net/routing/hat/client/queries.rs
@@ -17,12 +17,12 @@ use crate::net::routing::dispatcher::face::FaceState;
 use crate::net::routing::dispatcher::resource::{NodeId, Resource, SessionContext};
 use crate::net::routing::dispatcher::tables::Tables;
 use crate::net::routing::dispatcher::tables::{QueryTargetQabl, QueryTargetQablSet, RoutingExpr};
-use crate::net::routing::hat::HatQueriesTrait;
+use crate::net::routing::hat::{HatQueriesTrait, Sources};
 use crate::net::routing::router::RoutesIndexes;
 use crate::net::routing::{RoutingContext, PREFIX_LIVELINESS};
 use ordered_float::OrderedFloat;
 use std::borrow::Cow;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 use zenoh_buffers::ZBuf;
 use zenoh_protocol::core::key_expr::include::{Includer, DEFAULT_INCLUDER};
@@ -272,11 +272,16 @@ impl HatQueriesTrait for HatCode {
         forget_client_queryable(tables, face, res);
     }
 
-    fn get_queryables(&self, tables: &Tables) -> Vec<Arc<Resource>> {
-        let mut qabls = HashSet::new();
+    fn get_queryables(&self, tables: &Tables) -> Vec<(Arc<Resource>, Sources)> {
+        let mut qabls = HashMap::new();
         for src_face in tables.faces.values() {
             for qabl in &face_hat!(src_face).remote_qabls {
-                qabls.insert(qabl.clone());
+                let srcs = qabls.entry(qabl.clone()).or_insert_with(Sources::empty);
+                match src_face.whatami {
+                    WhatAmI::Router => srcs.routers.push(src_face.zid),
+                    WhatAmI::Peer => srcs.peers.push(src_face.zid),
+                    WhatAmI::Client => srcs.clients.push(src_face.zid),
+                }
             }
         }
         Vec::from_iter(qabls)

--- a/zenoh/src/net/routing/hat/client/queries.rs
+++ b/zenoh/src/net/routing/hat/client/queries.rs
@@ -273,10 +273,13 @@ impl HatQueriesTrait for HatCode {
     }
 
     fn get_queryables(&self, tables: &Tables) -> Vec<(Arc<Resource>, Sources)> {
+        // Compute the list of known queryables (keys)
         let mut qabls = HashMap::new();
         for src_face in tables.faces.values() {
             for qabl in &face_hat!(src_face).remote_qabls {
+                // Insert the key in the list of known queryables
                 let srcs = qabls.entry(qabl.clone()).or_insert_with(Sources::empty);
+                // Append src_face as a queryable source in the proper list
                 match src_face.whatami {
                     WhatAmI::Router => srcs.routers.push(src_face.zid),
                     WhatAmI::Peer => srcs.peers.push(src_face.zid),

--- a/zenoh/src/net/routing/hat/linkstate_peer/pubsub.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/pubsub.rs
@@ -19,7 +19,7 @@ use crate::net::routing::dispatcher::pubsub::*;
 use crate::net::routing::dispatcher::resource::{NodeId, Resource, SessionContext};
 use crate::net::routing::dispatcher::tables::Tables;
 use crate::net::routing::dispatcher::tables::{Route, RoutingExpr};
-use crate::net::routing::hat::HatPubSubTrait;
+use crate::net::routing::hat::{HatPubSubTrait, Sources};
 use crate::net::routing::router::RoutesIndexes;
 use crate::net::routing::{RoutingContext, PREFIX_LIVELINESS};
 use petgraph::graph::NodeIndex;
@@ -605,8 +605,28 @@ impl HatPubSubTrait for HatCode {
         }
     }
 
-    fn get_subscriptions(&self, tables: &Tables) -> Vec<Arc<Resource>> {
-        hat!(tables).peer_subs.iter().cloned().collect()
+    fn get_subscriptions(&self, tables: &Tables) -> Vec<(Arc<Resource>, Sources)> {
+        hat!(tables)
+            .peer_subs
+            .iter()
+            .map(|s| {
+                (
+                    s.clone(),
+                    Sources {
+                        routers: vec![],
+                        peers: Vec::from_iter(res_hat!(s).peer_subs.iter().cloned()),
+                        clients: s
+                            .session_ctxs
+                            .values()
+                            .filter_map(|f| {
+                                (f.face.whatami == WhatAmI::Client && f.subs.is_some())
+                                    .then_some(f.face.zid)
+                            })
+                            .collect(),
+                    },
+                )
+            })
+            .collect()
     }
 
     fn compute_data_route(

--- a/zenoh/src/net/routing/hat/linkstate_peer/pubsub.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/pubsub.rs
@@ -606,12 +606,15 @@ impl HatPubSubTrait for HatCode {
     }
 
     fn get_subscriptions(&self, tables: &Tables) -> Vec<(Arc<Resource>, Sources)> {
+        // Compute the list of known suscriptions (keys)
         hat!(tables)
             .peer_subs
             .iter()
             .map(|s| {
                 (
                     s.clone(),
+                    // Compute the list of routers, peers and clients that are known
+                    // sources of those subscriptions
                     Sources {
                         routers: vec![],
                         peers: Vec::from_iter(res_hat!(s).peer_subs.iter().cloned()),

--- a/zenoh/src/net/routing/hat/linkstate_peer/queries.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/queries.rs
@@ -671,12 +671,15 @@ impl HatQueriesTrait for HatCode {
     }
 
     fn get_queryables(&self, tables: &Tables) -> Vec<(Arc<Resource>, Sources)> {
+        // Compute the list of known queryables (keys)
         hat!(tables)
             .peer_qabls
             .iter()
             .map(|s| {
                 (
                     s.clone(),
+                    // Compute the list of routers, peers and clients that are known
+                    // sources of those queryables
                     Sources {
                         routers: vec![],
                         peers: Vec::from_iter(res_hat!(s).peer_qabls.keys().cloned()),

--- a/zenoh/src/net/routing/hat/mod.rs
+++ b/zenoh/src/net/routing/hat/mod.rs
@@ -27,7 +27,7 @@ use super::{
 use crate::runtime::Runtime;
 use std::{any::Any, sync::Arc};
 use zenoh_buffers::ZBuf;
-use zenoh_config::{unwrap_or_default, Config, WhatAmI};
+use zenoh_config::{unwrap_or_default, Config, WhatAmI, ZenohId};
 use zenoh_protocol::{
     core::WireExpr,
     network::{
@@ -45,6 +45,23 @@ mod router;
 
 zconfigurable! {
     pub static ref TREES_COMPUTATION_DELAY_MS: u64 = 100;
+}
+
+#[derive(serde::Serialize)]
+pub(crate) struct Sources {
+    routers: Vec<ZenohId>,
+    peers: Vec<ZenohId>,
+    clients: Vec<ZenohId>,
+}
+
+impl Sources {
+    pub(crate) fn empty() -> Self {
+        Self {
+            routers: vec![],
+            peers: vec![],
+            clients: vec![],
+        }
+    }
 }
 
 pub(crate) trait HatTrait: HatBaseTrait + HatPubSubTrait + HatQueriesTrait {}
@@ -129,7 +146,7 @@ pub(crate) trait HatPubSubTrait {
         node_id: NodeId,
     );
 
-    fn get_subscriptions(&self, tables: &Tables) -> Vec<Arc<Resource>>;
+    fn get_subscriptions(&self, tables: &Tables) -> Vec<(Arc<Resource>, Sources)>;
 
     fn compute_data_route(
         &self,

--- a/zenoh/src/net/routing/hat/mod.rs
+++ b/zenoh/src/net/routing/hat/mod.rs
@@ -176,7 +176,7 @@ pub(crate) trait HatQueriesTrait {
         node_id: NodeId,
     );
 
-    fn get_queryables(&self, tables: &Tables) -> Vec<Arc<Resource>>;
+    fn get_queryables(&self, tables: &Tables) -> Vec<(Arc<Resource>, Sources)>;
 
     fn compute_query_route(
         &self,

--- a/zenoh/src/net/routing/hat/p2p_peer/pubsub.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/pubsub.rs
@@ -276,10 +276,13 @@ impl HatPubSubTrait for HatCode {
     }
 
     fn get_subscriptions(&self, tables: &Tables) -> Vec<(Arc<Resource>, Sources)> {
+        // Compute the list of known suscriptions (keys)
         let mut subs = HashMap::new();
         for src_face in tables.faces.values() {
             for sub in &face_hat!(src_face).remote_subs {
+                // Insert the key in the list of known suscriptions
                 let srcs = subs.entry(sub.clone()).or_insert_with(Sources::empty);
+                // Append src_face as a suscription source in the proper list
                 match src_face.whatami {
                     WhatAmI::Router => srcs.routers.push(src_face.zid),
                     WhatAmI::Peer => srcs.peers.push(src_face.zid),

--- a/zenoh/src/net/routing/hat/p2p_peer/pubsub.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/pubsub.rs
@@ -17,11 +17,11 @@ use crate::net::routing::dispatcher::face::FaceState;
 use crate::net::routing::dispatcher::resource::{NodeId, Resource, SessionContext};
 use crate::net::routing::dispatcher::tables::Tables;
 use crate::net::routing::dispatcher::tables::{Route, RoutingExpr};
-use crate::net::routing::hat::HatPubSubTrait;
+use crate::net::routing::hat::{HatPubSubTrait, Sources};
 use crate::net::routing::router::RoutesIndexes;
 use crate::net::routing::{RoutingContext, PREFIX_LIVELINESS};
 use std::borrow::Cow;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 use zenoh_protocol::core::key_expr::OwnedKeyExpr;
 use zenoh_protocol::{
@@ -275,11 +275,16 @@ impl HatPubSubTrait for HatCode {
         forget_client_subscription(tables, face, res);
     }
 
-    fn get_subscriptions(&self, tables: &Tables) -> Vec<Arc<Resource>> {
-        let mut subs = HashSet::new();
+    fn get_subscriptions(&self, tables: &Tables) -> Vec<(Arc<Resource>, Sources)> {
+        let mut subs = HashMap::new();
         for src_face in tables.faces.values() {
             for sub in &face_hat!(src_face).remote_subs {
-                subs.insert(sub.clone());
+                let srcs = subs.entry(sub.clone()).or_insert_with(Sources::empty);
+                match src_face.whatami {
+                    WhatAmI::Router => srcs.routers.push(src_face.zid),
+                    WhatAmI::Peer => srcs.peers.push(src_face.zid),
+                    WhatAmI::Client => srcs.clients.push(src_face.zid),
+                }
             }
         }
         Vec::from_iter(subs)

--- a/zenoh/src/net/routing/hat/p2p_peer/queries.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/queries.rs
@@ -17,12 +17,12 @@ use crate::net::routing::dispatcher::face::FaceState;
 use crate::net::routing::dispatcher::resource::{NodeId, Resource, SessionContext};
 use crate::net::routing::dispatcher::tables::Tables;
 use crate::net::routing::dispatcher::tables::{QueryTargetQabl, QueryTargetQablSet, RoutingExpr};
-use crate::net::routing::hat::HatQueriesTrait;
+use crate::net::routing::hat::{HatQueriesTrait, Sources};
 use crate::net::routing::router::RoutesIndexes;
 use crate::net::routing::{RoutingContext, PREFIX_LIVELINESS};
 use ordered_float::OrderedFloat;
 use std::borrow::Cow;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 use zenoh_buffers::ZBuf;
 use zenoh_protocol::core::key_expr::include::{Includer, DEFAULT_INCLUDER};
@@ -272,11 +272,16 @@ impl HatQueriesTrait for HatCode {
         forget_client_queryable(tables, face, res);
     }
 
-    fn get_queryables(&self, tables: &Tables) -> Vec<Arc<Resource>> {
-        let mut qabls = HashSet::new();
+    fn get_queryables(&self, tables: &Tables) -> Vec<(Arc<Resource>, Sources)> {
+        let mut qabls = HashMap::new();
         for src_face in tables.faces.values() {
             for qabl in &face_hat!(src_face).remote_qabls {
-                qabls.insert(qabl.clone());
+                let srcs = qabls.entry(qabl.clone()).or_insert_with(Sources::empty);
+                match src_face.whatami {
+                    WhatAmI::Router => srcs.routers.push(src_face.zid),
+                    WhatAmI::Peer => srcs.peers.push(src_face.zid),
+                    WhatAmI::Client => srcs.clients.push(src_face.zid),
+                }
             }
         }
         Vec::from_iter(qabls)

--- a/zenoh/src/net/routing/hat/p2p_peer/queries.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/queries.rs
@@ -273,10 +273,13 @@ impl HatQueriesTrait for HatCode {
     }
 
     fn get_queryables(&self, tables: &Tables) -> Vec<(Arc<Resource>, Sources)> {
+        // Compute the list of known queryables (keys)
         let mut qabls = HashMap::new();
         for src_face in tables.faces.values() {
             for qabl in &face_hat!(src_face).remote_qabls {
+                // Insert the key in the list of known queryables
                 let srcs = qabls.entry(qabl.clone()).or_insert_with(Sources::empty);
+                // Append src_face as a queryable source in the proper list
                 match src_face.whatami {
                     WhatAmI::Router => srcs.routers.push(src_face.zid),
                     WhatAmI::Peer => srcs.peers.push(src_face.zid),

--- a/zenoh/src/net/routing/hat/router/pubsub.rs
+++ b/zenoh/src/net/routing/hat/router/pubsub.rs
@@ -926,12 +926,15 @@ impl HatPubSubTrait for HatCode {
     }
 
     fn get_subscriptions(&self, tables: &Tables) -> Vec<(Arc<Resource>, Sources)> {
+        // Compute the list of known suscriptions (keys)
         hat!(tables)
             .router_subs
             .iter()
             .map(|s| {
                 (
                     s.clone(),
+                    // Compute the list of routers, peers and clients that are known
+                    // sources of those subscriptions
                     Sources {
                         routers: Vec::from_iter(res_hat!(s).router_subs.iter().cloned()),
                         peers: if hat!(tables).full_net(WhatAmI::Peer) {

--- a/zenoh/src/net/routing/hat/router/queries.rs
+++ b/zenoh/src/net/routing/hat/router/queries.rs
@@ -1074,12 +1074,15 @@ impl HatQueriesTrait for HatCode {
     }
 
     fn get_queryables(&self, tables: &Tables) -> Vec<(Arc<Resource>, Sources)> {
+        // Compute the list of known queryables (keys)
         hat!(tables)
             .router_qabls
             .iter()
             .map(|s| {
                 (
                     s.clone(),
+                    // Compute the list of routers, peers and clients that are known
+                    // sources of those queryables
                     Sources {
                         routers: Vec::from_iter(res_hat!(s).router_qabls.keys().cloned()),
                         peers: if hat!(tables).full_net(WhatAmI::Peer) {

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -665,11 +665,18 @@ fn subscribers_data(context: &AdminContext, query: Query) {
         let key = KeyExpr::try_from(format!(
             "@/router/{}/subscriber/{}",
             context.zid_str,
-            sub.expr()
+            sub.0.expr()
         ))
         .unwrap();
         if query.key_expr().intersects(&key) {
-            if let Err(e) = query.reply(Ok(Sample::new(key, Value::empty()))).res() {
+            if let Err(e) = query
+                .reply(Ok(Sample::new(
+                    key,
+                    Value::from(serde_json::to_string(&sub.1).unwrap_or("".to_string()))
+                        .encoding(KnownEncoding::AppJson.into()),
+                )))
+                .res()
+            {
                 tracing::error!("Error sending AdminSpace reply: {:?}", e);
             }
         }

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -672,7 +672,7 @@ fn subscribers_data(context: &AdminContext, query: Query) {
             if let Err(e) = query
                 .reply(Ok(Sample::new(
                     key,
-                    Value::from(serde_json::to_string(&sub.1).unwrap_or("{}".to_string()))
+                    Value::from(serde_json::to_string(&sub.1).unwrap_or_else(|_| "{}".to_string()))
                         .encoding(KnownEncoding::AppJson.into()),
                 )))
                 .res()
@@ -696,8 +696,10 @@ fn queryables_data(context: &AdminContext, query: Query) {
             if let Err(e) = query
                 .reply(Ok(Sample::new(
                     key,
-                    Value::from(serde_json::to_string(&qabl.1).unwrap_or("{}".to_string()))
-                        .encoding(KnownEncoding::AppJson.into()),
+                    Value::from(
+                        serde_json::to_string(&qabl.1).unwrap_or_else(|_| "{}".to_string()),
+                    )
+                    .encoding(KnownEncoding::AppJson.into()),
                 )))
                 .res()
             {

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -689,11 +689,18 @@ fn queryables_data(context: &AdminContext, query: Query) {
         let key = KeyExpr::try_from(format!(
             "@/router/{}/queryable/{}",
             context.zid_str,
-            qabl.expr()
+            qabl.0.expr()
         ))
         .unwrap();
         if query.key_expr().intersects(&key) {
-            if let Err(e) = query.reply(Ok(Sample::new(key, Value::empty()))).res() {
+            if let Err(e) = query
+                .reply(Ok(Sample::new(
+                    key,
+                    Value::from(serde_json::to_string(&qabl.1).unwrap_or("{}".to_string()))
+                        .encoding(KnownEncoding::AppJson.into()),
+                )))
+                .res()
+            {
                 tracing::error!("Error sending AdminSpace reply: {:?}", e);
             }
         }

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -672,7 +672,7 @@ fn subscribers_data(context: &AdminContext, query: Query) {
             if let Err(e) = query
                 .reply(Ok(Sample::new(
                     key,
-                    Value::from(serde_json::to_string(&sub.1).unwrap_or("".to_string()))
+                    Value::from(serde_json::to_string(&sub.1).unwrap_or("{}".to_string()))
                         .encoding(KnownEncoding::AppJson.into()),
                 )))
                 .res()


### PR DESCRIPTION
When reporting it's known Subscribers and Queryables, a router also reports the known source nodes of those Subscribers and Queryables. 
The reported information is local. The list of sources may not be exhaustive in the whole system and some sources may be intermediate (typically a router may be reported as the source of a subscription while in fact one or more of the clients served by this router are the real source of the subscription).
Those informations are valuable in a monitoring/debugging tool for example in the PaaS.

Known limitation: linkstate peers will report router sources in the list of peers sources. They don't necessarily have the information to distinguish peers and routers in the local mesh. Linkstate peers don't have an admin space yet anyway.