### PR TITLE
Fix runtime start calling

### DIFF
--- a/plugins/zenoh-plugin-storage-manager/tests/operations.rs
+++ b/plugins/zenoh-plugin-storage-manager/tests/operations.rs
@@ -78,7 +78,10 @@ async fn test_updates_in_order() {
         )
         .unwrap();
 
-    let runtime = zenoh::runtime::Runtime::new(config).await.unwrap();
+    let runtime = zenoh::runtime::RuntimeBuilder::new(config)
+        .build()
+        .await
+        .unwrap();
     let storage =
         zenoh_plugin_storage_manager::StoragesPlugin::start("storage-manager", &runtime).unwrap();
 

--- a/plugins/zenoh-plugin-storage-manager/tests/wildcard.rs
+++ b/plugins/zenoh-plugin-storage-manager/tests/wildcard.rs
@@ -79,7 +79,10 @@ async fn test_wild_card_in_order() {
         )
         .unwrap();
 
-    let runtime = zenoh::runtime::Runtime::new(config).await.unwrap();
+    let runtime = zenoh::runtime::RuntimeBuilder::new(config)
+        .build()
+        .await
+        .unwrap();
     let storage =
         zenoh_plugin_storage_manager::StoragesPlugin::start("storage-manager", &runtime).unwrap();
 

--- a/zenoh/src/net/runtime/orchestrator.rs
+++ b/zenoh/src/net/runtime/orchestrator.rs
@@ -43,7 +43,7 @@ pub enum Loop {
 }
 
 impl Runtime {
-    pub(crate) async fn start(&mut self) -> ZResult<()> {
+    pub async fn start(&mut self) -> ZResult<()> {
         match self.whatami() {
             WhatAmI::Client => self.start_client().await,
             WhatAmI::Peer => self.start_peer().await,

--- a/zenoh/src/session.rs
+++ b/zenoh/src/session.rs
@@ -28,6 +28,7 @@ use crate::prelude::{KeyExpr, Parameters};
 use crate::publication::*;
 use crate::query::*;
 use crate::queryable::*;
+use crate::runtime::RuntimeBuilder;
 #[cfg(feature = "unstable")]
 use crate::sample::Attachment;
 use crate::sample::DataInfo;
@@ -824,7 +825,7 @@ impl Session {
             tracing::debug!("Config: {:?}", &config);
             let aggregated_subscribers = config.aggregation().subscribers().clone();
             let aggregated_publishers = config.aggregation().publishers().clone();
-            let mut runtime = Runtime::init(config).await?;
+            let mut runtime = RuntimeBuilder::new(config).build().await?;
 
             let mut session = Self::init(
                 runtime.clone(),

--- a/zenoh/tests/session.rs
+++ b/zenoh/tests/session.rs
@@ -209,7 +209,7 @@ async fn open_session_unicast_runtime(endpoints: &[&str]) -> (Runtime, Runtime) 
         .collect::<Vec<_>>();
     config.scouting.multicast.set_enabled(Some(false)).unwrap();
     println!("[  ][01a] Creating r1 session runtime: {:?}", endpoints);
-    let r1 = RuntimeBuilder::new(config).build().await.unwrap();
+    let mut r1 = RuntimeBuilder::new(config).build().await.unwrap();
     r1.start().await.unwrap();
 
     let mut config = config::peer();

--- a/zenoh/tests/session.rs
+++ b/zenoh/tests/session.rs
@@ -210,6 +210,7 @@ async fn open_session_unicast_runtime(endpoints: &[&str]) -> (Runtime, Runtime) 
     config.scouting.multicast.set_enabled(Some(false)).unwrap();
     println!("[  ][01a] Creating r1 session runtime: {:?}", endpoints);
     let r1 = RuntimeBuilder::new(config).build().await.unwrap();
+    r1.start().await.unwrap();
 
     let mut config = config::peer();
     config.connect.endpoints = endpoints
@@ -218,7 +219,8 @@ async fn open_session_unicast_runtime(endpoints: &[&str]) -> (Runtime, Runtime) 
         .collect::<Vec<_>>();
     config.scouting.multicast.set_enabled(Some(false)).unwrap();
     println!("[  ][02a] Creating r2 session runtime: {:?}", endpoints);
-    let r2 = RuntimeBuilder::new(config).build().await.unwrap();
+    let mut r2 = RuntimeBuilder::new(config).build().await.unwrap();
+    r2.start().await.unwrap();
 
     (r1, r2)
 }

--- a/zenoh/tests/session.rs
+++ b/zenoh/tests/session.rs
@@ -15,7 +15,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use zenoh::prelude::r#async::*;
-use zenoh::runtime::Runtime;
+use zenoh::runtime::{Runtime, RuntimeBuilder};
 use zenoh_core::ztimeout;
 
 const TIMEOUT: Duration = Duration::from_secs(60);
@@ -209,7 +209,7 @@ async fn open_session_unicast_runtime(endpoints: &[&str]) -> (Runtime, Runtime) 
         .collect::<Vec<_>>();
     config.scouting.multicast.set_enabled(Some(false)).unwrap();
     println!("[  ][01a] Creating r1 session runtime: {:?}", endpoints);
-    let r1 = Runtime::new(config).await.unwrap();
+    let r1 = RuntimeBuilder::new(config).build().await.unwrap();
 
     let mut config = config::peer();
     config.connect.endpoints = endpoints
@@ -218,7 +218,7 @@ async fn open_session_unicast_runtime(endpoints: &[&str]) -> (Runtime, Runtime) 
         .collect::<Vec<_>>();
     config.scouting.multicast.set_enabled(Some(false)).unwrap();
     println!("[  ][02a] Creating r2 session runtime: {:?}", endpoints);
-    let r2 = Runtime::new(config).await.unwrap();
+    let r2 = RuntimeBuilder::new(config).build().await.unwrap();
 
     (r1, r2)
 }


### PR DESCRIPTION
Fix missing or double calling to `runtime.start()`.