### PR TITLE
refactor: use `Into` bound for `KeyExpr::with_parameters`

### DIFF
--- a/zenoh/src/key_expr.rs
+++ b/zenoh/src/key_expr.rs
@@ -57,7 +57,9 @@ use zenoh_protocol::{
 };
 use zenoh_result::ZResult;
 
-use crate::{net::primitives::Primitives, prelude::Selector, Session, Undeclarable};
+use crate::{
+    net::primitives::Primitives, prelude::Selector, selector::Parameters, Session, Undeclarable,
+};
 
 #[derive(Clone, Debug)]
 pub(crate) enum KeyExprInner<'a> {
@@ -302,17 +304,10 @@ impl<'a> KeyExpr<'a> {
         }
     }
 
-    pub fn with_parameters(self, selector: &'a str) -> Selector<'a> {
+    pub fn with_parameters<P: Into<Parameters<'a>>>(self, parameters: P) -> Selector<'a> {
         Selector {
             key_expr: self,
-            parameters: selector.into(),
-        }
-    }
-
-    pub fn with_owned_parameters(self, selector: String) -> Selector<'a> {
-        Selector {
-            key_expr: self,
-            parameters: selector.into(),
+            parameters: parameters.into(),
         }
     }
 }

--- a/zenoh/src/selector.rs
+++ b/zenoh/src/selector.rs
@@ -239,7 +239,7 @@ impl TryFrom<String> for Selector<'_> {
             Some(qmark_position) => {
                 let parameters = s[qmark_position + 1..].to_owned();
                 s.truncate(qmark_position);
-                Ok(KeyExpr::try_from(s)?.with_owned_parameters(parameters))
+                Ok(KeyExpr::try_from(s)?.with_parameters(parameters))
             }
             None => Ok(KeyExpr::try_from(s)?.into()),
         }


### PR DESCRIPTION
@Mallets @milyin 