### PR TITLE
Fix interface name scanning when listening on IP unspecified for TCP/TLS/QUIC/WS

### DIFF
--- a/io/zenoh-links/zenoh-link-quic/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/unicast.rs
@@ -387,7 +387,16 @@ async fn accept_task(
                             }
                         };
 
+                        // Get the right source address in case an unsepecified IP (i.e. 0.0.0.0 or [::]) is used
+                        let src_addr =  match quic_conn.local_ip()  {
+                            Some(ip) => SocketAddr::new(ip, src_addr.port()),
+                            None => {
+                                tracing::debug!("Can not accept QUIC connection: empty local IP");
+                                continue;
+                            }
+                        };
                         let dst_addr = quic_conn.remote_address();
+
                         tracing::debug!("Accepted QUIC connection on {:?}: {:?}", src_addr, dst_addr);
                         // Create the new link object
                         let link = Arc::new(LinkUnicastQuic::new(

--- a/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
@@ -409,6 +409,15 @@ async fn accept_task(
             res = accept(&socket) => {
                 match res {
                     Ok((stream, dst_addr)) => {
+                        // Get the right source address in case an unsepecified IP (i.e. 0.0.0.0 or [::]) is used
+                        let src_addr =  match stream.local_addr()  {
+                            Ok(sa) => sa,
+                            Err(e) => {
+                                tracing::debug!("Can not accept TCP connection: {}", e);
+                                continue;
+                            }
+                        };
+
                         tracing::debug!("Accepted TCP connection on {:?}: {:?}", src_addr, dst_addr);
                         // Create the new link object
                         let link = Arc::new(LinkUnicastTcp::new(stream, src_addr, dst_addr));

--- a/io/zenoh-links/zenoh-link-udp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/unicast.rs
@@ -499,7 +499,7 @@ async fn accept_read_task(
     tracing::trace!("Ready to accept UDP connections on: {:?}", src_addr);
 
     if src_addr.ip().is_unspecified() {
-        tracing::warn!("Interceptors (e.g. Access Control, Downsampling) are not guaranteed to work on UDP when listening on 0.0.0.0 or [::]. Their usage is discouraged. See https://github.com/eclipse-zenoh/zenoh/issues/1093.");
+        tracing::warn!("Interceptors (e.g. Access Control, Downsampling) are not guaranteed to work on UDP when listening on 0.0.0.0 or [::]. Their usage is discouraged. See https://github.com/eclipse-zenoh/zenoh/issues/1126.");
     }
 
     loop {

--- a/io/zenoh-links/zenoh-link-udp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/unicast.rs
@@ -498,6 +498,10 @@ async fn accept_read_task(
 
     tracing::trace!("Ready to accept UDP connections on: {:?}", src_addr);
 
+    if src_addr.ip().is_unspecified() {
+        tracing::warn!("Interceptors (e.g. Access Control, Downsampling) are not guaranteed to work on UDP when listening on 0.0.0.0 or [::]. See https://github.com/eclipse-zenoh/zenoh/issues/1093.");
+    }
+
     loop {
         // Buffers for deserialization
         let mut buff = zenoh_buffers::vec::uninit(UDP_MAX_MTU as usize);

--- a/io/zenoh-links/zenoh-link-udp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/unicast.rs
@@ -499,7 +499,7 @@ async fn accept_read_task(
     tracing::trace!("Ready to accept UDP connections on: {:?}", src_addr);
 
     if src_addr.ip().is_unspecified() {
-        tracing::warn!("Interceptors (e.g. Access Control, Downsampling) are not guaranteed to work on UDP when listening on 0.0.0.0 or [::]. See https://github.com/eclipse-zenoh/zenoh/issues/1093.");
+        tracing::warn!("Interceptors (e.g. Access Control, Downsampling) are not guaranteed to work on UDP when listening on 0.0.0.0 or [::]. Their usage is discouraged. See https://github.com/eclipse-zenoh/zenoh/issues/1093.");
     }
 
     loop {

--- a/io/zenoh-links/zenoh-link-ws/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-ws/src/unicast.rs
@@ -498,6 +498,15 @@ async fn accept_task(
             _ = token.cancelled() => break,
         };
 
+        // Get the right source address in case an unsepecified IP (i.e. 0.0.0.0 or [::]) is used
+        let src_addr = match stream.local_addr() {
+            Ok(sa) => sa,
+            Err(e) => {
+                tracing::debug!("Can not accept TCP connection: {}", e);
+                continue;
+            }
+        };
+
         tracing::debug!(
             "Accepted TCP (WebSocket) connection on {:?}: {:?}",
             src_addr,


### PR DESCRIPTION
Mostly fixes https://github.com/eclipse-zenoh/zenoh/issues/1093.

While the fix is quite straightforward for connection-oriented links, i.e. TCP/TLS/QUIC/WS, a major work may be needed in the UDP implementation to retrieve the right interface a message was received on.
For this reason, UDP is left out of this PR and a warning is added.