### PR TITLE
Remove set_priority and set_congestion_control from publisher

### DIFF
--- a/zenoh/src/api/publisher.rs
+++ b/zenoh/src/api/publisher.rs
@@ -174,22 +174,10 @@ impl<'a> Publisher<'a> {
         self.congestion_control
     }
 
-    /// Change the `congestion_control` to apply when routing the data.
-    #[inline]
-    pub fn set_congestion_control(&mut self, congestion_control: CongestionControl) {
-        self.congestion_control = congestion_control;
-    }
-
     /// Get the priority of the written data.
     #[inline]
     pub fn priority(&self) -> Priority {
         self.priority
-    }
-
-    /// Change the priority of the written data.
-    #[inline]
-    pub fn set_priority(&mut self, priority: Priority) {
-        self.priority = priority;
     }
 
     /// Consumes the given `Publisher`, returning a thread-safe reference-counting


### PR DESCRIPTION
A publisher is configured with all the necessary parameters at building time.
This allows Zenoh to know which parameters are going to be used for future publications and prepare the underlying infrastructure/network accordingly. By allowing to update the publisher parameters it becomes more difficult to prepare and/or pre-provision resources. Therefore, it is safer to remove the possibility in the API.