### PR TITLE
ci: rearrange doc test to shorten the testing time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   check:
-    name: Run checks on ${{ matrix.os }}
+    name: Lints and documentation tests on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -70,7 +70,7 @@ jobs:
         run: cargo test --doc
 
   test:
-    name: Run tests on ${{ matrix.os }}
+    name: Unit tests on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Perform no_std checks
         run: cargo check --bin nostd_check --target x86_64-unknown-none --manifest-path ci/nostd-check/Cargo.toml
 
+      - name: Run doctests
+        run: cargo test --doc
+
   test:
     name: Run tests on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -104,9 +107,6 @@ jobs:
       - name: Check for feature leaks
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: cargo nextest run -p zenohd --no-default-features
-
-      - name: Run doctests
-        run: cargo test --doc
 
   valgrind:
     name: Memory leak checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   check:
-    name: Lints and documentation tests on ${{ matrix.os }}
+    name: Lints and doc tests on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
The _check_ job often finishes earlier than the _test_ job. Move the _doc test_ step to _check_ can save us a few minutes.