### PR TITLE
rename wrapped zenoh-protocol structures to `...Proto`, wrap and expose `EntityGlobalId`

### DIFF
--- a/commons/zenoh-codec/src/core/timestamp.rs
+++ b/commons/zenoh-codec/src/core/timestamp.rs
@@ -17,7 +17,7 @@ use zenoh_buffers::{
     reader::{DidntRead, Reader},
     writer::{DidntWrite, Writer},
 };
-use zenoh_protocol::core::{Timestamp, ZenohId};
+use zenoh_protocol::core::{Timestamp, ZenohIdInner};
 
 use crate::{LCodec, RCodec, WCodec, Zenoh080};
 
@@ -53,7 +53,7 @@ where
         if size > (uhlc::ID::MAX_SIZE) {
             return Err(DidntRead);
         }
-        let mut id = [0_u8; ZenohId::MAX_SIZE];
+        let mut id = [0_u8; ZenohIdInner::MAX_SIZE];
         reader.read_exact(&mut id[..size])?;
 
         let time = uhlc::NTP64(time);

--- a/commons/zenoh-codec/src/core/timestamp.rs
+++ b/commons/zenoh-codec/src/core/timestamp.rs
@@ -17,7 +17,7 @@ use zenoh_buffers::{
     reader::{DidntRead, Reader},
     writer::{DidntWrite, Writer},
 };
-use zenoh_protocol::core::{Timestamp, ZenohIdInner};
+use zenoh_protocol::core::{Timestamp, ZenohIdProto};
 
 use crate::{LCodec, RCodec, WCodec, Zenoh080};
 
@@ -53,7 +53,7 @@ where
         if size > (uhlc::ID::MAX_SIZE) {
             return Err(DidntRead);
         }
-        let mut id = [0_u8; ZenohIdInner::MAX_SIZE];
+        let mut id = [0_u8; ZenohIdProto::MAX_SIZE];
         reader.read_exact(&mut id[..size])?;
 
         let time = uhlc::NTP64(time);

--- a/commons/zenoh-codec/src/core/zenohid.rs
+++ b/commons/zenoh-codec/src/core/zenohid.rs
@@ -17,70 +17,70 @@ use zenoh_buffers::{
     reader::{DidntRead, Reader},
     writer::{DidntWrite, Writer},
 };
-use zenoh_protocol::core::ZenohId;
+use zenoh_protocol::core::ZenohIdInner;
 
 use crate::{LCodec, RCodec, WCodec, Zenoh080, Zenoh080Length};
 
