### PR TITLE
feat: add unstable background method to subscriber/queryable/matching listeners

### DIFF
--- a/zenoh/src/api/admin.rs
+++ b/zenoh/src/api/admin.rs
@@ -30,7 +30,7 @@ use super::{
     key_expr::KeyExpr,
     queryable::Query,
     sample::{DataInfo, Locality, SampleKind},
-    session::Session,
+    session::{Session, SessionClone},
 };
 
 macro_rules! ke_for_sure {
@@ -121,11 +121,11 @@ pub(crate) fn on_admin_query(session: &Session, query: Query) {
 
 #[derive(Clone)]
 pub(crate) struct Handler {
-    pub(crate) session: Arc<Session>,
+    pub(crate) session: Arc<SessionClone>,
 }
 
 impl Handler {
-    pub(crate) fn new(session: Session) -> Self {
+    pub(crate) fn new(session: SessionClone) -> Self {
         Self {
             session: Arc::new(session),
         }
@@ -193,7 +193,7 @@ impl TransportMulticastEventHandler for Handler {
 
 pub(crate) struct PeerHandler {
     pub(crate) expr: WireExpr<'static>,
-    pub(crate) session: Arc<Session>,
+    pub(crate) session: Arc<SessionClone>,
 }
 
 impl TransportPeerEventHandler for PeerHandler {

--- a/zenoh/src/api/admin.rs
+++ b/zenoh/src/api/admin.rs
@@ -30,7 +30,7 @@ use super::{
     key_expr::KeyExpr,
     queryable::Query,
     sample::{DataInfo, Locality, SampleKind},
-    session::{Session, SessionClone},
+    session::Session,
 };
 
 macro_rules! ke_for_sure {
@@ -121,11 +121,11 @@ pub(crate) fn on_admin_query(session: &Session, query: Query) {
 
 #[derive(Clone)]
 pub(crate) struct Handler {
-    pub(crate) session: Arc<SessionClone>,
+    pub(crate) session: Arc<Session>,
 }
 
 impl Handler {
-    pub(crate) fn new(session: SessionClone) -> Self {
+    pub(crate) fn new(session: Session) -> Self {
         Self {
             session: Arc::new(session),
         }
@@ -193,7 +193,7 @@ impl TransportMulticastEventHandler for Handler {
 
 pub(crate) struct PeerHandler {
     pub(crate) expr: WireExpr<'static>,
-    pub(crate) session: Arc<SessionClone>,
+    pub(crate) session: Arc<Session>,
 }
 
 impl TransportPeerEventHandler for PeerHandler {

--- a/zenoh/src/api/builders/publisher.rs
+++ b/zenoh/src/api/builders/publisher.rs
@@ -321,6 +321,7 @@ impl<'a, 'b> PublisherBuilder<'a, 'b> {
             is_express: self.is_express,
             destination: self.destination,
             matching_listeners: Default::default(),
+            undeclare_on_drop: true,
         })
     }
 }
@@ -373,6 +374,7 @@ impl<'a, 'b> Wait for PublisherBuilder<'a, 'b> {
                 is_express: self.is_express,
                 destination: self.destination,
                 matching_listeners: Default::default(),
+                undeclare_on_drop: true,
             })
     }
 }

--- a/zenoh/src/api/builders/publisher.rs
+++ b/zenoh/src/api/builders/publisher.rs
@@ -320,6 +320,7 @@ impl<'a, 'b> PublisherBuilder<'a, 'b> {
             priority: self.priority,
             is_express: self.is_express,
             destination: self.destination,
+            matching_listeners: Default::default(),
         })
     }
 }
@@ -371,6 +372,7 @@ impl<'a, 'b> Wait for PublisherBuilder<'a, 'b> {
                 priority: self.priority,
                 is_express: self.is_express,
                 destination: self.destination,
+                matching_listeners: Default::default(),
             })
     }
 }

--- a/zenoh/src/api/liveliness.rs
+++ b/zenoh/src/api/liveliness.rs
@@ -314,6 +314,8 @@ pub struct LivelinessToken<'a> {
 #[must_use = "Resolvables do nothing unless you resolve them using the `res` method from either `SyncResolve` or `AsyncResolve`"]
 #[zenoh_macros::unstable]
 pub struct LivelinessTokenUndeclaration<'a> {
+    // ManuallyDrop wrapper prevents the drop code to be executed,
+    // which would lead to a double undeclaration
     token: ManuallyDrop<LivelinessToken<'a>>,
 }
 

--- a/zenoh/src/api/liveliness.rs
+++ b/zenoh/src/api/liveliness.rs
@@ -553,6 +553,7 @@ where
                 subscriber: SubscriberInner {
                     session,
                     state: sub_state,
+                    background: false,
                 },
                 handler,
             })

--- a/zenoh/src/api/liveliness.rs
+++ b/zenoh/src/api/liveliness.rs
@@ -15,7 +15,6 @@
 use std::{
     convert::TryInto,
     future::{IntoFuture, Ready},
-    mem::ManuallyDrop,
     sync::Arc,
     time::Duration,
 };
