### PR TITLE
Expose TimedHandle via internal

### DIFF
--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -370,7 +370,9 @@ pub mod internal {
     pub use zenoh_result::bail;
     pub use zenoh_sync::Condition;
     pub use zenoh_task::{TaskController, TerminatableTask};
-    pub use zenoh_util::{zenoh_home, LibLoader, Timed, TimedEvent, Timer, ZENOH_HOME_ENV_VAR};
+    pub use zenoh_util::{
+        zenoh_home, LibLoader, Timed, TimedEvent, TimedHandle, Timer, ZENOH_HOME_ENV_VAR,
+    };
 
     /// A collection of useful buffers used by zenoh internally and exposed to the user to facilitate
     /// reading and writing data.


### PR DESCRIPTION
`TimedHandle` is used in the influxDB plugin, not being exposed in new internal API 

https://github.com/ZettaScaleLabs/zenoh-backend-influxdb/blob/7ff1fa9e8383d1635ff2be73832e05c3ac32996e/v2/src/lib.rs#L424
