### PR TITLE
refactor: make `Encoding` take only one word in memory

### DIFF
--- a/commons/zenoh-codec/src/core/encoding.rs
+++ b/commons/zenoh-codec/src/core/encoding.rs
@@ -73,7 +73,7 @@ where
         let mut encoding = Encoding::new(id);
         if has_schema {
             let zodec = Zenoh080Bounded::<u8>::new();
-            let schema: String = zodec.read(&mut *reader)?;
+            let schema: alloc::string::String = zodec.read(&mut *reader)?;
             encoding = encoding.with_schema(schema);
         }
 

--- a/commons/zenoh-codec/src/core/encoding.rs
+++ b/commons/zenoh-codec/src/core/encoding.rs
@@ -24,9 +24,10 @@ use crate::{LCodec, RCodec, WCodec, Zenoh080, Zenoh080Bounded};
 
 impl LCodec<&Encoding> for Zenoh080 {
     fn w_len(self, x: &Encoding) -> usize {
-        let mut len = self.w_len((x.id as u32) << 1);
-        if let Some(schema) = x.schema.as_ref() {
-            len += self.w_len(schema.as_slice());
+        let (id, schema) = x.id_and_schema();
+        let mut len = self.w_len((id as u32) << 1);
+        if let Some(schema) = schema {
+            len += self.w_len(schema);
         }
         len
     }
@@ -39,14 +40,15 @@ where
     type Output = Result<(), DidntWrite>;
 
     fn write(self, writer: &mut W, x: &Encoding) -> Self::Output {
-        let mut id = (x.id as u32) << 1;
+        let (id, schema) = x.id_and_schema();
+        let mut id = (id as u32) << 1;
 
-        if x.schema.is_some() {
+        if schema.is_some() {
             id |= flag::S;
         }
         let zodec = Zenoh080Bounded::<u32>::new();
         zodec.write(&mut *writer, id)?;
-        if let Some(schema) = x.schema.as_ref() {
+        if let Some(schema) = schema {
             let zodec = Zenoh080Bounded::<u8>::new();
             zodec.write(&mut *writer, schema)?;
         }
@@ -68,13 +70,13 @@ where
             imsg::has_flag(id as u8, flag::S as u8),
         );
 
-        let mut schema = None;
+        let mut encoding = Encoding::new(id);
         if has_schema {
             let zodec = Zenoh080Bounded::<u8>::new();
-            schema = Some(zodec.read(&mut *reader)?);
+            let schema: String = zodec.read(&mut *reader)?;
+            encoding = encoding.with_schema(schema);
         }
 
-        let encoding = Encoding { id, schema };
         Ok(encoding)
     }
 }

--- a/commons/zenoh-protocol/src/core/encoding.rs
+++ b/commons/zenoh-protocol/src/core/encoding.rs
@@ -150,9 +150,13 @@ impl Clone for Encoding {
         let inner = unsafe { &*self.0.ptr };
         // See `Arc` code
         if inner.rc.fetch_add(1, Ordering::Relaxed) > (isize::MAX as usize) {
+            #[cfg(feature = "std")]
+            std::process::abort();
             // intrinsics::abort is not available on stable rust...
-            // However, this situation should never be encountered in normal program
-            loop {}
+            // However, this situation should never be encountered in normal program, so panic,
+            // hoping than panic handler will abort.
+            #[cfg(not(feature = "std"))]
+            panic!("This program is incredibly degenerate");
         }
         Self(EncodingIdOrPointer { ptr: inner })
     }

--- a/zenoh/src/api/encoding.rs
+++ b/zenoh/src/api/encoding.rs
@@ -14,7 +14,7 @@
 use std::{borrow::Cow, convert::Infallible, fmt, str::FromStr};
 
 use phf::phf_map;
-use zenoh_buffers::{ZBuf, ZSlice};
+use zenoh_buffers::ZBuf;
 use zenoh_protocol::core::EncodingId;
 #[cfg(feature = "shared-memory")]
 use zenoh_shm::api::buffer::{zshm::ZShm, zshmmut::ZShmMut};
@@ -85,405 +85,237 @@ impl Encoding {
     /// Just some bytes.
     ///
     /// Constant alias for string: `"zenoh/bytes"`.
-    pub const ZENOH_BYTES: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 0,
-        schema: None,
-    });
+    pub const ZENOH_BYTES: Encoding = Self(zenoh_protocol::core::Encoding::new(0));
     /// A VLE-encoded signed little-endian integer. Either 8bit, 16bit, 32bit, or 64bit. Binary reprensentation uses two's complement.
     ///
     /// Constant alias for string: `"zenoh/int"`.
-    pub const ZENOH_INT: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 1,
-        schema: None,
-    });
+    pub const ZENOH_INT: Encoding = Self(zenoh_protocol::core::Encoding::new(1));
     /// A VLE-encoded little-endian unsigned integer. Either 8bit, 16bit, 32bit, or 64bit.
     ///
     /// Constant alias for string: `"zenoh/uint"`.
