### PR TITLE
Remove StringOrBase64

### DIFF
--- a/plugins/zenoh-plugin-rest/src/lib.rs
+++ b/plugins/zenoh-plugin-rest/src/lib.rs
@@ -26,7 +26,7 @@ use http_types::Method;
 use serde::{Deserialize, Serialize};
 use tide::{http::Mime, sse::Sender, Request, Response, Server, StatusCode};
 use zenoh::{
-    bytes::{StringOrBase64, ZBytes},
+    bytes::ZBytes,
     encoding::Encoding,
     internal::{
         plugins::{RunningPluginTrait, ZenohPlugin},
@@ -76,11 +76,11 @@ fn payload_to_json(payload: &ZBytes, encoding: &Encoding) -> serde_json::Value {
                     payload
                         .deserialize::<serde_json::Value>()
                         .unwrap_or_else(|_| {
-                            serde_json::Value::String(StringOrBase64::from(payload).into_string())
+                            serde_json::Value::String(base64_encode(&Cow::from(payload)))
                         })
                 }
                 // otherwise convert to JSON string
-                _ => serde_json::Value::String(StringOrBase64::from(payload).into_string()),
+                _ => serde_json::Value::String(base64_encode(&Cow::from(payload))),
             }
         }
     }

--- a/plugins/zenoh-plugin-storage-manager/src/replica/aligner.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/aligner.rs
@@ -216,16 +216,10 @@ impl Aligner {
             let mut other_intervals: HashMap<u64, u64> = HashMap::new();
             // expecting sample.payload to be a vec of intervals with their checksum
             for each in reply_content {
-                match each.payload().deserialize::<Cow<str>>() {
-                    Ok(s) => match serde_json::from_str(&s) {
-                        Ok((i, c)) => {
-                            other_intervals.insert(i, c);
-                        }
-                        Err(e) => {
-                            tracing::error!("[ALIGNER] Error decoding reply: {}", e);
-                            no_err = false;
-                        }
-                    },
+                match serde_json::from_reader(each.payload().reader()) {
+                    Ok((i, c)) => {
+                        other_intervals.insert(i, c);
+                    }
                     Err(e) => {
                         tracing::error!("[ALIGNER] Error decoding reply: {}", e);
                         no_err = false;
@@ -268,16 +262,10 @@ impl Aligner {
                 let (reply_content, mut no_err) = self.perform_query(other_rep, properties).await;
                 let mut other_subintervals: HashMap<u64, u64> = HashMap::new();
                 for each in reply_content {
-                    match each.payload().deserialize::<Cow<str>>() {
-                        Ok(s) => match serde_json::from_str(&s) {
-                            Ok((i, c)) => {
-                                other_subintervals.insert(i, c);
-                            }
-                            Err(e) => {
-                                tracing::error!("[ALIGNER] Error decoding reply: {}", e);
-                                no_err = false;
-                            }
-                        },
+                    match serde_json::from_reader(each.payload().reader()) {
+                        Ok((i, c)) => {
+                            other_subintervals.insert(i, c);
+                        }
                         Err(e) => {
                             tracing::error!("[ALIGNER] Error decoding reply: {}", e);
                             no_err = false;
@@ -315,16 +303,10 @@ impl Aligner {
             let (reply_content, mut no_err) = self.perform_query(other_rep, properties).await;
             let mut other_content: HashMap<u64, Vec<LogEntry>> = HashMap::new();
             for each in reply_content {
-                match each.payload().deserialize::<Cow<str>>() {
-                    Ok(s) => match serde_json::from_str(&s) {
-                        Ok((i, c)) => {
-                            other_content.insert(i, c);
-                        }
-                        Err(e) => {
-                            tracing::error!("[ALIGNER] Error decoding reply: {}", e);
-                            no_err = false;
-                        }
-                    },
+                match serde_json::from_reader(each.payload().reader()) {
+                    Ok((i, c)) => {
+                        other_content.insert(i, c);
+                    }
                     Err(e) => {
                         tracing::error!("[ALIGNER] Error decoding reply: {}", e);
                         no_err = false;

--- a/plugins/zenoh-plugin-storage-manager/src/replica/aligner.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/aligner.rs
@@ -346,7 +346,7 @@ impl Aligner {
                                 sample
                                     .payload()
                                     .deserialize::<Cow<str>>()
-                                    .unwrap_or(Cow::Borrowed("invalid"))
+                                    .unwrap_or(Cow::Borrowed("<malformed>"))
                             );
                             return_val.push(sample);
                         }

--- a/plugins/zenoh-plugin-storage-manager/src/replica/mod.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/mod.rs
@@ -15,9 +15,9 @@
 // This module extends Storage with alignment protocol that aligns storages subscribing to the same key_expr
 
 use std::{
+    borrow::Cow,
     collections::{HashMap, HashSet},
-    str,
-    str::FromStr,
+    str::{self, FromStr},
     time::{Duration, SystemTime},
 };
 
@@ -44,9 +44,7 @@ pub use aligner::Aligner;
 pub use digest::{Digest, DigestConfig, EraType, LogEntry};
 pub use snapshotter::Snapshotter;
 pub use storage::{ReplicationService, StorageService};
-use zenoh::{
-    bytes::StringOrBase64, key_expr::OwnedKeyExpr, sample::Locality, time::Timestamp, Session,
-};
+use zenoh::{key_expr::OwnedKeyExpr, sample::Locality, time::Timestamp, Session};
 
 const ERA: &str = "era";
 const INTERVALS: &str = "intervals";
@@ -227,21 +225,29 @@ impl Replica {
             };
             let from = &sample.key_expr().as_str()
                 [Replica::get_digest_key(&self.key_expr, ALIGN_PREFIX).len() + 1..];
-            tracing::trace!(
-                "[DIGEST_SUB] From {} Received {} ('{}': '{}')",
-                from,
-                sample.kind(),
-                sample.key_expr().as_str(),
-                StringOrBase64::from(sample.payload())
-            );
-            let digest: Digest = match serde_json::from_str(&StringOrBase64::from(sample.payload()))
-            {
-                Ok(digest) => digest,
+
+            let digest: Digest = match sample.payload().deserialize::<Cow<str>>() {
+                Ok(s) => match serde_json::from_str(&s) {
+                    Ok(digest) => digest,
+                    Err(e) => {
+                        tracing::error!("[DIGEST_SUB] Error in decoding the digest: {}", e);
+                        continue;
+                    }
+                },
                 Err(e) => {
                     tracing::error!("[DIGEST_SUB] Error in decoding the digest: {}", e);
                     continue;
                 }
             };
+
+            tracing::trace!(
+                "[DIGEST_SUB] From {} Received {} ('{}': '{:?}')",
+                from,
+                sample.kind(),
+                sample.key_expr().as_str(),
+                digest,
+            );
+
             let ts = digest.timestamp;
             let to_be_processed = self
                 .processing_needed(
@@ -260,7 +266,7 @@ impl Replica {
                         tracing::error!("[DIGEST_SUB] Error sending digest to aligner: {}", e)
                     }
                 }
-            };
+            }
             received.insert(from.to_string(), ts);
         }
     }

--- a/plugins/zenoh-plugin-storage-manager/src/replica/mod.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/mod.rs
@@ -15,7 +15,6 @@
 // This module extends Storage with alignment protocol that aligns storages subscribing to the same key_expr
 
 use std::{
-    borrow::Cow,
     collections::{HashMap, HashSet},
     str::{self, FromStr},
     time::{Duration, SystemTime},

--- a/plugins/zenoh-plugin-storage-manager/src/replica/mod.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/mod.rs
@@ -226,14 +226,8 @@ impl Replica {
             let from = &sample.key_expr().as_str()
                 [Replica::get_digest_key(&self.key_expr, ALIGN_PREFIX).len() + 1..];
 
-            let digest: Digest = match sample.payload().deserialize::<Cow<str>>() {
-                Ok(s) => match serde_json::from_str(&s) {
-                    Ok(digest) => digest,
-                    Err(e) => {
-                        tracing::error!("[DIGEST_SUB] Error in decoding the digest: {}", e);
-                        continue;
-                    }
-                },
+            let digest: Digest = match serde_json::from_reader(sample.payload().reader()) {
+                Ok(digest) => digest,
                 Err(e) => {
                     tracing::error!("[DIGEST_SUB] Error in decoding the digest: {}", e);
                     continue;

--- a/plugins/zenoh-plugin-storage-manager/tests/operations.rs
+++ b/plugins/zenoh-plugin-storage-manager/tests/operations.rs
@@ -16,12 +16,13 @@
 // 1. normal case, just some wild card puts and deletes on existing keys and ensure it works
 // 2. check for dealing with out of order updates
 
+use std::borrow::Cow;
 use std::{str::FromStr, thread::sleep};
 
 use async_std::task;
 use zenoh::{
-    bytes::StringOrBase64, internal::zasync_executor_init, prelude::*, query::Reply,
-    sample::Sample, time::Timestamp, Config, Session,
+    internal::zasync_executor_init, prelude::*, query::Reply, sample::Sample, time::Timestamp,
+    Config, Session,
 };
 use zenoh_plugin_trait::Plugin;
 
@@ -96,7 +97,7 @@ async fn test_updates_in_order() {
     // expects exactly one sample
     let data = get_data(&session, "operation/test/a").await;
     assert_eq!(data.len(), 1);
-    assert_eq!(StringOrBase64::from(data[0].payload()).as_str(), "1");
+    assert_eq!(data[0].payload().deserialize::<Cow<str>>().unwrap(), "1");
 
     put_data(
         &session,
@@ -112,7 +113,7 @@ async fn test_updates_in_order() {
     // expects exactly one sample
     let data = get_data(&session, "operation/test/b").await;
     assert_eq!(data.len(), 1);
-    assert_eq!(StringOrBase64::from(data[0].payload()).as_str(), "2");
+    assert_eq!(data[0].payload().deserialize::<Cow<str>>().unwrap(), "2");
 
     delete_data(
         &session,
@@ -131,7 +132,7 @@ async fn test_updates_in_order() {
     // expects exactly one sample
     let data = get_data(&session, "operation/test/b").await;
     assert_eq!(data.len(), 1);
-    assert_eq!(StringOrBase64::from(data[0].payload()).as_str(), "2");
+    assert_eq!(data[0].payload().deserialize::<Cow<str>>().unwrap(), "2");
     assert_eq!(data[0].key_expr().as_str(), "operation/test/b");
 
     drop(storage);

--- a/plugins/zenoh-plugin-storage-manager/tests/operations.rs
+++ b/plugins/zenoh-plugin-storage-manager/tests/operations.rs
@@ -16,8 +16,7 @@
 // 1. normal case, just some wild card puts and deletes on existing keys and ensure it works
 // 2. check for dealing with out of order updates
 
-use std::borrow::Cow;
-use std::{str::FromStr, thread::sleep};
+use std::{borrow::Cow, str::FromStr, thread::sleep};
 
 use async_std::task;
 use zenoh::{

--- a/plugins/zenoh-plugin-storage-manager/tests/wildcard.rs
+++ b/plugins/zenoh-plugin-storage-manager/tests/wildcard.rs
@@ -16,8 +16,7 @@
 // 1. normal case, just some wild card puts and deletes on existing keys and ensure it works
 // 2. check for dealing with out of order updates
 
-use std::borrow::Cow;
-use std::{str::FromStr, thread::sleep};
+use std::{borrow::Cow, str::FromStr, thread::sleep};
 
 // use std::collections::HashMap;
 use async_std::task;

--- a/plugins/zenoh-plugin-storage-manager/tests/wildcard.rs
+++ b/plugins/zenoh-plugin-storage-manager/tests/wildcard.rs
@@ -16,13 +16,14 @@
 // 1. normal case, just some wild card puts and deletes on existing keys and ensure it works
 // 2. check for dealing with out of order updates
 
+use std::borrow::Cow;
 use std::{str::FromStr, thread::sleep};
 
 // use std::collections::HashMap;
 use async_std::task;
 use zenoh::{
-    bytes::StringOrBase64, internal::zasync_executor_init, prelude::*, query::Reply,
-    sample::Sample, time::Timestamp, Config, Session,
+    internal::zasync_executor_init, prelude::*, query::Reply, sample::Sample, time::Timestamp,
+    Config, Session,
 };
 use zenoh_plugin_trait::Plugin;
 
@@ -113,7 +114,7 @@ async fn test_wild_card_in_order() {
     let data = get_data(&session, "wild/test/*").await;
     assert_eq!(data.len(), 1);
     assert_eq!(data[0].key_expr().as_str(), "wild/test/a");
-    assert_eq!(StringOrBase64::from(data[0].payload()).as_str(), "2");
+    assert_eq!(data[0].payload().deserialize::<Cow<str>>().unwrap(), "2");
 
     put_data(
         &session,
@@ -131,8 +132,20 @@ async fn test_wild_card_in_order() {
     assert_eq!(data.len(), 2);
     assert!(["wild/test/a", "wild/test/b"].contains(&data[0].key_expr().as_str()));
     assert!(["wild/test/a", "wild/test/b"].contains(&data[1].key_expr().as_str()));
-    assert!(["2", "3"].contains(&StringOrBase64::from(data[0].payload()).as_str()));
-    assert!(["2", "3"].contains(&StringOrBase64::from(data[1].payload()).as_str()));
+    assert!(["2", "3"].contains(
+        &data[0]
+            .payload()
+            .deserialize::<Cow<str>>()
+            .unwrap()
+            .as_ref()
+    ));
+    assert!(["2", "3"].contains(
+        &data[1]
+            .payload()
+            .deserialize::<Cow<str>>()
+            .unwrap()
+            .as_ref()
+    ));
 
     put_data(
         &session,
@@ -150,8 +163,8 @@ async fn test_wild_card_in_order() {
     assert_eq!(data.len(), 2);
     assert!(["wild/test/a", "wild/test/b"].contains(&data[0].key_expr().as_str()));
     assert!(["wild/test/a", "wild/test/b"].contains(&data[1].key_expr().as_str()));
-    assert_eq!(StringOrBase64::from(data[0].payload()).as_str(), "4");
-    assert_eq!(StringOrBase64::from(data[1].payload()).as_str(), "4");
+    assert_eq!(data[0].payload().deserialize::<Cow<str>>().unwrap(), "4");
+    assert_eq!(data[1].payload().deserialize::<Cow<str>>().unwrap(), "4");
 
     delete_data(
         &session,

--- a/zenoh/src/api/bytes.rs
+++ b/zenoh/src/api/bytes.rs
@@ -14,7 +14,7 @@
 
 //! ZBytes primitives.
 use std::{
-    borrow::Cow, convert::Infallible, fmt::Debug, marker::PhantomData, ops::Deref, str::Utf8Error,
+    borrow::Cow, convert::Infallible, fmt::Debug, marker::PhantomData, str::Utf8Error,
     string::FromUtf8Error, sync::Arc,
 };
 
@@ -1803,53 +1803,6 @@ where
 
     fn try_from(value: &mut ZBytes) -> Result<Self, Self::Error> {
         ZSerde.deserialize(&*value)
-    }
-}
-
-// For convenience to always convert a Value in the examples
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum StringOrBase64 {
-    String(String),
-    Base64(String),
-}
-
-impl StringOrBase64 {
-    pub fn into_string(self) -> String {
-        match self {
-            StringOrBase64::String(s) | StringOrBase64::Base64(s) => s,
-        }
-    }
-}
-
-impl Deref for StringOrBase64 {
-    type Target = String;
-
-    fn deref(&self) -> &Self::Target {
-        match self {
-            Self::String(s) | Self::Base64(s) => s,
-        }
-    }
-}
-
-impl std::fmt::Display for StringOrBase64 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self)
-    }
-}
-
-impl From<&ZBytes> for StringOrBase64 {
-    fn from(v: &ZBytes) -> Self {
-        use base64::{engine::general_purpose::STANDARD as b64_std_engine, Engine};
-        match v.deserialize::<String>() {
-            Ok(s) => StringOrBase64::String(s),
-            Err(_) => StringOrBase64::Base64(b64_std_engine.encode(v.into::<Vec<u8>>())),
-        }
-    }
-}
-
-impl From<&mut ZBytes> for StringOrBase64 {
-    fn from(v: &mut ZBytes) -> Self {
-        StringOrBase64::from(&*v)
     }
 }
 

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -240,8 +240,8 @@ pub mod encoding {
 /// Payload primitives
 pub mod bytes {
     pub use crate::api::bytes::{
-        Deserialize, OptionZBytes, Serialize, StringOrBase64, ZBytes, ZBytesIterator, ZBytesReader,
-        ZBytesWriter, ZDeserializeError, ZSerde,
+        Deserialize, OptionZBytes, Serialize, ZBytes, ZBytesIterator, ZBytesReader, ZBytesWriter,
+        ZDeserializeError, ZSerde,
     };
 }
 


### PR DESCRIPTION
This PR remove temporary `StringOrBase64` type that was introduced to avoid completely rework of the whole codebase when `ZBytes` was defined.