### PR TITLE
fix: add the missing unstable feature

### DIFF
--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -109,6 +109,10 @@ zenoh-util = { workspace = true }
 zenoh-runtime = { workspace = true }
 zenoh-task = { workspace = true }
 
+[dev-dependencies]
+# Enable the unstable feature for the tests
+zenoh = { workspace = true, features = ["unstable"] }
+
 [build-dependencies]
 rustc_version = { workspace = true }
 


### PR DESCRIPTION
Closes #963. The change of feature flags only affects the dev-dependencies and is safe for the downstream dependencies/bindings.