-    pub const ZENOH_UINT: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 2,
-        schema: None,
-    });
+    pub const ZENOH_UINT: Encoding = Self(zenoh_protocol::core::Encoding::new(2));
     /// A VLE-encoded float. Either little-endian 32bit or 64bit. Binary representation uses *IEEE 754-2008* *binary32* or *binary64*, respectively.
     ///
     /// Constant alias for string: `"zenoh/float"`.
-    pub const ZENOH_FLOAT: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 3,
-        schema: None,
-    });
+    pub const ZENOH_FLOAT: Encoding = Self(zenoh_protocol::core::Encoding::new(3));
     /// A boolean. `0` is `false`, `1` is `true`. Other values are invalid.
     ///
     /// Constant alias for string: `"zenoh/bool"`.
-    pub const ZENOH_BOOL: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 4,
-        schema: None,
-    });
+    pub const ZENOH_BOOL: Encoding = Self(zenoh_protocol::core::Encoding::new(4));
     /// A UTF-8 string.
     ///
     /// Constant alias for string: `"zenoh/string"`.
-    pub const ZENOH_STRING: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 5,
-        schema: None,
-    });
+    pub const ZENOH_STRING: Encoding = Self(zenoh_protocol::core::Encoding::new(5));
     /// A zenoh error.
     ///
     /// Constant alias for string: `"zenoh/error"`.
-    pub const ZENOH_ERROR: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 6,
-        schema: None,
-    });
+    pub const ZENOH_ERROR: Encoding = Self(zenoh_protocol::core::Encoding::new(6));
 
     // - Advanced types may be supported in some of the Zenoh bindings.
     /// An application-specific stream of bytes.
     ///
     /// Constant alias for string: `"application/octet-stream"`.
-    pub const APPLICATION_OCTET_STREAM: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 7,
-        schema: None,
-    });
+    pub const APPLICATION_OCTET_STREAM: Encoding = Self(zenoh_protocol::core::Encoding::new(7));
     /// A textual file.
     ///
     /// Constant alias for string: `"text/plain"`.
-    pub const TEXT_PLAIN: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 8,
-        schema: None,
-    });
+    pub const TEXT_PLAIN: Encoding = Self(zenoh_protocol::core::Encoding::new(8));
     /// JSON data intended to be consumed by an application.
     ///
     /// Constant alias for string: `"application/json"`.
-    pub const APPLICATION_JSON: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 9,
-        schema: None,
-    });
+    pub const APPLICATION_JSON: Encoding = Self(zenoh_protocol::core::Encoding::new(9));
     /// JSON data intended to be human readable.
     ///
     /// Constant alias for string: `"text/json"`.