@@ -236,6 +235,7 @@ impl Wait for LivelinessTokenBuilder<'_, '_> {
             .map(|tok_state| LivelinessToken {
                 session,
                 state: tok_state,
+                undeclare_on_drop: true,
             })
     }
 }
@@ -291,6 +291,7 @@ pub(crate) struct LivelinessTokenState {
 pub struct LivelinessToken<'a> {
     pub(crate) session: SessionRef<'a>,
     pub(crate) state: Arc<LivelinessTokenState>,
+    undeclare_on_drop: bool,
 }
 
 /// A [`Resolvable`] returned when undeclaring a [`LivelinessToken`](LivelinessToken).
@@ -314,9 +315,7 @@ pub struct LivelinessToken<'a> {
 #[must_use = "Resolvables do nothing unless you resolve them using the `res` method from either `SyncResolve` or `AsyncResolve`"]
 #[zenoh_macros::unstable]
 pub struct LivelinessTokenUndeclaration<'a> {
-    // ManuallyDrop wrapper prevents the drop code to be executed,
-    // which would lead to a double undeclaration
-    token: ManuallyDrop<LivelinessToken<'a>>,
+    token: LivelinessToken<'a>,
 }
 
 #[zenoh_macros::unstable]
@@ -326,7 +325,9 @@ impl Resolvable for LivelinessTokenUndeclaration<'_> {
 
 #[zenoh_macros::unstable]
 impl Wait for LivelinessTokenUndeclaration<'_> {
-    fn wait(self) -> <Self as Resolvable>::To {
+    fn wait(mut self) -> <Self as Resolvable>::To {
+        // set the flag first to avoid double panic if this function panic
+        self.token.undeclare_on_drop = false;
         self.token.session.undeclare_liveliness(self.token.state.id)
     }
 }
@@ -369,21 +370,31 @@ impl<'a> LivelinessToken<'a> {
     pub fn undeclare(self) -> impl Resolve<ZResult<()>> + 'a {
         Undeclarable::undeclare_inner(self, ())
     }
+
+    /// Keep this liveliness token in background, until the session is closed.
+    #[inline]
+    #[zenoh_macros::unstable]
+    pub fn background(mut self) {
+        // It's not necessary to undeclare this resource when session close, as other sessions
+        // will clean all resources related to the closed one.
+        // So we can just never undeclare it.
+        self.undeclare_on_drop = false;
+    }
 }
 
 #[zenoh_macros::unstable]
 impl<'a> Undeclarable<(), LivelinessTokenUndeclaration<'a>> for LivelinessToken<'a> {
     fn undeclare_inner(self, _: ()) -> LivelinessTokenUndeclaration<'a> {
-        LivelinessTokenUndeclaration {
-            token: ManuallyDrop::new(self),
-        }
+        LivelinessTokenUndeclaration { token: self }
     }
 }
 
 #[zenoh_macros::unstable]
 impl Drop for LivelinessToken<'_> {
     fn drop(&mut self) {
-        let _ = self.session.undeclare_liveliness(self.state.id);
+        if self.undeclare_on_drop {
+            let _ = self.session.undeclare_liveliness(self.state.id);
+        }
     }
 }
 
@@ -553,7 +564,7 @@ where
                 subscriber: SubscriberInner {
                     session,
                     state: sub_state,
-                    background: false,
+                    undeclare_on_drop: true,
                 },
                 handler,
             })

--- a/zenoh/src/api/publisher.rs
+++ b/zenoh/src/api/publisher.rs
@@ -23,7 +23,6 @@ use std::{
 
 use futures::Sink;
 use zenoh_core::{zread, Resolvable, Resolve, Wait};
-use zenoh_keyexpr::keyexpr;
 use zenoh_protocol::{
     core::CongestionControl,
     network::{push::ext, Push},
@@ -464,6 +463,8 @@ impl<'a> Undeclarable<(), PublisherUndeclaration<'a>> for Publisher<'a> {
 /// ```
 #[must_use = "Resolvables do nothing unless you resolve them using the `res` method from either `SyncResolve` or `AsyncResolve`"]
 pub struct PublisherUndeclaration<'a> {
+    // ManuallyDrop wrapper prevents the drop code to be executed,
+    // which would lead to a double undeclaration
     publisher: ManuallyDrop<Publisher<'a>>,
 }
 
@@ -1031,6 +1032,8 @@ impl<Receiver> std::ops::DerefMut for MatchingListener<'_, Receiver> {
 
 #[zenoh_macros::unstable]
 pub struct MatchingListenerUndeclaration<'a> {
+    // ManuallyDrop wrapper prevents the drop code to be executed,
+    // which would lead to a double undeclaration
     subscriber: ManuallyDrop<MatchingListenerInner<'a>>,
 }
 

--- a/zenoh/src/api/publisher.rs
+++ b/zenoh/src/api/publisher.rs
@@ -338,7 +338,6 @@ impl<'a> Publisher<'a> {
     pub fn matching_listener(&self) -> MatchingListenerBuilder<'_, DefaultHandler> {
         MatchingListenerBuilder {
             publisher: PublisherRef::Borrow(self),
-            background: false,
             handler: DefaultHandler::default(),
         }
     }
