### PR TITLE
fix: adminspace encodings

### DIFF
--- a/plugins/zenoh-plugin-rest/src/lib.rs
+++ b/plugins/zenoh-plugin-rest/src/lib.rs
@@ -67,6 +67,7 @@ pub fn base64_encode(data: &[u8]) -> String {
 }
 
 fn payload_to_json(payload: &ZBytes, encoding: &Encoding) -> serde_json::Value {
+    println!("Encoding is: {encoding:?}");
     match payload.is_empty() {
         // If the value is empty return a JSON null
         true => serde_json::Value::Null,
@@ -77,10 +78,19 @@ fn payload_to_json(payload: &ZBytes, encoding: &Encoding) -> serde_json::Value {
                 &Encoding::APPLICATION_JSON | &Encoding::TEXT_JSON | &Encoding::TEXT_JSON5 => {
                     payload
                         .deserialize::<serde_json::Value>()
-                        .unwrap_or_else(|_| {
+                        .unwrap_or_else(|e| {
+                            tracing::warn!("Encoding is JSON but data is not JSON, converting to base64, Error: {e:?}");
                             serde_json::Value::String(base64_encode(&Cow::from(payload)))
                         })
                 }
+                &Encoding::TEXT_PLAIN | &Encoding::ZENOH_STRING  => serde_json::Value::String(
+                    payload
+                        .deserialize::<String>()
+                        .unwrap_or_else(|e| {
+                            tracing::warn!("Encoding is String but data is not String, converting to base64, Error: {e:?}");
+                            base64_encode(&Cow::from(payload))
+                        }),
+                ),
                 // otherwise convert to JSON string
                 _ => serde_json::Value::String(base64_encode(&Cow::from(payload))),
             }

--- a/plugins/zenoh-plugin-rest/src/lib.rs
+++ b/plugins/zenoh-plugin-rest/src/lib.rs
@@ -67,7 +67,6 @@ pub fn base64_encode(data: &[u8]) -> String {
 }
 
 fn payload_to_json(payload: &ZBytes, encoding: &Encoding) -> serde_json::Value {
-    println!("Encoding is: {encoding:?}");
     match payload.is_empty() {
         // If the value is empty return a JSON null
         true => serde_json::Value::Null,

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -622,8 +622,15 @@ fn local_data(context: &AdminContext, query: Query) {
     }
 
     tracing::trace!("AdminSpace router_data: {:?}", json);
+    let payload = match ZBytes::try_from(json) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::error!("Error serializing AdminSpace reply: {:?}", e);
+            return;
+        }
+    };
     if let Err(e) = query
-        .reply(reply_key, json.to_string())
+        .reply(reply_key, payload)
         .encoding(Encoding::APPLICATION_JSON)
         .wait()
     {

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -664,7 +664,11 @@ zenoh_build{{version="{}"}} 1
             .openmetrics_text(),
     );
 
-    if let Err(e) = query.reply(reply_key, metrics).wait() {
+    if let Err(e) = query
+        .reply(reply_key, metrics)
+        .encoding(Encoding::APPLICATION_JSON)
+        .wait()
+    {
         tracing::error!("Error sending AdminSpace reply: {:?}", e);
     }
 }
@@ -681,6 +685,7 @@ fn routers_linkstate_data(context: &AdminContext, query: Query) {
 
     if let Err(e) = query
         .reply(reply_key, tables.hat_code.info(&tables, WhatAmI::Router))
+        .encoding(Encoding::APPLICATION_JSON)
         .wait()
     {
         tracing::error!("Error sending AdminSpace reply: {:?}", e);
@@ -699,6 +704,7 @@ fn peers_linkstate_data(context: &AdminContext, query: Query) {
 
     if let Err(e) = query
         .reply(reply_key, tables.hat_code.info(&tables, WhatAmI::Peer))
+        .encoding(Encoding::APPLICATION_JSON)
         .wait()
     {
         tracing::error!("Error sending AdminSpace reply: {:?}", e);
@@ -770,7 +776,11 @@ fn plugins_data(context: &AdminContext, query: Query) {
             let status = serde_json::to_value(status).unwrap();
             match ZBytes::try_from(status) {
                 Ok(zbuf) => {
-                    if let Err(e) = query.reply(key, zbuf).wait() {
+                    if let Err(e) = query
+                        .reply(key, zbuf)
+                        .encoding(Encoding::APPLICATION_JSON)
+                        .wait()
+                    {
                         tracing::error!("Error sending AdminSpace reply: {:?}", e);
                     }
                 }
@@ -799,6 +809,7 @@ fn plugins_status(context: &AdminContext, query: Query) {
                     if query.key_expr().intersects(&key_expr) {
                         if let Err(e) = query
                             .reply(key_expr, ZSerde.serialize(plugin.path()))
+                            .encoding(Encoding::APPLICATION_JSON)
                             .wait()
                         {
                             tracing::error!("Error sending AdminSpace reply: {:?}", e);
@@ -824,7 +835,7 @@ fn plugins_status(context: &AdminContext, query: Query) {
                         if let Ok(key_expr) = KeyExpr::try_from(response.key) {
                             match ZBytes::try_from(response.value) {
                                 Ok(zbuf) => {
-                                    if let Err(e) = query.reply(key_expr, zbuf).wait() {
+                                    if let Err(e) = query.reply(key_expr, zbuf).encoding(Encoding::APPLICATION_JSON).wait() {
                                         tracing::error!("Error sending AdminSpace reply: {:?}", e);
                                     }
                                 },


### PR DESCRIPTION
After the removal of `Value` the encoding of the Admin Space have been lost.

So for instance this:

```
{
        "key": "@/router/8f2aef5a89c14100b70184094f5bdea9/status/plugins/storage_manager/volumes/file-system-volume",
        "value": {"root":"/home/vscode/.zenoh/zenoh_backend_fs","version":"0.11.0-dev"},
        "encoding": "application/json",
        "time": null
    }
```

becomes this:

```
{
        "key": "@/router/8f2aef5a89c14100b70184094f5bdea9/status/plugins/storage_manager/volumes/file-system-volume",
        "value": "eyJyb290IjoiL2hvbWUvdnNjb2RlLy56ZW5vaC96ZW5vaF9iYWNrZW5kX2ZzIiwidmVyc2lvbiI6IjAuMTEuMC1kZXYifQ==",
        "encoding": "zenoh/bytes",
        "time": null
    }
```

This PR aims at solving this bug.
