### PR TITLE
refactor: downsampling test

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -10,8 +10,7 @@ test(=zenoh_session_unicast) |
 test(=zenoh_session_multicast) |
 test(=transport_tcp_intermittent) |
 test(=transport_tcp_intermittent_for_lowlatency_transport) |
-test(=three_node_combination) |
-test(=downsampling_by_keyexpr)
+test(=three_node_combination)
 """
 threads-required = 'num-cpus'
 slow-timeout = { period = "60s", terminate-after = 6 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5454,7 +5454,6 @@ dependencies = [
  "ron",
  "serde",
  "tokio",
- "tracing",
  "zenoh-collections",
  "zenoh-macros",
  "zenoh-result",

--- a/zenoh/tests/interceptors.rs
+++ b/zenoh/tests/interceptors.rs
@@ -160,9 +160,9 @@ fn downsampling_by_keyexpr_impl(flow: InterceptorFlow) {
     let rate_check = move |ke: KeyExpr, rate: usize| -> bool {
         tracing::info!("keyexpr: {ke}, rate: {rate}");
         if ke == ke_10hz {
-            rate > 0 && rate <= 10
+            rate > 0 && rate <= 10 + 1
         } else if ke == ke_20hz {
-            rate > 0 && rate <= 20
+            rate > 0 && rate <= 20 + 1
         } else {
             tracing::error!("Shouldn't reach this case. Invalid keyexpr {ke} detected.");
             false
@@ -212,7 +212,7 @@ fn downsampling_by_interface_impl(flow: InterceptorFlow) {
     let rate_check = move |ke: KeyExpr, rate: usize| -> bool {
         tracing::info!("keyexpr: {ke}, rate: {rate}");
         if ke == ke_10hz {
-            rate > 0 && rate <= 10
+            rate > 0 && rate <= 10 + 1
         } else if ke == ke_no_effect {
             rate > 10
         } else {


### PR DESCRIPTION
This PR aims to make the test

1. Less ambiguous by renaming "r100" to "10Hz" and "r50" to "20Hz". 
2. More deterministic. Previously, we began counting the message rate once the auxiliary keyexpr "all" received sufficient messages. However, the interaction between the normal flow and the downsampled flows is non-deterministic. Let's stick to the original meaning of "downsample the message flow" by measuring the number of messages per second. Furthermore, we can control the total test time and repeat the test specifically.

It also includes
1. Better code reusability. For example, we could extend the `rate_check` in the future if more rigorous criteria are in demand. (Actually, a similar logic can apply to the other tests.)
2. No mutex needed.
3. Make the downsampling test run in parallel with the others as the issue of sleeping time has been resolved. 