### PR TITLE
Fix compression test

### DIFF
--- a/io/zenoh-transport/src/unicast/link.rs
+++ b/io/zenoh-transport/src/unicast/link.rs
@@ -66,7 +66,9 @@ impl TransportLinkUnicast {
                     .batch
                     .is_compression
                     .then_some(BBuf::with_capacity(
-                        lz4_flex::block::get_maximum_output_size(self.config.batch.mtu as usize),
+                        lz4_flex::block::get_maximum_output_size(
+                            self.config.batch.max_buffer_size()
+                        ),
                     )),
                 None
             ),

--- a/io/zenoh-transport/tests/unicast_compression.rs
+++ b/io/zenoh-transport/tests/unicast_compression.rs
@@ -178,7 +178,8 @@ mod tests {
             #[cfg(feature = "shared-memory")]
             false,
             lowlatency_transport,
-        );
+        )
+        .compression(true);
         let router_manager = TransportManager::builder()
             .zid(router_id)
             .whatami(WhatAmI::Router)


### PR DESCRIPTION
Compression wasn't properly activated in the test, yielding false-positive results.