-    pub const TEXT_JSON: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 10,
-        schema: None,
-    });
+    pub const TEXT_JSON: Encoding = Self(zenoh_protocol::core::Encoding::new(10));
     /// A Common Data Representation (CDR)-encoded data.
     ///
     /// Constant alias for string: `"application/cdr"`.
-    pub const APPLICATION_CDR: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 11,
-        schema: None,
-    });
+    pub const APPLICATION_CDR: Encoding = Self(zenoh_protocol::core::Encoding::new(11));
     /// A Concise Binary Object Representation (CBOR)-encoded data.
     ///
     /// Constant alias for string: `"application/cbor"`.
-    pub const APPLICATION_CBOR: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 12,
-        schema: None,
-    });
+    pub const APPLICATION_CBOR: Encoding = Self(zenoh_protocol::core::Encoding::new(12));
     /// YAML data intended to be consumed by an application.
     ///
     /// Constant alias for string: `"application/yaml"`.
-    pub const APPLICATION_YAML: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 13,
-        schema: None,
-    });
+    pub const APPLICATION_YAML: Encoding = Self(zenoh_protocol::core::Encoding::new(13));
     /// YAML data intended to be human readable.
     ///
     /// Constant alias for string: `"text/yaml"`.
-    pub const TEXT_YAML: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 14,
-        schema: None,
-    });
+    pub const TEXT_YAML: Encoding = Self(zenoh_protocol::core::Encoding::new(14));
     /// JSON5 encoded data that are human readable.
     ///
     /// Constant alias for string: `"text/json5"`.
-    pub const TEXT_JSON5: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 15,
-        schema: None,
-    });
+    pub const TEXT_JSON5: Encoding = Self(zenoh_protocol::core::Encoding::new(15));
     /// A Python object serialized using [pickle](https://docs.python.org/3/library/pickle.html).
     ///
     /// Constant alias for string: `"application/python-serialized-object"`.
     pub const APPLICATION_PYTHON_SERIALIZED_OBJECT: Encoding =
-        Self(zenoh_protocol::core::Encoding {
-            id: 16,
-            schema: None,
-        });
+        Self(zenoh_protocol::core::Encoding::new(16));
     /// An application-specific protobuf-encoded data.
     ///
     /// Constant alias for string: `"application/protobuf"`.
-    pub const APPLICATION_PROTOBUF: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 17,
-        schema: None,
-    });
+    pub const APPLICATION_PROTOBUF: Encoding = Self(zenoh_protocol::core::Encoding::new(17));
     /// A Java serialized object.
     ///
     /// Constant alias for string: `"application/java-serialized-object"`.
-    pub const APPLICATION_JAVA_SERIALIZED_OBJECT: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 18,
-        schema: None,
-    });
+    pub const APPLICATION_JAVA_SERIALIZED_OBJECT: Encoding =
+        Self(zenoh_protocol::core::Encoding::new(18));
     /// An [openmetrics](https://github.com/OpenObservability/OpenMetrics) data, common used by [Prometheus](https://prometheus.io/).
     ///
     /// Constant alias for string: `"application/openmetrics-text"`.
-    pub const APPLICATION_OPENMETRICS_TEXT: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 19,
-        schema: None,
-    });
+    pub const APPLICATION_OPENMETRICS_TEXT: Encoding =
+        Self(zenoh_protocol::core::Encoding::new(19));
     /// A Portable Network Graphics (PNG) image.
     ///
     /// Constant alias for string: `"image/png"`.
-    pub const IMAGE_PNG: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 20,
-        schema: None,
-    });
+    pub const IMAGE_PNG: Encoding = Self(zenoh_protocol::core::Encoding::new(20));
     /// A Joint Photographic Experts Group (JPEG) image.
     ///
     /// Constant alias for string: `"image/jpeg"`.
-    pub const IMAGE_JPEG: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 21,
-        schema: None,
-    });
+    pub const IMAGE_JPEG: Encoding = Self(zenoh_protocol::core::Encoding::new(21));
     /// A Graphics Interchange Format (GIF) image.
     ///
     /// Constant alias for string: `"image/gif"`.
