### PR TITLE
fix: remove zenoh::scouting::WhatAmI reexport

### DIFF
--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -49,9 +49,9 @@ impl From<&CommonArgs> for Config {
             None => Config::default(),
         };
         match value.mode {
-            Some(Wai::Peer) => config.set_mode(Some(zenoh::scouting::WhatAmI::Peer)),
-            Some(Wai::Client) => config.set_mode(Some(zenoh::scouting::WhatAmI::Client)),
-            Some(Wai::Router) => config.set_mode(Some(zenoh::scouting::WhatAmI::Router)),
+            Some(Wai::Peer) => config.set_mode(Some(zenoh::config::WhatAmI::Peer)),
+            Some(Wai::Client) => config.set_mode(Some(zenoh::config::WhatAmI::Client)),
+            Some(Wai::Router) => config.set_mode(Some(zenoh::config::WhatAmI::Router)),
             None => Ok(None),
         }
         .unwrap();

--- a/zenoh-ext/examples/src/lib.rs
+++ b/zenoh-ext/examples/src/lib.rs
@@ -43,9 +43,9 @@ impl From<&CommonArgs> for Config {
             None => Config::default(),
         };
         match value.mode {
-            Some(Wai::Peer) => config.set_mode(Some(zenoh::scouting::WhatAmI::Peer)),
-            Some(Wai::Client) => config.set_mode(Some(zenoh::scouting::WhatAmI::Client)),
-            Some(Wai::Router) => config.set_mode(Some(zenoh::scouting::WhatAmI::Router)),
+            Some(Wai::Peer) => config.set_mode(Some(zenoh::config::WhatAmI::Peer)),
+            Some(Wai::Client) => config.set_mode(Some(zenoh::config::WhatAmI::Client)),
+            Some(Wai::Router) => config.set_mode(Some(zenoh::config::WhatAmI::Router)),
             None => Ok(None),
         }
         .unwrap();

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -321,8 +321,6 @@ pub mod handlers {
 
 /// Scouting primitives
 pub mod scouting {
-    /// Constants and helpers for zenoh `whatami` flags.
-    pub use zenoh_protocol::core::WhatAmI;
     /// A zenoh Hello message.
     pub use zenoh_protocol::scouting::Hello;
 

--- a/zenohd/src/main.rs
+++ b/zenohd/src/main.rs
@@ -18,9 +18,8 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilte
 #[cfg(feature = "loki")]
 use url::Url;
 use zenoh::{
-    config::{Config, EndPoint, ModeDependentValue, PermissionsConf, ValidatedMap},
+    config::{Config, EndPoint, ModeDependentValue, PermissionsConf, ValidatedMap, WhatAmI},
     core::Result,
-    scouting::WhatAmI,
 };
 
 #[cfg(feature = "loki")]


### PR DESCRIPTION
`WhatAmI` is already present in `zenoh::config`.

This PR is based on #1007, so it will be draft until its base is merged.