### PR TITLE
Exposing api::encoding internal values through `mod internals`

### DIFF
--- a/zenoh/src/api/encoding.rs
+++ b/zenoh/src/api/encoding.rs
@@ -836,6 +836,22 @@ impl EncodingMapping for serde_pickle::Value {
     const ENCODING: Encoding = Encoding::APPLICATION_PYTHON_SERIALIZED_OBJECT;
 }
 
+pub trait EncodingInternals {
+    fn id(&self) -> u16;
+
+    fn schema(&self) -> Option<&ZSlice>;
+}
+
+impl EncodingInternals for Encoding {
+    fn id(&self) -> u16 {
+        self.0.id
+    }
+
+    fn schema(&self) -> Option<&ZSlice> {
+        self.0.schema.as_ref()
+    }
+}
+
 // - Zenoh SHM
 #[cfg(feature = "shared-memory")]
 impl EncodingMapping for ZShm {

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -376,6 +376,8 @@ pub mod internal {
     pub use zenoh_util::{
         core::ResolveFuture, zenoh_home, LibLoader, Timed, TimedEvent, Timer, ZENOH_HOME_ENV_VAR,
     };
+
+    pub use crate::api::encoding::EncodingInternals;
 }
 
 #[cfg(all(feature = "unstable", feature = "shared-memory"))]


### PR DESCRIPTION
This allows bindings to access them, simplifying the communication with the end language.