### PR TITLE
fix: replace some unsafe code with safe version

### DIFF
--- a/commons/zenoh-buffers/src/bbuf.rs
+++ b/commons/zenoh-buffers/src/bbuf.rs
@@ -127,7 +127,7 @@ impl Writer for &mut BBuf {
         self.capacity() - self.len()
     }
 
-    fn with_slot<F>(&mut self, len: usize, f: F) -> Result<NonZeroUsize, DidntWrite>
+    unsafe fn with_slot<F>(&mut self, len: usize, f: F) -> Result<NonZeroUsize, DidntWrite>
     where
         F: FnOnce(&mut [u8]) -> usize,
     {

--- a/commons/zenoh-buffers/src/bbuf.rs
+++ b/commons/zenoh-buffers/src/bbuf.rs
@@ -127,7 +127,7 @@ impl Writer for &mut BBuf {
         self.capacity() - self.len()
     }
 
-    unsafe fn with_slot<F>(&mut self, len: usize, f: F) -> Result<NonZeroUsize, DidntWrite>
+    unsafe fn with_slot<F>(&mut self, len: usize, write: F) -> Result<NonZeroUsize, DidntWrite>
     where
         F: FnOnce(&mut [u8]) -> usize,
     {
@@ -135,7 +135,7 @@ impl Writer for &mut BBuf {
             return Err(DidntWrite);
         }
 
-        let written = f(self.as_writable_slice());
+        let written = write(self.as_writable_slice());
         self.len += written;
 
         NonZeroUsize::new(written).ok_or(DidntWrite)

--- a/commons/zenoh-buffers/src/bbuf.rs
+++ b/commons/zenoh-buffers/src/bbuf.rs
@@ -135,7 +135,8 @@ impl Writer for &mut BBuf {
             return Err(DidntWrite);
         }
 
-        let written = write(self.as_writable_slice());
+        // SAFETY: self.remaining() >= len
+        let written = write(unsafe { self.as_writable_slice().get_unchecked_mut(..len) });
         self.len += written;
 
         NonZeroUsize::new(written).ok_or(DidntWrite)

--- a/commons/zenoh-buffers/src/lib.rs
+++ b/commons/zenoh-buffers/src/lib.rs
@@ -139,7 +139,7 @@ pub mod writer {
         }
         /// Provides a buffer of exactly `len` uninitialized bytes to `f` to allow in-place writing.
         /// `f` must return the number of bytes it actually wrote.
-        fn with_slot<F>(&mut self, len: usize, f: F) -> Result<NonZeroUsize, DidntWrite>
+        unsafe fn with_slot<F>(&mut self, len: usize, f: F) -> Result<NonZeroUsize, DidntWrite>
         where
             F: FnOnce(&mut [u8]) -> usize;
     }

--- a/commons/zenoh-buffers/src/lib.rs
+++ b/commons/zenoh-buffers/src/lib.rs
@@ -137,9 +137,14 @@ pub mod writer {
         fn can_write(&self) -> bool {
             self.remaining() != 0
         }
-        /// Provides a buffer of exactly `len` uninitialized bytes to `f` to allow in-place writing.
-        /// `f` must return the number of bytes it actually wrote.
-        unsafe fn with_slot<F>(&mut self, len: usize, f: F) -> Result<NonZeroUsize, DidntWrite>
+        /// Provides a buffer of exactly `len` uninitialized bytes to `write` to allow in-place writing.
+        /// `write` must return the number of bytes it actually wrote.
+        ///
+        /// # Safety
+        ///
+        /// Caller must ensure that `write` return an integer lesser than or equal to the length of
+        /// the slice passed in argument
+        unsafe fn with_slot<F>(&mut self, len: usize, write: F) -> Result<NonZeroUsize, DidntWrite>
         where
             F: FnOnce(&mut [u8]) -> usize;
     }

--- a/commons/zenoh-buffers/src/slice.rs
+++ b/commons/zenoh-buffers/src/slice.rs
@@ -201,10 +201,12 @@ impl<'a> SiphonableReader for &'a [u8] {
     where
         W: Writer,
     {
-        let len = writer.write(self).map_err(|_| DidntSiphon)?;
-        // SAFETY: len is returned from the writer, therefore it means
-        //         len amount of bytes have been written to the slice.
-        *self = unsafe { self.get_unchecked(len.get()..) };
-        Ok(len)
+        let res = writer.write(self).map_err(|_| DidntSiphon);
+        if let Ok(len) = res {
+            // SAFETY: len is returned from the writer, therefore it means
+            //         len amount of bytes have been written to the slice.
+            *self = crate::unsafe_slice!(self, len.get()..);
+        }
+        res
     }
 }

--- a/commons/zenoh-buffers/src/slice.rs
+++ b/commons/zenoh-buffers/src/slice.rs
@@ -83,10 +83,6 @@ impl Writer for &mut [u8] {
         self.len()
     }
 
-    /// # Safety
-    ///
-    /// Caller must ensure that `write` return a length lesser than or equal to the length of
-    /// the slice passed in argument
     unsafe fn with_slot<F>(&mut self, len: usize, write: F) -> Result<NonZeroUsize, DidntWrite>
     where
         F: FnOnce(&mut [u8]) -> usize,

--- a/commons/zenoh-buffers/src/vec.rs
+++ b/commons/zenoh-buffers/src/vec.rs
@@ -93,7 +93,7 @@ impl Writer for &mut Vec<u8> {
         usize::MAX
     }
 
-    unsafe fn with_slot<F>(&mut self, mut len: usize, f: F) -> Result<NonZeroUsize, DidntWrite>
+    unsafe fn with_slot<F>(&mut self, mut len: usize, write: F) -> Result<NonZeroUsize, DidntWrite>
     where
         F: FnOnce(&mut [u8]) -> usize,
     {
@@ -103,7 +103,7 @@ impl Writer for &mut Vec<u8> {
         let s = crate::unsafe_slice_mut!(self.spare_capacity_mut(), ..len);
         // SAFETY: converting MaybeUninit<u8> into [u8] is safe because we are going to write on it.
         //         The returned len tells us how many bytes have been written so as to update the len accordingly.
-        len = unsafe { f(&mut *(s as *mut [mem::MaybeUninit<u8>] as *mut [u8])) };
+        len = unsafe { write(&mut *(s as *mut [mem::MaybeUninit<u8>] as *mut [u8])) };
         // SAFETY: we already reserved len elements on the vector.
         unsafe { self.set_len(self.len() + len) };
 

--- a/commons/zenoh-buffers/src/vec.rs
+++ b/commons/zenoh-buffers/src/vec.rs
@@ -93,7 +93,7 @@ impl Writer for &mut Vec<u8> {
         usize::MAX
     }
 
-    fn with_slot<F>(&mut self, mut len: usize, f: F) -> Result<NonZeroUsize, DidntWrite>
+    unsafe fn with_slot<F>(&mut self, mut len: usize, f: F) -> Result<NonZeroUsize, DidntWrite>
     where
         F: FnOnce(&mut [u8]) -> usize,
     {

--- a/commons/zenoh-buffers/src/zbuf.rs
+++ b/commons/zenoh-buffers/src/zbuf.rs
@@ -590,12 +590,11 @@ impl<'a> HasWriter for &'a mut ZBuf {
 
 impl Writer for ZBufWriter<'_> {
     fn write(&mut self, bytes: &[u8]) -> Result<NonZeroUsize, DidntWrite> {
-        if bytes.is_empty() {
+        let Some(len) = NonZeroUsize::new(bytes.len()) else {
             return Err(DidntWrite);
-        }
+        };
         self.write_exact(bytes)?;
-        // SAFETY: this operation is safe since we check if bytes is empty
-        Ok(unsafe { NonZeroUsize::new_unchecked(bytes.len()) })
+        Ok(len)
     }
 
     fn write_exact(&mut self, bytes: &[u8]) -> Result<(), DidntWrite> {
@@ -646,7 +645,7 @@ impl Writer for ZBufWriter<'_> {
         Ok(())
     }
 
-    fn with_slot<F>(&mut self, mut len: usize, f: F) -> Result<NonZeroUsize, DidntWrite>
+    unsafe fn with_slot<F>(&mut self, mut len: usize, f: F) -> Result<NonZeroUsize, DidntWrite>
     where
         F: FnOnce(&mut [u8]) -> usize,
     {

--- a/commons/zenoh-buffers/src/zbuf.rs
+++ b/commons/zenoh-buffers/src/zbuf.rs
@@ -645,7 +645,7 @@ impl Writer for ZBufWriter<'_> {
         Ok(())
     }
 
-    unsafe fn with_slot<F>(&mut self, mut len: usize, f: F) -> Result<NonZeroUsize, DidntWrite>
+    unsafe fn with_slot<F>(&mut self, mut len: usize, write: F) -> Result<NonZeroUsize, DidntWrite>
     where
         F: FnOnce(&mut [u8]) -> usize,
     {
@@ -657,7 +657,7 @@ impl Writer for ZBufWriter<'_> {
         let s = crate::unsafe_slice_mut!(cache.spare_capacity_mut(), ..len);
         // SAFETY: converting MaybeUninit<u8> into [u8] is safe because we are going to write on it.
         //         The returned len tells us how many bytes have been written so as to update the len accordingly.
-        len = unsafe { f(&mut *(s as *mut [mem::MaybeUninit<u8>] as *mut [u8])) };
+        len = unsafe { write(&mut *(s as *mut [mem::MaybeUninit<u8>] as *mut [u8])) };
         // SAFETY: we already reserved len elements on the vector.
         unsafe { cache.set_len(prev_cache_len + len) };
 

--- a/commons/zenoh-buffers/src/zslice.rs
+++ b/commons/zenoh-buffers/src/zslice.rs
@@ -122,7 +122,7 @@ impl ZSlice {
     }
 
     pub fn empty() -> Self {
-        unsafe { ZSlice::new_unchecked(Arc::new([]), 0, 0) }
+        Self::new(Arc::new([]), 0, 0).unwrap()
     }
 
     /// # Safety

--- a/commons/zenoh-buffers/tests/readwrite.rs
+++ b/commons/zenoh-buffers/tests/readwrite.rs
@@ -46,13 +46,15 @@ macro_rules! run_write {
 
         writer.write_exact(&WBS4).unwrap();
 
-        writer
-            .with_slot(4, |mut buffer| {
+        // SAFETY: callback returns the length of the buffer
+        unsafe {
+            writer.with_slot(4, |mut buffer| {
                 let w = buffer.write(&WBS5).unwrap();
                 assert_eq!(4, w.get());
                 w.get()
             })
-            .unwrap();
+        }
+        .unwrap();
     };
 }
 

--- a/commons/zenoh-codec/src/core/zint.rs
+++ b/commons/zenoh-codec/src/core/zint.rs
@@ -112,7 +112,7 @@ where
     type Output = Result<(), DidntWrite>;
 
     fn write(self, writer: &mut W, mut x: u64) -> Self::Output {
-        writer.with_slot(VLE_LEN_MAX, move |buffer| {
+        let write = move |buffer| {
             let mut len = 0;
             while (x & !0x7f_u64) != 0 {
                 // SAFETY: buffer is guaranteed to be VLE_LEN long where VLE_LEN is
@@ -139,7 +139,10 @@ where
             }
             // The number of written bytes
             len
-        })?;
+        };
+        // SAFETY: write algorithm guarantees than returned length is lesser than or equal to
+        // `VLE_LEN_MAX`.
+        unsafe { writer.with_slot(VLE_LEN_MAX, write)? };
         Ok(())
     }
 }

--- a/commons/zenoh-codec/src/core/zint.rs
+++ b/commons/zenoh-codec/src/core/zint.rs
@@ -112,7 +112,7 @@ where
     type Output = Result<(), DidntWrite>;
 
     fn write(self, writer: &mut W, mut x: u64) -> Self::Output {
-        let write = move |buffer| {
+        let write = move |buffer: &mut [u8]| {
             let mut len = 0;
             while (x & !0x7f_u64) != 0 {
                 // SAFETY: buffer is guaranteed to be VLE_LEN long where VLE_LEN is


### PR DESCRIPTION
Compiler is able to optimize bound checks based on previous checks See https://godbolt.org/z/oGesnb6a4 or https://godbolt.org/z/c6c41bvE5

`Writer::with_slot` has been made unsafe, because its implementations rely on a precondition on the write callback