### PR TITLE
Start link tx_task before notifying router

### DIFF
--- a/io/zenoh-transport/src/unicast/lowlatency/transport.rs
+++ b/io/zenoh-transport/src/unicast/lowlatency/transport.rs
@@ -246,17 +246,19 @@ impl TransportUnicastTrait for TransportUnicastLowlatency {
         drop(guard);
 
         // create a callback to start the link
-        let start_link = Box::new(move || {
+        let start_tx = Box::new(move || {
             // start keepalive task
             let keep_alive =
                 self.manager.config.unicast.lease / self.manager.config.unicast.keep_alive as u32;
             self.start_keepalive(keep_alive);
+        });
 
+        let start_rx = Box::new(move || {
             // start RX task
             self.internal_start_rx(other_lease);
         });
 
-        Ok((start_link, ack))
+        Ok((start_tx, start_rx, ack))
     }
 
     /*************************************/

--- a/io/zenoh-transport/src/unicast/transport_unicast_inner.rs
+++ b/io/zenoh-transport/src/unicast/transport_unicast_inner.rs
@@ -36,8 +36,14 @@ pub(crate) enum InitTransportError {
     Transport(TransportError),
 }
 
-pub(crate) type AddLinkResult<'a> =
-    Result<(Box<dyn FnOnce() + Send + Sync + 'a>, MaybeOpenAck), LinkError>;
+pub(crate) type AddLinkResult<'a> = Result<
+    (
+        Box<dyn FnOnce() + Send + Sync + 'a>,
+        Box<dyn FnOnce() + Send + Sync + 'a>,
+        MaybeOpenAck,
+    ),
+    LinkError,
+>;
 pub(crate) type InitTransportResult = Result<Arc<dyn TransportUnicastTrait>, InitTransportError>;
 
 /*************************************/

--- a/io/zenoh-transport/src/unicast/universal/transport.rs
+++ b/io/zenoh-transport/src/unicast/universal/transport.rs
@@ -292,17 +292,21 @@ impl TransportUnicastTrait for TransportUnicastUniversal {
 
         // create a callback to start the link
         let transport = self.clone();
-        let start_link = Box::new(move || {
+        let mut c_link = link.clone();
+        let c_transport = transport.clone();
+        let start_tx = Box::new(move || {
             // Start the TX loop
             let keep_alive =
                 self.manager.config.unicast.lease / self.manager.config.unicast.keep_alive as u32;
-            link.start_tx(transport.clone(), consumer, keep_alive);
+            c_link.start_tx(c_transport, consumer, keep_alive);
+        });
 
+        let start_rx = Box::new(move || {
             // Start the RX loop
             link.start_rx(transport, other_lease);
         });
 
-        Ok((start_link, ack))
+        Ok((start_tx, start_rx, ack))
     }
 
     /*************************************/


### PR DESCRIPTION
The routing logic is notified of a new link available upon new transport or link establishment.
However, the task consuming the transmission queue for that link is started only after the routing callback returns.
In case the routing logic needs to propagate many declarations, it will be filling up the queue and it will block since no transmission task has been started yet. 

This PR modifies this behaviour by starting the transmission task before calling the routing logic callback.