### PR TITLE
Dev/1.0.0 plugin update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5189,6 +5189,7 @@ dependencies = [
  "uhlc",
  "validated_struct",
  "zenoh-core",
+ "zenoh-macros",
  "zenoh-protocol",
  "zenoh-result",
  "zenoh-util",

--- a/commons/zenoh-config/Cargo.toml
+++ b/commons/zenoh-config/Cargo.toml
@@ -23,6 +23,9 @@ license = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh."
 
+[features]
+unstable = []
+
 [dependencies]
 tracing = { workspace = true }
 flume = { workspace = true }

--- a/commons/zenoh-config/Cargo.toml
+++ b/commons/zenoh-config/Cargo.toml
@@ -24,7 +24,7 @@ categories = { workspace = true }
 description = "Internal crate for zenoh."
 
 [dependencies]
-tracing = {workspace = true}
+tracing = { workspace = true }
 flume = { workspace = true }
 json5 = { workspace = true }
 num_cpus = { workspace = true }
@@ -36,5 +36,6 @@ zenoh-core = { workspace = true }
 zenoh-protocol = { workspace = true }
 zenoh-result = { workspace = true }
 zenoh-util = { workspace = true }
+zenoh-macros = { workspace = true }
 secrecy = { workspace = true }
 uhlc = { workspace = true }

--- a/commons/zenoh-config/src/wrappers.rs
+++ b/commons/zenoh-config/src/wrappers.rs
@@ -20,7 +20,7 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 use zenoh_protocol::{
-    core::{EntityGlobalIdProto, EntityId, Locator, WhatAmI, ZenohIdProto},
+    core::{key_expr::OwnedKeyExpr, EntityGlobalIdProto, EntityId, Locator, WhatAmI, ZenohIdProto},
     scouting::HelloProto,
 };
 
@@ -55,6 +55,18 @@ impl From<ZenohId> for ZenohIdProto {
 impl From<ZenohId> for uhlc::ID {
     fn from(zid: ZenohId) -> Self {
         zid.0.into()
+    }
+}
+
+impl From<ZenohId> for OwnedKeyExpr {
+    fn from(zid: ZenohId) -> Self {
+        zid.0.into()
+    }
+}
+
+impl From<&ZenohId> for OwnedKeyExpr {
+    fn from(zid: &ZenohId) -> Self {
+        (*zid).into()
     }
 }
 

--- a/commons/zenoh-config/src/wrappers.rs
+++ b/commons/zenoh-config/src/wrappers.rs
@@ -29,6 +29,14 @@ use zenoh_protocol::{
 #[repr(transparent)]
 pub struct ZenohId(ZenohIdProto);
 
+impl ZenohId {
+    /// Used by plugins for crating adminspace path
+    #[zenoh_macros::unstable]
+    pub fn into_keyexpr(self) -> OwnedKeyExpr {
+        self.into()
+    }
+}
+
 impl fmt::Debug for ZenohId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -63,7 +63,7 @@ transport_udp = ["zenoh-transport/transport_udp"]
 transport_unixsock-stream = ["zenoh-transport/transport_unixsock-stream"]
 transport_ws = ["zenoh-transport/transport_ws"]
 transport_vsock = ["zenoh-transport/transport_vsock"]
-unstable = ["zenoh-keyexpr/unstable"]
+unstable = ["zenoh-keyexpr/unstable", "zenoh-config/unstable"]
 
 [dependencies]
 tokio = { workspace = true, features = ["rt", "macros", "time"] }

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -119,7 +119,7 @@ pub use {
         scouting::scout,
         session::{open, Session},
     },
-    zenoh_util::try_init_log_from_env,
+    zenoh_util::{init_log_from_env_or, try_init_log_from_env},
 };
 
 pub mod prelude;


### PR DESCRIPTION
updates necessary for external plugins:
- conversion of `ZenohId` to keyexpr exposed - it's used by plugins for making adminspace path
- exported function `init_log_from_env_or`