### PR TITLE
ci: speedup the cargo deny installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Update Stable Rust toolchain
         run: rustup update stable
 
-      - name: Install dependencies
-        run: cargo +stable install cargo-deny --locked
+      - name: Install latest cargo-deny
+        uses: taiki-e/install-action@cargo-deny
 
       - name: Code format check
         run: cargo fmt --check


### PR DESCRIPTION
With this change, the CI would download the binary instead and save us up to four minutes for each check.