### PR TITLE
Clarify queue size config

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -287,6 +287,7 @@
         /// Each zenoh link has a transmission queue that can be configured
         queue: {
           /// The size of each priority queue indicates the number of batches a given queue can contain.
+          /// NOTE: the maximum number of batches in each priority is 16. Larger values will yield an error.
           /// The amount of memory being allocated for each queue is then SIZE_XXX * BATCH_SIZE.
           /// In the case of the transport link MTU being smaller than the ZN_BATCH_SIZE,
           /// then amount of memory being allocated for each queue is SIZE_XXX * LINK_MTU.

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -287,7 +287,7 @@
         /// Each zenoh link has a transmission queue that can be configured
         queue: {
           /// The size of each priority queue indicates the number of batches a given queue can contain.
-          /// NOTE: the maximum number of batches in each priority is 16. Larger values will yield an error.
+          /// NOTE: the number of batches in each priority mut be included between 1 and 16. Different values will result in an error.
           /// The amount of memory being allocated for each queue is then SIZE_XXX * BATCH_SIZE.
           /// In the case of the transport link MTU being smaller than the ZN_BATCH_SIZE,
           /// then amount of memory being allocated for each queue is SIZE_XXX * LINK_MTU.

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -287,7 +287,7 @@
         /// Each zenoh link has a transmission queue that can be configured
         queue: {
           /// The size of each priority queue indicates the number of batches a given queue can contain.
-          /// NOTE: the number of batches in each priority mut be included between 1 and 16. Different values will result in an error.
+          /// NOTE: the number of batches in each priority must be included between 1 and 16. Different values will result in an error.
           /// The amount of memory being allocated for each queue is then SIZE_XXX * BATCH_SIZE.
           /// In the case of the transport link MTU being smaller than the ZN_BATCH_SIZE,
           /// then amount of memory being allocated for each queue is SIZE_XXX * LINK_MTU.


### PR DESCRIPTION
Update the description on `DEFAULT_CONFIG` on queue size limits.
The number of batches in each priority must be included between 1 and 16.
