### PR TITLE
Fix invalid Json in admin space for static plugins

### DIFF
--- a/plugins/zenoh-plugin-trait/src/manager/static_plugin.rs
+++ b/plugins/zenoh-plugin-trait/src/manager/static_plugin.rs
@@ -51,7 +51,7 @@ where
         Some(P::PLUGIN_LONG_VERSION)
     }
     fn path(&self) -> &str {
-        "<static>"
+        r#""<static>""#
     }
     fn state(&self) -> PluginState {
         self.instance


### PR DESCRIPTION
In case of a static plugin the admin space includes such a key/value (in JSON5):
```json5
{ "key": "@/peer/1cdbe046daa889a6a88c48dccb82ead0/status/plugins/dds/__path__", "value": <static>, "encoding": "application/json", "time": "None" }
```
This is invalid because `<static>` is not between quotes.

This PR fixes that.