### PR TITLE
fix: remove zenoh_util from examples 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5229,10 +5229,10 @@ dependencies = [
  "rustc_version 0.4.0",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "zenoh",
  "zenoh-collections",
  "zenoh-ext",
- "zenoh-util",
 ]
 
 [[package]]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -34,13 +34,13 @@ transport_unixpipe = ["zenoh/transport_unixpipe"]
 [dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "time", "io-std"] }
 clap = { workspace = true, features = ["derive"] }
-zenoh-util = { workspace = true }
 flume = { workspace = true }
 futures = { workspace = true }
 git-version = { workspace = true }
 json5 = { workspace = true }
 zenoh-collections = { workspace = true }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 zenoh = { workspace = true, default-features = true }
 zenoh-ext = { workspace = true }
 

--- a/examples/examples/z_alloc_shm.rs
+++ b/examples/examples/z_alloc_shm.rs
@@ -22,8 +22,8 @@ use zenoh::{
 
 #[tokio::main]
 async fn main() {
-    // Initiate logging
-    zenoh_util::try_init_log_from_env();
+    initialize_logging();
+
     run().await.unwrap()
 }
 
@@ -143,4 +143,10 @@ async fn run() -> ZResult<()> {
 
     // Publish SHM buffer
     publisher.put(sbuf).await
+}
+
+fn initialize_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init()
 }

--- a/examples/examples/z_delete.rs
+++ b/examples/examples/z_delete.rs
@@ -17,8 +17,7 @@ use zenoh_examples::CommonArgs;
 
 #[tokio::main]
 async fn main() {
-    // initiate logging
-    zenoh_util::try_init_log_from_env();
+    initialize_logging();
 
     let (config, key_expr) = parse_args();
 
@@ -29,6 +28,12 @@ async fn main() {
     session.delete(&key_expr).await.unwrap();
 
     session.close().await.unwrap();
+}
+
+fn initialize_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init()
 }
 
 #[derive(clap::Parser, Clone, PartialEq, Eq, Hash, Debug)]

--- a/examples/examples/z_forward.rs
+++ b/examples/examples/z_forward.rs
@@ -18,8 +18,7 @@ use zenoh_ext::SubscriberForward;
 
 #[tokio::main]
 async fn main() {
-    // Initiate logging
-    zenoh_util::try_init_log_from_env();
+    initialize_logging();
 
     let (config, key_expr, forward) = parse_args();
 
@@ -32,6 +31,12 @@ async fn main() {
     let publisher = session.declare_publisher(&forward).await.unwrap();
     println!("Forwarding data from '{key_expr}' to '{forward}'...");
     subscriber.forward(publisher).await.unwrap();
+}
+
+fn initialize_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init()
 }
 
 #[derive(clap::Parser, Clone, PartialEq, Eq, Hash, Debug)]

--- a/examples/examples/z_get.rs
+++ b/examples/examples/z_get.rs
@@ -19,8 +19,7 @@ use zenoh_examples::CommonArgs;
 
 #[tokio::main]
 async fn main() {
-    // initiate logging
-    zenoh_util::try_init_log_from_env();
+    initialize_logging();
 
     let (config, selector, value, target, timeout) = parse_args();
 
@@ -61,6 +60,12 @@ async fn main() {
             }
         }
     }
+}
+
+fn initialize_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init()
 }
 
 #[derive(clap::ValueEnum, Clone, Copy, Debug)]

--- a/examples/examples/z_get_liveliness.rs
+++ b/examples/examples/z_get_liveliness.rs
@@ -19,8 +19,7 @@ use zenoh_examples::CommonArgs;
 
 #[tokio::main]
 async fn main() {
-    // initiate logging
-    zenoh_util::try_init_log_from_env();
+    initialize_logging();
 
     let (config, key_expr, timeout) = parse_args();
 
@@ -46,6 +45,12 @@ async fn main() {
             }
         }
     }
+}
+
+fn initialize_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init()
 }
 
 #[derive(Parser, Clone, Debug)]

--- a/examples/examples/z_get_shm.rs
+++ b/examples/examples/z_get_shm.rs
@@ -30,8 +30,7 @@ const N: usize = 10;
 
 #[tokio::main]
 async fn main() {
-    // initiate logging
-    zenoh_util::try_init_log_from_env();
+    initialize_logging();
 
     let (mut config, selector, mut value, target, timeout) = parse_args();
 
@@ -99,6 +98,12 @@ async fn main() {
             }
         }
     }
+}
+
+fn initialize_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init()
 }
 
 #[derive(clap::ValueEnum, Clone, Copy, Debug)]

