### PR TITLE
replier_id() returns Option<ZenohId>

### DIFF
--- a/zenoh/src/api/query.rs
+++ b/zenoh/src/api/query.rs
@@ -18,6 +18,7 @@ use std::{
     time::Duration,
 };
 
+use zenoh_config::ZenohId;
 use zenoh_core::{Resolvable, Wait};
 use zenoh_keyexpr::OwnedKeyExpr;
 use zenoh_protocol::core::{CongestionControl, Parameters, ZenohIdProto};
@@ -117,7 +118,7 @@ impl From<Value> for ReplyError {
 #[derive(Clone, Debug)]
 pub struct Reply {
     pub(crate) result: Result<Sample, ReplyError>,
-    pub(crate) replier_id: ZenohIdProto,
+    pub(crate) replier_id: Option<ZenohIdProto>,
 }
 
 impl Reply {
@@ -137,8 +138,8 @@ impl Reply {
     }
 
     /// Gets the id of the zenoh instance that answered this Reply.
-    pub fn replier_id(&self) -> ZenohIdProto {
-        self.replier_id
+    pub fn replier_id(&self) -> Option<ZenohId> {
+        self.replier_id.map(Into::into)
     }
 }
 

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -1702,7 +1702,7 @@ impl Session {
                                 }
                                 (query.callback)(Reply {
                                     result: Err(Value::from("Timeout").into()),
-                                    replier_id: zid.into(),
+                                    replier_id: Some(zid.into()),
                                 });
                             }
                         }
@@ -2194,12 +2194,8 @@ impl Primitives for Session {
                             payload: e.payload.into(),
                             encoding: e.encoding.into(),
                         };
-                        let replier_id = match e.ext_sinfo {
-                            Some(info) => info.id.zid,
-                            None => zenoh_protocol::core::ZenohIdProto::rand(),
-                        };
                         let new_reply = Reply {
-                            replier_id,
+                            replier_id: e.ext_sinfo.map(|info| info.id.zid),
                             result: Err(value.into()),
                         };
                         callback(new_reply);
@@ -2308,7 +2304,7 @@ impl Primitives for Session {
                         let sample = info.into_sample(key_expr.into_owned(), payload, attachment);
                         let new_reply = Reply {
                             result: Ok(sample),
-                            replier_id: zenoh_protocol::core::ZenohIdProto::rand(), // TODO
+                            replier_id: None,
                         };
                         let callback =
                             match query.reception_mode {


### PR DESCRIPTION
Fix for issue #709 
Also leak of `ZenohIdProto` fixed