### PR TITLE
fix: Decrease `zenoh_link_udp::UDP_MAX_MTU` to fit UDP over IPv6

### DIFF
--- a/io/zenoh-links/zenoh-link-udp/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/lib.rs
@@ -37,14 +37,15 @@ use zenoh_result::{zerror, ZResult};
 //           $ sysctl -w net.core.rmem_max=4194304
 //           $ sysctl -w net.core.rmem_default=4194304
 
-// Maximum MTU (UDP PDU) in bytes.
-// NOTE: The UDP field size sets a theoretical limit of 65,535 bytes (8 byte header + 65,527 bytes of
-//       data) for a UDP datagram. However the actual limit for the data length, which is imposed by
-//       the underlying IPv4 protocol, is 65,507 bytes (65,535 − 8 byte UDP header − 20 byte IP header).
-//       Although in IPv6 it is possible to have UDP datagrams of size greater than 65,535 bytes via
-//       IPv6 Jumbograms, its usage in Zenoh is discouraged unless the consequences are very well
-//       understood.
-const UDP_MAX_MTU: u16 = 65_507;
+/// Maximum MTU (UDP PDU) in bytes.
+///
+/// # Note
+/// The UDP field size sets a theoretical limit of 65,535 bytes (8 byte header + 65,527 bytes of
+/// data) for a UDP datagram. However the actual limit for the data length, which is imposed by the
+/// underlying IPv4 protocol, is 65,507 bytes (65,535 − 8 byte UDP header − 20 byte IP header).
+/// Although in IPv6 it is possible to have UDP datagrams of size greater than 65,535 bytes via IPv6
+/// Jumbograms, its usage in Zenoh is discouraged unless the consequences are very well understood.
+const UDP_MAX_MTU: u16 = u16::MAX - 8 - 40;
 
 pub const UDP_LOCATOR_PREFIX: &str = "udp";
 

--- a/io/zenoh-links/zenoh-link-udp/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/lib.rs
@@ -40,9 +40,10 @@ use zenoh_result::{zerror, ZResult};
 /// Maximum MTU (UDP PDU) in bytes.
 ///
 /// # Note
-/// The UDP field size sets a theoretical limit of 65,535 bytes (8 byte header + 65,527 bytes of
-/// data) for a UDP datagram. However the actual limit for the data length, which is imposed by the
-/// underlying IPv4 protocol, is 65,507 bytes (65,535 − 8 byte UDP header − 20 byte IP header).
+///
+/// The theoretical Maximum Transmission Unit (MTU) of UDP is `u16::MAX`. From that we substract the
+/// size of a UDP header (8 bytes) and the size of IPv4/IPv6 headers (resp. 20 and 40 bytes).
+///
 /// Although in IPv6 it is possible to have UDP datagrams of size greater than 65,535 bytes via IPv6
 /// Jumbograms, its usage in Zenoh is discouraged unless the consequences are very well understood.
 const UDP_MAX_MTU: u16 = u16::MAX - 8 - 40;


### PR DESCRIPTION
IPv6 headers are _at least_ 40 bytes (because of optional extensions). This pull request changes `zenoh_link_udp::UDP_MAX_MTU` to accomodate that. Up until now, only the IPv4 header size (20 bytes) was substracted from the theoretical UDP MTU.