### PR TITLE
Fix admin space: __path__ was invalid JSON

### DIFF
--- a/plugins/zenoh-plugin-trait/src/manager/dynamic_plugin.rs
+++ b/plugins/zenoh-plugin-trait/src/manager/dynamic_plugin.rs
@@ -142,7 +142,7 @@ impl<StartArgs: PluginStartArgs, Instance: PluginInstance> PluginStatus
         if let Some(starter) = &self.starter {
             starter.path()
         } else {
-            "<not loaded>"
+            "__not_loaded__>"
         }
     }
     fn state(&self) -> PluginState {

--- a/plugins/zenoh-plugin-trait/src/manager/dynamic_plugin.rs
+++ b/plugins/zenoh-plugin-trait/src/manager/dynamic_plugin.rs
@@ -142,7 +142,7 @@ impl<StartArgs: PluginStartArgs, Instance: PluginInstance> PluginStatus
         if let Some(starter) = &self.starter {
             starter.path()
         } else {
-            "__not_loaded__>"
+            "__not_loaded__"
         }
     }
     fn state(&self) -> PluginState {

--- a/plugins/zenoh-plugin-trait/src/manager/static_plugin.rs
+++ b/plugins/zenoh-plugin-trait/src/manager/static_plugin.rs
@@ -51,7 +51,7 @@ where
         Some(P::PLUGIN_LONG_VERSION)
     }
     fn path(&self) -> &str {
-        r#""<static>""#
+        "__static_lib__"
     }
     fn state(&self) -> PluginState {
         self.instance

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -800,7 +800,7 @@ fn plugins_status(context: &AdminContext, query: Query) {
                         if let Err(e) = query
                             .reply(Ok(Sample::new(
                                 key_expr,
-                                Value::from(plugin.path()).encoding(KnownEncoding::AppJson.into()),
+                                serde_json::Value::String(plugin.path().into()),
                             )))
                             .res()
                         {


### PR DESCRIPTION
For plugins the admin space includes such a key/value (in JSON5):
```json5
{ "key": "@/peer/1cdbe046daa889a6a88c48dccb82ead0/status/plugins/dds/__path__", "value": /home/guest/.zenoh/lib/libzenoh_plugin_dds.so, "encoding": "application/json", "time": "None" }
```
This is invalid because the value is not between quotes.

This PR fixes that. It overrides #988