-    pub const IMAGE_GIF: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 22,
-        schema: None,
-    });
+    pub const IMAGE_GIF: Encoding = Self(zenoh_protocol::core::Encoding::new(22));
     /// A BitMap (BMP) image.
     ///
     /// Constant alias for string: `"image/bmp"`.
-    pub const IMAGE_BMP: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 23,
-        schema: None,
-    });
+    pub const IMAGE_BMP: Encoding = Self(zenoh_protocol::core::Encoding::new(23));
     /// A Web Protable (WebP) image.
     ///
     ///  Constant alias for string: `"image/webp"`.
-    pub const IMAGE_WEBP: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 24,
-        schema: None,
-    });
+    pub const IMAGE_WEBP: Encoding = Self(zenoh_protocol::core::Encoding::new(24));
     /// An XML file intended to be consumed by an application..
     ///
     /// Constant alias for string: `"application/xml"`.
-    pub const APPLICATION_XML: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 25,
-        schema: None,
-    });
+    pub const APPLICATION_XML: Encoding = Self(zenoh_protocol::core::Encoding::new(25));
     /// An encoded a list of tuples, each consisting of a name and a value.
     ///
     /// Constant alias for string: `"application/x-www-form-urlencoded"`.
-    pub const APPLICATION_X_WWW_FORM_URLENCODED: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 26,
-        schema: None,
-    });
+    pub const APPLICATION_X_WWW_FORM_URLENCODED: Encoding =
+        Self(zenoh_protocol::core::Encoding::new(26));
     /// An HTML file.
     ///
     /// Constant alias for string: `"text/html"`.
-    pub const TEXT_HTML: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 27,
-        schema: None,
-    });
+    pub const TEXT_HTML: Encoding = Self(zenoh_protocol::core::Encoding::new(27));
     /// An XML file that is human readable.
     ///
     /// Constant alias for string: `"text/xml"`.
-    pub const TEXT_XML: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 28,
-        schema: None,
-    });
+    pub const TEXT_XML: Encoding = Self(zenoh_protocol::core::Encoding::new(28));
     /// A CSS file.
     ///
     /// Constant alias for string: `"text/css"`.
-    pub const TEXT_CSS: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 29,
-        schema: None,
-    });
+    pub const TEXT_CSS: Encoding = Self(zenoh_protocol::core::Encoding::new(29));
     /// A JavaScript file.
     ///
     /// Constant alias for string: `"text/javascript"`.
-    pub const TEXT_JAVASCRIPT: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 30,
-        schema: None,
-    });
+    pub const TEXT_JAVASCRIPT: Encoding = Self(zenoh_protocol::core::Encoding::new(30));
     /// A MarkDown file.
     ///
     /// Constant alias for string: `"text/markdown"`.
-    pub const TEXT_MARKDOWN: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 31,
-        schema: None,
-    });
+    pub const TEXT_MARKDOWN: Encoding = Self(zenoh_protocol::core::Encoding::new(31));
     /// A CSV file.
     ///
     /// Constant alias for string: `"text/csv"`.
-    pub const TEXT_CSV: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 32,
-        schema: None,
-    });
+    pub const TEXT_CSV: Encoding = Self(zenoh_protocol::core::Encoding::new(32));
     /// An application-specific SQL query.
     ///
     /// Constant alias for string: `"application/sql"`.
-    pub const APPLICATION_SQL: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 33,
-        schema: None,
-    });
+    pub const APPLICATION_SQL: Encoding = Self(zenoh_protocol::core::Encoding::new(33));
     /// Constrained Application Protocol (CoAP) data intended for CoAP-to-HTTP and HTTP-to-CoAP proxies.
     ///
     /// Constant alias for string: `"application/coap-payload"`.
