### PR TITLE
Add z_bytes in the examples.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2200,8 +2200,8 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f56d36f573486ba7f462b62cbae597fef7d5d93665e7047956b457531b8a1ced"
 dependencies = [
- "prost",
- "prost-types",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
 ]
 
 [[package]]
@@ -2972,7 +2972,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.11.9",
+]
+
+[[package]]
+name = "prost"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+dependencies = [
+ "bytes",
+ "prost-derive 0.12.6",
 ]
 
 [[package]]
@@ -2989,12 +2999,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
- "prost",
+ "prost 0.11.9",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+dependencies = [
+ "prost 0.12.6",
 ]
 
 [[package]]
@@ -5497,8 +5529,12 @@ dependencies = [
  "futures",
  "git-version",
  "json5",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
  "rand 0.8.5",
  "rustc_version 0.4.0",
+ "serde_json",
+ "serde_yaml",
  "tokio",
  "tracing",
  "zenoh",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -43,6 +43,10 @@ zenoh-collections = { workspace = true }
 tracing = { workspace = true }
 zenoh = { workspace = true, default-features = true }
 zenoh-ext = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+prost = "0.12.6"
+prost-types = "0.12.6"
 
 [dev-dependencies]
 rand = { workspace = true, features = ["default"] }

--- a/examples/README.md
+++ b/examples/README.md
@@ -295,3 +295,7 @@
    ```bash
    z_sub_liveliness -k 'group1/**'
    ```
+
+### z_bytes
+
+   Show how to serialize different message types into ZBytes, and then deserialize from ZBytes to the original message types.

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,6 +3,7 @@
 ## Start instructions
 
    When Zenoh is built in release mode:
+
    ```bash
    ./target/release/example/<example_name>
    ```
@@ -20,6 +21,7 @@
    Scouts for Zenoh peers and routers available on the network.
 
    Typical usage:
+
    ```bash
    z_scout
    ```
@@ -29,10 +31,10 @@
    Gets information about the Zenoh session.
 
    Typical usage:
+
    ```bash
    z_info
    ```
-
 
 ### z_put
 
@@ -41,10 +43,13 @@
    and [z_storage](#z_storage) examples.
 
    Typical usage:
+
    ```bash
    z_put
    ```
+
    or
+
    ```bash
    z_put -k demo/example/test -v 'Hello World'
    ```
@@ -55,10 +60,13 @@
    The published value will be received by all matching subscribers, for instance the [z_sub](#z_sub) and [z_storage](#z_storage) examples.
 
    Typical usage:
+
    ```bash
    z_pub
    ```
+
    or
+
    ```bash
    z_pub -k demo/example/test -v 'Hello World'
    ```
@@ -69,10 +77,13 @@
    The subscriber will be notified of each `put` or `delete` made on any key expression matching the subscriber key expression, and will print this notification.
 
    Typical usage:
+
    ```bash
    z_sub
    ```
+
    or
+
    ```bash
    z_sub -k 'demo/**'
    ```
@@ -82,14 +93,16 @@
    Declares a key expression and a pull subscriber.  
    On each pull, the pull subscriber will be notified of the last N `put` or `delete` made on each key expression matching the subscriber key expression, and will print this notification.
 
-
    Typical usage:
+
    ```bash
    z_pull
    ```
+
    or
+
    ```bash
-      z_pull -k demo/** --size 3
+   z_pull -k demo/** --size 3
    ```
 
 ### z_get
@@ -99,10 +112,13 @@
    will receive this query and reply with paths/values that will be received by the receiver stream.
 
    Typical usage:
+
    ```bash
    z_get
    ```
+
    or
+
    ```bash
    z_get -s 'demo/**'
    ```
@@ -114,10 +130,13 @@
    with a selector that matches the path, and will return a value to the querier.
 
    Typical usage:
+
    ```bash
    z_queryable
    ```
+
    or
+
    ```bash
    z_queryable -k demo/example/queryable -v 'This is the result'
    ```
@@ -131,10 +150,13 @@
    and that match the queried selector.
 
    Typical usage:
+
    ```bash
    z_storage
    ```
+
    or
+
    ```bash
    z_storage -k 'demo/**'
    ```
@@ -145,11 +167,13 @@
    Note that on subscriber side, the same `z_sub` example than for non-shared-memory example is used.
 
    Typical Subscriber usage:
+
    ```bash
    z_sub
    ```
 
    Typical Publisher usage:
+
    ```bash
    z_pub_shm
    ```
@@ -161,11 +185,13 @@
    put operations and a subscriber receiving notifications of those puts.
 
    Typical Subscriber usage:
+
    ```bash
    z_sub_thr
    ```
 
    Typical Publisher usage:
+
    ```bash
    z_pub_thr 1024
    ```
@@ -182,11 +208,13 @@
   :warning: z_pong needs to start first to avoid missing the kickoff from z_ping.
 
    Typical Pong usage:
+
    ```bash
    z_pong
    ```
 
    Typical Ping usage:
+
    ```bash
    z_ping 1024
    ```
@@ -200,11 +228,13 @@
    Note that on subscriber side, the same `z_sub_thr` example than for non-shared-memory example is used.
 
    Typical Subscriber usage:
+
    ```bash
    z_sub_thr
    ```
 
    Typical Publisher usage:
+
    ```bash
    z_pub_shm_thr
    ```
@@ -217,10 +247,13 @@
    or killing the `z_liveliness` example.
 
    Typical usage:
+
    ```bash
    z_liveliness
    ```
+
    or
+
    ```bash
    z_liveliness -k 'group1/member1'
    ```
@@ -231,10 +264,13 @@
    (`group1/**` by default). Those tokens could be declared by the `z_liveliness` example.
 
    Typical usage:
+
    ```bash
    z_get_liveliness
    ```
+
    or
+
    ```bash
    z_get_liveliness -k 'group1/**'
    ```
@@ -249,10 +285,13 @@
    matching liveliness tokens that were alive before it's start.
 
    Typical usage:
+
    ```bash
    z_sub_liveliness
    ```
+
    or
+
    ```bash
    z_sub_liveliness -k 'group1/**'
    ```

--- a/examples/examples/z_bytes.rs
+++ b/examples/examples/z_bytes.rs
@@ -1,0 +1,83 @@
+//
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+use std::{borrow::Cow, collections::HashMap};
+
+use zenoh::bytes::ZBytes;
+
+fn main() {
+    // Numeric: u8, u16, u32, u128, usize, i8, i16, i32, i128, isize, f32, f64
+    let input = 1234_u32;
+    let payload = ZBytes::from(input);
+    let output: u32 = payload.deserialize().unwrap();
+    assert_eq!(input, output);
+
+    // String
+    let input = String::from("test");
+    let payload = ZBytes::from(&input);
+    let output: String = payload.deserialize().unwrap();
+    assert_eq!(input, output);
+
+    // Cow
+    let input = Cow::from("test");
+    let payload = ZBytes::from(&input);
+    let output: Cow<str> = payload.deserialize().unwrap();
+    assert_eq!(input, output);
+
+    // Vec<u8>: The deserialization should be infallible
+    let input: Vec<u8> = vec![1, 2, 3, 4];
+    let payload = ZBytes::from(&input);
+    let output: Vec<u8> = payload.into();
+    assert_eq!(input, output);
+
+    // Writer & Reader
+    // serialization
+    let mut bytes = ZBytes::empty();
+    let mut writer = bytes.writer();
+    let i1 = 1234_u32;
+    let i2 = String::from("test");
+    let i3 = vec![1, 2, 3, 4];
+    writer.serialize(i1);
+    writer.serialize(&i2);
+    writer.serialize(&i3);
+    // deserialization
+    let mut reader = bytes.reader();
+    let o1: u32 = reader.deserialize().unwrap();
+    let o2: String = reader.deserialize().unwrap();
+    let o3: Vec<u8> = reader.deserialize().unwrap();
+    assert_eq!(i1, o1);
+    assert_eq!(i2, o2);
+    assert_eq!(i3, o3);
+
+    // Tuple
+    let input = (1234_u32, String::from("test"));
+    let payload = ZBytes::serialize(input.clone());
+    let output: (u32, String) = payload.deserialize().unwrap();
+    assert_eq!(input, output);
+
+    // Iterator
+    let input: [i32; 4] = [1, 2, 3, 4];
+    let payload = ZBytes::from_iter(input.iter());
+    for (idx, value) in payload.iter::<i32>().enumerate() {
+        assert_eq!(input[idx], value.unwrap());
+    }
+
+    // HashMap
+    let mut input: HashMap<usize, String> = HashMap::new();
+    input.insert(0, String::from("abc"));
+    input.insert(1, String::from("def"));
+    let payload = ZBytes::from(input.clone());
+    let output = payload.deserialize::<HashMap<usize, String>>().unwrap();
+    assert_eq!(input, output);
+}

--- a/examples/examples/z_bytes.rs
+++ b/examples/examples/z_bytes.rs
@@ -22,24 +22,32 @@ fn main() {
     let payload = ZBytes::from(input);
     let output: u32 = payload.deserialize().unwrap();
     assert_eq!(input, output);
+    // Corresponding encoding to be used in operations like `.put()`, `.reply()`, etc.
+    // let encoding = Encoding::ZENOH_UINT32;
 
     // String
     let input = String::from("test");
     let payload = ZBytes::from(&input);
     let output: String = payload.deserialize().unwrap();
     assert_eq!(input, output);
+    // Corresponding encoding to be used in operations like `.put()`, `.reply()`, etc.
+    // let encoding = Encoding::ZENOH_STRING;
 
     // Cow
     let input = Cow::from("test");
     let payload = ZBytes::from(&input);
     let output: Cow<str> = payload.deserialize().unwrap();
     assert_eq!(input, output);
+    // Corresponding encoding to be used in operations like `.put()`, `.reply()`, etc.
+    // let encoding = Encoding::ZENOH_STRING;
 
     // Vec<u8>: The deserialization should be infallible
     let input: Vec<u8> = vec![1, 2, 3, 4];
     let payload = ZBytes::from(&input);
     let output: Vec<u8> = payload.into();
     assert_eq!(input, output);
+    // Corresponding encoding to be used in operations like `.put()`, `.reply()`, etc.
+    // let encoding = Encoding::ZENOH_BYTES;
 
     // Writer & Reader
     // serialization

--- a/examples/examples/z_bytes.rs
+++ b/examples/examples/z_bytes.rs
@@ -136,7 +136,7 @@ fn main() {
     };
     let payload = ZBytes::from(input.encode_to_vec());
     let output =
-        EntityInfo::decode(Cursor::new(payload.deserialize::<Vec<u8>>().unwrap())).unwrap();
+        EntityInfo::decode(Cursor::new(payload.deserialize::<Cow<[u8]>>().unwrap())).unwrap();
     assert_eq!(input, output);
     // Corresponding encoding to be used in operations like `.put()`, `.reply()`, etc.
     // let encoding = Encoding::APPLICATION_PROTOBUF;

--- a/examples/examples/z_bytes.rs
+++ b/examples/examples/z_bytes.rs
@@ -13,6 +13,7 @@
 //
 
 use std::{borrow::Cow, collections::HashMap, io::Cursor};
+
 use zenoh::bytes::ZBytes;
 
 fn main() {

--- a/examples/examples/z_get.rs
+++ b/examples/examples/z_get.rs
@@ -34,6 +34,7 @@ async fn main() {
         // // Uncomment this line to use a ring channel instead.
         // // More information on the ring channel are available in the z_pull example.
         // .with(zenoh::handlers::RingChannel::default())
+        // Refer to z_bytes.rs to see how to serialize different types of message
         .payload(payload.unwrap_or_default())
         .target(target)
         .timeout(timeout)
@@ -42,6 +43,7 @@ async fn main() {
     while let Ok(reply) = replies.recv_async().await {
         match reply.result() {
             Ok(sample) => {
+                // Refer to z_bytes.rs to see how to deserialize different types of message
                 let payload = sample
                     .payload()
                     .deserialize::<String>()

--- a/examples/examples/z_pub.rs
+++ b/examples/examples/z_pub.rs
@@ -35,6 +35,7 @@ async fn main() {
         tokio::time::sleep(Duration::from_secs(1)).await;
         let buf = format!("[{idx:4}] {payload}");
         println!("Putting Data ('{}': '{}')...", &key_expr, buf);
+        // Refer to z_bytes.rs to see how to put different types of message
         publisher
             .put(buf)
             .encoding(Encoding::TEXT_PLAIN) // Optionally set the encoding metadata 

--- a/examples/examples/z_pub.rs
+++ b/examples/examples/z_pub.rs
@@ -35,7 +35,7 @@ async fn main() {
         tokio::time::sleep(Duration::from_secs(1)).await;
         let buf = format!("[{idx:4}] {payload}");
         println!("Putting Data ('{}': '{}')...", &key_expr, buf);
-        // Refer to z_bytes.rs to see how to put different types of message
+        // Refer to z_bytes.rs to see how to serialize different types of message
         publisher
             .put(buf)
             .encoding(Encoding::TEXT_PLAIN) // Optionally set the encoding metadata 

--- a/examples/examples/z_put.rs
+++ b/examples/examples/z_put.rs
@@ -26,6 +26,7 @@ async fn main() {
     let session = zenoh::open(config).await.unwrap();
 
     println!("Putting Data ('{key_expr}': '{payload}')...");
+    // Refer to z_bytes.rs to see how to put different types of message
     session.put(&key_expr, payload).await.unwrap();
 }
 

--- a/examples/examples/z_put.rs
+++ b/examples/examples/z_put.rs
@@ -26,7 +26,7 @@ async fn main() {
     let session = zenoh::open(config).await.unwrap();
 
     println!("Putting Data ('{key_expr}': '{payload}')...");
-    // Refer to z_bytes.rs to see how to put different types of message
+    // Refer to z_bytes.rs to see how to serialize different types of message
     session.put(&key_expr, payload).await.unwrap();
 }
 

--- a/examples/examples/z_queryable.rs
+++ b/examples/examples/z_queryable.rs
@@ -46,6 +46,7 @@ async fn main() {
         match query.payload() {
             None => println!(">> [Queryable ] Received Query '{}'", query.selector()),
             Some(query_payload) => {
+                // Refer to z_bytes.rs to see how to deserialize different types of message
                 let deserialized_payload = query_payload
                     .deserialize::<String>()
                     .unwrap_or_else(|e| format!("{}", e));
@@ -61,6 +62,7 @@ async fn main() {
             key_expr.as_str(),
             payload,
         );
+        // Refer to z_bytes.rs to see how to serialize different types of message
         query
             .reply(key_expr.clone(), payload.clone())
             .await

--- a/examples/examples/z_sub.rs
+++ b/examples/examples/z_sub.rs
@@ -35,6 +35,7 @@ async fn main() {
 
     println!("Press CTRL-C to quit...");
     while let Ok(sample) = subscriber.recv_async().await {
+        // Refer to z_bytes.rs to see how to deserialize different types of message
         let payload = sample
             .payload()
             .deserialize::<String>()


### PR DESCRIPTION
Now we use ZBytes to replace Value, and we should provide some examples for users to know how to do the transformation.
Add z_bytes.rs in the example to help users know how it works.
Waiting for https://github.com/eclipse-zenoh/zenoh/pull/1174 to be merged and need some update.