-impl LCodec<&ZenohId> for Zenoh080 {
-    fn w_len(self, x: &ZenohId) -> usize {
+impl LCodec<&ZenohIdInner> for Zenoh080 {
+    fn w_len(self, x: &ZenohIdInner) -> usize {
         x.size()
     }
 }
 
-impl<W> WCodec<&ZenohId, &mut W> for Zenoh080
+impl<W> WCodec<&ZenohIdInner, &mut W> for Zenoh080
 where
     W: Writer,
 {
     type Output = Result<(), DidntWrite>;
 
-    fn write(self, writer: &mut W, x: &ZenohId) -> Self::Output {
+    fn write(self, writer: &mut W, x: &ZenohIdInner) -> Self::Output {
         self.write(&mut *writer, &x.to_le_bytes()[..x.size()])
     }
 }
 
-impl<R> RCodec<ZenohId, &mut R> for Zenoh080
+impl<R> RCodec<ZenohIdInner, &mut R> for Zenoh080
 where
     R: Reader,
 {
     type Error = DidntRead;
 
-    fn read(self, reader: &mut R) -> Result<ZenohId, Self::Error> {
+    fn read(self, reader: &mut R) -> Result<ZenohIdInner, Self::Error> {
         let size: usize = self.read(&mut *reader)?;
-        if size > ZenohId::MAX_SIZE {
+        if size > ZenohIdInner::MAX_SIZE {
             return Err(DidntRead);
         }
-        let mut id = [0; ZenohId::MAX_SIZE];
+        let mut id = [0; ZenohIdInner::MAX_SIZE];
         reader.read_exact(&mut id[..size])?;
-        ZenohId::try_from(&id[..size]).map_err(|_| DidntRead)
+        ZenohIdInner::try_from(&id[..size]).map_err(|_| DidntRead)
     }
 }
 
-impl<W> WCodec<&ZenohId, &mut W> for Zenoh080Length
+impl<W> WCodec<&ZenohIdInner, &mut W> for Zenoh080Length
 where
     W: Writer,
 {
     type Output = Result<(), DidntWrite>;
 
-    fn write(self, writer: &mut W, x: &ZenohId) -> Self::Output {
-        if self.length > ZenohId::MAX_SIZE {
+    fn write(self, writer: &mut W, x: &ZenohIdInner) -> Self::Output {
+        if self.length > ZenohIdInner::MAX_SIZE {
             return Err(DidntWrite);
         }
         writer.write_exact(&x.to_le_bytes()[..x.size()])
     }
 }
 
-impl<R> RCodec<ZenohId, &mut R> for Zenoh080Length
+impl<R> RCodec<ZenohIdInner, &mut R> for Zenoh080Length
 where
     R: Reader,
 {
     type Error = DidntRead;
 
-    fn read(self, reader: &mut R) -> Result<ZenohId, Self::Error> {
-        if self.length > ZenohId::MAX_SIZE {
+    fn read(self, reader: &mut R) -> Result<ZenohIdInner, Self::Error> {
+        if self.length > ZenohIdInner::MAX_SIZE {
             return Err(DidntRead);
         }
-        let mut id = [0; ZenohId::MAX_SIZE];
+        let mut id = [0; ZenohIdInner::MAX_SIZE];
         reader.read_exact(&mut id[..self.length])?;
-        ZenohId::try_from(&id[..self.length]).map_err(|_| DidntRead)
+        ZenohIdInner::try_from(&id[..self.length]).map_err(|_| DidntRead)
     }
 }

--- a/commons/zenoh-codec/src/core/zenohid.rs
+++ b/commons/zenoh-codec/src/core/zenohid.rs
@@ -17,70 +17,70 @@ use zenoh_buffers::{
     reader::{DidntRead, Reader},
     writer::{DidntWrite, Writer},
 };
-use zenoh_protocol::core::ZenohIdInner;
+use zenoh_protocol::core::ZenohIdProto;
 
 use crate::{LCodec, RCodec, WCodec, Zenoh080, Zenoh080Length};
 
-impl LCodec<&ZenohIdInner> for Zenoh080 {
-    fn w_len(self, x: &ZenohIdInner) -> usize {
+impl LCodec<&ZenohIdProto> for Zenoh080 {
+    fn w_len(self, x: &ZenohIdProto) -> usize {
         x.size()
     }
 }
 
-impl<W> WCodec<&ZenohIdInner, &mut W> for Zenoh080
+impl<W> WCodec<&ZenohIdProto, &mut W> for Zenoh080
 where
     W: Writer,
 {
     type Output = Result<(), DidntWrite>;
 
-    fn write(self, writer: &mut W, x: &ZenohIdInner) -> Self::Output {
+    fn write(self, writer: &mut W, x: &ZenohIdProto) -> Self::Output {
         self.write(&mut *writer, &x.to_le_bytes()[..x.size()])
     }
 }
 
-impl<R> RCodec<ZenohIdInner, &mut R> for Zenoh080
+impl<R> RCodec<ZenohIdProto, &mut R> for Zenoh080
 where
     R: Reader,
 {
     type Error = DidntRead;
 
-    fn read(self, reader: &mut R) -> Result<ZenohIdInner, Self::Error> {
+    fn read(self, reader: &mut R) -> Result<ZenohIdProto, Self::Error> {
         let size: usize = self.read(&mut *reader)?;
-        if size > ZenohIdInner::MAX_SIZE {
+        if size > ZenohIdProto::MAX_SIZE {
             return Err(DidntRead);
         }
-        let mut id = [0; ZenohIdInner::MAX_SIZE];
+        let mut id = [0; ZenohIdProto::MAX_SIZE];
         reader.read_exact(&mut id[..size])?;
-        ZenohIdInner::try_from(&id[..size]).map_err(|_| DidntRead)
+        ZenohIdProto::try_from(&id[..size]).map_err(|_| DidntRead)
     }
 }
 
-impl<W> WCodec<&ZenohIdInner, &mut W> for Zenoh080Length
+impl<W> WCodec<&ZenohIdProto, &mut W> for Zenoh080Length
 where
     W: Writer,
 {
     type Output = Result<(), DidntWrite>;
 
-    fn write(self, writer: &mut W, x: &ZenohIdInner) -> Self::Output {
-        if self.length > ZenohIdInner::MAX_SIZE {
+    fn write(self, writer: &mut W, x: &ZenohIdProto) -> Self::Output {
+        if self.length > ZenohIdProto::MAX_SIZE {
             return Err(DidntWrite);
         }
         writer.write_exact(&x.to_le_bytes()[..x.size()])
     }
 }
 
-impl<R> RCodec<ZenohIdInner, &mut R> for Zenoh080Length
+impl<R> RCodec<ZenohIdProto, &mut R> for Zenoh080Length
 where
     R: Reader,
 {
     type Error = DidntRead;
 
-    fn read(self, reader: &mut R) -> Result<ZenohIdInner, Self::Error> {
-        if self.length > ZenohIdInner::MAX_SIZE {
+    fn read(self, reader: &mut R) -> Result<ZenohIdProto, Self::Error> {
+        if self.length > ZenohIdProto::MAX_SIZE {
             return Err(DidntRead);
         }
-        let mut id = [0; ZenohIdInner::MAX_SIZE];
+        let mut id = [0; ZenohIdProto::MAX_SIZE];
         reader.read_exact(&mut id[..self.length])?;
-        ZenohIdInner::try_from(&id[..self.length]).map_err(|_| DidntRead)
+        ZenohIdProto::try_from(&id[..self.length]).map_err(|_| DidntRead)
     }
 }

--- a/commons/zenoh-codec/src/network/mod.rs
+++ b/commons/zenoh-codec/src/network/mod.rs
@@ -24,7 +24,7 @@ use zenoh_buffers::{
 };
 use zenoh_protocol::{
     common::{imsg, ZExtZ64, ZExtZBufHeader},
-    core::{EntityId, Reliability, ZenohIdInner},
+    core::{EntityId, Reliability, ZenohIdProto},
     network::{ext::EntityGlobalIdType, *},
 };
 
@@ -265,7 +265,7 @@ where
         let length = 1 + ((flags >> 4) as usize);
 
         let lodec = Zenoh080Length::new(length);
-        let zid: ZenohIdInner = lodec.read(&mut *reader)?;
+        let zid: ZenohIdProto = lodec.read(&mut *reader)?;
 
         let eid: EntityId = self.codec.read(&mut *reader)?;
 

--- a/commons/zenoh-codec/src/network/mod.rs
+++ b/commons/zenoh-codec/src/network/mod.rs
@@ -24,7 +24,7 @@ use zenoh_buffers::{
 };
 use zenoh_protocol::{
     common::{imsg, ZExtZ64, ZExtZBufHeader},
-    core::{EntityId, Reliability, ZenohId},
+    core::{EntityId, Reliability, ZenohIdInner},
     network::{ext::EntityGlobalIdType, *},
 };
 
@@ -265,7 +265,7 @@ where
         let length = 1 + ((flags >> 4) as usize);
 
         let lodec = Zenoh080Length::new(length);
-        let zid: ZenohId = lodec.read(&mut *reader)?;
+        let zid: ZenohIdInner = lodec.read(&mut *reader)?;
 
         let eid: EntityId = self.codec.read(&mut *reader)?;
 

--- a/commons/zenoh-codec/src/scouting/hello.rs
+++ b/commons/zenoh-codec/src/scouting/hello.rs
@@ -21,21 +21,21 @@ use zenoh_protocol::{
     common::{imsg, ZExtUnknown},
     core::{Locator, WhatAmI, ZenohIdInner},
     scouting::{
-        hello::{flag, Hello},
+        hello::{flag, HelloInner},
         id,
     },
 };
 
 use crate::{RCodec, WCodec, Zenoh080, Zenoh080Header, Zenoh080Length};
 
-impl<W> WCodec<&Hello, &mut W> for Zenoh080
+impl<W> WCodec<&HelloInner, &mut W> for Zenoh080
 where
     W: Writer,
 {
     type Output = Result<(), DidntWrite>;
 
-    fn write(self, writer: &mut W, x: &Hello) -> Self::Output {
-        let Hello {
+    fn write(self, writer: &mut W, x: &HelloInner) -> Self::Output {
+        let HelloInner {
             version,
             whatami,
             zid,
@@ -73,26 +73,26 @@ where
     }
 }
 
-impl<R> RCodec<Hello, &mut R> for Zenoh080
+impl<R> RCodec<HelloInner, &mut R> for Zenoh080
 where
     R: Reader,
 {
     type Error = DidntRead;
 
-    fn read(self, reader: &mut R) -> Result<Hello, Self::Error> {
+    fn read(self, reader: &mut R) -> Result<HelloInner, Self::Error> {
         let header: u8 = self.read(&mut *reader)?;
         let codec = Zenoh080Header::new(header);
         codec.read(reader)
     }
 }
 
-impl<R> RCodec<Hello, &mut R> for Zenoh080Header
+impl<R> RCodec<HelloInner, &mut R> for Zenoh080Header
 where
     R: Reader,
 {
     type Error = DidntRead;
 
-    fn read(self, reader: &mut R) -> Result<Hello, Self::Error> {
+    fn read(self, reader: &mut R) -> Result<HelloInner, Self::Error> {
         if imsg::mid(self.header) != id::HELLO {
             return Err(DidntRead);
         }
@@ -124,7 +124,7 @@ where
             has_extensions = more;
         }
 
-        Ok(Hello {
+        Ok(HelloInner {
             version,
             zid,
             whatami,

--- a/commons/zenoh-codec/src/scouting/hello.rs
+++ b/commons/zenoh-codec/src/scouting/hello.rs
@@ -19,7 +19,7 @@ use zenoh_buffers::{
 };
 use zenoh_protocol::{
     common::{imsg, ZExtUnknown},
-    core::{Locator, WhatAmI, ZenohId},
+    core::{Locator, WhatAmI, ZenohIdInner},
     scouting::{
         hello::{flag, Hello},
         id,
@@ -108,7 +108,7 @@ where
         };
         let length = 1 + ((flags >> 4) as usize);
         let lodec = Zenoh080Length::new(length);
-        let zid: ZenohId = lodec.read(&mut *reader)?;
+        let zid: ZenohIdInner = lodec.read(&mut *reader)?;
 
         let locators = if imsg::has_flag(self.header, flag::L) {
             let locs: Vec<Locator> = self.codec.read(&mut *reader)?;

--- a/commons/zenoh-codec/src/scouting/hello.rs
+++ b/commons/zenoh-codec/src/scouting/hello.rs
@@ -19,23 +19,23 @@ use zenoh_buffers::{
 };
 use zenoh_protocol::{
     common::{imsg, ZExtUnknown},
-    core::{Locator, WhatAmI, ZenohIdInner},
+    core::{Locator, WhatAmI, ZenohIdProto},
     scouting::{
-        hello::{flag, HelloInner},
+        hello::{flag, HelloProto},
         id,
     },
 };
 
 use crate::{RCodec, WCodec, Zenoh080, Zenoh080Header, Zenoh080Length};
 
-impl<W> WCodec<&HelloInner, &mut W> for Zenoh080
+impl<W> WCodec<&HelloProto, &mut W> for Zenoh080
 where
     W: Writer,
 {
     type Output = Result<(), DidntWrite>;
 
-    fn write(self, writer: &mut W, x: &HelloInner) -> Self::Output {
-        let HelloInner {
+    fn write(self, writer: &mut W, x: &HelloProto) -> Self::Output {
+        let HelloProto {
             version,
             whatami,
             zid,
@@ -73,26 +73,26 @@ where
     }
 }
 
-impl<R> RCodec<HelloInner, &mut R> for Zenoh080
+impl<R> RCodec<HelloProto, &mut R> for Zenoh080
 where
     R: Reader,
 {
     type Error = DidntRead;
 
-    fn read(self, reader: &mut R) -> Result<HelloInner, Self::Error> {
+    fn read(self, reader: &mut R) -> Result<HelloProto, Self::Error> {
         let header: u8 = self.read(&mut *reader)?;
         let codec = Zenoh080Header::new(header);
         codec.read(reader)
     }
 }
 
-impl<R> RCodec<HelloInner, &mut R> for Zenoh080Header
+impl<R> RCodec<HelloProto, &mut R> for Zenoh080Header
 where
     R: Reader,
 {
     type Error = DidntRead;
 
-    fn read(self, reader: &mut R) -> Result<HelloInner, Self::Error> {
+    fn read(self, reader: &mut R) -> Result<HelloProto, Self::Error> {
         if imsg::mid(self.header) != id::HELLO {
             return Err(DidntRead);
         }
@@ -108,7 +108,7 @@ where
         };
         let length = 1 + ((flags >> 4) as usize);
         let lodec = Zenoh080Length::new(length);
-        let zid: ZenohIdInner = lodec.read(&mut *reader)?;
+        let zid: ZenohIdProto = lodec.read(&mut *reader)?;
 
         let locators = if imsg::has_flag(self.header, flag::L) {
             let locs: Vec<Locator> = self.codec.read(&mut *reader)?;
@@ -124,7 +124,7 @@ where
             has_extensions = more;
         }
 
-        Ok(HelloInner {
+        Ok(HelloProto {
             version,
             zid,
             whatami,

--- a/commons/zenoh-codec/src/scouting/scout.rs
+++ b/commons/zenoh-codec/src/scouting/scout.rs
@@ -19,7 +19,7 @@ use zenoh_buffers::{
 };
 use zenoh_protocol::{
     common::{imsg, ZExtUnknown},
-    core::{whatami::WhatAmIMatcher, ZenohId},
+    core::{whatami::WhatAmIMatcher, ZenohIdInner},
     scouting::{
         id,
         scout::{flag, Scout},
@@ -93,7 +93,7 @@ where
         let zid = if imsg::has_flag(flags, flag::I) {
             let length = 1 + ((flags >> 4) as usize);
             let lodec = Zenoh080Length::new(length);
-            let zid: ZenohId = lodec.read(&mut *reader)?;
+            let zid: ZenohIdInner = lodec.read(&mut *reader)?;
             Some(zid)
         } else {
             None

--- a/commons/zenoh-codec/src/scouting/scout.rs
+++ b/commons/zenoh-codec/src/scouting/scout.rs
@@ -19,7 +19,7 @@ use zenoh_buffers::{
 };
 use zenoh_protocol::{
     common::{imsg, ZExtUnknown},
-    core::{whatami::WhatAmIMatcher, ZenohIdInner},
+    core::{whatami::WhatAmIMatcher, ZenohIdProto},
     scouting::{
         id,
         scout::{flag, Scout},
@@ -93,7 +93,7 @@ where
         let zid = if imsg::has_flag(flags, flag::I) {
             let length = 1 + ((flags >> 4) as usize);
             let lodec = Zenoh080Length::new(length);
-            let zid: ZenohIdInner = lodec.read(&mut *reader)?;
+            let zid: ZenohIdProto = lodec.read(&mut *reader)?;
             Some(zid)
         } else {
             None

--- a/commons/zenoh-codec/src/transport/init.rs
+++ b/commons/zenoh-codec/src/transport/init.rs
@@ -18,7 +18,7 @@ use zenoh_buffers::{
 };
 use zenoh_protocol::{
     common::{iext, imsg},
-    core::{Resolution, WhatAmI, ZenohId},
+    core::{Resolution, WhatAmI, ZenohIdInner},
     transport::{
         batch_size, id,
         init::{ext, flag, InitAck, InitSyn},
@@ -160,7 +160,7 @@ where
         };
         let length = 1 + ((flags >> 4) as usize);
         let lodec = Zenoh080Length::new(length);
-        let zid: ZenohId = lodec.read(&mut *reader)?;
+        let zid: ZenohIdInner = lodec.read(&mut *reader)?;
 
         let mut resolution = Resolution::default();
         let mut batch_size = batch_size::UNICAST.to_le_bytes();
@@ -373,7 +373,7 @@ where
         };
         let length = 1 + ((flags >> 4) as usize);
         let lodec = Zenoh080Length::new(length);
-        let zid: ZenohId = lodec.read(&mut *reader)?;
+        let zid: ZenohIdInner = lodec.read(&mut *reader)?;
 
         let mut resolution = Resolution::default();
         let mut batch_size = batch_size::UNICAST.to_le_bytes();

--- a/commons/zenoh-codec/src/transport/init.rs
+++ b/commons/zenoh-codec/src/transport/init.rs
@@ -18,7 +18,7 @@ use zenoh_buffers::{
 };
 use zenoh_protocol::{
     common::{iext, imsg},
-    core::{Resolution, WhatAmI, ZenohIdInner},
+    core::{Resolution, WhatAmI, ZenohIdProto},
     transport::{
         batch_size, id,
         init::{ext, flag, InitAck, InitSyn},
@@ -160,7 +160,7 @@ where
         };
         let length = 1 + ((flags >> 4) as usize);
         let lodec = Zenoh080Length::new(length);
-        let zid: ZenohIdInner = lodec.read(&mut *reader)?;
+        let zid: ZenohIdProto = lodec.read(&mut *reader)?;
 
         let mut resolution = Resolution::default();
         let mut batch_size = batch_size::UNICAST.to_le_bytes();
@@ -373,7 +373,7 @@ where
         };
         let length = 1 + ((flags >> 4) as usize);
         let lodec = Zenoh080Length::new(length);
-        let zid: ZenohIdInner = lodec.read(&mut *reader)?;
+        let zid: ZenohIdProto = lodec.read(&mut *reader)?;
 
         let mut resolution = Resolution::default();
         let mut batch_size = batch_size::UNICAST.to_le_bytes();

--- a/commons/zenoh-codec/src/transport/join.rs
+++ b/commons/zenoh-codec/src/transport/join.rs
@@ -20,7 +20,7 @@ use zenoh_buffers::{
 };
 use zenoh_protocol::{
     common::{iext, imsg, ZExtZBufHeader},
-    core::{Priority, Resolution, WhatAmI, ZenohId},
+    core::{Priority, Resolution, WhatAmI, ZenohIdInner},
     transport::{
         batch_size, id,
         join::{ext, flag, Join},
@@ -242,7 +242,7 @@ where
         };
         let length = 1 + ((flags >> 4) as usize);
         let lodec = Zenoh080Length::new(length);
-        let zid: ZenohId = lodec.read(&mut *reader)?;
+        let zid: ZenohIdInner = lodec.read(&mut *reader)?;
 
         let mut resolution = Resolution::default();
         let mut batch_size = batch_size::MULTICAST.to_le_bytes();

--- a/commons/zenoh-codec/src/transport/join.rs
+++ b/commons/zenoh-codec/src/transport/join.rs
@@ -20,7 +20,7 @@ use zenoh_buffers::{
 };
 use zenoh_protocol::{
     common::{iext, imsg, ZExtZBufHeader},
-    core::{Priority, Resolution, WhatAmI, ZenohIdInner},
+    core::{Priority, Resolution, WhatAmI, ZenohIdProto},
     transport::{
         batch_size, id,
         join::{ext, flag, Join},
@@ -242,7 +242,7 @@ where
         };
         let length = 1 + ((flags >> 4) as usize);
         let lodec = Zenoh080Length::new(length);
-        let zid: ZenohIdInner = lodec.read(&mut *reader)?;
+        let zid: ZenohIdProto = lodec.read(&mut *reader)?;
 
         let mut resolution = Resolution::default();
         let mut batch_size = batch_size::MULTICAST.to_le_bytes();

--- a/commons/zenoh-codec/src/zenoh/mod.rs
+++ b/commons/zenoh-codec/src/zenoh/mod.rs
@@ -26,7 +26,7 @@ use zenoh_buffers::{
 use zenoh_protocol::common::{iext, ZExtUnit};
 use zenoh_protocol::{
     common::{imsg, ZExtZBufHeader},
-    core::{Encoding, EntityGlobalId, EntityId, ZenohIdInner},
+    core::{Encoding, EntityGlobalIdInner, EntityId, ZenohIdInner},
     zenoh::{ext, id, PushBody, RequestBody, ResponseBody},
 };
 
@@ -193,7 +193,7 @@ where
 
         Ok((
             ext::SourceInfoType {
-                id: EntityGlobalId { zid, eid },
+                id: EntityGlobalIdInner { zid, eid },
                 sn,
             },
             more,

--- a/commons/zenoh-codec/src/zenoh/mod.rs
+++ b/commons/zenoh-codec/src/zenoh/mod.rs
@@ -26,7 +26,7 @@ use zenoh_buffers::{
 use zenoh_protocol::common::{iext, ZExtUnit};
 use zenoh_protocol::{
     common::{imsg, ZExtZBufHeader},
-    core::{Encoding, EntityGlobalIdInner, EntityId, ZenohIdInner},
+    core::{Encoding, EntityGlobalIdProto, EntityId, ZenohIdProto},
     zenoh::{ext, id, PushBody, RequestBody, ResponseBody},
 };
 
@@ -186,14 +186,14 @@ where
         let length = 1 + ((flags >> 4) as usize);
 
         let lodec = Zenoh080Length::new(length);
-        let zid: ZenohIdInner = lodec.read(&mut *reader)?;
+        let zid: ZenohIdProto = lodec.read(&mut *reader)?;
 
         let eid: EntityId = self.codec.read(&mut *reader)?;
         let sn: u32 = self.codec.read(&mut *reader)?;
 
         Ok((
             ext::SourceInfoType {
-                id: EntityGlobalIdInner { zid, eid },
+                id: EntityGlobalIdProto { zid, eid },
                 sn,
             },
             more,

--- a/commons/zenoh-codec/src/zenoh/mod.rs
+++ b/commons/zenoh-codec/src/zenoh/mod.rs
@@ -26,7 +26,7 @@ use zenoh_buffers::{
 use zenoh_protocol::common::{iext, ZExtUnit};
 use zenoh_protocol::{
     common::{imsg, ZExtZBufHeader},
-    core::{Encoding, EntityGlobalId, EntityId, ZenohId},
+    core::{Encoding, EntityGlobalId, EntityId, ZenohIdInner},
     zenoh::{ext, id, PushBody, RequestBody, ResponseBody},
 };
 
@@ -186,7 +186,7 @@ where
         let length = 1 + ((flags >> 4) as usize);
 
         let lodec = Zenoh080Length::new(length);
-        let zid: ZenohId = lodec.read(&mut *reader)?;
+        let zid: ZenohIdInner = lodec.read(&mut *reader)?;
 
         let eid: EntityId = self.codec.read(&mut *reader)?;
         let sn: u32 = self.codec.read(&mut *reader)?;

--- a/commons/zenoh-codec/tests/codec.rs
+++ b/commons/zenoh-codec/tests/codec.rs
@@ -272,7 +272,7 @@ fn codec_string_bounded() {
 
 #[test]
 fn codec_zid() {
-    run!(ZenohIdInner, ZenohIdInner::default());
+    run!(ZenohIdProto, ZenohIdProto::default());
 }
 
 #[test]
@@ -348,7 +348,7 @@ fn codec_locator() {
 fn codec_timestamp() {
     run!(Timestamp, {
         let time = uhlc::NTP64(thread_rng().gen());
-        let id = uhlc::ID::try_from(ZenohIdInner::rand().to_le_bytes()).unwrap();
+        let id = uhlc::ID::try_from(ZenohIdProto::rand().to_le_bytes()).unwrap();
         Timestamp::new(time, id)
     });
 }
@@ -447,7 +447,7 @@ fn codec_scout() {
 
 #[test]
 fn codec_hello() {
-    run!(HelloInner, HelloInner::rand());
+    run!(HelloProto, HelloProto::rand());
 }
 
 #[test]

--- a/commons/zenoh-codec/tests/codec.rs
+++ b/commons/zenoh-codec/tests/codec.rs
@@ -447,7 +447,7 @@ fn codec_scout() {
 
 #[test]
 fn codec_hello() {
-    run!(Hello, Hello::rand());
+    run!(HelloInner, HelloInner::rand());
 }
 
 #[test]

--- a/commons/zenoh-codec/tests/codec.rs
+++ b/commons/zenoh-codec/tests/codec.rs
@@ -272,7 +272,7 @@ fn codec_string_bounded() {
 
 #[test]
 fn codec_zid() {
-    run!(ZenohId, ZenohId::default());
+    run!(ZenohIdInner, ZenohIdInner::default());
 }
 
 #[test]
@@ -348,7 +348,7 @@ fn codec_locator() {
 fn codec_timestamp() {
     run!(Timestamp, {
         let time = uhlc::NTP64(thread_rng().gen());
-        let id = uhlc::ID::try_from(ZenohId::rand().to_le_bytes()).unwrap();
+        let id = uhlc::ID::try_from(ZenohIdInner::rand().to_le_bytes()).unwrap();
         Timestamp::new(time, id)
     });
 }

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -25,7 +25,6 @@ use std::{
     io::Read,
     net::SocketAddr,
     path::Path,
-    str::FromStr,
     sync::{Arc, Mutex, MutexGuard, Weak},
 };
 
@@ -40,7 +39,7 @@ pub use zenoh_protocol::core::{
     whatami, EndPoint, Locator, WhatAmI, WhatAmIMatcher, WhatAmIMatcherVisitor,
 };
 use zenoh_protocol::{
-    core::{key_expr::OwnedKeyExpr, Bits},
+    core::{key_expr::OwnedKeyExpr, Bits, ZenohId},
     transport::{BatchSize, TransportSn},
 };
 use zenoh_result::{bail, zerror, ZResult};
@@ -51,45 +50,6 @@ pub use mode_dependent::*;
 
 pub mod connection_retry;
 pub use connection_retry::*;
-
-/// The global unique id of a zenoh peer.
-#[derive(
-    Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Debug, Default,
-)]
-#[repr(transparent)]
-pub struct ZenohId(zenoh_protocol::core::ZenohId);
-
-impl fmt::Display for ZenohId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl From<zenoh_protocol::core::ZenohId> for ZenohId {
-    fn from(id: zenoh_protocol::core::ZenohId) -> Self {
-        Self(id)
-    }
-}
-
-impl From<ZenohId> for zenoh_protocol::core::ZenohId {
-    fn from(id: ZenohId) -> Self {
-        id.0
-    }
-}
-
-impl From<ZenohId> for uhlc::ID {
-    fn from(zid: ZenohId) -> Self {
-        zid.0.into()
-    }
-}
-
-impl FromStr for ZenohId {
-    type Err = zenoh_result::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        zenoh_protocol::core::ZenohId::from_str(s).map(|zid| zid.into())
-    }
-}
 
 // Wrappers for secrecy of values
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -15,6 +15,7 @@
 //! Configuration to pass to `zenoh::open()` and `zenoh::scout()` functions and associated constants.
 pub mod defaults;
 mod include;
+pub mod wrappers;
 
 #[allow(unused_imports)]
 use std::convert::TryFrom; // This is a false positive from the rust analyser
@@ -34,12 +35,13 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use validated_struct::ValidatedMapAssociatedTypes;
 pub use validated_struct::{GetError, ValidatedMap};
+use wrappers::ZenohId;
 use zenoh_core::zlock;
 pub use zenoh_protocol::core::{
     whatami, EndPoint, Locator, WhatAmI, WhatAmIMatcher, WhatAmIMatcherVisitor,
 };
 use zenoh_protocol::{
-    core::{key_expr::OwnedKeyExpr, Bits, ZenohId},
+    core::{key_expr::OwnedKeyExpr, Bits},
     transport::{BatchSize, TransportSn},
 };
 use zenoh_result::{bail, zerror, ZResult};

--- a/commons/zenoh-config/src/mode_dependent.rs
+++ b/commons/zenoh-config/src/mode_dependent.rs
@@ -19,7 +19,7 @@ use serde::{
     Deserialize, Serialize,
 };
 pub use zenoh_protocol::core::{
-    whatami, EndPoint, Locator, WhatAmI, WhatAmIMatcher, WhatAmIMatcherVisitor, ZenohIdInner,
+    whatami, EndPoint, Locator, WhatAmI, WhatAmIMatcher, WhatAmIMatcherVisitor, ZenohIdProto,
 };
 
 pub trait ModeDependent<T> {

--- a/commons/zenoh-config/src/mode_dependent.rs
+++ b/commons/zenoh-config/src/mode_dependent.rs
@@ -19,7 +19,7 @@ use serde::{
     Deserialize, Serialize,
 };
 pub use zenoh_protocol::core::{
-    whatami, EndPoint, Locator, WhatAmI, WhatAmIMatcher, WhatAmIMatcherVisitor, ZenohId,
+    whatami, EndPoint, Locator, WhatAmI, WhatAmIMatcher, WhatAmIMatcherVisitor, ZenohIdInner,
 };
 
 pub trait ModeDependent<T> {

--- a/commons/zenoh-config/src/wrappers.rs
+++ b/commons/zenoh-config/src/wrappers.rs
@@ -1,0 +1,120 @@
+//
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+//! Wrappers around types reexported by `zenoh` from subcrates.
+//! These wrappers are used to avoid exposing the the API necessary only for zenoh internals into the public API.
+
+use core::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+use zenoh_protocol::{
+    core::{EntityGlobalIdProto, EntityId, Locator, WhatAmI, ZenohIdProto},
+    scouting::HelloProto,
+};
+
+/// The global unique id of a zenoh peer.
+#[derive(
+    Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Debug, Default,
+)]
+#[repr(transparent)]
+pub struct ZenohId(ZenohIdProto);
+
+impl fmt::Display for ZenohId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl From<ZenohIdProto> for ZenohId {
+    fn from(id: ZenohIdProto) -> Self {
+        Self(id)
+    }
+}
+
+impl From<ZenohId> for ZenohIdProto {
+    fn from(id: ZenohId) -> Self {
+        id.0
+    }
+}
+
+impl From<ZenohId> for uhlc::ID {
+    fn from(zid: ZenohId) -> Self {
+        zid.0.into()
+    }
+}
+
+impl FromStr for ZenohId {
+    type Err = zenoh_result::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        ZenohIdProto::from_str(s).map(|zid| zid.into())
+    }
+}
+
+/// A zenoh Hello message.
+pub struct Hello(HelloProto);
+
+impl Hello {
+    /// Get the locators of this Hello message.
+    pub fn locators(&self) -> &[Locator] {
+        &self.0.locators
+    }
+
+    /// Get the zenoh id of this Hello message.
+    pub fn zid(&self) -> ZenohIdProto {
+        self.0.zid
+    }
+
+    /// Get the whatami of this Hello message.
+    pub fn whatami(&self) -> WhatAmI {
+        self.0.whatami
+    }
+}
+
+impl From<HelloProto> for Hello {
+    fn from(inner: HelloProto) -> Self {
+        Hello(inner)
+    }
+}
+
+impl fmt::Display for Hello {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Hello")
+            .field("zid", &self.zid())
+            .field("whatami", &self.whatami())
+            .field("locators", &self.locators())
+            .finish()
+    }
+}
+
+#[derive(Debug, Default, Copy, Clone, Eq, Hash, PartialEq)]
+#[repr(transparent)]
+pub struct EntityGlobalId(EntityGlobalIdProto);
+
+impl EntityGlobalId {
+    pub fn zid(&self) -> ZenohId {
+        self.0.zid.into()
+    }
+
+    pub fn eid(&self) -> EntityId {
+        self.0.eid
+    }
+}
+
+impl From<EntityGlobalIdProto> for EntityGlobalId {
+    fn from(id: EntityGlobalIdProto) -> Self {
+        Self(id)
+    }
+}

--- a/commons/zenoh-protocol/src/core/mod.rs
+++ b/commons/zenoh-protocol/src/core/mod.rs
@@ -341,8 +341,8 @@ impl EntityGlobalIdProto {
 pub struct EntityGlobalId(EntityGlobalIdProto);
 
 impl EntityGlobalId {
-    pub fn zid(&self) -> ZenohIdProto {
-        self.0.zid
+    pub fn zid(&self) -> ZenohId {
+        self.0.zid.into()
     }
 
     pub fn eid(&self) -> EntityId {

--- a/commons/zenoh-protocol/src/core/mod.rs
+++ b/commons/zenoh-protocol/src/core/mod.rs
@@ -319,12 +319,12 @@ pub type EntityId = u32;
 
 /// The global unique id of a zenoh entity.
 #[derive(Debug, Default, Copy, Clone, Eq, Hash, PartialEq)]
-pub struct EntityGlobalId {
+pub struct EntityGlobalIdInner {
     pub zid: ZenohIdInner,
     pub eid: EntityId,
 }
 
-impl EntityGlobalId {
+impl EntityGlobalIdInner {
     #[cfg(feature = "test")]
     pub fn rand() -> Self {
         use rand::Rng;
@@ -334,6 +334,27 @@ impl EntityGlobalId {
         }
     }
 }
+
+#[derive(Debug, Default, Copy, Clone, Eq, Hash, PartialEq)]
+#[repr(transparent)]
+pub struct EntityGlobalId(EntityGlobalIdInner);
+
+impl EntityGlobalId {
+    pub fn zid(&self) -> ZenohIdInner {
+        self.0.zid
+    }
+
+    pub fn eid(&self) -> EntityId {
+        self.0.eid
+    }
+}
+
+impl From<EntityGlobalIdInner> for EntityGlobalId {
+    fn from(id: EntityGlobalIdInner) -> Self {
+        Self(id)
+    }
+}
+
 
 #[repr(u8)]
 #[derive(Debug, Default, Copy, Clone, Eq, Hash, PartialEq)]

--- a/commons/zenoh-protocol/src/core/mod.rs
+++ b/commons/zenoh-protocol/src/core/mod.rs
@@ -24,7 +24,6 @@ use core::{
     str::FromStr,
 };
 
-use serde::{Deserialize, Serialize};
 pub use uhlc::{Timestamp, NTP64};
 use zenoh_keyexpr::OwnedKeyExpr;
 use zenoh_result::{bail, zerror};
@@ -89,45 +88,6 @@ impl ZenohIdProto {
 impl Default for ZenohIdProto {
     fn default() -> Self {
         Self::rand()
-    }
-}
-
-/// The global unique id of a zenoh peer.
-#[derive(
-    Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Debug, Default,
-)]
-#[repr(transparent)]
-pub struct ZenohId(ZenohIdProto);
-
-impl fmt::Display for ZenohId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl From<ZenohIdProto> for ZenohId {
-    fn from(id: ZenohIdProto) -> Self {
-        Self(id)
-    }
-}
-
-impl From<ZenohId> for ZenohIdProto {
-    fn from(id: ZenohId) -> Self {
-        id.0
-    }
-}
-
-impl From<ZenohId> for uhlc::ID {
-    fn from(zid: ZenohId) -> Self {
-        zid.0.into()
-    }
-}
-
-impl FromStr for ZenohId {
-    type Err = zenoh_result::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        ZenohIdProto::from_str(s).map(|zid| zid.into())
     }
 }
 
@@ -333,26 +293,6 @@ impl EntityGlobalIdProto {
             zid: ZenohIdProto::rand(),
             eid: rand::thread_rng().gen(),
         }
-    }
-}
-
-#[derive(Debug, Default, Copy, Clone, Eq, Hash, PartialEq)]
-#[repr(transparent)]
-pub struct EntityGlobalId(EntityGlobalIdProto);
-
-impl EntityGlobalId {
-    pub fn zid(&self) -> ZenohId {
-        self.0.zid.into()
-    }
-
-    pub fn eid(&self) -> EntityId {
-        self.0.eid
-    }
-}
-
-impl From<EntityGlobalIdProto> for EntityGlobalId {
-    fn from(id: EntityGlobalIdProto) -> Self {
-        Self(id)
     }
 }
 

--- a/commons/zenoh-protocol/src/core/mod.rs
+++ b/commons/zenoh-protocol/src/core/mod.rs
@@ -62,9 +62,9 @@ pub use properties::*;
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
-pub struct ZenohIdInner(uhlc::ID);
+pub struct ZenohIdProto(uhlc::ID);
 
-impl ZenohIdInner {
+impl ZenohIdProto {
     pub const MAX_SIZE: usize = 16;
 
     #[inline]
@@ -77,8 +77,8 @@ impl ZenohIdInner {
         self.0.to_le_bytes()
     }
 
-    pub fn rand() -> ZenohIdInner {
-        ZenohIdInner(uhlc::ID::rand())
+    pub fn rand() -> ZenohIdProto {
+        ZenohIdProto(uhlc::ID::rand())
     }
 
     pub fn into_keyexpr(self) -> OwnedKeyExpr {
@@ -86,7 +86,7 @@ impl ZenohIdInner {
     }
 }
 
-impl Default for ZenohIdInner {
+impl Default for ZenohIdProto {
     fn default() -> Self {
         Self::rand()
     }
@@ -97,7 +97,7 @@ impl Default for ZenohIdInner {
     Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Debug, Default,
 )]
 #[repr(transparent)]
-pub struct ZenohId(ZenohIdInner);
+pub struct ZenohId(ZenohIdProto);
 
 impl fmt::Display for ZenohId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -105,13 +105,13 @@ impl fmt::Display for ZenohId {
     }
 }
 
-impl From<ZenohIdInner> for ZenohId {
-    fn from(id: ZenohIdInner) -> Self {
+impl From<ZenohIdProto> for ZenohId {
+    fn from(id: ZenohIdProto) -> Self {
         Self(id)
     }
 }
 
-impl From<ZenohId> for ZenohIdInner {
+impl From<ZenohId> for ZenohIdProto {
     fn from(id: ZenohId) -> Self {
         id.0
     }
@@ -127,7 +127,7 @@ impl FromStr for ZenohId {
     type Err = zenoh_result::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        ZenohIdInner::from_str(s).map(|zid| zid.into())
+        ZenohIdProto::from_str(s).map(|zid| zid.into())
     }
 }
 
@@ -160,7 +160,7 @@ impl fmt::Display for SizeError {
 
 macro_rules! derive_tryfrom {
     ($T: ty) => {
-        impl TryFrom<$T> for ZenohIdInner {
+        impl TryFrom<$T> for ZenohIdProto {
             type Error = zenoh_result::Error;
             fn try_from(val: $T) -> Result<Self, Self::Error> {
                 match val.try_into() {
@@ -205,7 +205,7 @@ derive_tryfrom!([u8; 16]);
 derive_tryfrom!(&[u8; 16]);
 derive_tryfrom!(&[u8]);
 
-impl FromStr for ZenohIdInner {
+impl FromStr for ZenohIdProto {
     type Err = zenoh_result::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -218,37 +218,37 @@ impl FromStr for ZenohIdInner {
         let u: uhlc::ID = s
             .parse()
             .map_err(|e: uhlc::ParseIDError| zerror!("Invalid id: {} - {}", s, e.cause))?;
-        Ok(ZenohIdInner(u))
+        Ok(ZenohIdProto(u))
     }
 }
 
-impl fmt::Debug for ZenohIdInner {
+impl fmt::Debug for ZenohIdProto {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
-impl fmt::Display for ZenohIdInner {
+impl fmt::Display for ZenohIdProto {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(self, f)
     }
 }
 
 // A PeerID can be converted into a Timestamp's ID
-impl From<&ZenohIdInner> for uhlc::ID {
-    fn from(zid: &ZenohIdInner) -> Self {
+impl From<&ZenohIdProto> for uhlc::ID {
+    fn from(zid: &ZenohIdProto) -> Self {
         zid.0
     }
 }
 
-impl From<ZenohIdInner> for uhlc::ID {
-    fn from(zid: ZenohIdInner) -> Self {
+impl From<ZenohIdProto> for uhlc::ID {
+    fn from(zid: ZenohIdProto) -> Self {
         zid.0
     }
 }
 
-impl From<ZenohIdInner> for OwnedKeyExpr {
-    fn from(zid: ZenohIdInner) -> Self {
+impl From<ZenohIdProto> for OwnedKeyExpr {
+    fn from(zid: ZenohIdProto) -> Self {
         // SAFETY: zid.to_string() returns an stringified hexadecimal
         // representation of the zid. Therefore, building a OwnedKeyExpr
         // by calling from_string_unchecked() is safe because it is
@@ -257,13 +257,13 @@ impl From<ZenohIdInner> for OwnedKeyExpr {
     }
 }
 
-impl From<&ZenohIdInner> for OwnedKeyExpr {
-    fn from(zid: &ZenohIdInner) -> Self {
+impl From<&ZenohIdProto> for OwnedKeyExpr {
+    fn from(zid: &ZenohIdProto) -> Self {
         (*zid).into()
     }
 }
 
-impl serde::Serialize for ZenohIdInner {
+impl serde::Serialize for ZenohIdProto {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -272,7 +272,7 @@ impl serde::Serialize for ZenohIdInner {
     }
 }
 
-impl<'de> serde::Deserialize<'de> for ZenohIdInner {
+impl<'de> serde::Deserialize<'de> for ZenohIdProto {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -280,12 +280,12 @@ impl<'de> serde::Deserialize<'de> for ZenohIdInner {
         struct ZenohIdVisitor;
 
         impl<'de> serde::de::Visitor<'de> for ZenohIdVisitor {
-            type Value = ZenohIdInner;
+            type Value = ZenohIdProto;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str(&format!(
                     "An hex string of 1-{} bytes",
-                    ZenohIdInner::MAX_SIZE
+                    ZenohIdProto::MAX_SIZE
                 ))
             }
 
@@ -320,17 +320,17 @@ pub type EntityId = u32;
 
 /// The global unique id of a zenoh entity.
 #[derive(Debug, Default, Copy, Clone, Eq, Hash, PartialEq)]
-pub struct EntityGlobalIdInner {
-    pub zid: ZenohIdInner,
+pub struct EntityGlobalIdProto {
+    pub zid: ZenohIdProto,
     pub eid: EntityId,
 }
 
-impl EntityGlobalIdInner {
+impl EntityGlobalIdProto {
     #[cfg(feature = "test")]
     pub fn rand() -> Self {
         use rand::Rng;
         Self {
-            zid: ZenohIdInner::rand(),
+            zid: ZenohIdProto::rand(),
             eid: rand::thread_rng().gen(),
         }
     }
@@ -338,10 +338,10 @@ impl EntityGlobalIdInner {
 
 #[derive(Debug, Default, Copy, Clone, Eq, Hash, PartialEq)]
 #[repr(transparent)]
-pub struct EntityGlobalId(EntityGlobalIdInner);
+pub struct EntityGlobalId(EntityGlobalIdProto);
 
 impl EntityGlobalId {
-    pub fn zid(&self) -> ZenohIdInner {
+    pub fn zid(&self) -> ZenohIdProto {
         self.0.zid
     }
 
@@ -350,8 +350,8 @@ impl EntityGlobalId {
     }
 }
 
-impl From<EntityGlobalIdInner> for EntityGlobalId {
-    fn from(id: EntityGlobalIdInner) -> Self {
+impl From<EntityGlobalIdProto> for EntityGlobalId {
+    fn from(id: EntityGlobalIdProto) -> Self {
         Self(id)
     }
 }

--- a/commons/zenoh-protocol/src/core/mod.rs
+++ b/commons/zenoh-protocol/src/core/mod.rs
@@ -17,7 +17,6 @@ use alloc::{
     format,
     string::{String, ToString},
 };
-use serde::{Deserialize, Serialize};
 use core::{
     convert::{From, TryFrom, TryInto},
     fmt,
@@ -25,6 +24,7 @@ use core::{
     str::FromStr,
 };
 
+use serde::{Deserialize, Serialize};
 pub use uhlc::{Timestamp, NTP64};
 use zenoh_keyexpr::OwnedKeyExpr;
 use zenoh_result::{bail, zerror};
@@ -130,8 +130,6 @@ impl FromStr for ZenohId {
         ZenohIdInner::from_str(s).map(|zid| zid.into())
     }
 }
-
-
 
 // Mimics uhlc::SizeError,
 #[derive(Debug, Clone, Copy)]
@@ -285,7 +283,10 @@ impl<'de> serde::Deserialize<'de> for ZenohIdInner {
             type Value = ZenohIdInner;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str(&format!("An hex string of 1-{} bytes", ZenohIdInner::MAX_SIZE))
+                formatter.write_str(&format!(
+                    "An hex string of 1-{} bytes",
+                    ZenohIdInner::MAX_SIZE
+                ))
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
@@ -354,7 +355,6 @@ impl From<EntityGlobalIdInner> for EntityGlobalId {
         Self(id)
     }
 }
-
 
 #[repr(u8)]
 #[derive(Debug, Default, Copy, Clone, Eq, Hash, PartialEq)]

--- a/commons/zenoh-protocol/src/network/mod.rs
+++ b/commons/zenoh-protocol/src/network/mod.rs
@@ -221,7 +221,7 @@ pub mod ext {
 
     use crate::{
         common::{imsg, ZExtZ64},
-        core::{CongestionControl, EntityId, Priority, ZenohIdInner},
+        core::{CongestionControl, EntityId, Priority, ZenohIdProto},
     };
 
     /// ```text
@@ -366,7 +366,7 @@ pub mod ext {
             let mut rng = rand::thread_rng();
 
             let time = uhlc::NTP64(rng.gen());
-            let id = uhlc::ID::try_from(ZenohIdInner::rand().to_le_bytes()).unwrap();
+            let id = uhlc::ID::try_from(ZenohIdProto::rand().to_le_bytes()).unwrap();
             let timestamp = uhlc::Timestamp::new(time, id);
             Self { timestamp }
         }
@@ -428,7 +428,7 @@ pub mod ext {
     /// +---------------+
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct EntityGlobalIdType<const ID: u8> {
-        pub zid: ZenohIdInner,
+        pub zid: ZenohIdProto,
         pub eid: EntityId,
     }
 
@@ -438,7 +438,7 @@ pub mod ext {
             use rand::Rng;
             let mut rng = rand::thread_rng();
 
-            let zid = ZenohIdInner::rand();
+            let zid = ZenohIdProto::rand();
             let eid: EntityId = rng.gen();
             Self { zid, eid }
         }

--- a/commons/zenoh-protocol/src/network/mod.rs
+++ b/commons/zenoh-protocol/src/network/mod.rs
@@ -221,7 +221,7 @@ pub mod ext {
 
     use crate::{
         common::{imsg, ZExtZ64},
-        core::{CongestionControl, EntityId, Priority, ZenohId},
+        core::{CongestionControl, EntityId, Priority, ZenohIdInner},
     };
 
     /// ```text
@@ -366,7 +366,7 @@ pub mod ext {
             let mut rng = rand::thread_rng();
 
             let time = uhlc::NTP64(rng.gen());
-            let id = uhlc::ID::try_from(ZenohId::rand().to_le_bytes()).unwrap();
+            let id = uhlc::ID::try_from(ZenohIdInner::rand().to_le_bytes()).unwrap();
             let timestamp = uhlc::Timestamp::new(time, id);
             Self { timestamp }
         }
@@ -428,7 +428,7 @@ pub mod ext {
     /// +---------------+
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct EntityGlobalIdType<const ID: u8> {
-        pub zid: ZenohId,
+        pub zid: ZenohIdInner,
         pub eid: EntityId,
     }
 
@@ -438,7 +438,7 @@ pub mod ext {
             use rand::Rng;
             let mut rng = rand::thread_rng();
 
-            let zid = ZenohId::rand();
+            let zid = ZenohIdInner::rand();
             let eid: EntityId = rng.gen();
             Self { zid, eid }
         }

--- a/commons/zenoh-protocol/src/scouting/hello.rs
+++ b/commons/zenoh-protocol/src/scouting/hello.rs
@@ -13,6 +13,7 @@
 //
 use alloc::vec::Vec;
 use std::fmt;
+
 use crate::core::{Locator, WhatAmI, ZenohIdInner};
 
 /// # Hello message
@@ -165,4 +166,3 @@ impl fmt::Display for Hello {
             .finish()
     }
 }
-

--- a/commons/zenoh-protocol/src/scouting/hello.rs
+++ b/commons/zenoh-protocol/src/scouting/hello.rs
@@ -13,7 +13,7 @@
 //
 use alloc::vec::Vec;
 
-use crate::core::{Locator, WhatAmI, ZenohId};
+use crate::core::{Locator, WhatAmI, ZenohIdInner};
 
 /// # Hello message
 ///
@@ -102,7 +102,7 @@ pub mod flag {
 pub struct Hello {
     pub version: u8,
     pub whatami: WhatAmI,
-    pub zid: ZenohId,
+    pub zid: ZenohIdInner,
     pub locators: Vec<Locator>,
 }
 
@@ -114,7 +114,7 @@ impl Hello {
         let mut rng = rand::thread_rng();
 
         let version: u8 = rng.gen();
-        let zid = ZenohId::default();
+        let zid = ZenohIdInner::default();
         let whatami = WhatAmI::rand();
         let locators = if rng.gen_bool(0.5) {
             Vec::from_iter((1..5).map(|_| Locator::rand()))

--- a/commons/zenoh-protocol/src/scouting/hello.rs
+++ b/commons/zenoh-protocol/src/scouting/hello.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use alloc::vec::Vec;
-use std::fmt;
+use core::fmt;
 
 use crate::core::{Locator, WhatAmI, ZenohIdInner};
 

--- a/commons/zenoh-protocol/src/scouting/hello.rs
+++ b/commons/zenoh-protocol/src/scouting/hello.rs
@@ -12,7 +12,6 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use alloc::vec::Vec;
-use core::fmt;
 
 use crate::core::{Locator, WhatAmI, ZenohIdProto};
 
@@ -128,41 +127,5 @@ impl HelloProto {
             whatami,
             locators,
         }
-    }
-}
-
-/// A zenoh Hello message.
-pub struct Hello(HelloProto);
-
-impl Hello {
-    /// Get the locators of this Hello message.
-    pub fn locators(&self) -> &[Locator] {
-        &self.0.locators
-    }
-
-    /// Get the zenoh id of this Hello message.
-    pub fn zid(&self) -> ZenohIdProto {
-        self.0.zid
-    }
-
-    /// Get the whatami of this Hello message.
-    pub fn whatami(&self) -> WhatAmI {
-        self.0.whatami
-    }
-}
-
-impl From<HelloProto> for Hello {
-    fn from(inner: HelloProto) -> Self {
-        Hello(inner)
-    }
-}
-
-impl fmt::Display for Hello {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Hello")
-            .field("zid", &self.zid())
-            .field("whatami", &self.whatami())
-            .field("locators", &self.locators())
-            .finish()
     }
 }

--- a/commons/zenoh-protocol/src/scouting/hello.rs
+++ b/commons/zenoh-protocol/src/scouting/hello.rs
@@ -14,7 +14,7 @@
 use alloc::vec::Vec;
 use core::fmt;
 
-use crate::core::{Locator, WhatAmI, ZenohIdInner};
+use crate::core::{Locator, WhatAmI, ZenohIdProto};
 
 /// # Hello message
 ///
@@ -100,14 +100,14 @@ pub mod flag {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct HelloInner {
+pub struct HelloProto {
     pub version: u8,
     pub whatami: WhatAmI,
-    pub zid: ZenohIdInner,
+    pub zid: ZenohIdProto,
     pub locators: Vec<Locator>,
 }
 
-impl HelloInner {
+impl HelloProto {
     #[cfg(feature = "test")]
     pub fn rand() -> Self {
         use rand::Rng;
@@ -115,7 +115,7 @@ impl HelloInner {
         let mut rng = rand::thread_rng();
 
         let version: u8 = rng.gen();
-        let zid = ZenohIdInner::default();
+        let zid = ZenohIdProto::default();
         let whatami = WhatAmI::rand();
         let locators = if rng.gen_bool(0.5) {
             Vec::from_iter((1..5).map(|_| Locator::rand()))
@@ -132,7 +132,7 @@ impl HelloInner {
 }
 
 /// A zenoh Hello message.
-pub struct Hello(HelloInner);
+pub struct Hello(HelloProto);
 
 impl Hello {
     /// Get the locators of this Hello message.
@@ -141,7 +141,7 @@ impl Hello {
     }
 
     /// Get the zenoh id of this Hello message.
-    pub fn zid(&self) -> ZenohIdInner {
+    pub fn zid(&self) -> ZenohIdProto {
         self.0.zid
     }
 
@@ -151,8 +151,8 @@ impl Hello {
     }
 }
 
-impl From<HelloInner> for Hello {
-    fn from(inner: HelloInner) -> Self {
+impl From<HelloProto> for Hello {
+    fn from(inner: HelloProto) -> Self {
         Hello(inner)
     }
 }

--- a/commons/zenoh-protocol/src/scouting/hello.rs
+++ b/commons/zenoh-protocol/src/scouting/hello.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use alloc::vec::Vec;
-
+use std::fmt;
 use crate::core::{Locator, WhatAmI, ZenohIdInner};
 
 /// # Hello message
@@ -99,14 +99,14 @@ pub mod flag {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Hello {
+pub struct HelloInner {
     pub version: u8,
     pub whatami: WhatAmI,
     pub zid: ZenohIdInner,
     pub locators: Vec<Locator>,
 }
 
-impl Hello {
+impl HelloInner {
     #[cfg(feature = "test")]
     pub fn rand() -> Self {
         use rand::Rng;
@@ -129,3 +129,40 @@ impl Hello {
         }
     }
 }
+
+/// A zenoh Hello message.
+pub struct Hello(HelloInner);
+
+impl Hello {
+    /// Get the locators of this Hello message.
+    pub fn locators(&self) -> &[Locator] {
+        &self.0.locators
+    }
+
+    /// Get the zenoh id of this Hello message.
+    pub fn zid(&self) -> ZenohIdInner {
+        self.0.zid
+    }
+
+    /// Get the whatami of this Hello message.
+    pub fn whatami(&self) -> WhatAmI {
+        self.0.whatami
+    }
+}
+
+impl From<HelloInner> for Hello {
+    fn from(inner: HelloInner) -> Self {
+        Hello(inner)
+    }
+}
+
+impl fmt::Display for Hello {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Hello")
+            .field("zid", &self.zid())
+            .field("whatami", &self.whatami())
+            .field("locators", &self.locators())
+            .finish()
+    }
+}
+

--- a/commons/zenoh-protocol/src/scouting/mod.rs
+++ b/commons/zenoh-protocol/src/scouting/mod.rs
@@ -14,7 +14,7 @@
 pub mod hello;
 pub mod scout;
 
-pub use hello::HelloInner;
+pub use hello::HelloProto;
 pub use scout::Scout;
 
 pub mod id {
@@ -27,7 +27,7 @@ pub mod id {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ScoutingBody {
     Scout(Scout),
-    Hello(HelloInner),
+    Hello(HelloProto),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -46,7 +46,7 @@ impl ScoutingMessage {
 
         match rng.gen_range(0..2) {
             0 => ScoutingBody::Scout(Scout::rand()),
-            1 => ScoutingBody::Hello(HelloInner::rand()),
+            1 => ScoutingBody::Hello(HelloProto::rand()),
             _ => unreachable!(),
         }
         .into()
@@ -69,8 +69,8 @@ impl From<Scout> for ScoutingMessage {
     }
 }
 
-impl From<HelloInner> for ScoutingMessage {
-    fn from(hello: HelloInner) -> Self {
+impl From<HelloProto> for ScoutingMessage {
+    fn from(hello: HelloProto) -> Self {
         ScoutingBody::Hello(hello).into()
     }
 }

--- a/commons/zenoh-protocol/src/scouting/mod.rs
+++ b/commons/zenoh-protocol/src/scouting/mod.rs
@@ -14,7 +14,7 @@
 pub mod hello;
 pub mod scout;
 
-pub use hello::Hello;
+pub use hello::HelloInner;
 pub use scout::Scout;
 
 pub mod id {
@@ -27,7 +27,7 @@ pub mod id {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ScoutingBody {
     Scout(Scout),
-    Hello(Hello),
+    Hello(HelloInner),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -46,7 +46,7 @@ impl ScoutingMessage {
 
         match rng.gen_range(0..2) {
             0 => ScoutingBody::Scout(Scout::rand()),
-            1 => ScoutingBody::Hello(Hello::rand()),
+            1 => ScoutingBody::Hello(HelloInner::rand()),
             _ => unreachable!(),
         }
         .into()
@@ -69,8 +69,8 @@ impl From<Scout> for ScoutingMessage {
     }
 }
 
-impl From<Hello> for ScoutingMessage {
-    fn from(hello: Hello) -> Self {
+impl From<HelloInner> for ScoutingMessage {
+    fn from(hello: HelloInner) -> Self {
         ScoutingBody::Hello(hello).into()
     }
 }

--- a/commons/zenoh-protocol/src/scouting/scout.rs
+++ b/commons/zenoh-protocol/src/scouting/scout.rs
@@ -11,7 +11,7 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use crate::core::{whatami::WhatAmIMatcher, ZenohId};
+use crate::core::{whatami::WhatAmIMatcher, ZenohIdInner};
 
 /// # Scout message
 ///
@@ -75,7 +75,7 @@ pub mod flag {
 pub struct Scout {
     pub version: u8,
     pub what: WhatAmIMatcher,
-    pub zid: Option<ZenohId>,
+    pub zid: Option<ZenohIdInner>,
 }
 
 impl Scout {
@@ -87,7 +87,7 @@ impl Scout {
 
         let version: u8 = rng.gen();
         let what = WhatAmIMatcher::rand();
-        let zid = rng.gen_bool(0.5).then_some(ZenohId::rand());
+        let zid = rng.gen_bool(0.5).then_some(ZenohIdInner::rand());
         Self { version, what, zid }
     }
 }

--- a/commons/zenoh-protocol/src/scouting/scout.rs
+++ b/commons/zenoh-protocol/src/scouting/scout.rs
@@ -11,7 +11,7 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use crate::core::{whatami::WhatAmIMatcher, ZenohIdInner};
+use crate::core::{whatami::WhatAmIMatcher, ZenohIdProto};
 
 /// # Scout message
 ///
@@ -75,7 +75,7 @@ pub mod flag {
 pub struct Scout {
     pub version: u8,
     pub what: WhatAmIMatcher,
-    pub zid: Option<ZenohIdInner>,
+    pub zid: Option<ZenohIdProto>,
 }
 
 impl Scout {
@@ -87,7 +87,7 @@ impl Scout {
 
         let version: u8 = rng.gen();
         let what = WhatAmIMatcher::rand();
-        let zid = rng.gen_bool(0.5).then_some(ZenohIdInner::rand());
+        let zid = rng.gen_bool(0.5).then_some(ZenohIdProto::rand());
         Self { version, what, zid }
     }
 }

--- a/commons/zenoh-protocol/src/transport/init.rs
+++ b/commons/zenoh-protocol/src/transport/init.rs
@@ -14,7 +14,7 @@
 use zenoh_buffers::ZSlice;
 
 use crate::{
-    core::{Resolution, WhatAmI, ZenohIdInner},
+    core::{Resolution, WhatAmI, ZenohIdProto},
     transport::BatchSize,
 };
 
@@ -111,7 +111,7 @@ pub mod flag {
 pub struct InitSyn {
     pub version: u8,
     pub whatami: WhatAmI,
-    pub zid: ZenohIdInner,
+    pub zid: ZenohIdProto,
     pub resolution: Resolution,
     pub batch_size: BatchSize,
     pub ext_qos: Option<ext::QoS>,
@@ -167,7 +167,7 @@ impl InitSyn {
 
         let version: u8 = rng.gen();
         let whatami = WhatAmI::rand();
-        let zid = ZenohIdInner::default();
+        let zid = ZenohIdProto::default();
         let resolution = Resolution::rand();
         let batch_size: BatchSize = rng.gen();
         let ext_qos = rng.gen_bool(0.5).then_some(ZExtUnit::rand());
@@ -199,7 +199,7 @@ impl InitSyn {
 pub struct InitAck {
     pub version: u8,
     pub whatami: WhatAmI,
-    pub zid: ZenohIdInner,
+    pub zid: ZenohIdProto,
     pub resolution: Resolution,
     pub batch_size: BatchSize,
     pub cookie: ZSlice,
@@ -223,7 +223,7 @@ impl InitAck {
 
         let version: u8 = rng.gen();
         let whatami = WhatAmI::rand();
-        let zid = ZenohIdInner::default();
+        let zid = ZenohIdProto::default();
         let resolution = if rng.gen_bool(0.5) {
             Resolution::default()
         } else {

--- a/commons/zenoh-protocol/src/transport/init.rs
+++ b/commons/zenoh-protocol/src/transport/init.rs
@@ -14,7 +14,7 @@
 use zenoh_buffers::ZSlice;
 
 use crate::{
-    core::{Resolution, WhatAmI, ZenohId},
+    core::{Resolution, WhatAmI, ZenohIdInner},
     transport::BatchSize,
 };
 
@@ -111,7 +111,7 @@ pub mod flag {
 pub struct InitSyn {
     pub version: u8,
     pub whatami: WhatAmI,
-    pub zid: ZenohId,
+    pub zid: ZenohIdInner,
     pub resolution: Resolution,
     pub batch_size: BatchSize,
     pub ext_qos: Option<ext::QoS>,
@@ -167,7 +167,7 @@ impl InitSyn {
 
         let version: u8 = rng.gen();
         let whatami = WhatAmI::rand();
-        let zid = ZenohId::default();
+        let zid = ZenohIdInner::default();
         let resolution = Resolution::rand();
         let batch_size: BatchSize = rng.gen();
         let ext_qos = rng.gen_bool(0.5).then_some(ZExtUnit::rand());
@@ -199,7 +199,7 @@ impl InitSyn {
 pub struct InitAck {
     pub version: u8,
     pub whatami: WhatAmI,
-    pub zid: ZenohId,
+    pub zid: ZenohIdInner,
     pub resolution: Resolution,
     pub batch_size: BatchSize,
     pub cookie: ZSlice,
@@ -223,7 +223,7 @@ impl InitAck {
 
         let version: u8 = rng.gen();
         let whatami = WhatAmI::rand();
-        let zid = ZenohId::default();
+        let zid = ZenohIdInner::default();
         let resolution = if rng.gen_bool(0.5) {
             Resolution::default()
         } else {

--- a/commons/zenoh-protocol/src/transport/join.rs
+++ b/commons/zenoh-protocol/src/transport/join.rs
@@ -14,7 +14,7 @@
 use core::time::Duration;
 
 use crate::{
-    core::{Priority, Resolution, WhatAmI, ZenohIdInner},
+    core::{Priority, Resolution, WhatAmI, ZenohIdProto},
     transport::{BatchSize, PrioritySn},
 };
 
@@ -105,7 +105,7 @@ pub mod flag {
 pub struct Join {
     pub version: u8,
     pub whatami: WhatAmI,
-    pub zid: ZenohIdInner,
+    pub zid: ZenohIdProto,
     pub resolution: Resolution,
     pub batch_size: BatchSize,
     pub lease: Duration,
@@ -142,7 +142,7 @@ impl Join {
 
         let version: u8 = rng.gen();
         let whatami = WhatAmI::rand();
-        let zid = ZenohIdInner::default();
+        let zid = ZenohIdProto::default();
         let resolution = Resolution::rand();
         let batch_size: BatchSize = rng.gen();
         let lease = if rng.gen_bool(0.5) {

--- a/commons/zenoh-protocol/src/transport/join.rs
+++ b/commons/zenoh-protocol/src/transport/join.rs
@@ -14,7 +14,7 @@
 use core::time::Duration;
 
 use crate::{
-    core::{Priority, Resolution, WhatAmI, ZenohId},
+    core::{Priority, Resolution, WhatAmI, ZenohIdInner},
     transport::{BatchSize, PrioritySn},
 };
 
@@ -105,7 +105,7 @@ pub mod flag {
 pub struct Join {
     pub version: u8,
     pub whatami: WhatAmI,
-    pub zid: ZenohId,
+    pub zid: ZenohIdInner,
     pub resolution: Resolution,
     pub batch_size: BatchSize,
     pub lease: Duration,
@@ -142,7 +142,7 @@ impl Join {
 
         let version: u8 = rng.gen();
         let whatami = WhatAmI::rand();
-        let zid = ZenohId::default();
+        let zid = ZenohIdInner::default();
         let resolution = Resolution::rand();
         let batch_size: BatchSize = rng.gen();
         let lease = if rng.gen_bool(0.5) {

--- a/commons/zenoh-protocol/src/zenoh/del.rs
+++ b/commons/zenoh-protocol/src/zenoh/del.rs
@@ -66,12 +66,12 @@ impl Del {
     pub fn rand() -> Self {
         use rand::Rng;
 
-        use crate::{common::iext, core::ZenohIdInner};
+        use crate::{common::iext, core::ZenohIdProto};
         let mut rng = rand::thread_rng();
 
         let timestamp = rng.gen_bool(0.5).then_some({
             let time = uhlc::NTP64(rng.gen());
-            let id = uhlc::ID::try_from(ZenohIdInner::rand().to_le_bytes()).unwrap();
+            let id = uhlc::ID::try_from(ZenohIdProto::rand().to_le_bytes()).unwrap();
             Timestamp::new(time, id)
         });
         let ext_sinfo = rng.gen_bool(0.5).then_some(ext::SourceInfoType::rand());

--- a/commons/zenoh-protocol/src/zenoh/del.rs
+++ b/commons/zenoh-protocol/src/zenoh/del.rs
@@ -66,12 +66,12 @@ impl Del {
     pub fn rand() -> Self {
         use rand::Rng;
 
-        use crate::{common::iext, core::ZenohId};
+        use crate::{common::iext, core::ZenohIdInner};
         let mut rng = rand::thread_rng();
 
         let timestamp = rng.gen_bool(0.5).then_some({
             let time = uhlc::NTP64(rng.gen());
-            let id = uhlc::ID::try_from(ZenohId::rand().to_le_bytes()).unwrap();
+            let id = uhlc::ID::try_from(ZenohIdInner::rand().to_le_bytes()).unwrap();
             Timestamp::new(time, id)
         });
         let ext_sinfo = rng.gen_bool(0.5).then_some(ext::SourceInfoType::rand());

--- a/commons/zenoh-protocol/src/zenoh/mod.rs
+++ b/commons/zenoh-protocol/src/zenoh/mod.rs
@@ -136,7 +136,7 @@ impl From<Err> for ResponseBody {
 pub mod ext {
     use zenoh_buffers::ZBuf;
 
-    use crate::core::{Encoding, EntityGlobalIdInner};
+    use crate::core::{Encoding, EntityGlobalIdProto};
 
     ///  7 6 5 4 3 2 1 0
     /// +-+-+-+-+-+-+-+-+
@@ -150,7 +150,7 @@ pub mod ext {
     /// +---------------+
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct SourceInfoType<const ID: u8> {
-        pub id: EntityGlobalIdInner,
+        pub id: EntityGlobalIdProto,
         pub sn: u32,
     }
 
@@ -160,7 +160,7 @@ pub mod ext {
             use rand::Rng;
             let mut rng = rand::thread_rng();
 
-            let id = EntityGlobalIdInner::rand();
+            let id = EntityGlobalIdProto::rand();
             let sn: u32 = rng.gen();
             Self { id, sn }
         }

--- a/commons/zenoh-protocol/src/zenoh/mod.rs
+++ b/commons/zenoh-protocol/src/zenoh/mod.rs
@@ -136,7 +136,7 @@ impl From<Err> for ResponseBody {
 pub mod ext {
     use zenoh_buffers::ZBuf;
 
-    use crate::core::{Encoding, EntityGlobalId};
+    use crate::core::{Encoding, EntityGlobalIdInner};
 
     ///  7 6 5 4 3 2 1 0
     /// +-+-+-+-+-+-+-+-+
@@ -150,7 +150,7 @@ pub mod ext {
     /// +---------------+
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct SourceInfoType<const ID: u8> {
-        pub id: EntityGlobalId,
+        pub id: EntityGlobalIdInner,
         pub sn: u32,
     }
 
@@ -160,7 +160,7 @@ pub mod ext {
             use rand::Rng;
             let mut rng = rand::thread_rng();
 
-            let id = EntityGlobalId::rand();
+            let id = EntityGlobalIdInner::rand();
             let sn: u32 = rng.gen();
             Self { id, sn }
         }

--- a/commons/zenoh-protocol/src/zenoh/put.rs
+++ b/commons/zenoh-protocol/src/zenoh/put.rs
@@ -84,12 +84,12 @@ impl Put {
     pub fn rand() -> Self {
         use rand::Rng;
 
-        use crate::{common::iext, core::ZenohId};
+        use crate::{common::iext, core::ZenohIdInner};
         let mut rng = rand::thread_rng();
 
         let timestamp = rng.gen_bool(0.5).then_some({
             let time = uhlc::NTP64(rng.gen());
-            let id = uhlc::ID::try_from(ZenohId::rand().to_le_bytes()).unwrap();
+            let id = uhlc::ID::try_from(ZenohIdInner::rand().to_le_bytes()).unwrap();
             Timestamp::new(time, id)
         });
         let encoding = Encoding::rand();

--- a/commons/zenoh-protocol/src/zenoh/put.rs
+++ b/commons/zenoh-protocol/src/zenoh/put.rs
@@ -84,12 +84,12 @@ impl Put {
     pub fn rand() -> Self {
         use rand::Rng;
 
-        use crate::{common::iext, core::ZenohIdInner};
+        use crate::{common::iext, core::ZenohIdProto};
         let mut rng = rand::thread_rng();
 
         let timestamp = rng.gen_bool(0.5).then_some({
             let time = uhlc::NTP64(rng.gen());
-            let id = uhlc::ID::try_from(ZenohIdInner::rand().to_le_bytes()).unwrap();
+            let id = uhlc::ID::try_from(ZenohIdProto::rand().to_le_bytes()).unwrap();
             Timestamp::new(time, id)
         });
         let encoding = Encoding::rand();

--- a/examples/examples/z_info.rs
+++ b/examples/examples/z_info.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use clap::Parser;
-use zenoh::{config::ZenohId, prelude::*};
+use zenoh::{info::ZenohId, prelude::*};
 use zenoh_examples::CommonArgs;
 
 #[tokio::main]

--- a/io/zenoh-transport/src/lib.rs
+++ b/io/zenoh-transport/src/lib.rs
@@ -34,7 +34,7 @@ pub use manager::*;
 use serde::Serialize;
 use zenoh_link::Link;
 use zenoh_protocol::{
-    core::{WhatAmI, ZenohIdInner},
+    core::{WhatAmI, ZenohIdProto},
     network::NetworkMessage,
 };
 use zenoh_result::ZResult;
@@ -108,7 +108,7 @@ impl TransportMulticastEventHandler for DummyTransportMulticastEventHandler {
 #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
 #[serde(rename = "Transport")]
 pub struct TransportPeer {
-    pub zid: ZenohIdInner,
+    pub zid: ZenohIdProto,
     pub whatami: WhatAmI,
     pub is_qos: bool,
     #[serde(skip)]

--- a/io/zenoh-transport/src/lib.rs
+++ b/io/zenoh-transport/src/lib.rs
@@ -34,7 +34,7 @@ pub use manager::*;
 use serde::Serialize;
 use zenoh_link::Link;
 use zenoh_protocol::{
-    core::{WhatAmI, ZenohId},
+    core::{WhatAmI, ZenohIdInner},
     network::NetworkMessage,
 };
 use zenoh_result::ZResult;
@@ -108,7 +108,7 @@ impl TransportMulticastEventHandler for DummyTransportMulticastEventHandler {
 #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
 #[serde(rename = "Transport")]
 pub struct TransportPeer {
-    pub zid: ZenohId,
+    pub zid: ZenohIdInner,
     pub whatami: WhatAmI,
     pub is_qos: bool,
     #[serde(skip)]

--- a/io/zenoh-transport/src/manager.rs
+++ b/io/zenoh-transport/src/manager.rs
@@ -45,7 +45,7 @@ use crate::multicast::manager::{
 /// ```
 /// use std::sync::Arc;
 /// use std::time::Duration;
-/// use zenoh_protocol::core::{ZenohId, Resolution, Field, Bits, WhatAmI, whatami};
+/// use zenoh_protocol::core::{ZenohIdInner, Resolution, Field, Bits, WhatAmI, whatami};
 /// use zenoh_transport::*;
 /// use zenoh_result::ZResult;
 ///
@@ -85,7 +85,7 @@ use crate::multicast::manager::{
 /// let mut resolution = Resolution::default();
 /// resolution.set(Field::FrameSN, Bits::U8);
 /// let manager = TransportManager::builder()
-///         .zid(ZenohId::rand())
+///         .zid(ZenohIdInner::rand().into())
 ///         .whatami(WhatAmI::Peer)
 ///         .batch_size(1_024)              // Use a batch size of 1024 bytes
 ///         .resolution(resolution)         // Use a sequence number resolution of 128

--- a/io/zenoh-transport/src/manager.rs
+++ b/io/zenoh-transport/src/manager.rs
@@ -19,7 +19,7 @@ use zenoh_config::{Config, LinkRxConf, QueueConf, QueueSizeConf};
 use zenoh_crypto::{BlockCipher, PseudoRng};
 use zenoh_link::NewLinkChannelSender;
 use zenoh_protocol::{
-    core::{EndPoint, Field, Locator, Priority, Resolution, WhatAmI, ZenohId},
+    core::{EndPoint, Field, Locator, Priority, Resolution, WhatAmI, ZenohIdInner},
     transport::BatchSize,
     VERSION,
 };
@@ -96,7 +96,7 @@ use crate::multicast::manager::{
 
 pub struct TransportManagerConfig {
     pub version: u8,
-    pub zid: ZenohId,
+    pub zid: ZenohIdInner,
     pub whatami: WhatAmI,
     pub resolution: Resolution,
     pub batch_size: BatchSize,
@@ -125,7 +125,7 @@ pub struct TransportManagerParams {
 
 pub struct TransportManagerBuilder {
     version: u8,
-    zid: ZenohId,
+    zid: ZenohIdInner,
     whatami: WhatAmI,
     resolution: Resolution,
     batch_size: BatchSize,
@@ -150,7 +150,7 @@ impl TransportManagerBuilder {
         self
     }
 
-    pub fn zid(mut self, zid: ZenohId) -> Self {
+    pub fn zid(mut self, zid: ZenohIdInner) -> Self {
         self.zid = zid;
         self
     }
@@ -335,7 +335,7 @@ impl Default for TransportManagerBuilder {
         let wait_before_drop = *queue.congestion_control().wait_before_drop();
         Self {
             version: VERSION,
-            zid: ZenohId::rand(),
+            zid: ZenohIdInner::rand(),
             whatami: zenoh_config::defaults::mode,
             resolution: Resolution::default(),
             batch_size: BatchSize::MAX,
@@ -424,7 +424,7 @@ impl TransportManager {
         TransportManagerBuilder::default()
     }
 
-    pub fn zid(&self) -> ZenohId {
+    pub fn zid(&self) -> ZenohIdInner {
         self.config.zid
     }
 

--- a/io/zenoh-transport/src/manager.rs
+++ b/io/zenoh-transport/src/manager.rs
@@ -19,7 +19,7 @@ use zenoh_config::{Config, LinkRxConf, QueueConf, QueueSizeConf};
 use zenoh_crypto::{BlockCipher, PseudoRng};
 use zenoh_link::NewLinkChannelSender;
 use zenoh_protocol::{
-    core::{EndPoint, Field, Locator, Priority, Resolution, WhatAmI, ZenohIdInner},
+    core::{EndPoint, Field, Locator, Priority, Resolution, WhatAmI, ZenohIdProto},
     transport::BatchSize,
     VERSION,
 };
@@ -45,7 +45,7 @@ use crate::multicast::manager::{
 /// ```
 /// use std::sync::Arc;
 /// use std::time::Duration;
-/// use zenoh_protocol::core::{ZenohIdInner, Resolution, Field, Bits, WhatAmI, whatami};
+/// use zenoh_protocol::core::{ZenohIdProto, Resolution, Field, Bits, WhatAmI, whatami};
 /// use zenoh_transport::*;
 /// use zenoh_result::ZResult;
 ///
@@ -85,7 +85,7 @@ use crate::multicast::manager::{
 /// let mut resolution = Resolution::default();
 /// resolution.set(Field::FrameSN, Bits::U8);
 /// let manager = TransportManager::builder()
-///         .zid(ZenohIdInner::rand().into())
+///         .zid(ZenohIdProto::rand().into())
 ///         .whatami(WhatAmI::Peer)
 ///         .batch_size(1_024)              // Use a batch size of 1024 bytes
 ///         .resolution(resolution)         // Use a sequence number resolution of 128
@@ -96,7 +96,7 @@ use crate::multicast::manager::{
 
 pub struct TransportManagerConfig {
     pub version: u8,
-    pub zid: ZenohIdInner,
+    pub zid: ZenohIdProto,
     pub whatami: WhatAmI,
     pub resolution: Resolution,
     pub batch_size: BatchSize,
@@ -125,7 +125,7 @@ pub struct TransportManagerParams {
 
 pub struct TransportManagerBuilder {
     version: u8,
-    zid: ZenohIdInner,
+    zid: ZenohIdProto,
     whatami: WhatAmI,
     resolution: Resolution,
     batch_size: BatchSize,
@@ -150,7 +150,7 @@ impl TransportManagerBuilder {
         self
     }
 
-    pub fn zid(mut self, zid: ZenohIdInner) -> Self {
+    pub fn zid(mut self, zid: ZenohIdProto) -> Self {
         self.zid = zid;
         self
     }
@@ -335,7 +335,7 @@ impl Default for TransportManagerBuilder {
         let wait_before_drop = *queue.congestion_control().wait_before_drop();
         Self {
             version: VERSION,
-            zid: ZenohIdInner::rand(),
+            zid: ZenohIdProto::rand(),
             whatami: zenoh_config::defaults::mode,
             resolution: Resolution::default(),
             batch_size: BatchSize::MAX,
@@ -424,7 +424,7 @@ impl TransportManager {
         TransportManagerBuilder::default()
     }
 
-    pub fn zid(&self) -> ZenohIdInner {
+    pub fn zid(&self) -> ZenohIdProto {
         self.config.zid
     }
 

--- a/io/zenoh-transport/src/multicast/link.rs
+++ b/io/zenoh-transport/src/multicast/link.rs
@@ -23,7 +23,7 @@ use zenoh_buffers::{BBuf, ZSlice, ZSliceBuffer};
 use zenoh_core::{zcondfeat, zlock};
 use zenoh_link::{Link, LinkMulticast, Locator};
 use zenoh_protocol::{
-    core::{Bits, Priority, Resolution, WhatAmI, ZenohIdInner},
+    core::{Bits, Priority, Resolution, WhatAmI, ZenohIdProto},
     transport::{BatchSize, Close, Join, PrioritySn, TransportMessage, TransportSn},
 };
 use zenoh_result::{zerror, ZResult};
@@ -251,7 +251,7 @@ impl fmt::Debug for TransportLinkMulticastRx {
 /**************************************/
 pub(super) struct TransportLinkMulticastConfigUniversal {
     pub(super) version: u8,
-    pub(super) zid: ZenohIdInner,
+    pub(super) zid: ZenohIdProto,
     pub(super) whatami: WhatAmI,
     pub(super) lease: Duration,
     pub(super) join_interval: Duration,

--- a/io/zenoh-transport/src/multicast/link.rs
+++ b/io/zenoh-transport/src/multicast/link.rs
@@ -23,7 +23,7 @@ use zenoh_buffers::{BBuf, ZSlice, ZSliceBuffer};
 use zenoh_core::{zcondfeat, zlock};
 use zenoh_link::{Link, LinkMulticast, Locator};
 use zenoh_protocol::{
-    core::{Bits, Priority, Resolution, WhatAmI, ZenohId},
+    core::{Bits, Priority, Resolution, WhatAmI, ZenohIdInner},
     transport::{BatchSize, Close, Join, PrioritySn, TransportMessage, TransportSn},
 };
 use zenoh_result::{zerror, ZResult};
@@ -251,7 +251,7 @@ impl fmt::Debug for TransportLinkMulticastRx {
 /**************************************/
 pub(super) struct TransportLinkMulticastConfigUniversal {
     pub(super) version: u8,
-    pub(super) zid: ZenohId,
+    pub(super) zid: ZenohIdInner,
     pub(super) whatami: WhatAmI,
     pub(super) lease: Duration,
     pub(super) join_interval: Duration,

--- a/io/zenoh-transport/src/multicast/manager.rs
+++ b/io/zenoh-transport/src/multicast/manager.rs
@@ -22,7 +22,7 @@ use zenoh_config::{Config, LinkTxConf};
 use zenoh_core::zasynclock;
 use zenoh_link::*;
 use zenoh_protocol::{
-    core::{Parameters, ZenohIdInner},
+    core::{Parameters, ZenohIdProto},
     transport::close,
 };
 use zenoh_result::{bail, zerror, ZResult};
@@ -266,7 +266,7 @@ impl TransportManager {
         super::establishment::open_link(self, link).await
     }
 
-    pub async fn get_transport_multicast(&self, zid: &ZenohIdInner) -> Option<TransportMulticast> {
+    pub async fn get_transport_multicast(&self, zid: &ZenohIdProto) -> Option<TransportMulticast> {
         for t in zasynclock!(self.state.multicast.transports).values() {
             if t.get_peers().iter().any(|p| p.zid == *zid) {
                 return Some(t.into());

--- a/io/zenoh-transport/src/multicast/manager.rs
+++ b/io/zenoh-transport/src/multicast/manager.rs
@@ -22,7 +22,7 @@ use zenoh_config::{Config, LinkTxConf};
 use zenoh_core::zasynclock;
 use zenoh_link::*;
 use zenoh_protocol::{
-    core::{Parameters, ZenohId},
+    core::{Parameters, ZenohIdInner},
     transport::close,
 };
 use zenoh_result::{bail, zerror, ZResult};
@@ -266,7 +266,7 @@ impl TransportManager {
         super::establishment::open_link(self, link).await
     }
 
-    pub async fn get_transport_multicast(&self, zid: &ZenohId) -> Option<TransportMulticast> {
+    pub async fn get_transport_multicast(&self, zid: &ZenohIdInner) -> Option<TransportMulticast> {
         for t in zasynclock!(self.state.multicast.transports).values() {
             if t.get_peers().iter().any(|p| p.zid == *zid) {
                 return Some(t.into());

--- a/io/zenoh-transport/src/multicast/transport.rs
+++ b/io/zenoh-transport/src/multicast/transport.rs
@@ -24,7 +24,7 @@ use tokio_util::sync::CancellationToken;
 use zenoh_core::{zcondfeat, zread, zwrite};
 use zenoh_link::{Link, Locator};
 use zenoh_protocol::{
-    core::{Bits, Field, Priority, Resolution, WhatAmI, ZenohIdInner},
+    core::{Bits, Field, Priority, Resolution, WhatAmI, ZenohIdProto},
     transport::{batch_size, close, Close, Join, TransportMessage},
 };
 use zenoh_result::{bail, ZResult};
@@ -53,7 +53,7 @@ use crate::{
 pub(super) struct TransportMulticastPeer {
     pub(super) version: u8,
     pub(super) locator: Locator,
-    pub(super) zid: ZenohIdInner,
+    pub(super) zid: ZenohIdProto,
     pub(super) whatami: WhatAmI,
     pub(super) resolution: Resolution,
     pub(super) lease: Duration,

--- a/io/zenoh-transport/src/multicast/transport.rs
+++ b/io/zenoh-transport/src/multicast/transport.rs
@@ -24,7 +24,7 @@ use tokio_util::sync::CancellationToken;
 use zenoh_core::{zcondfeat, zread, zwrite};
 use zenoh_link::{Link, Locator};
 use zenoh_protocol::{
-    core::{Bits, Field, Priority, Resolution, WhatAmI, ZenohId},
+    core::{Bits, Field, Priority, Resolution, WhatAmI, ZenohIdInner},
     transport::{batch_size, close, Close, Join, TransportMessage},
 };
 use zenoh_result::{bail, ZResult};
@@ -53,7 +53,7 @@ use crate::{
 pub(super) struct TransportMulticastPeer {
     pub(super) version: u8,
     pub(super) locator: Locator,
-    pub(super) zid: ZenohId,
+    pub(super) zid: ZenohIdInner,
     pub(super) whatami: WhatAmI,
     pub(super) resolution: Resolution,
     pub(super) lease: Duration,

--- a/io/zenoh-transport/src/unicast/establishment/accept.rs
+++ b/io/zenoh-transport/src/unicast/establishment/accept.rs
@@ -22,7 +22,7 @@ use zenoh_core::{zasynclock, zcondfeat, zerror};
 use zenoh_crypto::{BlockCipher, PseudoRng};
 use zenoh_link::LinkUnicast;
 use zenoh_protocol::{
-    core::{Field, Resolution, WhatAmI, ZenohIdInner},
+    core::{Field, Resolution, WhatAmI, ZenohIdProto},
     transport::{
         batch_size,
         close::{self, Close},
@@ -80,7 +80,7 @@ struct RecvInitSynIn {
     mine_version: u8,
 }
 struct RecvInitSynOut {
-    other_zid: ZenohIdInner,
+    other_zid: ZenohIdProto,
     other_whatami: WhatAmI,
     #[cfg(feature = "shared-memory")]
     ext_shm: Option<AuthSegment>,
@@ -89,9 +89,9 @@ struct RecvInitSynOut {
 // InitAck
 struct SendInitAckIn {
     mine_version: u8,
-    mine_zid: ZenohIdInner,
+    mine_zid: ZenohIdProto,
     mine_whatami: WhatAmI,
-    other_zid: ZenohIdInner,
+    other_zid: ZenohIdProto,
     other_whatami: WhatAmI,
     #[cfg(feature = "shared-memory")]
     ext_shm: Option<AuthSegment>,
@@ -107,7 +107,7 @@ struct RecvOpenSynIn {
     cookie_nonce: u64,
 }
 struct RecvOpenSynOut {
-    other_zid: ZenohIdInner,
+    other_zid: ZenohIdProto,
     other_whatami: WhatAmI,
     other_lease: Duration,
     other_initial_sn: TransportSn,
@@ -115,9 +115,9 @@ struct RecvOpenSynOut {
 
 // OpenAck
 struct SendOpenAckIn {
-    mine_zid: ZenohIdInner,
+    mine_zid: ZenohIdProto,
     mine_lease: Duration,
-    other_zid: ZenohIdInner,
+    other_zid: ZenohIdProto,
 }
 struct SendOpenAckOut {
     open_ack: OpenAck,

--- a/io/zenoh-transport/src/unicast/establishment/accept.rs
+++ b/io/zenoh-transport/src/unicast/establishment/accept.rs
@@ -22,7 +22,7 @@ use zenoh_core::{zasynclock, zcondfeat, zerror};
 use zenoh_crypto::{BlockCipher, PseudoRng};
 use zenoh_link::LinkUnicast;
 use zenoh_protocol::{
-    core::{Field, Resolution, WhatAmI, ZenohId},
+    core::{Field, Resolution, WhatAmI, ZenohIdInner},
     transport::{
         batch_size,
         close::{self, Close},
@@ -80,7 +80,7 @@ struct RecvInitSynIn {
     mine_version: u8,
 }
 struct RecvInitSynOut {
-    other_zid: ZenohId,
+    other_zid: ZenohIdInner,
     other_whatami: WhatAmI,
     #[cfg(feature = "shared-memory")]
     ext_shm: Option<AuthSegment>,
@@ -89,9 +89,9 @@ struct RecvInitSynOut {
 // InitAck
 struct SendInitAckIn {
     mine_version: u8,
-    mine_zid: ZenohId,
+    mine_zid: ZenohIdInner,
     mine_whatami: WhatAmI,
-    other_zid: ZenohId,
+    other_zid: ZenohIdInner,
     other_whatami: WhatAmI,
     #[cfg(feature = "shared-memory")]
     ext_shm: Option<AuthSegment>,
@@ -107,7 +107,7 @@ struct RecvOpenSynIn {
     cookie_nonce: u64,
 }
 struct RecvOpenSynOut {
-    other_zid: ZenohId,
+    other_zid: ZenohIdInner,
     other_whatami: WhatAmI,
     other_lease: Duration,
     other_initial_sn: TransportSn,
@@ -115,9 +115,9 @@ struct RecvOpenSynOut {
 
 // OpenAck
 struct SendOpenAckIn {
-    mine_zid: ZenohId,
+    mine_zid: ZenohIdInner,
     mine_lease: Duration,
-    other_zid: ZenohId,
+    other_zid: ZenohIdInner,
 }
 struct SendOpenAckOut {
     open_ack: OpenAck,

--- a/io/zenoh-transport/src/unicast/establishment/cookie.rs
+++ b/io/zenoh-transport/src/unicast/establishment/cookie.rs
@@ -20,7 +20,7 @@ use zenoh_buffers::{
 use zenoh_codec::{RCodec, WCodec, Zenoh080};
 use zenoh_crypto::{BlockCipher, PseudoRng};
 use zenoh_protocol::{
-    core::{Resolution, WhatAmI, ZenohId},
+    core::{Resolution, WhatAmI, ZenohIdInner},
     transport::BatchSize,
 };
 
@@ -28,7 +28,7 @@ use crate::unicast::establishment::ext;
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct Cookie {
-    pub(crate) zid: ZenohId,
+    pub(crate) zid: ZenohIdInner,
     pub(crate) whatami: WhatAmI,
     pub(crate) resolution: Resolution,
     pub(crate) batch_size: BatchSize,
@@ -82,7 +82,7 @@ where
     type Error = DidntRead;
 
     fn read(self, reader: &mut R) -> Result<Cookie, Self::Error> {
-        let zid: ZenohId = self.read(&mut *reader)?;
+        let zid: ZenohIdInner = self.read(&mut *reader)?;
         let wai: u8 = self.read(&mut *reader)?;
         let whatami = WhatAmI::try_from(wai).map_err(|_| DidntRead)?;
         let resolution: u8 = self.read(&mut *reader)?;
@@ -173,7 +173,7 @@ impl Cookie {
         let mut rng = rand::thread_rng();
 
         Self {
-            zid: ZenohId::default(),
+            zid: ZenohIdInner::default(),
             whatami: WhatAmI::rand(),
             resolution: Resolution::rand(),
             batch_size: rng.gen(),

--- a/io/zenoh-transport/src/unicast/establishment/cookie.rs
+++ b/io/zenoh-transport/src/unicast/establishment/cookie.rs
@@ -20,7 +20,7 @@ use zenoh_buffers::{
 use zenoh_codec::{RCodec, WCodec, Zenoh080};
 use zenoh_crypto::{BlockCipher, PseudoRng};
 use zenoh_protocol::{
-    core::{Resolution, WhatAmI, ZenohIdInner},
+    core::{Resolution, WhatAmI, ZenohIdProto},
     transport::BatchSize,
 };
 
@@ -28,7 +28,7 @@ use crate::unicast::establishment::ext;
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct Cookie {
-    pub(crate) zid: ZenohIdInner,
+    pub(crate) zid: ZenohIdProto,
     pub(crate) whatami: WhatAmI,
     pub(crate) resolution: Resolution,
     pub(crate) batch_size: BatchSize,
@@ -82,7 +82,7 @@ where
     type Error = DidntRead;
 
     fn read(self, reader: &mut R) -> Result<Cookie, Self::Error> {
-        let zid: ZenohIdInner = self.read(&mut *reader)?;
+        let zid: ZenohIdProto = self.read(&mut *reader)?;
         let wai: u8 = self.read(&mut *reader)?;
         let whatami = WhatAmI::try_from(wai).map_err(|_| DidntRead)?;
         let resolution: u8 = self.read(&mut *reader)?;
@@ -173,7 +173,7 @@ impl Cookie {
         let mut rng = rand::thread_rng();
 
         Self {
-            zid: ZenohIdInner::default(),
+            zid: ZenohIdProto::default(),
             whatami: WhatAmI::rand(),
             resolution: Resolution::rand(),
             batch_size: rng.gen(),

--- a/io/zenoh-transport/src/unicast/establishment/mod.rs
+++ b/io/zenoh-transport/src/unicast/establishment/mod.rs
@@ -23,7 +23,7 @@ use sha3::{
     Shake128,
 };
 use zenoh_protocol::{
-    core::{Field, Resolution, ZenohIdInner},
+    core::{Field, Resolution, ZenohIdProto},
     transport::TransportSn,
 };
 
@@ -102,8 +102,8 @@ pub trait AcceptFsm {
 /*           FUNCTIONS               */
 /*************************************/
 pub(super) fn compute_sn(
-    zid1: ZenohIdInner,
-    zid2: ZenohIdInner,
+    zid1: ZenohIdProto,
+    zid2: ZenohIdProto,
     resolution: Resolution,
 ) -> TransportSn {
     // Create a random yet deterministic initial_sn.

--- a/io/zenoh-transport/src/unicast/establishment/mod.rs
+++ b/io/zenoh-transport/src/unicast/establishment/mod.rs
@@ -101,7 +101,11 @@ pub trait AcceptFsm {
 /*************************************/
 /*           FUNCTIONS               */
 /*************************************/
-pub(super) fn compute_sn(zid1: ZenohIdInner, zid2: ZenohIdInner, resolution: Resolution) -> TransportSn {
+pub(super) fn compute_sn(
+    zid1: ZenohIdInner,
+    zid2: ZenohIdInner,
+    resolution: Resolution,
+) -> TransportSn {
     // Create a random yet deterministic initial_sn.
     // In case of multilink it's important that the same initial_sn is used for every connection attempt.
     // Instead of storing the state everywhere, we make sure that the we always compute the same initial_sn.

--- a/io/zenoh-transport/src/unicast/establishment/mod.rs
+++ b/io/zenoh-transport/src/unicast/establishment/mod.rs
@@ -23,7 +23,7 @@ use sha3::{
     Shake128,
 };
 use zenoh_protocol::{
-    core::{Field, Resolution, ZenohId},
+    core::{Field, Resolution, ZenohIdInner},
     transport::TransportSn,
 };
 
@@ -101,7 +101,7 @@ pub trait AcceptFsm {
 /*************************************/
 /*           FUNCTIONS               */
 /*************************************/
-pub(super) fn compute_sn(zid1: ZenohId, zid2: ZenohId, resolution: Resolution) -> TransportSn {
+pub(super) fn compute_sn(zid1: ZenohIdInner, zid2: ZenohIdInner, resolution: Resolution) -> TransportSn {
     // Create a random yet deterministic initial_sn.
     // In case of multilink it's important that the same initial_sn is used for every connection attempt.
     // Instead of storing the state everywhere, we make sure that the we always compute the same initial_sn.

--- a/io/zenoh-transport/src/unicast/establishment/open.rs
+++ b/io/zenoh-transport/src/unicast/establishment/open.rs
@@ -20,7 +20,7 @@ use zenoh_core::zasynclock;
 use zenoh_core::{zcondfeat, zerror};
 use zenoh_link::LinkUnicast;
 use zenoh_protocol::{
-    core::{Field, Resolution, WhatAmI, ZenohId},
+    core::{Field, Resolution, WhatAmI, ZenohIdInner},
     transport::{
         batch_size, close, BatchSize, Close, InitSyn, OpenSyn, TransportBody, TransportMessage,
         TransportSn,
@@ -75,13 +75,13 @@ struct State {
 // InitSyn
 struct SendInitSynIn {
     mine_version: u8,
-    mine_zid: ZenohId,
+    mine_zid: ZenohIdInner,
     mine_whatami: WhatAmI,
 }
 
 // InitAck
 struct RecvInitAckOut {
-    other_zid: ZenohId,
+    other_zid: ZenohIdInner,
     other_whatami: WhatAmI,
     other_cookie: ZSlice,
     #[cfg(feature = "shared-memory")]
@@ -90,9 +90,9 @@ struct RecvInitAckOut {
 
 // OpenSyn
 struct SendOpenSynIn {
-    mine_zid: ZenohId,
+    mine_zid: ZenohIdInner,
     mine_lease: Duration,
-    other_zid: ZenohId,
+    other_zid: ZenohIdInner,
     other_cookie: ZSlice,
     #[cfg(feature = "shared-memory")]
     ext_shm: Option<AuthSegment>,

--- a/io/zenoh-transport/src/unicast/establishment/open.rs
+++ b/io/zenoh-transport/src/unicast/establishment/open.rs
@@ -20,7 +20,7 @@ use zenoh_core::zasynclock;
 use zenoh_core::{zcondfeat, zerror};
 use zenoh_link::LinkUnicast;
 use zenoh_protocol::{
-    core::{Field, Resolution, WhatAmI, ZenohIdInner},
+    core::{Field, Resolution, WhatAmI, ZenohIdProto},
     transport::{
         batch_size, close, BatchSize, Close, InitSyn, OpenSyn, TransportBody, TransportMessage,
         TransportSn,
@@ -75,13 +75,13 @@ struct State {
 // InitSyn
 struct SendInitSynIn {
     mine_version: u8,
-    mine_zid: ZenohIdInner,
+    mine_zid: ZenohIdProto,
     mine_whatami: WhatAmI,
 }
 
 // InitAck
 struct RecvInitAckOut {
-    other_zid: ZenohIdInner,
+    other_zid: ZenohIdProto,
     other_whatami: WhatAmI,
     other_cookie: ZSlice,
     #[cfg(feature = "shared-memory")]
@@ -90,9 +90,9 @@ struct RecvInitAckOut {
 
 // OpenSyn
 struct SendOpenSynIn {
-    mine_zid: ZenohIdInner,
+    mine_zid: ZenohIdProto,
     mine_lease: Duration,
-    other_zid: ZenohIdInner,
+    other_zid: ZenohIdProto,
     other_cookie: ZSlice,
     #[cfg(feature = "shared-memory")]
     ext_shm: Option<AuthSegment>,

--- a/io/zenoh-transport/src/unicast/lowlatency/transport.rs
+++ b/io/zenoh-transport/src/unicast/lowlatency/transport.rs
@@ -22,7 +22,7 @@ use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use zenoh_core::{zasynclock, zasyncread, zasyncwrite, zread, zwrite};
 use zenoh_link::Link;
 use zenoh_protocol::{
-    core::{WhatAmI, ZenohId},
+    core::{WhatAmI, ZenohIdInner},
     network::NetworkMessage,
     transport::{close, Close, TransportBodyLowLatency, TransportMessageLowLatency, TransportSn},
 };
@@ -183,7 +183,7 @@ impl TransportUnicastTrait for TransportUnicastLowlatency {
         vec![]
     }
 
-    fn get_zid(&self) -> ZenohId {
+    fn get_zid(&self) -> ZenohIdInner {
         self.config.zid
     }
 

--- a/io/zenoh-transport/src/unicast/lowlatency/transport.rs
+++ b/io/zenoh-transport/src/unicast/lowlatency/transport.rs
@@ -22,7 +22,7 @@ use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use zenoh_core::{zasynclock, zasyncread, zasyncwrite, zread, zwrite};
 use zenoh_link::Link;
 use zenoh_protocol::{
-    core::{WhatAmI, ZenohIdInner},
+    core::{WhatAmI, ZenohIdProto},
     network::NetworkMessage,
     transport::{close, Close, TransportBodyLowLatency, TransportMessageLowLatency, TransportSn},
 };
@@ -183,7 +183,7 @@ impl TransportUnicastTrait for TransportUnicastLowlatency {
         vec![]
     }
 
-    fn get_zid(&self) -> ZenohIdInner {
+    fn get_zid(&self) -> ZenohIdProto {
         self.config.zid
     }
 

--- a/io/zenoh-transport/src/unicast/manager.rs
+++ b/io/zenoh-transport/src/unicast/manager.rs
@@ -30,7 +30,7 @@ use zenoh_core::{zasynclock, zcondfeat};
 use zenoh_crypto::PseudoRng;
 use zenoh_link::*;
 use zenoh_protocol::{
-    core::{Parameters, ZenohIdInner},
+    core::{Parameters, ZenohIdProto},
     transport::{close, TransportSn},
 };
 use zenoh_result::{bail, zerror, ZResult};
@@ -79,7 +79,7 @@ pub struct TransportManagerStateUnicast {
     // Established listeners
     pub(super) protocols: Arc<AsyncMutex<HashMap<String, LinkManagerUnicast>>>,
     // Established transports
-    pub(super) transports: Arc<AsyncMutex<HashMap<ZenohIdInner, Arc<dyn TransportUnicastTrait>>>>,
+    pub(super) transports: Arc<AsyncMutex<HashMap<ZenohIdProto, Arc<dyn TransportUnicastTrait>>>>,
     // Multilink
     #[cfg(feature = "transport_multilink")]
     pub(super) multilink: Arc<MultiLink>,
@@ -510,7 +510,7 @@ impl TransportManager {
         link: LinkUnicastWithOpenAck,
         other_initial_sn: TransportSn,
         other_lease: Duration,
-        mut guard: AsyncMutexGuard<'_, HashMap<ZenohIdInner, Arc<dyn TransportUnicastTrait>>>,
+        mut guard: AsyncMutexGuard<'_, HashMap<ZenohIdProto, Arc<dyn TransportUnicastTrait>>>,
     ) -> InitTransportResult {
         macro_rules! link_error {
             ($s:expr, $reason:expr) => {
@@ -707,7 +707,7 @@ impl TransportManager {
         super::establishment::open::open_link(link, self).await
     }
 
-    pub async fn get_transport_unicast(&self, peer: &ZenohIdInner) -> Option<TransportUnicast> {
+    pub async fn get_transport_unicast(&self, peer: &ZenohIdProto) -> Option<TransportUnicast> {
         zasynclock!(self.state.unicast.transports)
             .get(peer)
             .map(|t| TransportUnicast(Arc::downgrade(t)))
@@ -720,7 +720,7 @@ impl TransportManager {
             .collect()
     }
 
-    pub(super) async fn del_transport_unicast(&self, peer: &ZenohIdInner) -> ZResult<()> {
+    pub(super) async fn del_transport_unicast(&self, peer: &ZenohIdProto) -> ZResult<()> {
         zasynclock!(self.state.unicast.transports)
             .remove(peer)
             .ok_or_else(|| {

--- a/io/zenoh-transport/src/unicast/manager.rs
+++ b/io/zenoh-transport/src/unicast/manager.rs
@@ -30,7 +30,7 @@ use zenoh_core::{zasynclock, zcondfeat};
 use zenoh_crypto::PseudoRng;
 use zenoh_link::*;
 use zenoh_protocol::{
-    core::{Parameters, ZenohId},
+    core::{Parameters, ZenohIdInner},
     transport::{close, TransportSn},
 };
 use zenoh_result::{bail, zerror, ZResult};
@@ -79,7 +79,7 @@ pub struct TransportManagerStateUnicast {
     // Established listeners
     pub(super) protocols: Arc<AsyncMutex<HashMap<String, LinkManagerUnicast>>>,
     // Established transports
-    pub(super) transports: Arc<AsyncMutex<HashMap<ZenohId, Arc<dyn TransportUnicastTrait>>>>,
+    pub(super) transports: Arc<AsyncMutex<HashMap<ZenohIdInner, Arc<dyn TransportUnicastTrait>>>>,
     // Multilink
     #[cfg(feature = "transport_multilink")]
     pub(super) multilink: Arc<MultiLink>,
@@ -510,7 +510,7 @@ impl TransportManager {
         link: LinkUnicastWithOpenAck,
         other_initial_sn: TransportSn,
         other_lease: Duration,
-        mut guard: AsyncMutexGuard<'_, HashMap<ZenohId, Arc<dyn TransportUnicastTrait>>>,
+        mut guard: AsyncMutexGuard<'_, HashMap<ZenohIdInner, Arc<dyn TransportUnicastTrait>>>,
     ) -> InitTransportResult {
         macro_rules! link_error {
             ($s:expr, $reason:expr) => {
@@ -707,7 +707,7 @@ impl TransportManager {
         super::establishment::open::open_link(link, self).await
     }
 
-    pub async fn get_transport_unicast(&self, peer: &ZenohId) -> Option<TransportUnicast> {
+    pub async fn get_transport_unicast(&self, peer: &ZenohIdInner) -> Option<TransportUnicast> {
         zasynclock!(self.state.unicast.transports)
             .get(peer)
             .map(|t| TransportUnicast(Arc::downgrade(t)))
@@ -720,7 +720,7 @@ impl TransportManager {
             .collect()
     }
 
-    pub(super) async fn del_transport_unicast(&self, peer: &ZenohId) -> ZResult<()> {
+    pub(super) async fn del_transport_unicast(&self, peer: &ZenohIdInner) -> ZResult<()> {
         zasynclock!(self.state.unicast.transports)
             .remove(peer)
             .ok_or_else(|| {

--- a/io/zenoh-transport/src/unicast/mod.rs
+++ b/io/zenoh-transport/src/unicast/mod.rs
@@ -32,7 +32,7 @@ pub use manager::*;
 use zenoh_core::zcondfeat;
 use zenoh_link::Link;
 use zenoh_protocol::{
-    core::{Bits, WhatAmI, ZenohIdInner},
+    core::{Bits, WhatAmI, ZenohIdProto},
     network::NetworkMessage,
     transport::{close, TransportSn},
 };
@@ -48,7 +48,7 @@ use crate::shm::TransportShmConfig;
 /*************************************/
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct TransportConfigUnicast {
-    pub(crate) zid: ZenohIdInner,
+    pub(crate) zid: ZenohIdProto,
     pub(crate) whatami: WhatAmI,
     pub(crate) sn_resolution: Bits,
     pub(crate) tx_initial_sn: TransportSn,
@@ -74,7 +74,7 @@ impl TransportUnicast {
     }
 
     #[inline(always)]
-    pub fn get_zid(&self) -> ZResult<ZenohIdInner> {
+    pub fn get_zid(&self) -> ZResult<ZenohIdProto> {
         let transport = self.get_inner()?;
         Ok(transport.get_zid())
     }

--- a/io/zenoh-transport/src/unicast/mod.rs
+++ b/io/zenoh-transport/src/unicast/mod.rs
@@ -32,7 +32,7 @@ pub use manager::*;
 use zenoh_core::zcondfeat;
 use zenoh_link::Link;
 use zenoh_protocol::{
-    core::{Bits, WhatAmI, ZenohId},
+    core::{Bits, WhatAmI, ZenohIdInner},
     network::NetworkMessage,
     transport::{close, TransportSn},
 };
@@ -48,7 +48,7 @@ use crate::shm::TransportShmConfig;
 /*************************************/
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct TransportConfigUnicast {
-    pub(crate) zid: ZenohId,
+    pub(crate) zid: ZenohIdInner,
     pub(crate) whatami: WhatAmI,
     pub(crate) sn_resolution: Bits,
     pub(crate) tx_initial_sn: TransportSn,
@@ -74,7 +74,7 @@ impl TransportUnicast {
     }
 
     #[inline(always)]
-    pub fn get_zid(&self) -> ZResult<ZenohId> {
+    pub fn get_zid(&self) -> ZResult<ZenohIdInner> {
         let transport = self.get_inner()?;
         Ok(transport.get_zid())
     }

--- a/io/zenoh-transport/src/unicast/transport_unicast_inner.rs
+++ b/io/zenoh-transport/src/unicast/transport_unicast_inner.rs
@@ -18,7 +18,7 @@ use async_trait::async_trait;
 use tokio::sync::MutexGuard as AsyncMutexGuard;
 use zenoh_link::Link;
 use zenoh_protocol::{
-    core::{WhatAmI, ZenohId},
+    core::{WhatAmI, ZenohIdInner},
     network::NetworkMessage,
     transport::TransportSn,
 };
@@ -52,7 +52,7 @@ pub(crate) trait TransportUnicastTrait: Send + Sync {
     fn set_callback(&self, callback: Arc<dyn TransportPeerEventHandler>);
 
     async fn get_alive(&self) -> AsyncMutexGuard<'_, bool>;
-    fn get_zid(&self) -> ZenohId;
+    fn get_zid(&self) -> ZenohIdInner;
     fn get_whatami(&self) -> WhatAmI;
     fn get_callback(&self) -> Option<Arc<dyn TransportPeerEventHandler>>;
     fn get_links(&self) -> Vec<Link>;

--- a/io/zenoh-transport/src/unicast/transport_unicast_inner.rs
+++ b/io/zenoh-transport/src/unicast/transport_unicast_inner.rs
@@ -18,7 +18,7 @@ use async_trait::async_trait;
 use tokio::sync::MutexGuard as AsyncMutexGuard;
 use zenoh_link::Link;
 use zenoh_protocol::{
-    core::{WhatAmI, ZenohIdInner},
+    core::{WhatAmI, ZenohIdProto},
     network::NetworkMessage,
     transport::TransportSn,
 };
@@ -52,7 +52,7 @@ pub(crate) trait TransportUnicastTrait: Send + Sync {
     fn set_callback(&self, callback: Arc<dyn TransportPeerEventHandler>);
 
     async fn get_alive(&self) -> AsyncMutexGuard<'_, bool>;
-    fn get_zid(&self) -> ZenohIdInner;
+    fn get_zid(&self) -> ZenohIdProto;
     fn get_whatami(&self) -> WhatAmI;
     fn get_callback(&self) -> Option<Arc<dyn TransportPeerEventHandler>>;
     fn get_links(&self) -> Vec<Link>;

--- a/io/zenoh-transport/src/unicast/universal/transport.rs
+++ b/io/zenoh-transport/src/unicast/universal/transport.rs
@@ -22,7 +22,7 @@ use tokio::sync::{Mutex as AsyncMutex, MutexGuard as AsyncMutexGuard};
 use zenoh_core::{zasynclock, zcondfeat, zread, zwrite};
 use zenoh_link::Link;
 use zenoh_protocol::{
-    core::{Priority, WhatAmI, ZenohId},
+    core::{Priority, WhatAmI, ZenohIdInner},
     network::NetworkMessage,
     transport::{close, Close, PrioritySn, TransportMessage, TransportSn},
 };
@@ -320,7 +320,7 @@ impl TransportUnicastTrait for TransportUnicastUniversal {
         zasynclock!(self.alive)
     }
 
-    fn get_zid(&self) -> ZenohId {
+    fn get_zid(&self) -> ZenohIdInner {
         self.config.zid
     }
 

--- a/io/zenoh-transport/src/unicast/universal/transport.rs
+++ b/io/zenoh-transport/src/unicast/universal/transport.rs
@@ -22,7 +22,7 @@ use tokio::sync::{Mutex as AsyncMutex, MutexGuard as AsyncMutexGuard};
 use zenoh_core::{zasynclock, zcondfeat, zread, zwrite};
 use zenoh_link::Link;
 use zenoh_protocol::{
-    core::{Priority, WhatAmI, ZenohIdInner},
+    core::{Priority, WhatAmI, ZenohIdProto},
     network::NetworkMessage,
     transport::{close, Close, PrioritySn, TransportMessage, TransportSn},
 };
@@ -320,7 +320,7 @@ impl TransportUnicastTrait for TransportUnicastUniversal {
         zasynclock!(self.alive)
     }
 
-    fn get_zid(&self) -> ZenohIdInner {
+    fn get_zid(&self) -> ZenohIdProto {
         self.config.zid
     }
 

--- a/io/zenoh-transport/tests/endpoints.rs
+++ b/io/zenoh-transport/tests/endpoints.rs
@@ -16,7 +16,7 @@ use std::{any::Any, convert::TryFrom, sync::Arc, time::Duration};
 use zenoh_core::ztimeout;
 use zenoh_link::{EndPoint, Link};
 use zenoh_protocol::{
-    core::{WhatAmI, ZenohId},
+    core::{WhatAmI, ZenohIdInner},
     network::NetworkMessage,
 };
 use zenoh_result::ZResult;
@@ -74,7 +74,7 @@ async fn run(endpoints: &[EndPoint]) {
     // Create the transport manager
     let sm = TransportManager::builder()
         .whatami(WhatAmI::Peer)
-        .zid(ZenohId::try_from([1]).unwrap())
+        .zid(ZenohIdInner::try_from([1]).unwrap())
         .build(Arc::new(SH))
         .unwrap();
 

--- a/io/zenoh-transport/tests/endpoints.rs
+++ b/io/zenoh-transport/tests/endpoints.rs
@@ -16,7 +16,7 @@ use std::{any::Any, convert::TryFrom, sync::Arc, time::Duration};
 use zenoh_core::ztimeout;
 use zenoh_link::{EndPoint, Link};
 use zenoh_protocol::{
-    core::{WhatAmI, ZenohIdInner},
+    core::{WhatAmI, ZenohIdProto},
     network::NetworkMessage,
 };
 use zenoh_result::ZResult;
@@ -74,7 +74,7 @@ async fn run(endpoints: &[EndPoint]) {
     // Create the transport manager
     let sm = TransportManager::builder()
         .whatami(WhatAmI::Peer)
-        .zid(ZenohIdInner::try_from([1]).unwrap())
+        .zid(ZenohIdProto::try_from([1]).unwrap())
         .build(Arc::new(SH))
         .unwrap();
 

--- a/io/zenoh-transport/tests/multicast_compression.rs
+++ b/io/zenoh-transport/tests/multicast_compression.rs
@@ -29,7 +29,7 @@ mod tests {
     use zenoh_link::Link;
     use zenoh_protocol::{
         core::{
-            Channel, CongestionControl, Encoding, EndPoint, Priority, Reliability, WhatAmI, ZenohId,
+            Channel, CongestionControl, Encoding, EndPoint, Priority, Reliability, WhatAmI, ZenohIdInner,
         },
         network::{
             push::{
@@ -144,8 +144,8 @@ mod tests {
         endpoint: &EndPoint,
     ) -> (TransportMulticastPeer, TransportMulticastPeer) {
         // Define peer01 and peer02 IDs
-        let peer01_id = ZenohId::try_from([1]).unwrap();
-        let peer02_id = ZenohId::try_from([2]).unwrap();
+        let peer01_id = ZenohIdInner::try_from([1]).unwrap();
+        let peer02_id = ZenohIdInner::try_from([2]).unwrap();
 
         // Create the peer01 transport manager
         let peer01_handler = Arc::new(SHPeer::default());

--- a/io/zenoh-transport/tests/multicast_compression.rs
+++ b/io/zenoh-transport/tests/multicast_compression.rs
@@ -29,7 +29,8 @@ mod tests {
     use zenoh_link::Link;
     use zenoh_protocol::{
         core::{
-            Channel, CongestionControl, Encoding, EndPoint, Priority, Reliability, WhatAmI, ZenohIdInner,
+            Channel, CongestionControl, Encoding, EndPoint, Priority, Reliability, WhatAmI,
+            ZenohIdInner,
         },
         network::{
             push::{

--- a/io/zenoh-transport/tests/multicast_compression.rs
+++ b/io/zenoh-transport/tests/multicast_compression.rs
@@ -30,7 +30,7 @@ mod tests {
     use zenoh_protocol::{
         core::{
             Channel, CongestionControl, Encoding, EndPoint, Priority, Reliability, WhatAmI,
-            ZenohIdInner,
+            ZenohIdProto,
         },
         network::{
             push::{
@@ -145,8 +145,8 @@ mod tests {
         endpoint: &EndPoint,
     ) -> (TransportMulticastPeer, TransportMulticastPeer) {
         // Define peer01 and peer02 IDs
-        let peer01_id = ZenohIdInner::try_from([1]).unwrap();
-        let peer02_id = ZenohIdInner::try_from([2]).unwrap();
+        let peer01_id = ZenohIdProto::try_from([1]).unwrap();
+        let peer02_id = ZenohIdProto::try_from([2]).unwrap();
 
         // Create the peer01 transport manager
         let peer01_handler = Arc::new(SHPeer::default());

--- a/io/zenoh-transport/tests/multicast_transport.rs
+++ b/io/zenoh-transport/tests/multicast_transport.rs
@@ -31,7 +31,7 @@ mod tests {
     use zenoh_protocol::{
         core::{
             Channel, CongestionControl, Encoding, EndPoint, Priority, Reliability, WhatAmI,
-            ZenohIdInner,
+            ZenohIdProto,
         },
         network::{
             push::{
@@ -144,8 +144,8 @@ mod tests {
         endpoint: &EndPoint,
     ) -> (TransportMulticastPeer, TransportMulticastPeer) {
         // Define peer01 and peer02 IDs
-        let peer01_id = ZenohIdInner::try_from([1]).unwrap();
-        let peer02_id = ZenohIdInner::try_from([2]).unwrap();
+        let peer01_id = ZenohIdProto::try_from([1]).unwrap();
+        let peer02_id = ZenohIdProto::try_from([2]).unwrap();
 
         // Create the peer01 transport manager
         let peer01_handler = Arc::new(SHPeer::default());

--- a/io/zenoh-transport/tests/multicast_transport.rs
+++ b/io/zenoh-transport/tests/multicast_transport.rs
@@ -30,7 +30,7 @@ mod tests {
     use zenoh_link::Link;
     use zenoh_protocol::{
         core::{
-            Channel, CongestionControl, Encoding, EndPoint, Priority, Reliability, WhatAmI, ZenohId,
+            Channel, CongestionControl, Encoding, EndPoint, Priority, Reliability, WhatAmI, ZenohIdInner,
         },
         network::{
             push::{
@@ -143,8 +143,8 @@ mod tests {
         endpoint: &EndPoint,
     ) -> (TransportMulticastPeer, TransportMulticastPeer) {
         // Define peer01 and peer02 IDs
-        let peer01_id = ZenohId::try_from([1]).unwrap();
-        let peer02_id = ZenohId::try_from([2]).unwrap();
+        let peer01_id = ZenohIdInner::try_from([1]).unwrap();
+        let peer02_id = ZenohIdInner::try_from([2]).unwrap();
 
         // Create the peer01 transport manager
         let peer01_handler = Arc::new(SHPeer::default());

--- a/io/zenoh-transport/tests/multicast_transport.rs
+++ b/io/zenoh-transport/tests/multicast_transport.rs
@@ -30,7 +30,8 @@ mod tests {
     use zenoh_link::Link;
     use zenoh_protocol::{
         core::{
-            Channel, CongestionControl, Encoding, EndPoint, Priority, Reliability, WhatAmI, ZenohIdInner,
+            Channel, CongestionControl, Encoding, EndPoint, Priority, Reliability, WhatAmI,
+            ZenohIdInner,
         },
         network::{
             push::{

--- a/io/zenoh-transport/tests/transport_whitelist.rs
+++ b/io/zenoh-transport/tests/transport_whitelist.rs
@@ -16,7 +16,7 @@ use std::{any::Any, convert::TryFrom, iter::FromIterator, sync::Arc, time::Durat
 use zenoh_core::ztimeout;
 use zenoh_link::Link;
 use zenoh_protocol::{
-    core::{EndPoint, ZenohIdInner},
+    core::{EndPoint, ZenohIdProto},
     network::NetworkMessage,
 };
 use zenoh_result::ZResult;
@@ -68,7 +68,7 @@ impl TransportPeerEventHandler for SCRouter {
 
 async fn run(endpoints: &[EndPoint]) {
     // Define client and router IDs
-    let router_id = ZenohIdInner::try_from([1]).unwrap();
+    let router_id = ZenohIdProto::try_from([1]).unwrap();
 
     // Create the router transport manager
     println!(">>> Transport Whitelist [1a1]");

--- a/io/zenoh-transport/tests/transport_whitelist.rs
+++ b/io/zenoh-transport/tests/transport_whitelist.rs
@@ -16,7 +16,7 @@ use std::{any::Any, convert::TryFrom, iter::FromIterator, sync::Arc, time::Durat
 use zenoh_core::ztimeout;
 use zenoh_link::Link;
 use zenoh_protocol::{
-    core::{EndPoint, ZenohId},
+    core::{EndPoint, ZenohIdInner},
     network::NetworkMessage,
 };
 use zenoh_result::ZResult;
@@ -68,7 +68,7 @@ impl TransportPeerEventHandler for SCRouter {
 
 async fn run(endpoints: &[EndPoint]) {
     // Define client and router IDs
-    let router_id = ZenohId::try_from([1]).unwrap();
+    let router_id = ZenohIdInner::try_from([1]).unwrap();
 
     // Create the router transport manager
     println!(">>> Transport Whitelist [1a1]");

--- a/io/zenoh-transport/tests/unicast_authenticator.rs
+++ b/io/zenoh-transport/tests/unicast_authenticator.rs
@@ -16,7 +16,7 @@ use std::{any::Any, sync::Arc, time::Duration};
 use zenoh_core::{zasyncwrite, ztimeout};
 use zenoh_link::Link;
 use zenoh_protocol::{
-    core::{EndPoint, WhatAmI, ZenohIdInner},
+    core::{EndPoint, WhatAmI, ZenohIdProto},
     network::NetworkMessage,
 };
 use zenoh_result::ZResult;
@@ -111,7 +111,7 @@ async fn auth_pubkey(endpoint: &EndPoint, lowlatency_transport: bool) {
     };
 
     // Create the transport transport manager for the client 01
-    let client01_id = ZenohIdInner::try_from([2]).unwrap();
+    let client01_id = ZenohIdProto::try_from([2]).unwrap();
 
     let n = BigUint::from_bytes_le(&[
         0x41, 0x74, 0xc6, 0x40, 0x18, 0x63, 0xbd, 0x59, 0xe6, 0x0d, 0xe9, 0x23, 0x3e, 0x95, 0xca,
@@ -170,7 +170,7 @@ async fn auth_pubkey(endpoint: &EndPoint, lowlatency_transport: bool) {
         .unwrap();
 
     // Create the transport transport manager for the client 02
-    let client02_id = ZenohIdInner::try_from([3]).unwrap();
+    let client02_id = ZenohIdProto::try_from([3]).unwrap();
 
     let n = BigUint::from_bytes_le(&[
         0xd1, 0x36, 0xcf, 0x94, 0xda, 0x04, 0x7e, 0x9f, 0x53, 0x39, 0xb8, 0x7b, 0x53, 0x3a, 0xe6,
@@ -229,7 +229,7 @@ async fn auth_pubkey(endpoint: &EndPoint, lowlatency_transport: bool) {
         .unwrap();
 
     // Create the transport transport manager for the client 03 with the same key as client 02
-    let client03_id = ZenohIdInner::try_from([4]).unwrap();
+    let client03_id = ZenohIdProto::try_from([4]).unwrap();
     let mut auth = Auth::empty();
     auth.set_pubkey(Some(AuthPubKey::new(
         client02_pub_key.clone().into(),
@@ -249,7 +249,7 @@ async fn auth_pubkey(endpoint: &EndPoint, lowlatency_transport: bool) {
         .unwrap();
 
     // Create the router transport manager
-    let router_id = ZenohIdInner::try_from([1]).unwrap();
+    let router_id = ZenohIdProto::try_from([1]).unwrap();
     let router_handler = Arc::new(SHRouterAuthenticator::new());
     let n = BigUint::from_bytes_le(&[
         0x31, 0xd1, 0xfc, 0x7e, 0x70, 0x5f, 0xd7, 0xe3, 0xcc, 0xa4, 0xca, 0xcb, 0x38, 0x84, 0x2f,
@@ -414,11 +414,11 @@ async fn auth_usrpwd(endpoint: &EndPoint, lowlatency_transport: bool) {
     };
 
     /* [CLIENT] */
-    let client01_id = ZenohIdInner::try_from([2]).unwrap();
+    let client01_id = ZenohIdProto::try_from([2]).unwrap();
     let user01 = "user01".to_string();
     let password01 = "password01".to_string();
 
-    let client02_id = ZenohIdInner::try_from([3]).unwrap();
+    let client02_id = ZenohIdProto::try_from([3]).unwrap();
     let user02 = "invalid".to_string();
     let password02 = "invalid".to_string();
 
@@ -427,7 +427,7 @@ async fn auth_usrpwd(endpoint: &EndPoint, lowlatency_transport: bool) {
     let password03 = "password03".to_string();
 
     /* [ROUTER] */
-    let router_id = ZenohIdInner::try_from([1]).unwrap();
+    let router_id = ZenohIdProto::try_from([1]).unwrap();
     let router_handler = Arc::new(SHRouterAuthenticator::new());
     // Create the router transport manager
     let mut auth_usrpwd_router = AuthUsrPwd::new(None);

--- a/io/zenoh-transport/tests/unicast_authenticator.rs
+++ b/io/zenoh-transport/tests/unicast_authenticator.rs
@@ -16,7 +16,7 @@ use std::{any::Any, sync::Arc, time::Duration};
 use zenoh_core::{zasyncwrite, ztimeout};
 use zenoh_link::Link;
 use zenoh_protocol::{
-    core::{EndPoint, WhatAmI, ZenohId},
+    core::{EndPoint, WhatAmI, ZenohIdInner},
     network::NetworkMessage,
 };
 use zenoh_result::ZResult;
@@ -111,7 +111,7 @@ async fn auth_pubkey(endpoint: &EndPoint, lowlatency_transport: bool) {
     };
 
     // Create the transport transport manager for the client 01
-    let client01_id = ZenohId::try_from([2]).unwrap();
+    let client01_id = ZenohIdInner::try_from([2]).unwrap();
 
     let n = BigUint::from_bytes_le(&[
         0x41, 0x74, 0xc6, 0x40, 0x18, 0x63, 0xbd, 0x59, 0xe6, 0x0d, 0xe9, 0x23, 0x3e, 0x95, 0xca,
@@ -170,7 +170,7 @@ async fn auth_pubkey(endpoint: &EndPoint, lowlatency_transport: bool) {
         .unwrap();
 
     // Create the transport transport manager for the client 02
-    let client02_id = ZenohId::try_from([3]).unwrap();
+    let client02_id = ZenohIdInner::try_from([3]).unwrap();
 
     let n = BigUint::from_bytes_le(&[
         0xd1, 0x36, 0xcf, 0x94, 0xda, 0x04, 0x7e, 0x9f, 0x53, 0x39, 0xb8, 0x7b, 0x53, 0x3a, 0xe6,
@@ -229,7 +229,7 @@ async fn auth_pubkey(endpoint: &EndPoint, lowlatency_transport: bool) {
         .unwrap();
 
     // Create the transport transport manager for the client 03 with the same key as client 02
-    let client03_id = ZenohId::try_from([4]).unwrap();
+    let client03_id = ZenohIdInner::try_from([4]).unwrap();
     let mut auth = Auth::empty();
     auth.set_pubkey(Some(AuthPubKey::new(
         client02_pub_key.clone().into(),
@@ -249,7 +249,7 @@ async fn auth_pubkey(endpoint: &EndPoint, lowlatency_transport: bool) {
         .unwrap();
 
     // Create the router transport manager
-    let router_id = ZenohId::try_from([1]).unwrap();
+    let router_id = ZenohIdInner::try_from([1]).unwrap();
     let router_handler = Arc::new(SHRouterAuthenticator::new());
     let n = BigUint::from_bytes_le(&[
         0x31, 0xd1, 0xfc, 0x7e, 0x70, 0x5f, 0xd7, 0xe3, 0xcc, 0xa4, 0xca, 0xcb, 0x38, 0x84, 0x2f,
@@ -414,11 +414,11 @@ async fn auth_usrpwd(endpoint: &EndPoint, lowlatency_transport: bool) {
     };
 
     /* [CLIENT] */
-    let client01_id = ZenohId::try_from([2]).unwrap();
+    let client01_id = ZenohIdInner::try_from([2]).unwrap();
     let user01 = "user01".to_string();
     let password01 = "password01".to_string();
 
-    let client02_id = ZenohId::try_from([3]).unwrap();
+    let client02_id = ZenohIdInner::try_from([3]).unwrap();
     let user02 = "invalid".to_string();
     let password02 = "invalid".to_string();
 
@@ -427,7 +427,7 @@ async fn auth_usrpwd(endpoint: &EndPoint, lowlatency_transport: bool) {
     let password03 = "password03".to_string();
 
     /* [ROUTER] */
-    let router_id = ZenohId::try_from([1]).unwrap();
+    let router_id = ZenohIdInner::try_from([1]).unwrap();
     let router_handler = Arc::new(SHRouterAuthenticator::new());
     // Create the router transport manager
     let mut auth_usrpwd_router = AuthUsrPwd::new(None);

--- a/io/zenoh-transport/tests/unicast_compression.rs
+++ b/io/zenoh-transport/tests/unicast_compression.rs
@@ -28,7 +28,7 @@ mod tests {
     use zenoh_link::Link;
     use zenoh_protocol::{
         core::{
-            Channel, CongestionControl, Encoding, EndPoint, Priority, Reliability, WhatAmI, ZenohId,
+            Channel, CongestionControl, Encoding, EndPoint, Priority, Reliability, WhatAmI, ZenohIdInner,
         },
         network::{
             push::ext::{NodeIdType, QoSType},
@@ -168,8 +168,8 @@ mod tests {
         TransportUnicast,
     ) {
         // Define client and router IDs
-        let client_id = ZenohId::try_from([1]).unwrap();
-        let router_id = ZenohId::try_from([2]).unwrap();
+        let client_id = ZenohIdInner::try_from([1]).unwrap();
+        let router_id = ZenohIdInner::try_from([2]).unwrap();
 
         // Create the router transport manager
         let router_handler = Arc::new(SHRouter::default());

--- a/io/zenoh-transport/tests/unicast_compression.rs
+++ b/io/zenoh-transport/tests/unicast_compression.rs
@@ -28,7 +28,8 @@ mod tests {
     use zenoh_link::Link;
     use zenoh_protocol::{
         core::{
-            Channel, CongestionControl, Encoding, EndPoint, Priority, Reliability, WhatAmI, ZenohIdInner,
+            Channel, CongestionControl, Encoding, EndPoint, Priority, Reliability, WhatAmI,
+            ZenohIdInner,
         },
         network::{
             push::ext::{NodeIdType, QoSType},

--- a/io/zenoh-transport/tests/unicast_compression.rs
+++ b/io/zenoh-transport/tests/unicast_compression.rs
@@ -29,7 +29,7 @@ mod tests {
     use zenoh_protocol::{
         core::{
             Channel, CongestionControl, Encoding, EndPoint, Priority, Reliability, WhatAmI,
-            ZenohIdInner,
+            ZenohIdProto,
         },
         network::{
             push::ext::{NodeIdType, QoSType},
@@ -169,8 +169,8 @@ mod tests {
         TransportUnicast,
     ) {
         // Define client and router IDs
-        let client_id = ZenohIdInner::try_from([1]).unwrap();
-        let router_id = ZenohIdInner::try_from([2]).unwrap();
+        let client_id = ZenohIdProto::try_from([1]).unwrap();
+        let router_id = ZenohIdProto::try_from([2]).unwrap();
 
         // Create the router transport manager
         let router_handler = Arc::new(SHRouter::default());

--- a/io/zenoh-transport/tests/unicast_concurrent.rs
+++ b/io/zenoh-transport/tests/unicast_concurrent.rs
@@ -24,7 +24,7 @@ use tokio::sync::Barrier;
 use zenoh_core::ztimeout;
 use zenoh_link::Link;
 use zenoh_protocol::{
-    core::{CongestionControl, Encoding, EndPoint, Priority, WhatAmI, ZenohIdInner},
+    core::{CongestionControl, Encoding, EndPoint, Priority, WhatAmI, ZenohIdProto},
     network::{
         push::{
             ext::{NodeIdType, QoSType},
@@ -108,8 +108,8 @@ impl TransportPeerEventHandler for MHPeer {
 
 async fn transport_concurrent(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPoint>) {
     /* [Peers] */
-    let peer_id01 = ZenohIdInner::try_from([2]).unwrap();
-    let peer_id02 = ZenohIdInner::try_from([3]).unwrap();
+    let peer_id01 = ZenohIdProto::try_from([2]).unwrap();
+    let peer_id02 = ZenohIdProto::try_from([3]).unwrap();
 
     // Create the peer01 transport manager
     let peer_sh01 = Arc::new(SHPeer::new());

--- a/io/zenoh-transport/tests/unicast_concurrent.rs
+++ b/io/zenoh-transport/tests/unicast_concurrent.rs
@@ -24,7 +24,7 @@ use tokio::sync::Barrier;
 use zenoh_core::ztimeout;
 use zenoh_link::Link;
 use zenoh_protocol::{
-    core::{CongestionControl, Encoding, EndPoint, Priority, WhatAmI, ZenohId},
+    core::{CongestionControl, Encoding, EndPoint, Priority, WhatAmI, ZenohIdInner},
     network::{
         push::{
             ext::{NodeIdType, QoSType},
@@ -108,8 +108,8 @@ impl TransportPeerEventHandler for MHPeer {
 
 async fn transport_concurrent(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPoint>) {
     /* [Peers] */
-    let peer_id01 = ZenohId::try_from([2]).unwrap();
-    let peer_id02 = ZenohId::try_from([3]).unwrap();
+    let peer_id01 = ZenohIdInner::try_from([2]).unwrap();
+    let peer_id02 = ZenohIdInner::try_from([3]).unwrap();
 
     // Create the peer01 transport manager
     let peer_sh01 = Arc::new(SHPeer::new());

--- a/io/zenoh-transport/tests/unicast_defragmentation.rs
+++ b/io/zenoh-transport/tests/unicast_defragmentation.rs
@@ -16,7 +16,7 @@ use std::{convert::TryFrom, sync::Arc, time::Duration};
 use zenoh_core::ztimeout;
 use zenoh_protocol::{
     core::{
-        Channel, CongestionControl, Encoding, EndPoint, Priority, Reliability, WhatAmI, ZenohId,
+        Channel, CongestionControl, Encoding, EndPoint, Priority, Reliability, WhatAmI, ZenohIdInner,
     },
     network::{
         push::{
@@ -37,8 +37,8 @@ const MSG_DEFRAG_BUF: usize = 128_000;
 
 async fn run(endpoint: &EndPoint, channel: Channel, msg_size: usize) {
     // Define client and router IDs
-    let client_id = ZenohId::try_from([1]).unwrap();
-    let router_id = ZenohId::try_from([2]).unwrap();
+    let client_id = ZenohIdInner::try_from([1]).unwrap();
+    let router_id = ZenohIdInner::try_from([2]).unwrap();
 
     // Create the router transport manager
     let router_manager = TransportManager::builder()

--- a/io/zenoh-transport/tests/unicast_defragmentation.rs
+++ b/io/zenoh-transport/tests/unicast_defragmentation.rs
@@ -17,7 +17,7 @@ use zenoh_core::ztimeout;
 use zenoh_protocol::{
     core::{
         Channel, CongestionControl, Encoding, EndPoint, Priority, Reliability, WhatAmI,
-        ZenohIdInner,
+        ZenohIdProto,
     },
     network::{
         push::{
@@ -38,8 +38,8 @@ const MSG_DEFRAG_BUF: usize = 128_000;
 
 async fn run(endpoint: &EndPoint, channel: Channel, msg_size: usize) {
     // Define client and router IDs
-    let client_id = ZenohIdInner::try_from([1]).unwrap();
-    let router_id = ZenohIdInner::try_from([2]).unwrap();
+    let client_id = ZenohIdProto::try_from([1]).unwrap();
+    let router_id = ZenohIdProto::try_from([2]).unwrap();
 
     // Create the router transport manager
     let router_manager = TransportManager::builder()

--- a/io/zenoh-transport/tests/unicast_defragmentation.rs
+++ b/io/zenoh-transport/tests/unicast_defragmentation.rs
@@ -16,7 +16,8 @@ use std::{convert::TryFrom, sync::Arc, time::Duration};
 use zenoh_core::ztimeout;
 use zenoh_protocol::{
     core::{
-        Channel, CongestionControl, Encoding, EndPoint, Priority, Reliability, WhatAmI, ZenohIdInner,
+        Channel, CongestionControl, Encoding, EndPoint, Priority, Reliability, WhatAmI,
+        ZenohIdInner,
     },
     network::{
         push::{

--- a/io/zenoh-transport/tests/unicast_intermittent.rs
+++ b/io/zenoh-transport/tests/unicast_intermittent.rs
@@ -25,7 +25,7 @@ use std::{
 use zenoh_core::ztimeout;
 use zenoh_link::Link;
 use zenoh_protocol::{
-    core::{CongestionControl, Encoding, EndPoint, Priority, WhatAmI, ZenohId},
+    core::{CongestionControl, Encoding, EndPoint, Priority, WhatAmI, ZenohIdInner},
     network::{
         push::{
             ext::{NodeIdType, QoSType},
@@ -148,7 +148,7 @@ impl TransportPeerEventHandler for SCClient {
 
 async fn transport_intermittent(endpoint: &EndPoint, lowlatency_transport: bool) {
     /* [ROUTER] */
-    let router_id = ZenohId::try_from([1]).unwrap();
+    let router_id = ZenohIdInner::try_from([1]).unwrap();
 
     let router_handler = Arc::new(SHRouterIntermittent);
     // Create the router transport manager
@@ -168,9 +168,9 @@ async fn transport_intermittent(endpoint: &EndPoint, lowlatency_transport: bool)
         .unwrap();
 
     /* [CLIENT] */
-    let client01_id = ZenohId::try_from([2]).unwrap();
-    let client02_id = ZenohId::try_from([3]).unwrap();
-    let client03_id = ZenohId::try_from([4]).unwrap();
+    let client01_id = ZenohIdInner::try_from([2]).unwrap();
+    let client02_id = ZenohIdInner::try_from([3]).unwrap();
+    let client03_id = ZenohIdInner::try_from([4]).unwrap();
 
     // Create the transport transport manager for the first client
     let counter = Arc::new(AtomicUsize::new(0));

--- a/io/zenoh-transport/tests/unicast_intermittent.rs
+++ b/io/zenoh-transport/tests/unicast_intermittent.rs
@@ -25,7 +25,7 @@ use std::{
 use zenoh_core::ztimeout;
 use zenoh_link::Link;
 use zenoh_protocol::{
-    core::{CongestionControl, Encoding, EndPoint, Priority, WhatAmI, ZenohIdInner},
+    core::{CongestionControl, Encoding, EndPoint, Priority, WhatAmI, ZenohIdProto},
     network::{
         push::{
             ext::{NodeIdType, QoSType},
@@ -148,7 +148,7 @@ impl TransportPeerEventHandler for SCClient {
 
 async fn transport_intermittent(endpoint: &EndPoint, lowlatency_transport: bool) {
     /* [ROUTER] */
-    let router_id = ZenohIdInner::try_from([1]).unwrap();
+    let router_id = ZenohIdProto::try_from([1]).unwrap();
 
     let router_handler = Arc::new(SHRouterIntermittent);
     // Create the router transport manager
@@ -168,9 +168,9 @@ async fn transport_intermittent(endpoint: &EndPoint, lowlatency_transport: bool)
         .unwrap();
 
     /* [CLIENT] */
-    let client01_id = ZenohIdInner::try_from([2]).unwrap();
-    let client02_id = ZenohIdInner::try_from([3]).unwrap();
-    let client03_id = ZenohIdInner::try_from([4]).unwrap();
+    let client01_id = ZenohIdProto::try_from([2]).unwrap();
+    let client02_id = ZenohIdProto::try_from([3]).unwrap();
+    let client03_id = ZenohIdProto::try_from([4]).unwrap();
 
     // Create the transport transport manager for the first client
     let counter = Arc::new(AtomicUsize::new(0));

--- a/io/zenoh-transport/tests/unicast_multilink.rs
+++ b/io/zenoh-transport/tests/unicast_multilink.rs
@@ -17,7 +17,7 @@ mod tests {
 
     use zenoh_core::ztimeout;
     use zenoh_link::EndPoint;
-    use zenoh_protocol::core::{WhatAmI, ZenohIdInner};
+    use zenoh_protocol::core::{WhatAmI, ZenohIdProto};
     use zenoh_result::ZResult;
     use zenoh_transport::{
         multicast::TransportMulticast, unicast::TransportUnicast, DummyTransportPeerEventHandler,
@@ -77,7 +77,7 @@ mod tests {
 
     async fn multilink_transport(endpoint: &EndPoint) {
         /* [ROUTER] */
-        let router_id = ZenohIdInner::try_from([1]).unwrap();
+        let router_id = ZenohIdProto::try_from([1]).unwrap();
 
         let router_handler = Arc::new(SHRouterOpenClose);
         // Create the router transport manager
@@ -92,8 +92,8 @@ mod tests {
             .unwrap();
 
         /* [CLIENT] */
-        let client01_id = ZenohIdInner::try_from([2]).unwrap();
-        let client02_id = ZenohIdInner::try_from([3]).unwrap();
+        let client01_id = ZenohIdProto::try_from([2]).unwrap();
+        let client02_id = ZenohIdProto::try_from([3]).unwrap();
 
         // Create the transport transport manager for the first client
         let unicast = TransportManager::config_unicast()

--- a/io/zenoh-transport/tests/unicast_multilink.rs
+++ b/io/zenoh-transport/tests/unicast_multilink.rs
@@ -17,7 +17,7 @@ mod tests {
 
     use zenoh_core::ztimeout;
     use zenoh_link::EndPoint;
-    use zenoh_protocol::core::{WhatAmI, ZenohId};
+    use zenoh_protocol::core::{WhatAmI, ZenohIdInner};
     use zenoh_result::ZResult;
     use zenoh_transport::{
         multicast::TransportMulticast, unicast::TransportUnicast, DummyTransportPeerEventHandler,
@@ -77,7 +77,7 @@ mod tests {
 
     async fn multilink_transport(endpoint: &EndPoint) {
         /* [ROUTER] */
-        let router_id = ZenohId::try_from([1]).unwrap();
+        let router_id = ZenohIdInner::try_from([1]).unwrap();
 
         let router_handler = Arc::new(SHRouterOpenClose);
         // Create the router transport manager
@@ -92,8 +92,8 @@ mod tests {
             .unwrap();
 
         /* [CLIENT] */
-        let client01_id = ZenohId::try_from([2]).unwrap();
-        let client02_id = ZenohId::try_from([3]).unwrap();
+        let client01_id = ZenohIdInner::try_from([2]).unwrap();
+        let client02_id = ZenohIdInner::try_from([3]).unwrap();
 
         // Create the transport transport manager for the first client
         let unicast = TransportManager::config_unicast()

--- a/io/zenoh-transport/tests/unicast_openclose.rs
+++ b/io/zenoh-transport/tests/unicast_openclose.rs
@@ -15,7 +15,7 @@ use std::{convert::TryFrom, sync::Arc, time::Duration};
 
 use zenoh_core::ztimeout;
 use zenoh_link::EndPoint;
-use zenoh_protocol::core::{WhatAmI, ZenohIdInner};
+use zenoh_protocol::core::{WhatAmI, ZenohIdProto};
 use zenoh_result::ZResult;
 use zenoh_transport::{
     multicast::TransportMulticast,
@@ -90,7 +90,7 @@ async fn openclose_transport(
     lowlatency_transport: bool,
 ) {
     /* [ROUTER] */
-    let router_id = ZenohIdInner::try_from([1]).unwrap();
+    let router_id = ZenohIdProto::try_from([1]).unwrap();
 
     let router_handler = Arc::new(SHRouterOpenClose);
     // Create the router transport manager
@@ -110,8 +110,8 @@ async fn openclose_transport(
         .unwrap();
 
     /* [CLIENT] */
-    let client01_id = ZenohIdInner::try_from([2]).unwrap();
-    let client02_id = ZenohIdInner::try_from([3]).unwrap();
+    let client01_id = ZenohIdProto::try_from([2]).unwrap();
+    let client02_id = ZenohIdProto::try_from([3]).unwrap();
 
     // Create the transport transport manager for the first client
     let unicast = make_transport_manager_builder(

--- a/io/zenoh-transport/tests/unicast_openclose.rs
+++ b/io/zenoh-transport/tests/unicast_openclose.rs
@@ -15,7 +15,7 @@ use std::{convert::TryFrom, sync::Arc, time::Duration};
 
 use zenoh_core::ztimeout;
 use zenoh_link::EndPoint;
-use zenoh_protocol::core::{WhatAmI, ZenohId};
+use zenoh_protocol::core::{WhatAmI, ZenohIdInner};
 use zenoh_result::ZResult;
 use zenoh_transport::{
     multicast::TransportMulticast,
@@ -90,7 +90,7 @@ async fn openclose_transport(
     lowlatency_transport: bool,
 ) {
     /* [ROUTER] */
-    let router_id = ZenohId::try_from([1]).unwrap();
+    let router_id = ZenohIdInner::try_from([1]).unwrap();
 
     let router_handler = Arc::new(SHRouterOpenClose);
     // Create the router transport manager
@@ -110,8 +110,8 @@ async fn openclose_transport(
         .unwrap();
 
     /* [CLIENT] */
-    let client01_id = ZenohId::try_from([2]).unwrap();
-    let client02_id = ZenohId::try_from([3]).unwrap();
+    let client01_id = ZenohIdInner::try_from([2]).unwrap();
+    let client02_id = ZenohIdInner::try_from([3]).unwrap();
 
     // Create the transport transport manager for the first client
     let unicast = make_transport_manager_builder(

--- a/io/zenoh-transport/tests/unicast_priorities.rs
+++ b/io/zenoh-transport/tests/unicast_priorities.rs
@@ -25,7 +25,7 @@ use std::{
 use zenoh_core::ztimeout;
 use zenoh_link::Link;
 use zenoh_protocol::{
-    core::{CongestionControl, Encoding, EndPoint, Priority, WhatAmI, ZenohId},
+    core::{CongestionControl, Encoding, EndPoint, Priority, WhatAmI, ZenohIdInner},
     network::{
         push::{
             ext::{NodeIdType, QoSType},
@@ -200,8 +200,8 @@ async fn open_transport_unicast(
     TransportUnicast,
 ) {
     // Define client and router IDs
-    let client_id = ZenohId::try_from([1]).unwrap();
-    let router_id = ZenohId::try_from([2]).unwrap();
+    let client_id = ZenohIdInner::try_from([1]).unwrap();
+    let router_id = ZenohIdInner::try_from([2]).unwrap();
 
     // Create the router transport manager
     let router_handler = Arc::new(SHRouter::new());

--- a/io/zenoh-transport/tests/unicast_priorities.rs
+++ b/io/zenoh-transport/tests/unicast_priorities.rs
@@ -25,7 +25,7 @@ use std::{
 use zenoh_core::ztimeout;
 use zenoh_link::Link;
 use zenoh_protocol::{
-    core::{CongestionControl, Encoding, EndPoint, Priority, WhatAmI, ZenohIdInner},
+    core::{CongestionControl, Encoding, EndPoint, Priority, WhatAmI, ZenohIdProto},
     network::{
         push::{
             ext::{NodeIdType, QoSType},
@@ -200,8 +200,8 @@ async fn open_transport_unicast(
     TransportUnicast,
 ) {
     // Define client and router IDs
-    let client_id = ZenohIdInner::try_from([1]).unwrap();
-    let router_id = ZenohIdInner::try_from([2]).unwrap();
+    let client_id = ZenohIdProto::try_from([1]).unwrap();
+    let router_id = ZenohIdProto::try_from([2]).unwrap();
 
     // Create the router transport manager
     let router_handler = Arc::new(SHRouter::new());

--- a/io/zenoh-transport/tests/unicast_shm.rs
+++ b/io/zenoh-transport/tests/unicast_shm.rs
@@ -27,7 +27,7 @@ mod tests {
     use zenoh_core::ztimeout;
     use zenoh_link::Link;
     use zenoh_protocol::{
-        core::{CongestionControl, Encoding, EndPoint, Priority, WhatAmI, ZenohIdInner},
+        core::{CongestionControl, Encoding, EndPoint, Priority, WhatAmI, ZenohIdProto},
         network::{
             push::ext::{NodeIdType, QoSType},
             NetworkBody, NetworkMessage, Push,
@@ -153,9 +153,9 @@ mod tests {
         println!("Transport SHM [0a]: {endpoint:?}");
 
         // Define client and router IDs
-        let peer_shm01 = ZenohIdInner::try_from([1]).unwrap();
-        let peer_shm02 = ZenohIdInner::try_from([2]).unwrap();
-        let peer_net01 = ZenohIdInner::try_from([3]).unwrap();
+        let peer_shm01 = ZenohIdProto::try_from([1]).unwrap();
+        let peer_shm02 = ZenohIdProto::try_from([2]).unwrap();
+        let peer_net01 = ZenohIdProto::try_from([3]).unwrap();
 
         // create SHM provider
         let backend = PosixShmProviderBackend::builder()

--- a/io/zenoh-transport/tests/unicast_shm.rs
+++ b/io/zenoh-transport/tests/unicast_shm.rs
@@ -27,7 +27,7 @@ mod tests {
     use zenoh_core::ztimeout;
     use zenoh_link::Link;
     use zenoh_protocol::{
-        core::{CongestionControl, Encoding, EndPoint, Priority, WhatAmI, ZenohId},
+        core::{CongestionControl, Encoding, EndPoint, Priority, WhatAmI, ZenohIdInner},
         network::{
             push::ext::{NodeIdType, QoSType},
             NetworkBody, NetworkMessage, Push,

--- a/io/zenoh-transport/tests/unicast_shm.rs
+++ b/io/zenoh-transport/tests/unicast_shm.rs
@@ -153,9 +153,9 @@ mod tests {
         println!("Transport SHM [0a]: {endpoint:?}");
 
         // Define client and router IDs
-        let peer_shm01 = ZenohId::try_from([1]).unwrap();
-        let peer_shm02 = ZenohId::try_from([2]).unwrap();
-        let peer_net01 = ZenohId::try_from([3]).unwrap();
+        let peer_shm01 = ZenohIdInner::try_from([1]).unwrap();
+        let peer_shm02 = ZenohIdInner::try_from([2]).unwrap();
+        let peer_net01 = ZenohIdInner::try_from([3]).unwrap();
 
         // create SHM provider
         let backend = PosixShmProviderBackend::builder()

--- a/io/zenoh-transport/tests/unicast_simultaneous.rs
+++ b/io/zenoh-transport/tests/unicast_simultaneous.rs
@@ -26,7 +26,7 @@ mod tests {
     use zenoh_core::ztimeout;
     use zenoh_link::Link;
     use zenoh_protocol::{
-        core::{CongestionControl, Encoding, EndPoint, Priority, WhatAmI, ZenohId},
+        core::{CongestionControl, Encoding, EndPoint, Priority, WhatAmI, ZenohIdInner},
         network::{
             push::ext::{NodeIdType, QoSType},
             NetworkMessage, Push,
@@ -47,12 +47,12 @@ mod tests {
 
     // Transport Handler for the router
     struct SHPeer {
-        zid: ZenohId,
+        zid: ZenohIdInner,
         count: Arc<AtomicUsize>,
     }
 
     impl SHPeer {
-        fn new(zid: ZenohId) -> Self {
+        fn new(zid: ZenohIdInner) -> Self {
             Self {
                 zid,
                 count: Arc::new(AtomicUsize::new(0)),
@@ -136,8 +136,8 @@ mod tests {
 
     async fn transport_simultaneous(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPoint>) {
         /* [Peers] */
-        let peer_id01 = ZenohId::try_from([2]).unwrap();
-        let peer_id02 = ZenohId::try_from([3]).unwrap();
+        let peer_id01 = ZenohIdInner::try_from([2]).unwrap();
+        let peer_id02 = ZenohIdInner::try_from([3]).unwrap();
 
         // Create the peer01 transport manager
         let peer_sh01 = Arc::new(SHPeer::new(peer_id01));

--- a/io/zenoh-transport/tests/unicast_simultaneous.rs
+++ b/io/zenoh-transport/tests/unicast_simultaneous.rs
@@ -26,7 +26,7 @@ mod tests {
     use zenoh_core::ztimeout;
     use zenoh_link::Link;
     use zenoh_protocol::{
-        core::{CongestionControl, Encoding, EndPoint, Priority, WhatAmI, ZenohIdInner},
+        core::{CongestionControl, Encoding, EndPoint, Priority, WhatAmI, ZenohIdProto},
         network::{
             push::ext::{NodeIdType, QoSType},
             NetworkMessage, Push,
@@ -47,12 +47,12 @@ mod tests {
 
     // Transport Handler for the router
     struct SHPeer {
-        zid: ZenohIdInner,
+        zid: ZenohIdProto,
         count: Arc<AtomicUsize>,
     }
 
     impl SHPeer {
-        fn new(zid: ZenohIdInner) -> Self {
+        fn new(zid: ZenohIdProto) -> Self {
             Self {
                 zid,
                 count: Arc::new(AtomicUsize::new(0)),
@@ -136,8 +136,8 @@ mod tests {
 
     async fn transport_simultaneous(endpoint01: Vec<EndPoint>, endpoint02: Vec<EndPoint>) {
         /* [Peers] */
-        let peer_id01 = ZenohIdInner::try_from([2]).unwrap();
-        let peer_id02 = ZenohIdInner::try_from([3]).unwrap();
+        let peer_id01 = ZenohIdProto::try_from([2]).unwrap();
+        let peer_id02 = ZenohIdProto::try_from([3]).unwrap();
 
         // Create the peer01 transport manager
         let peer_sh01 = Arc::new(SHPeer::new(peer_id01));

--- a/io/zenoh-transport/tests/unicast_time.rs
+++ b/io/zenoh-transport/tests/unicast_time.rs
@@ -19,7 +19,7 @@ use std::{
 
 use zenoh_core::ztimeout;
 use zenoh_link::EndPoint;
-use zenoh_protocol::core::{WhatAmI, ZenohIdInner};
+use zenoh_protocol::core::{WhatAmI, ZenohIdProto};
 use zenoh_result::ZResult;
 use zenoh_transport::{
     multicast::TransportMulticast,
@@ -96,7 +96,7 @@ async fn time_transport(
         println!(">>> Universal transport");
     }
     /* [ROUTER] */
-    let router_id = ZenohIdInner::try_from([1]).unwrap();
+    let router_id = ZenohIdProto::try_from([1]).unwrap();
 
     let router_handler = Arc::new(SHRouterOpenClose);
     // Create the router transport manager
@@ -116,7 +116,7 @@ async fn time_transport(
         .unwrap();
 
     /* [CLIENT] */
-    let client01_id = ZenohIdInner::try_from([2]).unwrap();
+    let client01_id = ZenohIdProto::try_from([2]).unwrap();
 
     // Create the transport transport manager for the first client
     let unicast = make_transport_manager_builder(

--- a/io/zenoh-transport/tests/unicast_time.rs
+++ b/io/zenoh-transport/tests/unicast_time.rs
@@ -19,7 +19,7 @@ use std::{
 
 use zenoh_core::ztimeout;
 use zenoh_link::EndPoint;
-use zenoh_protocol::core::{WhatAmI, ZenohId};
+use zenoh_protocol::core::{WhatAmI, ZenohIdInner};
 use zenoh_result::ZResult;
 use zenoh_transport::{
     multicast::TransportMulticast,
@@ -96,7 +96,7 @@ async fn time_transport(
         println!(">>> Universal transport");
     }
     /* [ROUTER] */
-    let router_id = ZenohId::try_from([1]).unwrap();
+    let router_id = ZenohIdInner::try_from([1]).unwrap();
 
     let router_handler = Arc::new(SHRouterOpenClose);
     // Create the router transport manager
@@ -116,7 +116,7 @@ async fn time_transport(
         .unwrap();
 
     /* [CLIENT] */
-    let client01_id = ZenohId::try_from([2]).unwrap();
+    let client01_id = ZenohIdInner::try_from([2]).unwrap();
 
     // Create the transport transport manager for the first client
     let unicast = make_transport_manager_builder(

--- a/io/zenoh-transport/tests/unicast_transport.rs
+++ b/io/zenoh-transport/tests/unicast_transport.rs
@@ -27,7 +27,7 @@ use zenoh_link::Link;
 use zenoh_protocol::{
     core::{
         Channel, CongestionControl, Encoding, EndPoint, Priority, Reliability, WhatAmI,
-        ZenohIdInner,
+        ZenohIdProto,
     },
     network::{
         push::ext::{NodeIdType, QoSType},
@@ -355,8 +355,8 @@ async fn open_transport_unicast(
     TransportUnicast,
 ) {
     // Define client and router IDs
-    let client_id = ZenohIdInner::try_from([1]).unwrap();
-    let router_id = ZenohIdInner::try_from([2]).unwrap();
+    let client_id = ZenohIdProto::try_from([1]).unwrap();
+    let router_id = ZenohIdProto::try_from([2]).unwrap();
 
     // Create the router transport manager
     let router_handler = Arc::new(SHRouter::default());

--- a/io/zenoh-transport/tests/unicast_transport.rs
+++ b/io/zenoh-transport/tests/unicast_transport.rs
@@ -26,7 +26,8 @@ use zenoh_core::ztimeout;
 use zenoh_link::Link;
 use zenoh_protocol::{
     core::{
-        Channel, CongestionControl, Encoding, EndPoint, Priority, Reliability, WhatAmI, ZenohIdInner,
+        Channel, CongestionControl, Encoding, EndPoint, Priority, Reliability, WhatAmI,
+        ZenohIdInner,
     },
     network::{
         push::ext::{NodeIdType, QoSType},

--- a/io/zenoh-transport/tests/unicast_transport.rs
+++ b/io/zenoh-transport/tests/unicast_transport.rs
@@ -26,7 +26,7 @@ use zenoh_core::ztimeout;
 use zenoh_link::Link;
 use zenoh_protocol::{
     core::{
-        Channel, CongestionControl, Encoding, EndPoint, Priority, Reliability, WhatAmI, ZenohId,
+        Channel, CongestionControl, Encoding, EndPoint, Priority, Reliability, WhatAmI, ZenohIdInner,
     },
     network::{
         push::ext::{NodeIdType, QoSType},
@@ -354,8 +354,8 @@ async fn open_transport_unicast(
     TransportUnicast,
 ) {
     // Define client and router IDs
-    let client_id = ZenohId::try_from([1]).unwrap();
-    let router_id = ZenohId::try_from([2]).unwrap();
+    let client_id = ZenohIdInner::try_from([1]).unwrap();
+    let router_id = ZenohIdInner::try_from([2]).unwrap();
 
     // Create the router transport manager
     let router_handler = Arc::new(SHRouter::default());

--- a/plugins/zenoh-plugin-storage-manager/src/replica/snapshotter.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/snapshotter.rs
@@ -24,7 +24,7 @@ use async_std::{
 };
 use flume::Receiver;
 use futures::join;
-use zenoh::{config::ZenohId, key_expr::OwnedKeyExpr, time::Timestamp};
+use zenoh::{info::ZenohId, key_expr::OwnedKeyExpr, time::Timestamp};
 use zenoh_backend_traits::config::ReplicaConfig;
 
 use super::{Digest, DigestConfig, LogEntry};

--- a/zenoh/src/api/info.rs
+++ b/zenoh/src/api/info.rs
@@ -15,9 +15,8 @@
 //! Tools to access information about the current zenoh [`Session`](crate::Session).
 use std::future::{IntoFuture, Ready};
 
-use zenoh_config::ZenohId;
 use zenoh_core::{Resolvable, Wait};
-use zenoh_protocol::core::WhatAmI;
+use zenoh_protocol::core::{WhatAmI, ZenohId};
 
 use super::session::SessionRef;
 

--- a/zenoh/src/api/info.rs
+++ b/zenoh/src/api/info.rs
@@ -15,8 +15,9 @@
 //! Tools to access information about the current zenoh [`Session`](crate::Session).
 use std::future::{IntoFuture, Ready};
 
+use zenoh_config::wrappers::ZenohId;
 use zenoh_core::{Resolvable, Wait};
-use zenoh_protocol::core::{WhatAmI, ZenohId};
+use zenoh_protocol::core::WhatAmI;
 
 use super::session::SessionRef;
 

--- a/zenoh/src/api/publisher.rs
+++ b/zenoh/src/api/publisher.rs
@@ -23,6 +23,8 @@ use std::{
 };
 
 use futures::Sink;
+#[zenoh_macros::unstable]
+use zenoh_config::wrappers::EntityGlobalId;
 use zenoh_core::{zread, Resolvable, Resolve, Wait};
 use zenoh_protocol::{
     core::CongestionControl,
@@ -34,7 +36,6 @@ use zenoh_result::{Error, ZResult};
 use {
     crate::api::handlers::{Callback, DefaultHandler, IntoHandler},
     crate::api::sample::SourceInfo,
-    zenoh_protocol::core::EntityGlobalId,
     zenoh_protocol::core::EntityGlobalIdProto,
 };
 

--- a/zenoh/src/api/publisher.rs
+++ b/zenoh/src/api/publisher.rs
@@ -35,7 +35,7 @@ use {
     crate::api::handlers::{Callback, DefaultHandler, IntoHandler},
     crate::api::sample::SourceInfo,
     zenoh_protocol::core::EntityGlobalId,
-    zenoh_protocol::core::EntityGlobalIdInner,
+    zenoh_protocol::core::EntityGlobalIdProto,
 };
 
 use super::{
@@ -158,7 +158,7 @@ impl<'a> Publisher<'a> {
     /// ```
     #[zenoh_macros::unstable]
     pub fn id(&self) -> EntityGlobalId {
-        EntityGlobalIdInner {
+        EntityGlobalIdProto {
             zid: self.session.zid().into(),
             eid: self.id,
         }

--- a/zenoh/src/api/publisher.rs
+++ b/zenoh/src/api/publisher.rs
@@ -35,6 +35,7 @@ use {
     crate::api::handlers::{Callback, DefaultHandler, IntoHandler},
     crate::api::sample::SourceInfo,
     zenoh_protocol::core::EntityGlobalId,
+    zenoh_protocol::core::EntityGlobalIdInner,
 };
 
 use super::{
@@ -157,10 +158,11 @@ impl<'a> Publisher<'a> {
     /// ```
     #[zenoh_macros::unstable]
     pub fn id(&self) -> EntityGlobalId {
-        EntityGlobalId {
+        EntityGlobalIdInner {
             zid: self.session.zid().into(),
             eid: self.id,
         }
+        .into()
     }
 
     #[inline]

--- a/zenoh/src/api/query.rs
+++ b/zenoh/src/api/query.rs
@@ -20,7 +20,7 @@ use std::{
 
 use zenoh_core::{Resolvable, Wait};
 use zenoh_keyexpr::OwnedKeyExpr;
-use zenoh_protocol::core::{CongestionControl, ZenohIdInner};
+use zenoh_protocol::core::{CongestionControl, ZenohIdProto};
 use zenoh_result::ZResult;
 
 #[zenoh_macros::unstable]
@@ -84,7 +84,7 @@ impl Default for QueryConsolidation {
 #[derive(Clone, Debug)]
 pub struct Reply {
     pub(crate) result: Result<Sample, Value>,
-    pub(crate) replier_id: ZenohIdInner,
+    pub(crate) replier_id: ZenohIdProto,
 }
 
 impl Reply {
@@ -104,7 +104,7 @@ impl Reply {
     }
 
     /// Gets the id of the zenoh instance that answered this Reply.
-    pub fn replier_id(&self) -> ZenohIdInner {
+    pub fn replier_id(&self) -> ZenohIdProto {
         self.replier_id
     }
 }

--- a/zenoh/src/api/query.rs
+++ b/zenoh/src/api/query.rs
@@ -20,7 +20,7 @@ use std::{
 
 use zenoh_core::{Resolvable, Wait};
 use zenoh_keyexpr::OwnedKeyExpr;
-use zenoh_protocol::core::{CongestionControl, ZenohId};
+use zenoh_protocol::core::{CongestionControl, ZenohIdInner};
 use zenoh_result::ZResult;
 
 #[zenoh_macros::unstable]
@@ -84,7 +84,7 @@ impl Default for QueryConsolidation {
 #[derive(Clone, Debug)]
 pub struct Reply {
     pub(crate) result: Result<Sample, Value>,
-    pub(crate) replier_id: ZenohId,
+    pub(crate) replier_id: ZenohIdInner,
 }
 
 impl Reply {
@@ -104,7 +104,7 @@ impl Reply {
     }
 
     /// Gets the id of the zenoh instance that answered this Reply.
-    pub fn replier_id(&self) -> ZenohId {
+    pub fn replier_id(&self) -> ZenohIdInner {
         self.replier_id
     }
 }

--- a/zenoh/src/api/queryable.rs
+++ b/zenoh/src/api/queryable.rs
@@ -29,7 +29,7 @@ use zenoh_result::ZResult;
 #[zenoh_macros::unstable]
 use {
     super::{query::ReplyKeyExpr, sample::SourceInfo},
-    zenoh_protocol::core::EntityGlobalId,
+    zenoh_protocol::core::EntityGlobalIdInner,
 };
 
 use super::{
@@ -870,8 +870,8 @@ impl<'a, Handler> Queryable<'a, Handler> {
     /// # }
     /// ```
     #[zenoh_macros::unstable]
-    pub fn id(&self) -> EntityGlobalId {
-        EntityGlobalId {
+    pub fn id(&self) -> EntityGlobalIdInner {
+        EntityGlobalIdInner {
             zid: self.queryable.session.zid().into(),
             eid: self.queryable.state.id,
         }

--- a/zenoh/src/api/queryable.rs
+++ b/zenoh/src/api/queryable.rs
@@ -21,7 +21,7 @@ use std::{
 use uhlc::Timestamp;
 use zenoh_core::{Resolvable, Resolve, Wait};
 use zenoh_protocol::{
-    core::{CongestionControl, EntityId, WireExpr, ZenohIdInner},
+    core::{CongestionControl, EntityId, WireExpr, ZenohIdProto},
     network::{response, Mapping, RequestId, Response, ResponseFinal},
     zenoh::{self, reply::ReplyBody, Del, Put, ResponseBody},
 };
@@ -29,7 +29,7 @@ use zenoh_result::ZResult;
 #[zenoh_macros::unstable]
 use {
     super::{query::ReplyKeyExpr, sample::SourceInfo},
-    zenoh_protocol::core::EntityGlobalIdInner,
+    zenoh_protocol::core::EntityGlobalIdProto,
 };
 
 use super::{
@@ -54,7 +54,7 @@ pub(crate) struct QueryInner {
     pub(crate) key_expr: KeyExpr<'static>,
     pub(crate) parameters: Parameters<'static>,
     pub(crate) qid: RequestId,
-    pub(crate) zid: ZenohIdInner,
+    pub(crate) zid: ZenohIdProto,
     pub(crate) primitives: Arc<dyn Primitives>,
 }
 
@@ -870,8 +870,8 @@ impl<'a, Handler> Queryable<'a, Handler> {
     /// # }
     /// ```
     #[zenoh_macros::unstable]
-    pub fn id(&self) -> EntityGlobalIdInner {
-        EntityGlobalIdInner {
+    pub fn id(&self) -> EntityGlobalIdProto {
+        EntityGlobalIdProto {
             zid: self.queryable.session.zid().into(),
             eid: self.queryable.state.id,
         }

--- a/zenoh/src/api/queryable.rs
+++ b/zenoh/src/api/queryable.rs
@@ -21,7 +21,7 @@ use std::{
 use uhlc::Timestamp;
 use zenoh_core::{Resolvable, Resolve, Wait};
 use zenoh_protocol::{
-    core::{CongestionControl, EntityId, WireExpr, ZenohId},
+    core::{CongestionControl, EntityId, WireExpr, ZenohIdInner},
     network::{response, Mapping, RequestId, Response, ResponseFinal},
     zenoh::{self, reply::ReplyBody, Del, Put, ResponseBody},
 };
@@ -54,7 +54,7 @@ pub(crate) struct QueryInner {
     pub(crate) key_expr: KeyExpr<'static>,
     pub(crate) parameters: Parameters<'static>,
     pub(crate) qid: RequestId,
-    pub(crate) zid: ZenohId,
+    pub(crate) zid: ZenohIdInner,
     pub(crate) primitives: Arc<dyn Primitives>,
 }
 

--- a/zenoh/src/api/sample.rs
+++ b/zenoh/src/api/sample.rs
@@ -18,7 +18,7 @@ use std::{convert::TryFrom, fmt};
 #[cfg(feature = "unstable")]
 use serde::Serialize;
 use zenoh_protocol::{
-    core::{CongestionControl, EntityGlobalIdInner, Timestamp},
+    core::{CongestionControl, EntityGlobalIdProto, Timestamp},
     network::declare::ext::QoSType,
 };
 
@@ -52,7 +52,7 @@ pub(crate) struct DataInfo {
     pub kind: SampleKind,
     pub encoding: Option<Encoding>,
     pub timestamp: Option<Timestamp>,
-    pub source_id: Option<EntityGlobalIdInner>,
+    pub source_id: Option<EntityGlobalIdProto>,
     pub source_sn: Option<SourceSn>,
     pub qos: QoS,
 }
@@ -137,7 +137,7 @@ impl DataInfoIntoSample for Option<DataInfo> {
 #[derive(Debug, Clone)]
 pub struct SourceInfo {
     /// The [`EntityGlobalId`] of the zenoh entity that published the concerned [`Sample`].
-    pub source_id: Option<EntityGlobalIdInner>,
+    pub source_id: Option<EntityGlobalIdProto>,
     /// The sequence number of the [`Sample`] from the source.
     pub source_sn: Option<SourceSn>,
 }
@@ -145,12 +145,12 @@ pub struct SourceInfo {
 #[test]
 #[cfg(feature = "unstable")]
 fn source_info_stack_size() {
-    use zenoh_protocol::core::ZenohIdInner;
+    use zenoh_protocol::core::ZenohIdProto;
 
     use crate::api::sample::{SourceInfo, SourceSn};
 
-    assert_eq!(std::mem::size_of::<ZenohIdInner>(), 16);
-    assert_eq!(std::mem::size_of::<Option<ZenohIdInner>>(), 17);
+    assert_eq!(std::mem::size_of::<ZenohIdProto>(), 16);
+    assert_eq!(std::mem::size_of::<Option<ZenohIdProto>>(), 17);
     assert_eq!(std::mem::size_of::<Option<SourceSn>>(), 16);
     assert_eq!(std::mem::size_of::<SourceInfo>(), 17 + 16 + 7);
 }

--- a/zenoh/src/api/sample.rs
+++ b/zenoh/src/api/sample.rs
@@ -18,7 +18,7 @@ use std::{convert::TryFrom, fmt};
 #[cfg(feature = "unstable")]
 use serde::Serialize;
 use zenoh_protocol::{
-    core::{CongestionControl, EntityGlobalId, Timestamp},
+    core::{CongestionControl, EntityGlobalIdInner, Timestamp},
     network::declare::ext::QoSType,
 };
 
@@ -52,7 +52,7 @@ pub(crate) struct DataInfo {
     pub kind: SampleKind,
     pub encoding: Option<Encoding>,
     pub timestamp: Option<Timestamp>,
-    pub source_id: Option<EntityGlobalId>,
+    pub source_id: Option<EntityGlobalIdInner>,
     pub source_sn: Option<SourceSn>,
     pub qos: QoS,
 }
@@ -137,7 +137,7 @@ impl DataInfoIntoSample for Option<DataInfo> {
 #[derive(Debug, Clone)]
 pub struct SourceInfo {
     /// The [`EntityGlobalId`] of the zenoh entity that published the concerned [`Sample`].
-    pub source_id: Option<EntityGlobalId>,
+    pub source_id: Option<EntityGlobalIdInner>,
     /// The sequence number of the [`Sample`] from the source.
     pub source_sn: Option<SourceSn>,
 }

--- a/zenoh/src/api/sample.rs
+++ b/zenoh/src/api/sample.rs
@@ -145,12 +145,12 @@ pub struct SourceInfo {
 #[test]
 #[cfg(feature = "unstable")]
 fn source_info_stack_size() {
-    use zenoh_protocol::core::ZenohId;
+    use zenoh_protocol::core::ZenohIdInner;
 
     use crate::api::sample::{SourceInfo, SourceSn};
 
-    assert_eq!(std::mem::size_of::<ZenohId>(), 16);
-    assert_eq!(std::mem::size_of::<Option<ZenohId>>(), 17);
+    assert_eq!(std::mem::size_of::<ZenohIdInner>(), 16);
+    assert_eq!(std::mem::size_of::<Option<ZenohIdInner>>(), 17);
     assert_eq!(std::mem::size_of::<Option<SourceSn>>(), 16);
     assert_eq!(std::mem::size_of::<SourceInfo>(), 17 + 16 + 7);
 }

--- a/zenoh/src/api/scouting.rs
+++ b/zenoh/src/api/scouting.rs
@@ -21,7 +21,7 @@ use std::{
 
 use tokio::net::UdpSocket;
 use zenoh_core::{Resolvable, Wait};
-use zenoh_protocol::core::WhatAmIMatcher;
+use zenoh_protocol::{core::WhatAmIMatcher, scouting::hello::Hello};
 use zenoh_result::ZResult;
 use zenoh_task::TerminatableTask;
 
@@ -29,36 +29,6 @@ use crate::{
     api::handlers::{locked, Callback, DefaultHandler, IntoHandler},
     net::runtime::{orchestrator::Loop, Runtime},
 };
-
-/// A zenoh Hello message.
-pub struct Hello(zenoh_protocol::scouting::Hello);
-
-impl Hello {
-    /// Get the locators of this Hello message.
-    pub fn locators(&self) -> &[zenoh_protocol::core::Locator] {
-        &self.0.locators
-    }
-
-    /// Get the zenoh id of this Hello message.
-    pub fn zid(&self) -> zenoh_protocol::core::ZenohIdInner {
-        self.0.zid
-    }
-
-    /// Get the whatami of this Hello message.
-    pub fn whatami(&self) -> zenoh_protocol::core::WhatAmI {
-        self.0.whatami
-    }
-}
-
-impl fmt::Display for Hello {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Hello")
-            .field("zid", &self.zid())
-            .field("whatami", &self.whatami())
-            .field("locators", &self.locators())
-            .finish()
-    }
-}
 
 /// A builder for initializing a [`Scout`].
 ///
@@ -354,7 +324,7 @@ fn _scout(
                     let scout = Runtime::scout(&sockets, what, &addr, move |hello| {
                         let callback = callback.clone();
                         async move {
-                            callback(Hello(hello));
+                            callback(hello.into());
                             Loop::Continue
                         }
                     });

--- a/zenoh/src/api/scouting.rs
+++ b/zenoh/src/api/scouting.rs
@@ -40,7 +40,7 @@ impl Hello {
     }
 
     /// Get the zenoh id of this Hello message.
-    pub fn zid(&self) -> zenoh_protocol::core::ZenohId {
+    pub fn zid(&self) -> zenoh_protocol::core::ZenohIdInner {
         self.0.zid
     }
 

--- a/zenoh/src/api/scouting.rs
+++ b/zenoh/src/api/scouting.rs
@@ -20,8 +20,9 @@ use std::{
 };
 
 use tokio::net::UdpSocket;
+use zenoh_config::wrappers::Hello;
 use zenoh_core::{Resolvable, Wait};
-use zenoh_protocol::{core::WhatAmIMatcher, scouting::hello::Hello};
+use zenoh_protocol::core::WhatAmIMatcher;
 use zenoh_result::ZResult;
 use zenoh_task::TerminatableTask;
 

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -2196,7 +2196,7 @@ impl Primitives for Session {
                         };
                         let replier_id = match e.ext_sinfo {
                             Some(info) => info.id.zid,
-                            None => zenoh_protocol::core::ZenohIdInner::rand(),
+                            None => zenoh_protocol::core::ZenohIdProto::rand(),
                         };
                         let new_reply = Reply {
                             replier_id,
@@ -2314,7 +2314,7 @@ impl Primitives for Session {
                         let sample = info.into_sample(key_expr.into_owned(), payload, attachment);
                         let new_reply = Reply {
                             result: Ok(sample),
-                            replier_id: zenoh_protocol::core::ZenohIdInner::rand(), // TODO
+                            replier_id: zenoh_protocol::core::ZenohIdProto::rand(), // TODO
                         };
                         let callback =
                             match query.reception_mode {

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -28,15 +28,14 @@ use tracing::{error, trace, warn};
 use uhlc::HLC;
 use zenoh_buffers::ZBuf;
 use zenoh_collections::SingleOrVec;
-use zenoh_config::{unwrap_or_default, Config, Notifier};
+use zenoh_config::{unwrap_or_default, wrappers::ZenohId, Config, Notifier};
 use zenoh_core::{zconfigurable, zread, Resolvable, Resolve, ResolveClosure, ResolveFuture, Wait};
 #[cfg(feature = "unstable")]
 use zenoh_protocol::network::{declare::SubscriberId, ext};
 use zenoh_protocol::{
     core::{
         key_expr::{keyexpr, OwnedKeyExpr},
-        AtomicExprId, CongestionControl, EntityId, ExprId, Reliability, WireExpr, ZenohId,
-        EMPTY_EXPR_ID,
+        AtomicExprId, CongestionControl, EntityId, ExprId, Reliability, WireExpr, EMPTY_EXPR_ID,
     },
     network::{
         self,

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -34,7 +34,9 @@ use zenoh_core::{zconfigurable, zread, Resolvable, Resolve, ResolveClosure, Reso
 use zenoh_protocol::network::{declare::SubscriberId, ext};
 use zenoh_protocol::{
     core::{
-        key_expr::{keyexpr, OwnedKeyExpr}, AtomicExprId, CongestionControl, EntityId, ExprId, Reliability, WireExpr, ZenohId, EMPTY_EXPR_ID
+        key_expr::{keyexpr, OwnedKeyExpr},
+        AtomicExprId, CongestionControl, EntityId, ExprId, Reliability, WireExpr, ZenohId,
+        EMPTY_EXPR_ID,
     },
     network::{
         self,

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -28,14 +28,13 @@ use tracing::{error, trace, warn};
 use uhlc::HLC;
 use zenoh_buffers::ZBuf;
 use zenoh_collections::SingleOrVec;
-use zenoh_config::{unwrap_or_default, Config, Notifier, ZenohId};
+use zenoh_config::{unwrap_or_default, Config, Notifier};
 use zenoh_core::{zconfigurable, zread, Resolvable, Resolve, ResolveClosure, ResolveFuture, Wait};
 #[cfg(feature = "unstable")]
 use zenoh_protocol::network::{declare::SubscriberId, ext};
 use zenoh_protocol::{
     core::{
-        key_expr::{keyexpr, OwnedKeyExpr},
-        AtomicExprId, CongestionControl, EntityId, ExprId, Reliability, WireExpr, EMPTY_EXPR_ID,
+        key_expr::{keyexpr, OwnedKeyExpr}, AtomicExprId, CongestionControl, EntityId, ExprId, Reliability, WireExpr, ZenohId, EMPTY_EXPR_ID
     },
     network::{
         self,
@@ -2195,7 +2194,7 @@ impl Primitives for Session {
                         };
                         let replier_id = match e.ext_sinfo {
                             Some(info) => info.id.zid,
-                            None => zenoh_protocol::core::ZenohId::rand(),
+                            None => zenoh_protocol::core::ZenohIdInner::rand(),
                         };
                         let new_reply = Reply {
                             replier_id,
@@ -2313,7 +2312,7 @@ impl Primitives for Session {
                         let sample = info.into_sample(key_expr.into_owned(), payload, attachment);
                         let new_reply = Reply {
                             result: Ok(sample),
-                            replier_id: zenoh_protocol::core::ZenohId::rand(), // TODO
+                            replier_id: zenoh_protocol::core::ZenohIdInner::rand(), // TODO
                         };
                         let callback =
                             match query.reception_mode {

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -2657,7 +2657,7 @@ impl crate::net::primitives::EPrimitives for Session {
 /// # #[tokio::main]
 /// # async fn main() {
 /// use std::str::FromStr;
-/// use zenoh::{config::ZenohId, prelude::*};
+/// use zenoh::{info::ZenohId, prelude::*};
 ///
 /// let mut config = zenoh::config::peer();
 /// config.set_id(ZenohId::from_str("221b72df20924c15b8794c6bdb471150").unwrap());

--- a/zenoh/src/api/subscriber.rs
+++ b/zenoh/src/api/subscriber.rs
@@ -21,7 +21,7 @@ use std::{
 
 use zenoh_core::{Resolvable, Wait};
 #[cfg(feature = "unstable")]
-use zenoh_protocol::core::EntityGlobalIdInner;
+use zenoh_protocol::core::EntityGlobalIdProto;
 use zenoh_protocol::{core::Reliability, network::declare::subscriber::ext::SubscriberInfo};
 use zenoh_result::ZResult;
 
@@ -458,8 +458,8 @@ impl<'a, Handler> Subscriber<'a, Handler> {
     /// # }
     /// ```
     #[zenoh_macros::unstable]
-    pub fn id(&self) -> EntityGlobalIdInner {
-        EntityGlobalIdInner {
+    pub fn id(&self) -> EntityGlobalIdProto {
+        EntityGlobalIdProto {
             zid: self.subscriber.session.zid().into(),
             eid: self.subscriber.state.id,
         }

--- a/zenoh/src/api/subscriber.rs
+++ b/zenoh/src/api/subscriber.rs
@@ -21,7 +21,7 @@ use std::{
 
 use zenoh_core::{Resolvable, Wait};
 #[cfg(feature = "unstable")]
-use zenoh_protocol::core::EntityGlobalId;
+use zenoh_protocol::core::EntityGlobalIdInner;
 use zenoh_protocol::{core::Reliability, network::declare::subscriber::ext::SubscriberInfo};
 use zenoh_result::ZResult;
 
@@ -458,8 +458,8 @@ impl<'a, Handler> Subscriber<'a, Handler> {
     /// # }
     /// ```
     #[zenoh_macros::unstable]
-    pub fn id(&self) -> EntityGlobalId {
-        EntityGlobalId {
+    pub fn id(&self) -> EntityGlobalIdInner {
+        EntityGlobalIdInner {
             zid: self.subscriber.session.zid().into(),
             eid: self.subscriber.state.id,
         }

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -207,6 +207,8 @@ pub mod session {
 
 /// Tools to access information about the current zenoh [`Session`](crate::Session).
 pub mod info {
+    pub use zenoh_protocol::core::EntityGlobalId;
+    pub use zenoh_protocol::core::EntityId;
     pub use crate::api::info::{
         PeersZenohIdBuilder, RoutersZenohIdBuilder, SessionInfo, ZenohIdBuilder,
     };

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -207,6 +207,7 @@ pub mod session {
 
 /// Tools to access information about the current zenoh [`Session`](crate::Session).
 pub mod info {
+    pub use zenoh_protocol::core::ZenohId;
     pub use zenoh_protocol::core::EntityGlobalId;
     pub use zenoh_protocol::core::EntityId;
     pub use crate::api::info::{
@@ -348,7 +349,6 @@ pub mod time {
 
 /// Configuration to pass to [`open`](crate::session::open) and [`scout`](crate::scouting::scout) functions and associated constants
 pub mod config {
-    pub use zenoh_protocol::core::ZenohId;
     // pub use zenoh_config::{
     //     client, default, peer, Config, EndPoint, Locator, ModeDependentValue, PermissionsConf,
     //     PluginLoad, ValidatedMap, ZenohId,

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -207,9 +207,8 @@ pub mod session {
 
 /// Tools to access information about the current zenoh [`Session`](crate::Session).
 pub mod info {
-    pub use zenoh_protocol::core::ZenohId;
-    pub use zenoh_protocol::core::EntityGlobalId;
-    pub use zenoh_protocol::core::EntityId;
+    pub use zenoh_protocol::core::{EntityGlobalId, EntityId, ZenohId};
+
     pub use crate::api::info::{
         PeersZenohIdBuilder, RoutersZenohIdBuilder, SessionInfo, ZenohIdBuilder,
     };
@@ -328,6 +327,7 @@ pub mod handlers {
 /// Scouting primitives
 pub mod scouting {
     pub use zenoh_protocol::scouting::hello::Hello;
+
     pub use crate::api::scouting::{scout, Scout, ScoutBuilder};
 }
 

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -207,7 +207,8 @@ pub mod session {
 
 /// Tools to access information about the current zenoh [`Session`](crate::Session).
 pub mod info {
-    pub use zenoh_protocol::core::{EntityGlobalId, EntityId, ZenohId};
+    pub use zenoh_config::wrappers::{EntityGlobalId, ZenohId};
+    pub use zenoh_protocol::core::EntityId;
 
     pub use crate::api::info::{
         PeersZenohIdBuilder, RoutersZenohIdBuilder, SessionInfo, ZenohIdBuilder,
@@ -326,7 +327,7 @@ pub mod handlers {
 
 /// Scouting primitives
 pub mod scouting {
-    pub use zenoh_protocol::scouting::hello::Hello;
+    pub use zenoh_config::wrappers::Hello;
 
     pub use crate::api::scouting::{scout, Scout, ScoutBuilder};
 }

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -326,7 +326,8 @@ pub mod handlers {
 
 /// Scouting primitives
 pub mod scouting {
-    pub use crate::api::scouting::{scout, Hello, Scout, ScoutBuilder};
+    pub use zenoh_protocol::scouting::hello::Hello;
+    pub use crate::api::scouting::{scout, Scout, ScoutBuilder};
 }
 
 /// Liveliness primitives

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -345,6 +345,7 @@ pub mod time {
 
 /// Configuration to pass to [`open`](crate::session::open) and [`scout`](crate::scouting::scout) functions and associated constants
 pub mod config {
+    pub use zenoh_protocol::core::ZenohId;
     // pub use zenoh_config::{
     //     client, default, peer, Config, EndPoint, Locator, ModeDependentValue, PermissionsConf,
     //     PluginLoad, ValidatedMap, ZenohId,

--- a/zenoh/src/net/codec/linkstate.rs
+++ b/zenoh/src/net/codec/linkstate.rs
@@ -20,7 +20,7 @@ use zenoh_buffers::{
 use zenoh_codec::{RCodec, WCodec, Zenoh080};
 use zenoh_protocol::{
     common::imsg,
-    core::{Locator, WhatAmI, ZenohId},
+    core::{Locator, WhatAmI, ZenohIdInner},
 };
 
 use super::Zenoh080Routing;
@@ -85,7 +85,7 @@ where
         let psid: u64 = codec.read(&mut *reader)?;
         let sn: u64 = codec.read(&mut *reader)?;
         let zid = if imsg::has_option(options, linkstate::PID) {
-            let zid: ZenohId = codec.read(&mut *reader)?;
+            let zid: ZenohIdInner = codec.read(&mut *reader)?;
             Some(zid)
         } else {
             None

--- a/zenoh/src/net/codec/linkstate.rs
+++ b/zenoh/src/net/codec/linkstate.rs
@@ -20,7 +20,7 @@ use zenoh_buffers::{
 use zenoh_codec::{RCodec, WCodec, Zenoh080};
 use zenoh_protocol::{
     common::imsg,
-    core::{Locator, WhatAmI, ZenohIdInner},
+    core::{Locator, WhatAmI, ZenohIdProto},
 };
 
 use super::Zenoh080Routing;
@@ -85,7 +85,7 @@ where
         let psid: u64 = codec.read(&mut *reader)?;
         let sn: u64 = codec.read(&mut *reader)?;
         let zid = if imsg::has_option(options, linkstate::PID) {
-            let zid: ZenohIdInner = codec.read(&mut *reader)?;
+            let zid: ZenohIdProto = codec.read(&mut *reader)?;
             Some(zid)
         } else {
             None

--- a/zenoh/src/net/protocol/linkstate.rs
+++ b/zenoh/src/net/protocol/linkstate.rs
@@ -11,7 +11,7 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use zenoh_protocol::core::{Locator, WhatAmI, ZenohIdInner};
+use zenoh_protocol::core::{Locator, WhatAmI, ZenohIdProto};
 
 pub const PID: u64 = 1; // 0x01
 pub const WAI: u64 = 1 << 1; // 0x02
@@ -37,7 +37,7 @@ pub const LOC: u64 = 1 << 2; // 0x04
 pub(crate) struct LinkState {
     pub(crate) psid: u64,
     pub(crate) sn: u64,
-    pub(crate) zid: Option<ZenohIdInner>,
+    pub(crate) zid: Option<ZenohIdProto>,
     pub(crate) whatami: Option<WhatAmI>,
     pub(crate) locators: Option<Vec<Locator>>,
     pub(crate) links: Vec<u64>,
@@ -56,7 +56,7 @@ impl LinkState {
         let psid: u64 = rng.gen();
         let sn: u64 = rng.gen();
         let zid = if rng.gen_bool(0.5) {
-            Some(ZenohIdInner::default())
+            Some(ZenohIdProto::default())
         } else {
             None
         };

--- a/zenoh/src/net/protocol/linkstate.rs
+++ b/zenoh/src/net/protocol/linkstate.rs
@@ -11,7 +11,7 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use zenoh_protocol::core::{Locator, WhatAmI, ZenohId};
+use zenoh_protocol::core::{Locator, WhatAmI, ZenohIdInner};
 
 pub const PID: u64 = 1; // 0x01
 pub const WAI: u64 = 1 << 1; // 0x02
@@ -37,7 +37,7 @@ pub const LOC: u64 = 1 << 2; // 0x04
 pub(crate) struct LinkState {
     pub(crate) psid: u64,
     pub(crate) sn: u64,
-    pub(crate) zid: Option<ZenohId>,
+    pub(crate) zid: Option<ZenohIdInner>,
     pub(crate) whatami: Option<WhatAmI>,
     pub(crate) locators: Option<Vec<Locator>>,
     pub(crate) links: Vec<u64>,
@@ -56,7 +56,7 @@ impl LinkState {
         let psid: u64 = rng.gen();
         let sn: u64 = rng.gen();
         let zid = if rng.gen_bool(0.5) {
-            Some(ZenohId::default())
+            Some(ZenohIdInner::default())
         } else {
             None
         };

--- a/zenoh/src/net/routing/dispatcher/face.rs
+++ b/zenoh/src/net/routing/dispatcher/face.rs
@@ -20,7 +20,7 @@ use std::{
 
 use tokio_util::sync::CancellationToken;
 use zenoh_protocol::{
-    core::{ExprId, WhatAmI, ZenohId},
+    core::{ExprId, WhatAmI, ZenohIdInner},
     network::{
         declare::ext,
         interest::{InterestId, InterestMode, InterestOptions},
@@ -55,7 +55,7 @@ pub(crate) struct InterestState {
 
 pub struct FaceState {
     pub(crate) id: usize,
-    pub(crate) zid: ZenohId,
+    pub(crate) zid: ZenohIdInner,
     pub(crate) whatami: WhatAmI,
     #[cfg(feature = "stats")]
     pub(crate) stats: Option<Arc<TransportStats>>,
@@ -76,7 +76,7 @@ impl FaceState {
     #[allow(clippy::too_many_arguments)] // @TODO fix warning
     pub(crate) fn new(
         id: usize,
-        zid: ZenohId,
+        zid: ZenohIdInner,
         whatami: WhatAmI,
         #[cfg(feature = "stats")] stats: Option<Arc<TransportStats>>,
         primitives: Arc<dyn crate::net::primitives::EPrimitives + Send + Sync>,

--- a/zenoh/src/net/routing/dispatcher/face.rs
+++ b/zenoh/src/net/routing/dispatcher/face.rs
@@ -20,7 +20,7 @@ use std::{
 
 use tokio_util::sync::CancellationToken;
 use zenoh_protocol::{
-    core::{ExprId, WhatAmI, ZenohIdInner},
+    core::{ExprId, WhatAmI, ZenohIdProto},
     network::{
         declare::ext,
         interest::{InterestId, InterestMode, InterestOptions},
@@ -55,7 +55,7 @@ pub(crate) struct InterestState {
 
 pub struct FaceState {
     pub(crate) id: usize,
-    pub(crate) zid: ZenohIdInner,
+    pub(crate) zid: ZenohIdProto,
     pub(crate) whatami: WhatAmI,
     #[cfg(feature = "stats")]
     pub(crate) stats: Option<Arc<TransportStats>>,
@@ -76,7 +76,7 @@ impl FaceState {
     #[allow(clippy::too_many_arguments)] // @TODO fix warning
     pub(crate) fn new(
         id: usize,
-        zid: ZenohIdInner,
+        zid: ZenohIdProto,
         whatami: WhatAmI,
         #[cfg(feature = "stats")] stats: Option<Arc<TransportStats>>,
         primitives: Arc<dyn crate::net::primitives::EPrimitives + Send + Sync>,

--- a/zenoh/src/net/routing/dispatcher/tables.rs
+++ b/zenoh/src/net/routing/dispatcher/tables.rs
@@ -21,7 +21,7 @@ use std::{
 use uhlc::HLC;
 use zenoh_config::{unwrap_or_default, Config};
 use zenoh_protocol::{
-    core::{ExprId, WhatAmI, ZenohId},
+    core::{ExprId, WhatAmI, ZenohIdInner},
     network::Mapping,
 };
 use zenoh_result::ZResult;
@@ -61,7 +61,7 @@ impl<'a> RoutingExpr<'a> {
 }
 
 pub struct Tables {
-    pub(crate) zid: ZenohId,
+    pub(crate) zid: ZenohIdInner,
     pub(crate) whatami: WhatAmI,
     pub(crate) face_counter: usize,
     #[allow(dead_code)]
@@ -79,7 +79,7 @@ pub struct Tables {
 
 impl Tables {
     pub fn new(
-        zid: ZenohId,
+        zid: ZenohIdInner,
         whatami: WhatAmI,
         hlc: Option<Arc<HLC>>,
         config: &Config,
@@ -145,7 +145,7 @@ impl Tables {
     }
 
     #[inline]
-    pub(crate) fn get_face(&self, zid: &ZenohId) -> Option<&Arc<FaceState>> {
+    pub(crate) fn get_face(&self, zid: &ZenohIdInner) -> Option<&Arc<FaceState>> {
         self.faces.values().find(|face| face.zid == *zid)
     }
 

--- a/zenoh/src/net/routing/dispatcher/tables.rs
+++ b/zenoh/src/net/routing/dispatcher/tables.rs
@@ -21,7 +21,7 @@ use std::{
 use uhlc::HLC;
 use zenoh_config::{unwrap_or_default, Config};
 use zenoh_protocol::{
-    core::{ExprId, WhatAmI, ZenohIdInner},
+    core::{ExprId, WhatAmI, ZenohIdProto},
     network::Mapping,
 };
 use zenoh_result::ZResult;
@@ -61,7 +61,7 @@ impl<'a> RoutingExpr<'a> {
 }
 
 pub struct Tables {
-    pub(crate) zid: ZenohIdInner,
+    pub(crate) zid: ZenohIdProto,
     pub(crate) whatami: WhatAmI,
     pub(crate) face_counter: usize,
     #[allow(dead_code)]
@@ -79,7 +79,7 @@ pub struct Tables {
 
 impl Tables {
     pub fn new(
-        zid: ZenohIdInner,
+        zid: ZenohIdProto,
         whatami: WhatAmI,
         hlc: Option<Arc<HLC>>,
         config: &Config,
@@ -145,7 +145,7 @@ impl Tables {
     }
 
     #[inline]
-    pub(crate) fn get_face(&self, zid: &ZenohIdInner) -> Option<&Arc<FaceState>> {
+    pub(crate) fn get_face(&self, zid: &ZenohIdProto) -> Option<&Arc<FaceState>> {
         self.faces.values().find(|face| face.zid == *zid)
     }
 

--- a/zenoh/src/net/routing/hat/linkstate_peer/mod.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/mod.rs
@@ -27,7 +27,7 @@ use std::{
 use zenoh_config::{unwrap_or_default, ModeDependent, WhatAmI, WhatAmIMatcher};
 use zenoh_protocol::{
     common::ZExtBody,
-    core::ZenohId,
+    core::ZenohIdInner,
     network::{
         declare::{queryable::ext::QueryableInfoType, QueryableId, SubscriberId},
         interest::InterestId,
@@ -463,9 +463,9 @@ impl HatBaseTrait for HatCode {
 }
 
 struct HatContext {
-    router_subs: HashSet<ZenohId>,
-    peer_subs: HashSet<ZenohId>,
-    peer_qabls: HashMap<ZenohId, QueryableInfoType>,
+    router_subs: HashSet<ZenohIdInner>,
+    peer_subs: HashSet<ZenohIdInner>,
+    peer_qabls: HashMap<ZenohIdInner, QueryableInfoType>,
 }
 
 impl HatContext {
@@ -504,7 +504,7 @@ impl HatFace {
     }
 }
 
-fn get_peer(tables: &Tables, face: &Arc<FaceState>, nodeid: NodeId) -> Option<ZenohId> {
+fn get_peer(tables: &Tables, face: &Arc<FaceState>, nodeid: NodeId) -> Option<ZenohIdInner> {
     match hat!(tables)
         .peers_net
         .as_ref()

--- a/zenoh/src/net/routing/hat/linkstate_peer/mod.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/mod.rs
@@ -27,7 +27,7 @@ use std::{
 use zenoh_config::{unwrap_or_default, ModeDependent, WhatAmI, WhatAmIMatcher};
 use zenoh_protocol::{
     common::ZExtBody,
-    core::ZenohIdInner,
+    core::ZenohIdProto,
     network::{
         declare::{queryable::ext::QueryableInfoType, QueryableId, SubscriberId},
         interest::InterestId,
@@ -463,9 +463,9 @@ impl HatBaseTrait for HatCode {
 }
 
 struct HatContext {
-    router_subs: HashSet<ZenohIdInner>,
-    peer_subs: HashSet<ZenohIdInner>,
-    peer_qabls: HashMap<ZenohIdInner, QueryableInfoType>,
+    router_subs: HashSet<ZenohIdProto>,
+    peer_subs: HashSet<ZenohIdProto>,
+    peer_qabls: HashMap<ZenohIdProto, QueryableInfoType>,
 }
 
 impl HatContext {
@@ -504,7 +504,7 @@ impl HatFace {
     }
 }
 
-fn get_peer(tables: &Tables, face: &Arc<FaceState>, nodeid: NodeId) -> Option<ZenohIdInner> {
+fn get_peer(tables: &Tables, face: &Arc<FaceState>, nodeid: NodeId) -> Option<ZenohIdProto> {
     match hat!(tables)
         .peers_net
         .as_ref()

--- a/zenoh/src/net/routing/hat/linkstate_peer/network.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/network.rs
@@ -344,7 +344,11 @@ impl Network {
         self.graph.update_edge(idx1, idx2, weight);
     }
 
-    pub(super) fn link_states(&mut self, link_states: Vec<LinkState>, src: ZenohIdInner) -> Changes {
+    pub(super) fn link_states(
+        &mut self,
+        link_states: Vec<LinkState>,
+        src: ZenohIdInner,
+    ) -> Changes {
         tracing::trace!("{} Received from {} raw: {:?}", self.name, src, link_states);
         let strong_runtime = self.runtime.upgrade().unwrap();
 

--- a/zenoh/src/net/routing/hat/linkstate_peer/network.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/network.rs
@@ -27,7 +27,7 @@ use zenoh_codec::WCodec;
 use zenoh_link::Locator;
 use zenoh_protocol::{
     common::ZExtBody,
-    core::{WhatAmI, WhatAmIMatcher, ZenohIdInner},
+    core::{WhatAmI, WhatAmIMatcher, ZenohIdProto},
     network::{oam, oam::id::OAM_LINKSTATE, NetworkBody, NetworkMessage, Oam},
 };
 use zenoh_transport::unicast::TransportUnicast;
@@ -48,11 +48,11 @@ struct Details {
 
 #[derive(Clone)]
 pub(super) struct Node {
-    pub(super) zid: ZenohIdInner,
+    pub(super) zid: ZenohIdProto,
     pub(super) whatami: Option<WhatAmI>,
     pub(super) locators: Option<Vec<Locator>>,
     pub(super) sn: u64,
-    pub(super) links: Vec<ZenohIdInner>,
+    pub(super) links: Vec<ZenohIdProto>,
 }
 
 impl std::fmt::Debug for Node {
@@ -63,8 +63,8 @@ impl std::fmt::Debug for Node {
 
 pub(super) struct Link {
     pub(super) transport: TransportUnicast,
-    zid: ZenohIdInner,
-    mappings: VecMap<ZenohIdInner>,
+    zid: ZenohIdProto,
+    mappings: VecMap<ZenohIdProto>,
     local_mappings: VecMap<u64>,
 }
 
@@ -80,12 +80,12 @@ impl Link {
     }
 
     #[inline]
-    pub(super) fn set_zid_mapping(&mut self, psid: u64, zid: ZenohIdInner) {
+    pub(super) fn set_zid_mapping(&mut self, psid: u64, zid: ZenohIdProto) {
         self.mappings.insert(psid.try_into().unwrap(), zid);
     }
 
     #[inline]
-    pub(super) fn get_zid(&self, psid: &u64) -> Option<&ZenohIdInner> {
+    pub(super) fn get_zid(&self, psid: &u64) -> Option<&ZenohIdProto> {
         self.mappings.get((*psid).try_into().unwrap())
     }
 
@@ -132,7 +132,7 @@ impl Network {
     #[allow(clippy::too_many_arguments)]
     pub(super) fn new(
         name: String,
-        zid: ZenohIdInner,
+        zid: ZenohIdProto,
         runtime: Runtime,
         full_linkstate: bool,
         router_peers_failover_brokering: bool,
@@ -177,7 +177,7 @@ impl Network {
     }
 
     #[inline]
-    pub(super) fn get_idx(&self, zid: &ZenohIdInner) -> Option<NodeIndex> {
+    pub(super) fn get_idx(&self, zid: &ZenohIdProto) -> Option<NodeIndex> {
         self.graph
             .node_indices()
             .find(|idx| self.graph[*idx].zid == *zid)
@@ -189,7 +189,7 @@ impl Network {
     }
 
     #[inline]
-    pub(super) fn get_link_from_zid(&self, zid: &ZenohIdInner) -> Option<&Link> {
+    pub(super) fn get_link_from_zid(&self, zid: &ZenohIdProto) -> Option<&Link> {
         self.links.values().find(|link| link.zid == *zid)
     }
 
@@ -347,7 +347,7 @@ impl Network {
     pub(super) fn link_states(
         &mut self,
         link_states: Vec<LinkState>,
-        src: ZenohIdInner,
+        src: ZenohIdProto,
     ) -> Changes {
         tracing::trace!("{} Received from {} raw: {:?}", self.name, src, link_states);
         let strong_runtime = self.runtime.upgrade().unwrap();
@@ -413,7 +413,7 @@ impl Network {
         let link_states = link_states
             .into_iter()
             .map(|(zid, wai, locs, sn, links)| {
-                let links: Vec<ZenohIdInner> = links
+                let links: Vec<ZenohIdProto> = links
                     .iter()
                     .filter_map(|l| {
                         if let Some(zid) = src_link.get_zid(l) {
@@ -563,7 +563,7 @@ impl Network {
                     }
                 },
             )
-            .collect::<Vec<(Vec<ZenohIdInner>, NodeIndex, bool)>>();
+            .collect::<Vec<(Vec<ZenohIdProto>, NodeIndex, bool)>>();
 
         // Add/remove edges from graph
         let mut reintroduced_nodes = vec![];
@@ -615,7 +615,7 @@ impl Network {
         let link_states = link_states
             .into_iter()
             .filter(|ls| !removed.iter().any(|(idx, _)| idx == &ls.1))
-            .collect::<Vec<(Vec<ZenohIdInner>, NodeIndex, bool)>>();
+            .collect::<Vec<(Vec<ZenohIdProto>, NodeIndex, bool)>>();
 
         if !self.autoconnect.is_empty() {
             // Connect discovered peers
@@ -654,8 +654,8 @@ impl Network {
         #[allow(clippy::type_complexity)] // This is only used here
         if !link_states.is_empty() {
             let (new_idxs, updated_idxs): (
-                Vec<(Vec<ZenohIdInner>, NodeIndex, bool)>,
-                Vec<(Vec<ZenohIdInner>, NodeIndex, bool)>,
+                Vec<(Vec<ZenohIdProto>, NodeIndex, bool)>,
+                Vec<(Vec<ZenohIdProto>, NodeIndex, bool)>,
             ) = link_states.into_iter().partition(|(_, _, new)| *new);
             let new_idxs = new_idxs
                 .into_iter()
@@ -819,7 +819,7 @@ impl Network {
         free_index
     }
 
-    pub(super) fn remove_link(&mut self, zid: &ZenohIdInner) -> Vec<(NodeIndex, Node)> {
+    pub(super) fn remove_link(&mut self, zid: &ZenohIdProto) -> Vec<(NodeIndex, Node)> {
         tracing::trace!("{} remove_link {}", self.name, zid);
         self.links.retain(|_, link| link.zid != *zid);
         self.graph[self.idx].links.retain(|link| *link != *zid);

--- a/zenoh/src/net/routing/hat/linkstate_peer/pubsub.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/pubsub.rs
@@ -19,7 +19,7 @@ use std::{
 
 use petgraph::graph::NodeIndex;
 use zenoh_protocol::{
-    core::{key_expr::OwnedKeyExpr, Reliability, WhatAmI, ZenohId},
+    core::{key_expr::OwnedKeyExpr, Reliability, WhatAmI, ZenohIdInner},
     network::{
         declare::{
             common::ext::WireExprType, ext, subscriber::ext::SubscriberInfo, Declare, DeclareBody,
@@ -179,7 +179,7 @@ fn propagate_sourced_subscription(
     res: &Arc<Resource>,
     sub_info: &SubscriberInfo,
     src_face: Option<&Arc<FaceState>>,
-    source: &ZenohId,
+    source: &ZenohIdInner,
 ) {
     let net = hat!(tables).peers_net.as_ref().unwrap();
     match net.get_idx(source) {
@@ -216,7 +216,7 @@ fn register_peer_subscription(
     face: &mut Arc<FaceState>,
     res: &mut Arc<Resource>,
     sub_info: &SubscriberInfo,
-    peer: ZenohId,
+    peer: ZenohIdInner,
 ) {
     if !res_hat!(res).peer_subs.contains(&peer) {
         // Register peer subscription
@@ -240,7 +240,7 @@ fn declare_peer_subscription(
     face: &mut Arc<FaceState>,
     res: &mut Arc<Resource>,
     sub_info: &SubscriberInfo,
-    peer: ZenohId,
+    peer: ZenohIdInner,
 ) {
     register_peer_subscription(tables, face, res, sub_info, peer);
 }
@@ -407,7 +407,7 @@ fn propagate_forget_sourced_subscription(
     tables: &Tables,
     res: &Arc<Resource>,
     src_face: Option<&Arc<FaceState>>,
-    source: &ZenohId,
+    source: &ZenohIdInner,
 ) {
     let net = hat!(tables).peers_net.as_ref().unwrap();
     match net.get_idx(source) {
@@ -438,7 +438,7 @@ fn propagate_forget_sourced_subscription(
     }
 }
 
-fn unregister_peer_subscription(tables: &mut Tables, res: &mut Arc<Resource>, peer: &ZenohId) {
+fn unregister_peer_subscription(tables: &mut Tables, res: &mut Arc<Resource>, peer: &ZenohIdInner) {
     res_hat_mut!(res).peer_subs.retain(|sub| sub != peer);
 
     if res_hat!(res).peer_subs.is_empty() {
@@ -456,7 +456,7 @@ fn undeclare_peer_subscription(
     tables: &mut Tables,
     face: Option<&Arc<FaceState>>,
     res: &mut Arc<Resource>,
-    peer: &ZenohId,
+    peer: &ZenohIdInner,
 ) {
     if res_hat!(res).peer_subs.contains(peer) {
         unregister_peer_subscription(tables, res, peer);
@@ -468,7 +468,7 @@ fn forget_peer_subscription(
     tables: &mut Tables,
     face: &mut Arc<FaceState>,
     res: &mut Arc<Resource>,
-    peer: &ZenohId,
+    peer: &ZenohIdInner,
 ) {
     undeclare_peer_subscription(tables, Some(face), res, peer);
 }
@@ -554,7 +554,7 @@ fn forget_client_subscription(
     }
 }
 
-pub(super) fn pubsub_remove_node(tables: &mut Tables, node: &ZenohId) {
+pub(super) fn pubsub_remove_node(tables: &mut Tables, node: &ZenohIdInner) {
     for mut res in hat!(tables)
         .peer_subs
         .iter()
@@ -813,7 +813,7 @@ impl HatPubSubTrait for HatCode {
             tables: &Tables,
             net: &Network,
             source: NodeId,
-            subs: &HashSet<ZenohId>,
+            subs: &HashSet<ZenohIdInner>,
         ) {
             if net.trees.len() > source as usize {
                 for sub in subs {
@@ -924,7 +924,7 @@ impl HatPubSubTrait for HatCode {
             tables: &Tables,
             net: &Network,
             source: usize,
-            subs: &HashSet<ZenohId>,
+            subs: &HashSet<ZenohIdInner>,
         ) {
             if net.trees.len() > source {
                 for sub in subs {

--- a/zenoh/src/net/routing/hat/linkstate_peer/pubsub.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/pubsub.rs
@@ -19,7 +19,7 @@ use std::{
 
 use petgraph::graph::NodeIndex;
 use zenoh_protocol::{
-    core::{key_expr::OwnedKeyExpr, Reliability, WhatAmI, ZenohIdInner},
+    core::{key_expr::OwnedKeyExpr, Reliability, WhatAmI, ZenohIdProto},
     network::{
         declare::{
             common::ext::WireExprType, ext, subscriber::ext::SubscriberInfo, Declare, DeclareBody,
@@ -179,7 +179,7 @@ fn propagate_sourced_subscription(
     res: &Arc<Resource>,
     sub_info: &SubscriberInfo,
     src_face: Option<&Arc<FaceState>>,
-    source: &ZenohIdInner,
+    source: &ZenohIdProto,
 ) {
     let net = hat!(tables).peers_net.as_ref().unwrap();
     match net.get_idx(source) {
@@ -216,7 +216,7 @@ fn register_peer_subscription(
     face: &mut Arc<FaceState>,
     res: &mut Arc<Resource>,
     sub_info: &SubscriberInfo,
-    peer: ZenohIdInner,
+    peer: ZenohIdProto,
 ) {
     if !res_hat!(res).peer_subs.contains(&peer) {
         // Register peer subscription
@@ -240,7 +240,7 @@ fn declare_peer_subscription(
     face: &mut Arc<FaceState>,
     res: &mut Arc<Resource>,
     sub_info: &SubscriberInfo,
-    peer: ZenohIdInner,
+    peer: ZenohIdProto,
 ) {
     register_peer_subscription(tables, face, res, sub_info, peer);
 }
@@ -407,7 +407,7 @@ fn propagate_forget_sourced_subscription(
     tables: &Tables,
     res: &Arc<Resource>,
     src_face: Option<&Arc<FaceState>>,
-    source: &ZenohIdInner,
+    source: &ZenohIdProto,
 ) {
     let net = hat!(tables).peers_net.as_ref().unwrap();
     match net.get_idx(source) {
@@ -438,7 +438,7 @@ fn propagate_forget_sourced_subscription(
     }
 }
 
-fn unregister_peer_subscription(tables: &mut Tables, res: &mut Arc<Resource>, peer: &ZenohIdInner) {
+fn unregister_peer_subscription(tables: &mut Tables, res: &mut Arc<Resource>, peer: &ZenohIdProto) {
     res_hat_mut!(res).peer_subs.retain(|sub| sub != peer);
 
     if res_hat!(res).peer_subs.is_empty() {
@@ -456,7 +456,7 @@ fn undeclare_peer_subscription(
     tables: &mut Tables,
     face: Option<&Arc<FaceState>>,
     res: &mut Arc<Resource>,
-    peer: &ZenohIdInner,
+    peer: &ZenohIdProto,
 ) {
     if res_hat!(res).peer_subs.contains(peer) {
         unregister_peer_subscription(tables, res, peer);
@@ -468,7 +468,7 @@ fn forget_peer_subscription(
     tables: &mut Tables,
     face: &mut Arc<FaceState>,
     res: &mut Arc<Resource>,
-    peer: &ZenohIdInner,
+    peer: &ZenohIdProto,
 ) {
     undeclare_peer_subscription(tables, Some(face), res, peer);
 }
@@ -554,7 +554,7 @@ fn forget_client_subscription(
     }
 }
 
-pub(super) fn pubsub_remove_node(tables: &mut Tables, node: &ZenohIdInner) {
+pub(super) fn pubsub_remove_node(tables: &mut Tables, node: &ZenohIdProto) {
     for mut res in hat!(tables)
         .peer_subs
         .iter()
@@ -813,7 +813,7 @@ impl HatPubSubTrait for HatCode {
             tables: &Tables,
             net: &Network,
             source: NodeId,
-            subs: &HashSet<ZenohIdInner>,
+            subs: &HashSet<ZenohIdProto>,
         ) {
             if net.trees.len() > source as usize {
                 for sub in subs {
@@ -924,7 +924,7 @@ impl HatPubSubTrait for HatCode {
             tables: &Tables,
             net: &Network,
             source: usize,
-            subs: &HashSet<ZenohIdInner>,
+            subs: &HashSet<ZenohIdProto>,
         ) {
             if net.trees.len() > source {
                 for sub in subs {

--- a/zenoh/src/net/routing/hat/linkstate_peer/queries.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/queries.rs
@@ -26,7 +26,7 @@ use zenoh_protocol::{
             include::{Includer, DEFAULT_INCLUDER},
             OwnedKeyExpr,
         },
-        WhatAmI, WireExpr, ZenohId,
+        WhatAmI, WireExpr, ZenohIdInner,
     },
     network::{
         declare::{
@@ -208,7 +208,7 @@ fn propagate_sourced_queryable(
     res: &Arc<Resource>,
     qabl_info: &QueryableInfoType,
     src_face: Option<&mut Arc<FaceState>>,
-    source: &ZenohId,
+    source: &ZenohIdInner,
 ) {
     let net = hat!(tables).peers_net.as_ref().unwrap();
     match net.get_idx(source) {
@@ -245,7 +245,7 @@ fn register_peer_queryable(
     mut face: Option<&mut Arc<FaceState>>,
     res: &mut Arc<Resource>,
     qabl_info: &QueryableInfoType,
-    peer: ZenohId,
+    peer: ZenohIdInner,
 ) {
     let current_info = res_hat!(res).peer_qabls.get(&peer);
     if current_info.is_none() || current_info.unwrap() != qabl_info {
@@ -270,7 +270,7 @@ fn declare_peer_queryable(
     face: &mut Arc<FaceState>,
     res: &mut Arc<Resource>,
     qabl_info: &QueryableInfoType,
-    peer: ZenohId,
+    peer: ZenohIdInner,
 ) {
     let face = Some(face);
     register_peer_queryable(tables, face, res, qabl_info, peer);
@@ -431,7 +431,7 @@ fn propagate_forget_sourced_queryable(
     tables: &mut Tables,
     res: &mut Arc<Resource>,
     src_face: Option<&Arc<FaceState>>,
-    source: &ZenohId,
+    source: &ZenohIdInner,
 ) {
     let net = hat!(tables).peers_net.as_ref().unwrap();
     match net.get_idx(source) {
@@ -462,7 +462,7 @@ fn propagate_forget_sourced_queryable(
     }
 }
 
-fn unregister_peer_queryable(tables: &mut Tables, res: &mut Arc<Resource>, peer: &ZenohId) {
+fn unregister_peer_queryable(tables: &mut Tables, res: &mut Arc<Resource>, peer: &ZenohIdInner) {
     res_hat_mut!(res).peer_qabls.remove(peer);
 
     if res_hat!(res).peer_qabls.is_empty() {
@@ -480,7 +480,7 @@ fn undeclare_peer_queryable(
     tables: &mut Tables,
     face: Option<&Arc<FaceState>>,
     res: &mut Arc<Resource>,
-    peer: &ZenohId,
+    peer: &ZenohIdInner,
 ) {
     if res_hat!(res).peer_qabls.contains_key(peer) {
         unregister_peer_queryable(tables, res, peer);
@@ -492,7 +492,7 @@ fn forget_peer_queryable(
     tables: &mut Tables,
     face: &mut Arc<FaceState>,
     res: &mut Arc<Resource>,
-    peer: &ZenohId,
+    peer: &ZenohIdInner,
 ) {
     undeclare_peer_queryable(tables, Some(face), res, peer);
 }
@@ -584,7 +584,7 @@ fn forget_client_queryable(
     }
 }
 
-pub(super) fn queries_remove_node(tables: &mut Tables, node: &ZenohId) {
+pub(super) fn queries_remove_node(tables: &mut Tables, node: &ZenohIdInner) {
     let mut qabls = vec![];
     for res in hat!(tables).peer_qabls.iter() {
         for qabl in res_hat!(res).peer_qabls.keys() {
@@ -641,7 +641,7 @@ fn insert_target_for_qabls(
     tables: &Tables,
     net: &Network,
     source: NodeId,
-    qabls: &HashMap<ZenohId, QueryableInfoType>,
+    qabls: &HashMap<ZenohIdInner, QueryableInfoType>,
     complete: bool,
 ) {
     if net.trees.len() > source as usize {

--- a/zenoh/src/net/routing/hat/linkstate_peer/queries.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/queries.rs
@@ -26,7 +26,7 @@ use zenoh_protocol::{
             include::{Includer, DEFAULT_INCLUDER},
             OwnedKeyExpr,
         },
-        WhatAmI, WireExpr, ZenohIdInner,
+        WhatAmI, WireExpr, ZenohIdProto,
     },
     network::{
         declare::{
@@ -208,7 +208,7 @@ fn propagate_sourced_queryable(
     res: &Arc<Resource>,
     qabl_info: &QueryableInfoType,
     src_face: Option<&mut Arc<FaceState>>,
-    source: &ZenohIdInner,
+    source: &ZenohIdProto,
 ) {
     let net = hat!(tables).peers_net.as_ref().unwrap();
     match net.get_idx(source) {
@@ -245,7 +245,7 @@ fn register_peer_queryable(
     mut face: Option<&mut Arc<FaceState>>,
     res: &mut Arc<Resource>,
     qabl_info: &QueryableInfoType,
-    peer: ZenohIdInner,
+    peer: ZenohIdProto,
 ) {
     let current_info = res_hat!(res).peer_qabls.get(&peer);
     if current_info.is_none() || current_info.unwrap() != qabl_info {
@@ -270,7 +270,7 @@ fn declare_peer_queryable(
     face: &mut Arc<FaceState>,
     res: &mut Arc<Resource>,
     qabl_info: &QueryableInfoType,
-    peer: ZenohIdInner,
+    peer: ZenohIdProto,
 ) {
     let face = Some(face);
     register_peer_queryable(tables, face, res, qabl_info, peer);
@@ -431,7 +431,7 @@ fn propagate_forget_sourced_queryable(
     tables: &mut Tables,
     res: &mut Arc<Resource>,
     src_face: Option<&Arc<FaceState>>,
-    source: &ZenohIdInner,
+    source: &ZenohIdProto,
 ) {
     let net = hat!(tables).peers_net.as_ref().unwrap();
     match net.get_idx(source) {
@@ -462,7 +462,7 @@ fn propagate_forget_sourced_queryable(
     }
 }
 
-fn unregister_peer_queryable(tables: &mut Tables, res: &mut Arc<Resource>, peer: &ZenohIdInner) {
+fn unregister_peer_queryable(tables: &mut Tables, res: &mut Arc<Resource>, peer: &ZenohIdProto) {
     res_hat_mut!(res).peer_qabls.remove(peer);
 
     if res_hat!(res).peer_qabls.is_empty() {
@@ -480,7 +480,7 @@ fn undeclare_peer_queryable(
     tables: &mut Tables,
     face: Option<&Arc<FaceState>>,
     res: &mut Arc<Resource>,
-    peer: &ZenohIdInner,
+    peer: &ZenohIdProto,
 ) {
     if res_hat!(res).peer_qabls.contains_key(peer) {
         unregister_peer_queryable(tables, res, peer);
@@ -492,7 +492,7 @@ fn forget_peer_queryable(
     tables: &mut Tables,
     face: &mut Arc<FaceState>,
     res: &mut Arc<Resource>,
-    peer: &ZenohIdInner,
+    peer: &ZenohIdProto,
 ) {
     undeclare_peer_queryable(tables, Some(face), res, peer);
 }
@@ -584,7 +584,7 @@ fn forget_client_queryable(
     }
 }
 
-pub(super) fn queries_remove_node(tables: &mut Tables, node: &ZenohIdInner) {
+pub(super) fn queries_remove_node(tables: &mut Tables, node: &ZenohIdProto) {
     let mut qabls = vec![];
     for res in hat!(tables).peer_qabls.iter() {
         for qabl in res_hat!(res).peer_qabls.keys() {
@@ -641,7 +641,7 @@ fn insert_target_for_qabls(
     tables: &Tables,
     net: &Network,
     source: NodeId,
-    qabls: &HashMap<ZenohIdInner, QueryableInfoType>,
+    qabls: &HashMap<ZenohIdProto, QueryableInfoType>,
     complete: bool,
 ) {
     if net.trees.len() > source as usize {

--- a/zenoh/src/net/routing/hat/mod.rs
+++ b/zenoh/src/net/routing/hat/mod.rs
@@ -22,7 +22,7 @@ use std::{any::Any, collections::HashMap, sync::Arc};
 use zenoh_buffers::ZBuf;
 use zenoh_config::{unwrap_or_default, Config, WhatAmI};
 use zenoh_protocol::{
-    core::{WireExpr, ZenohIdInner},
+    core::{WireExpr, ZenohIdProto},
     network::{
         declare::{
             queryable::ext::QueryableInfoType, subscriber::ext::SubscriberInfo, QueryableId,
@@ -55,9 +55,9 @@ zconfigurable! {
 
 #[derive(serde::Serialize)]
 pub(crate) struct Sources {
-    routers: Vec<ZenohIdInner>,
-    peers: Vec<ZenohIdInner>,
-    clients: Vec<ZenohIdInner>,
+    routers: Vec<ZenohIdProto>,
+    peers: Vec<ZenohIdProto>,
+    clients: Vec<ZenohIdProto>,
 }
 
 impl Sources {

--- a/zenoh/src/net/routing/hat/mod.rs
+++ b/zenoh/src/net/routing/hat/mod.rs
@@ -22,7 +22,7 @@ use std::{any::Any, collections::HashMap, sync::Arc};
 use zenoh_buffers::ZBuf;
 use zenoh_config::{unwrap_or_default, Config, WhatAmI};
 use zenoh_protocol::{
-    core::{WireExpr, ZenohId},
+    core::{WireExpr, ZenohIdInner},
     network::{
         declare::{
             queryable::ext::QueryableInfoType, subscriber::ext::SubscriberInfo, QueryableId,
@@ -55,9 +55,9 @@ zconfigurable! {
 
 #[derive(serde::Serialize)]
 pub(crate) struct Sources {
-    routers: Vec<ZenohId>,
-    peers: Vec<ZenohId>,
-    clients: Vec<ZenohId>,
+    routers: Vec<ZenohIdInner>,
+    peers: Vec<ZenohIdInner>,
+    clients: Vec<ZenohIdInner>,
 }
 
 impl Sources {

--- a/zenoh/src/net/routing/hat/p2p_peer/gossip.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/gossip.rs
@@ -23,7 +23,7 @@ use zenoh_codec::WCodec;
 use zenoh_link::Locator;
 use zenoh_protocol::{
     common::ZExtBody,
-    core::{WhatAmI, WhatAmIMatcher, ZenohIdInner},
+    core::{WhatAmI, WhatAmIMatcher, ZenohIdProto},
     network::{oam, oam::id::OAM_LINKSTATE, NetworkBody, NetworkMessage, Oam},
 };
 use zenoh_transport::unicast::TransportUnicast;
@@ -43,11 +43,11 @@ struct Details {
 
 #[derive(Clone)]
 pub(super) struct Node {
-    pub(super) zid: ZenohIdInner,
+    pub(super) zid: ZenohIdProto,
     pub(super) whatami: Option<WhatAmI>,
     pub(super) locators: Option<Vec<Locator>>,
     pub(super) sn: u64,
-    pub(super) links: Vec<ZenohIdInner>,
+    pub(super) links: Vec<ZenohIdProto>,
 }
 
 impl std::fmt::Debug for Node {
@@ -58,8 +58,8 @@ impl std::fmt::Debug for Node {
 
 pub(super) struct Link {
     pub(super) transport: TransportUnicast,
-    zid: ZenohIdInner,
-    mappings: VecMap<ZenohIdInner>,
+    zid: ZenohIdProto,
+    mappings: VecMap<ZenohIdProto>,
     local_mappings: VecMap<u64>,
 }
 
@@ -75,12 +75,12 @@ impl Link {
     }
 
     #[inline]
-    pub(super) fn set_zid_mapping(&mut self, psid: u64, zid: ZenohIdInner) {
+    pub(super) fn set_zid_mapping(&mut self, psid: u64, zid: ZenohIdProto) {
         self.mappings.insert(psid.try_into().unwrap(), zid);
     }
 
     #[inline]
-    pub(super) fn get_zid(&self, psid: &u64) -> Option<&ZenohIdInner> {
+    pub(super) fn get_zid(&self, psid: &u64) -> Option<&ZenohIdProto> {
         self.mappings.get((*psid).try_into().unwrap())
     }
 
@@ -106,7 +106,7 @@ pub(super) struct Network {
 impl Network {
     pub(super) fn new(
         name: String,
-        zid: ZenohIdInner,
+        zid: ZenohIdProto,
         runtime: Runtime,
         router_peers_failover_brokering: bool,
         gossip: bool,
@@ -144,14 +144,14 @@ impl Network {
     // }
 
     #[inline]
-    pub(super) fn get_idx(&self, zid: &ZenohIdInner) -> Option<NodeIndex> {
+    pub(super) fn get_idx(&self, zid: &ZenohIdProto) -> Option<NodeIndex> {
         self.graph
             .node_indices()
             .find(|idx| self.graph[*idx].zid == *zid)
     }
 
     #[inline]
-    pub(super) fn get_link_from_zid(&self, zid: &ZenohIdInner) -> Option<&Link> {
+    pub(super) fn get_link_from_zid(&self, zid: &ZenohIdProto) -> Option<&Link> {
         self.links.values().find(|link| link.zid == *zid)
     }
 
@@ -271,7 +271,7 @@ impl Network {
                 }))
     }
 
-    pub(super) fn link_states(&mut self, link_states: Vec<LinkState>, src: ZenohIdInner) {
+    pub(super) fn link_states(&mut self, link_states: Vec<LinkState>, src: ZenohIdProto) {
         tracing::trace!("{} Received from {} raw: {:?}", self.name, src, link_states);
         let strong_runtime = self.runtime.upgrade().unwrap();
 
@@ -333,7 +333,7 @@ impl Network {
         let link_states = link_states
             .into_iter()
             .map(|(zid, wai, locs, sn, links)| {
-                let links: Vec<ZenohIdInner> = links
+                let links: Vec<ZenohIdProto> = links
                     .iter()
                     .filter_map(|l| {
                         if let Some(zid) = src_link.get_zid(l) {
@@ -551,7 +551,7 @@ impl Network {
         free_index
     }
 
-    pub(super) fn remove_link(&mut self, zid: &ZenohIdInner) -> Vec<(NodeIndex, Node)> {
+    pub(super) fn remove_link(&mut self, zid: &ZenohIdProto) -> Vec<(NodeIndex, Node)> {
         tracing::trace!("{} remove_link {}", self.name, zid);
         self.links.retain(|_, link| link.zid != *zid);
         self.graph[self.idx].links.retain(|link| *link != *zid);

--- a/zenoh/src/net/routing/hat/p2p_peer/gossip.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/gossip.rs
@@ -23,7 +23,7 @@ use zenoh_codec::WCodec;
 use zenoh_link::Locator;
 use zenoh_protocol::{
     common::ZExtBody,
-    core::{WhatAmI, WhatAmIMatcher, ZenohId},
+    core::{WhatAmI, WhatAmIMatcher, ZenohIdInner},
     network::{oam, oam::id::OAM_LINKSTATE, NetworkBody, NetworkMessage, Oam},
 };
 use zenoh_transport::unicast::TransportUnicast;
@@ -43,11 +43,11 @@ struct Details {
 
 #[derive(Clone)]
 pub(super) struct Node {
-    pub(super) zid: ZenohId,
+    pub(super) zid: ZenohIdInner,
     pub(super) whatami: Option<WhatAmI>,
     pub(super) locators: Option<Vec<Locator>>,
     pub(super) sn: u64,
-    pub(super) links: Vec<ZenohId>,
+    pub(super) links: Vec<ZenohIdInner>,
 }
 
 impl std::fmt::Debug for Node {
@@ -58,8 +58,8 @@ impl std::fmt::Debug for Node {
 
 pub(super) struct Link {
     pub(super) transport: TransportUnicast,
-    zid: ZenohId,
-    mappings: VecMap<ZenohId>,
+    zid: ZenohIdInner,
+    mappings: VecMap<ZenohIdInner>,
     local_mappings: VecMap<u64>,
 }
 
@@ -75,12 +75,12 @@ impl Link {
     }
 
     #[inline]
-    pub(super) fn set_zid_mapping(&mut self, psid: u64, zid: ZenohId) {
+    pub(super) fn set_zid_mapping(&mut self, psid: u64, zid: ZenohIdInner) {
         self.mappings.insert(psid.try_into().unwrap(), zid);
     }
 
     #[inline]
-    pub(super) fn get_zid(&self, psid: &u64) -> Option<&ZenohId> {
+    pub(super) fn get_zid(&self, psid: &u64) -> Option<&ZenohIdInner> {
         self.mappings.get((*psid).try_into().unwrap())
     }
 
@@ -106,7 +106,7 @@ pub(super) struct Network {
 impl Network {
     pub(super) fn new(
         name: String,
-        zid: ZenohId,
+        zid: ZenohIdInner,
         runtime: Runtime,
         router_peers_failover_brokering: bool,
         gossip: bool,
@@ -144,14 +144,14 @@ impl Network {
     // }
 
     #[inline]
-    pub(super) fn get_idx(&self, zid: &ZenohId) -> Option<NodeIndex> {
+    pub(super) fn get_idx(&self, zid: &ZenohIdInner) -> Option<NodeIndex> {
         self.graph
             .node_indices()
             .find(|idx| self.graph[*idx].zid == *zid)
     }
 
     #[inline]
-    pub(super) fn get_link_from_zid(&self, zid: &ZenohId) -> Option<&Link> {
+    pub(super) fn get_link_from_zid(&self, zid: &ZenohIdInner) -> Option<&Link> {
         self.links.values().find(|link| link.zid == *zid)
     }
 
@@ -271,7 +271,7 @@ impl Network {
                 }))
     }
 
-    pub(super) fn link_states(&mut self, link_states: Vec<LinkState>, src: ZenohId) {
+    pub(super) fn link_states(&mut self, link_states: Vec<LinkState>, src: ZenohIdInner) {
         tracing::trace!("{} Received from {} raw: {:?}", self.name, src, link_states);
         let strong_runtime = self.runtime.upgrade().unwrap();
 
@@ -333,7 +333,7 @@ impl Network {
         let link_states = link_states
             .into_iter()
             .map(|(zid, wai, locs, sn, links)| {
-                let links: Vec<ZenohId> = links
+                let links: Vec<ZenohIdInner> = links
                     .iter()
                     .filter_map(|l| {
                         if let Some(zid) = src_link.get_zid(l) {
@@ -551,7 +551,7 @@ impl Network {
         free_index
     }
 
-    pub(super) fn remove_link(&mut self, zid: &ZenohId) -> Vec<(NodeIndex, Node)> {
+    pub(super) fn remove_link(&mut self, zid: &ZenohIdInner) -> Vec<(NodeIndex, Node)> {
         tracing::trace!("{} remove_link {}", self.name, zid);
         self.links.retain(|_, link| link.zid != *zid);
         self.graph[self.idx].links.retain(|link| *link != *zid);

--- a/zenoh/src/net/routing/hat/router/mod.rs
+++ b/zenoh/src/net/routing/hat/router/mod.rs
@@ -28,7 +28,7 @@ use std::{
 use zenoh_config::{unwrap_or_default, ModeDependent, WhatAmI, WhatAmIMatcher};
 use zenoh_protocol::{
     common::ZExtBody,
-    core::ZenohId,
+    core::ZenohIdInner,
     network::{
         declare::{queryable::ext::QueryableInfoType, QueryableId, SubscriberId},
         interest::InterestId,
@@ -121,7 +121,7 @@ struct HatTables {
     peer_qabls: HashSet<Arc<Resource>>,
     routers_net: Option<Network>,
     peers_net: Option<Network>,
-    shared_nodes: Vec<ZenohId>,
+    shared_nodes: Vec<ZenohIdInner>,
     routers_trees_task: Option<TerminatableTask>,
     peers_trees_task: Option<TerminatableTask>,
     router_peers_failover_brokering: bool,
@@ -183,7 +183,7 @@ impl HatTables {
     }
 
     #[inline]
-    fn get_router_links(&self, peer: ZenohId) -> impl Iterator<Item = &ZenohId> + '_ {
+    fn get_router_links(&self, peer: ZenohIdInner) -> impl Iterator<Item = &ZenohIdInner> + '_ {
         self.peers_net
             .as_ref()
             .unwrap()
@@ -201,14 +201,14 @@ impl HatTables {
     #[inline]
     fn elect_router<'a>(
         &'a self,
-        self_zid: &'a ZenohId,
+        self_zid: &'a ZenohIdInner,
         key_expr: &str,
-        mut routers: impl Iterator<Item = &'a ZenohId>,
-    ) -> &'a ZenohId {
+        mut routers: impl Iterator<Item = &'a ZenohIdInner>,
+    ) -> &'a ZenohIdInner {
         match routers.next() {
             None => self_zid,
             Some(router) => {
-                let hash = |r: &ZenohId| {
+                let hash = |r: &ZenohIdInner| {
                     let mut hasher = DefaultHasher::new();
                     for b in key_expr.as_bytes() {
                         hasher.write_u8(*b);
@@ -233,13 +233,13 @@ impl HatTables {
     }
 
     #[inline]
-    fn failover_brokering_to(source_links: &[ZenohId], dest: ZenohId) -> bool {
+    fn failover_brokering_to(source_links: &[ZenohIdInner], dest: ZenohIdInner) -> bool {
         // if source_links is empty then gossip is probably disabled in source peer
         !source_links.is_empty() && !source_links.contains(&dest)
     }
 
     #[inline]
-    fn failover_brokering(&self, peer1: ZenohId, peer2: ZenohId) -> bool {
+    fn failover_brokering(&self, peer1: ZenohIdInner, peer2: ZenohIdInner) -> bool {
         self.router_peers_failover_brokering
             && self
                 .peers_net
@@ -762,10 +762,10 @@ impl HatBaseTrait for HatCode {
 }
 
 struct HatContext {
-    router_subs: HashSet<ZenohId>,
-    peer_subs: HashSet<ZenohId>,
-    router_qabls: HashMap<ZenohId, QueryableInfoType>,
-    peer_qabls: HashMap<ZenohId, QueryableInfoType>,
+    router_subs: HashSet<ZenohIdInner>,
+    peer_subs: HashSet<ZenohIdInner>,
+    router_qabls: HashMap<ZenohIdInner, QueryableInfoType>,
+    peer_qabls: HashMap<ZenohIdInner, QueryableInfoType>,
 }
 
 impl HatContext {
@@ -805,7 +805,7 @@ impl HatFace {
     }
 }
 
-fn get_router(tables: &Tables, face: &Arc<FaceState>, nodeid: NodeId) -> Option<ZenohId> {
+fn get_router(tables: &Tables, face: &Arc<FaceState>, nodeid: NodeId) -> Option<ZenohIdInner> {
     match hat!(tables)
         .routers_net
         .as_ref()
@@ -832,7 +832,7 @@ fn get_router(tables: &Tables, face: &Arc<FaceState>, nodeid: NodeId) -> Option<
     }
 }
 
-fn get_peer(tables: &Tables, face: &Arc<FaceState>, nodeid: NodeId) -> Option<ZenohId> {
+fn get_peer(tables: &Tables, face: &Arc<FaceState>, nodeid: NodeId) -> Option<ZenohIdInner> {
     match hat!(tables)
         .peers_net
         .as_ref()

--- a/zenoh/src/net/routing/hat/router/mod.rs
+++ b/zenoh/src/net/routing/hat/router/mod.rs
@@ -28,7 +28,7 @@ use std::{
 use zenoh_config::{unwrap_or_default, ModeDependent, WhatAmI, WhatAmIMatcher};
 use zenoh_protocol::{
     common::ZExtBody,
-    core::ZenohIdInner,
+    core::ZenohIdProto,
     network::{
         declare::{queryable::ext::QueryableInfoType, QueryableId, SubscriberId},
         interest::InterestId,
@@ -121,7 +121,7 @@ struct HatTables {
     peer_qabls: HashSet<Arc<Resource>>,
     routers_net: Option<Network>,
     peers_net: Option<Network>,
-    shared_nodes: Vec<ZenohIdInner>,
+    shared_nodes: Vec<ZenohIdProto>,
     routers_trees_task: Option<TerminatableTask>,
     peers_trees_task: Option<TerminatableTask>,
     router_peers_failover_brokering: bool,
@@ -183,7 +183,7 @@ impl HatTables {
     }
 
     #[inline]
-    fn get_router_links(&self, peer: ZenohIdInner) -> impl Iterator<Item = &ZenohIdInner> + '_ {
+    fn get_router_links(&self, peer: ZenohIdProto) -> impl Iterator<Item = &ZenohIdProto> + '_ {
         self.peers_net
             .as_ref()
             .unwrap()
@@ -201,14 +201,14 @@ impl HatTables {
     #[inline]
     fn elect_router<'a>(
         &'a self,
-        self_zid: &'a ZenohIdInner,
+        self_zid: &'a ZenohIdProto,
         key_expr: &str,
-        mut routers: impl Iterator<Item = &'a ZenohIdInner>,
-    ) -> &'a ZenohIdInner {
+        mut routers: impl Iterator<Item = &'a ZenohIdProto>,
+    ) -> &'a ZenohIdProto {
         match routers.next() {
             None => self_zid,
             Some(router) => {
-                let hash = |r: &ZenohIdInner| {
+                let hash = |r: &ZenohIdProto| {
                     let mut hasher = DefaultHasher::new();
                     for b in key_expr.as_bytes() {
                         hasher.write_u8(*b);
@@ -233,13 +233,13 @@ impl HatTables {
     }
 
     #[inline]
-    fn failover_brokering_to(source_links: &[ZenohIdInner], dest: ZenohIdInner) -> bool {
+    fn failover_brokering_to(source_links: &[ZenohIdProto], dest: ZenohIdProto) -> bool {
         // if source_links is empty then gossip is probably disabled in source peer
         !source_links.is_empty() && !source_links.contains(&dest)
     }
 
     #[inline]
-    fn failover_brokering(&self, peer1: ZenohIdInner, peer2: ZenohIdInner) -> bool {
+    fn failover_brokering(&self, peer1: ZenohIdProto, peer2: ZenohIdProto) -> bool {
         self.router_peers_failover_brokering
             && self
                 .peers_net
@@ -762,10 +762,10 @@ impl HatBaseTrait for HatCode {
 }
 
 struct HatContext {
-    router_subs: HashSet<ZenohIdInner>,
-    peer_subs: HashSet<ZenohIdInner>,
-    router_qabls: HashMap<ZenohIdInner, QueryableInfoType>,
-    peer_qabls: HashMap<ZenohIdInner, QueryableInfoType>,
+    router_subs: HashSet<ZenohIdProto>,
+    peer_subs: HashSet<ZenohIdProto>,
+    router_qabls: HashMap<ZenohIdProto, QueryableInfoType>,
+    peer_qabls: HashMap<ZenohIdProto, QueryableInfoType>,
 }
 
 impl HatContext {
@@ -805,7 +805,7 @@ impl HatFace {
     }
 }
 
-fn get_router(tables: &Tables, face: &Arc<FaceState>, nodeid: NodeId) -> Option<ZenohIdInner> {
+fn get_router(tables: &Tables, face: &Arc<FaceState>, nodeid: NodeId) -> Option<ZenohIdProto> {
     match hat!(tables)
         .routers_net
         .as_ref()
@@ -832,7 +832,7 @@ fn get_router(tables: &Tables, face: &Arc<FaceState>, nodeid: NodeId) -> Option<
     }
 }
 
-fn get_peer(tables: &Tables, face: &Arc<FaceState>, nodeid: NodeId) -> Option<ZenohIdInner> {
+fn get_peer(tables: &Tables, face: &Arc<FaceState>, nodeid: NodeId) -> Option<ZenohIdProto> {
     match hat!(tables)
         .peers_net
         .as_ref()

--- a/zenoh/src/net/routing/hat/router/network.rs
+++ b/zenoh/src/net/routing/hat/router/network.rs
@@ -27,7 +27,7 @@ use zenoh_codec::WCodec;
 use zenoh_link::Locator;
 use zenoh_protocol::{
     common::ZExtBody,
-    core::{WhatAmI, WhatAmIMatcher, ZenohId},
+    core::{WhatAmI, WhatAmIMatcher, ZenohIdInner},
     network::{oam, oam::id::OAM_LINKSTATE, NetworkBody, NetworkMessage, Oam},
 };
 use zenoh_transport::unicast::TransportUnicast;
@@ -48,11 +48,11 @@ struct Details {
 
 #[derive(Clone)]
 pub(super) struct Node {
-    pub(super) zid: ZenohId,
+    pub(super) zid: ZenohIdInner,
     pub(super) whatami: Option<WhatAmI>,
     pub(super) locators: Option<Vec<Locator>>,
     pub(super) sn: u64,
-    pub(super) links: Vec<ZenohId>,
+    pub(super) links: Vec<ZenohIdInner>,
 }
 
 impl std::fmt::Debug for Node {
@@ -63,8 +63,8 @@ impl std::fmt::Debug for Node {
 
 pub(super) struct Link {
     pub(super) transport: TransportUnicast,
-    zid: ZenohId,
-    mappings: VecMap<ZenohId>,
+    zid: ZenohIdInner,
+    mappings: VecMap<ZenohIdInner>,
     local_mappings: VecMap<u64>,
 }
 
@@ -80,12 +80,12 @@ impl Link {
     }
 
     #[inline]
-    pub(super) fn set_zid_mapping(&mut self, psid: u64, zid: ZenohId) {
+    pub(super) fn set_zid_mapping(&mut self, psid: u64, zid: ZenohIdInner) {
         self.mappings.insert(psid.try_into().unwrap(), zid);
     }
 
     #[inline]
-    pub(super) fn get_zid(&self, psid: &u64) -> Option<&ZenohId> {
+    pub(super) fn get_zid(&self, psid: &u64) -> Option<&ZenohIdInner> {
         self.mappings.get((*psid).try_into().unwrap())
     }
 
@@ -132,7 +132,7 @@ impl Network {
     #[allow(clippy::too_many_arguments)]
     pub(super) fn new(
         name: String,
-        zid: ZenohId,
+        zid: ZenohIdInner,
         runtime: Runtime,
         full_linkstate: bool,
         router_peers_failover_brokering: bool,
@@ -177,12 +177,12 @@ impl Network {
     }
 
     #[inline]
-    pub(super) fn get_node(&self, zid: &ZenohId) -> Option<&Node> {
+    pub(super) fn get_node(&self, zid: &ZenohIdInner) -> Option<&Node> {
         self.graph.node_weights().find(|weight| weight.zid == *zid)
     }
 
     #[inline]
-    pub(super) fn get_idx(&self, zid: &ZenohId) -> Option<NodeIndex> {
+    pub(super) fn get_idx(&self, zid: &ZenohIdInner) -> Option<NodeIndex> {
         self.graph
             .node_indices()
             .find(|idx| self.graph[*idx].zid == *zid)
@@ -194,7 +194,7 @@ impl Network {
     }
 
     #[inline]
-    pub(super) fn get_link_from_zid(&self, zid: &ZenohId) -> Option<&Link> {
+    pub(super) fn get_link_from_zid(&self, zid: &ZenohIdInner) -> Option<&Link> {
         self.links.values().find(|link| link.zid == *zid)
     }
 
@@ -349,7 +349,7 @@ impl Network {
         self.graph.update_edge(idx1, idx2, weight);
     }
 
-    pub(super) fn link_states(&mut self, link_states: Vec<LinkState>, src: ZenohId) -> Changes {
+    pub(super) fn link_states(&mut self, link_states: Vec<LinkState>, src: ZenohIdInner) -> Changes {
         tracing::trace!("{} Received from {} raw: {:?}", self.name, src, link_states);
 
         let graph = &self.graph;
@@ -413,7 +413,7 @@ impl Network {
         let link_states = link_states
             .into_iter()
             .map(|(zid, wai, locs, sn, links)| {
-                let links: Vec<ZenohId> = links
+                let links: Vec<ZenohIdInner> = links
                     .iter()
                     .filter_map(|l| {
                         if let Some(zid) = src_link.get_zid(l) {
@@ -563,7 +563,7 @@ impl Network {
                     }
                 },
             )
-            .collect::<Vec<(Vec<ZenohId>, NodeIndex, bool)>>();
+            .collect::<Vec<(Vec<ZenohIdInner>, NodeIndex, bool)>>();
 
         // Add/remove edges from graph
         let mut reintroduced_nodes = vec![];
@@ -615,7 +615,7 @@ impl Network {
         let link_states = link_states
             .into_iter()
             .filter(|ls| !removed.iter().any(|(idx, _)| idx == &ls.1))
-            .collect::<Vec<(Vec<ZenohId>, NodeIndex, bool)>>();
+            .collect::<Vec<(Vec<ZenohIdInner>, NodeIndex, bool)>>();
 
         if !self.autoconnect.is_empty() {
             // Connect discovered peers
@@ -654,8 +654,8 @@ impl Network {
         #[allow(clippy::type_complexity)] // This is only used here
         if !link_states.is_empty() {
             let (new_idxs, updated_idxs): (
-                Vec<(Vec<ZenohId>, NodeIndex, bool)>,
-                Vec<(Vec<ZenohId>, NodeIndex, bool)>,
+                Vec<(Vec<ZenohIdInner>, NodeIndex, bool)>,
+                Vec<(Vec<ZenohIdInner>, NodeIndex, bool)>,
             ) = link_states.into_iter().partition(|(_, _, new)| *new);
             let new_idxs = new_idxs
                 .into_iter()
@@ -819,7 +819,7 @@ impl Network {
         free_index
     }
 
-    pub(super) fn remove_link(&mut self, zid: &ZenohId) -> Vec<(NodeIndex, Node)> {
+    pub(super) fn remove_link(&mut self, zid: &ZenohIdInner) -> Vec<(NodeIndex, Node)> {
         tracing::trace!("{} remove_link {}", self.name, zid);
         self.links.retain(|_, link| link.zid != *zid);
         self.graph[self.idx].links.retain(|link| *link != *zid);
@@ -999,7 +999,7 @@ impl Network {
     }
 
     #[inline]
-    pub(super) fn get_links(&self, node: ZenohId) -> &[ZenohId] {
+    pub(super) fn get_links(&self, node: ZenohIdInner) -> &[ZenohIdInner] {
         self.get_node(&node)
             .map(|node| &node.links[..])
             .unwrap_or_default()
@@ -1007,7 +1007,7 @@ impl Network {
 }
 
 #[inline]
-pub(super) fn shared_nodes(net1: &Network, net2: &Network) -> Vec<ZenohId> {
+pub(super) fn shared_nodes(net1: &Network, net2: &Network) -> Vec<ZenohIdInner> {
     net1.graph
         .node_references()
         .filter_map(|(_, node1)| {

--- a/zenoh/src/net/routing/hat/router/network.rs
+++ b/zenoh/src/net/routing/hat/router/network.rs
@@ -349,7 +349,11 @@ impl Network {
         self.graph.update_edge(idx1, idx2, weight);
     }
 
-    pub(super) fn link_states(&mut self, link_states: Vec<LinkState>, src: ZenohIdInner) -> Changes {
+    pub(super) fn link_states(
+        &mut self,
+        link_states: Vec<LinkState>,
+        src: ZenohIdInner,
+    ) -> Changes {
         tracing::trace!("{} Received from {} raw: {:?}", self.name, src, link_states);
 
         let graph = &self.graph;

--- a/zenoh/src/net/routing/hat/router/pubsub.rs
+++ b/zenoh/src/net/routing/hat/router/pubsub.rs
@@ -523,7 +523,11 @@ fn propagate_forget_sourced_subscription(
     }
 }
 
-fn unregister_router_subscription(tables: &mut Tables, res: &mut Arc<Resource>, router: &ZenohIdInner) {
+fn unregister_router_subscription(
+    tables: &mut Tables,
+    res: &mut Arc<Resource>,
+    router: &ZenohIdInner,
+) {
     res_hat_mut!(res).router_subs.retain(|sub| sub != router);
 
     if res_hat!(res).router_subs.is_empty() {
@@ -771,7 +775,11 @@ pub(super) fn pubsub_tree_change(
     update_data_routes_from(tables, &mut tables.root_res.clone());
 }
 
-pub(super) fn pubsub_linkstate_change(tables: &mut Tables, zid: &ZenohIdInner, links: &[ZenohIdInner]) {
+pub(super) fn pubsub_linkstate_change(
+    tables: &mut Tables,
+    zid: &ZenohIdInner,
+    links: &[ZenohIdInner],
+) {
     if let Some(src_face) = tables.get_face(zid).cloned() {
         if hat!(tables).router_peers_failover_brokering && src_face.whatami == WhatAmI::Peer {
             for res in face_hat!(src_face).remote_subs.values() {

--- a/zenoh/src/net/routing/hat/router/queries.rs
+++ b/zenoh/src/net/routing/hat/router/queries.rs
@@ -26,7 +26,7 @@ use zenoh_protocol::{
             include::{Includer, DEFAULT_INCLUDER},
             OwnedKeyExpr,
         },
-        WhatAmI, WireExpr, ZenohIdInner,
+        WhatAmI, WireExpr, ZenohIdProto,
     },
     network::{
         declare::{
@@ -286,7 +286,7 @@ fn propagate_sourced_queryable(
     res: &Arc<Resource>,
     qabl_info: &QueryableInfoType,
     src_face: Option<&mut Arc<FaceState>>,
-    source: &ZenohIdInner,
+    source: &ZenohIdProto,
     net_type: WhatAmI,
 ) {
     let net = hat!(tables).get_net(net_type).unwrap();
@@ -324,7 +324,7 @@ fn register_router_queryable(
     mut face: Option<&mut Arc<FaceState>>,
     res: &mut Arc<Resource>,
     qabl_info: &QueryableInfoType,
-    router: ZenohIdInner,
+    router: ZenohIdProto,
 ) {
     let current_info = res_hat!(res).router_qabls.get(&router);
     if current_info.is_none() || current_info.unwrap() != qabl_info {
@@ -362,7 +362,7 @@ fn declare_router_queryable(
     face: &mut Arc<FaceState>,
     res: &mut Arc<Resource>,
     qabl_info: &QueryableInfoType,
-    router: ZenohIdInner,
+    router: ZenohIdProto,
 ) {
     register_router_queryable(tables, Some(face), res, qabl_info, router);
 }
@@ -372,7 +372,7 @@ fn register_peer_queryable(
     face: Option<&mut Arc<FaceState>>,
     res: &mut Arc<Resource>,
     qabl_info: &QueryableInfoType,
-    peer: ZenohIdInner,
+    peer: ZenohIdProto,
 ) {
     let current_info = res_hat!(res).peer_qabls.get(&peer);
     if current_info.is_none() || current_info.unwrap() != qabl_info {
@@ -392,7 +392,7 @@ fn declare_peer_queryable(
     face: &mut Arc<FaceState>,
     res: &mut Arc<Resource>,
     qabl_info: &QueryableInfoType,
-    peer: ZenohIdInner,
+    peer: ZenohIdProto,
 ) {
     let mut face = Some(face);
     register_peer_queryable(tables, face.as_deref_mut(), res, qabl_info, peer);
@@ -608,7 +608,7 @@ fn propagate_forget_sourced_queryable(
     tables: &mut Tables,
     res: &mut Arc<Resource>,
     src_face: Option<&Arc<FaceState>>,
-    source: &ZenohIdInner,
+    source: &ZenohIdProto,
     net_type: WhatAmI,
 ) {
     let net = hat!(tables).get_net(net_type).unwrap();
@@ -643,7 +643,7 @@ fn propagate_forget_sourced_queryable(
 fn unregister_router_queryable(
     tables: &mut Tables,
     res: &mut Arc<Resource>,
-    router: &ZenohIdInner,
+    router: &ZenohIdProto,
 ) {
     res_hat_mut!(res).router_qabls.remove(router);
 
@@ -665,7 +665,7 @@ fn undeclare_router_queryable(
     tables: &mut Tables,
     face: Option<&Arc<FaceState>>,
     res: &mut Arc<Resource>,
-    router: &ZenohIdInner,
+    router: &ZenohIdProto,
 ) {
     if res_hat!(res).router_qabls.contains_key(router) {
         unregister_router_queryable(tables, res, router);
@@ -677,12 +677,12 @@ fn forget_router_queryable(
     tables: &mut Tables,
     face: &mut Arc<FaceState>,
     res: &mut Arc<Resource>,
-    router: &ZenohIdInner,
+    router: &ZenohIdProto,
 ) {
     undeclare_router_queryable(tables, Some(face), res, router);
 }
 
-fn unregister_peer_queryable(tables: &mut Tables, res: &mut Arc<Resource>, peer: &ZenohIdInner) {
+fn unregister_peer_queryable(tables: &mut Tables, res: &mut Arc<Resource>, peer: &ZenohIdProto) {
     res_hat_mut!(res).peer_qabls.remove(peer);
 
     if res_hat!(res).peer_qabls.is_empty() {
@@ -696,7 +696,7 @@ fn undeclare_peer_queryable(
     tables: &mut Tables,
     face: Option<&Arc<FaceState>>,
     res: &mut Arc<Resource>,
-    peer: &ZenohIdInner,
+    peer: &ZenohIdProto,
 ) {
     if res_hat!(res).peer_qabls.contains_key(peer) {
         unregister_peer_queryable(tables, res, peer);
@@ -708,7 +708,7 @@ fn forget_peer_queryable(
     tables: &mut Tables,
     face: &mut Arc<FaceState>,
     res: &mut Arc<Resource>,
-    peer: &ZenohIdInner,
+    peer: &ZenohIdProto,
 ) {
     undeclare_peer_queryable(tables, Some(face), res, peer);
 
@@ -814,7 +814,7 @@ fn forget_client_queryable(
     }
 }
 
-pub(super) fn queries_remove_node(tables: &mut Tables, node: &ZenohIdInner, net_type: WhatAmI) {
+pub(super) fn queries_remove_node(tables: &mut Tables, node: &ZenohIdProto, net_type: WhatAmI) {
     match net_type {
         WhatAmI::Router => {
             let mut qabls = vec![];
@@ -863,8 +863,8 @@ pub(super) fn queries_remove_node(tables: &mut Tables, node: &ZenohIdInner, net_
 
 pub(super) fn queries_linkstate_change(
     tables: &mut Tables,
-    zid: &ZenohIdInner,
-    links: &[ZenohIdInner],
+    zid: &ZenohIdProto,
+    links: &[ZenohIdProto],
 ) {
     if let Some(src_face) = tables.get_face(zid) {
         if hat!(tables).router_peers_failover_brokering && src_face.whatami == WhatAmI::Peer {
@@ -998,7 +998,7 @@ fn insert_target_for_qabls(
     tables: &Tables,
     net: &Network,
     source: NodeId,
-    qabls: &HashMap<ZenohIdInner, QueryableInfoType>,
+    qabls: &HashMap<ZenohIdProto, QueryableInfoType>,
     complete: bool,
 ) {
     if net.trees.len() > source as usize {

--- a/zenoh/src/net/routing/hat/router/queries.rs
+++ b/zenoh/src/net/routing/hat/router/queries.rs
@@ -640,7 +640,11 @@ fn propagate_forget_sourced_queryable(
     }
 }
 
-fn unregister_router_queryable(tables: &mut Tables, res: &mut Arc<Resource>, router: &ZenohIdInner) {
+fn unregister_router_queryable(
+    tables: &mut Tables,
+    res: &mut Arc<Resource>,
+    router: &ZenohIdInner,
+) {
     res_hat_mut!(res).router_qabls.remove(router);
 
     if res_hat!(res).router_qabls.is_empty() {
@@ -857,7 +861,11 @@ pub(super) fn queries_remove_node(tables: &mut Tables, node: &ZenohIdInner, net_
     }
 }
 
-pub(super) fn queries_linkstate_change(tables: &mut Tables, zid: &ZenohIdInner, links: &[ZenohIdInner]) {
+pub(super) fn queries_linkstate_change(
+    tables: &mut Tables,
+    zid: &ZenohIdInner,
+    links: &[ZenohIdInner],
+) {
     if let Some(src_face) = tables.get_face(zid) {
         if hat!(tables).router_peers_failover_brokering && src_face.whatami == WhatAmI::Peer {
             for res in face_hat!(src_face).remote_qabls.values() {

--- a/zenoh/src/net/routing/hat/router/queries.rs
+++ b/zenoh/src/net/routing/hat/router/queries.rs
@@ -26,7 +26,7 @@ use zenoh_protocol::{
             include::{Includer, DEFAULT_INCLUDER},
             OwnedKeyExpr,
         },
-        WhatAmI, WireExpr, ZenohId,
+        WhatAmI, WireExpr, ZenohIdInner,
     },
     network::{
         declare::{
@@ -286,7 +286,7 @@ fn propagate_sourced_queryable(
     res: &Arc<Resource>,
     qabl_info: &QueryableInfoType,
     src_face: Option<&mut Arc<FaceState>>,
-    source: &ZenohId,
+    source: &ZenohIdInner,
     net_type: WhatAmI,
 ) {
     let net = hat!(tables).get_net(net_type).unwrap();
@@ -324,7 +324,7 @@ fn register_router_queryable(
     mut face: Option<&mut Arc<FaceState>>,
     res: &mut Arc<Resource>,
     qabl_info: &QueryableInfoType,
-    router: ZenohId,
+    router: ZenohIdInner,
 ) {
     let current_info = res_hat!(res).router_qabls.get(&router);
     if current_info.is_none() || current_info.unwrap() != qabl_info {
@@ -362,7 +362,7 @@ fn declare_router_queryable(
     face: &mut Arc<FaceState>,
     res: &mut Arc<Resource>,
     qabl_info: &QueryableInfoType,
-    router: ZenohId,
+    router: ZenohIdInner,
 ) {
     register_router_queryable(tables, Some(face), res, qabl_info, router);
 }
@@ -372,7 +372,7 @@ fn register_peer_queryable(
     face: Option<&mut Arc<FaceState>>,
     res: &mut Arc<Resource>,
     qabl_info: &QueryableInfoType,
-    peer: ZenohId,
+    peer: ZenohIdInner,
 ) {
     let current_info = res_hat!(res).peer_qabls.get(&peer);
     if current_info.is_none() || current_info.unwrap() != qabl_info {
@@ -392,7 +392,7 @@ fn declare_peer_queryable(
     face: &mut Arc<FaceState>,
     res: &mut Arc<Resource>,
     qabl_info: &QueryableInfoType,
-    peer: ZenohId,
+    peer: ZenohIdInner,
 ) {
     let mut face = Some(face);
     register_peer_queryable(tables, face.as_deref_mut(), res, qabl_info, peer);
@@ -608,7 +608,7 @@ fn propagate_forget_sourced_queryable(
     tables: &mut Tables,
     res: &mut Arc<Resource>,
     src_face: Option<&Arc<FaceState>>,
-    source: &ZenohId,
+    source: &ZenohIdInner,
     net_type: WhatAmI,
 ) {
     let net = hat!(tables).get_net(net_type).unwrap();
@@ -640,7 +640,7 @@ fn propagate_forget_sourced_queryable(
     }
 }
 
-fn unregister_router_queryable(tables: &mut Tables, res: &mut Arc<Resource>, router: &ZenohId) {
+fn unregister_router_queryable(tables: &mut Tables, res: &mut Arc<Resource>, router: &ZenohIdInner) {
     res_hat_mut!(res).router_qabls.remove(router);
 
     if res_hat!(res).router_qabls.is_empty() {
@@ -661,7 +661,7 @@ fn undeclare_router_queryable(
     tables: &mut Tables,
     face: Option<&Arc<FaceState>>,
     res: &mut Arc<Resource>,
-    router: &ZenohId,
+    router: &ZenohIdInner,
 ) {
     if res_hat!(res).router_qabls.contains_key(router) {
         unregister_router_queryable(tables, res, router);
@@ -673,12 +673,12 @@ fn forget_router_queryable(
     tables: &mut Tables,
     face: &mut Arc<FaceState>,
     res: &mut Arc<Resource>,
-    router: &ZenohId,
+    router: &ZenohIdInner,
 ) {
     undeclare_router_queryable(tables, Some(face), res, router);
 }
 
-fn unregister_peer_queryable(tables: &mut Tables, res: &mut Arc<Resource>, peer: &ZenohId) {
+fn unregister_peer_queryable(tables: &mut Tables, res: &mut Arc<Resource>, peer: &ZenohIdInner) {
     res_hat_mut!(res).peer_qabls.remove(peer);
 
     if res_hat!(res).peer_qabls.is_empty() {
@@ -692,7 +692,7 @@ fn undeclare_peer_queryable(
     tables: &mut Tables,
     face: Option<&Arc<FaceState>>,
     res: &mut Arc<Resource>,
-    peer: &ZenohId,
+    peer: &ZenohIdInner,
 ) {
     if res_hat!(res).peer_qabls.contains_key(peer) {
         unregister_peer_queryable(tables, res, peer);
@@ -704,7 +704,7 @@ fn forget_peer_queryable(
     tables: &mut Tables,
     face: &mut Arc<FaceState>,
     res: &mut Arc<Resource>,
-    peer: &ZenohId,
+    peer: &ZenohIdInner,
 ) {
     undeclare_peer_queryable(tables, Some(face), res, peer);
 
@@ -810,7 +810,7 @@ fn forget_client_queryable(
     }
 }
 
-pub(super) fn queries_remove_node(tables: &mut Tables, node: &ZenohId, net_type: WhatAmI) {
+pub(super) fn queries_remove_node(tables: &mut Tables, node: &ZenohIdInner, net_type: WhatAmI) {
     match net_type {
         WhatAmI::Router => {
             let mut qabls = vec![];
@@ -857,7 +857,7 @@ pub(super) fn queries_remove_node(tables: &mut Tables, node: &ZenohId, net_type:
     }
 }
 
-pub(super) fn queries_linkstate_change(tables: &mut Tables, zid: &ZenohId, links: &[ZenohId]) {
+pub(super) fn queries_linkstate_change(tables: &mut Tables, zid: &ZenohIdInner, links: &[ZenohIdInner]) {
     if let Some(src_face) = tables.get_face(zid) {
         if hat!(tables).router_peers_failover_brokering && src_face.whatami == WhatAmI::Peer {
             for res in face_hat!(src_face).remote_qabls.values() {
@@ -990,7 +990,7 @@ fn insert_target_for_qabls(
     tables: &Tables,
     net: &Network,
     source: NodeId,
-    qabls: &HashMap<ZenohId, QueryableInfoType>,
+    qabls: &HashMap<ZenohIdInner, QueryableInfoType>,
     complete: bool,
 ) {
     if net.trees.len() > source as usize {

--- a/zenoh/src/net/routing/interceptor/access_control.rs
+++ b/zenoh/src/net/routing/interceptor/access_control.rs
@@ -22,7 +22,7 @@ use std::{any::Any, sync::Arc};
 
 use zenoh_config::{AclConfig, Action, InterceptorFlow, Permission, Subject};
 use zenoh_protocol::{
-    core::ZenohIdInner,
+    core::ZenohIdProto,
     network::{Declare, DeclareBody, NetworkBody, NetworkMessage, Push, Request},
     zenoh::{PushBody, RequestBody},
 };
@@ -45,12 +45,12 @@ pub struct Interface {
 struct EgressAclEnforcer {
     policy_enforcer: Arc<PolicyEnforcer>,
     interface_list: Vec<Interface>,
-    zid: ZenohIdInner,
+    zid: ZenohIdProto,
 }
 struct IngressAclEnforcer {
     policy_enforcer: Arc<PolicyEnforcer>,
     interface_list: Vec<Interface>,
-    zid: ZenohIdInner,
+    zid: ZenohIdProto,
 }
 
 pub(crate) fn acl_interceptor_factories(
@@ -284,7 +284,7 @@ impl InterceptorTrait for EgressAclEnforcer {
 pub trait AclActionMethods {
     fn policy_enforcer(&self) -> Arc<PolicyEnforcer>;
     fn interface_list(&self) -> Vec<Interface>;
-    fn zid(&self) -> ZenohIdInner;
+    fn zid(&self) -> ZenohIdProto;
     fn flow(&self) -> InterceptorFlow;
     fn action(&self, action: Action, log_msg: &str, key_expr: &str) -> Permission {
         let policy_enforcer = self.policy_enforcer();
@@ -342,7 +342,7 @@ impl AclActionMethods for EgressAclEnforcer {
         self.interface_list.clone()
     }
 
-    fn zid(&self) -> ZenohIdInner {
+    fn zid(&self) -> ZenohIdProto {
         self.zid
     }
     fn flow(&self) -> InterceptorFlow {
@@ -359,7 +359,7 @@ impl AclActionMethods for IngressAclEnforcer {
         self.interface_list.clone()
     }
 
-    fn zid(&self) -> ZenohIdInner {
+    fn zid(&self) -> ZenohIdProto {
         self.zid
     }
     fn flow(&self) -> InterceptorFlow {

--- a/zenoh/src/net/routing/interceptor/access_control.rs
+++ b/zenoh/src/net/routing/interceptor/access_control.rs
@@ -22,7 +22,7 @@ use std::{any::Any, sync::Arc};
 
 use zenoh_config::{AclConfig, Action, InterceptorFlow, Permission, Subject};
 use zenoh_protocol::{
-    core::ZenohId,
+    core::ZenohIdInner,
     network::{Declare, DeclareBody, NetworkBody, NetworkMessage, Push, Request},
     zenoh::{PushBody, RequestBody},
 };
@@ -45,12 +45,12 @@ pub struct Interface {
 struct EgressAclEnforcer {
     policy_enforcer: Arc<PolicyEnforcer>,
     interface_list: Vec<Interface>,
-    zid: ZenohId,
+    zid: ZenohIdInner,
 }
 struct IngressAclEnforcer {
     policy_enforcer: Arc<PolicyEnforcer>,
     interface_list: Vec<Interface>,
-    zid: ZenohId,
+    zid: ZenohIdInner,
 }
 
 pub(crate) fn acl_interceptor_factories(
@@ -284,7 +284,7 @@ impl InterceptorTrait for EgressAclEnforcer {
 pub trait AclActionMethods {
     fn policy_enforcer(&self) -> Arc<PolicyEnforcer>;
     fn interface_list(&self) -> Vec<Interface>;
-    fn zid(&self) -> ZenohId;
+    fn zid(&self) -> ZenohIdInner;
     fn flow(&self) -> InterceptorFlow;
     fn action(&self, action: Action, log_msg: &str, key_expr: &str) -> Permission {
         let policy_enforcer = self.policy_enforcer();
@@ -342,7 +342,7 @@ impl AclActionMethods for EgressAclEnforcer {
         self.interface_list.clone()
     }
 
-    fn zid(&self) -> ZenohId {
+    fn zid(&self) -> ZenohIdInner {
         self.zid
     }
     fn flow(&self) -> InterceptorFlow {
@@ -359,7 +359,7 @@ impl AclActionMethods for IngressAclEnforcer {
         self.interface_list.clone()
     }
 
-    fn zid(&self) -> ZenohId {
+    fn zid(&self) -> ZenohIdInner {
         self.zid
     }
     fn flow(&self) -> InterceptorFlow {

--- a/zenoh/src/net/routing/router.rs
+++ b/zenoh/src/net/routing/router.rs
@@ -18,7 +18,7 @@ use std::{
 
 use uhlc::HLC;
 use zenoh_config::Config;
-use zenoh_protocol::core::{WhatAmI, ZenohIdInner};
+use zenoh_protocol::core::{WhatAmI, ZenohIdProto};
 // use zenoh_collections::Timer;
 use zenoh_result::ZResult;
 use zenoh_transport::{multicast::TransportMulticast, unicast::TransportUnicast, TransportPeer};
@@ -45,7 +45,7 @@ pub struct Router {
 
 impl Router {
     pub fn new(
-        zid: ZenohIdInner,
+        zid: ZenohIdProto,
         whatami: WhatAmI,
         hlc: Option<Arc<HLC>>,
         config: &Config,
@@ -176,7 +176,7 @@ impl Router {
         let mux = Arc::new(McastMux::new(transport.clone(), interceptor));
         let face = FaceState::new(
             fid,
-            ZenohIdInner::from_str("1").unwrap(),
+            ZenohIdProto::from_str("1").unwrap(),
             WhatAmI::Peer,
             #[cfg(feature = "stats")]
             None,

--- a/zenoh/src/net/routing/router.rs
+++ b/zenoh/src/net/routing/router.rs
@@ -18,7 +18,7 @@ use std::{
 
 use uhlc::HLC;
 use zenoh_config::Config;
-use zenoh_protocol::core::{WhatAmI, ZenohId};
+use zenoh_protocol::core::{WhatAmI, ZenohIdInner};
 // use zenoh_collections::Timer;
 use zenoh_result::ZResult;
 use zenoh_transport::{multicast::TransportMulticast, unicast::TransportUnicast, TransportPeer};
@@ -45,7 +45,7 @@ pub struct Router {
 
 impl Router {
     pub fn new(
-        zid: ZenohId,
+        zid: ZenohIdInner,
         whatami: WhatAmI,
         hlc: Option<Arc<HLC>>,
         config: &Config,
@@ -176,7 +176,7 @@ impl Router {
         let mux = Arc::new(McastMux::new(transport.clone(), interceptor));
         let face = FaceState::new(
             fid,
-            ZenohId::from_str("1").unwrap(),
+            ZenohIdInner::from_str("1").unwrap(),
             WhatAmI::Peer,
             #[cfg(feature = "stats")]
             None,

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -19,14 +19,14 @@ use std::{
 use serde_json::json;
 use tracing::{error, trace};
 use zenoh_buffers::buffer::SplitBuffer;
-use zenoh_config::{unwrap_or_default, ConfigValidator, ValidatedMap, WhatAmI, ZenohId};
+use zenoh_config::{unwrap_or_default, ConfigValidator, ValidatedMap, WhatAmI};
 use zenoh_core::Wait;
 #[cfg(feature = "plugins")]
 use zenoh_plugin_trait::{PluginControl, PluginStatus};
 #[cfg(feature = "plugins")]
 use zenoh_protocol::core::key_expr::keyexpr;
 use zenoh_protocol::{
-    core::{key_expr::OwnedKeyExpr, ExprId, WireExpr, EMPTY_EXPR_ID},
+    core::{key_expr::OwnedKeyExpr, ExprId, WireExpr, ZenohId, EMPTY_EXPR_ID},
     network::{
         declare::{
             queryable::ext::QueryableInfoType, subscriber::ext::SubscriberInfo, QueryableId,

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -19,14 +19,14 @@ use std::{
 use serde_json::json;
 use tracing::{error, trace};
 use zenoh_buffers::buffer::SplitBuffer;
-use zenoh_config::{unwrap_or_default, ConfigValidator, ValidatedMap, WhatAmI};
+use zenoh_config::{unwrap_or_default, wrappers::ZenohId, ConfigValidator, ValidatedMap, WhatAmI};
 use zenoh_core::Wait;
 #[cfg(feature = "plugins")]
 use zenoh_plugin_trait::{PluginControl, PluginStatus};
 #[cfg(feature = "plugins")]
 use zenoh_protocol::core::key_expr::keyexpr;
 use zenoh_protocol::{
-    core::{key_expr::OwnedKeyExpr, ExprId, WireExpr, ZenohId, EMPTY_EXPR_ID},
+    core::{key_expr::OwnedKeyExpr, ExprId, WireExpr, EMPTY_EXPR_ID},
     network::{
         declare::{
             queryable::ext::QueryableInfoType, subscriber::ext::SubscriberInfo, QueryableId,

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -36,10 +36,11 @@ use futures::{stream::StreamExt, Future};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use uhlc::{HLCBuilder, HLC};
+use zenoh_config::wrappers::ZenohId;
 use zenoh_link::{EndPoint, Link};
 use zenoh_plugin_trait::{PluginStartArgs, StructVersion};
 use zenoh_protocol::{
-    core::{Locator, WhatAmI, ZenohId},
+    core::{Locator, WhatAmI},
     network::NetworkMessage,
 };
 use zenoh_result::{bail, ZResult};

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -36,11 +36,10 @@ use futures::{stream::StreamExt, Future};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use uhlc::{HLCBuilder, HLC};
-use zenoh_config::ZenohId;
 use zenoh_link::{EndPoint, Link};
 use zenoh_plugin_trait::{PluginStartArgs, StructVersion};
 use zenoh_protocol::{
-    core::{Locator, WhatAmI},
+    core::{Locator, WhatAmI, ZenohId},
     network::NetworkMessage,
 };
 use zenoh_result::{bail, ZResult};

--- a/zenoh/src/net/runtime/orchestrator.rs
+++ b/zenoh/src/net/runtime/orchestrator.rs
@@ -32,7 +32,7 @@ use zenoh_config::{
 };
 use zenoh_link::{Locator, LocatorInspector};
 use zenoh_protocol::{
-    core::{whatami::WhatAmIMatcher, EndPoint, WhatAmI, ZenohId},
+    core::{whatami::WhatAmIMatcher, EndPoint, WhatAmI, ZenohIdInner},
     scouting::{Hello, Scout, ScoutingBody, ScoutingMessage},
 };
 use zenoh_result::{bail, zerror, ZResult};
@@ -53,7 +53,7 @@ pub enum Loop {
 
 #[derive(Default, Debug)]
 pub(crate) struct PeerConnector {
-    zid: Option<ZenohId>,
+    zid: Option<ZenohIdInner>,
     terminated: bool,
 }
 
@@ -74,7 +74,7 @@ impl StartConditions {
         peer_connectors.len() - 1
     }
 
-    pub(crate) async fn add_peer_connector_zid(&self, zid: ZenohId) {
+    pub(crate) async fn add_peer_connector_zid(&self, zid: ZenohIdInner) {
         let mut peer_connectors = self.peer_connectors.lock().await;
         if !peer_connectors.iter().any(|pc| pc.zid == Some(zid)) {
             peer_connectors.push(PeerConnector {
@@ -84,7 +84,7 @@ impl StartConditions {
         }
     }
 
-    pub(crate) async fn set_peer_connector_zid(&self, idx: usize, zid: ZenohId) {
+    pub(crate) async fn set_peer_connector_zid(&self, idx: usize, zid: ZenohIdInner) {
         let mut peer_connectors = self.peer_connectors.lock().await;
         if let Some(peer_connector) = peer_connectors.get_mut(idx) {
             peer_connector.zid = Some(zid);
@@ -101,7 +101,7 @@ impl StartConditions {
         }
     }
 
-    pub(crate) async fn terminate_peer_connector_zid(&self, zid: ZenohId) {
+    pub(crate) async fn terminate_peer_connector_zid(&self, zid: ZenohIdInner) {
         let mut peer_connectors = self.peer_connectors.lock().await;
         if let Some(peer_connector) = peer_connectors.iter_mut().find(|pc| pc.zid == Some(zid)) {
             peer_connector.terminated = true;
@@ -777,7 +777,7 @@ impl Runtime {
         }
     }
 
-    async fn peer_connector_retry(&self, peer: EndPoint) -> ZResult<ZenohId> {
+    async fn peer_connector_retry(&self, peer: EndPoint) -> ZResult<ZenohIdInner> {
         let retry_config = self.get_connect_retry_config(&peer);
         let mut period = retry_config.period();
         let cancellation_token = self.get_cancellation_token();
@@ -920,7 +920,7 @@ impl Runtime {
     }
 
     #[must_use]
-    async fn connect(&self, zid: &ZenohId, locators: &[Locator]) -> bool {
+    async fn connect(&self, zid: &ZenohIdInner, locators: &[Locator]) -> bool {
         const ERR: &str = "Unable to connect to newly scouted peer ";
 
         let inspector = LocatorInspector::default();
@@ -981,7 +981,7 @@ impl Runtime {
         false
     }
 
-    pub async fn connect_peer(&self, zid: &ZenohId, locators: &[Locator]) {
+    pub async fn connect_peer(&self, zid: &ZenohIdInner, locators: &[Locator]) {
         let manager = self.manager();
         if zid != &manager.zid() {
             let has_unicast = manager.get_transport_unicast(zid).await.is_some();

--- a/zenoh/src/net/runtime/orchestrator.rs
+++ b/zenoh/src/net/runtime/orchestrator.rs
@@ -32,8 +32,8 @@ use zenoh_config::{
 };
 use zenoh_link::{Locator, LocatorInspector};
 use zenoh_protocol::{
-    core::{whatami::WhatAmIMatcher, EndPoint, WhatAmI, ZenohIdInner},
-    scouting::{HelloInner, Scout, ScoutingBody, ScoutingMessage},
+    core::{whatami::WhatAmIMatcher, EndPoint, WhatAmI, ZenohIdProto},
+    scouting::{HelloProto, Scout, ScoutingBody, ScoutingMessage},
 };
 use zenoh_result::{bail, zerror, ZResult};
 
@@ -53,7 +53,7 @@ pub enum Loop {
 
 #[derive(Default, Debug)]
 pub(crate) struct PeerConnector {
-    zid: Option<ZenohIdInner>,
+    zid: Option<ZenohIdProto>,
     terminated: bool,
 }
 
@@ -74,7 +74,7 @@ impl StartConditions {
         peer_connectors.len() - 1
     }
 
-    pub(crate) async fn add_peer_connector_zid(&self, zid: ZenohIdInner) {
+    pub(crate) async fn add_peer_connector_zid(&self, zid: ZenohIdProto) {
         let mut peer_connectors = self.peer_connectors.lock().await;
         if !peer_connectors.iter().any(|pc| pc.zid == Some(zid)) {
             peer_connectors.push(PeerConnector {
@@ -84,7 +84,7 @@ impl StartConditions {
         }
     }
 
-    pub(crate) async fn set_peer_connector_zid(&self, idx: usize, zid: ZenohIdInner) {
+    pub(crate) async fn set_peer_connector_zid(&self, idx: usize, zid: ZenohIdProto) {
         let mut peer_connectors = self.peer_connectors.lock().await;
         if let Some(peer_connector) = peer_connectors.get_mut(idx) {
             peer_connector.zid = Some(zid);
@@ -101,7 +101,7 @@ impl StartConditions {
         }
     }
 
-    pub(crate) async fn terminate_peer_connector_zid(&self, zid: ZenohIdInner) {
+    pub(crate) async fn terminate_peer_connector_zid(&self, zid: ZenohIdProto) {
         let mut peer_connectors = self.peer_connectors.lock().await;
         if let Some(peer_connector) = peer_connectors.iter_mut().find(|pc| pc.zid == Some(zid)) {
             peer_connector.terminated = true;
@@ -777,7 +777,7 @@ impl Runtime {
         }
     }
 
-    async fn peer_connector_retry(&self, peer: EndPoint) -> ZResult<ZenohIdInner> {
+    async fn peer_connector_retry(&self, peer: EndPoint) -> ZResult<ZenohIdProto> {
         let retry_config = self.get_connect_retry_config(&peer);
         let mut period = retry_config.period();
         let cancellation_token = self.get_cancellation_token();
@@ -829,7 +829,7 @@ impl Runtime {
         mcast_addr: &SocketAddr,
         f: F,
     ) where
-        F: Fn(HelloInner) -> Fut + std::marker::Send + std::marker::Sync + Clone,
+        F: Fn(HelloProto) -> Fut + std::marker::Send + std::marker::Sync + Clone,
         Fut: Future<Output = Loop> + std::marker::Send,
         Self: Sized,
     {
@@ -920,7 +920,7 @@ impl Runtime {
     }
 
     #[must_use]
-    async fn connect(&self, zid: &ZenohIdInner, locators: &[Locator]) -> bool {
+    async fn connect(&self, zid: &ZenohIdProto, locators: &[Locator]) -> bool {
         const ERR: &str = "Unable to connect to newly scouted peer ";
 
         let inspector = LocatorInspector::default();
@@ -981,7 +981,7 @@ impl Runtime {
         false
     }
 
-    pub async fn connect_peer(&self, zid: &ZenohIdInner, locators: &[Locator]) {
+    pub async fn connect_peer(&self, zid: &ZenohIdProto, locators: &[Locator]) {
         let manager = self.manager();
         if zid != &manager.zid() {
             let has_unicast = manager.get_transport_unicast(zid).await.is_some();
@@ -1104,7 +1104,7 @@ impl Runtime {
                         let codec = Zenoh080::new();
 
                         let zid = self.manager().zid();
-                        let hello: ScoutingMessage = HelloInner {
+                        let hello: ScoutingMessage = HelloProto {
                             version: zenoh_protocol::VERSION,
                             whatami: self.whatami(),
                             zid,

--- a/zenoh/src/net/runtime/orchestrator.rs
+++ b/zenoh/src/net/runtime/orchestrator.rs
@@ -33,7 +33,7 @@ use zenoh_config::{
 use zenoh_link::{Locator, LocatorInspector};
 use zenoh_protocol::{
     core::{whatami::WhatAmIMatcher, EndPoint, WhatAmI, ZenohIdInner},
-    scouting::{Hello, Scout, ScoutingBody, ScoutingMessage},
+    scouting::{HelloInner, Scout, ScoutingBody, ScoutingMessage},
 };
 use zenoh_result::{bail, zerror, ZResult};
 
@@ -829,7 +829,7 @@ impl Runtime {
         mcast_addr: &SocketAddr,
         f: F,
     ) where
-        F: Fn(Hello) -> Fut + std::marker::Send + std::marker::Sync + Clone,
+        F: Fn(HelloInner) -> Fut + std::marker::Send + std::marker::Sync + Clone,
         Fut: Future<Output = Loop> + std::marker::Send,
         Self: Sized,
     {
@@ -1104,7 +1104,7 @@ impl Runtime {
                         let codec = Zenoh080::new();
 
                         let zid = self.manager().zid();
-                        let hello: ScoutingMessage = Hello {
+                        let hello: ScoutingMessage = HelloInner {
                             version: zenoh_protocol::VERSION,
                             whatami: self.whatami(),
                             zid,

--- a/zenoh/src/net/tests/tables.rs
+++ b/zenoh/src/net/tests/tables.rs
@@ -22,7 +22,8 @@ use zenoh_config::Config;
 use zenoh_core::zlock;
 use zenoh_protocol::{
     core::{
-        key_expr::keyexpr, Encoding, ExprId, Reliability, WhatAmI, WireExpr, ZenohIdInner, EMPTY_EXPR_ID,
+        key_expr::keyexpr, Encoding, ExprId, Reliability, WhatAmI, WireExpr, ZenohIdInner,
+        EMPTY_EXPR_ID,
     },
     network::{
         declare::subscriber::ext::SubscriberInfo, ext, Declare, DeclareBody, DeclareKeyExpr,

--- a/zenoh/src/net/tests/tables.rs
+++ b/zenoh/src/net/tests/tables.rs
@@ -22,7 +22,7 @@ use zenoh_config::Config;
 use zenoh_core::zlock;
 use zenoh_protocol::{
     core::{
-        key_expr::keyexpr, Encoding, ExprId, Reliability, WhatAmI, WireExpr, ZenohId, EMPTY_EXPR_ID,
+        key_expr::keyexpr, Encoding, ExprId, Reliability, WhatAmI, WireExpr, ZenohIdInner, EMPTY_EXPR_ID,
     },
     network::{
         declare::subscriber::ext::SubscriberInfo, ext, Declare, DeclareBody, DeclareKeyExpr,
@@ -43,7 +43,7 @@ use crate::net::{
 fn base_test() {
     let config = Config::default();
     let router = Router::new(
-        ZenohId::try_from([1]).unwrap(),
+        ZenohIdInner::try_from([1]).unwrap(),
         WhatAmI::Client,
         Some(Arc::new(HLC::default())),
         &config,
@@ -139,7 +139,7 @@ fn match_test() {
 
     let config = Config::default();
     let router = Router::new(
-        ZenohId::try_from([1]).unwrap(),
+        ZenohIdInner::try_from([1]).unwrap(),
         WhatAmI::Client,
         Some(Arc::new(HLC::default())),
         &config,
@@ -179,7 +179,7 @@ fn match_test() {
 fn multisub_test() {
     let config = Config::default();
     let router = Router::new(
-        ZenohId::try_from([1]).unwrap(),
+        ZenohIdInner::try_from([1]).unwrap(),
         WhatAmI::Client,
         Some(Arc::new(HLC::default())),
         &config,
@@ -248,7 +248,7 @@ fn multisub_test() {
 async fn clean_test() {
     let config = Config::default();
     let router = Router::new(
-        ZenohId::try_from([1]).unwrap(),
+        ZenohIdInner::try_from([1]).unwrap(),
         WhatAmI::Client,
         Some(Arc::new(HLC::default())),
         &config,
@@ -568,7 +568,7 @@ impl EPrimitives for ClientPrimitives {
 fn client_test() {
     let config = Config::default();
     let router = Router::new(
-        ZenohId::try_from([1]).unwrap(),
+        ZenohIdInner::try_from([1]).unwrap(),
         WhatAmI::Client,
         Some(Arc::new(HLC::default())),
         &config,

--- a/zenoh/src/net/tests/tables.rs
+++ b/zenoh/src/net/tests/tables.rs
@@ -22,7 +22,7 @@ use zenoh_config::Config;
 use zenoh_core::zlock;
 use zenoh_protocol::{
     core::{
-        key_expr::keyexpr, Encoding, ExprId, Reliability, WhatAmI, WireExpr, ZenohIdInner,
+        key_expr::keyexpr, Encoding, ExprId, Reliability, WhatAmI, WireExpr, ZenohIdProto,
         EMPTY_EXPR_ID,
     },
     network::{
@@ -44,7 +44,7 @@ use crate::net::{
 fn base_test() {
     let config = Config::default();
     let router = Router::new(
-        ZenohIdInner::try_from([1]).unwrap(),
+        ZenohIdProto::try_from([1]).unwrap(),
         WhatAmI::Client,
         Some(Arc::new(HLC::default())),
         &config,
@@ -140,7 +140,7 @@ fn match_test() {
 
     let config = Config::default();
     let router = Router::new(
-        ZenohIdInner::try_from([1]).unwrap(),
+        ZenohIdProto::try_from([1]).unwrap(),
         WhatAmI::Client,
         Some(Arc::new(HLC::default())),
         &config,
@@ -180,7 +180,7 @@ fn match_test() {
 fn multisub_test() {
     let config = Config::default();
     let router = Router::new(
-        ZenohIdInner::try_from([1]).unwrap(),
+        ZenohIdProto::try_from([1]).unwrap(),
         WhatAmI::Client,
         Some(Arc::new(HLC::default())),
         &config,
@@ -249,7 +249,7 @@ fn multisub_test() {
 async fn clean_test() {
     let config = Config::default();
     let router = Router::new(
-        ZenohIdInner::try_from([1]).unwrap(),
+        ZenohIdProto::try_from([1]).unwrap(),
         WhatAmI::Client,
         Some(Arc::new(HLC::default())),
         &config,
@@ -569,7 +569,7 @@ impl EPrimitives for ClientPrimitives {
 fn client_test() {
     let config = Config::default();
     let router = Router::new(
-        ZenohIdInner::try_from([1]).unwrap(),
+        ZenohIdProto::try_from([1]).unwrap(),
         WhatAmI::Client,
         Some(Arc::new(HLC::default())),
         &config,


### PR DESCRIPTION
There are structures with public fields and/or public methods which should not be in the API in the internal crates. These structures should be also exported in the API without these public items. This update proposes common rule how tho handle such structures:
- structures which are completely internal for zenoh crate should have suffix `Inner` (this is the case for some shm structs)
- structures which are used by extra libraries / tools, like structures exposed by zenoh-protocol should have suffix corresponding to crate name, like `...Proto`
- corresponding wrapper API structures reexported by zenoh have no suffix and located now in `zenoh-config::wrappers` crate

This PR proposes updates above for `ZenohId`, `EntityGlobalId` and `Hello`

Also it moves `ZenohId` from `config::` to `info::`. This seems more logical 