-    pub const APPLICATION_COAP_PAYLOAD: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 34,
-        schema: None,
-    });
+    pub const APPLICATION_COAP_PAYLOAD: Encoding = Self(zenoh_protocol::core::Encoding::new(34));
     /// Defines a JSON document structure for expressing a sequence of operations to apply to a JSON document.
     ///
     /// Constant alias for string: `"application/json-patch+json"`.
-    pub const APPLICATION_JSON_PATCH_JSON: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 35,
-        schema: None,
-    });
+    pub const APPLICATION_JSON_PATCH_JSON: Encoding = Self(zenoh_protocol::core::Encoding::new(35));
     /// A JSON text sequence consists of any number of JSON texts, all encoded in UTF-8.
     ///
     /// Constant alias for string: `"application/json-seq"`.
-    pub const APPLICATION_JSON_SEQ: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 36,
-        schema: None,
-    });
+    pub const APPLICATION_JSON_SEQ: Encoding = Self(zenoh_protocol::core::Encoding::new(36));
     /// A JSONPath defines a string syntax for selecting and extracting JSON values from within a given JSON value.
     ///
     /// Constant alias for string: `"application/jsonpath"`.
-    pub const APPLICATION_JSONPATH: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 37,
-        schema: None,
-    });
+    pub const APPLICATION_JSONPATH: Encoding = Self(zenoh_protocol::core::Encoding::new(37));
     /// A JSON Web Token (JWT).
     ///
     /// Constant alias for string: `"application/jwt"`.
-    pub const APPLICATION_JWT: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 38,
-        schema: None,
-    });
+    pub const APPLICATION_JWT: Encoding = Self(zenoh_protocol::core::Encoding::new(38));
     /// An application-specific MPEG-4 encoded data, either audio or video.
     ///
     /// Constant alias for string: `"application/mp4"`.
-    pub const APPLICATION_MP4: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 39,
-        schema: None,
-    });
+    pub const APPLICATION_MP4: Encoding = Self(zenoh_protocol::core::Encoding::new(39));
     /// A SOAP 1.2 message serialized as XML 1.0.
     ///
     /// Constant alias for string: `"application/soap+xml"`.
-    pub const APPLICATION_SOAP_XML: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 40,
-        schema: None,
-    });
+    pub const APPLICATION_SOAP_XML: Encoding = Self(zenoh_protocol::core::Encoding::new(40));
     /// A YANG-encoded data commonly used by the Network Configuration Protocol (NETCONF).
     ///
     /// Constant alias for string: `"application/yang"`.
-    pub const APPLICATION_YANG: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 41,
-        schema: None,
-    });
+    pub const APPLICATION_YANG: Encoding = Self(zenoh_protocol::core::Encoding::new(41));
     /// A MPEG-4 Advanced Audio Coding (AAC) media.
     ///
     /// Constant alias for string: `"audio/aac"`.
-    pub const AUDIO_AAC: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 42,
-        schema: None,
-    });
+    pub const AUDIO_AAC: Encoding = Self(zenoh_protocol::core::Encoding::new(42));
     /// A Free Lossless Audio Codec (FLAC) media.
     ///
     /// Constant alias for string: `"audio/flac"`.
-    pub const AUDIO_FLAC: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 43,
-        schema: None,
-    });
+    pub const AUDIO_FLAC: Encoding = Self(zenoh_protocol::core::Encoding::new(43));
     /// An audio codec defined in MPEG-1, MPEG-2, MPEG-4, or registered at the MP4 registration authority.
     ///
     /// Constant alias for string: `"audio/mp4"`.
-    pub const AUDIO_MP4: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 44,
-        schema: None,
-    });
+    pub const AUDIO_MP4: Encoding = Self(zenoh_protocol::core::Encoding::new(44));
     /// An Ogg-encapsulated audio stream.
     ///
     /// Constant alias for string: `"audio/ogg"`.
