### PR TITLE
fix: Improve debug messages in `zenoh-transport`

### DIFF
--- a/io/zenoh-transport/src/multicast/link.rs
+++ b/io/zenoh-transport/src/multicast/link.rs
@@ -342,7 +342,7 @@ impl TransportLinkMulticastUniversal {
                 )
                 .await;
                 if let Err(e) = res {
-                    tracing::debug!("{}", e);
+                    tracing::debug!("TX task failed: {}", e);
                     // Spawn a task to avoid a deadlock waiting for this same task
                     // to finish in the close() joining its handle
                     zenoh_runtime::ZRuntime::Net.spawn(async move { c_transport.delete().await });
@@ -378,7 +378,7 @@ impl TransportLinkMulticastUniversal {
                 .await;
                 c_signal.trigger();
                 if let Err(e) = res {
-                    tracing::debug!("{}", e);
+                    tracing::debug!("RX task failed: {}", e);
                     // Spawn a task to avoid a deadlock waiting for this same task
                     // to finish in the close() joining its handle
                     zenoh_runtime::ZRuntime::Net.spawn(async move { c_transport.delete().await });

--- a/io/zenoh-transport/src/unicast/manager.rs
+++ b/io/zenoh-transport/src/unicast/manager.rs
@@ -746,13 +746,16 @@ impl TransportManager {
         let c_manager = self.clone();
         self.task_controller
             .spawn_with_rt(zenoh_runtime::ZRuntime::Acceptor, async move {
-                if let Err(e) = tokio::time::timeout(
+                if let Err(_) = tokio::time::timeout(
                     c_manager.config.unicast.accept_timeout,
                     super::establishment::accept::accept_link(link, &c_manager),
                 )
                 .await
                 {
-                    tracing::debug!("{}", e);
+                    tracing::debug!(
+                        "Failed to accept link before deadline ({}ms)",
+                        c_manager.config.unicast.accept_timeout.as_millis()
+                    );
                 }
                 incoming_counter.fetch_sub(1, SeqCst);
             });

--- a/io/zenoh-transport/src/unicast/manager.rs
+++ b/io/zenoh-transport/src/unicast/manager.rs
@@ -746,11 +746,12 @@ impl TransportManager {
         let c_manager = self.clone();
         self.task_controller
             .spawn_with_rt(zenoh_runtime::ZRuntime::Acceptor, async move {
-                if let Err(_) = tokio::time::timeout(
+                if tokio::time::timeout(
                     c_manager.config.unicast.accept_timeout,
                     super::establishment::accept::accept_link(link, &c_manager),
                 )
                 .await
+                .is_err()
                 {
                     tracing::debug!(
                         "Failed to accept link before deadline ({}ms)",

--- a/io/zenoh-transport/src/unicast/universal/link.rs
+++ b/io/zenoh-transport/src/unicast/universal/link.rs
@@ -97,7 +97,7 @@ impl TransportLinkUnicastUniversal {
             .await;
 
             if let Err(e) = res {
-                tracing::debug!("{}", e);
+                tracing::debug!("TX task failed: {}", e);
                 // Spawn a task to avoid a deadlock waiting for this same task
                 // to finish in the close() joining its handle
                 // TODO(yuyuan): do more study to check which ZRuntime should be used or refine the
@@ -125,7 +125,7 @@ impl TransportLinkUnicastUniversal {
 
             // TODO(yuyuan): improve this callback
             if let Err(e) = res {
-                tracing::debug!("{}", e);
+                tracing::debug!("RX task failed: {}", e);
 
                 // Spawn a task to avoid a deadlock waiting for this same task
                 // to finish in the close() joining its handle


### PR DESCRIPTION
The affected messages provide no context around the error they report.