### PR TITLE
fix: Enable `unstable` and `plugins` features in plugins

### DIFF
--- a/plugins/zenoh-plugin-example/Cargo.toml
+++ b/plugins/zenoh-plugin-example/Cargo.toml
@@ -20,7 +20,7 @@ edition = { workspace = true }
 publish = false
 
 [features]
-default = ["no_mangle", "zenoh/default"]
+default = ["no_mangle", "zenoh/default", "zenoh/unstable", "zenoh/plugins"]
 no_mangle = []
 
 [lib]

--- a/plugins/zenoh-plugin-rest/Cargo.toml
+++ b/plugins/zenoh-plugin-rest/Cargo.toml
@@ -24,7 +24,7 @@ categories = ["network-programming", "web-programming::http-server"]
 description = "The zenoh REST plugin"
 
 [features]
-default = ["no_mangle", "zenoh/default"]
+default = ["no_mangle", "zenoh/default", "zenoh/unstable", "zenoh/plugins"]
 no_mangle = []
 
 [lib]

--- a/plugins/zenoh-plugin-storage-manager/Cargo.toml
+++ b/plugins/zenoh-plugin-storage-manager/Cargo.toml
@@ -24,7 +24,7 @@ categories = { workspace = true }
 description = "The zenoh storages plugin."
 
 [features]
-default = ["no_mangle", "zenoh/default"]
+default = ["no_mangle", "zenoh/default", "zenoh/unstable", "zenoh/plugins"]
 no_mangle = []
 
 [lib]


### PR DESCRIPTION
[This fixes the Cargo publishing job in the Release workflow.](https://github.com/eclipse-zenoh/zenoh/actions/runs/8792564813/job/24129028790)