### PR TITLE
fix: Relax lifetime bounds in endpoint `as_str` methods

### DIFF
--- a/commons/zenoh-protocol/src/core/endpoint.rs
+++ b/commons/zenoh-protocol/src/core/endpoint.rs
@@ -141,7 +141,7 @@ impl Parameters {
 pub struct Protocol<'a>(pub(super) &'a str);
 
 impl<'a> Protocol<'a> {
-    pub fn as_str(&'a self) -> &'a str {
+    pub fn as_str(&self) -> &'a str {
         self.0
     }
 }
@@ -205,7 +205,7 @@ impl fmt::Debug for ProtocolMut<'_> {
 pub struct Address<'a>(pub(super) &'a str);
 
 impl<'a> Address<'a> {
-    pub fn as_str(&'a self) -> &'a str {
+    pub fn as_str(&self) -> &'a str {
         self.0
     }
 }
@@ -269,7 +269,7 @@ impl fmt::Debug for AddressMut<'_> {
 pub struct Metadata<'a>(pub(super) &'a str);
 
 impl<'a> Metadata<'a> {
-    pub fn as_str(&'a self) -> &'a str {
+    pub fn as_str(&self) -> &'a str {
         self.0
     }
 
@@ -386,7 +386,7 @@ impl fmt::Debug for MetadataMut<'_> {
 pub struct Config<'a>(pub(super) &'a str);
 
 impl<'a> Config<'a> {
-    pub fn as_str(&'a self) -> &'a str {
+    pub fn as_str(&self) -> &'a str {
         self.0
     }
 


### PR DESCRIPTION
Writing

```rust
pub struct Protocol<'a>(pub(super) &'a str);

impl<'a> Protocol<'a> {
    pub fn as_str(&self) -> &'a str {
        self.0
    }
}
```

means that given a a borrow of arbitrary lifetime to `Protocol<'a>`, we can produce a `str` borrow of lifetime `'a`.

Previously, the lifetime bounds necessitated having a `&'a Protocol<'a>`. This means that the reference to the `Protocol<'a>` would have to outlive `'a`, which is not necessarily the case and leads to errors like:

```text
let mut addresses = endpoint.address().as_str();
                    ^^^^^^^^^^^^^^^^^^---------- temporary value is freed at the end of this statement
                    |
                    creates a temporary value which is freed while still in use
                    argument requires that borrow lasts for `'a`
```

Note that this cannot apply to the `*Mut` structures.