### PR TITLE
fix(test): sporadic failures of downsampling test on Windows

### DIFF
--- a/zenoh/tests/interceptors.rs
+++ b/zenoh/tests/interceptors.rs
@@ -14,6 +14,11 @@
 use std::sync::{Arc, Mutex};
 use zenoh_core::zlock;
 
+#[cfg(target_os = "windows")]
+static MINIMAL_SLEEP_INTERVAL_MS: u64 = 2;
+#[cfg(not(target_os = "windows"))]
+static MINIMAL_SLEEP_INTERVAL_MS: u64 = 17;
+
 struct IntervalCounter {
     first_tick: bool,
     last_time: std::time::Instant,
@@ -248,7 +253,7 @@ fn downsampling_by_interface_impl(egress: bool) {
         .unwrap();
 
     // WARN(yuyuan): 2 ms is the limit of tokio
-    let interval = std::time::Duration::from_millis(2);
+    let interval = std::time::Duration::from_millis(MINIMAL_SLEEP_INTERVAL_MS);
     let messages_count = 1000;
     for i in 0..messages_count {
         publisher_r100.put(format!("message {}", i)).res().unwrap();

--- a/zenoh/tests/interceptors.rs
+++ b/zenoh/tests/interceptors.rs
@@ -149,7 +149,7 @@ fn downsampling_by_keyexpr_impl(egress: bool) {
         .unwrap();
 
     // WARN(yuyuan): 2 ms is the limit of tokio
-    let interval = std::time::Duration::from_millis(2);
+    let interval = std::time::Duration::from_millis(MINIMAL_SLEEP_INTERVAL_MS);
     let messages_count = 1000;
     for i in 0..messages_count {
         publisher_r100.put(format!("message {}", i)).res().unwrap();

--- a/zenoh/tests/interceptors.rs
+++ b/zenoh/tests/interceptors.rs
@@ -15,9 +15,9 @@ use std::sync::{Arc, Mutex};
 use zenoh_core::zlock;
 
 #[cfg(target_os = "windows")]
-static MINIMAL_SLEEP_INTERVAL_MS: u64 = 2;
-#[cfg(not(target_os = "windows"))]
 static MINIMAL_SLEEP_INTERVAL_MS: u64 = 17;
+#[cfg(not(target_os = "windows"))]
+static MINIMAL_SLEEP_INTERVAL_MS: u64 = 2;
 
 struct IntervalCounter {
     first_tick: bool,


### PR DESCRIPTION
It turns out the failures are due to the temporal granularity issue on Windows. Here are my observations in a Windows VM. The minimal sleep time is at least 17ms.

```txt
# 17ms

2024-04-29T16:01:23.403698Z  INFO ThreadId(10) downsampling: 10Hz=8, 20Hz=15
2024-04-29T16:01:24.405787Z  INFO ThreadId(10) downsampling: 10Hz=10, 20Hz=21
2024-04-29T16:01:25.407855Z  INFO ThreadId(10) downsampling: 10Hz=8, 20Hz=17
2024-04-29T16:01:26.422084Z  INFO ThreadId(10) downsampling: 10Hz=10, 20Hz=20
2024-04-29T16:01:27.424019Z  INFO ThreadId(10) downsampling: 10Hz=9, 20Hz=18
2024-04-29T16:01:28.426127Z  INFO ThreadId(10) downsampling: 10Hz=9, 20Hz=18
2024-04-29T16:01:29.428190Z  INFO ThreadId(10) downsampling: 10Hz=9, 20Hz=18

# 16ms

2024-04-29T15:57:10.429109Z  INFO ThreadId(10) downsampling: 10Hz=0, 20Hz=0
2024-04-29T15:57:11.154594Z  WARN tx-0 ThreadId(05) zenoh_transport::common::pipeline: Pipeline pull backoff overflow detected! Retrying in 4294967295ns.
2024-04-29T15:57:11.430796Z  INFO ThreadId(10) downsampling: 10Hz=0, 20Hz=0
2024-04-29T15:57:12.432699Z  INFO ThreadId(10) downsampling: 10Hz=0, 20Hz=0
2024-04-29T15:57:13.434388Z  INFO ThreadId(10) downsampling: 10Hz=0, 20Hz=0
2024-04-29T15:57:13.660384Z  WARN tx-0 ThreadId(05) zenoh_transport::common::pipeline: Pipeline pull backoff overflow detected! Retrying in 4294967295ns.
2024-04-29T15:57:14.435656Z  INFO ThreadId(10) downsampling: 10Hz=0, 20Hz=0
2024-04-29T15:57:15.436879Z  INFO ThreadId(10) downsampling: 10Hz=0, 20Hz=0
2024-04-29T15:57:16.437866Z  INFO ThreadId(10) downsampling: 10Hz=383, 20Hz=698
2024-04-29T15:57:17.439384Z  INFO ThreadId(10) downsampling: 10Hz=0, 20Hz=0

```
