### PR TITLE
refactor: keep only trait in prelude

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5579,6 +5579,7 @@ dependencies = [
  "zenoh",
  "zenoh-plugin-trait",
  "zenoh-result",
+ "zenoh-util",
 ]
 
 [[package]]
@@ -5604,6 +5605,7 @@ dependencies = [
  "urlencoding",
  "zenoh",
  "zenoh-plugin-trait",
+ "zenoh-util",
  "zenoh_backend_traits",
 ]
 

--- a/ci/valgrind-check/src/pub_sub/bin/z_pub_sub.rs
+++ b/ci/valgrind-check/src/pub_sub/bin/z_pub_sub.rs
@@ -13,7 +13,7 @@
 //
 use std::time::Duration;
 
-use zenoh::{config::Config, prelude::*};
+use zenoh::{config::Config, key_expr::KeyExpr, prelude::*};
 
 #[tokio::main]
 async fn main() {

--- a/ci/valgrind-check/src/queryable_get/bin/z_queryable_get.rs
+++ b/ci/valgrind-check/src/queryable_get/bin/z_queryable_get.rs
@@ -13,7 +13,9 @@
 //
 use std::{convert::TryFrom, time::Duration};
 
-use zenoh::{config::Config, prelude::*};
+use zenoh::{
+    config::Config, key_expr::KeyExpr, prelude::*, query::QueryTarget, selector::Selector,
+};
 
 #[tokio::main]
 async fn main() {

--- a/examples/examples/z_alloc_shm.rs
+++ b/examples/examples/z_alloc_shm.rs
@@ -11,7 +11,14 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use zenoh::prelude::*;
+use zenoh::{
+    prelude::*,
+    shm::{
+        AllocAlignment, BlockOn, Deallocate, Defragment, GarbageCollect,
+        PosixSharedMemoryProviderBackend, SharedMemoryProviderBuilder, POSIX_PROTOCOL_ID,
+    },
+    Config,
+};
 
 #[tokio::main]
 async fn main() {

--- a/examples/examples/z_bytes_shm.rs
+++ b/examples/examples/z_bytes_shm.rs
@@ -11,7 +11,14 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use zenoh::prelude::*;
+use zenoh::{
+    bytes::ZBytes,
+    prelude::*,
+    shm::{
+        zshm, zshmmut, PosixSharedMemoryProviderBackend, SharedMemoryProviderBuilder, ZShm,
+        ZShmMut, POSIX_PROTOCOL_ID,
+    },
+};
 
 fn main() {
     // create an SHM backend...

--- a/examples/examples/z_delete.rs
+++ b/examples/examples/z_delete.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use clap::Parser;
-use zenoh::prelude::*;
+use zenoh::{key_expr::KeyExpr, Config};
 use zenoh_examples::CommonArgs;
 
 #[tokio::main]

--- a/examples/examples/z_formats.rs
+++ b/examples/examples/z_formats.rs
@@ -12,8 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-use zenoh::prelude as zenoh;
-
+use zenoh::key_expr::keyexpr;
 zenoh::kedefine!(
     pub file_format: "user_id/${user_id:*}/file/${file:*/**}",
     pub(crate) settings_format: "user_id/${user_id:*}/settings/${setting:**}"
@@ -26,8 +25,8 @@ fn main() {
     let ke = zenoh::keformat!(formatter, user_id = 42, file).unwrap();
     println!("{formatter:?} => {ke}");
     // Parsing
-    let settings_ke = zenoh::keyexpr::new("user_id/30/settings/dark_mode").unwrap();
+    let settings_ke = keyexpr::new("user_id/30/settings/dark_mode").unwrap();
     let parsed = settings_format::parse(settings_ke).unwrap();
-    assert_eq!(parsed.user_id(), zenoh::keyexpr::new("30").unwrap());
-    assert_eq!(parsed.setting(), zenoh::keyexpr::new("dark_mode").ok());
+    assert_eq!(parsed.user_id(), keyexpr::new("30").unwrap());
+    assert_eq!(parsed.setting(), keyexpr::new("dark_mode").ok());
 }

--- a/examples/examples/z_forward.rs
+++ b/examples/examples/z_forward.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use clap::Parser;
-use zenoh::prelude::*;
+use zenoh::{key_expr::KeyExpr, prelude::*, Config};
 use zenoh_examples::CommonArgs;
 use zenoh_ext::SubscriberForward;
 

--- a/examples/examples/z_get.rs
+++ b/examples/examples/z_get.rs
@@ -14,7 +14,7 @@
 use std::time::Duration;
 
 use clap::Parser;
-use zenoh::prelude::*;
+use zenoh::{prelude::*, query::QueryTarget, selector::Selector, Config};
 use zenoh_examples::CommonArgs;
 
 #[tokio::main]

--- a/examples/examples/z_get_liveliness.rs
+++ b/examples/examples/z_get_liveliness.rs
@@ -14,7 +14,7 @@
 use std::time::Duration;
 
 use clap::Parser;
-use zenoh::prelude::*;
+use zenoh::{key_expr::KeyExpr, prelude::*, Config};
 use zenoh_examples::CommonArgs;
 
 #[tokio::main]

--- a/examples/examples/z_get_shm.rs
+++ b/examples/examples/z_get_shm.rs
@@ -14,7 +14,16 @@
 use std::time::Duration;
 
 use clap::Parser;
-use zenoh::prelude::*;
+use zenoh::{
+    prelude::*,
+    query::QueryTarget,
+    selector::Selector,
+    shm::{
+        zshm, BlockOn, GarbageCollect, PosixSharedMemoryProviderBackend,
+        SharedMemoryProviderBuilder, POSIX_PROTOCOL_ID,
+    },
+    Config,
+};
 use zenoh_examples::CommonArgs;
 
 const N: usize = 10;

--- a/examples/examples/z_info.rs
+++ b/examples/examples/z_info.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use clap::Parser;
-use zenoh::prelude::*;
+use zenoh::{config::ZenohId, prelude::*};
 use zenoh_examples::CommonArgs;
 
 #[tokio::main]
@@ -43,7 +43,7 @@ struct Args {
     common: CommonArgs,
 }
 
-fn parse_args() -> Config {
+fn parse_args() -> zenoh::Config {
     let args = Args::parse();
     args.common.into()
 }

--- a/examples/examples/z_liveliness.rs
+++ b/examples/examples/z_liveliness.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use clap::Parser;
-use zenoh::prelude::*;
+use zenoh::{key_expr::KeyExpr, prelude::*, Config};
 use zenoh_examples::CommonArgs;
 
 #[tokio::main]

--- a/examples/examples/z_ping.rs
+++ b/examples/examples/z_ping.rs
@@ -14,7 +14,7 @@
 use std::time::{Duration, Instant};
 
 use clap::Parser;
-use zenoh::prelude::*;
+use zenoh::{bytes::ZBytes, key_expr::keyexpr, prelude::*, publisher::CongestionControl, Config};
 use zenoh_examples::CommonArgs;
 
 fn main() {

--- a/examples/examples/z_ping_shm.rs
+++ b/examples/examples/z_ping_shm.rs
@@ -14,7 +14,14 @@
 use std::time::{Duration, Instant};
 
 use clap::Parser;
-use zenoh::prelude::*;
+use zenoh::{
+    buffers::ZSlice,
+    key_expr::keyexpr,
+    prelude::*,
+    publisher::CongestionControl,
+    shm::{PosixSharedMemoryProviderBackend, SharedMemoryProviderBuilder, POSIX_PROTOCOL_ID},
+    Config,
+};
 use zenoh_examples::CommonArgs;
 
 fn main() {

--- a/examples/examples/z_pong.rs
+++ b/examples/examples/z_pong.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use clap::Parser;
-use zenoh::prelude::*;
+use zenoh::{key_expr::keyexpr, prelude::*, publisher::CongestionControl, Config};
 use zenoh_examples::CommonArgs;
 
 fn main() {

--- a/examples/examples/z_posix_shm_provider.rs
+++ b/examples/examples/z_posix_shm_provider.rs
@@ -11,7 +11,10 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use zenoh::prelude::*;
+use zenoh::shm::{
+    AllocAlignment, MemoryLayout, PosixSharedMemoryProviderBackend, SharedMemoryProviderBuilder,
+    POSIX_PROTOCOL_ID,
+};
 
 fn main() {
     // Construct an SHM backend

--- a/examples/examples/z_pub.rs
+++ b/examples/examples/z_pub.rs
@@ -14,7 +14,7 @@
 use std::time::Duration;
 
 use clap::Parser;
-use zenoh::prelude::*;
+use zenoh::{key_expr::KeyExpr, prelude::*, Config};
 use zenoh_examples::CommonArgs;
 
 #[tokio::main]

--- a/examples/examples/z_pub_shm.rs
+++ b/examples/examples/z_pub_shm.rs
@@ -12,7 +12,15 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use clap::Parser;
-use zenoh::prelude::*;
+use zenoh::{
+    key_expr::KeyExpr,
+    prelude::*,
+    shm::{
+        BlockOn, GarbageCollect, PosixSharedMemoryProviderBackend, SharedMemoryProviderBuilder,
+        POSIX_PROTOCOL_ID,
+    },
+    Config,
+};
 use zenoh_examples::CommonArgs;
 
 const N: usize = 10;

--- a/examples/examples/z_pub_shm_thr.rs
+++ b/examples/examples/z_pub_shm_thr.rs
@@ -12,7 +12,13 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use clap::Parser;
-use zenoh::prelude::*;
+use zenoh::{
+    buffers::ZSlice,
+    prelude::*,
+    publisher::CongestionControl,
+    shm::{PosixSharedMemoryProviderBackend, SharedMemoryProviderBuilder, POSIX_PROTOCOL_ID},
+    Config,
+};
 use zenoh_examples::CommonArgs;
 
 #[tokio::main]

--- a/examples/examples/z_pub_thr.rs
+++ b/examples/examples/z_pub_thr.rs
@@ -15,7 +15,11 @@
 use std::convert::TryInto;
 
 use clap::Parser;
-use zenoh::prelude::*;
+use zenoh::{
+    bytes::ZBytes,
+    prelude::*,
+    publisher::{CongestionControl, Priority},
+};
 use zenoh_examples::CommonArgs;
 
 fn main() {

--- a/examples/examples/z_pull.rs
+++ b/examples/examples/z_pull.rs
@@ -14,7 +14,7 @@
 use std::time::Duration;
 
 use clap::Parser;
-use zenoh::prelude::*;
+use zenoh::{handlers::RingChannel, key_expr::KeyExpr, prelude::*, Config};
 use zenoh_examples::CommonArgs;
 
 #[tokio::main]

--- a/examples/examples/z_put.rs
+++ b/examples/examples/z_put.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use clap::Parser;
-use zenoh::prelude::*;
+use zenoh::{key_expr::KeyExpr, Config};
 use zenoh_examples::CommonArgs;
 
 #[tokio::main]

--- a/examples/examples/z_put_float.rs
+++ b/examples/examples/z_put_float.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use clap::Parser;
-use zenoh::prelude::*;
+use zenoh::{key_expr::KeyExpr, Config};
 use zenoh_examples::CommonArgs;
 
 #[tokio::main]

--- a/examples/examples/z_queryable.rs
+++ b/examples/examples/z_queryable.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use clap::Parser;
-use zenoh::prelude::*;
+use zenoh::{key_expr::KeyExpr, prelude::*, Config};
 use zenoh_examples::CommonArgs;
 
 #[tokio::main]

--- a/examples/examples/z_queryable_shm.rs
+++ b/examples/examples/z_queryable_shm.rs
@@ -12,7 +12,15 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use clap::Parser;
-use zenoh::prelude::*;
+use zenoh::{
+    key_expr::KeyExpr,
+    prelude::*,
+    shm::{
+        zshm, BlockOn, GarbageCollect, PosixSharedMemoryProviderBackend,
+        SharedMemoryProviderBuilder, POSIX_PROTOCOL_ID,
+    },
+    Config,
+};
 use zenoh_examples::CommonArgs;
 
 const N: usize = 10;

--- a/examples/examples/z_scout.rs
+++ b/examples/examples/z_scout.rs
@@ -11,7 +11,7 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use zenoh::prelude::*;
+use zenoh::{config::WhatAmI, scout, Config};
 
 #[tokio::main]
 async fn main() {

--- a/examples/examples/z_storage.rs
+++ b/examples/examples/z_storage.rs
@@ -17,7 +17,12 @@ use std::collections::HashMap;
 
 use clap::Parser;
 use futures::select;
-use zenoh::prelude::*;
+use zenoh::{
+    key_expr::{keyexpr, KeyExpr},
+    prelude::*,
+    sample::{Sample, SampleKind},
+    Config,
+};
 use zenoh_examples::CommonArgs;
 
 #[tokio::main]

--- a/examples/examples/z_sub.rs
+++ b/examples/examples/z_sub.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use clap::Parser;
-use zenoh::prelude::*;
+use zenoh::{key_expr::KeyExpr, prelude::*, Config};
 use zenoh_examples::CommonArgs;
 
 #[tokio::main]

--- a/examples/examples/z_sub_liveliness.rs
+++ b/examples/examples/z_sub_liveliness.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use clap::Parser;
-use zenoh::prelude::*;
+use zenoh::{key_expr::KeyExpr, prelude::*, sample::SampleKind, Config};
 use zenoh_examples::CommonArgs;
 
 #[tokio::main]

--- a/examples/examples/z_sub_shm.rs
+++ b/examples/examples/z_sub_shm.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use clap::Parser;
-use zenoh::{config::Config, prelude::*};
+use zenoh::{config::Config, key_expr::KeyExpr, prelude::*, shm::zshm};
 use zenoh_examples::CommonArgs;
 
 #[tokio::main]

--- a/examples/examples/z_sub_thr.rs
+++ b/examples/examples/z_sub_thr.rs
@@ -14,7 +14,7 @@
 use std::time::Instant;
 
 use clap::Parser;
-use zenoh::prelude::*;
+use zenoh::{prelude::*, Config};
 use zenoh_examples::CommonArgs;
 
 struct Stats {

--- a/plugins/zenoh-backend-traits/src/lib.rs
+++ b/plugins/zenoh-backend-traits/src/lib.rs
@@ -29,6 +29,7 @@
 //! ```
 //! use std::sync::Arc;
 //! use async_trait::async_trait;
+//! use zenoh::{OwnedKeyExpr, Timestamp, Value};
 //! use zenoh::prelude::*;
 //! use zenoh_backend_traits::*;
 //! use zenoh_backend_traits::config::*;

--- a/plugins/zenoh-backend-traits/src/lib.rs
+++ b/plugins/zenoh-backend-traits/src/lib.rs
@@ -29,8 +29,7 @@
 //! ```
 //! use std::sync::Arc;
 //! use async_trait::async_trait;
-//! use zenoh::{OwnedKeyExpr, Timestamp, Value};
-//! use zenoh::prelude::*;
+//! use zenoh::{key_expr::OwnedKeyExpr, prelude::*, time::Timestamp, value::Value};
 //! use zenoh_backend_traits::*;
 //! use zenoh_backend_traits::config::*;
 //!

--- a/plugins/zenoh-plugin-rest/Cargo.toml
+++ b/plugins/zenoh-plugin-rest/Cargo.toml
@@ -41,7 +41,7 @@ futures = { workspace = true }
 git-version = { workspace = true }
 http-types = { workspace = true }
 lazy_static = { workspace = true }
-tracing = {workspace = true}
+tracing = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["default"] }
 serde_json = { workspace = true }
@@ -49,6 +49,7 @@ tide = { workspace = true }
 zenoh = { workspace = true, features = ["unstable"] }
 zenoh-plugin-trait = { workspace = true }
 zenoh-result = { workspace = true }
+zenoh-util = { workspace = true }
 
 [build-dependencies]
 rustc_version = { workspace = true }

--- a/plugins/zenoh-plugin-rest/examples/z_serve_sse.rs
+++ b/plugins/zenoh-plugin-rest/examples/z_serve_sse.rs
@@ -15,8 +15,8 @@ use std::time::Duration;
 
 use clap::{arg, Command};
 use zenoh::{
-    config::Config, core::try_init_log_from_env, key_expr::keyexpr, publication::CongestionControl,
-    sample::QoSBuilderTrait, session::SessionDeclarations,
+    config::Config, key_expr::keyexpr, publisher::CongestionControl, sample::QoSBuilderTrait,
+    session::SessionDeclarations,
 };
 
 const HTML: &str = r#"
@@ -35,7 +35,7 @@ if(typeof(EventSource) !== "undefined") {
 #[async_std::main]
 async fn main() {
     // initiate logging
-    try_init_log_from_env();
+    zenoh_util::try_init_log_from_env();
 
     let config = parse_args();
     let key = keyexpr::new("demo/sse").unwrap();

--- a/plugins/zenoh-plugin-rest/src/lib.rs
+++ b/plugins/zenoh-plugin-rest/src/lib.rs
@@ -27,7 +27,6 @@ use serde::{Deserialize, Serialize};
 use tide::{http::Mime, sse::Sender, Request, Response, Server, StatusCode};
 use zenoh::{
     bytes::{StringOrBase64, ZBytes},
-    core::try_init_log_from_env,
     encoding::Encoding,
     key_expr::{keyexpr, KeyExpr},
     plugins::{RunningPluginTrait, ZenohPlugin},
@@ -222,7 +221,7 @@ impl Plugin for RestPlugin {
         // Try to initiate login.
         // Required in case of dynamic lib, otherwise no logs.
         // But cannot be done twice in case of static link.
-        try_init_log_from_env();
+        zenoh_util::try_init_log_from_env();
         tracing::debug!("REST plugin {}", LONG_VERSION.as_str());
 
         let runtime_conf = runtime.config().lock();
@@ -466,7 +465,7 @@ pub async fn run(runtime: Runtime, conf: Config) -> ZResult<()> {
     // Try to initiate login.
     // Required in case of dynamic lib, otherwise no logs.
     // But cannot be done twice in case of static link.
-    try_init_log_from_env();
+    zenoh_util::try_init_log_from_env();
 
     let zid = runtime.zid().to_string();
     let session = zenoh::session::init(runtime).await.unwrap();

--- a/plugins/zenoh-plugin-storage-manager/Cargo.toml
+++ b/plugins/zenoh-plugin-storage-manager/Cargo.toml
@@ -47,6 +47,7 @@ serde_json = { workspace = true }
 urlencoding = { workspace = true }
 zenoh = { workspace = true, features = ["unstable"] }
 zenoh-plugin-trait = { workspace = true }
+zenoh-util = { workspace = true }
 zenoh_backend_traits = { workspace = true }
 
 [build-dependencies]

--- a/plugins/zenoh-plugin-storage-manager/src/lib.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/lib.rs
@@ -30,7 +30,7 @@ use flume::Sender;
 use memory_backend::MemoryBackend;
 use storages_mgt::StorageMessage;
 use zenoh::{
-    core::{try_init_log_from_env, Result as ZResult},
+    core::Result as ZResult,
     internal::{zlock, LibLoader},
     key_expr::keyexpr,
     plugins::{RunningPluginTrait, ZenohPlugin},
@@ -68,7 +68,7 @@ impl Plugin for StoragesPlugin {
     type Instance = zenoh::plugins::RunningPlugin;
 
     fn start(name: &str, runtime: &Self::StartArgs) -> ZResult<Self::Instance> {
-        try_init_log_from_env();
+        zenoh_util::try_init_log_from_env();
         tracing::debug!("StorageManager plugin {}", Self::PLUGIN_VERSION);
         let config =
             { PluginConfig::try_from((name, runtime.config().lock().plugin(name).unwrap())) }?;
@@ -101,7 +101,7 @@ impl StorageRuntimeInner {
         // Try to initiate login.
         // Required in case of dynamic lib, otherwise no logs.
         // But cannot be done twice in case of static link.
-        try_init_log_from_env();
+        zenoh_util::try_init_log_from_env();
         let PluginConfig {
             name,
             backend_search_dirs,

--- a/plugins/zenoh-plugin-storage-manager/src/replica/align_queryable.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/align_queryable.rs
@@ -19,7 +19,10 @@ use std::{
 };
 
 use async_std::sync::Arc;
-use zenoh::prelude::*;
+use zenoh::{
+    bytes::StringOrBase64, key_expr::OwnedKeyExpr, prelude::*, sample::Sample, selector::Selector,
+    time::Timestamp, value::Value, Session,
+};
 
 use super::{digest::*, Snapshotter};
 

--- a/plugins/zenoh-plugin-storage-manager/src/replica/aligner.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/aligner.rs
@@ -19,7 +19,16 @@ use std::{
 
 use async_std::sync::{Arc, RwLock};
 use flume::{Receiver, Sender};
-use zenoh::prelude::*;
+use zenoh::{
+    bytes::StringOrBase64,
+    key_expr::{KeyExpr, OwnedKeyExpr},
+    prelude::*,
+    sample::{Sample, SampleBuilder},
+    selector::Selector,
+    time::Timestamp,
+    value::Value,
+    Session,
+};
 
 use super::{Digest, EraType, LogEntry, Snapshotter, CONTENTS, ERA, INTERVALS, SUBINTERVALS};
 

--- a/plugins/zenoh-plugin-storage-manager/src/replica/mod.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/mod.rs
@@ -44,6 +44,9 @@ pub use aligner::Aligner;
 pub use digest::{Digest, DigestConfig, EraType, LogEntry};
 pub use snapshotter::Snapshotter;
 pub use storage::{ReplicationService, StorageService};
+use zenoh::{
+    bytes::StringOrBase64, key_expr::OwnedKeyExpr, sample::Locality, time::Timestamp, Session,
+};
 
 const ERA: &str = "era";
 const INTERVALS: &str = "intervals";

--- a/plugins/zenoh-plugin-storage-manager/tests/operations.rs
+++ b/plugins/zenoh-plugin-storage-manager/tests/operations.rs
@@ -19,7 +19,10 @@
 use std::{str::FromStr, thread::sleep};
 
 use async_std::task;
-use zenoh::{internal::zasync_executor_init, prelude::*};
+use zenoh::{
+    bytes::StringOrBase64, internal::zasync_executor_init, prelude::*, query::Reply,
+    sample::Sample, time::Timestamp, Config, Session,
+};
 use zenoh_plugin_trait::Plugin;
 
 async fn put_data(session: &Session, key_expr: &str, value: &str, _timestamp: Timestamp) {

--- a/plugins/zenoh-plugin-storage-manager/tests/wildcard.rs
+++ b/plugins/zenoh-plugin-storage-manager/tests/wildcard.rs
@@ -20,7 +20,10 @@ use std::{str::FromStr, thread::sleep};
 
 // use std::collections::HashMap;
 use async_std::task;
-use zenoh::{internal::zasync_executor_init, prelude::*};
+use zenoh::{
+    bytes::StringOrBase64, internal::zasync_executor_init, prelude::*, query::Reply,
+    sample::Sample, time::Timestamp, Config, Session,
+};
 use zenoh_plugin_trait::Plugin;
 
 async fn put_data(session: &Session, key_expr: &str, value: &str, _timestamp: Timestamp) {

--- a/zenoh-ext/examples/examples/z_member.rs
+++ b/zenoh-ext/examples/examples/z_member.rs
@@ -14,7 +14,7 @@
 use std::{sync::Arc, time::Duration};
 
 use futures::StreamExt;
-use zenoh::prelude::*;
+use zenoh::Config;
 use zenoh_ext::group::*;
 
 #[tokio::main]

--- a/zenoh-ext/examples/examples/z_pub_cache.rs
+++ b/zenoh-ext/examples/examples/z_pub_cache.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 use clap::{arg, Parser};
 use zenoh::{
     config::{Config, ModeDependentValue},
-    prelude::*,
+    key_expr::KeyExpr,
 };
 use zenoh_ext::*;
 use zenoh_ext_examples::CommonArgs;

--- a/zenoh-ext/examples/examples/z_query_sub.rs
+++ b/zenoh-ext/examples/examples/z_query_sub.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use clap::{arg, Parser};
-use zenoh::{config::Config, prelude::*};
+use zenoh::{config::Config, prelude::*, query::ReplyKeyExpr};
 use zenoh_ext::*;
 use zenoh_ext_examples::CommonArgs;
 

--- a/zenoh-ext/src/group.rs
+++ b/zenoh-ext/src/group.rs
@@ -27,8 +27,12 @@ use futures::{prelude::*, select};
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use zenoh::{
+    bytes::ZBytesReader,
     internal::{bail, Condition, TaskController},
+    key_expr::{keyexpr, KeyExpr, OwnedKeyExpr},
     prelude::*,
+    publisher::{Priority, Publisher},
+    Session,
 };
 
 const GROUP_PREFIX: &str = "zenoh/ext/net/group";
@@ -289,7 +293,7 @@ async fn net_event_handler(z: Arc<Session>, state: Arc<GroupState>) {
                                 );
                                 let qres = format!("{}/{}/{}", GROUP_PREFIX, &state.gid, kae.mid);
                                 // @TODO: we could also send this member info
-                                let qc = ConsolidationMode::None;
+                                let qc = zenoh::query::ConsolidationMode::None;
                                 tracing::trace!("Issuing Query for {}", &qres);
                                 let receiver = z.get(&qres).consolidation(qc).await.unwrap();
 

--- a/zenoh-ext/src/querying_subscriber.rs
+++ b/zenoh-ext/src/querying_subscriber.rs
@@ -605,7 +605,7 @@ where
 /// use zenoh::prelude::*;
 /// use zenoh_ext::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// let subscriber = session
 ///     .declare_subscriber("key/expr")
 ///     .fetching( |cb| {
@@ -740,11 +740,10 @@ impl<'a, Handler> FetchingSubscriber<'a, Handler> {
     /// use zenoh::prelude::*;
     /// use zenoh_ext::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let mut subscriber = session
     ///     .declare_subscriber("key/expr")
     ///     .fetching( |cb| {
-    ///         use zenoh::prelude::sync::SyncResolve;
     ///         session
     ///             .get("key/expr")
     ///             .callback(cb)
@@ -756,7 +755,6 @@ impl<'a, Handler> FetchingSubscriber<'a, Handler> {
     /// // perform an additional fetch
     /// subscriber
     ///     .fetch( |cb| {
-    ///         use zenoh::prelude::sync::SyncResolve;
     ///         session
     ///             .get("key/expr")
     ///             .callback(cb)
@@ -820,11 +818,10 @@ impl Drop for RepliesHandler {
 /// # use zenoh::prelude::*;
 /// # use zenoh_ext::*;
 /// #
-/// # let session = zenoh::open(config::peer()).await.unwrap();
+/// # let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// # let mut fetching_subscriber = session
 /// #     .declare_subscriber("key/expr")
 /// #     .fetching( |cb| {
-/// #         use zenoh::prelude::sync::SyncResolve;
 /// #         session
 /// #             .get("key/expr")
 /// #             .callback(cb)
@@ -835,7 +832,6 @@ impl Drop for RepliesHandler {
 /// #
 /// fetching_subscriber
 ///     .fetch( |cb| {
-///         use zenoh::prelude::sync::SyncResolve;
 ///         session
 ///             .get("key/expr")
 ///             .callback(cb)

--- a/zenoh-ext/src/session_ext.rs
+++ b/zenoh-ext/src/session_ext.rs
@@ -67,7 +67,7 @@ impl<'s> SessionExt<'s, 'static> for Arc<Session> {
     /// use zenoh::config::ModeDependentValue::Unique;
     /// use zenoh_ext::SessionExt;
     ///
-    /// let mut config = config::default();
+    /// let mut config = zenoh::config::default();
     /// config.timestamping.set_enabled(Some(Unique(true)));
     /// let session = zenoh::open(config).await.unwrap().into_arc();
     /// let publication_cache = session.declare_publication_cache("key/expression").await.unwrap();

--- a/zenoh-ext/src/subscriber_ext.rs
+++ b/zenoh-ext/src/subscriber_ext.rs
@@ -63,11 +63,10 @@ pub trait SubscriberBuilderExt<'a, 'b, Handler> {
     /// use zenoh::prelude::*;
     /// use zenoh_ext::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let subscriber = session
     ///     .declare_subscriber("key/expr")
     ///     .fetching( |cb| {
-    ///         use zenoh::prelude::sync::SyncResolve;
     ///         session
     ///             .get("key/expr")
     ///             .callback(cb)
@@ -108,7 +107,7 @@ pub trait SubscriberBuilderExt<'a, 'b, Handler> {
     /// use zenoh::prelude::*;
     /// use zenoh_ext::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let subscriber = session
     ///     .declare_subscriber("key/expr")
     ///     .querying()
@@ -142,11 +141,10 @@ impl<'a, 'b, Handler> SubscriberBuilderExt<'a, 'b, Handler> for SubscriberBuilde
     /// use zenoh::prelude::*;
     /// use zenoh_ext::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let subscriber = session
     ///     .declare_subscriber("key/expr")
     ///     .fetching( |cb| {
-    ///         use zenoh::prelude::sync::SyncResolve;
     ///         session
     ///             .get("key/expr")
     ///             .callback(cb)
@@ -199,7 +197,7 @@ impl<'a, 'b, Handler> SubscriberBuilderExt<'a, 'b, Handler> for SubscriberBuilde
     /// use zenoh::prelude::*;
     /// use zenoh_ext::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let subscriber = session
     ///     .declare_subscriber("key/expr")
     ///     .querying()
@@ -253,12 +251,11 @@ impl<'a, 'b, Handler> SubscriberBuilderExt<'a, 'b, Handler>
     /// use zenoh::prelude::*;
     /// use zenoh_ext::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let subscriber = session
     ///     .liveliness()
     ///     .declare_subscriber("key/expr")
     ///     .fetching( |cb| {
-    ///         use zenoh::prelude::sync::SyncResolve;
     ///         session
     ///             .liveliness()
     ///             .get("key/expr")
@@ -313,7 +310,7 @@ impl<'a, 'b, Handler> SubscriberBuilderExt<'a, 'b, Handler>
     /// use zenoh::prelude::*;
     /// use zenoh_ext::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let subscriber = session
     ///     .liveliness()
     ///     .declare_subscriber("key/expr")

--- a/zenoh/src/api/builders.rs
+++ b/zenoh/src/api/builders.rs
@@ -12,5 +12,5 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-pub(crate) mod publication;
+pub(crate) mod publisher;
 pub(crate) mod sample;

--- a/zenoh/src/api/builders/publication.rs
+++ b/zenoh/src/api/builders/publication.rs
@@ -27,7 +27,7 @@ use crate::api::{
     bytes::ZBytes,
     encoding::Encoding,
     key_expr::KeyExpr,
-    publication::{Priority, Publisher},
+    publisher::{Priority, Publisher},
     sample::{Locality, SampleKind},
     session::SessionRef,
     value::Value,
@@ -53,7 +53,7 @@ pub struct PublicationBuilderPut {
 pub struct PublicationBuilderDelete;
 
 /// A builder for initializing  [`Session::put`](crate::session::Session::put), [`Session::delete`](crate::session::Session::delete),
-/// [`Publisher::put`](crate::publication::Publisher::put), and [`Publisher::delete`](crate::publication::Publisher::delete) operations.
+/// [`Publisher::put`](crate::publisher::Publisher::put), and [`Publisher::delete`](crate::publisher::Publisher::delete) operations.
 ///
 /// # Examples
 /// ```
@@ -61,11 +61,11 @@ pub struct PublicationBuilderDelete;
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// session
 ///     .put("key/expression", "payload")
-///     .encoding(Encoding::TEXT_PLAIN)
-///     .congestion_control(CongestionControl::Block)
+///     .encoding(zenoh::Encoding::TEXT_PLAIN)
+///     .congestion_control(zenoh::CongestionControl::Block)
 ///     .await
 ///     .unwrap();
 /// # }
@@ -240,10 +240,10 @@ impl IntoFuture for PublicationBuilder<PublisherBuilder<'_, '_>, PublicationBuil
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// let publisher = session
 ///     .declare_publisher("key/expression")
-///     .congestion_control(CongestionControl::Block)
+///     .congestion_control(zenoh::CongestionControl::Block)
 ///     .await
 ///     .unwrap();
 /// # }

--- a/zenoh/src/api/builders/publisher.rs
+++ b/zenoh/src/api/builders/publisher.rs
@@ -59,13 +59,13 @@ pub struct PublicationBuilderDelete;
 /// ```
 /// # #[tokio::main]
 /// # async fn main() {
-/// use zenoh::prelude::*;
+/// use zenoh::{encoding::Encoding, prelude::*, publisher::CongestionControl};
 ///
 /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// session
 ///     .put("key/expression", "payload")
-///     .encoding(zenoh::Encoding::TEXT_PLAIN)
-///     .congestion_control(zenoh::CongestionControl::Block)
+///     .encoding(Encoding::TEXT_PLAIN)
+///     .congestion_control(CongestionControl::Block)
 ///     .await
 ///     .unwrap();
 /// # }
@@ -238,12 +238,12 @@ impl IntoFuture for PublicationBuilder<PublisherBuilder<'_, '_>, PublicationBuil
 /// ```
 /// # #[tokio::main]
 /// # async fn main() {
-/// use zenoh::prelude::*;
+/// use zenoh::{prelude::*, publisher::CongestionControl};
 ///
 /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// let publisher = session
 ///     .declare_publisher("key/expression")
-///     .congestion_control(zenoh::CongestionControl::Block)
+///     .congestion_control(CongestionControl::Block)
 ///     .await
 ///     .unwrap();
 /// # }

--- a/zenoh/src/api/builders/sample.rs
+++ b/zenoh/src/api/builders/sample.rs
@@ -21,7 +21,7 @@ use crate::api::{
     bytes::ZBytes,
     encoding::Encoding,
     key_expr::KeyExpr,
-    publication::Priority,
+    publisher::Priority,
     sample::{QoS, QoSBuilder, Sample, SampleKind},
     value::Value,
 };

--- a/zenoh/src/api/encoding.rs
+++ b/zenoh/src/api/encoding.rs
@@ -37,7 +37,7 @@ use super::bytes::ZBytes;
 ///
 /// Create an [`Encoding`] from a string and viceversa.
 /// ```
-/// use zenoh::prelude::Encoding;
+/// use zenoh::Encoding;
 ///
 /// let encoding: Encoding = "text/plain".into();
 /// let text: String = encoding.clone().into();
@@ -49,7 +49,7 @@ use super::bytes::ZBytes;
 /// Since some encoding values are internally optimized by Zenoh, it's generally more efficient to use
 /// the defined constants and [`Cow`][std::borrow::Cow] conversion to obtain its string representation.
 /// ```
-/// use zenoh::prelude::Encoding;
+/// use zenoh::Encoding;
 /// use std::borrow::Cow;
 ///
 /// // This allocates
@@ -64,7 +64,7 @@ use super::bytes::ZBytes;
 /// The convetions is to use the `;` separator if an encoding is created from a string.
 /// Alternatively, [`with_schema()`](Encoding::with_schema) can be used to add a schme to one of the associated constants.
 /// ```
-/// use zenoh::prelude::Encoding;
+/// use zenoh::Encoding;
 ///
 /// let encoding1 = Encoding::from("text/plain;utf-8");
 /// let encoding2 = Encoding::TEXT_PLAIN.with_schema("utf-8");

--- a/zenoh/src/api/encoding.rs
+++ b/zenoh/src/api/encoding.rs
@@ -37,7 +37,7 @@ use super::bytes::ZBytes;
 ///
 /// Create an [`Encoding`] from a string and viceversa.
 /// ```
-/// use zenoh::Encoding;
+/// use zenoh::encoding::Encoding;
 ///
 /// let encoding: Encoding = "text/plain".into();
 /// let text: String = encoding.clone().into();
@@ -49,7 +49,7 @@ use super::bytes::ZBytes;
 /// Since some encoding values are internally optimized by Zenoh, it's generally more efficient to use
 /// the defined constants and [`Cow`][std::borrow::Cow] conversion to obtain its string representation.
 /// ```
-/// use zenoh::Encoding;
+/// use zenoh::encoding::Encoding;
 /// use std::borrow::Cow;
 ///
 /// // This allocates
@@ -64,7 +64,7 @@ use super::bytes::ZBytes;
 /// The convetions is to use the `;` separator if an encoding is created from a string.
 /// Alternatively, [`with_schema()`](Encoding::with_schema) can be used to add a schme to one of the associated constants.
 /// ```
-/// use zenoh::Encoding;
+/// use zenoh::encoding::Encoding;
 ///
 /// let encoding1 = Encoding::from("text/plain;utf-8");
 /// let encoding2 = Encoding::TEXT_PLAIN.with_schema("utf-8");

--- a/zenoh/src/api/info.rs
+++ b/zenoh/src/api/info.rs
@@ -29,7 +29,7 @@ use super::session::SessionRef;
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// let zid = session.info().zid().await;
 /// # }
 /// ```
@@ -68,7 +68,7 @@ impl<'a> IntoFuture for ZenohIdBuilder<'a> {
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// let mut routers_zid = session.info().routers_zid().await;
 /// while let Some(router_zid) = routers_zid.next() {}
 /// # }
@@ -117,7 +117,7 @@ impl<'a> IntoFuture for RoutersZenohIdBuilder<'a> {
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// let zid = session.info().zid().await;
 /// let mut peers_zid = session.info().peers_zid().await;
 /// while let Some(peer_zid) = peers_zid.next() {}
@@ -167,7 +167,7 @@ impl<'a> IntoFuture for PeersZenohIdBuilder<'a> {
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// let info = session.info();
 /// let zid = info.zid().await;
 /// # }
@@ -185,7 +185,7 @@ impl SessionInfo<'_> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let zid = session.info().zid().await;
     /// # }
     /// ```
@@ -204,7 +204,7 @@ impl SessionInfo<'_> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let mut routers_zid = session.info().routers_zid().await;
     /// while let Some(router_zid) = routers_zid.next() {}
     /// # }
@@ -223,7 +223,7 @@ impl SessionInfo<'_> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let mut peers_zid = session.info().peers_zid().await;
     /// while let Some(peer_zid) = peers_zid.next() {}
     /// # }

--- a/zenoh/src/api/key_expr.rs
+++ b/zenoh/src/api/key_expr.rs
@@ -205,7 +205,7 @@ impl<'a> KeyExpr<'a> {
     /// This is notably useful for workspaces:
     /// ```rust
     /// # use std::convert::TryFrom;
-    /// # use zenoh::prelude::KeyExpr;
+    /// # use zenoh::KeyExpr;
     /// # let get_workspace = || KeyExpr::try_from("some/workspace").unwrap();
     /// let workspace: KeyExpr = get_workspace();
     /// let topic = workspace.join("some/topic").unwrap();
@@ -566,7 +566,7 @@ impl<'a> Undeclarable<&'a Session, KeyExprUndeclaration<'a>> for KeyExpr<'a> {
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// let key_expr = session.declare_keyexpr("key/expression").await.unwrap();
 /// session.undeclare(key_expr).await.unwrap();
 /// # }

--- a/zenoh/src/api/key_expr.rs
+++ b/zenoh/src/api/key_expr.rs
@@ -205,7 +205,7 @@ impl<'a> KeyExpr<'a> {
     /// This is notably useful for workspaces:
     /// ```rust
     /// # use std::convert::TryFrom;
-    /// # use zenoh::KeyExpr;
+    /// # use zenoh::key_expr::KeyExpr;
     /// # let get_workspace = || KeyExpr::try_from("some/workspace").unwrap();
     /// let workspace: KeyExpr = get_workspace();
     /// let topic = workspace.join("some/topic").unwrap();

--- a/zenoh/src/api/liveliness.rs
+++ b/zenoh/src/api/liveliness.rs
@@ -123,14 +123,14 @@ impl<'a> Liveliness<'a> {
     /// ```no_run
     /// # #[tokio::main]
     /// # async fn main() {
-    /// use zenoh::prelude::*;
+    /// use zenoh::{prelude::*, sample::SampleKind};
     ///
     /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let subscriber = session.liveliness().declare_subscriber("key/expression").await.unwrap();
     /// while let Ok(sample) = subscriber.recv_async().await {
     ///     match sample.kind() {
-    ///         zenoh::SampleKind::Put => println!("New liveliness: {}", sample.key_expr()),
-    ///         zenoh::SampleKind::Delete => println!("Lost liveliness: {}", sample.key_expr()),
+    ///         SampleKind::Put => println!("New liveliness: {}", sample.key_expr()),
+    ///         SampleKind::Delete => println!("Lost liveliness: {}", sample.key_expr()),
     ///     }
     /// }
     /// # }

--- a/zenoh/src/api/liveliness.rs
+++ b/zenoh/src/api/liveliness.rs
@@ -63,7 +63,7 @@ lazy_static::lazy_static!(
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// let liveliness = session
 ///     .liveliness()
 ///     .declare_token("key/expression")
@@ -90,7 +90,7 @@ impl<'a> Liveliness<'a> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let liveliness = session
     ///     .liveliness()
     ///     .declare_token("key/expression")
@@ -125,12 +125,12 @@ impl<'a> Liveliness<'a> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let subscriber = session.liveliness().declare_subscriber("key/expression").await.unwrap();
     /// while let Ok(sample) = subscriber.recv_async().await {
     ///     match sample.kind() {
-    ///         SampleKind::Put => println!("New liveliness: {}", sample.key_expr()),
-    ///         SampleKind::Delete => println!("Lost liveliness: {}", sample.key_expr()),
+    ///         zenoh::SampleKind::Put => println!("New liveliness: {}", sample.key_expr()),
+    ///         zenoh::SampleKind::Delete => println!("Lost liveliness: {}", sample.key_expr()),
     ///     }
     /// }
     /// # }
@@ -163,7 +163,7 @@ impl<'a> Liveliness<'a> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let replies = session.liveliness().get("key/expression").await.unwrap();
     /// while let Ok(reply) = replies.recv_async().await {
     ///     if let Ok(sample) = reply.result() {
@@ -203,7 +203,7 @@ impl<'a> Liveliness<'a> {
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// let liveliness = session
 ///     .liveliness()
 ///     .declare_token("key/expression")
@@ -278,7 +278,7 @@ pub(crate) struct LivelinessTokenState {
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// let liveliness = session
 ///     .liveliness()
 ///     .declare_token("key/expression")
@@ -302,7 +302,7 @@ pub struct LivelinessToken<'a> {
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// let liveliness = session
 ///     .liveliness()
 ///     .declare_token("key/expression")
@@ -355,7 +355,7 @@ impl<'a> LivelinessToken<'a> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let liveliness = session
     ///     .liveliness()
     ///     .declare_token("key/expression")
@@ -395,7 +395,7 @@ impl Drop for LivelinessToken<'_> {
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// let subscriber = session
 ///     .declare_subscriber("key/expression")
 ///     .best_effort()
@@ -422,7 +422,7 @@ impl<'a, 'b> LivelinessSubscriberBuilder<'a, 'b, DefaultHandler> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let subscriber = session
     ///     .declare_subscriber("key/expression")
     ///     .callback(|sample| { println!("Received: {} {:?}", sample.key_expr(), sample.payload()); })
@@ -462,7 +462,7 @@ impl<'a, 'b> LivelinessSubscriberBuilder<'a, 'b, DefaultHandler> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let mut n = 0;
     /// let subscriber = session
     ///     .declare_subscriber("key/expression")
@@ -491,7 +491,7 @@ impl<'a, 'b> LivelinessSubscriberBuilder<'a, 'b, DefaultHandler> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let subscriber = session
     ///     .declare_subscriber("key/expression")
     ///     .with(flume::bounded(32))
@@ -584,7 +584,7 @@ where
 /// # use std::convert::TryFrom;
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// let tokens = session
 ///     .liveliness()
 ///     .get("key/expression")
@@ -616,7 +616,7 @@ impl<'a, 'b> LivelinessGetBuilder<'a, 'b, DefaultHandler> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let queryable = session
     ///     .liveliness()
     ///     .get("key/expression")
@@ -655,7 +655,7 @@ impl<'a, 'b> LivelinessGetBuilder<'a, 'b, DefaultHandler> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let mut n = 0;
     /// let queryable = session
     ///     .liveliness()
@@ -684,7 +684,7 @@ impl<'a, 'b> LivelinessGetBuilder<'a, 'b, DefaultHandler> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let replies = session
     ///     .liveliness()
     ///     .get("key/expression")

--- a/zenoh/src/api/mod.rs
+++ b/zenoh/src/api/mod.rs
@@ -27,7 +27,7 @@ pub(crate) mod liveliness;
 pub(crate) mod loader;
 #[cfg(all(feature = "unstable", feature = "plugins"))]
 pub(crate) mod plugins;
-pub(crate) mod publication;
+pub(crate) mod publisher;
 pub(crate) mod query;
 pub(crate) mod queryable;
 pub(crate) mod sample;

--- a/zenoh/src/api/publisher.rs
+++ b/zenoh/src/api/publisher.rs
@@ -104,7 +104,7 @@ impl std::fmt::Debug for PublisherRef<'_> {
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap().into_arc();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap().into_arc();
 /// let publisher = session.declare_publisher("key/expression").await.unwrap();
 /// publisher.put("value").await.unwrap();
 /// # }
@@ -119,7 +119,7 @@ impl std::fmt::Debug for PublisherRef<'_> {
 /// use futures::StreamExt;
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap().into_arc();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap().into_arc();
 /// let mut subscriber = session.declare_subscriber("key/expression").await.unwrap();
 /// let publisher = session.declare_publisher("another/key/expression").await.unwrap();
 /// subscriber.stream().map(Ok).forward(publisher).await.unwrap();
@@ -145,7 +145,7 @@ impl<'a> Publisher<'a> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let publisher = session.declare_publisher("key/expression")
     ///     .await
     ///     .unwrap();
@@ -200,7 +200,7 @@ impl<'a> Publisher<'a> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap().into_arc();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap().into_arc();
     /// let publisher = session.declare_publisher("key/expression").await.unwrap().into_arc();
     /// let matching_listener = publisher.matching_listener().await.unwrap();
     ///
@@ -228,7 +228,7 @@ impl<'a> Publisher<'a> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap().into_arc();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap().into_arc();
     /// let publisher = session.declare_publisher("key/expression").await.unwrap();
     /// publisher.put("value").await.unwrap();
     /// # }
@@ -260,7 +260,7 @@ impl<'a> Publisher<'a> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap().into_arc();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap().into_arc();
     /// let publisher = session.declare_publisher("key/expression").await.unwrap();
     /// publisher.delete().await.unwrap();
     /// # }
@@ -288,7 +288,7 @@ impl<'a> Publisher<'a> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap().into_arc();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap().into_arc();
     /// let publisher = session.declare_publisher("key/expression").await.unwrap();
     /// let matching_subscribers: bool = publisher
     ///     .matching_status()
@@ -316,7 +316,7 @@ impl<'a> Publisher<'a> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let publisher = session.declare_publisher("key/expression").await.unwrap();
     /// let matching_listener = publisher.matching_listener().await.unwrap();
     /// while let Ok(matching_status) = matching_listener.recv_async().await {
@@ -344,7 +344,7 @@ impl<'a> Publisher<'a> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let publisher = session.declare_publisher("key/expression").await.unwrap();
     /// publisher.undeclare().await.unwrap();
     /// # }
@@ -368,7 +368,7 @@ impl<'a> Publisher<'a> {
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap().into_arc();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap().into_arc();
 /// let publisher = session.declare_publisher("key/expression").await.unwrap().into_arc();
 /// let matching_listener = publisher.matching_listener().await.unwrap();
 ///
@@ -391,7 +391,7 @@ pub trait PublisherDeclarations {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap().into_arc();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap().into_arc();
     /// let publisher = session.declare_publisher("key/expression").await.unwrap().into_arc();
     /// let matching_listener = publisher.matching_listener().await.unwrap();
     ///
@@ -418,7 +418,7 @@ impl PublisherDeclarations for std::sync::Arc<Publisher<'static>> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap().into_arc();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap().into_arc();
     /// let publisher = session.declare_publisher("key/expression").await.unwrap().into_arc();
     /// let matching_listener = publisher.matching_listener().await.unwrap();
     ///
@@ -456,7 +456,7 @@ impl<'a> Undeclarable<(), PublisherUndeclaration<'a>> for Publisher<'a> {
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// let publisher = session.declare_publisher("key/expression").await.unwrap();
 /// publisher.undeclare().await.unwrap();
 /// # }
@@ -737,7 +737,7 @@ impl TryFrom<ProtocolPriority> for Priority {
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap().into_arc();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap().into_arc();
 /// let publisher = session.declare_publisher("key/expression").await.unwrap();
 /// let matching_status = publisher.matching_status().await.unwrap();
 /// # }
@@ -758,7 +758,7 @@ impl MatchingStatus {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap().into_arc();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap().into_arc();
     /// let publisher = session.declare_publisher("key/expression").await.unwrap();
     /// let matching_subscribers: bool = publisher
     ///     .matching_status()
@@ -790,7 +790,7 @@ impl<'a> MatchingListenerBuilder<'a, DefaultHandler> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let publisher = session.declare_publisher("key/expression").await.unwrap();
     /// let matching_listener = publisher
     ///     .matching_listener()
@@ -830,7 +830,7 @@ impl<'a> MatchingListenerBuilder<'a, DefaultHandler> {
     /// use zenoh::prelude::*;
     ///
     /// let mut n = 0;
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let publisher = session.declare_publisher("key/expression").await.unwrap();
     /// let matching_listener = publisher
     ///     .matching_listener()
@@ -859,7 +859,7 @@ impl<'a> MatchingListenerBuilder<'a, DefaultHandler> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let publisher = session.declare_publisher("key/expression").await.unwrap();
     /// let matching_listener = publisher
     ///     .matching_listener()
@@ -986,7 +986,7 @@ impl<'a> Undeclarable<(), MatchingListenerUndeclaration<'a>> for MatchingListene
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// let publisher = session.declare_publisher("key/expression").await.unwrap();
 /// let matching_listener = publisher.matching_listener().await.unwrap();
 /// while let Ok(matching_status) = matching_listener.recv_async().await {
@@ -1017,7 +1017,7 @@ impl<'a, Receiver> MatchingListener<'a, Receiver> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let publisher = session.declare_publisher("key/expression").await.unwrap();
     /// let matching_listener = publisher.matching_listener().await.unwrap();
     /// matching_listener.undeclare().await.unwrap();

--- a/zenoh/src/api/publisher.rs
+++ b/zenoh/src/api/publisher.rs
@@ -37,7 +37,7 @@ use {
 };
 
 use super::{
-    builders::publication::{
+    builders::publisher::{
         PublicationBuilder, PublicationBuilderDelete, PublicationBuilderPut,
         PublisherDeleteBuilder, PublisherPutBuilder,
     },

--- a/zenoh/src/api/query.rs
+++ b/zenoh/src/api/query.rs
@@ -130,13 +130,13 @@ pub(crate) struct QueryState {
 /// ```
 /// # #[tokio::main]
 /// # async fn main() {
-/// use zenoh::prelude::*;
+/// use zenoh::{prelude::*, query::{ConsolidationMode, QueryTarget}};
 ///
 /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// let replies = session
 ///     .get("key/expression?value>1")
-///     .target(zenoh::QueryTarget::All)
-///     .consolidation(zenoh::ConsolidationMode::None)
+///     .target(QueryTarget::All)
+///     .consolidation(ConsolidationMode::None)
 ///     .await
 ///     .unwrap();
 /// while let Ok(reply) = replies.recv_async().await {

--- a/zenoh/src/api/query.rs
+++ b/zenoh/src/api/query.rs
@@ -31,7 +31,7 @@ use super::{
     encoding::Encoding,
     handlers::{locked, Callback, DefaultHandler, IntoHandler},
     key_expr::KeyExpr,
-    publication::Priority,
+    publisher::Priority,
     sample::{Locality, QoSBuilder, Sample},
     selector::Selector,
     session::Session,
@@ -132,11 +132,11 @@ pub(crate) struct QueryState {
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// let replies = session
 ///     .get("key/expression?value>1")
-///     .target(QueryTarget::All)
-///     .consolidation(ConsolidationMode::None)
+///     .target(zenoh::QueryTarget::All)
+///     .consolidation(zenoh::ConsolidationMode::None)
 ///     .await
 ///     .unwrap();
 /// while let Ok(reply) = replies.recv_async().await {
@@ -236,7 +236,7 @@ impl<'a, 'b> GetBuilder<'a, 'b, DefaultHandler> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let queryable = session
     ///     .get("key/expression")
     ///     .callback(|reply| {println!("Received {:?}", reply.result());})
@@ -294,7 +294,7 @@ impl<'a, 'b> GetBuilder<'a, 'b, DefaultHandler> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let mut n = 0;
     /// let queryable = session
     ///     .get("key/expression")
@@ -322,7 +322,7 @@ impl<'a, 'b> GetBuilder<'a, 'b, DefaultHandler> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let replies = session
     ///     .get("key/expression")
     ///     .with(flume::bounded(32))

--- a/zenoh/src/api/queryable.rs
+++ b/zenoh/src/api/queryable.rs
@@ -41,7 +41,7 @@ use super::{
     encoding::Encoding,
     handlers::{locked, DefaultHandler, IntoHandler},
     key_expr::KeyExpr,
-    publication::Priority,
+    publisher::Priority,
     sample::{Locality, QoSBuilder, Sample, SampleKind},
     selector::{Parameters, Selector},
     session::{SessionRef, Undeclarable},
@@ -611,11 +611,11 @@ impl fmt::Debug for QueryableState {
 /// use futures::prelude::*;
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// let queryable = session.declare_queryable("key/expression").await.unwrap();
 /// while let Ok(query) = queryable.recv_async().await {
 ///     println!(">> Handling query '{}'", query.selector());
-///     query.reply(KeyExpr::try_from("key/expression").unwrap(), "value")
+///     query.reply("key/expression", "value")
 ///         .await
 ///         .unwrap();
 /// }
@@ -642,7 +642,7 @@ impl<'a> Undeclarable<(), QueryableUndeclaration<'a>> for CallbackQueryable<'a> 
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// let queryable = session.declare_queryable("key/expression").await.unwrap();
 /// queryable.undeclare().await.unwrap();
 /// # }
@@ -690,7 +690,7 @@ impl Drop for CallbackQueryable<'_> {
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// let queryable = session.declare_queryable("key/expression").await.unwrap();
 /// # }
 /// ```
@@ -713,7 +713,7 @@ impl<'a, 'b> QueryableBuilder<'a, 'b, DefaultHandler> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let queryable = session
     ///     .declare_queryable("key/expression")
     ///     .callback(|query| {println!(">> Handling query '{}'", query.selector());})
@@ -753,7 +753,7 @@ impl<'a, 'b> QueryableBuilder<'a, 'b, DefaultHandler> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let mut n = 0;
     /// let queryable = session
     ///     .declare_queryable("key/expression")
@@ -781,7 +781,7 @@ impl<'a, 'b> QueryableBuilder<'a, 'b, DefaultHandler> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let queryable = session
     ///     .declare_queryable("key/expression")
     ///     .with(flume::bounded(32))
@@ -846,7 +846,7 @@ impl<'a, 'b, Handler> QueryableBuilder<'a, 'b, Handler> {
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// let queryable = session
 ///     .declare_queryable("key/expression")
 ///     .with(flume::bounded(32))
@@ -854,7 +854,7 @@ impl<'a, 'b, Handler> QueryableBuilder<'a, 'b, Handler> {
 ///     .unwrap();
 /// while let Ok(query) = queryable.recv_async().await {
 ///     println!(">> Handling query '{}'", query.selector());
-///     query.reply(KeyExpr::try_from("key/expression").unwrap(), "value")
+///     query.reply("key/expression", "value")
 ///         .await
 ///         .unwrap();
 /// }
@@ -876,7 +876,7 @@ impl<'a, Handler> Queryable<'a, Handler> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let queryable = session.declare_queryable("key/expression")
     ///     .await
     ///     .unwrap();

--- a/zenoh/src/api/sample.rs
+++ b/zenoh/src/api/sample.rs
@@ -24,7 +24,7 @@ use zenoh_protocol::{
 
 use super::{
     builders::sample::QoSBuilderTrait, bytes::ZBytes, encoding::Encoding, key_expr::KeyExpr,
-    publication::Priority, value::Value,
+    publisher::Priority, value::Value,
 };
 
 pub type SourceSn = u64;

--- a/zenoh/src/api/scouting.rs
+++ b/zenoh/src/api/scouting.rs
@@ -36,9 +36,9 @@ use crate::{
 /// ```no_run
 /// # #[tokio::main]
 /// # async fn main() {
-/// use zenoh::prelude::*;
+/// use zenoh::{config::WhatAmI, prelude::*};
 ///
-/// let receiver = zenoh::scout(zenoh::WhatAmI::Peer | zenoh::WhatAmI::Router, zenoh::config::default())
+/// let receiver = zenoh::scout(WhatAmI::Peer | WhatAmI::Router, zenoh::config::default())
 ///     .await
 ///     .unwrap();
 /// while let Ok(hello) = receiver.recv_async().await {
@@ -61,9 +61,9 @@ impl ScoutBuilder<DefaultHandler> {
     /// ```
     /// # #[tokio::main]
     /// # async fn main() {
-    /// use zenoh::prelude::*;
+    /// use zenoh::{config::WhatAmI, prelude::*};
     ///
-    /// let scout = zenoh::scout(zenoh::WhatAmI::Peer | zenoh::WhatAmI::Router, zenoh::config::default())
+    /// let scout = zenoh::scout(WhatAmI::Peer | WhatAmI::Router, zenoh::config::default())
     ///     .callback(|hello| { println!("{}", hello); })
     ///     .await
     ///     .unwrap();
@@ -95,10 +95,10 @@ impl ScoutBuilder<DefaultHandler> {
     /// ```
     /// # #[tokio::main]
     /// # async fn main() {
-    /// use zenoh::prelude::*;
+    /// use zenoh::{config::WhatAmI, prelude::*};
     ///
     /// let mut n = 0;
-    /// let scout = zenoh::scout(zenoh:: WhatAmI::Peer | zenoh::WhatAmI::Router, zenoh::config::default())
+    /// let scout = zenoh::scout(WhatAmI::Peer | WhatAmI::Router, zenoh::config::default())
     ///     .callback_mut(move |_hello| { n += 1; })
     ///     .await
     ///     .unwrap();
@@ -121,9 +121,9 @@ impl ScoutBuilder<DefaultHandler> {
     /// ```no_run
     /// # #[tokio::main]
     /// # async fn main() {
-    /// use zenoh::prelude::*;
+    /// use zenoh::{config::WhatAmI, prelude::*};
     ///
-    /// let receiver = zenoh::scout(zenoh::WhatAmI::Peer | zenoh::WhatAmI::Router, zenoh::config::default())
+    /// let receiver = zenoh::scout(WhatAmI::Peer | WhatAmI::Router, zenoh::config::default())
     ///     .with(flume::bounded(32))
     ///     .await
     ///     .unwrap();
@@ -188,9 +188,9 @@ where
 /// ```
 /// # #[tokio::main]
 /// # async fn main() {
-/// use zenoh::prelude::*;
+/// use zenoh::{config::WhatAmI, prelude::*};
 ///
-/// let scout = zenoh::scout(zenoh::WhatAmI::Peer | zenoh::WhatAmI::Router, zenoh::config::default())
+/// let scout = zenoh::scout(WhatAmI::Peer | WhatAmI::Router, zenoh::config::default())
 ///     .callback(|hello| { println!("{}", hello); })
 ///     .await
 ///     .unwrap();
@@ -208,9 +208,9 @@ impl ScoutInner {
     /// ```
     /// # #[tokio::main]
     /// # async fn main() {
-    /// use zenoh::prelude::*;
+    /// use zenoh::{config::WhatAmI, prelude::*};
     ///
-    /// let scout = zenoh::scout(zenoh::WhatAmI::Peer | zenoh::WhatAmI::Router, zenoh::config::default())
+    /// let scout = zenoh::scout(WhatAmI::Peer | WhatAmI::Router, zenoh::config::default())
     ///     .callback(|hello| { println!("{}", hello); })
     ///     .await
     ///     .unwrap();
@@ -243,9 +243,9 @@ impl fmt::Debug for ScoutInner {
 /// ```no_run
 /// # #[tokio::main]
 /// # async fn main() {
-/// use zenoh::prelude::*;
+/// use zenoh::{config::WhatAmI, prelude::*};
 ///
-/// let receiver = zenoh::scout(zenoh::WhatAmI::Peer | zenoh::WhatAmI::Router, zenoh::config::default())
+/// let receiver = zenoh::scout(WhatAmI::Peer | WhatAmI::Router, zenoh::config::default())
 ///     .with(flume::bounded(32))
 ///     .await
 ///     .unwrap();
@@ -276,9 +276,9 @@ impl<Receiver> Scout<Receiver> {
     /// ```no_run
     /// # #[tokio::main]
     /// # async fn main() {
-    /// use zenoh::prelude::*;
+    /// use zenoh::{config::WhatAmI, prelude::*};
     ///
-    /// let scout = zenoh::scout(zenoh::WhatAmI::Router, zenoh::config::default())
+    /// let scout = zenoh::scout(WhatAmI::Router, zenoh::config::default())
     ///     .with(flume::bounded(32))
     ///     .await
     ///     .unwrap();
@@ -352,10 +352,9 @@ fn _scout(
 /// ```no_run
 /// # #[tokio::main]
 /// # async fn main() {
-/// use zenoh::prelude::*;
-/// use zenoh::scouting::WhatAmI;
+/// use zenoh::{config::WhatAmI, prelude::*};
 ///
-/// let receiver = zenoh::scout(zenoh::WhatAmI::Peer | zenoh::WhatAmI::Router, zenoh::config::default())
+/// let receiver = zenoh::scout(WhatAmI::Peer | WhatAmI::Router, zenoh::config::default())
 ///     .await
 ///     .unwrap();
 /// while let Ok(hello) = receiver.recv_async().await {

--- a/zenoh/src/api/scouting.rs
+++ b/zenoh/src/api/scouting.rs
@@ -38,7 +38,7 @@ use crate::{
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let receiver = zenoh::scout(WhatAmI::Peer | WhatAmI::Router, config::default())
+/// let receiver = zenoh::scout(zenoh::WhatAmI::Peer | zenoh::WhatAmI::Router, zenoh::config::default())
 ///     .await
 ///     .unwrap();
 /// while let Ok(hello) = receiver.recv_async().await {
@@ -63,7 +63,7 @@ impl ScoutBuilder<DefaultHandler> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let scout = zenoh::scout(WhatAmI::Peer | WhatAmI::Router, config::default())
+    /// let scout = zenoh::scout(zenoh::WhatAmI::Peer | zenoh::WhatAmI::Router, zenoh::config::default())
     ///     .callback(|hello| { println!("{}", hello); })
     ///     .await
     ///     .unwrap();
@@ -98,7 +98,7 @@ impl ScoutBuilder<DefaultHandler> {
     /// use zenoh::prelude::*;
     ///
     /// let mut n = 0;
-    /// let scout = zenoh::scout(WhatAmI::Peer | WhatAmI::Router, config::default())
+    /// let scout = zenoh::scout(zenoh:: WhatAmI::Peer | zenoh::WhatAmI::Router, zenoh::config::default())
     ///     .callback_mut(move |_hello| { n += 1; })
     ///     .await
     ///     .unwrap();
@@ -123,7 +123,7 @@ impl ScoutBuilder<DefaultHandler> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let receiver = zenoh::scout(WhatAmI::Peer | WhatAmI::Router, config::default())
+    /// let receiver = zenoh::scout(zenoh::WhatAmI::Peer | zenoh::WhatAmI::Router, zenoh::config::default())
     ///     .with(flume::bounded(32))
     ///     .await
     ///     .unwrap();
@@ -190,7 +190,7 @@ where
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let scout = zenoh::scout(WhatAmI::Peer | WhatAmI::Router, config::default())
+/// let scout = zenoh::scout(zenoh::WhatAmI::Peer | zenoh::WhatAmI::Router, zenoh::config::default())
 ///     .callback(|hello| { println!("{}", hello); })
 ///     .await
 ///     .unwrap();
@@ -210,7 +210,7 @@ impl ScoutInner {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let scout = zenoh::scout(WhatAmI::Peer | WhatAmI::Router, config::default())
+    /// let scout = zenoh::scout(zenoh::WhatAmI::Peer | zenoh::WhatAmI::Router, zenoh::config::default())
     ///     .callback(|hello| { println!("{}", hello); })
     ///     .await
     ///     .unwrap();
@@ -245,7 +245,7 @@ impl fmt::Debug for ScoutInner {
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let receiver = zenoh::scout(WhatAmI::Peer | WhatAmI::Router, config::default())
+/// let receiver = zenoh::scout(zenoh::WhatAmI::Peer | zenoh::WhatAmI::Router, zenoh::config::default())
 ///     .with(flume::bounded(32))
 ///     .await
 ///     .unwrap();
@@ -278,7 +278,7 @@ impl<Receiver> Scout<Receiver> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let scout = zenoh::scout(WhatAmI::Router, config::default())
+    /// let scout = zenoh::scout(zenoh::WhatAmI::Router, zenoh::config::default())
     ///     .with(flume::bounded(32))
     ///     .await
     ///     .unwrap();
@@ -355,7 +355,7 @@ fn _scout(
 /// use zenoh::prelude::*;
 /// use zenoh::scouting::WhatAmI;
 ///
-/// let receiver = zenoh::scout(WhatAmI::Peer | WhatAmI::Router, config::default())
+/// let receiver = zenoh::scout(zenoh::WhatAmI::Peer | zenoh::WhatAmI::Router, zenoh::config::default())
 ///     .await
 ///     .unwrap();
 /// while let Ok(hello) = receiver.recv_async().await {

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -62,7 +62,7 @@ use zenoh_task::TaskController;
 
 use super::{
     admin,
-    builders::publication::{
+    builders::publisher::{
         PublicationBuilderDelete, PublicationBuilderPut, PublisherBuilder, SessionDeleteBuilder,
         SessionPutBuilder,
     },
@@ -701,12 +701,12 @@ impl Session {
     /// ```
     /// # #[tokio::main]
     /// # async fn main() {
-    /// use zenoh::prelude::*;
+    /// use zenoh::{encoding::Encoding, prelude::*};
     ///
     /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// session
     ///     .put("key/expression", "payload")
-    ///     .encoding(zenoh::Encoding::TEXT_PLAIN)
+    ///     .encoding(Encoding::TEXT_PLAIN)
     ///     .await
     ///     .unwrap();
     /// # }
@@ -2697,10 +2697,10 @@ impl crate::net::primitives::EPrimitives for Session {
 /// # #[tokio::main]
 /// # async fn main() {
 /// use std::str::FromStr;
-/// use zenoh::prelude::*;
+/// use zenoh::{config::ZenohId, prelude::*};
 ///
 /// let mut config = zenoh::config::peer();
-/// config.set_id(zenoh::ZenohId::from_str("221b72df20924c15b8794c6bdb471150").unwrap());
+/// config.set_id(ZenohId::from_str("221b72df20924c15b8794c6bdb471150").unwrap());
 /// config.connect.endpoints.extend("tcp/10.10.10.10:7447,tcp/11.11.11.11:7447".split(',').map(|s|s.parse().unwrap()));
 ///
 /// let session = zenoh::open(config).await.unwrap();

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -71,7 +71,7 @@ use super::{
     handlers::{Callback, DefaultHandler},
     info::SessionInfo,
     key_expr::{KeyExpr, KeyExprInner},
-    publication::{Priority, PublisherState},
+    publisher::{Priority, PublisherState},
     query::{ConsolidationMode, GetBuilder, QueryConsolidation, QueryState, QueryTarget, Reply},
     queryable::{Query, QueryInner, QueryableBuilder, QueryableState},
     sample::{DataInfo, DataInfoIntoSample, Locality, QoS, Sample, SampleKind},
@@ -83,8 +83,8 @@ use super::{
 #[cfg(feature = "unstable")]
 use super::{
     liveliness::{Liveliness, LivelinessTokenState},
-    publication::Publisher,
-    publication::{MatchingListenerState, MatchingStatus},
+    publisher::Publisher,
+    publisher::{MatchingListenerState, MatchingStatus},
     query::_REPLY_KEY_EXPR_ANY_SEL_PARAM,
     sample::SourceInfo,
 };
@@ -458,7 +458,7 @@ impl Session {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap().into_arc();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap().into_arc();
     /// let subscriber = session.declare_subscriber("key/expression")
     ///     .await
     ///     .unwrap();
@@ -491,7 +491,7 @@ impl Session {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = Session::leak(zenoh::open(config::peer()).await.unwrap());
+    /// let session = zenoh::Session::leak(zenoh::open(zenoh::config::peer()).await.unwrap());
     /// let subscriber = session.declare_subscriber("key/expression").await.unwrap();
     /// tokio::task::spawn(async move {
     ///     while let Ok(sample) = subscriber.recv_async().await {
@@ -525,7 +525,7 @@ impl Session {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// session.close().await.unwrap();
     /// # }
     /// ```
@@ -569,7 +569,7 @@ impl Session {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let peers = session.config().get("connect/endpoints").unwrap();
     /// # }
     /// ```
@@ -580,7 +580,7 @@ impl Session {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let _ = session.config().insert_json5("connect/endpoints", r#"["tcp/127.0.0.1/7447"]"#);
     /// # }
     /// ```
@@ -641,7 +641,7 @@ impl Session {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let key_expr = session.declare_keyexpr("key/expression").await.unwrap();
     /// # }
     /// ```
@@ -703,10 +703,10 @@ impl Session {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// session
     ///     .put("key/expression", "payload")
-    ///     .encoding(Encoding::TEXT_PLAIN)
+    ///     .encoding(zenoh::Encoding::TEXT_PLAIN)
     ///     .await
     ///     .unwrap();
     /// # }
@@ -748,7 +748,7 @@ impl Session {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// session.delete("key/expression").await.unwrap();
     /// # }
     /// ```
@@ -786,7 +786,7 @@ impl Session {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let replies = session.get("key/expression").await.unwrap();
     /// while let Ok(reply) = replies.recv_async().await {
     ///     println!(">> Received {:?}", reply.result());
@@ -1893,7 +1893,7 @@ impl<'s> SessionDeclarations<'s, 'static> for Arc<Session> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap().into_arc();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap().into_arc();
     /// let subscriber = session.declare_subscriber("key/expression")
     ///     .await
     ///     .unwrap();
@@ -1934,14 +1934,14 @@ impl<'s> SessionDeclarations<'s, 'static> for Arc<Session> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap().into_arc();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap().into_arc();
     /// let queryable = session.declare_queryable("key/expression")
     ///     .await
     ///     .unwrap();
     /// tokio::task::spawn(async move {
     ///     while let Ok(query) = queryable.recv_async().await {
     ///         query.reply(
-    ///             KeyExpr::try_from("key/expression").unwrap(),
+    ///             "key/expression",
     ///             "value",
     ///         ).await.unwrap();
     ///     }
@@ -1965,7 +1965,7 @@ impl<'s> SessionDeclarations<'s, 'static> for Arc<Session> {
         }
     }
 
-    /// Create a [`Publisher`](crate::publication::Publisher) for the given key expression.
+    /// Create a [`Publisher`](crate::publisher::Publisher) for the given key expression.
     ///
     /// # Arguments
     ///
@@ -1977,7 +1977,7 @@ impl<'s> SessionDeclarations<'s, 'static> for Arc<Session> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap().into_arc();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap().into_arc();
     /// let publisher = session.declare_publisher("key/expression")
     ///     .await
     ///     .unwrap();
@@ -2010,7 +2010,7 @@ impl<'s> SessionDeclarations<'s, 'static> for Arc<Session> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap().into_arc();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap().into_arc();
     /// let liveliness = session
     ///     .liveliness()
     ///     .declare_token("key/expression")
@@ -2503,7 +2503,7 @@ impl fmt::Debug for Session {
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap().into_arc();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap().into_arc();
 /// let subscriber = session.declare_subscriber("key/expression")
 ///     .await
 ///     .unwrap();
@@ -2527,7 +2527,7 @@ pub trait SessionDeclarations<'s, 'a> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap().into_arc();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap().into_arc();
     /// let subscriber = session.declare_subscriber("key/expression")
     ///     .await
     ///     .unwrap();
@@ -2559,14 +2559,14 @@ pub trait SessionDeclarations<'s, 'a> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap().into_arc();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap().into_arc();
     /// let queryable = session.declare_queryable("key/expression")
     ///     .await
     ///     .unwrap();
     /// tokio::task::spawn(async move {
     ///     while let Ok(query) = queryable.recv_async().await {
     ///         query.reply(
-    ///             KeyExpr::try_from("key/expression").unwrap(),
+    ///             "key/expression",
     ///             "value",
     ///         ).await.unwrap();
     ///     }
@@ -2581,7 +2581,7 @@ pub trait SessionDeclarations<'s, 'a> {
         TryIntoKeyExpr: TryInto<KeyExpr<'b>>,
         <TryIntoKeyExpr as TryInto<KeyExpr<'b>>>::Error: Into<zenoh_result::Error>;
 
-    /// Create a [`Publisher`](crate::publication::Publisher) for the given key expression.
+    /// Create a [`Publisher`](crate::publisher::Publisher) for the given key expression.
     ///
     /// # Arguments
     ///
@@ -2593,7 +2593,7 @@ pub trait SessionDeclarations<'s, 'a> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap().into_arc();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap().into_arc();
     /// let publisher = session.declare_publisher("key/expression")
     ///     .await
     ///     .unwrap();
@@ -2616,7 +2616,7 @@ pub trait SessionDeclarations<'s, 'a> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap().into_arc();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap().into_arc();
     /// let liveliness = session
     ///     .liveliness()
     ///     .declare_token("key/expression")
@@ -2634,7 +2634,7 @@ pub trait SessionDeclarations<'s, 'a> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let info = session.info();
     /// # }
     /// ```
@@ -2689,7 +2689,7 @@ impl crate::net::primitives::EPrimitives for Session {
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// # }
 /// ```
 ///
@@ -2699,8 +2699,8 @@ impl crate::net::primitives::EPrimitives for Session {
 /// use std::str::FromStr;
 /// use zenoh::prelude::*;
 ///
-/// let mut config = config::peer();
-/// config.set_id(ZenohId::from_str("221b72df20924c15b8794c6bdb471150").unwrap());
+/// let mut config = zenoh::config::peer();
+/// config.set_id(zenoh::ZenohId::from_str("221b72df20924c15b8794c6bdb471150").unwrap());
 /// config.connect.endpoints.extend("tcp/10.10.10.10:7447,tcp/11.11.11.11:7447".split(',').map(|s|s.parse().unwrap()));
 ///
 /// let session = zenoh::open(config).await.unwrap();
@@ -2726,7 +2726,7 @@ where
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// # }
 /// ```
 #[must_use = "Resolvables do nothing unless you resolve them using the `res` method from either `SyncResolve` or `AsyncResolve`"]

--- a/zenoh/src/api/subscriber.rs
+++ b/zenoh/src/api/subscriber.rs
@@ -66,7 +66,7 @@ impl fmt::Debug for SubscriberState {
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// let subscriber = session
 ///     .declare_subscriber("key/expression")
 ///     .callback(|sample| { println!("Received: {} {:?}", sample.key_expr(), sample.payload()) })
@@ -93,8 +93,8 @@ impl<'a> SubscriberInner<'a> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
-    /// # fn data_handler(_sample: Sample) { };
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// # fn data_handler(_sample: zenoh::Sample) { };
     /// let subscriber = session
     ///     .declare_subscriber("key/expression")
     ///     .callback(data_handler)
@@ -123,7 +123,7 @@ impl<'a> Undeclarable<(), SubscriberUndeclaration<'a>> for SubscriberInner<'a> {
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// let subscriber = session
 ///     .declare_subscriber("key/expression")
 ///     .await
@@ -174,7 +174,7 @@ impl Drop for SubscriberInner<'_> {
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// let subscriber = session
 ///     .declare_subscriber("key/expression")
 ///     .best_effort()
@@ -220,7 +220,7 @@ impl<'a, 'b> SubscriberBuilder<'a, 'b, DefaultHandler> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let subscriber = session
     ///     .declare_subscriber("key/expression")
     ///     .callback(|sample| { println!("Received: {} {:?}", sample.key_expr(), sample.payload()); })
@@ -262,7 +262,7 @@ impl<'a, 'b> SubscriberBuilder<'a, 'b, DefaultHandler> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let mut n = 0;
     /// let subscriber = session
     ///     .declare_subscriber("key/expression")
@@ -290,7 +290,7 @@ impl<'a, 'b> SubscriberBuilder<'a, 'b, DefaultHandler> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let subscriber = session
     ///     .declare_subscriber("key/expression")
     ///     .with(flume::bounded(32))
@@ -422,7 +422,7 @@ where
 /// # async fn main() {
 /// use zenoh::prelude::*;
 ///
-/// let session = zenoh::open(config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
 /// let subscriber = session
 ///     .declare_subscriber("key/expression")
 ///     .with(flume::bounded(32))
@@ -449,7 +449,7 @@ impl<'a, Handler> Subscriber<'a, Handler> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let subscriber = session.declare_subscriber("key/expression")
     ///     .await
     ///     .unwrap();
@@ -494,7 +494,7 @@ impl<'a, Handler> Subscriber<'a, Handler> {
     /// # async fn main() {
     /// use zenoh::prelude::*;
     ///
-    /// let session = zenoh::open(config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
     /// let subscriber = session.declare_subscriber("key/expression")
     ///     .await
     ///     .unwrap();

--- a/zenoh/src/api/subscriber.rs
+++ b/zenoh/src/api/subscriber.rs
@@ -91,10 +91,10 @@ impl<'a> SubscriberInner<'a> {
     /// ```
     /// # #[tokio::main]
     /// # async fn main() {
-    /// use zenoh::prelude::*;
+    /// use zenoh::{prelude::*, sample::Sample};
     ///
     /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
-    /// # fn data_handler(_sample: zenoh::Sample) { };
+    /// # fn data_handler(_sample: Sample) { };
     /// let subscriber = session
     ///     .declare_subscriber("key/expression")
     ///     .callback(data_handler)

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -204,7 +204,7 @@ pub mod session {
     #[doc(hidden)]
     pub use crate::api::session::InitBuilder;
     pub use crate::api::{
-        builders::publication::{SessionDeleteBuilder, SessionPutBuilder},
+        builders::publisher::{SessionDeleteBuilder, SessionPutBuilder},
         session::{open, OpenBuilder, Session, SessionDeclarations, SessionRef, Undeclarable},
     };
 }
@@ -282,7 +282,7 @@ pub mod publisher {
     #[zenoh_macros::unstable]
     pub use crate::api::publisher::PublisherRef;
     pub use crate::api::{
-        builders::publication::{
+        builders::publisher::{
             PublicationBuilder, PublicationBuilderDelete, PublicationBuilderPut, PublisherBuilder,
             PublisherDeleteBuilder, PublisherPutBuilder,
         },

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -38,7 +38,7 @@
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!     let session = zenoh::open(config::default()).await.unwrap();
+//!     let session = zenoh::open(zenoh::config::default()).await.unwrap();
 //!     session.put("key/expression", "value").await.unwrap();
 //!     session.close().await.unwrap();
 //! }
@@ -52,7 +52,7 @@
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!     let session = zenoh::open(config::default()).await.unwrap();
+//!     let session = zenoh::open(zenoh::config::default()).await.unwrap();
 //!     let subscriber = session.declare_subscriber("key/expression").await.unwrap();
 //!     while let Ok(sample) = subscriber.recv_async().await {
 //!         println!("Received: {:?}", sample);
@@ -69,7 +69,7 @@
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!     let session = zenoh::open(config::default()).await.unwrap();
+//!     let session = zenoh::open(zenoh::config::default()).await.unwrap();
 //!     let replies = session.get("key/expression").await.unwrap();
 //!     while let Ok(reply) = replies.recv_async().await {
 //!         println!(">> Received {:?}", reply.result());
@@ -111,23 +111,27 @@ pub const FEATURES: &str = zenoh_util::concat_enabled_features!(
     ]
 );
 
-// Expose some functions directly to root `zenoh::`` namespace for convenience
-pub use crate::api::{scouting::scout, session::open};
+#[doc(inline)]
+pub use crate::{
+    config::Config,
+    core::{Error, Result},
+    key_expr::{kedefine, keformat, kewrite},
+    scouting::scout,
+    session::{open, Session},
+};
 
 pub mod prelude;
 
 /// Zenoh core types
 pub mod core {
     #[allow(deprecated)]
-    pub use zenoh_core::AsyncResolve;
-    #[allow(deprecated)]
-    pub use zenoh_core::SyncResolve;
+    pub use zenoh_core::{AsyncResolve, SyncResolve};
     pub use zenoh_core::{Resolvable, Resolve, Wait};
+    pub use zenoh_result::ErrNo;
     /// A zenoh error.
     pub use zenoh_result::Error;
     /// A zenoh result.
     pub use zenoh_result::ZResult as Result;
-    pub use zenoh_util::{core::zresult::ErrNo, try_init_log_from_env};
 }
 
 /// A collection of useful buffers used by zenoh internally and exposed to the user to facilitate
@@ -262,27 +266,27 @@ pub mod subscriber {
 }
 
 /// Publishing primitives
-pub mod publication {
+pub mod publisher {
     pub use zenoh_protocol::core::CongestionControl;
 
     #[zenoh_macros::unstable]
-    pub use crate::api::publication::MatchingListener;
+    pub use crate::api::publisher::MatchingListener;
     #[zenoh_macros::unstable]
-    pub use crate::api::publication::MatchingListenerBuilder;
+    pub use crate::api::publisher::MatchingListenerBuilder;
     #[zenoh_macros::unstable]
-    pub use crate::api::publication::MatchingListenerUndeclaration;
+    pub use crate::api::publisher::MatchingListenerUndeclaration;
     #[zenoh_macros::unstable]
-    pub use crate::api::publication::MatchingStatus;
+    pub use crate::api::publisher::MatchingStatus;
     #[zenoh_macros::unstable]
-    pub use crate::api::publication::PublisherDeclarations;
+    pub use crate::api::publisher::PublisherDeclarations;
     #[zenoh_macros::unstable]
-    pub use crate::api::publication::PublisherRef;
+    pub use crate::api::publisher::PublisherRef;
     pub use crate::api::{
         builders::publication::{
             PublicationBuilder, PublicationBuilderDelete, PublicationBuilderPut, PublisherBuilder,
             PublisherDeleteBuilder, PublisherPutBuilder,
         },
-        publication::{Priority, Publisher, PublisherUndeclaration},
+        publisher::{Priority, Publisher, PublisherUndeclaration},
     };
 }
 
@@ -369,13 +373,11 @@ pub mod plugins {
 
 #[doc(hidden)]
 pub mod internal {
-    pub use zenoh_core::{zasync_executor_init, zerror, zlock, ztimeout};
+    pub use zenoh_core::{zasync_executor_init, zerror, zlock, ztimeout, ResolveFuture};
     pub use zenoh_result::bail;
     pub use zenoh_sync::Condition;
     pub use zenoh_task::{TaskController, TerminatableTask};
-    pub use zenoh_util::{
-        core::ResolveFuture, zenoh_home, LibLoader, Timed, TimedEvent, Timer, ZENOH_HOME_ENV_VAR,
-    };
+    pub use zenoh_util::{zenoh_home, LibLoader, Timed, TimedEvent, Timer, ZENOH_HOME_ENV_VAR};
 
     pub use crate::api::encoding::EncodingInternals;
 }

--- a/zenoh/src/prelude.rs
+++ b/zenoh/src/prelude.rs
@@ -24,43 +24,22 @@
 //!use zenoh::prelude::*;
 //! ```
 
-// Reexport API in flat namespace
-pub(crate) mod flat {
-    #[cfg(all(feature = "unstable", feature = "shared-memory"))]
-    pub use crate::shm::*;
+mod _prelude {
+    #[zenoh_macros::unstable]
+    pub use crate::api::publisher::PublisherDeclarations;
     pub use crate::{
-        buffers::*,
-        bytes::*,
-        config::*,
+        api::{
+            builders::sample::{
+                QoSBuilderTrait, SampleBuilderTrait, TimestampBuilderTrait, ValueBuilderTrait,
+            },
+            session::{SessionDeclarations, Undeclarable},
+        },
+        config::ValidatedMap,
         core::{Error as ZError, Resolvable, Resolve, Result as ZResult},
-        encoding::*,
-        handlers::*,
-        key_expr::*,
-        publication::*,
-        query::*,
-        queryable::*,
-        sample::*,
-        scouting::*,
-        selector::*,
-        session::*,
-        subscriber::*,
-        time::*,
-        value::*,
     };
 }
 
-// Reexport API in hierarchical namespace
-pub(crate) mod mods {
-    #[cfg(all(feature = "unstable", feature = "shared-memory"))]
-    pub use crate::shm;
-    pub use crate::{
-        buffers, bytes, config, core, encoding, handlers, key_expr, publication, query, queryable,
-        sample, scouting, selector, session, subscriber, time, value,
-    };
-}
-
-pub use flat::*;
-pub use mods::*;
+pub use _prelude::*;
 
 #[allow(deprecated)]
 pub use crate::core::AsyncResolve;
@@ -71,14 +50,14 @@ pub use crate::core::Wait;
 /// Prelude to import when using Zenoh's sync API.
 #[deprecated = "use `zenoh::prelude` instead"]
 pub mod sync {
-    pub use super::{flat::*, mods::*};
+    pub use super::_prelude::*;
     #[allow(deprecated)]
     pub use crate::core::SyncResolve;
 }
 /// Prelude to import when using Zenoh's async API.
 #[deprecated = "use `zenoh::prelude` instead"]
 pub mod r#async {
-    pub use super::{flat::*, mods::*};
+    pub use super::_prelude::*;
     #[allow(deprecated)]
     pub use crate::core::AsyncResolve;
 }

--- a/zenoh/tests/acl.rs
+++ b/zenoh/tests/acl.rs
@@ -19,8 +19,13 @@ mod test {
     };
 
     use tokio::runtime::Handle;
-    use zenoh::prelude::*;
-    use zenoh_core::{zlock, ztimeout};
+    use zenoh::{
+        config,
+        config::{EndPoint, WhatAmI},
+        internal::{zlock, ztimeout},
+        prelude::*,
+        Config, Session,
+    };
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);

--- a/zenoh/tests/attachments.rs
+++ b/zenoh/tests/attachments.rs
@@ -11,10 +11,11 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-#[cfg(feature = "unstable")]
+#![cfg(feature = "unstable")]
+use zenoh::{bytes::ZBytes, config::Config, prelude::*};
+
 #[test]
 fn attachment_pubsub() {
-    use zenoh::{bytes::ZBytes, prelude::*};
     let zenoh = zenoh::open(Config::default()).wait().unwrap();
     let _sub = zenoh
         .declare_subscriber("test/attachment")
@@ -53,7 +54,6 @@ fn attachment_pubsub() {
     }
 }
 
-#[cfg(feature = "unstable")]
 #[test]
 fn attachment_queries() {
     use zenoh::prelude::*;

--- a/zenoh/tests/bytes.rs
+++ b/zenoh/tests/bytes.rs
@@ -11,12 +11,18 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
+#![cfg(all(feature = "shared-memory", feature = "unstable"))]
+use zenoh::{
+    bytes::ZBytes,
+    prelude::*,
+    shm::{
+        zshm, zshmmut, PosixSharedMemoryProviderBackend, SharedMemoryProviderBuilder, ZShm,
+        ZShmMut, POSIX_PROTOCOL_ID,
+    },
+};
 
 #[test]
-#[cfg(all(feature = "shared-memory", feature = "unstable"))]
 fn shm_bytes_single_buf() {
-    use zenoh::prelude::*;
-
     // create an SHM backend...
     let backend = PosixSharedMemoryProviderBackend::builder()
         .with_size(4096)

--- a/zenoh/tests/connection_retry.rs
+++ b/zenoh/tests/connection_retry.rs
@@ -11,7 +11,11 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use zenoh::prelude::*;
+use zenoh::{
+    config::{ConnectionRetryConf, EndPoint},
+    prelude::*,
+    Config,
+};
 
 #[test]
 fn retry_config_overriding() {
@@ -132,7 +136,7 @@ fn retry_config_const_period() {
 }
 
 #[test]
-fn retry_config_infinit_period() {
+fn retry_config_infinite_period() {
     let mut config = Config::default();
     config
         .insert_json5(

--- a/zenoh/tests/events.rs
+++ b/zenoh/tests/events.rs
@@ -13,12 +13,12 @@
 //
 use std::time::Duration;
 
-use zenoh::{internal::ztimeout, prelude::*};
+use zenoh::{config, internal::ztimeout, prelude::*, query::Reply, sample::SampleKind, Session};
 
 const TIMEOUT: Duration = Duration::from_secs(10);
 
 async fn open_session(listen: &[&str], connect: &[&str]) -> Session {
-    let mut config = peer();
+    let mut config = config::peer();
     config.listen.endpoints = listen
         .iter()
         .map(|e| e.parse().unwrap())

--- a/zenoh/tests/formatters.rs
+++ b/zenoh/tests/formatters.rs
@@ -11,13 +11,15 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
+use zenoh::{kedefine, keformat};
+
 #[test]
 fn kedefine_reuse() {
-    zenoh::key_expr::kedefine!(
+    kedefine!(
         pub gkeys: "zenoh/${group:*}/${member:*}",
     );
     let mut formatter = gkeys::formatter();
-    let k1 = zenoh::key_expr::keformat!(formatter, group = "foo", member = "bar").unwrap();
+    let k1 = keformat!(formatter, group = "foo", member = "bar").unwrap();
     assert_eq!(dbg!(k1).as_str(), "zenoh/foo/bar");
 
     formatter.set("member", "*").unwrap();
@@ -29,8 +31,8 @@ fn kedefine_reuse() {
     let k2 = dbg!(&mut formatter).build().unwrap();
     assert_eq!(dbg!(k2).as_str(), "zenoh/foo/*");
 
-    let k3 = zenoh::key_expr::keformat!(formatter, group = "foo", member = "*").unwrap();
+    let k3 = keformat!(formatter, group = "foo", member = "*").unwrap();
     assert_eq!(dbg!(k3).as_str(), "zenoh/foo/*");
 
-    zenoh::key_expr::keformat!(formatter, group = "**", member = "**").unwrap_err();
+    keformat!(formatter, group = "**", member = "**").unwrap_err();
 }

--- a/zenoh/tests/handler.rs
+++ b/zenoh/tests/handler.rs
@@ -13,7 +13,7 @@
 //
 use std::{thread, time::Duration};
 
-use zenoh::prelude::*;
+use zenoh::{handlers::RingChannel, prelude::*, Config};
 
 #[test]
 fn pubsub_with_ringbuffer() {

--- a/zenoh/tests/interceptors.rs
+++ b/zenoh/tests/interceptors.rs
@@ -19,8 +19,12 @@ use std::{
     },
 };
 
-use zenoh::prelude::*;
-use zenoh_config::{DownsamplingItemConf, DownsamplingRuleConf, InterceptorFlow};
+use zenoh::{
+    config::{DownsamplingItemConf, DownsamplingRuleConf, InterceptorFlow},
+    key_expr::KeyExpr,
+    prelude::*,
+    Config,
+};
 
 // Tokio's time granularity on different platforms
 #[cfg(target_os = "windows")]

--- a/zenoh/tests/liveliness.rs
+++ b/zenoh/tests/liveliness.rs
@@ -11,12 +11,18 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-#[cfg(feature = "unstable")]
+#![cfg(feature = "unstable")]
+use std::time::Duration;
+
+use zenoh::{
+    config,
+    internal::ztimeout,
+    prelude::*,
+    sample::{Sample, SampleKind},
+};
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn zenoh_liveliness() {
-    use std::time::Duration;
-
-    use zenoh::{internal::ztimeout, prelude::*};
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
 

--- a/zenoh/tests/matching.rs
+++ b/zenoh/tests/matching.rs
@@ -11,21 +11,18 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-#[cfg(feature = "unstable")]
-use {
-    flume::RecvTimeoutError, std::str::FromStr, std::time::Duration, zenoh::internal::ztimeout,
-    zenoh::prelude::*,
-};
+#![cfg(feature = "unstable")]
+use std::{str::FromStr, time::Duration};
 
-#[cfg(feature = "unstable")]
+use flume::RecvTimeoutError;
+use zenoh::{config, config::Locator, internal::ztimeout, prelude::*, sample::Locality, Session};
+
 const TIMEOUT: Duration = Duration::from_secs(60);
-#[cfg(feature = "unstable")]
 const RECV_TIMEOUT: Duration = Duration::from_secs(1);
 
-#[cfg(feature = "unstable")]
 async fn create_session_pair(locator: &str) -> (Session, Session) {
     let config1 = {
-        let mut config = zenoh::config::peer();
+        let mut config = config::peer();
         config.scouting.multicast.set_enabled(Some(false)).unwrap();
         config
             .listen
@@ -33,14 +30,13 @@ async fn create_session_pair(locator: &str) -> (Session, Session) {
             .unwrap();
         config
     };
-    let config2 = zenoh::config::client([Locator::from_str(locator).unwrap()]);
+    let config2 = config::client([Locator::from_str(locator).unwrap()]);
 
     let session1 = ztimeout!(zenoh::open(config1)).unwrap();
     let session2 = ztimeout!(zenoh::open(config2)).unwrap();
     (session1, session2)
 }
 
-#[cfg(feature = "unstable")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn zenoh_matching_status_any() -> ZResult<()> {
     let (session1, session2) = create_session_pair("tcp/127.0.0.1:18001").await;
@@ -92,12 +88,11 @@ async fn zenoh_matching_status_any() -> ZResult<()> {
     Ok(())
 }
 
-#[cfg(feature = "unstable")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn zenoh_matching_status_remote() -> ZResult<()> {
-    let session1 = ztimeout!(zenoh::open(peer())).unwrap();
+    let session1 = ztimeout!(zenoh::open(config::peer())).unwrap();
 
-    let session2 = ztimeout!(zenoh::open(peer())).unwrap();
+    let session2 = ztimeout!(zenoh::open(config::peer())).unwrap();
 
     let publisher1 = ztimeout!(session1
         .declare_publisher("zenoh_matching_status_remote_test")
@@ -147,12 +142,11 @@ async fn zenoh_matching_status_remote() -> ZResult<()> {
     Ok(())
 }
 
-#[cfg(feature = "unstable")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn zenoh_matching_status_local() -> ZResult<()> {
-    let session1 = ztimeout!(zenoh::open(config::peer())).unwrap();
+    let session1 = ztimeout!(zenoh::open(zenoh::config::peer())).unwrap();
 
-    let session2 = ztimeout!(zenoh::open(config::peer())).unwrap();
+    let session2 = ztimeout!(zenoh::open(zenoh::config::peer())).unwrap();
 
     let publisher1 = ztimeout!(session1
         .declare_publisher("zenoh_matching_status_local_test")

--- a/zenoh/tests/qos.rs
+++ b/zenoh/tests/qos.rs
@@ -13,7 +13,11 @@
 //
 use std::time::Duration;
 
-use zenoh::{internal::ztimeout, prelude::*};
+use zenoh::{
+    internal::ztimeout,
+    prelude::*,
+    publisher::{CongestionControl, Priority},
+};
 
 const TIMEOUT: Duration = Duration::from_secs(60);
 const SLEEP: Duration = Duration::from_secs(1);

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -22,9 +22,11 @@ use std::{
 
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use zenoh::{
-    core::Result,
+    config::{ModeDependentValue, WhatAmI, WhatAmIMatcher},
     internal::{bail, ztimeout},
     prelude::*,
+    publisher::CongestionControl,
+    Config, Result, Session,
 };
 
 const TIMEOUT: Duration = Duration::from_secs(10);

--- a/zenoh/tests/session.rs
+++ b/zenoh/tests/session.rs
@@ -21,7 +21,10 @@ use std::{
 
 #[cfg(feature = "unstable")]
 use zenoh::runtime::{Runtime, RuntimeBuilder};
-use zenoh::{internal::ztimeout, prelude::*};
+use zenoh::{
+    config, internal::ztimeout, key_expr::KeyExpr, prelude::*, publisher::CongestionControl,
+    sample::SampleKind, subscriber::Reliability, Session,
+};
 
 const TIMEOUT: Duration = Duration::from_secs(60);
 const SLEEP: Duration = Duration::from_secs(1);
@@ -295,7 +298,7 @@ async fn zenoh_2sessions_1runtime_init() {
     println!("[RI][02c] Creating peer01a session from runtime 1");
     let peer01a = zenoh::session::init(r1.clone()).await.unwrap();
     println!("[RI][03c] Closing peer01a session");
-    std::mem::drop(peer01a);
+    drop(peer01a);
     test_session_pubsub(&peer01, &peer02, Reliability::Reliable).await;
     close_session(peer01, peer02).await;
     println!("[  ][01e] Closing r1 runtime");

--- a/zenoh/tests/shm.rs
+++ b/zenoh/tests/shm.rs
@@ -11,188 +11,194 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-#[cfg(all(feature = "unstable", feature = "shared-memory"))]
-mod tests {
-    use std::{
-        sync::{
-            atomic::{AtomicUsize, Ordering},
-            Arc,
-        },
-        time::Duration,
+#![cfg(all(feature = "unstable", feature = "shared-memory"))]
+use std::{
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use zenoh::{
+    config,
+    internal::ztimeout,
+    prelude::*,
+    publisher::CongestionControl,
+    shm::{
+        BlockOn, GarbageCollect, PosixSharedMemoryProviderBackend, SharedMemoryProviderBuilder,
+        POSIX_PROTOCOL_ID,
+    },
+    subscriber::Reliability,
+    Session,
+};
+
+const TIMEOUT: Duration = Duration::from_secs(60);
+const SLEEP: Duration = Duration::from_secs(1);
+
+const MSG_COUNT: usize = 1_00;
+const MSG_SIZE: [usize; 2] = [1_024, 100_000];
+
+async fn open_session_unicast(endpoints: &[&str]) -> (Session, Session) {
+    // Open the sessions
+    let mut config = config::peer();
+    config.listen.endpoints = endpoints
+        .iter()
+        .map(|e| e.parse().unwrap())
+        .collect::<Vec<_>>();
+    config.scouting.multicast.set_enabled(Some(false)).unwrap();
+    config.transport.shared_memory.set_enabled(true).unwrap();
+    println!("[  ][01a] Opening peer01 session: {:?}", endpoints);
+    let peer01 = ztimeout!(zenoh::open(config)).unwrap();
+
+    let mut config = config::peer();
+    config.connect.endpoints = endpoints
+        .iter()
+        .map(|e| e.parse().unwrap())
+        .collect::<Vec<_>>();
+    config.scouting.multicast.set_enabled(Some(false)).unwrap();
+    config.transport.shared_memory.set_enabled(true).unwrap();
+    println!("[  ][02a] Opening peer02 session: {:?}", endpoints);
+    let peer02 = ztimeout!(zenoh::open(config)).unwrap();
+
+    (peer01, peer02)
+}
+
+async fn open_session_multicast(endpoint01: &str, endpoint02: &str) -> (Session, Session) {
+    // Open the sessions
+    let mut config = config::peer();
+    config.listen.endpoints = vec![endpoint01.parse().unwrap()];
+    config.scouting.multicast.set_enabled(Some(true)).unwrap();
+    config.transport.shared_memory.set_enabled(true).unwrap();
+    println!("[  ][01a] Opening peer01 session: {}", endpoint01);
+    let peer01 = ztimeout!(zenoh::open(config)).unwrap();
+
+    let mut config = config::peer();
+    config.listen.endpoints = vec![endpoint02.parse().unwrap()];
+    config.scouting.multicast.set_enabled(Some(true)).unwrap();
+    config.transport.shared_memory.set_enabled(true).unwrap();
+    println!("[  ][02a] Opening peer02 session: {}", endpoint02);
+    let peer02 = ztimeout!(zenoh::open(config)).unwrap();
+
+    (peer01, peer02)
+}
+
+async fn close_session(peer01: Session, peer02: Session) {
+    println!("[  ][01d] Closing peer02 session");
+    ztimeout!(peer01.close()).unwrap();
+    println!("[  ][02d] Closing peer02 session");
+    ztimeout!(peer02.close()).unwrap();
+}
+
+async fn test_session_pubsub(peer01: &Session, peer02: &Session, reliability: Reliability) {
+    let msg_count = match reliability {
+        Reliability::Reliable => MSG_COUNT,
+        Reliability::BestEffort => 1,
     };
+    let msgs = Arc::new(AtomicUsize::new(0));
 
-    use zenoh::{internal::ztimeout, prelude::*};
+    for size in MSG_SIZE {
+        let key_expr = format!("shm{size}");
 
-    const TIMEOUT: Duration = Duration::from_secs(60);
-    const SLEEP: Duration = Duration::from_secs(1);
+        msgs.store(0, Ordering::SeqCst);
 
-    const MSG_COUNT: usize = 1_00;
-    const MSG_SIZE: [usize; 2] = [1_024, 100_000];
+        // Subscribe to data
+        println!("[PS][01b] Subscribing on peer01 session");
+        let c_msgs = msgs.clone();
+        let _sub = ztimeout!(peer01
+            .declare_subscriber(&key_expr)
+            .callback(move |sample| {
+                assert_eq!(sample.payload().len(), size);
+                c_msgs.fetch_add(1, Ordering::Relaxed);
+            }))
+        .unwrap();
 
-    async fn open_session_unicast(endpoints: &[&str]) -> (Session, Session) {
-        // Open the sessions
-        let mut config = config::peer();
-        config.listen.endpoints = endpoints
-            .iter()
-            .map(|e| e.parse().unwrap())
-            .collect::<Vec<_>>();
-        config.scouting.multicast.set_enabled(Some(false)).unwrap();
-        config.transport.shared_memory.set_enabled(true).unwrap();
-        println!("[  ][01a] Opening peer01 session: {:?}", endpoints);
-        let peer01 = ztimeout!(zenoh::open(config)).unwrap();
+        // Wait for the declaration to propagate
+        tokio::time::sleep(SLEEP).await;
 
-        let mut config = config::peer();
-        config.connect.endpoints = endpoints
-            .iter()
-            .map(|e| e.parse().unwrap())
-            .collect::<Vec<_>>();
-        config.scouting.multicast.set_enabled(Some(false)).unwrap();
-        config.transport.shared_memory.set_enabled(true).unwrap();
-        println!("[  ][02a] Opening peer02 session: {:?}", endpoints);
-        let peer02 = ztimeout!(zenoh::open(config)).unwrap();
-
-        (peer01, peer02)
-    }
-
-    async fn open_session_multicast(endpoint01: &str, endpoint02: &str) -> (Session, Session) {
-        // Open the sessions
-        let mut config = config::peer();
-        config.listen.endpoints = vec![endpoint01.parse().unwrap()];
-        config.scouting.multicast.set_enabled(Some(true)).unwrap();
-        config.transport.shared_memory.set_enabled(true).unwrap();
-        println!("[  ][01a] Opening peer01 session: {}", endpoint01);
-        let peer01 = ztimeout!(zenoh::open(config)).unwrap();
-
-        let mut config = config::peer();
-        config.listen.endpoints = vec![endpoint02.parse().unwrap()];
-        config.scouting.multicast.set_enabled(Some(true)).unwrap();
-        config.transport.shared_memory.set_enabled(true).unwrap();
-        println!("[  ][02a] Opening peer02 session: {}", endpoint02);
-        let peer02 = ztimeout!(zenoh::open(config)).unwrap();
-
-        (peer01, peer02)
-    }
-
-    async fn close_session(peer01: Session, peer02: Session) {
-        println!("[  ][01d] Closing peer02 session");
-        ztimeout!(peer01.close()).unwrap();
-        println!("[  ][02d] Closing peer02 session");
-        ztimeout!(peer02.close()).unwrap();
-    }
-
-    async fn test_session_pubsub(peer01: &Session, peer02: &Session, reliability: Reliability) {
-        let msg_count = match reliability {
-            Reliability::Reliable => MSG_COUNT,
-            Reliability::BestEffort => 1,
-        };
-        let msgs = Arc::new(AtomicUsize::new(0));
-
-        for size in MSG_SIZE {
-            let key_expr = format!("shm{size}");
-
-            msgs.store(0, Ordering::SeqCst);
-
-            // Subscribe to data
-            println!("[PS][01b] Subscribing on peer01 session");
-            let c_msgs = msgs.clone();
-            let _sub = ztimeout!(peer01
-                .declare_subscriber(&key_expr)
-                .callback(move |sample| {
-                    assert_eq!(sample.payload().len(), size);
-                    c_msgs.fetch_add(1, Ordering::Relaxed);
-                }))
+        // create SHM backend...
+        let backend = PosixSharedMemoryProviderBackend::builder()
+            .with_size(size * MSG_COUNT / 10)
+            .unwrap()
+            .res()
             .unwrap();
+        // ...and SHM provider
+        let shm01 = SharedMemoryProviderBuilder::builder()
+            .protocol_id::<POSIX_PROTOCOL_ID>()
+            .backend(backend)
+            .res();
 
-            // Wait for the declaration to propagate
-            tokio::time::sleep(SLEEP).await;
+        // remember segment size that was allocated
+        let shm_segment_size = shm01.available();
 
-            // create SHM backend...
-            let backend = PosixSharedMemoryProviderBackend::builder()
-                .with_size(size * MSG_COUNT / 10)
-                .unwrap()
-                .res()
-                .unwrap();
-            // ...and SHM provider
-            let shm01 = SharedMemoryProviderBuilder::builder()
-                .protocol_id::<POSIX_PROTOCOL_ID>()
-                .backend(backend)
-                .res();
+        // Prepare a layout for allocations
+        let layout = shm01.alloc(size).into_layout().unwrap();
 
-            // remember segment size that was allocated
-            let shm_segment_size = shm01.available();
+        // Put data
+        println!("[PS][03b] Putting on peer02 session. {MSG_COUNT} msgs of {size} bytes.");
+        for c in 0..msg_count {
+            // Allocate new message
+            let sbuf = ztimeout!(layout.alloc().with_policy::<BlockOn<GarbageCollect>>()).unwrap();
+            println!("{c} created");
 
-            // Prepare a layout for allocations
-            let layout = shm01.alloc(size).into_layout().unwrap();
-
-            // Put data
-            println!("[PS][03b] Putting on peer02 session. {MSG_COUNT} msgs of {size} bytes.");
-            for c in 0..msg_count {
-                // Allocate new message
-                let sbuf =
-                    ztimeout!(layout.alloc().with_policy::<BlockOn<GarbageCollect>>()).unwrap();
-                println!("{c} created");
-
-                // Publish this message
-                ztimeout!(peer02
-                    .put(&key_expr, sbuf)
-                    .congestion_control(CongestionControl::Block))
-                .unwrap();
-                println!("{c} putted");
-            }
-
-            // wat for all messages received
-            ztimeout!(async {
-                loop {
-                    let cnt = msgs.load(Ordering::Relaxed);
-                    println!("[PS][03b] Received {cnt}/{msg_count}.");
-                    if cnt != msg_count {
-                        tokio::time::sleep(SLEEP).await;
-                    } else {
-                        break;
-                    }
-                }
-            });
-
-            // wat for all memory reclaimed
-            ztimeout!(async {
-                loop {
-                    shm01.garbage_collect();
-                    let available = shm01.available();
-                    println!("[PS][03b] SHM available {available}/{shm_segment_size}");
-                    if available != shm_segment_size {
-                        tokio::time::sleep(SLEEP).await;
-                    } else {
-                        break;
-                    }
-                }
-            });
+            // Publish this message
+            ztimeout!(peer02
+                .put(&key_expr, sbuf)
+                .congestion_control(CongestionControl::Block))
+            .unwrap();
+            println!("{c} putted");
         }
-    }
 
-    #[cfg(feature = "shared-memory")]
-    #[test]
-    fn zenoh_shm_unicast() {
-        tokio::runtime::Runtime::new().unwrap().block_on(async {
-            // Initiate logging
-            zenoh_util::try_init_log_from_env();
+        // wat for all messages received
+        ztimeout!(async {
+            loop {
+                let cnt = msgs.load(Ordering::Relaxed);
+                println!("[PS][03b] Received {cnt}/{msg_count}.");
+                if cnt != msg_count {
+                    tokio::time::sleep(SLEEP).await;
+                } else {
+                    break;
+                }
+            }
+        });
 
-            let (peer01, peer02) = open_session_unicast(&["tcp/127.0.0.1:19447"]).await;
-            test_session_pubsub(&peer01, &peer02, Reliability::Reliable).await;
-            close_session(peer01, peer02).await;
+        // wat for all memory reclaimed
+        ztimeout!(async {
+            loop {
+                shm01.garbage_collect();
+                let available = shm01.available();
+                println!("[PS][03b] SHM available {available}/{shm_segment_size}");
+                if available != shm_segment_size {
+                    tokio::time::sleep(SLEEP).await;
+                } else {
+                    break;
+                }
+            }
         });
     }
+}
 
-    #[cfg(feature = "shared-memory")]
-    #[test]
-    fn zenoh_shm_multicast() {
-        tokio::runtime::Runtime::new().unwrap().block_on(async {
-            // Initiate logging
-            zenoh_util::try_init_log_from_env();
+#[test]
+fn zenoh_shm_unicast() {
+    tokio::runtime::Runtime::new().unwrap().block_on(async {
+        // Initiate logging
+        zenoh_util::try_init_log_from_env();
 
-            let (peer01, peer02) =
-                open_session_multicast("udp/224.0.0.1:19448", "udp/224.0.0.1:19448").await;
-            test_session_pubsub(&peer01, &peer02, Reliability::BestEffort).await;
-            close_session(peer01, peer02).await;
-        });
-    }
+        let (peer01, peer02) = open_session_unicast(&["tcp/127.0.0.1:19447"]).await;
+        test_session_pubsub(&peer01, &peer02, Reliability::Reliable).await;
+        close_session(peer01, peer02).await;
+    });
+}
+
+#[test]
+fn zenoh_shm_multicast() {
+    tokio::runtime::Runtime::new().unwrap().block_on(async {
+        // Initiate logging
+        zenoh_util::try_init_log_from_env();
+
+        let (peer01, peer02) =
+            open_session_multicast("udp/224.0.0.1:19448", "udp/224.0.0.1:19448").await;
+        test_session_pubsub(&peer01, &peer02, Reliability::BestEffort).await;
+        close_session(peer01, peer02).await;
+    });
 }

--- a/zenoh/tests/unicity.rs
+++ b/zenoh/tests/unicity.rs
@@ -20,7 +20,15 @@ use std::{
 };
 
 use tokio::runtime::Handle;
-use zenoh::{internal::ztimeout, prelude::*};
+use zenoh::{
+    config,
+    config::{EndPoint, WhatAmI},
+    internal::ztimeout,
+    key_expr::KeyExpr,
+    prelude::*,
+    publisher::CongestionControl,
+    Session,
+};
 
 const TIMEOUT: Duration = Duration::from_secs(60);
 const SLEEP: Duration = Duration::from_secs(1);


### PR DESCRIPTION
The current prelude exposes all the types of the API. This is considered as a bad practice, as many of these names are quite common and could conflict. Most of the popular crate using prelude are only putting traits in it (plus some types with particular names).
These PR removes all types from the prelude, and put the main ones directly in the root.