### PR TITLE
Remove some duplicate imports

### DIFF
--- a/examples/examples/z_scout.rs
+++ b/examples/examples/z_scout.rs
@@ -11,7 +11,7 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use zenoh::{config::WhatAmI, scout, Config};
+use zenoh::{config::WhatAmI, scouting::scout, Config};
 
 #[tokio::main]
 async fn main() {

--- a/zenoh/src/api/scouting.rs
+++ b/zenoh/src/api/scouting.rs
@@ -39,7 +39,7 @@ use crate::{
 /// # async fn main() {
 /// use zenoh::{config::WhatAmI, prelude::*};
 ///
-/// let receiver = zenoh::scout(WhatAmI::Peer | WhatAmI::Router, zenoh::config::default())
+/// let receiver = zenoh::scouting::scout(WhatAmI::Peer | WhatAmI::Router, zenoh::config::default())
 ///     .await
 ///     .unwrap();
 /// while let Ok(hello) = receiver.recv_async().await {
@@ -64,7 +64,7 @@ impl ScoutBuilder<DefaultHandler> {
     /// # async fn main() {
     /// use zenoh::{config::WhatAmI, prelude::*};
     ///
-    /// let scout = zenoh::scout(WhatAmI::Peer | WhatAmI::Router, zenoh::config::default())
+    /// let scout = zenoh::scouting::scout(WhatAmI::Peer | WhatAmI::Router, zenoh::config::default())
     ///     .callback(|hello| { println!("{}", hello); })
     ///     .await
     ///     .unwrap();
@@ -99,7 +99,7 @@ impl ScoutBuilder<DefaultHandler> {
     /// use zenoh::{config::WhatAmI, prelude::*};
     ///
     /// let mut n = 0;
-    /// let scout = zenoh::scout(WhatAmI::Peer | WhatAmI::Router, zenoh::config::default())
+    /// let scout = zenoh::scouting::scout(WhatAmI::Peer | WhatAmI::Router, zenoh::config::default())
     ///     .callback_mut(move |_hello| { n += 1; })
     ///     .await
     ///     .unwrap();
@@ -124,7 +124,7 @@ impl ScoutBuilder<DefaultHandler> {
     /// # async fn main() {
     /// use zenoh::{config::WhatAmI, prelude::*};
     ///
-    /// let receiver = zenoh::scout(WhatAmI::Peer | WhatAmI::Router, zenoh::config::default())
+    /// let receiver = zenoh::scouting::scout(WhatAmI::Peer | WhatAmI::Router, zenoh::config::default())
     ///     .with(flume::bounded(32))
     ///     .await
     ///     .unwrap();
@@ -191,7 +191,7 @@ where
 /// # async fn main() {
 /// use zenoh::{config::WhatAmI, prelude::*};
 ///
-/// let scout = zenoh::scout(WhatAmI::Peer | WhatAmI::Router, zenoh::config::default())
+/// let scout = zenoh::scouting::scout(WhatAmI::Peer | WhatAmI::Router, zenoh::config::default())
 ///     .callback(|hello| { println!("{}", hello); })
 ///     .await
 ///     .unwrap();
@@ -211,7 +211,7 @@ impl ScoutInner {
     /// # async fn main() {
     /// use zenoh::{config::WhatAmI, prelude::*};
     ///
-    /// let scout = zenoh::scout(WhatAmI::Peer | WhatAmI::Router, zenoh::config::default())
+    /// let scout = zenoh::scouting::scout(WhatAmI::Peer | WhatAmI::Router, zenoh::config::default())
     ///     .callback(|hello| { println!("{}", hello); })
     ///     .await
     ///     .unwrap();
@@ -246,7 +246,7 @@ impl fmt::Debug for ScoutInner {
 /// # async fn main() {
 /// use zenoh::{config::WhatAmI, prelude::*};
 ///
-/// let receiver = zenoh::scout(WhatAmI::Peer | WhatAmI::Router, zenoh::config::default())
+/// let receiver = zenoh::scouting::scout(WhatAmI::Peer | WhatAmI::Router, zenoh::config::default())
 ///     .with(flume::bounded(32))
 ///     .await
 ///     .unwrap();
@@ -279,7 +279,7 @@ impl<Receiver> Scout<Receiver> {
     /// # async fn main() {
     /// use zenoh::{config::WhatAmI, prelude::*};
     ///
-    /// let scout = zenoh::scout(WhatAmI::Router, zenoh::config::default())
+    /// let scout = zenoh::scouting::scout(WhatAmI::Router, zenoh::config::default())
     ///     .with(flume::bounded(32))
     ///     .await
     ///     .unwrap();
@@ -361,7 +361,7 @@ fn _scout(
 /// # async fn main() {
 /// use zenoh::{config::WhatAmI, prelude::*};
 ///
-/// let receiver = zenoh::scout(WhatAmI::Peer | WhatAmI::Router, zenoh::config::default())
+/// let receiver = zenoh::scouting::scout(WhatAmI::Peer | WhatAmI::Router, zenoh::config::default())
 ///     .await
 ///     .unwrap();
 /// while let Ok(hello) = receiver.recv_async().await {

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -115,8 +115,6 @@ pub const FEATURES: &str = zenoh_util::concat_enabled_features!(
 pub use {
     crate::{
         config::Config,
-        core::{Error, Result},
-        scouting::scout,
         session::{open, Session},
     },
     zenoh_util::{init_log_from_env_or, try_init_log_from_env},

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -23,9 +23,10 @@ use std::{
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use zenoh::{
     config::{ModeDependentValue, WhatAmI, WhatAmIMatcher},
+    core::Result,
     prelude::*,
     publisher::CongestionControl,
-    Config, Result, Session,
+    Config, Session,
 };
 use zenoh_core::ztimeout;
 use zenoh_result::bail;


### PR DESCRIPTION
Now there are some duplicate imports in `lib.rs`

```rust
use zenoh::{Error, Result};
use zenoh::core::{Error, Result};

use zenoh::{Session, open};
use zenoh::session::{Session, open};

use zenoh::scout;
use zenoh::scouting::scout;
```

For session one, it's used commonly and perhaps it makes sense to have a shorter path. However, I would suggest not to have duplicate paths for others.