### PR TITLE
fix: implement missing `fmt::Debug` for all public types

### DIFF
--- a/zenoh/src/handlers/callback.rs
+++ b/zenoh/src/handlers/callback.rs
@@ -60,6 +60,7 @@ impl<T: Send + 'static> IntoHandler<'static, T> for (flume::Sender<T>, flume::Re
 ///   - `callback` will never be called once `drop` has started.
 ///   - `drop` will only be called **once**, and **after every** `callback` has ended.
 ///   - The two previous guarantees imply that `call` and `drop` are never called concurrently.
+#[derive(Debug)]
 pub struct CallbackDrop<Callback, DropFn>
 where
     DropFn: FnMut() + Send + Sync + 'static,

--- a/zenoh/src/handlers/fifo.rs
+++ b/zenoh/src/handlers/fifo.rs
@@ -17,6 +17,7 @@ use super::{callback::Callback, Dyn, IntoHandler, API_DATA_RECEPTION_CHANNEL_SIZ
 
 /// The default handler in Zenoh is a FIFO queue.
 
+#[derive(Debug)]
 pub struct FifoChannel {
     capacity: usize,
 }

--- a/zenoh/src/handlers/mod.rs
+++ b/zenoh/src/handlers/mod.rs
@@ -40,7 +40,7 @@ pub trait IntoHandler<'a, T> {
 
 /// The default handler in Zenoh is a FIFO queue.
 #[repr(transparent)]
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct DefaultHandler(FifoChannel);
 
 impl<T: Send + 'static> IntoHandler<'static, T> for DefaultHandler {

--- a/zenoh/src/handlers/ring.rs
+++ b/zenoh/src/handlers/ring.rs
@@ -21,6 +21,7 @@ use zenoh_collections::RingBuffer;
 use zenoh_result::ZResult;
 
 /// A synchrounous ring channel with a limited size that allows users to keep the last N data.
+#[derive(Debug)]
 pub struct RingChannel {
     capacity: usize,
 }
@@ -43,6 +44,7 @@ struct RingChannelInner<T> {
     not_empty: flume::Receiver<()>,
 }
 
+// TODO impl `fmt::Debug`, but obviously `Weak` implementation is not really user-friendly
 pub struct RingChannelHandler<T> {
     ring: Weak<RingChannelInner<T>>,
 }

--- a/zenoh/src/info.rs
+++ b/zenoh/src/info.rs
@@ -167,6 +167,7 @@ impl<'a> AsyncResolve for PeersZidBuilder<'a> {
 /// let zid = info.zid().res().await;
 /// # }
 /// ```
+#[derive(Debug)]
 pub struct SessionInfo<'a> {
     pub(crate) session: SessionRef<'a>,
 }

--- a/zenoh/src/key_expr.rs
+++ b/zenoh/src/key_expr.rs
@@ -616,6 +616,7 @@ impl<'a> Undeclarable<&'a Session, KeyExprUndeclaration<'a>> for KeyExpr<'a> {
 /// # }
 /// ```
 #[must_use = "Resolvables do nothing unless you resolve them using the `res` method from either `SyncResolve` or `AsyncResolve`"]
+#[derive(Debug)]
 pub struct KeyExprUndeclaration<'a> {
     session: &'a Session,
     expr: KeyExpr<'a>,

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -74,6 +74,7 @@
 //!     }
 //! }
 //! ```
+#![deny(missing_debug_implementations)]
 #[macro_use]
 extern crate zenoh_core;
 #[macro_use]
@@ -280,6 +281,7 @@ where
 /// # }
 /// ```
 #[must_use = "Resolvables do nothing unless you resolve them using the `res` method from either `SyncResolve` or `AsyncResolve`"]
+#[derive(Debug)]
 pub struct OpenBuilder<TryIntoConfig>
 where
     TryIntoConfig: std::convert::TryInto<crate::config::Config> + Send + 'static,
@@ -357,6 +359,7 @@ pub fn init(runtime: Runtime) -> InitBuilder {
 #[must_use = "Resolvables do nothing unless you resolve them using the `res` method from either `SyncResolve` or `AsyncResolve`"]
 #[doc(hidden)]
 #[zenoh_macros::unstable]
+// TODO impl `fmt::Debug`, but `Runtime` doesn't implement it
 pub struct InitBuilder {
     runtime: Runtime,
     aggregated_subscribers: Vec<OwnedKeyExpr>,

--- a/zenoh/src/liveliness.rs
+++ b/zenoh/src/liveliness.rs
@@ -79,6 +79,7 @@ lazy_static::lazy_static!(
 /// # }
 /// ```
 #[zenoh_macros::unstable]
+#[derive(Debug)]
 pub struct Liveliness<'a> {
     pub(crate) session: SessionRef<'a>,
 }
@@ -324,6 +325,7 @@ pub struct LivelinessToken<'a> {
 /// ```
 #[must_use = "Resolvables do nothing unless you resolve them using the `res` method from either `SyncResolve` or `AsyncResolve`"]
 #[zenoh_macros::unstable]
+#[derive(Debug)]
 pub struct LivelinessTokenUndeclaration<'a> {
     token: LivelinessToken<'a>,
 }

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -58,6 +58,7 @@ pub struct AdminContext {
 
 type Handler = Arc<dyn Fn(&AdminContext, Query) + Send + Sync>;
 
+// TODO impl `fmt::Debug`
 pub struct AdminSpace {
     zid: ZenohId,
     queryable_id: QueryableId,

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -71,6 +71,7 @@ pub(crate) struct RuntimeState {
     plugins_manager: Mutex<PluginsManager>,
 }
 
+#[derive(Debug)]
 pub struct WeakRuntime {
     state: Weak<RuntimeState>,
 }
@@ -81,6 +82,7 @@ impl WeakRuntime {
     }
 }
 
+// TODO impl `fmt::Debug`, but `PluginsManager` doesn't implement it
 pub struct RuntimeBuilder {
     config: Config,
     #[cfg(all(feature = "unstable", feature = "plugins"))]
@@ -222,6 +224,7 @@ impl RuntimeBuilder {
     }
 }
 
+// TODO impl `fmt::Debug`, but `RuntimeState` doesn't implement it
 #[derive(Clone)]
 pub struct Runtime {
     state: Arc<RuntimeState>,

--- a/zenoh/src/net/runtime/orchestrator.rs
+++ b/zenoh/src/net/runtime/orchestrator.rs
@@ -37,6 +37,7 @@ const SCOUT_PERIOD_INCREASE_FACTOR: u32 = 2;
 const ROUTER_DEFAULT_LISTENER: &str = "tcp/[::]:7447";
 const PEER_DEFAULT_LISTENER: &str = "tcp/[::]:0";
 
+#[derive(Debug)]
 pub enum Loop {
     Continue,
     Break,

--- a/zenoh/src/publication.rs
+++ b/zenoh/src/publication.rs
@@ -647,6 +647,7 @@ impl<'a> Undeclarable<(), PublisherUndeclaration<'a>> for Publisher<'a> {
 /// # }
 /// ```
 #[must_use = "Resolvables do nothing unless you resolve them using the `res` method from either `SyncResolve` or `AsyncResolve`"]
+#[derive(Debug)]
 pub struct PublisherUndeclaration<'a> {
     publisher: Publisher<'a>,
 }
@@ -1399,6 +1400,7 @@ impl<'a> Undeclarable<(), MatchingListenerUndeclaration<'a>> for MatchingListene
 /// # }
 /// ```
 #[zenoh_macros::unstable]
+// TODO impl `fmt::Debug`, but `MatchingListenerInner` doesn't implement it
 pub struct MatchingListener<'a, Receiver> {
     pub(crate) listener: MatchingListenerInner<'a>,
     pub(crate) receiver: Receiver,
@@ -1452,6 +1454,7 @@ impl<Receiver> std::ops::DerefMut for MatchingListener<'_, Receiver> {
 }
 
 #[zenoh_macros::unstable]
+// TODO impl `fmt::Debug`, but `MatchingListenerInner` doesn't implement it
 pub struct MatchingListenerUndeclaration<'a> {
     subscriber: MatchingListenerInner<'a>,
 }

--- a/zenoh/src/queryable.rs
+++ b/zenoh/src/queryable.rs
@@ -250,6 +250,7 @@ impl fmt::Display for Query {
     }
 }
 
+#[derive(Debug)]
 pub struct ReplySample<'a> {
     query: &'a Query,
     sample: Sample,
@@ -627,6 +628,7 @@ impl<'a> Undeclarable<(), QueryableUndeclaration<'a>> for CallbackQueryable<'a> 
 /// # }
 /// ```
 #[must_use = "Resolvables do nothing unless you resolve them using the `res` method from either `SyncResolve` or `AsyncResolve`"]
+#[derive(Debug)]
 pub struct QueryableUndeclaration<'a> {
     queryable: CallbackQueryable<'a>,
 }

--- a/zenoh/src/sample/mod.rs
+++ b/zenoh/src/sample/mod.rs
@@ -243,6 +243,7 @@ impl TryFrom<u64> for SampleKind {
 }
 
 /// Structure with public fields for sample. It's convenient if it's necessary to decompose a sample into its fields.
+#[derive(Debug)]
 pub struct SampleFields {
     pub key_expr: KeyExpr<'static>,
     pub payload: ZBytes,

--- a/zenoh/src/subscriber.rs
+++ b/zenoh/src/subscriber.rs
@@ -134,6 +134,7 @@ impl<'a> Undeclarable<(), SubscriberUndeclaration<'a>> for SubscriberInner<'a> {
 /// # }
 /// ```
 #[must_use = "Resolvables do nothing unless you resolve them using the `res` method from either `SyncResolve` or `AsyncResolve`"]
+#[derive(Debug)]
 pub struct SubscriberUndeclaration<'a> {
     subscriber: SubscriberInner<'a>,
 }


### PR DESCRIPTION
Fixes #967 

I've only added `#[derive(Debug)]` where it does compile, and  `// TODO` for the other types.