--- a/examples/examples/z_info.rs
+++ b/examples/examples/z_info.rs
@@ -17,8 +17,7 @@ use zenoh_examples::CommonArgs;
 
 #[tokio::main]
 async fn main() {
-    // initiate logging
-    zenoh_util::try_init_log_from_env();
+    initialize_logging();
 
     let config = parse_args();
 
@@ -35,6 +34,12 @@ async fn main() {
         "peers zid: {:?}",
         info.peers_zid().await.collect::<Vec<ZenohId>>()
     );
+}
+
+fn initialize_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init()
 }
 
 #[derive(clap::Parser, Clone, PartialEq, Eq, Hash, Debug)]

--- a/examples/examples/z_liveliness.rs
+++ b/examples/examples/z_liveliness.rs
@@ -17,8 +17,7 @@ use zenoh_examples::CommonArgs;
 
 #[tokio::main]
 async fn main() {
-    // Initiate logging
-    zenoh_util::try_init_log_from_env();
+    initialize_logging();
 
     let (config, key_expr) = parse_args();
 
@@ -36,6 +35,12 @@ async fn main() {
         println!("Undeclaring LivelinessToken...");
         token.undeclare().await.unwrap();
     };
+}
+
+fn initialize_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init()
 }
 
 #[derive(clap::Parser, Clone, PartialEq, Eq, Hash, Debug)]

--- a/examples/examples/z_ping.rs
+++ b/examples/examples/z_ping.rs
@@ -18,8 +18,7 @@ use zenoh::{bytes::ZBytes, key_expr::keyexpr, prelude::*, publisher::CongestionC
 use zenoh_examples::CommonArgs;
 
 fn main() {
-    // initiate logging
-    zenoh_util::try_init_log_from_env();
+    initialize_logging();
 
     let (config, warmup, size, n, express) = parse_args();
     let session = zenoh::open(config).wait().unwrap();
@@ -74,6 +73,12 @@ fn main() {
             rtt / 2
         );
     }
+}
+
+fn initialize_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init()
 }
 
 #[derive(Parser)]

--- a/examples/examples/z_ping_shm.rs
+++ b/examples/examples/z_ping_shm.rs
@@ -25,8 +25,7 @@ use zenoh::{
 use zenoh_examples::CommonArgs;
 
 fn main() {
-    // Initiate logging
-    zenoh_util::try_init_log_from_env();
+    initialize_logging();
 
     let (mut config, warmup, size, n) = parse_args();
 
@@ -100,6 +99,12 @@ fn main() {
             rtt / 2
         );
     }
+}
+
+fn initialize_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init()
 }
 
 #[derive(Parser)]

--- a/examples/examples/z_pong.rs
+++ b/examples/examples/z_pong.rs
@@ -16,8 +16,7 @@ use zenoh::{key_expr::keyexpr, prelude::*, publisher::CongestionControl, Config}
 use zenoh_examples::CommonArgs;
 
 fn main() {
-    // initiate logging
-    zenoh_util::try_init_log_from_env();
+    initialize_logging();
 
     let (mut config, express) = parse_args();
 
@@ -47,6 +46,12 @@ fn main() {
         .wait()
         .unwrap();
     std::thread::park();
+}
+
+fn initialize_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init()
 }
 
 #[derive(clap::Parser, Clone, PartialEq, Eq, Hash, Debug)]

--- a/examples/examples/z_pub.rs
+++ b/examples/examples/z_pub.rs
@@ -19,8 +19,7 @@ use zenoh_examples::CommonArgs;
 
 #[tokio::main]
 async fn main() {
-    // Initiate logging
-    zenoh_util::try_init_log_from_env();
+    initialize_logging();
 
     let (config, key_expr, value, attachment) = parse_args();
 
@@ -37,6 +36,12 @@ async fn main() {
         println!("Putting Data ('{}': '{}')...", &key_expr, buf);
         publisher.put(buf).attachment(&attachment).await.unwrap();
     }
+}
+
+fn initialize_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init()
 }
 
 #[derive(clap::Parser, Clone, PartialEq, Eq, Hash, Debug)]

--- a/examples/examples/z_pub_shm.rs
+++ b/examples/examples/z_pub_shm.rs
@@ -27,8 +27,7 @@ const N: usize = 10;
 
 #[tokio::main]
 async fn main() -> Result<(), ZError> {
-    // Initiate logging
-    zenoh_util::try_init_log_from_env();
+    initialize_logging();
 
     let (mut config, path, value) = parse_args();
 
@@ -90,6 +89,12 @@ async fn main() -> Result<(), ZError> {
     }
 
     Ok(())
+}
+
+fn initialize_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init()
 }
 
 #[derive(clap::Parser, Clone, PartialEq, Eq, Hash, Debug)]

