### PR TITLE
Check crate MSRVs 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,14 +144,20 @@ jobs:
         uses: crate-ci/typos@master
 
   msrvs:
-    name: MSRV checks on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    # NOTE: It is necessary to run the check-msrv action on multiple platforms since a crate's MSRV
+    name: MSRV checks for ${{ matrix.target }}
+    runs-on: macos-14
+    # NOTE: It is necessary to run the check-msrv action for multiple targets since a crate's MSRV
     # depends on the target it's compiled for.
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        target:
+          - aarch64-apple-darwin
+          - aarch64-unknown-linux-gnu
+          - x86_64-unknown-linux-gnu
+          - x86_64-pc-windows-msvc
+          - arm-unknown-linux-gnueabihf
+          - armv7-unknown-linux-gnueabihf
     steps:
       - name: Clone this repository
         uses: actions/checkout@v4
@@ -162,6 +168,7 @@ jobs:
           # NOTE: As of commit 25f06bd, the minimum MSRV found in the workspace is 1.68.
           # This value should be as high as possible to avoid needlessly checking older versions.
           min: 1.68.0
+          target: ${{ matrix.target }}
 
   # NOTE: In GitHub repository settings, the "Require status checks to pass
   # before merging" branch protection rule ensures that commits are only merged

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,8 +144,14 @@ jobs:
         uses: crate-ci/typos@master
 
   msrvs:
-    name: MSRV checks
-    runs-on: ubuntu-latest
+    name: MSRV checks on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    # NOTE: It is necessary to run the check-msrv action on multiple platforms since a crate's MSRV
+    # depends on the target it's compiled for.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
     steps:
       - name: Clone this repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,20 +144,18 @@ jobs:
         uses: crate-ci/typos@master
 
   msrvs:
-    name: MSRV checks for ${{ matrix.target }}
-    runs-on: macos-14
-    # NOTE: It is necessary to run the check-msrv action for multiple targets since a crate's MSRV
+    name: MSRV checks on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    # NOTE: It is necessary to run the check-msrv action on platforms since a crate's MSRV
     # depends on the target it's compiled for.
     strategy:
       fail-fast: false
       matrix:
-        target:
-          - aarch64-apple-darwin
-          - aarch64-unknown-linux-gnu
-          - x86_64-unknown-linux-gnu
-          - x86_64-pc-windows-msvc
-          - arm-unknown-linux-gnueabihf
-          - armv7-unknown-linux-gnueabihf
+        os:
+          - ubuntu-latest
+          - macos-13
+          - macos-14
+          # - windows-latest
     steps:
       - name: Clone this repository
         uses: actions/checkout@v4
@@ -167,8 +165,7 @@ jobs:
           repo: ${{ github.repository }}
           # NOTE: As of commit 25f06bd, the minimum MSRV found in the workspace is 1.68.
           # This value should be as high as possible to avoid needlessly checking older versions.
-          min: 1.68.0
-          target: ${{ matrix.target }}
+          min: 1.68.2
 
   # NOTE: In GitHub repository settings, the "Require status checks to pass
   # before merging" branch protection rule ensures that commits are only merged

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,9 @@ jobs:
       - uses: ZettaScaleLabs/ci/check-msrv@develop
         with:
           repo: ${{ github.repository }}
+          # NOTE: As of commit 25f06bd, the minimum MSRV found in the workspace is 1.68.
+          # This value should be as low as possible to avoid needlessly checking older versions.
+          min: 1.68
 
   # NOTE: In GitHub repository settings, the "Require status checks to pass
   # before merging" branch protection rule ensures that commits are only merged

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
         with:
           repo: ${{ github.repository }}
           # NOTE: As of commit 25f06bd, the minimum MSRV found in the workspace is 1.68.
-          # This value should be as low as possible to avoid needlessly checking older versions.
+          # This value should be as high as possible to avoid needlessly checking older versions.
           min: 1.68.0
 
   # NOTE: In GitHub repository settings, the "Require status checks to pass

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,11 @@ jobs:
       - name: Install latest cargo-deny
         uses: taiki-e/install-action@cargo-deny
 
