### PR TITLE
exposed zread and zwrite needed by plugins, zenohId::into_keyexpr internal

### DIFF
--- a/commons/zenoh-config/src/wrappers.rs
+++ b/commons/zenoh-config/src/wrappers.rs
@@ -31,7 +31,7 @@ pub struct ZenohId(ZenohIdProto);
 
 impl ZenohId {
     /// Used by plugins for crating adminspace path
-    #[zenoh_macros::unstable]
+    #[zenoh_macros::internal]
     pub fn into_keyexpr(self) -> OwnedKeyExpr {
         self.into()
     }

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -364,7 +364,9 @@ compile_error!(
 
 #[zenoh_macros::internal]
 pub mod internal {
-    pub use zenoh_core::{zasync_executor_init, zerror, zlock, ztimeout, ResolveFuture};
+    pub use zenoh_core::{
+        zasync_executor_init, zerror, zlock, zread, ztimeout, zwrite, ResolveFuture,
+    };
     pub use zenoh_result::bail;
     pub use zenoh_sync::Condition;
     pub use zenoh_task::{TaskController, TerminatableTask};

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -365,7 +365,7 @@ compile_error!(
 #[zenoh_macros::internal]
 pub mod internal {
     pub use zenoh_core::{
-        zasync_executor_init, zerror, zlock, zread, ztimeout, zwrite, ResolveFuture,
+        zasync_executor_init, zasynclock, zerror, zlock, zread, ztimeout, zwrite, ResolveFuture,
     };
     pub use zenoh_result::bail;
     pub use zenoh_sync::Condition;


### PR DESCRIPTION
- exposed zread and zwrite needed by plugins, 
- zenohId::into_keyexpr mae internal