### PR TITLE
fix(zenoh-runtime): zenoh-c DLL crash in `libc::atexit` handler

### DIFF
--- a/commons/zenoh-runtime/Cargo.toml
+++ b/commons/zenoh-runtime/Cargo.toml
@@ -22,3 +22,4 @@ zenoh-result = { workspace = true, features = ["std"] }
 zenoh-collections = { workspace = true, features = ["std"] }
 zenoh-macros = { workspace = true }
 tokio = { workspace = true, features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
+tracing = { workspace = true }

--- a/commons/zenoh-runtime/src/lib.rs
+++ b/commons/zenoh-runtime/src/lib.rs
@@ -157,6 +157,8 @@ pub struct ZRuntimePool(HashMap<ZRuntime, OnceLock<Runtime>>);
 
 impl ZRuntimePool {
     fn new() -> Self {
+        // NOTE: The atexit handler in DLL cannot spawn the new thread in `cleanup`
+        #[cfg(not(all(target_os = "windows")))]
         // Register a callback to clean the static variables.
         unsafe {
             libc::atexit(cleanup);


### PR DESCRIPTION
See #973 for the background of the issue.

In short, we need to disable the `atexit` callback while building to DLL on Windows.

It's hard to do conditional compilation on `zenoh-runtime` crate only since `zenoh-runtime` is a static lib to `zenoh`. To prevent introducing too complicated feature flags affecting both `zenoh` and `zenoh-c`, let's catch the panic error and process it accordingly.

To be clear,

1. On Windows, `zenoh-c` in DLL: panic is expected.
2. On Windows, `zenoh-c` in lib: panic shouldn't happen.
3. Any other cases should report the error.