-    pub const AUDIO_OGG: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 45,
-        schema: None,
-    });
+    pub const AUDIO_OGG: Encoding = Self(zenoh_protocol::core::Encoding::new(45));
     /// A Vorbis-encoded audio stream.
     ///
     /// Constant alias for string: `"audio/vorbis"`.
-    pub const AUDIO_VORBIS: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 46,
-        schema: None,
-    });
+    pub const AUDIO_VORBIS: Encoding = Self(zenoh_protocol::core::Encoding::new(46));
     /// A h261-encoded video stream.
     ///
     /// Constant alias for string: `"video/h261"`.
-    pub const VIDEO_H261: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 47,
-        schema: None,
-    });
+    pub const VIDEO_H261: Encoding = Self(zenoh_protocol::core::Encoding::new(47));
     /// A h263-encoded video stream.
     ///
     /// Constant alias for string: `"video/h263"`.
-    pub const VIDEO_H263: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 48,
-        schema: None,
-    });
+    pub const VIDEO_H263: Encoding = Self(zenoh_protocol::core::Encoding::new(48));
     /// A h264-encoded video stream.
     ///
     /// Constant alias for string: `"video/h264"`.
-    pub const VIDEO_H264: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 49,
-        schema: None,
-    });
+    pub const VIDEO_H264: Encoding = Self(zenoh_protocol::core::Encoding::new(49));
     /// A h265-encoded video stream.
     ///
     /// Constant alias for string: `"video/h265"`.
-    pub const VIDEO_H265: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 50,
-        schema: None,
-    });
+    pub const VIDEO_H265: Encoding = Self(zenoh_protocol::core::Encoding::new(50));
     /// A h266-encoded video stream.
     ///
     /// Constant alias for string: `"video/h266"`.
-    pub const VIDEO_H266: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 51,
-        schema: None,
-    });
+    pub const VIDEO_H266: Encoding = Self(zenoh_protocol::core::Encoding::new(51));
     /// A video codec defined in MPEG-1, MPEG-2, MPEG-4, or registered at the MP4 registration authority.
     ///
     /// Constant alias for string: `"video/mp4"`.
-    pub const VIDEO_MP4: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 52,
-        schema: None,
-    });
+    pub const VIDEO_MP4: Encoding = Self(zenoh_protocol::core::Encoding::new(52));
     /// An Ogg-encapsulated video stream.
     ///
     /// Constant alias for string: `"video/ogg"`.
-    pub const VIDEO_OGG: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 53,
-        schema: None,
-    });
+    pub const VIDEO_OGG: Encoding = Self(zenoh_protocol::core::Encoding::new(53));
     /// An uncompressed, studio-quality video stream.
     ///
     /// Constant alias for string: `"video/raw"`.
-    pub const VIDEO_RAW: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 54,
-        schema: None,
-    });
+    pub const VIDEO_RAW: Encoding = Self(zenoh_protocol::core::Encoding::new(54));
     /// A VP8-encoded video stream.
     ///
     /// Constant alias for string: `"video/vp8"`.
-    pub const VIDEO_VP8: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 55,
-        schema: None,
-    });
+    pub const VIDEO_VP8: Encoding = Self(zenoh_protocol::core::Encoding::new(55));
     /// A VP9-encoded video stream.
     ///
     /// Constant alias for string: `"video/vp9"`.
-    pub const VIDEO_VP9: Encoding = Self(zenoh_protocol::core::Encoding {
-        id: 56,
-        schema: None,
-    });
+    pub const VIDEO_VP9: Encoding = Self(zenoh_protocol::core::Encoding::new(56));
 
     const ID_TO_STR: phf::Map<EncodingId, &'static str> = phf_map! {
         0u16 => "zenoh/bytes",
