### PR TITLE
feat: use the bit manipulation to compute the alignment size

### DIFF
--- a/commons/zenoh-shm/src/api/provider/types.rs
+++ b/commons/zenoh-shm/src/api/provider/types.rs
@@ -114,17 +114,18 @@ impl AllocAlignment {
         //
         // Hence R = f(S+A-1) = (S+(A-1)) & !(A-1) is the desired value
 
-        // Overflow check: ensure S ≤ 2^B - 2^P so that R < S+A ≤ 2^B and hence it's a valid usize
-        let bound = usize::MAX - (1 << self.pow) + 1;
+        // Compute A - 1 = 2^P - 1
+        let a_minus_1 = self.get_alignment_value().get() - 1;
+
+        // Overflow check: ensure S ≤ 2^B - 2^P = (2^B - 1) - (A - 1)
+        // so that R < S+A ≤ 2^B and hence it's a valid usize
+        let bound = usize::MAX - a_minus_1;
         assert!(
             size.get() <= bound,
             "The given size {} exceeded the maximum {}",
             size.get(),
             bound
         );
-
-        // Compute A-1
-        let a_minus_1 = self.get_alignment_value().get() - 1;
 
         // Overflow never occurs due to the check above
         let r = (size.get() + a_minus_1) & !a_minus_1;

--- a/commons/zenoh-shm/src/api/provider/types.rs
+++ b/commons/zenoh-shm/src/api/provider/types.rs
@@ -109,7 +109,7 @@ impl AllocAlignment {
         // 1. x % A = 0 ⇔ ∀i < P, bᵢ = 0
         // 2. f(x) ≜ x & !(A-1) leads to ∀i < P, bᵢ = 0, hence f(x) % A = 0
         // (i.e. f zeros all bits before the P-th bit)
-        // 3. R = min{x | x ≥ S, x % A = 0} is equivlent to find the unique R where S ≤ R < S+A and R % A = 0
+        // 3. R = min{x | x ≥ S, x % A = 0} is equivalent to find the unique R where S ≤ R < S+A and R % A = 0
         // 4. x-A < f(x) ≤ x ⇒ S-1 < f(S+A-1) ≤ S+A-1 ⇒ S ≤ f(S+A-1) < S+A
         //
         // Hence R = f(S+A-1) = (S+(A-1)) & !(A-1) is the desired value

--- a/commons/zenoh-shm/src/api/provider/types.rs
+++ b/commons/zenoh-shm/src/api/provider/types.rs
@@ -105,7 +105,7 @@ impl AllocAlignment {
         // The properties are
         // 1. All bits after the alignment bit should be zero to be a valid multiple
         // 2. For any x, (x & !(A - 1)) % A = 0 since it wipes out all digits after the alignment bit.
-        // 3. S + (A-1) doesn't carry if S % A = 0, otherwise it carries one bit since the alignment bit.
+        // 3. S + (A-1) doesn't carry if S % A = 0, otherwise it carries one bit to the alignment bit.
         // Hence (S+(A-1)) & !(A-1) is min({x | x >= S, x % A = 0})
         let a = self.get_alignment_value().get() - 1;
         (size.get() + a) & !a

--- a/commons/zenoh-shm/src/api/provider/types.rs
+++ b/commons/zenoh-shm/src/api/provider/types.rs
@@ -100,10 +100,10 @@ impl AllocAlignment {
         // - alignment value A = 2^P
         // - return R = min{x | x ≥ S, x % A = 0}
         //
-        // Example 1: A = 4 = 0b00100, S = 4 = 0b00100 ⇒ R = 4  = 0b00100
-        // Example 2: A = 4 = 0b00100, S = 7 = 0b00111 ⇒ R = 8  = 0b01000
-        // Example 3: A = 4 = 0b00100, S = 8 = 0b01000 ⇒ R = 8  = 0b01000
-        // Example 4: A = 4 = 0b00100, S = 9 = 0b01001 ⇒ R = 12 = 0b01100
+        // Example 1: A = 4 = (00100)₂, S = 4 = (00100)₂ ⇒ R = 4  = (00100)₂
+        // Example 2: A = 4 = (00100)₂, S = 7 = (00111)₂ ⇒ R = 8  = (01000)₂
+        // Example 3: A = 4 = (00100)₂, S = 8 = (01000)₂ ⇒ R = 8  = (01000)₂
+        // Example 4: A = 4 = (00100)₂, S = 9 = (01001)₂ ⇒ R = 12 = (01100)₂
         //
         // Algorithm: For any x = (bₙ, ⋯, b₂, b₁)₂ in binary representation,
         // 1. x % A = 0 ⇔ ∀i < P, bᵢ = 0


### PR DESCRIPTION
## Issue of the current design

Despite the pow being limited, i.e. alignment is less than or equal to 2^63, a given size = 2^64-1 still can cause an overflow when computing `size.get() + (alignment.get() - remainder)` = 2^64 - 1 + (2^63 - (2^63 - 1)) = 2^64.
```rust
    pub fn align_size(&self, size: NonZeroUsize) -> NonZeroUsize {
        let alignment = self.get_alignment_value();
        match size.get() % alignment {
            0 => size,
            // SAFETY:
            // This unsafe block is always safe:
            // 1. 0 < remainder < alignment
            // 2. because of 1, the value of (alignment.get() - remainder) is always > 0
            // 3. because of 2, we add nonzero size to nonzero (alignment.get() - remainder) and it is always positive if no overflow
            // 4. we make sure that there is no overflow condition in 3 by means of alignment limitation in `new` by limiting pow value
            remainder => unsafe {
                NonZeroUsize::new_unchecked(size.get() + (alignment.get() - remainder))
            },
        }
    }
```

## New design

```rust
    pub fn align_size(&self, size: NonZeroUsize) -> NonZeroUsize {
        // Notations:
        // - size to align S
        // - usize::BITS B
        // - pow P where 0 ≤ P < B
        // - alignment value A = 2^P
        // - return R = min{x | x ≥ S, x % A = 0}
        //
        // Example 1: A = 4 = (00100)₂, S = 4 = (00100)₂ ⇒ R = 4  = (00100)₂
        // Example 2: A = 4 = (00100)₂, S = 7 = (00111)₂ ⇒ R = 8  = (01000)₂
        // Example 3: A = 4 = (00100)₂, S = 8 = (01000)₂ ⇒ R = 8  = (01000)₂
        // Example 4: A = 4 = (00100)₂, S = 9 = (01001)₂ ⇒ R = 12 = (01100)₂
        //
        // Algorithm: For any x = (bₙ, ⋯, b₂, b₁)₂ in binary representation,
        // 1. x % A = 0 ⇔ ∀i < P, bᵢ = 0
        // 2. f(x) ≜ x & !(A-1) leads to ∀i < P, bᵢ = 0, hence f(x) % A = 0
        // (i.e. f zeros all bits before the P-th bit)
        // 3. R = min{x | x ≥ S, x % A = 0} is equivlent to find the unique R where S ≤ R < S+A and R % A = 0
        // 4. x-A < f(x) ≤ x ⇒ S-1 < f(S+A-1) ≤ S+A-1 ⇒ S ≤ f(S+A-1) < S+A
        //
        // Hence R = f(S+A-1) = (S+(A-1)) & !(A-1) is the desired value

        // Overflow check: ensure S ≤ 2^B - 2^P so that R < S+A ≤ 2^B and hence it's a valid usize
        let bound = usize::MAX - (1 << self.pow) + 1;
        assert!(
            size.get() <= bound,
            "The given size {} exceeded the maximum {}",
            size.get(),
            bound
        );

        // Compute A-1
        let a_minus_1 = self.get_alignment_value().get() - 1;

        // Overflow never occurs due to the check above
        let r = (size.get() + a_minus_1) & !a_minus_1;

        // SAFETY: R ≥ 0 since R ≥ S ≥ 0
        unsafe { NonZeroUsize::new_unchecked(r) }
    }

```