### PR TITLE
fix(1059): adding explicit plugin id in PluginStatus and PluginManager

### DIFF
--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -1021,6 +1021,7 @@ fn load_external_plugin_config(title: &str, value: &mut Value) -> ZResult<()> {
 #[derive(Debug, Clone)]
 pub struct PluginLoad {
     pub name: String,
+    pub id: String,
     pub paths: Option<Vec<String>>,
     pub required: bool,
 }
@@ -1045,15 +1046,20 @@ impl PluginsConfig {
                 Some(Value::Bool(b)) => *b,
                 _ => panic!("Plugin '{}' has an invalid '__required__' configuration property (must be a boolean)", name)
             };
+            let id = match value.get("__plugin__") {
+                Some(Value::String(p)) => p,
+                _ => name,
+            };
+
             if let Some(paths) = value.get("__path__"){
                 let paths = match paths {
                     Value::String(s) => vec![s.clone()],
                     Value::Array(a) => a.iter().map(|s| if let Value::String(s) = s {s.clone()} else {panic!("Plugin '{}' has an invalid '__path__' configuration property (must be either string or array of strings)", name)}).collect(),
                     _ => panic!("Plugin '{}' has an invalid '__path__' configuration property (must be either string or array of strings)", name)
                 };
-                PluginLoad {name: name.clone(), paths: Some(paths), required}
+                PluginLoad {id: id.clone(), name: name.clone(), paths: Some(paths), required}
             } else {
-                PluginLoad {name: name.clone(), paths: None, required}
+                PluginLoad {id: id.clone(), name: name.clone(), paths: None, required}
             }
         })
     }

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -1020,8 +1020,8 @@ fn load_external_plugin_config(title: &str, value: &mut Value) -> ZResult<()> {
 
 #[derive(Debug, Clone)]
 pub struct PluginLoad {
-    pub name: String,
     pub id: String,
+    pub name: String,
     pub paths: Option<Vec<String>>,
     pub required: bool,
 }
@@ -1054,8 +1054,8 @@ impl PluginsConfig {
             if let Some(paths) = value.get("__path__"){
                 let paths = match paths {
                     Value::String(s) => vec![s.clone()],
-                    Value::Array(a) => a.iter().map(|s| if let Value::String(s) = s {s.clone()} else {panic!("Plugin '{}' has an invalid '__path__' configuration property (must be either string or array of strings)", name)}).collect(),
-                    _ => panic!("Plugin '{}' has an invalid '__path__' configuration property (must be either string or array of strings)", name)
+                    Value::Array(a) => a.iter().map(|s| if let Value::String(s) = s {s.clone()} else {panic!("Plugin '{}' has an invalid '__path__' configuration property (must be either string or array of strings)", id)}).collect(),
+                    _ => panic!("Plugin '{}' has an invalid '__path__' configuration property (must be either string or array of strings)", id)
                 };
                 PluginLoad {id: id.clone(), name: name.clone(), paths: Some(paths), required}
             } else {

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -1039,16 +1039,16 @@ impl PluginsConfig {
         Ok(())
     }
     pub fn load_requests(&'_ self) -> impl Iterator<Item = PluginLoad> + '_ {
-        self.values.as_object().unwrap().iter().map(|(name, value)| {
+        self.values.as_object().unwrap().iter().map(|(id, value)| {
             let value = value.as_object().expect("Plugin configurations must be objects");
             let required = match value.get("__required__") {
                 None => false,
                 Some(Value::Bool(b)) => *b,
-                _ => panic!("Plugin '{}' has an invalid '__required__' configuration property (must be a boolean)", name)
+                _ => panic!("Plugin '{}' has an invalid '__required__' configuration property (must be a boolean)", id)
             };
-            let id = match value.get("__plugin__") {
+            let name = match value.get("__plugin__") {
                 Some(Value::String(p)) => p,
-                _ => name,
+                _ => id,
             };
 
             if let Some(paths) = value.get("__path__"){

--- a/plugins/zenoh-backend-traits/src/config.rs
+++ b/plugins/zenoh-backend-traits/src/config.rs
@@ -36,7 +36,6 @@ pub struct PluginConfig {
     #[as_mut]
     #[schemars(skip)]
     pub rest: Map<String, Value>,
-    __plugin__: Option<String>,
 }
 #[derive(JsonSchema, Debug, Clone, AsMut, AsRef)]
 pub struct VolumeConfig {

--- a/plugins/zenoh-backend-traits/src/config.rs
+++ b/plugins/zenoh-backend-traits/src/config.rs
@@ -36,6 +36,7 @@ pub struct PluginConfig {
     #[as_mut]
     #[schemars(skip)]
     pub rest: Map<String, Value>,
+    __plugin__: Option<String>,
 }
 #[derive(JsonSchema, Debug, Clone, AsMut, AsRef)]
 pub struct VolumeConfig {

--- a/plugins/zenoh-plugin-rest/src/config.rs
+++ b/plugins/zenoh-plugin-rest/src/config.rs
@@ -27,6 +27,7 @@ pub struct Config {
     __path__: Option<Vec<String>>,
     __required__: Option<bool>,
     __config__: Option<String>,
+    __plugin__: Option<String>,
 }
 
 impl From<&Config> for serde_json::Value {

--- a/plugins/zenoh-plugin-storage-manager/src/lib.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/lib.rs
@@ -205,12 +205,8 @@ impl StorageRuntimeInner {
                 true,
             )?
         } else {
-            self.plugins_manager.declare_dynamic_plugin_by_name(
-                backend_name,
-                volume_id,
-                backend_name,
-                true,
-            )?
+            self.plugins_manager
+                .declare_dynamic_plugin_by_name(volume_id, backend_name, true)?
         };
         let loaded = declared.load()?;
         loaded.start(config)?;

--- a/plugins/zenoh-plugin-storage-manager/src/lib.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/lib.rs
@@ -111,8 +111,9 @@ impl StorageRuntimeInner {
             .map(|search_dirs| LibLoader::new(&search_dirs, false))
             .unwrap_or_default();
 
-        let plugins_manager = PluginsManager::dynamic(lib_loader.clone(), BACKEND_LIB_PREFIX)
-            .declare_static_plugin::<MemoryBackend>(true);
+        let plugins_manager =
+            PluginsManager::dynamic(lib_loader.clone(), BACKEND_LIB_PREFIX)
+                .declare_static_plugin::<MemoryBackend, &str>(MEMORY_BACKEND_NAME, true);
 
         let session = Arc::new(zenoh::init(runtime.clone()).res_sync()?);
 
@@ -197,11 +198,19 @@ impl StorageRuntimeInner {
         let declared = if let Some(declared) = self.plugins_manager.plugin_mut(volume_id) {
             declared
         } else if let Some(paths) = config.paths() {
-            self.plugins_manager
-                .declare_dynamic_plugin_by_paths(volume_id, paths, true)?
+            self.plugins_manager.declare_dynamic_plugin_by_paths(
+                backend_name,
+                volume_id,
+                paths,
+                true,
+            )?
         } else {
-            self.plugins_manager
-                .declare_dynamic_plugin_by_name(volume_id, backend_name, true)?
+            self.plugins_manager.declare_dynamic_plugin_by_name(
+                backend_name,
+                volume_id,
+                backend_name,
+                true,
+            )?
         };
         let loaded = declared.load()?;
         loaded.start(config)?;
@@ -319,7 +328,7 @@ impl RunningPluginTrait for StorageRuntime {
         let guard = self.0.lock().unwrap();
         with_extended_string(&mut key, &["/volumes/"], |key| {
             for plugin in guard.plugins_manager.started_plugins_iter() {
-                with_extended_string(key, &[plugin.name()], |key| {
+                with_extended_string(key, &[plugin.id()], |key| {
                     with_extended_string(key, &["/__path__"], |key| {
                         if keyexpr::new(key.as_str())
                             .unwrap()

--- a/plugins/zenoh-plugin-trait/src/manager/dynamic_plugin.rs
+++ b/plugins/zenoh-plugin-trait/src/manager/dynamic_plugin.rs
@@ -222,9 +222,7 @@ impl<StartArgs: PluginStartArgs, Instance: PluginInstance> LoadedPlugin<StartArg
             .add_error(&mut self.report)?;
         let already_started = self.instance.is_some();
         if !already_started {
-            let instance = starter
-                .start(self.name(), args)
-                .add_error(&mut self.report)?;
+            let instance = starter.start(self.id(), args).add_error(&mut self.report)?;
             tracing::debug!("Plugin `{}` started", self.name);
             self.instance = Some(instance);
         } else {

--- a/plugins/zenoh-plugin-trait/src/manager/dynamic_plugin.rs
+++ b/plugins/zenoh-plugin-trait/src/manager/dynamic_plugin.rs
@@ -106,6 +106,7 @@ impl<StartArgs: PluginStartArgs, Instance: PluginInstance>
 
 pub struct DynamicPlugin<StartArgs, Instance> {
     name: String,
+    id: String,
     required: bool,
     report: PluginReport,
     source: DynamicPluginSource,
@@ -114,9 +115,10 @@ pub struct DynamicPlugin<StartArgs, Instance> {
 }
 
 impl<StartArgs, Instance> DynamicPlugin<StartArgs, Instance> {
-    pub fn new(name: String, source: DynamicPluginSource, required: bool) -> Self {
+    pub fn new(name: String, id: String, source: DynamicPluginSource, required: bool) -> Self {
         Self {
             name,
+            id,
             required,
             report: PluginReport::new(),
             source,
@@ -132,6 +134,11 @@ impl<StartArgs: PluginStartArgs, Instance: PluginInstance> PluginStatus
     fn name(&self) -> &str {
         self.name.as_str()
     }
+
+    fn id(&self) -> &str {
+        self.id.as_str()
+    }
+
     fn version(&self) -> Option<&str> {
         self.starter.as_ref().map(|v| v.vtable.plugin_version)
     }

--- a/plugins/zenoh-plugin-trait/src/manager/static_plugin.rs
+++ b/plugins/zenoh-plugin-trait/src/manager/static_plugin.rs
@@ -22,17 +22,19 @@ where
     instance: Option<Instance>,
     required: bool,
     phantom: PhantomData<P>,
+    id: String,
 }
 
 impl<StartArgs, Instance: PluginInstance, P> StaticPlugin<StartArgs, Instance, P>
 where
     P: Plugin<StartArgs = StartArgs, Instance = Instance>,
 {
-    pub fn new(required: bool) -> Self {
+    pub fn new(id: String, required: bool) -> Self {
         Self {
             instance: None,
             required,
             phantom: PhantomData,
+            id,
         }
     }
 }
@@ -44,6 +46,11 @@ where
     fn name(&self) -> &str {
         P::DEFAULT_NAME
     }
+
+    fn id(&self) -> &str {
+        self.id.as_str()
+    }
+
     fn version(&self) -> Option<&str> {
         Some(P::PLUGIN_VERSION)
     }

--- a/plugins/zenoh-plugin-trait/src/manager/static_plugin.rs
+++ b/plugins/zenoh-plugin-trait/src/manager/static_plugin.rs
@@ -107,7 +107,7 @@ where
     fn start(&mut self, args: &StartArgs) -> ZResult<&mut dyn StartedPlugin<StartArgs, Instance>> {
         if self.instance.is_none() {
             tracing::debug!("Plugin `{}` started", self.name());
-            self.instance = Some(P::start(self.name(), args)?);
+            self.instance = Some(P::start(self.id(), args)?);
         } else {
             tracing::warn!("Plugin `{}` already started", self.name());
         }

--- a/plugins/zenoh-plugin-trait/src/plugin.rs
+++ b/plugins/zenoh-plugin-trait/src/plugin.rs
@@ -62,6 +62,8 @@ pub struct PluginReport {
 pub trait PluginStatus {
     /// Returns the name of the plugin
     fn name(&self) -> &str;
+    /// Returns the ID of the plugin
+    fn id(&self) -> &str;
     /// Returns the version of the loaded plugin (usually the version of the plugin's crate)
     fn version(&self) -> Option<&str>;
     /// Returns the long version of the loaded plugin (usually the version of the plugin's crate + git commit hash)
@@ -79,6 +81,7 @@ pub trait PluginStatus {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PluginStatusRec<'a> {
     pub name: Cow<'a, str>,
+    pub id: Cow<'a, str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<Cow<'a, str>>,
     pub long_version: Option<Cow<'a, str>>,
@@ -91,6 +94,11 @@ impl PluginStatus for PluginStatusRec<'_> {
     fn name(&self) -> &str {
         &self.name
     }
+
+    fn id(&self) -> &str {
+        &self.id
+    }
+
     fn version(&self) -> Option<&str> {
         self.version.as_deref()
     }
@@ -113,6 +121,7 @@ impl<'a> PluginStatusRec<'a> {
     pub fn new<T: PluginStatus + ?Sized>(plugin: &'a T) -> Self {
         Self {
             name: Cow::Borrowed(plugin.name()),
+            id: Cow::Borrowed(plugin.id()),
             version: plugin.version().map(Cow::Borrowed),
             long_version: plugin.long_version().map(Cow::Borrowed),
             path: Cow::Borrowed(plugin.path()),
@@ -124,6 +133,7 @@ impl<'a> PluginStatusRec<'a> {
     pub fn into_owned(self) -> PluginStatusRec<'static> {
         PluginStatusRec {
             name: Cow::Owned(self.name.into_owned()),
+            id: Cow::Owned(self.id.into_owned()),
             version: self.version.map(|v| Cow::Owned(v.into_owned())),
             long_version: self.long_version.map(|v| Cow::Owned(v.into_owned())),
             path: Cow::Owned(self.path.into_owned()),

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -110,7 +110,7 @@ impl AdminSpace {
         } else if let Some(paths) = &config.paths {
             plugin_mgr.declare_dynamic_plugin_by_paths(name, name, paths, required)?
         } else {
-            plugin_mgr.declare_dynamic_plugin_by_name(name, name, name, required)?
+            plugin_mgr.declare_dynamic_plugin_by_name(name, name, required)?
         };
 
         let loaded = if let Some(loaded) = declared.loaded_mut() {

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -773,7 +773,7 @@ fn plugins_data(context: &AdminContext, query: Query) {
         let statuses = guard.plugins_status(names);
         for status in statuses {
             tracing::debug!("plugin status: {:?}", status);
-            let key = root_key.join(status.id()).unwrap();
+            let key = root_key.join(status.name()).unwrap();
             let status = serde_json::to_value(status).unwrap();
             if let Err(e) = query.reply(Ok(Sample::new(key, Value::from(status)))).res() {
                 tracing::error!("Error sending AdminSpace reply: {:?}", e);

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -108,9 +108,9 @@ impl AdminSpace {
             tracing::warn!("Plugin `{}` was already declared", declared.name());
             declared
         } else if let Some(paths) = &config.paths {
-            plugin_mgr.declare_dynamic_plugin_by_paths(name, paths, required)?
+            plugin_mgr.declare_dynamic_plugin_by_paths(name, name, paths, required)?
         } else {
-            plugin_mgr.declare_dynamic_plugin_by_name(name, name, required)?
+            plugin_mgr.declare_dynamic_plugin_by_name(name, name, name, required)?
         };
 
         let loaded = if let Some(loaded) = declared.loaded_mut() {

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -792,7 +792,7 @@ fn plugins_status(context: &AdminContext, query: Query) {
     );
 
     for plugin in guard.started_plugins_iter() {
-        with_extended_string(&mut root_key, &[plugin.name()], |plugin_key| {
+        with_extended_string(&mut root_key, &[plugin.id()], |plugin_key| {
             // @TODO: response to "__version__", this need not to be implemented by each plugin
             with_extended_string(plugin_key, &["/__path__"], |plugin_path_key| {
                 if let Ok(key_expr) = KeyExpr::try_from(plugin_path_key.clone()) {

--- a/zenoh/src/plugins/loader.rs
+++ b/zenoh/src/plugins/loader.rs
@@ -29,7 +29,7 @@ pub(crate) fn load_plugin(
     } else if let Some(paths) = paths {
         plugin_mgr.declare_dynamic_plugin_by_paths(name, id, paths, required)?
     } else {
-        plugin_mgr.declare_dynamic_plugin_by_name(name, id, name, required)?
+        plugin_mgr.declare_dynamic_plugin_by_name(id, name, required)?
     };
 
     if let Some(loaded) = declared.loaded_mut() {
@@ -55,7 +55,7 @@ pub(crate) fn load_plugins(config: &Config) -> PluginsManager {
             required,
         } = plugin_load;
         tracing::info!(
-            "Loading {req} plugin \"{name}\"",
+            "Loading {req} plugin \"{id}\"",
             req = if required { "required" } else { "" }
         );
         if let Err(e) = load_plugin(&mut manager, &name, &id, &paths, required) {

--- a/zenoh/src/plugins/loader.rs
+++ b/zenoh/src/plugins/loader.rs
@@ -19,6 +19,7 @@ use zenoh_result::ZResult;
 pub(crate) fn load_plugin(
     plugin_mgr: &mut PluginsManager,
     name: &str,
+    id: &str,
     paths: &Option<Vec<String>>,
     required: bool,
 ) -> ZResult<()> {
@@ -26,9 +27,9 @@ pub(crate) fn load_plugin(
         tracing::warn!("Plugin `{}` was already declared", declared.name());
         declared
     } else if let Some(paths) = paths {
-        plugin_mgr.declare_dynamic_plugin_by_paths(name, paths, required)?
+        plugin_mgr.declare_dynamic_plugin_by_paths(name, id, paths, required)?
     } else {
-        plugin_mgr.declare_dynamic_plugin_by_name(name, name, required)?
+        plugin_mgr.declare_dynamic_plugin_by_name(name, id, name, required)?
     };
 
     if let Some(loaded) = declared.loaded_mut() {
@@ -56,7 +57,7 @@ pub(crate) fn load_plugins(config: &Config) -> PluginsManager {
             "Loading {req} plugin \"{name}\"",
             req = if required { "required" } else { "" }
         );
-        if let Err(e) = load_plugin(&mut manager, &name, &paths, required) {
+        if let Err(e) = load_plugin(&mut manager, &name, &name, &paths, required) {
             if required {
                 panic!("Plugin load failure: {}", e)
             } else {

--- a/zenoh/src/plugins/loader.rs
+++ b/zenoh/src/plugins/loader.rs
@@ -49,6 +49,7 @@ pub(crate) fn load_plugins(config: &Config) -> PluginsManager {
     // Static plugins are to be added here, with `.add_static::<PluginType>()`
     for plugin_load in config.plugins().load_requests() {
         let PluginLoad {
+            id,
             name,
             paths,
             required,
@@ -57,7 +58,7 @@ pub(crate) fn load_plugins(config: &Config) -> PluginsManager {
             "Loading {req} plugin \"{name}\"",
             req = if required { "required" } else { "" }
         );
-        if let Err(e) = load_plugin(&mut manager, &name, &name, &paths, required) {
+        if let Err(e) = load_plugin(&mut manager, &name, &id, &paths, required) {
             if required {
                 panic!("Plugin load failure: {}", e)
             } else {


### PR DESCRIPTION
This PR adds the `id()` method to the `PluginStatus` trait and allows passing it as a parameter in the `PluginManager` when dynamic loading or statically linking a plugin.
It exposes plugins in the admin space via their ID (see below what the ID is), and allows multiple instances of the same plugin with different configurations, essential for backends, and useful for other plugins.



Changes to configuration:
```json
        "rest2": { // plugin id, used in admin space, to retrieve plugin config
            "__required__": true,
            "http_port": 8000,
            "__plugin__":"rest", // plugin name used in libloading
        },
```

Sister PRs:
- [ ] MQTT: https://github.com/eclipse-zenoh/zenoh-plugin-mqtt/pull/110
- [ ] DDS: https://github.com/eclipse-zenoh/zenoh-plugin-dds/pull/245
- [ ] ROS2 https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/pull/156
- [ ] WebServer https://github.com/eclipse-zenoh/zenoh-plugin-webserver/pull/85

Sister PRs for testing, do not need a merge.
- [ ] FS Backend https://github.com/eclipse-zenoh/zenoh-backend-filesystem/pull/113
- [ ] RocksDB Backend https://github.com/eclipse-zenoh/zenoh-backend-rocksdb/pull/100
- [ ] S3 https://github.com/eclipse-zenoh/zenoh-backend-s3/pull/82
- [ ] Influx https://github.com/eclipse-zenoh/zenoh-backend-influxdb/pull/121


Closes #1059 