@@ -612,13 +444,11 @@ impl Encoding {
 
     /// Set a schema to this encoding. Zenoh does not define what a schema is and its semantichs is left to the implementer.
     /// E.g. a common schema for `text/plain` encoding is `utf-8`.
-    pub fn with_schema<S>(mut self, s: S) -> Self
+    pub fn with_schema<S>(&self, s: S) -> Self
     where
         S: Into<String>,
     {
-        let s: String = s.into();
-        self.0.schema = Some(s.into_boxed_str().into_boxed_bytes().into());
-        self
+        Self(self.0.with_schema(s.into()))
     }
 }
 
@@ -640,16 +470,16 @@ impl From<&str> for Encoding {
         // Everything before `;` may be mapped to a known id
         let (id, mut schema) = t.split_once(Encoding::SCHEMA_SEP).unwrap_or((t, ""));
         if let Some(id) = Encoding::STR_TO_ID.get(id).copied() {
-            inner.id = id;
+            inner = zenoh_protocol::core::Encoding::new(id);
         // if id is not recognized, e.g. `t == "my_encoding"`, put it in the schema
         } else {
             schema = t;
         }
         if !schema.is_empty() {
-            inner.schema = Some(ZSlice::from(schema.to_string().into_bytes()));
+            inner = inner.with_schema(schema)
         }
 
-        Encoding(inner)
+        Self(inner)
     }
 }
 
@@ -669,28 +499,15 @@ impl FromStr for Encoding {
 
 impl From<&Encoding> for Cow<'static, str> {
     fn from(encoding: &Encoding) -> Self {
-        fn su8_to_str(schema: &[u8]) -> &str {
-            std::str::from_utf8(schema).unwrap_or("unknown(non-utf8)")
-        }
-
-        match (
-            Encoding::ID_TO_STR.get(&encoding.0.id).copied(),
-            encoding.0.schema.as_ref(),
-        ) {
+        let (id, schema) = encoding.0.id_and_schema();
+        match (Encoding::ID_TO_STR.get(&id), schema) {
             // Perfect match
             (Some(i), None) => Cow::Borrowed(i),
             // ID and schema
-            (Some(i), Some(s)) => {
-                Cow::Owned(format!("{}{}{}", i, Encoding::SCHEMA_SEP, su8_to_str(s)))
-            }
+            (Some(i), Some(s)) => Cow::Owned(format!("{}{}{}", i, Encoding::SCHEMA_SEP, s)),
             //
-            (None, Some(s)) => Cow::Owned(format!(
-                "unknown({}){}{}",
-                encoding.0.id,
-                Encoding::SCHEMA_SEP,
-                su8_to_str(s)
-            )),
-            (None, None) => Cow::Owned(format!("unknown({})", encoding.0.id)),
+            (None, Some(s)) => Cow::Owned(format!("unknown({}){}{}", id, Encoding::SCHEMA_SEP, s)),
+            (None, None) => Cow::Owned(format!("unknown({})", id)),
         }
     }
 }
@@ -841,16 +658,20 @@ impl EncodingMapping for serde_pickle::Value {
 
 impl Encoding {
     #[zenoh_macros::internal]
-    pub fn id(&self) -> u16 {
-        self.0.id
+    pub fn id(&self) -> EncodingId {
+        self.0.id_and_schema().0
     }
     #[zenoh_macros::internal]
-    pub fn schema(&self) -> Option<&ZSlice> {
-        self.0.schema.as_ref()
+    pub fn schema(&self) -> Option<&str> {
+        self.0.id_and_schema().1
     }
     #[zenoh_macros::internal]
-    pub fn new(id: u16, schema: Option<ZSlice>) -> Self {
-        Encoding(zenoh_protocol::core::Encoding { id, schema })
+    pub fn new(id: EncodingId, schema: Option<&str>) -> Self {
+        let mut inner = zenoh_protocol::core::Encoding::new(id);
+        if let Some(schema) = schema {
+            inner = inner.with_schema(schema);
+        }
+        Self(inner)
     }
 }
 


### PR DESCRIPTION
The only visible side-effect is that encoding constants can no more be used in pattern matching.