### PR TITLE
Value fields public

### DIFF
--- a/zenoh/src/api/value.rs
+++ b/zenoh/src/api/value.rs
@@ -19,8 +19,8 @@ use super::{bytes::ZBytes, encoding::Encoding};
 #[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Value {
-    pub(crate) payload: ZBytes,
-    pub(crate) encoding: Encoding,
+    pub payload: ZBytes,
+    pub encoding: Encoding,
 }
 
 impl Value {


### PR DESCRIPTION
Make fields of `Value` public now that now that value is behind feature flag `internal`
https://github.com/eclipse-zenoh/zenoh/issues/1125

This would remove need to clone fields when  you want to separate out `payload` and `encoding`

