### PR TITLE
fix(zenoh_runtime): disable atexit on windows

### DIFF
--- a/commons/zenoh-runtime/Cargo.toml
+++ b/commons/zenoh-runtime/Cargo.toml
@@ -22,4 +22,3 @@ zenoh-result = { workspace = true, features = ["std"] }
 zenoh-collections = { workspace = true, features = ["std"] }
 zenoh-macros = { workspace = true }
 tokio = { workspace = true, features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
-tracing = { workspace = true }

--- a/commons/zenoh-runtime/src/lib.rs
+++ b/commons/zenoh-runtime/src/lib.rs
@@ -157,6 +157,8 @@ pub struct ZRuntimePool(HashMap<ZRuntime, OnceLock<Runtime>>);
 
 impl ZRuntimePool {
     fn new() -> Self {
+        // It has been recognized that using atexit within Windows DLL is problematic
+        #[cfg(not(target_os = "windows"))]
         // Register a callback to clean the static variables.
         unsafe {
             libc::atexit(cleanup);


### PR DESCRIPTION
As discussed today, we found that the previous is still problematic. Let's disable the atexit cleanup for the time being.