### PR TITLE
Fix zenoh-c DLL crash in `libc::atexit` handler

### DIFF
--- a/commons/zenoh-runtime/src/lib.rs
+++ b/commons/zenoh-runtime/src/lib.rs
@@ -186,7 +186,7 @@ impl Drop for ZRuntimePool {
     fn drop(&mut self) {
         for (_, mut rt) in self.0.drain() {
             if let Some(rt) = rt.take() {
-                rt.shutdown_timeout(Duration::from_millis(1));
+                rt.shutdown_timeout(Duration::from_secs(1));
             }
         }
     }

--- a/commons/zenoh-runtime/src/lib.rs
+++ b/commons/zenoh-runtime/src/lib.rs
@@ -184,17 +184,10 @@ impl ZRuntimePool {
 // If there are any blocking tasks spawned by ZRuntimes, the function will block until they return.
 impl Drop for ZRuntimePool {
     fn drop(&mut self) {
-        let handles: Vec<_> = self
-            .0
-            .drain()
-            .filter_map(|(_name, mut rt)| {
-                rt.take()
-                    .map(|r| std::thread::spawn(move || r.shutdown_timeout(Duration::from_secs(1))))
-            })
-            .collect();
-
-        for hd in handles {
-            let _ = hd.join();
+        for (_, mut rt) in self.0.drain() {
+            if let Some(rt) = rt.take() {
+                rt.shutdown_timeout(Duration::from_millis(1));
+            }
         }
     }
 }


### PR DESCRIPTION
Tries to fix https://github.com/eclipse-zenoh/zenoh/issues/973.

~~If I understand correctly, the reason for using threads here is to optimize the destructor, but the cost of spawning threads is usually too high. I tried to measure the execution time of this destructor and got 400µs. If we use one thread to shutdown all runtimes this actually _drops_ (pun intended) down to 20µs. And it resolves the above panic. This is what the pull request does, in addition to decreasing the shutdown timeout to 1ms~~. The shutdown threads are used because one supposedly cannot call `shutdown_timeout()` from the same thread that was used to create the runtime.