### PR TITLE
Adding `new` function to EncodingInternals

### DIFF
--- a/zenoh/src/api/encoding.rs
+++ b/zenoh/src/api/encoding.rs
@@ -840,6 +840,8 @@ pub trait EncodingInternals {
     fn id(&self) -> u16;
 
     fn schema(&self) -> Option<&ZSlice>;
+
+    fn new(id: u16, schema: Option<ZSlice>) -> Self;
 }
 
 impl EncodingInternals for Encoding {
@@ -849,6 +851,10 @@ impl EncodingInternals for Encoding {
 
     fn schema(&self) -> Option<&ZSlice> {
         self.0.schema.as_ref()
+    }
+
+    fn new(id: u16, schema: Option<ZSlice>) -> Self {
+        Encoding(zenoh_protocol::core::Encoding { id, schema })
     }
 }
 


### PR DESCRIPTION
Related to PR #1046. 

This PR adds a function to `EncodingInternals` with the signature `new(id: u16, schema: Option<ZSlice>) -> Encoding` which allows to recreate an Encoding instance.

This is meant to be used on bindings, providing the encoding id as a numeric value.