### PR TITLE
feat: Check licenses of the dependency graph

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,13 +38,11 @@ jobs:
       - name: Clone this repository
         uses: actions/checkout@v4
 
-      - name: Install Rust toolchain
-        run: |
-          rustup show
-          rustup component add rustfmt clippy
-
       - name: Setup rust-cache
         uses: Swatinem/rust-cache@v2
+
+      - name: Install dependencies
+        run: cargo +stable install cargo-deny --locked
 
       - name: Code format check
         run: cargo fmt --check
@@ -68,6 +66,9 @@ jobs:
 
       - name: Run doctests
         run: cargo test --doc
+
+      - name: Check licenses
+        run: cargo deny check licenses
 
   test:
     name: Unit tests on ${{ matrix.os }}

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,24 @@
+# NOTE: Before allowing a new license, make sure it is approved by the Eclipse Foundation.
+# A list of approved third party licenses is available at: https://www.eclipse.org/legal/licenses.php.
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "EPL-2.0",
+    "ISC",
+    "Unicode-DFS-2016",
+    "Zlib",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC0-1.0",
+    "MPL-2.0",
+    "OpenSSL",
+]
+
+# This was copied from https://github.com/EmbarkStudios/cargo-deny/blob/main/deny.toml#L64
+[[licenses.clarify]]
+crate = "ring"
+expression = "ISC AND MIT AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+[licenses.private]
+ignore = true


### PR DESCRIPTION
This pull request uses [cargo-deny](https://github.com/EmbarkStudios/cargo-deny) to disallow licenses not approved by the [Eclipse Foundation](https://www.eclipse.org/legal/licenses.php).