@@ -451,7 +450,6 @@ impl PublisherDeclarations for std::sync::Arc<Publisher<'static>> {
     fn matching_listener(&self) -> MatchingListenerBuilder<'static, DefaultHandler> {
         MatchingListenerBuilder {
             publisher: PublisherRef::Shared(self.clone()),
-            background: false,
             handler: DefaultHandler::default(),
         }
     }
@@ -775,7 +773,6 @@ impl MatchingStatus {
 #[derive(Debug)]
 pub struct MatchingListenerBuilder<'a, Handler> {
     pub(crate) publisher: PublisherRef<'a>,
-    pub(crate) background: bool,
     pub handler: Handler,
 }
 
@@ -812,12 +809,10 @@ impl<'a> MatchingListenerBuilder<'a, DefaultHandler> {
     {
         let MatchingListenerBuilder {
             publisher,
-            background,
             handler: _,
         } = self;
         MatchingListenerBuilder {
             publisher,
-            background,
             handler: callback,
         }
     }
@@ -884,14 +879,9 @@ impl<'a> MatchingListenerBuilder<'a, DefaultHandler> {
     {
         let MatchingListenerBuilder {
             publisher,
-            background,
             handler: _,
         } = self;
-        MatchingListenerBuilder {
-            publisher,
-            background,
-            handler,
-        }
+        MatchingListenerBuilder { publisher, handler }
     }
 }
 

--- a/zenoh/src/api/queryable.rs
+++ b/zenoh/src/api/queryable.rs
@@ -637,6 +637,8 @@ impl<'a> Undeclarable<(), QueryableUndeclaration<'a>> for CallbackQueryable<'a> 
 /// ```
 #[must_use = "Resolvables do nothing unless you resolve them using the `res` method from either `SyncResolve` or `AsyncResolve`"]
 pub struct QueryableUndeclaration<'a> {
+    // ManuallyDrop wrapper prevents the drop code to be executed,
+    // which would lead to a double undeclaration
     queryable: ManuallyDrop<CallbackQueryable<'a>>,
 }
 

--- a/zenoh/src/api/queryable.rs
+++ b/zenoh/src/api/queryable.rs
@@ -896,6 +896,13 @@ impl<'a, Handler> Queryable<'a, Handler> {
     pub fn undeclare(self) -> impl Resolve<ZResult<()>> + 'a {
         Undeclarable::undeclare_inner(self, ())
     }
+
+    /// Make the queryable run in background, until the session is closed.
+    #[inline]
+    #[zenoh_macros::unstable]
+    pub fn background(self) {
+        std::mem::forget(self);
+    }
 }
 
 impl<'a, T> Undeclarable<(), QueryableUndeclaration<'a>> for Queryable<'a, T> {

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -530,6 +530,8 @@ impl Session {
     /// # }
     /// ```
     pub fn close(self) -> impl Resolve<ZResult<()>> {
+        // ManuallyDrop wrapper prevents the drop code to be executed,
+        // which would lead to a double close
         let session = ManuallyDrop::new(self);
         ResolveFuture::new(async move {
             trace!("close()");

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -2484,6 +2484,7 @@ impl Primitives for SessionClone {
 
 impl Drop for Session {
     fn drop(&mut self) {
+        // Use clone inner session, as it will be rewrapped in ManuallyDrop inside Session::close
         let _ = ManuallyDrop::into_inner(self.clone().0).close().wait();
     }
 }

--- a/zenoh/src/api/subscriber.rs
+++ b/zenoh/src/api/subscriber.rs
@@ -505,6 +505,13 @@ impl<'a, Handler> Subscriber<'a, Handler> {
     pub fn undeclare(self) -> SubscriberUndeclaration<'a> {
         self.subscriber.undeclare()
     }
+
+    /// Make the subscriber run in background, until the session is closed.
+    #[inline]
+    #[zenoh_macros::unstable]
+    pub fn background(self) {
+        std::mem::forget(self);
+    }
 }
 
 impl<'a, T> Undeclarable<(), SubscriberUndeclaration<'a>> for Subscriber<'a, T> {

--- a/zenoh/src/api/subscriber.rs
+++ b/zenoh/src/api/subscriber.rs
@@ -135,6 +135,8 @@ impl<'a> Undeclarable<(), SubscriberUndeclaration<'a>> for SubscriberInner<'a> {
 /// ```
 #[must_use = "Resolvables do nothing unless you resolve them using the `res` method from either `SyncResolve` or `AsyncResolve`"]
 pub struct SubscriberUndeclaration<'a> {
+    // ManuallyDrop wrapper prevents the drop code to be executed,
+    // which would lead to a double undeclaration
     subscriber: ManuallyDrop<SubscriberInner<'a>>,
 }
 


### PR DESCRIPTION
Following #1012, but completely reworked (no more builder method), hence a new PR.

~~Based on #1104, should wait to have it merge before merging this PR.~~