--- a/examples/examples/z_pub_shm_thr.rs
+++ b/examples/examples/z_pub_shm_thr.rs
@@ -23,8 +23,8 @@ use zenoh_examples::CommonArgs;
 
 #[tokio::main]
 async fn main() {
-    // initiate logging
-    zenoh_util::try_init_log_from_env();
+    initialize_logging();
+
     let (mut config, sm_size, size) = parse_args();
 
     // A probing procedure for shared memory is performed upon session opening. To enable `z_pub_shm_thr` to operate
@@ -69,6 +69,12 @@ async fn main() {
     loop {
         publisher.put(buf.clone()).await.unwrap();
     }
+}
+
+fn initialize_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init()
 }
 
 #[derive(clap::Parser, Clone, PartialEq, Eq, Hash, Debug)]

--- a/examples/examples/z_pub_thr.rs
+++ b/examples/examples/z_pub_thr.rs
@@ -23,8 +23,8 @@ use zenoh::{
 use zenoh_examples::CommonArgs;
 
 fn main() {
-    // initiate logging
-    zenoh_util::try_init_log_from_env();
+    initialize_logging();
+
     let args = Args::parse();
 
     let mut prio = Priority::DEFAULT;
@@ -66,6 +66,12 @@ fn main() {
             }
         }
     }
+}
+
+fn initialize_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init()
 }
 
 #[derive(Parser, Clone, PartialEq, Eq, Hash, Debug)]

--- a/examples/examples/z_pull.rs
+++ b/examples/examples/z_pull.rs
@@ -19,8 +19,7 @@ use zenoh_examples::CommonArgs;
 
 #[tokio::main]
 async fn main() {
-    // initiate logging
-    zenoh_util::try_init_log_from_env();
+    initialize_logging();
 
     let (config, key_expr, size, interval) = parse_args();
 
@@ -89,6 +88,12 @@ async fn main() {
     //         }
     //     }
     // }
+}
+
+fn initialize_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init()
 }
 
 #[derive(clap::Parser, Clone, PartialEq, Debug)]

--- a/examples/examples/z_put.rs
+++ b/examples/examples/z_put.rs
@@ -17,8 +17,7 @@ use zenoh_examples::CommonArgs;
 
 #[tokio::main]
 async fn main() {
-    // initiate logging
-    zenoh_util::try_init_log_from_env();
+    initialize_logging();
 
     let (config, key_expr, value) = parse_args();
 
@@ -27,6 +26,12 @@ async fn main() {
 
     println!("Putting Data ('{key_expr}': '{value}')...");
     session.put(&key_expr, value).await.unwrap();
+}
+
+fn initialize_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init()
 }
 
 #[derive(clap::Parser, Clone, PartialEq, Eq, Hash, Debug)]

--- a/examples/examples/z_put_float.rs
+++ b/examples/examples/z_put_float.rs
@@ -17,8 +17,7 @@ use zenoh_examples::CommonArgs;
 
 #[tokio::main]
 async fn main() {
-    // initiate logging
-    zenoh_util::try_init_log_from_env();
+    initialize_logging();
 
     let (config, key_expr, value) = parse_args();
 
@@ -29,6 +28,12 @@ async fn main() {
     session.put(&key_expr, value).await.unwrap();
 
     session.close().await.unwrap();
+}
+
+fn initialize_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init()
 }
 
 #[derive(clap::Parser, Clone, PartialEq, Debug)]

--- a/examples/examples/z_queryable.rs
+++ b/examples/examples/z_queryable.rs
@@ -17,8 +17,7 @@ use zenoh_examples::CommonArgs;
 
 #[tokio::main]
 async fn main() {
-    // initiate logging
-    zenoh_util::try_init_log_from_env();
+    initialize_logging();
 
     let (mut config, key_expr, value, complete) = parse_args();
 
@@ -67,6 +66,12 @@ async fn main() {
             .await
             .unwrap_or_else(|e| println!(">> [Queryable ] Error sending reply: {e}"));
     }
+}
+
+fn initialize_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init()
 }
 
 #[derive(clap::Parser, Clone, PartialEq, Eq, Hash, Debug)]

