### PR TITLE
chore: renamed no_mangle feature to dynamic_plugin

### DIFF
--- a/plugins/zenoh-backend-example/Cargo.toml
+++ b/plugins/zenoh-backend-example/Cargo.toml
@@ -20,8 +20,8 @@ edition = { workspace = true }
 publish = false
 
 [features]
-default = ["no_mangle", "zenoh/default"]
-no_mangle = []
+default = ["dynamic_plugin", "zenoh/default"]
+dynamic_plugin = []
 
 [lib]
 name = "zenoh_backend_example"

--- a/plugins/zenoh-backend-example/src/lib.rs
+++ b/plugins/zenoh-backend-example/src/lib.rs
@@ -26,7 +26,7 @@ use zenoh_backend_traits::{
 use zenoh_plugin_trait::{plugin_long_version, plugin_version, Plugin};
 use zenoh_result::ZResult;
 
-#[cfg(feature = "no_mangle")]
+#[cfg(feature = "dynamic_plugin")]
 zenoh_plugin_trait::declare_plugin!(ExampleBackend);
 
 impl Plugin for ExampleBackend {

--- a/plugins/zenoh-backend-traits/src/lib.rs
+++ b/plugins/zenoh-backend-traits/src/lib.rs
@@ -23,7 +23,7 @@
 //!  - [`Storage`]
 //!
 //! Such library must also declare a `create_volume()` operation
-//! with the `#[dynamic_plugin]` attribute as an entrypoint to be called for the Backend creation.
+//! with the `#[no_mangle]` attribute as an entrypoint to be called for the Backend creation.
 //!
 //! # Example
 //! ```
@@ -35,7 +35,7 @@
 //! use zenoh_backend_traits::config::*;
 //! use zenoh::Result as ZResult;
 //!
-//! #[dynamic_plugin]
+//! #[no_mangle]
 //! pub fn create_volume(config: VolumeConfig) -> ZResult<Box<dyn Volume>> {
 //!     Ok(Box::new(MyVolumeType { config }))
 //! }

--- a/plugins/zenoh-backend-traits/src/lib.rs
+++ b/plugins/zenoh-backend-traits/src/lib.rs
@@ -23,7 +23,7 @@
 //!  - [`Storage`]
 //!
 //! Such library must also declare a `create_volume()` operation
-//! with the `#[no_mangle]` attribute as an entrypoint to be called for the Backend creation.
+//! with the `#[dynamic_plugin]` attribute as an entrypoint to be called for the Backend creation.
 //!
 //! # Example
 //! ```
@@ -35,7 +35,7 @@
 //! use zenoh_backend_traits::config::*;
 //! use zenoh::Result as ZResult;
 //!
-//! #[no_mangle]
+//! #[dynamic_plugin]
 //! pub fn create_volume(config: VolumeConfig) -> ZResult<Box<dyn Volume>> {
 //!     Ok(Box::new(MyVolumeType { config }))
 //! }

--- a/plugins/zenoh-plugin-example/Cargo.toml
+++ b/plugins/zenoh-plugin-example/Cargo.toml
@@ -20,8 +20,8 @@ edition = { workspace = true }
 publish = false
 
 [features]
-default = ["no_mangle", "zenoh/default", "zenoh/unstable", "zenoh/plugins"]
-no_mangle = []
+default = ["dynamic_plugin", "zenoh/default", "zenoh/unstable", "zenoh/plugins"]
+dynamic_plugin = []
 
 [lib]
 # When auto-detecting the "example" plugin, `zenohd` will look for a dynamic library named "zenoh_plugin_example"

--- a/plugins/zenoh-plugin-example/src/lib.rs
+++ b/plugins/zenoh-plugin-example/src/lib.rs
@@ -32,7 +32,7 @@ use zenoh_result::{bail, ZResult};
 pub struct ExamplePlugin {}
 
 // declaration of the plugin's VTable for zenohd to find the plugin's functions to be called
-#[cfg(feature = "no_mangle")]
+#[cfg(feature = "dynamic_plugin")]
 zenoh_plugin_trait::declare_plugin!(ExamplePlugin);
 
 // A default selector for this example of storage plugin (in case the config doesn't set it)

--- a/plugins/zenoh-plugin-rest/Cargo.toml
+++ b/plugins/zenoh-plugin-rest/Cargo.toml
@@ -24,8 +24,8 @@ categories = ["network-programming", "web-programming::http-server"]
 description = "The zenoh REST plugin"
 
 [features]
-default = ["no_mangle", "zenoh/default", "zenoh/unstable", "zenoh/plugins"]
-no_mangle = []
+default = ["dynamic_plugin", "zenoh/default", "zenoh/unstable", "zenoh/plugins"]
+dynamic_plugin = []
 
 [lib]
 name = "zenoh_plugin_rest"

--- a/plugins/zenoh-plugin-rest/src/lib.rs
+++ b/plugins/zenoh-plugin-rest/src/lib.rs
@@ -189,7 +189,7 @@ fn response(status: StatusCode, content_type: impl TryInto<Mime>, body: &str) ->
     builder.build()
 }
 
-#[cfg(feature = "no_mangle")]
+#[cfg(feature = "dynamic_plugin")]
 zenoh_plugin_trait::declare_plugin!(RestPlugin);
 
 pub struct RestPlugin {}

--- a/plugins/zenoh-plugin-storage-manager/Cargo.toml
+++ b/plugins/zenoh-plugin-storage-manager/Cargo.toml
@@ -24,8 +24,8 @@ categories = { workspace = true }
 description = "The zenoh storages plugin."
 
 [features]
-default = ["no_mangle", "zenoh/default", "zenoh/unstable", "zenoh/plugins"]
-no_mangle = []
+default = ["dynamic_plugin", "zenoh/default", "zenoh/unstable", "zenoh/plugins"]
+dynamic_plugin = []
 
 [lib]
 name = "zenoh_plugin_storage_manager"

--- a/plugins/zenoh-plugin-storage-manager/src/lib.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/lib.rs
@@ -52,7 +52,7 @@ mod memory_backend;
 mod replica;
 mod storages_mgt;
 
-#[cfg(feature = "no_mangle")]
+#[cfg(feature = "dynamic_plugin")]
 zenoh_plugin_trait::declare_plugin!(StoragesPlugin);
 
 pub struct StoragesPlugin {}


### PR DESCRIPTION
As suggested by @milyin this PR renames the `no_mangle` feature to `dynamic_plugin` which is easier to understand.

Sister PRs:
- https://github.com/eclipse-zenoh/zenoh-backend-filesystem/pull/102
- https://github.com/eclipse-zenoh/zenoh-backend-s3/pull/66
- https://github.com/eclipse-zenoh/zenoh-backend-rocksdb/pull/89
- https://github.com/eclipse-zenoh/zenoh-backend-influxdb/pull/111
- https://github.com/eclipse-zenoh/zenoh-plugin-dds/pull/232
- https://github.com/eclipse-zenoh/zenoh-plugin-mqtt/pull/95
- https://github.com/eclipse-zenoh/zenoh-plugin-ros1/pull/64
- https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/pull/135
- https://github.com/eclipse-zenoh/zenoh-plugin-webserver/pull/75