### PR TITLE
feat: remove `alive` flag in session/undeclarable objects

### DIFF
--- a/zenoh/src/api/admin.rs
+++ b/zenoh/src/api/admin.rs
@@ -30,7 +30,7 @@ use super::{
     key_expr::KeyExpr,
     queryable::Query,
     sample::{DataInfo, Locality, SampleKind},
-    session::Session,
+    session::{Session, SessionClone},
 };
 
 macro_rules! ke_for_sure {
@@ -121,11 +121,11 @@ pub(crate) fn on_admin_query(session: &Session, query: Query) {
 
 #[derive(Clone)]
 pub(crate) struct Handler {
-    pub(crate) session: Arc<Session>,
+    pub(crate) session: Arc<SessionClone>,
 }
 
 impl Handler {
-    pub(crate) fn new(session: Session) -> Self {
+    pub(crate) fn new(session: SessionClone) -> Self {
         Self {
             session: Arc::new(session),
         }
@@ -193,7 +193,7 @@ impl TransportMulticastEventHandler for Handler {
 
 pub(crate) struct PeerHandler {
     pub(crate) expr: WireExpr<'static>,
-    pub(crate) session: Arc<Session>,
+    pub(crate) session: Arc<SessionClone>,
 }
 
 impl TransportPeerEventHandler for PeerHandler {

--- a/zenoh/src/api/liveliness.rs
+++ b/zenoh/src/api/liveliness.rs
@@ -314,6 +314,8 @@ pub struct LivelinessToken<'a> {
 #[must_use = "Resolvables do nothing unless you resolve them using the `res` method from either `SyncResolve` or `AsyncResolve`"]
 #[zenoh_macros::unstable]
 pub struct LivelinessTokenUndeclaration<'a> {
+    // ManuallyDrop wrapper prevents the drop code to be executed,
+    // which would lead to a double undeclaration
     token: ManuallyDrop<LivelinessToken<'a>>,
 }
 

--- a/zenoh/src/api/publisher.rs
+++ b/zenoh/src/api/publisher.rs
@@ -23,7 +23,6 @@ use std::{
 
 use futures::Sink;
 use zenoh_core::{zread, Resolvable, Resolve, Wait};
-use zenoh_keyexpr::keyexpr;
 use zenoh_protocol::{
     core::CongestionControl,
     network::{push::ext, Push},
@@ -464,6 +463,8 @@ impl<'a> Undeclarable<(), PublisherUndeclaration<'a>> for Publisher<'a> {
 /// ```
 #[must_use = "Resolvables do nothing unless you resolve them using the `res` method from either `SyncResolve` or `AsyncResolve`"]
 pub struct PublisherUndeclaration<'a> {
+    // ManuallyDrop wrapper prevents the drop code to be executed,
+    // which would lead to a double undeclaration
     publisher: ManuallyDrop<Publisher<'a>>,
 }
 
@@ -1031,6 +1032,8 @@ impl<Receiver> std::ops::DerefMut for MatchingListener<'_, Receiver> {
 
 #[zenoh_macros::unstable]
 pub struct MatchingListenerUndeclaration<'a> {
+    // ManuallyDrop wrapper prevents the drop code to be executed,
+    // which would lead to a double undeclaration
     subscriber: ManuallyDrop<MatchingListenerInner<'a>>,
 }
 

--- a/zenoh/src/api/queryable.rs
+++ b/zenoh/src/api/queryable.rs
@@ -637,6 +637,8 @@ impl<'a> Undeclarable<(), QueryableUndeclaration<'a>> for CallbackQueryable<'a> 
 /// ```
 #[must_use = "Resolvables do nothing unless you resolve them using the `res` method from either `SyncResolve` or `AsyncResolve`"]
 pub struct QueryableUndeclaration<'a> {
+    // ManuallyDrop wrapper prevents the drop code to be executed,
+    // which would lead to a double undeclaration
     queryable: ManuallyDrop<CallbackQueryable<'a>>,
 }
 

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -530,6 +530,8 @@ impl Session {
     /// # }
     /// ```
     pub fn close(self) -> impl Resolve<ZResult<()>> {
+        // ManuallyDrop wrapper prevents the drop code to be executed,
+        // which would lead to a double close
         let session = ManuallyDrop::new(self);
         ResolveFuture::new(async move {
             trace!("close()");

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -2484,6 +2484,7 @@ impl Primitives for SessionClone {
 
 impl Drop for Session {
     fn drop(&mut self) {
+        // Use clone inner session, as it will be rewrapped in ManuallyDrop inside Session::close
         let _ = ManuallyDrop::into_inner(self.clone().0).close().wait();
     }
 }

--- a/zenoh/src/api/subscriber.rs
+++ b/zenoh/src/api/subscriber.rs
@@ -135,6 +135,8 @@ impl<'a> Undeclarable<(), SubscriberUndeclaration<'a>> for SubscriberInner<'a> {
 /// ```
 #[must_use = "Resolvables do nothing unless you resolve them using the `res` method from either `SyncResolve` or `AsyncResolve`"]
 pub struct SubscriberUndeclaration<'a> {
+    // ManuallyDrop wrapper prevents the drop code to be executed,
+    // which would lead to a double undeclaration
     subscriber: ManuallyDrop<SubscriberInner<'a>>,
 }
 


### PR DESCRIPTION
This flag was just used to prevent double close/undeclaration, i.e. object being drop after `close`/`undeclare`. Using `ManuallyDrop` instead in `close`/`undeclare` solve this issue, and save some space in structs (often one word counting the padding, which is not negligible).