+      - name: Check MSRV
+        uses: ZettaScaleLabs/ci/check-msrv@develop
+        with:
+          repo: ${{ github.repository }}
+
       - name: Code format check
         run: cargo fmt --check
 
@@ -73,11 +78,6 @@ jobs:
 
       - name: Check licenses
         run: cargo deny check licenses
-
-      - name: Check MSRV
-        uses: ZettaScaleLabs/ci/check-msrv@develop
-        with:
-          repo: ${{ github.repository }}
 
   test:
     name: Unit tests on ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,6 @@ jobs:
       - name: Install latest cargo-deny
         uses: taiki-e/install-action@cargo-deny
 
-      - name: Check MSRV
-        uses: ZettaScaleLabs/ci/check-msrv@develop
-        with:
-          repo: ${{ github.repository }}
-
       - name: Code format check
         run: cargo fmt --check
 
@@ -142,11 +137,22 @@ jobs:
     name: Typos Check
     runs-on: ubuntu-latest
     steps:
-      - name: Clone this repository 
+      - name: Clone this repository
         uses: actions/checkout@v4
 
       - name: Check spelling
         uses: crate-ci/typos@master
+
+  msrvs:
+    name: Check crate MSRVs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone this repository
+        uses: actions/checkout@v4
+
+      - uses: ZettaScaleLabs/ci/check-msrv@develop
+        with:
+          repo: ${{ github.repository }}
 
   # NOTE: In GitHub repository settings, the "Require status checks to pass
   # before merging" branch protection rule ensures that commits are only merged

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,11 @@ jobs:
       - name: Check licenses
         run: cargo deny check licenses
 
+      - name: Check MSRV
+        uses: ZettaScaleLabs/ci/check-msrv@develop
+        with:
+          repo: ${{ github.repository }}
+
   test:
     name: Unit tests on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
         uses: crate-ci/typos@master
 
   msrvs:
-    name: Check crate MSRVs
+    name: MSRV checks
     runs-on: ubuntu-latest
     steps:
       - name: Clone this repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
           repo: ${{ github.repository }}
           # NOTE: As of commit 25f06bd, the minimum MSRV found in the workspace is 1.68.
           # This value should be as low as possible to avoid needlessly checking older versions.
-          min: 1.68
+          min: 1.68.0
 
   # NOTE: In GitHub repository settings, the "Require status checks to pass
   # before merging" branch protection rule ensures that commits are only merged

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ crc = "3.0.1"
 criterion = "0.5"
 derive_more = "0.99.17"
 derive-new = "0.6.0"
-tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
+tracing-subscriber = {version = "0.3", features = ["json", "env-filter"]}
 tracing-loki = "0.2"
 event-listener = "4.0.0"
 flume = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ members = [
 exclude = ["ci/nostd-check", "ci/valgrind-check"]
 
 [workspace.package]
-rust-version = "1.72.0"
+rust-version = "1.72.1"
 version = "0.11.0-dev" # Zenoh version
 repository = "https://github.com/eclipse-zenoh/zenoh"
 homepage = "http://zenoh.io"
@@ -91,7 +91,7 @@ crc = "3.0.1"
 criterion = "0.5"
 derive_more = "0.99.17"
 derive-new = "0.6.0"
-tracing-subscriber = {version = "0.3", features = ["json", "env-filter"]}
+tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 tracing-loki = "0.2"
 event-listener = "4.0.0"
 flume = "0.11"

--- a/commons/zenoh-buffers/Cargo.toml
+++ b/commons/zenoh-buffers/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-buffers"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-buffers/Cargo.toml
+++ b/commons/zenoh-buffers/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.68.0"
+rust-version = "1.68.2"
 name = "zenoh-buffers"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-buffers/Cargo.toml
+++ b/commons/zenoh-buffers/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.68.0"
 name = "zenoh-buffers"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-codec/Cargo.toml
+++ b/commons/zenoh-codec/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.68.0"
 name = "zenoh-codec"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-codec/Cargo.toml
+++ b/commons/zenoh-codec/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.68.2"
+rust-version = "1.72.1"
 name = "zenoh-codec"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-codec/Cargo.toml
+++ b/commons/zenoh-codec/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-codec"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-codec/Cargo.toml
+++ b/commons/zenoh-codec/Cargo.toml
@@ -12,15 +12,15 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.68.0"
+rust-version = "1.68.2"
 name = "zenoh-codec"
 version = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 authors = [
-	"kydos <angelo@icorsaro.net>",
-	"Luca Cominardi <luca.cominardi@zettascale.tech>",
-	"Pierre Avital <pierre.avital@zettascale.tech>",
+    "kydos <angelo@icorsaro.net>",
+    "Luca Cominardi <luca.cominardi@zettascale.tech>",
+    "Pierre Avital <pierre.avital@zettascale.tech>",
 ]
 edition = { workspace = true }
 license = { workspace = true }
@@ -30,21 +30,12 @@ description = "Internal crate for zenoh."
 
 [features]
 default = ["std"]
-std = [
-    "tracing",
-    "serde/std",
-    "uhlc/std",
-    "zenoh-protocol/std"
-]
-shared-memory = [
-    "std",
-    "zenoh-shm",
-    "zenoh-protocol/shared-memory"
-]
+std = ["tracing", "serde/std", "uhlc/std", "zenoh-protocol/std"]
+shared-memory = ["std", "zenoh-shm", "zenoh-protocol/shared-memory"]
 complete_n = ["zenoh-protocol/complete_n"]
 
 [dependencies]
-tracing = {workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
 serde = { workspace = true, features = ["alloc"] }
 uhlc = { workspace = true }
 zenoh-buffers = { workspace = true, default-features = false }
@@ -57,7 +48,7 @@ criterion = { workspace = true }
 
 rand = { workspace = true, features = ["default"] }
 zenoh-protocol = { workspace = true, features = ["test"] }
-zenoh-util = {workspace = true }
+zenoh-util = { workspace = true }
 
 [[bench]]
 name = "codec"

--- a/commons/zenoh-collections/Cargo.toml
+++ b/commons/zenoh-collections/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.68.0"
 name = "zenoh-collections"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-collections/Cargo.toml
+++ b/commons/zenoh-collections/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.68.0"
+rust-version = "1.68.2"
 name = "zenoh-collections"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-collections/Cargo.toml
+++ b/commons/zenoh-collections/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-collections"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-config/Cargo.toml
+++ b/commons/zenoh-config/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.70.0"
 name = "zenoh-config"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-config/Cargo.toml
+++ b/commons/zenoh-config/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-config"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-config/Cargo.toml
+++ b/commons/zenoh-config/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.70.0"
+rust-version = "1.72.1"
 name = "zenoh-config"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-core/Cargo.toml
+++ b/commons/zenoh-core/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.70.0"
 name = "zenoh-core"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-core/Cargo.toml
+++ b/commons/zenoh-core/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-core"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-core/Cargo.toml
+++ b/commons/zenoh-core/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.70.0"
+rust-version = "1.72.1"
 name = "zenoh-core"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-crypto/Cargo.toml
+++ b/commons/zenoh-crypto/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.68.0"
+rust-version = "1.68.2"
 name = "zenoh-crypto"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-crypto/Cargo.toml
+++ b/commons/zenoh-crypto/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-crypto"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-crypto/Cargo.toml
+++ b/commons/zenoh-crypto/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.68.0"
 name = "zenoh-crypto"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-keyexpr/Cargo.toml
+++ b/commons/zenoh-keyexpr/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.68.0"
 name = "zenoh-keyexpr"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-keyexpr/Cargo.toml
+++ b/commons/zenoh-keyexpr/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.68.2"
+rust-version = "1.72.1"
 name = "zenoh-keyexpr"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-keyexpr/Cargo.toml
+++ b/commons/zenoh-keyexpr/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-keyexpr"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-keyexpr/Cargo.toml
+++ b/commons/zenoh-keyexpr/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.68.0"
+rust-version = "1.68.2"
 name = "zenoh-keyexpr"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-macros/Cargo.toml
+++ b/commons/zenoh-macros/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.70.0"
 name = "zenoh-macros"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-macros/Cargo.toml
+++ b/commons/zenoh-macros/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-macros"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-macros/Cargo.toml
+++ b/commons/zenoh-macros/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.70.0"
+rust-version = "1.72.1"
 name = "zenoh-macros"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-protocol/Cargo.toml
+++ b/commons/zenoh-protocol/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.68.0"
 name = "zenoh-protocol"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-protocol/Cargo.toml
+++ b/commons/zenoh-protocol/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.68.0"
+rust-version = "1.68.2"
 name = "zenoh-protocol"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-protocol/Cargo.toml
+++ b/commons/zenoh-protocol/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-protocol"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-protocol/Cargo.toml
+++ b/commons/zenoh-protocol/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.68.2"
+rust-version = "1.72.1"
 name = "zenoh-protocol"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-result/Cargo.toml
+++ b/commons/zenoh-result/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-result"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-result/Cargo.toml
+++ b/commons/zenoh-result/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.68.0"
 name = "zenoh-result"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-result/Cargo.toml
+++ b/commons/zenoh-result/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.68.0"
+rust-version = "1.68.2"
 name = "zenoh-result"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-runtime/Cargo.toml
+++ b/commons/zenoh-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zenoh-runtime"
-rust-version = "1.70.0"
+rust-version = "1.72.1"
 version = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/commons/zenoh-runtime/Cargo.toml
+++ b/commons/zenoh-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zenoh-runtime"
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 version = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/commons/zenoh-runtime/Cargo.toml
+++ b/commons/zenoh-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zenoh-runtime"
-rust-version = "1.66.1"
+rust-version = "1.70.0"
 version = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/commons/zenoh-shm/Cargo.toml
+++ b/commons/zenoh-shm/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-shm"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-shm/Cargo.toml
+++ b/commons/zenoh-shm/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.68.0"
+rust-version = "1.68.2"
 name = "zenoh-shm"
 version = { workspace = true }
 repository = { workspace = true }
@@ -29,7 +29,7 @@ description = "Internal crate for zenoh."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tracing = {workspace = true}
+tracing = { workspace = true }
 serde = { workspace = true, features = ["default"] }
 shared_memory = { workspace = true }
 zenoh-buffers = { workspace = true }

--- a/commons/zenoh-shm/Cargo.toml
+++ b/commons/zenoh-shm/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.68.0"
 name = "zenoh-shm"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-sync/Cargo.toml
+++ b/commons/zenoh-sync/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.70.0"
 name = "zenoh-sync"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-sync/Cargo.toml
+++ b/commons/zenoh-sync/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-sync"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-sync/Cargo.toml
+++ b/commons/zenoh-sync/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.70.0"
+rust-version = "1.72.1"
 name = "zenoh-sync"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-task/Cargo.toml
+++ b/commons/zenoh-task/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.70.0"
 name = "zenoh-task"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-task/Cargo.toml
+++ b/commons/zenoh-task/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.70.0"
+rust-version = "1.72.1"
 name = "zenoh-task"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-task/Cargo.toml
+++ b/commons/zenoh-task/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-task"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-util/Cargo.toml
+++ b/commons/zenoh-util/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-util"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-util/Cargo.toml
+++ b/commons/zenoh-util/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.70.0"
 name = "zenoh-util"
 version = { workspace = true }
 repository = { workspace = true }

--- a/commons/zenoh-util/Cargo.toml
+++ b/commons/zenoh-util/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.70.0"
+rust-version = "1.72.1"
 name = "zenoh-util"
 version = { workspace = true }
 repository = { workspace = true }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.70.0"
 name = "zenoh-examples"
 version = { workspace = true }
 repository = { workspace = true }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-examples"
 version = { workspace = true }
 repository = { workspace = true }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.70.0"
+rust-version = "1.72.1"
 name = "zenoh-examples"
 version = { workspace = true }
 repository = { workspace = true }

--- a/io/zenoh-link-commons/Cargo.toml
+++ b/io/zenoh-link-commons/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.70.0"
 authors = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh."
@@ -20,7 +21,6 @@ homepage = { workspace = true }
 license = { workspace = true }
 name = "zenoh-link-commons"
 repository = { workspace = true }
-rust-version = "1.66.1"
 version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/io/zenoh-link-commons/Cargo.toml
+++ b/io/zenoh-link-commons/Cargo.toml
@@ -20,7 +20,7 @@ homepage = { workspace = true }
 license = { workspace = true }
 name = "zenoh-link-commons"
 repository = { workspace = true }
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/io/zenoh-link-commons/Cargo.toml
+++ b/io/zenoh-link-commons/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.70.0"
+rust-version = "1.72.1"
 authors = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh."

--- a/io/zenoh-link/Cargo.toml
+++ b/io/zenoh-link/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-link"
 version = { workspace = true }
 repository = { workspace = true }

--- a/io/zenoh-link/Cargo.toml
+++ b/io/zenoh-link/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.70.0"
+rust-version = "1.72.1"
 name = "zenoh-link"
 version = { workspace = true }
 repository = { workspace = true }

--- a/io/zenoh-link/Cargo.toml
+++ b/io/zenoh-link/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.70.0"
 name = "zenoh-link"
 version = { workspace = true }
 repository = { workspace = true }

--- a/io/zenoh-links/zenoh-link-quic/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-quic/Cargo.toml
@@ -20,7 +20,7 @@ homepage = { workspace = true }
 license = { workspace = true }
 name = "zenoh-link-quic"
 repository = { workspace = true }
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/io/zenoh-links/zenoh-link-quic/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-quic/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.70.0"
+rust-version = "1.72.1"
 authors = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh."

--- a/io/zenoh-links/zenoh-link-quic/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-quic/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.70.0"
 authors = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh."
@@ -20,7 +21,6 @@ homepage = { workspace = true }
 license = { workspace = true }
 name = "zenoh-link-quic"
 repository = { workspace = true }
-rust-version = "1.66.1"
 version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/io/zenoh-links/zenoh-link-serial/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-serial/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-link-serial"
 version = { workspace = true }
 repository = { workspace = true }

--- a/io/zenoh-links/zenoh-link-serial/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-serial/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.70.0"
+rust-version = "1.72.1"
 name = "zenoh-link-serial"
 version = { workspace = true }
 repository = { workspace = true }

--- a/io/zenoh-links/zenoh-link-serial/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-serial/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.70.0"
 name = "zenoh-link-serial"
 version = { workspace = true }
 repository = { workspace = true }

--- a/io/zenoh-links/zenoh-link-tcp/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-tcp/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.70.0"
+rust-version = "1.72.1"
 name = "zenoh-link-tcp"
 version = { workspace = true }
 repository = { workspace = true }

--- a/io/zenoh-links/zenoh-link-tcp/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-tcp/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.70.0"
 name = "zenoh-link-tcp"
 version = { workspace = true }
 repository = { workspace = true }

--- a/io/zenoh-links/zenoh-link-tcp/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-tcp/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-link-tcp"
 version = { workspace = true }
 repository = { workspace = true }

--- a/io/zenoh-links/zenoh-link-tls/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-tls/Cargo.toml
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
+rust-version = "1.70.0"
 authors = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh."
@@ -20,7 +21,6 @@ homepage = { workspace = true }
 license = { workspace = true }
 name = "zenoh-link-tls"
 repository = { workspace = true }
-rust-version = "1.66.1"
 version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/io/zenoh-links/zenoh-link-tls/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-tls/Cargo.toml
@@ -20,7 +20,7 @@ homepage = { workspace = true }
 license = { workspace = true }
 name = "zenoh-link-tls"
 repository = { workspace = true }
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/io/zenoh-links/zenoh-link-tls/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-tls/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.70.0"
+rust-version = "1.72.1"
 authors = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh."

--- a/io/zenoh-links/zenoh-link-udp/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-udp/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.70.0"
 name = "zenoh-link-udp"
 version = { workspace = true }
 repository = { workspace = true }

--- a/io/zenoh-links/zenoh-link-udp/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-udp/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-link-udp"
 version = { workspace = true }
 repository = { workspace = true }

--- a/io/zenoh-links/zenoh-link-udp/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-udp/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.70.0"
+rust-version = "1.72.1"
 name = "zenoh-link-udp"
 version = { workspace = true }
 repository = { workspace = true }

--- a/io/zenoh-links/zenoh-link-unixpipe/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-unixpipe/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.70.0"
+rust-version = "1.72.1"
 name = "zenoh-link-unixpipe"
 version = { workspace = true }
 repository = { workspace = true }

--- a/io/zenoh-links/zenoh-link-unixpipe/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-unixpipe/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.70.0"
 name = "zenoh-link-unixpipe"
 version = { workspace = true }
 repository = { workspace = true }

--- a/io/zenoh-links/zenoh-link-unixpipe/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-unixpipe/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-link-unixpipe"
 version = { workspace = true }
 repository = { workspace = true }

--- a/io/zenoh-links/zenoh-link-unixsock_stream/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-unixsock_stream/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-link-unixsock_stream"
 version = { workspace = true }
 repository = { workspace = true }

--- a/io/zenoh-links/zenoh-link-unixsock_stream/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-unixsock_stream/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.70.0"
 name = "zenoh-link-unixsock_stream"
 version = { workspace = true }
 repository = { workspace = true }

--- a/io/zenoh-links/zenoh-link-unixsock_stream/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-unixsock_stream/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.70.0"
+rust-version = "1.72.1"
 name = "zenoh-link-unixsock_stream"
 version = { workspace = true }
 repository = { workspace = true }

--- a/io/zenoh-links/zenoh-link-vsock/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-vsock/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.70.0"
+rust-version = "1.72.1"
 name = "zenoh-link-vsock"
 version = { workspace = true }
 repository = { workspace = true }

--- a/io/zenoh-links/zenoh-link-vsock/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-vsock/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.70.0"
 name = "zenoh-link-vsock"
 version = { workspace = true }
 repository = { workspace = true }

--- a/io/zenoh-links/zenoh-link-vsock/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-vsock/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-link-vsock"
 version = { workspace = true }
 repository = { workspace = true }

--- a/io/zenoh-links/zenoh-link-ws/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-ws/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-link-ws"
 version = { workspace = true }
 repository = { workspace = true }

--- a/io/zenoh-links/zenoh-link-ws/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-ws/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.70.0"
+rust-version = "1.72.1"
 name = "zenoh-link-ws"
 version = { workspace = true }
 repository = { workspace = true }

--- a/io/zenoh-links/zenoh-link-ws/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-ws/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.70.0"
 name = "zenoh-link-ws"
 version = { workspace = true }
 repository = { workspace = true }

--- a/io/zenoh-transport/Cargo.toml
+++ b/io/zenoh-transport/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.70.0"
 name = "zenoh-transport"
 version = { workspace = true }
 repository = { workspace = true }

--- a/io/zenoh-transport/Cargo.toml
+++ b/io/zenoh-transport/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.70.0"
+rust-version = "1.72.1"
 name = "zenoh-transport"
 version = { workspace = true }
 repository = { workspace = true }

--- a/io/zenoh-transport/Cargo.toml
+++ b/io/zenoh-transport/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-transport"
 version = { workspace = true }
 repository = { workspace = true }

--- a/plugins/zenoh-backend-example/Cargo.toml
+++ b/plugins/zenoh-backend-example/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.70.0"
 name = "zenoh-backend-example"
 version = { workspace = true }
 authors = { workspace = true }

--- a/plugins/zenoh-backend-example/Cargo.toml
+++ b/plugins/zenoh-backend-example/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.70.0"
+rust-version = "1.72.1"
 name = "zenoh-backend-example"
 version = { workspace = true }
 authors = { workspace = true }

--- a/plugins/zenoh-backend-example/Cargo.toml
+++ b/plugins/zenoh-backend-example/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-backend-example"
 version = { workspace = true }
 authors = { workspace = true }

--- a/plugins/zenoh-backend-traits/Cargo.toml
+++ b/plugins/zenoh-backend-traits/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.70.0"
+rust-version = "1.72.1"
 name = "zenoh_backend_traits"
 version = { workspace = true }
 repository = { workspace = true }

--- a/plugins/zenoh-backend-traits/Cargo.toml
+++ b/plugins/zenoh-backend-traits/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh_backend_traits"
 version = { workspace = true }
 repository = { workspace = true }

--- a/plugins/zenoh-backend-traits/Cargo.toml
+++ b/plugins/zenoh-backend-traits/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.70.0"
 name = "zenoh_backend_traits"
 version = { workspace = true }
 repository = { workspace = true }

--- a/plugins/zenoh-plugin-example/Cargo.toml
+++ b/plugins/zenoh-plugin-example/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-plugin-example"
 version = { workspace = true }
 authors = { workspace = true }

--- a/plugins/zenoh-plugin-example/Cargo.toml
+++ b/plugins/zenoh-plugin-example/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.70.0"
 name = "zenoh-plugin-example"
 version = { workspace = true }
 authors = { workspace = true }

--- a/plugins/zenoh-plugin-example/Cargo.toml
+++ b/plugins/zenoh-plugin-example/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.70.0"
+rust-version = "1.72.1"
 name = "zenoh-plugin-example"
 version = { workspace = true }
 authors = { workspace = true }

--- a/plugins/zenoh-plugin-rest/Cargo.toml
+++ b/plugins/zenoh-plugin-rest/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.70.0"
+rust-version = "1.72.1"
 name = "zenoh-plugin-rest"
 version = { workspace = true }
 repository = { workspace = true }
@@ -36,13 +36,13 @@ anyhow = { workspace = true, features = ["default"] }
 async-std = { workspace = true, features = ["default", "attributes"] }
 base64 = { workspace = true }
 const_format = { workspace = true }
-zenoh-util = {workspace = true }
+zenoh-util = { workspace = true }
 flume = { workspace = true }
 futures = { workspace = true }
 git-version = { workspace = true }
 http-types = { workspace = true }
 lazy_static = { workspace = true }
-tracing = {workspace = true}
+tracing = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["default"] }
 serde_json = { workspace = true }

--- a/plugins/zenoh-plugin-rest/Cargo.toml
+++ b/plugins/zenoh-plugin-rest/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.70.0"
 name = "zenoh-plugin-rest"
 version = { workspace = true }
 repository = { workspace = true }

--- a/plugins/zenoh-plugin-rest/Cargo.toml
+++ b/plugins/zenoh-plugin-rest/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-plugin-rest"
 version = { workspace = true }
 repository = { workspace = true }

--- a/plugins/zenoh-plugin-storage-manager/Cargo.toml
+++ b/plugins/zenoh-plugin-storage-manager/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-plugin-storage-manager"
 version = { workspace = true }
 repository = { workspace = true }

--- a/plugins/zenoh-plugin-storage-manager/Cargo.toml
+++ b/plugins/zenoh-plugin-storage-manager/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.70.0"
 name = "zenoh-plugin-storage-manager"
 version = { workspace = true }
 repository = { workspace = true }

--- a/plugins/zenoh-plugin-storage-manager/Cargo.toml
+++ b/plugins/zenoh-plugin-storage-manager/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.70.0"
+rust-version = "1.72.1"
 name = "zenoh-plugin-storage-manager"
 version = { workspace = true }
 repository = { workspace = true }

--- a/plugins/zenoh-plugin-trait/Cargo.toml
+++ b/plugins/zenoh-plugin-trait/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.70.0"
+rust-version = "1.72.1"
 name = "zenoh-plugin-trait"
 version = { workspace = true }
 repository = { workspace = true }
@@ -28,7 +28,7 @@ name = "zenoh_plugin_trait"
 
 [dependencies]
 libloading = { workspace = true }
-tracing = {workspace = true}
+tracing = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 zenoh-macros = { workspace = true }

--- a/plugins/zenoh-plugin-trait/Cargo.toml
+++ b/plugins/zenoh-plugin-trait/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-plugin-trait"
 version = { workspace = true }
 repository = { workspace = true }

--- a/plugins/zenoh-plugin-trait/Cargo.toml
+++ b/plugins/zenoh-plugin-trait/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.70.0"
 name = "zenoh-plugin-trait"
 version = { workspace = true }
 repository = { workspace = true }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.72.0"
+channel = "1.72.1"

--- a/zenoh-ext/Cargo.toml
+++ b/zenoh-ext/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-ext"
 version = { workspace = true }
 repository = { workspace = true }

--- a/zenoh-ext/Cargo.toml
+++ b/zenoh-ext/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.70.0"
 name = "zenoh-ext"
 version = { workspace = true }
 repository = { workspace = true }

--- a/zenoh-ext/Cargo.toml
+++ b/zenoh-ext/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.70.0"
+rust-version = "1.72.1"
 name = "zenoh-ext"
 version = { workspace = true }
 repository = { workspace = true }

--- a/zenoh-ext/examples/Cargo.toml
+++ b/zenoh-ext/examples/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.70.0"
+rust-version = "1.72.1"
 name = "zenoh-ext-examples"
 version = { workspace = true }
 repository = { workspace = true }

--- a/zenoh-ext/examples/Cargo.toml
+++ b/zenoh-ext/examples/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh-ext-examples"
 version = { workspace = true }
 repository = { workspace = true }

--- a/zenoh-ext/examples/Cargo.toml
+++ b/zenoh-ext/examples/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.70.0"
 name = "zenoh-ext-examples"
 version = { workspace = true }
 repository = { workspace = true }

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.66.1"
+rust-version = "1.70.0"
 name = "zenoh"
 version = { workspace = true }
 repository = { workspace = true }

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.70.0"
+rust-version = "1.72.1"
 name = "zenoh"
 version = { workspace = true }
 repository = { workspace = true }

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.66.1"
 name = "zenoh"
 version = { workspace = true }
 repository = { workspace = true }

--- a/zenohd/Cargo.toml
+++ b/zenohd/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = "1.72.0"
+rust-version = "1.72.1"
 name = "zenohd"
 version = { workspace = true }
 repository = { workspace = true }
@@ -28,20 +28,20 @@ readme = "README.md"
 [features]
 default = ["zenoh/default"]
 shared-memory = ["zenoh/shared-memory"]
-loki = ["tracing-loki","url"]
+loki = ["tracing-loki", "url"]
 
 [dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 clap = { workspace = true, features = ["derive"] }
-zenoh-util = {workspace = true }
+zenoh-util = { workspace = true }
 futures = { workspace = true }
 git-version = { workspace = true }
 json5 = { workspace = true }
 lazy_static = { workspace = true }
-tracing = {workspace = true}
-tracing-subscriber = {workspace = true}
-tracing-loki = {workspace = true, optional = true }
-url = {workspace = true, optional = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+tracing-loki = { workspace = true, optional = true }
+url = { workspace = true, optional = true }
 zenoh = { workspace = true, features = ["unstable", "plugins"] }
 
 [dev-dependencies]

--- a/zenohd/Cargo.toml
+++ b/zenohd/Cargo.toml
@@ -12,7 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
+rust-version = "1.72.0"
 name = "zenohd"
 version = { workspace = true }
 repository = { workspace = true }


### PR DESCRIPTION
This add a check for the MSRV of all crates in the workspace. Each crate has its own MSRV specified through `package.rust-version`.