### PR TITLE
Apply Clippy lints from Rust 1.78

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Setup rust-cache
         uses: Swatinem/rust-cache@v2
 
+      - name: Update Stable Rust toolchain
+        run: rustup update stable
+
       - name: Install dependencies
         run: cargo +stable install cargo-deny --locked
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ members = [
 exclude = ["ci/nostd-check", "ci/valgrind-check"]
 
 [workspace.package]
-rust-version = "1.66.1"
+rust-version = "1.72.0"
 version = "0.11.0-dev" # Zenoh version
 repository = "https://github.com/eclipse-zenoh/zenoh"
 homepage = "http://zenoh.io"
@@ -91,7 +91,7 @@ crc = "3.0.1"
 criterion = "0.5"
 derive_more = "0.99.17"
 derive-new = "0.6.0"
-tracing-subscriber = {version = "0.3", features = ["json", "env-filter"]}
+tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 tracing-loki = "0.2"
 event-listener = "4.0.0"
 flume = "0.11"

--- a/commons/zenoh-codec/src/lib.rs
+++ b/commons/zenoh-codec/src/lib.rs
@@ -48,6 +48,12 @@ pub trait LCodec<Message> {
 #[derive(Clone, Copy)]
 pub struct Zenoh080;
 
+impl Default for Zenoh080 {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Zenoh080 {
     pub const fn new() -> Self {
         Self
@@ -117,6 +123,12 @@ impl Zenoh080Reliability {
 #[derive(Clone, Copy)]
 pub struct Zenoh080Bounded<T> {
     _t: PhantomData<T>,
+}
+
+impl<T> Default for Zenoh080Bounded<T> {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl<T> Zenoh080Bounded<T> {

--- a/commons/zenoh-codec/src/transport/batch.rs
+++ b/commons/zenoh-codec/src/transport/batch.rs
@@ -53,6 +53,12 @@ pub struct Zenoh080Batch {
     pub latest_sn: LatestSn,
 }
 
+impl Default for Zenoh080Batch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Zenoh080Batch {
     pub const fn new() -> Self {
         Self {

--- a/commons/zenoh-keyexpr/src/key_expr/fuzzer.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/fuzzer.rs
@@ -50,6 +50,9 @@ fn make(ke: &mut Vec<u8>, rng: &mut impl rand::Rng) {
 }
 
 pub struct KeyExprFuzzer<Rng: rand::Rng>(pub Rng);
+// NOTE: Denying `clippy::assigning_clones` causes:
+// error[E0502]: cannot borrow `next` as mutable because it is also borrowed as immutabl
+#[allow(clippy::assigning_clones)]
 impl<Rng: rand::Rng> Iterator for KeyExprFuzzer<Rng> {
     type Item = OwnedKeyExpr;
     fn next(&mut self) -> Option<Self::Item> {

--- a/commons/zenoh-keyexpr/src/key_expr/fuzzer.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/fuzzer.rs
@@ -50,17 +50,14 @@ fn make(ke: &mut Vec<u8>, rng: &mut impl rand::Rng) {
 }
 
 pub struct KeyExprFuzzer<Rng: rand::Rng>(pub Rng);
-// NOTE: Denying `clippy::assigning_clones` causes:
-// error[E0502]: cannot borrow `next` as mutable because it is also borrowed as immutabl
-#[allow(clippy::assigning_clones)]
 impl<Rng: rand::Rng> Iterator for KeyExprFuzzer<Rng> {
     type Item = OwnedKeyExpr;
     fn next(&mut self) -> Option<Self::Item> {
         let mut next = Vec::new();
         make(&mut next, &mut self.0);
         let mut next = String::from_utf8(next).unwrap();
-        if let Some(n) = next.strip_prefix('/') {
-            next = n.to_owned()
+        if let Some(n) = next.strip_prefix('/').map(ToOwned::to_owned) {
+            next = n
         }
         Some(OwnedKeyExpr::autocanonize(next).unwrap())
     }

--- a/commons/zenoh-keyexpr/src/key_expr/utils.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/utils.rs
@@ -204,3 +204,30 @@ impl<const N: usize> Split<[u8; N]> for [u8] {
         (None, self)
     }
 }
+
+#[allow(dead_code)]
+pub(crate) trait Utf {
+    fn utf(&self) -> &str;
+}
+
+#[allow(dead_code)]
+impl Utf for [u8] {
+    fn utf(&self) -> &str {
+        unsafe { ::core::str::from_utf8_unchecked(self) }
+    }
+}
+/// This macro is generally useful when introducing new matchers to debug them.
+#[allow(unused_macros)]
+macro_rules! utfdbg {
+    ($x: expr) => {{
+        let x = $x;
+        println!(
+            "[{}:{}] {} = {}",
+            file!(),
+            line!(),
+            stringify!($x),
+            $crate::key_expr::utils::Utf::utf(x)
+        );
+        x
+    }};
+}

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/box_tree.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/box_tree.rs
@@ -18,12 +18,8 @@ use alloc::string::String;
 use core::ptr::NonNull;
 
 use crate::keyexpr;
-use crate::keyexpr_tree::{
-    support::{IWildness, NonWild, UnknownWildness},
-    *,
-};
+use crate::keyexpr_tree::{support::IWildness, *};
 
-use super::impls::KeyedSetProvider;
 use super::support::IterOrOption;
 
 /// A fully owned KeTree.
@@ -399,26 +395,6 @@ impl<Weight, Wildness: IWildness, Children: IChildrenProvider<Box<Self>>> AsMut<
 {
     fn as_mut(&mut self) -> &mut Self {
         self
-    }
-}
-
-trait TransmuteInto<T> {
-    fn transmute_into(self) -> T;
-}
-impl<'a, Weight: 'static>
-    TransmuteInto<&'a mut KeyExprTreeNode<Weight, UnknownWildness, KeyedSetProvider>>
-    for &'a mut KeyExprTreeNode<Weight, NonWild, KeyedSetProvider>
-{
-    fn transmute_into(self) -> &'a mut KeyExprTreeNode<Weight, UnknownWildness, KeyedSetProvider> {
-        unsafe { core::mem::transmute(self) }
-    }
-}
-impl<'a, Weight: 'static>
-    TransmuteInto<&'a KeyExprTreeNode<Weight, UnknownWildness, KeyedSetProvider>>
-    for &'a KeyExprTreeNode<Weight, NonWild, KeyedSetProvider>
-{
-    fn transmute_into(self) -> &'a KeyExprTreeNode<Weight, UnknownWildness, KeyedSetProvider> {
-        unsafe { core::mem::transmute(self) }
     }
 }
 

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/test.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/test.rs
@@ -163,7 +163,7 @@ fn test_keyset<K: Deref<Target = keyexpr> + Debug>(keys: &[K]) {
                 assert!(expected.insert(k, v).is_none());
             }
         }
-        exclone = expected.clone();
+        exclone.clone_from(&expected);
         for node in tree.included_nodes(target) {
             let ke = node.keyexpr();
             let weight = node.weight();
@@ -203,7 +203,7 @@ fn test_keyset<K: Deref<Target = keyexpr> + Debug>(keys: &[K]) {
                 assert!(expected.insert(k, v).is_none());
             }
         }
-        exclone = expected.clone();
+        exclone.clone_from(&expected);
         for node in tree.nodes_including(dbg!(target)) {
             let ke = node.keyexpr();
             let weight = node.weight();
@@ -302,7 +302,7 @@ fn test_keyset_vec<K: Deref<Target = keyexpr>>(keys: &[K]) {
                 assert!(expected.insert(k, v).is_none());
             }
         }
-        exclone = expected.clone();
+        exclone.clone_from(&expected);
         for node in tree.included_nodes(target) {
             let ke = node.keyexpr();
             let weight = node.weight();

--- a/commons/zenoh-protocol/src/common/extension.rs
+++ b/commons/zenoh-protocol/src/common/extension.rs
@@ -110,6 +110,12 @@ pub struct DidntConvert;
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct ZExtUnit<const ID: u8>;
 
+impl<const ID: u8> Default for ZExtUnit<{ ID }> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<const ID: u8> ZExtUnit<{ ID }> {
     pub const ID: u8 = ID;
 

--- a/commons/zenoh-protocol/src/zenoh/mod.rs
+++ b/commons/zenoh-protocol/src/zenoh/mod.rs
@@ -219,6 +219,12 @@ pub mod ext {
             Self
         }
     }
+    #[cfg(feature = "shared-memory")]
+    impl<const ID: u8> Default for ShmType<{ ID }> {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
 
     ///   7 6 5 4 3 2 1 0
     ///  +-+-+-+-+-+-+-+-+

--- a/io/zenoh-transport/src/unicast/lowlatency/transport.rs
+++ b/io/zenoh-transport/src/unicast/lowlatency/transport.rs
@@ -262,11 +262,6 @@ impl TransportUnicastTrait for TransportUnicastLowlatency {
     /*************************************/
     /*           TERMINATION             */
     /*************************************/
-    async fn close_link(&self, link: Link, reason: u8) -> ZResult<()> {
-        tracing::trace!("Closing link {} with peer: {}", link, self.config.zid);
-        self.finalize(reason).await
-    }
-
     async fn close(&self, reason: u8) -> ZResult<()> {
         tracing::trace!("Closing transport with peer: {}", self.config.zid);
         self.finalize(reason).await

--- a/io/zenoh-transport/src/unicast/transport_unicast_inner.rs
+++ b/io/zenoh-transport/src/unicast/transport_unicast_inner.rs
@@ -80,7 +80,6 @@ pub(crate) trait TransportUnicastTrait: Send + Sync {
     /*************************************/
     /*            TERMINATION            */
     /*************************************/
-    async fn close_link(&self, link: Link, reason: u8) -> ZResult<()>;
     async fn close(&self, reason: u8) -> ZResult<()>;
 
     fn add_debug_fields<'a, 'b: 'a, 'c>(

--- a/io/zenoh-transport/src/unicast/universal/transport.rs
+++ b/io/zenoh-transport/src/unicast/universal/transport.rs
@@ -37,13 +37,6 @@ use zenoh_protocol::{
 };
 use zenoh_result::{bail, zerror, ZResult};
 
-macro_rules! zlinkget {
-    ($guard:expr, $link:expr) => {
-        // Compare LinkUnicast link to not compare TransportLinkUnicast direction
-        $guard.iter().find(|tl| tl.link == $link)
-    };
-}
-
 macro_rules! zlinkindex {
     ($guard:expr, $link:expr) => {
         // Compare LinkUnicast link to not compare TransportLinkUnicast direction
@@ -356,27 +349,6 @@ impl TransportUnicastTrait for TransportUnicastUniversal {
     /*************************************/
     /*           TERMINATION             */
     /*************************************/
-    async fn close_link(&self, link: Link, reason: u8) -> ZResult<()> {
-        tracing::trace!("Closing link {} with peer: {}", link, self.config.zid);
-
-        let transport_link_pipeline = zlinkget!(zread!(self.links), link)
-            .ok_or_else(|| zerror!("Cannot close Link {:?}: not found", link))?
-            .pipeline
-            .clone();
-
-        // Close message to be sent on the target link
-        let msg: TransportMessage = Close {
-            reason,
-            session: false,
-        }
-        .into();
-
-        transport_link_pipeline.push_transport_message(msg, Priority::Background);
-
-        // Remove the link from the channel
-        self.del_link(link).await
-    }
-
     async fn close(&self, reason: u8) -> ZResult<()> {
         tracing::trace!("Closing transport with peer: {}", self.config.zid);
 

--- a/plugins/zenoh-backend-traits/src/lib.rs
+++ b/plugins/zenoh-backend-traits/src/lib.rs
@@ -183,7 +183,6 @@ pub enum History {
     All,
 }
 
-///
 pub enum StorageInsertionResult {
     Outdated,
     Inserted,

--- a/plugins/zenoh-plugin-rest/src/lib.rs
+++ b/plugins/zenoh-plugin-rest/src/lib.rs
@@ -193,26 +193,6 @@ fn response(status: StatusCode, content_type: impl TryInto<Mime>, body: &str) ->
 zenoh_plugin_trait::declare_plugin!(RestPlugin);
 
 pub struct RestPlugin {}
-#[derive(Clone, Copy, Debug)]
-struct StrError {
-    err: &'static str,
-}
-impl std::error::Error for StrError {}
-impl std::fmt::Display for StrError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.err)
-    }
-}
-#[derive(Debug, Clone)]
-struct StringError {
-    err: String,
-}
-impl std::error::Error for StringError {}
-impl std::fmt::Display for StringError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.err)
-    }
-}
 
 impl ZenohPlugin for RestPlugin {}
 

--- a/plugins/zenoh-plugin-storage-manager/src/replica/align_queryable.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/align_queryable.rs
@@ -177,11 +177,11 @@ impl AlignQueryable {
     fn parse_selector(&self, selector: Selector) -> Option<AlignComponent> {
         let properties = selector.parameters_stringmap().unwrap(); // note: this is a hashmap
         tracing::trace!("[ALIGN QUERYABLE] Properties are: {:?}", properties);
-        if properties.get(super::ERA).is_some() {
+        if properties.contains_key(super::ERA) {
             Some(AlignComponent::Era(
                 EraType::from_str(properties.get(super::ERA).unwrap()).unwrap(),
             ))
-        } else if properties.get(super::INTERVALS).is_some() {
+        } else if properties.contains_key(super::INTERVALS) {
             let mut intervals = properties.get(super::INTERVALS).unwrap().to_string();
             intervals.remove(0);
             intervals.pop();
@@ -191,7 +191,7 @@ impl AlignQueryable {
                     .map(|x| x.parse::<u64>().unwrap())
                     .collect::<Vec<u64>>(),
             ))
-        } else if properties.get(super::SUBINTERVALS).is_some() {
+        } else if properties.contains_key(super::SUBINTERVALS) {
             let mut subintervals = properties.get(super::SUBINTERVALS).unwrap().to_string();
             subintervals.remove(0);
             subintervals.pop();
@@ -201,7 +201,7 @@ impl AlignQueryable {
                     .map(|x| x.parse::<u64>().unwrap())
                     .collect::<Vec<u64>>(),
             ))
-        } else if properties.get(super::CONTENTS).is_some() {
+        } else if properties.contains_key(super::CONTENTS) {
             let contents = serde_json::from_str(properties.get(super::CONTENTS).unwrap()).unwrap();
             Some(AlignComponent::Contents(contents))
         } else {

--- a/zenoh/src/net/primitives/mod.rs
+++ b/zenoh/src/net/primitives/mod.rs
@@ -48,8 +48,6 @@ pub(crate) trait EPrimitives: Send + Sync {
     fn send_response(&self, ctx: RoutingContext<Response>);
 
     fn send_response_final(&self, ctx: RoutingContext<ResponseFinal>);
-
-    fn send_close(&self);
 }
 
 #[derive(Default)]
@@ -79,8 +77,6 @@ impl EPrimitives for DummyPrimitives {
     fn send_response(&self, _ctx: RoutingContext<Response>) {}
 
     fn send_response_final(&self, _ctx: RoutingContext<ResponseFinal>) {}
-
-    fn send_close(&self) {}
 
     fn as_any(&self) -> &dyn Any {
         self

--- a/zenoh/src/net/primitives/mux.rs
+++ b/zenoh/src/net/primitives/mux.rs
@@ -290,10 +290,6 @@ impl EPrimitives for Mux {
         }
     }
 
-    fn send_close(&self) {
-        // self.handler.closing().await;
-    }
-
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -564,10 +560,6 @@ impl EPrimitives for McastMux {
         if let Some(ctx) = self.interceptor.intercept(ctx, cache) {
             let _ = self.handler.schedule(ctx.msg);
         }
-    }
-
-    fn send_close(&self) {
-        // self.handler.closing().await;
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/zenoh/src/net/routing/dispatcher/face.rs
+++ b/zenoh/src/net/routing/dispatcher/face.rs
@@ -106,7 +106,7 @@ impl FaceState {
 
     pub(crate) fn get_next_local_id(&self) -> ExprId {
         let mut id = 1;
-        while self.local_mappings.get(&id).is_some() || self.remote_mappings.get(&id).is_some() {
+        while self.local_mappings.contains_key(&id) || self.remote_mappings.contains_key(&id) {
             id += 1;
         }
         id

--- a/zenoh/src/net/routing/hat/client/mod.rs
+++ b/zenoh/src/net/routing/hat/client/mod.rs
@@ -252,10 +252,6 @@ impl HatBaseTrait for HatCode {
         Ok(())
     }
 
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     #[inline]
     fn ingress_filter(&self, _tables: &Tables, _face: &FaceState, _expr: &mut RoutingExpr) -> bool {
         true

--- a/zenoh/src/net/routing/hat/linkstate_peer/mod.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/mod.rs
@@ -431,10 +431,6 @@ impl HatBaseTrait for HatCode {
         Ok(())
     }
 
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     #[inline]
     fn ingress_filter(&self, _tables: &Tables, _face: &FaceState, _expr: &mut RoutingExpr) -> bool {
         true

--- a/zenoh/src/net/routing/hat/linkstate_peer/network.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/network.rs
@@ -460,10 +460,10 @@ impl Network {
                         (oldsn < sn)
                             .then(|| {
                                 node.sn = sn;
-                                node.links = links.clone();
+                                node.links.clone_from(&links);
                                 changes.updated_nodes.push((idx, node.clone()));
                                 (node.locators != locators && locators.is_some()).then(|| {
-                                    node.locators = locators.clone();
+                                    node.locators.clone_from(&locators);
                                     idx
                                 })
                             })
@@ -524,7 +524,7 @@ impl Network {
                         let oldsn = node.sn;
                         if oldsn < sn {
                             node.sn = sn;
-                            node.links = links.clone();
+                            node.links.clone_from(&links);
                             if locators.is_some() {
                                 node.locators = locators;
                             }

--- a/zenoh/src/net/routing/hat/mod.rs
+++ b/zenoh/src/net/routing/hat/mod.rs
@@ -67,8 +67,6 @@ impl Sources {
 pub(crate) trait HatTrait: HatBaseTrait + HatPubSubTrait + HatQueriesTrait {}
 
 pub(crate) trait HatBaseTrait {
-    fn as_any(&self) -> &dyn Any;
-
     fn init(&self, tables: &mut Tables, runtime: Runtime);
 
     fn new_tables(&self, router_peers_failover_brokering: bool) -> Box<dyn Any + Send + Sync>;

--- a/zenoh/src/net/routing/hat/p2p_peer/gossip.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/gossip.rs
@@ -381,9 +381,9 @@ impl Network {
                     (oldsn < sn)
                         .then(|| {
                             node.sn = sn;
-                            node.links = links.clone();
+                            node.links.clone_from(&links);
                             (node.locators != locators && locators.is_some()).then(|| {
-                                node.locators = locators.clone();
+                                node.locators.clone_from(&locators);
                                 idx
                             })
                         })

--- a/zenoh/src/net/routing/hat/p2p_peer/mod.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/mod.rs
@@ -325,10 +325,6 @@ impl HatBaseTrait for HatCode {
         Ok(())
     }
 
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     #[inline]
     fn ingress_filter(&self, _tables: &Tables, _face: &FaceState, _expr: &mut RoutingExpr) -> bool {
         true

--- a/zenoh/src/net/routing/hat/router/mod.rs
+++ b/zenoh/src/net/routing/hat/router/mod.rs
@@ -706,10 +706,6 @@ impl HatBaseTrait for HatCode {
         Ok(())
     }
 
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     #[inline]
     fn ingress_filter(&self, tables: &Tables, face: &FaceState, expr: &mut RoutingExpr) -> bool {
         face.whatami != WhatAmI::Peer

--- a/zenoh/src/net/routing/hat/router/network.rs
+++ b/zenoh/src/net/routing/hat/router/network.rs
@@ -463,10 +463,10 @@ impl Network {
                         (oldsn < sn)
                             .then(|| {
                                 node.sn = sn;
-                                node.links = links.clone();
+                                node.links.clone_from(&links);
                                 changes.updated_nodes.push((idx, node.clone()));
                                 (node.locators != locators && locators.is_some()).then(|| {
-                                    node.locators = locators.clone();
+                                    node.locators.clone_from(&locators);
                                     idx
                                 })
                             })
@@ -527,7 +527,7 @@ impl Network {
                         let oldsn = node.sn;
                         if oldsn < sn {
                             node.sn = sn;
-                            node.links = links.clone();
+                            node.links.clone_from(&links);
                             if locators.is_some() {
                                 node.locators = locators;
                             }

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -509,11 +509,6 @@ impl crate::net::primitives::EPrimitives for AdminSpace {
         (self as &dyn Primitives).send_response_final(ctx.msg)
     }
 
-    #[inline]
-    fn send_close(&self) {
-        (self as &dyn Primitives).send_close()
-    }
-
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }

--- a/zenoh/src/net/tests/tables.rs
+++ b/zenoh/src/net/tests/tables.rs
@@ -470,8 +470,6 @@ impl EPrimitives for ClientPrimitives {
 
     fn send_response_final(&self, _ctx: RoutingContext<zenoh_protocol::network::ResponseFinal>) {}
 
-    fn send_close(&self) {}
-
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }

--- a/zenoh/src/session.rs
+++ b/zenoh/src/session.rs
@@ -1698,7 +1698,7 @@ impl Session {
             let mut sample = Sample::with_info(key_expr, payload.clone(), info.clone());
             #[cfg(feature = "unstable")]
             {
-                sample.attachment = attachment.clone();
+                sample.attachment.clone_from(&attachment);
             }
             cb(sample);
         }
@@ -2719,11 +2719,6 @@ impl crate::net::primitives::EPrimitives for Session {
     #[inline]
     fn send_response_final(&self, ctx: crate::net::routing::RoutingContext<ResponseFinal>) {
         (self as &dyn Primitives).send_response_final(ctx.msg)
-    }
-
-    #[inline]
-    fn send_close(&self) {
-        (self as &dyn Primitives).send_close()
     }
 
     fn as_any(&self) -> &dyn std::any::Any {


### PR DESCRIPTION
With the release of Rust 1.78 comes new lints and previously undetected issues.