--- a/examples/examples/z_queryable_shm.rs
+++ b/examples/examples/z_queryable_shm.rs
@@ -27,8 +27,7 @@ const N: usize = 10;
 
 #[tokio::main]
 async fn main() {
-    // initiate logging
-    zenoh_util::try_init_log_from_env();
+    initialize_logging();
 
     let (mut config, key_expr, value, complete) = parse_args();
 
@@ -98,6 +97,12 @@ async fn main() {
             .await
             .unwrap_or_else(|e| println!(">> [Queryable ] Error sending reply: {e}"));
     }
+}
+
+fn initialize_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init()
 }
 
 #[derive(clap::Parser, Clone, PartialEq, Eq, Hash, Debug)]

--- a/examples/examples/z_scout.rs
+++ b/examples/examples/z_scout.rs
@@ -15,8 +15,7 @@ use zenoh::{config::WhatAmI, scout, Config};
 
 #[tokio::main]
 async fn main() {
-    // initiate logging
-    zenoh_util::try_init_log_from_env();
+    initialize_logging();
 
     println!("Scouting...");
     let receiver = scout(WhatAmI::Peer | WhatAmI::Router, Config::default())
@@ -32,4 +31,10 @@ async fn main() {
 
     // stop scouting
     receiver.stop();
+}
+
+fn initialize_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init()
 }

--- a/examples/examples/z_storage.rs
+++ b/examples/examples/z_storage.rs
@@ -27,8 +27,7 @@ use zenoh_examples::CommonArgs;
 
 #[tokio::main]
 async fn main() {
-    // initiate logging
-    zenoh_util::try_init_log_from_env();
+    initialize_logging();
 
     let (config, key_expr, complete) = parse_args();
 
@@ -71,6 +70,12 @@ async fn main() {
             }
         );
     }
+}
+
+fn initialize_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init()
 }
 
 #[derive(clap::Parser, Clone, PartialEq, Eq, Hash, Debug)]

--- a/examples/examples/z_sub.rs
+++ b/examples/examples/z_sub.rs
@@ -17,8 +17,7 @@ use zenoh_examples::CommonArgs;
 
 #[tokio::main]
 async fn main() {
-    // Initiate logging
-    zenoh_util::try_init_log_from_env();
+    initialize_logging();
 
     let (mut config, key_expr) = parse_args();
 
@@ -53,6 +52,12 @@ async fn main() {
         }
         println!();
     }
+}
+
+fn initialize_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init()
 }
 
 #[derive(clap::Parser, Clone, PartialEq, Eq, Hash, Debug)]

--- a/examples/examples/z_sub_liveliness.rs
+++ b/examples/examples/z_sub_liveliness.rs
@@ -17,8 +17,7 @@ use zenoh_examples::CommonArgs;
 
 #[tokio::main]
 async fn main() {
-    // Initiate logging
-    zenoh_util::try_init_log_from_env();
+    initialize_logging();
 
     let (config, key_expr) = parse_args();
 
@@ -46,6 +45,12 @@ async fn main() {
             ),
         }
     }
+}
+
+fn initialize_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init()
 }
 
 #[derive(clap::Parser, Clone, PartialEq, Eq, Hash, Debug)]

--- a/examples/examples/z_sub_shm.rs
+++ b/examples/examples/z_sub_shm.rs
@@ -17,8 +17,7 @@ use zenoh_examples::CommonArgs;
 
 #[tokio::main]
 async fn main() {
-    // Initiate logging
-    zenoh_util::try_init_log_from_env();
+    initialize_logging();
 
     let (mut config, key_expr) = parse_args();
 
@@ -66,6 +65,12 @@ async fn main() {
     //         }
     //     }
     // }
+}
+
+fn initialize_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init()
 }
 
 #[derive(clap::Parser, Clone, PartialEq, Eq, Hash, Debug)]

--- a/examples/examples/z_sub_thr.rs
+++ b/examples/examples/z_sub_thr.rs
@@ -68,8 +68,7 @@ impl Drop for Stats {
 }
 
 fn main() {
-    // initiate logging
-    zenoh_util::try_init_log_from_env();
+    initialize_logging();
 
     let (mut config, m, n) = parse_args();
 
@@ -96,6 +95,12 @@ fn main() {
 
     println!("Press CTRL-C to quit...");
     std::thread::park();
+}
+
+fn initialize_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init()
 }
 
 #[derive(clap::Parser, Clone, PartialEq, Eq, Hash, Debug)]


### PR DESCRIPTION
Users should not use `zenoh_util::try_init_log_from_env`. They should instead
register their own subscriber with their own formatting preferences.
Examples provides a basic logging initialization that users can copy-paste
if they don't want to learn tracing.

@Mallets @milyin @gabrik 