### PR TITLE
fix: Deny publishing of zenoh-ext-examples

### DIFF
--- a/zenoh-ext/examples/Cargo.toml
+++ b/zenoh-ext/examples/Cargo.toml
@@ -22,6 +22,7 @@ edition = { workspace = true }
 license = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh"
+publish = false
 
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION
In the `0.11.0-rc.1` release, zenoh-ext-examples was mistakenly published on crates.io: https://crates.io/crates/zenoh-ext-examples.