### PR TITLE
Remove subscriber and query scopes

### DIFF
--- a/zenoh/src/api/liveliness.rs
+++ b/zenoh/src/api/liveliness.rs
@@ -545,7 +545,7 @@ where
         let session = self.session;
         let (callback, handler) = self.handler.into_handler();
         session
-            .declare_liveliness_subscriber_inner(&key_expr, None, Locality::default(), callback)
+            .declare_liveliness_subscriber_inner(&key_expr, Locality::default(), callback)
             .map(|sub_state| Subscriber {
                 subscriber: SubscriberInner {
                     session,

--- a/zenoh/src/api/query.rs
+++ b/zenoh/src/api/query.rs
@@ -158,7 +158,6 @@ pub(crate) struct QueryState {
     pub(crate) nb_final: usize,
     pub(crate) key_expr: KeyExpr<'static>,
     pub(crate) parameters: Parameters<'static>,
-    pub(crate) scope: Option<KeyExpr<'static>>,
     pub(crate) reception_mode: ConsolidationMode,
     pub(crate) replies: Option<HashMap<OwnedKeyExpr, Reply>>,
     pub(crate) callback: Callback<'static, Reply>,
@@ -195,7 +194,6 @@ impl QueryState {
 pub struct SessionGetBuilder<'a, 'b, Handler> {
     pub(crate) session: &'a Session,
     pub(crate) selector: ZResult<Selector<'b>>,
-    pub(crate) scope: ZResult<Option<KeyExpr<'b>>>,
     pub(crate) target: QueryTarget,
     pub(crate) consolidation: QueryConsolidation,
     pub(crate) qos: QoSBuilder,
@@ -280,7 +278,6 @@ impl<'a, 'b> SessionGetBuilder<'a, 'b, DefaultHandler> {
         let SessionGetBuilder {
             session,
             selector,
-            scope,
             target,
             consolidation,
             qos,
@@ -295,7 +292,6 @@ impl<'a, 'b> SessionGetBuilder<'a, 'b, DefaultHandler> {
         SessionGetBuilder {
             session,
             selector,
-            scope,
             target,
             consolidation,
             qos,
@@ -367,7 +363,6 @@ impl<'a, 'b> SessionGetBuilder<'a, 'b, DefaultHandler> {
         let SessionGetBuilder {
             session,
             selector,
-            scope,
             target,
             consolidation,
             qos,
@@ -382,7 +377,6 @@ impl<'a, 'b> SessionGetBuilder<'a, 'b, DefaultHandler> {
         SessionGetBuilder {
             session,
             selector,
-            scope,
             target,
             consolidation,
             qos,
@@ -496,7 +490,6 @@ where
             .query(
                 &key_expr,
                 &parameters,
-                &self.scope?,
                 self.target,
                 self.consolidation,
                 self.qos.into(),

--- a/zenoh/src/api/subscriber.rs
+++ b/zenoh/src/api/subscriber.rs
@@ -37,7 +37,6 @@ pub(crate) struct SubscriberState {
     pub(crate) id: Id,
     pub(crate) remote_id: Id,
     pub(crate) key_expr: KeyExpr<'static>,
-    pub(crate) scope: Option<KeyExpr<'static>>,
     pub(crate) origin: Locality,
     pub(crate) callback: Callback<'static, Sample>,
 }
@@ -380,7 +379,6 @@ where
         session
             .declare_subscriber_inner(
                 &key_expr,
-                None,
                 self.origin,
                 callback,
                 &SubscriberInfo {


### PR DESCRIPTION
Subscriber and query scopes allow to declare subscribers and queries that would perform on let's say `some/scope/a/b` but would appear locally as performing on `a/b`.
This was done for the first subscribers based liveliness implementation. It's not needed any more with the new implementation. 
This could be useful for users but it's currently not exposed and so not used at all. 
Let's remove it until eventually reintroduced.