### PR TITLE
Use TCP MSS as TCP link MTU

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5695,6 +5695,7 @@ name = "zenoh-link-tcp"
 version = "0.11.0-dev"
 dependencies = [
  "async-trait",
+ "socket2 0.5.6",
  "tokio",
  "tokio-util",
  "tracing",
@@ -5719,6 +5720,7 @@ dependencies = [
  "rustls-pki-types",
  "rustls-webpki",
  "secrecy",
+ "socket2 0.5.6",
  "tokio",
  "tokio-rustls",
  "tokio-util",

--- a/io/zenoh-links/zenoh-link-tcp/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-tcp/Cargo.toml
@@ -26,6 +26,7 @@ description = "Internal crate for zenoh."
 
 [dependencies]
 async-trait = { workspace = true }
+socket2 = { workspace = true }
 tokio = { workspace = true, features = ["net", "io-util", "rt", "time"] }
 tokio-util = { workspace = true, features = ["rt"] }
 tracing = {workspace = true}

--- a/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
@@ -165,7 +165,8 @@ impl LinkUnicastTrait for LinkUnicastTcp {
         #[cfg(target_family = "unix")]
         {
             let socket = socket2::SockRef::from(self.get_socket());
-            let mss = socket.mss().unwrap_or(mtu as u32);
+            // Get the MSS and divide it by 2 to ensure we can at least fill half the MSS
+            let mss = socket.mss().unwrap_or(mtu as u32) / 2;
             // Compute largest multiple of TCP MSS that is smaller of default MTU
             let mut tgt = mss;
             while (tgt + mss) < mtu as u32 {

--- a/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
@@ -153,17 +153,22 @@ impl LinkUnicastTrait for LinkUnicastTcp {
 
     #[inline(always)]
     fn get_mtu(&self) -> BatchSize {
-        // target_os limitation of socket2: https://docs.rs/socket2/latest/src/socket2/sys/unix.rs.html#1544
-        #[cfg(not(target_os = "redox"))]
+        // target limitation of socket2: https://docs.rs/socket2/latest/src/socket2/sys/unix.rs.html#1544
+        #[cfg(target_family = "unix")]
         {
             let socket = socket2::SockRef::from(self.get_socket());
             let mss = socket.mss().unwrap_or(*TCP_DEFAULT_MTU as u32);
             mss.min(*TCP_DEFAULT_MTU as u32) as BatchSize
         }
 
-        #[cfg(target_os = "redox")]
+        #[cfg(not(target_family = "unix"))]
         {
-            *TCP_DEFAULT_MTU
+            // See IETF RFC6691 https://datatracker.ietf.org/doc/rfc6691/
+            let header = match self.src_addr.ip() {
+                std::net::IpAddr::V4(_) => 40,
+                std::net::IpAddr::V6(_) => 60,
+            };
+            *TCP_DEFAULT_MTU - header
         }
     }
 

--- a/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
@@ -81,7 +81,7 @@ impl LinkUnicastTcp {
         }
     }
 
-    #[allow(clippy::mut_from_ref)]
+    #[cfg(target_family = "unix")]
     fn get_socket(&self) -> &TcpStream {
         unsafe { &*self.socket.get() }
     }

--- a/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
@@ -153,23 +153,28 @@ impl LinkUnicastTrait for LinkUnicastTcp {
 
     #[inline(always)]
     fn get_mtu(&self) -> BatchSize {
+        // See IETF RFC6691: https://datatracker.ietf.org/doc/rfc6691/
+        let header = match self.src_addr.ip() {
+            std::net::IpAddr::V4(_) => 40,
+            std::net::IpAddr::V6(_) => 60,
+        };
+        #[allow(unused_mut)] // mut is not needed when target_family != unix
+        let mut mtu = *TCP_DEFAULT_MTU - header;
+
         // target limitation of socket2: https://docs.rs/socket2/latest/src/socket2/sys/unix.rs.html#1544
         #[cfg(target_family = "unix")]
         {
             let socket = socket2::SockRef::from(self.get_socket());
-            let mss = socket.mss().unwrap_or(*TCP_DEFAULT_MTU as u32);
-            mss.min(*TCP_DEFAULT_MTU as u32) as BatchSize
+            let mss = socket.mss().unwrap_or(mtu as u32);
+            // Compute largest multiple of TCP MSS that is smaller of default MTU
+            let mut tgt = mss;
+            while (tgt + mss) < mtu as u32 {
+                tgt += mss;
+            }
+            mtu = (mtu as u32).min(tgt) as BatchSize;
         }
 
-        #[cfg(not(target_family = "unix"))]
-        {
-            // See IETF RFC6691 https://datatracker.ietf.org/doc/rfc6691/
-            let header = match self.src_addr.ip() {
-                std::net::IpAddr::V4(_) => 40,
-                std::net::IpAddr::V6(_) => 60,
-            };
-            *TCP_DEFAULT_MTU - header
-        }
+        mtu
     }
 
     #[inline(always)]

--- a/io/zenoh-links/zenoh-link-tls/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-tls/Cargo.toml
@@ -33,6 +33,7 @@ rustls-pemfile = { workspace = true }
 rustls-pki-types = { workspace = true }
 rustls-webpki = { workspace = true }
 secrecy = { workspace = true }
+socket2 = { workspace = true }
 tokio = { workspace = true, features = ["fs", "io-util", "net", "sync"] }
 tokio-rustls = { workspace = true }
 tokio-util = { workspace = true, features = ["rt"] }

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -200,7 +200,8 @@ impl LinkUnicastTrait for LinkUnicastTls {
         #[cfg(target_family = "unix")]
         {
             let socket = socket2::SockRef::from(self.get_socket().get_ref().0);
-            let mss = socket.mss().unwrap_or(mtu as u32);
+            // Get the MSS and divide it by 2 to ensure we can at least fill half the MSS
+            let mss = socket.mss().unwrap_or(mtu as u32) / 2;
             // Compute largest multiple of TCP MSS that is smaller of default MTU
             let mut tgt = mss;
             while (tgt + mss) < mtu as u32 {

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -109,6 +109,7 @@ impl LinkUnicastTls {
         }
     }
 
+    #[cfg(target_family = "unix")]
     fn get_socket(&self) -> &TlsStream<TcpStream> {
         unsafe { &*self.inner.get() }
     }

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -193,7 +193,7 @@ impl LinkUnicastTrait for LinkUnicastTls {
             std::net::IpAddr::V4(_) => 40,
             std::net::IpAddr::V6(_) => 60,
         };
-        #[allow(unused_mut, assign)] // mut is not needed when target_family != unix
+        #[allow(unused_mut)] // mut is not needed when target_family != unix
         let mut mtu = *TLS_DEFAULT_MTU - header;
 
         // target limitation of socket2: https://docs.rs/socket2/latest/src/socket2/sys/unix.rs.html#1544

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -187,17 +187,22 @@ impl LinkUnicastTrait for LinkUnicastTls {
 
     #[inline(always)]
     fn get_mtu(&self) -> BatchSize {
-        // target_os limitation of socket2: https://docs.rs/socket2/latest/src/socket2/sys/unix.rs.html#1544
-        #[cfg(not(target_os = "redox"))]
+        // target limitation of socket2: https://docs.rs/socket2/latest/src/socket2/sys/unix.rs.html#1544
+        #[cfg(target_family = "unix")]
         {
             let socket = socket2::SockRef::from(self.get_socket().get_ref().0);
             let mss = socket.mss().unwrap_or(*TLS_DEFAULT_MTU as u32);
             mss.min(*TLS_DEFAULT_MTU as u32) as BatchSize
         }
 
-        #[cfg(target_os = "redox")]
+        #[cfg(not(target_family = "unix"))]
         {
-            *TLS_DEFAULT_MTU
+            // See IETF RFC6691 https://datatracker.ietf.org/doc/rfc6691/
+            let header = match self.src_addr.ip() {
+                std::net::IpAddr::V4(_) => 40,
+                std::net::IpAddr::V6(_) => 60,
+            };
+            *TLS_DEFAULT_MTU - header
         }
     }
 

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -61,6 +61,7 @@ pub struct LinkUnicastTls {
     write_mtx: AsyncMutex<()>,
     read_mtx: AsyncMutex<()>,
     auth_identifier: LinkAuthId,
+    mtu: BatchSize,
 }
 
 unsafe impl Send for LinkUnicastTls {}
@@ -96,6 +97,29 @@ impl LinkUnicastTls {
             );
         }
 
+        // Compute the MTU
+        // See IETF RFC6691: https://datatracker.ietf.org/doc/rfc6691/
+        let header = match src_addr.ip() {
+            std::net::IpAddr::V4(_) => 40,
+            std::net::IpAddr::V6(_) => 60,
+        };
+        #[allow(unused_mut)] // mut is not needed when target_family != unix
+        let mut mtu = *TLS_DEFAULT_MTU - header;
+
+        // target limitation of socket2: https://docs.rs/socket2/latest/src/socket2/sys/unix.rs.html#1544
+        #[cfg(target_family = "unix")]
+        {
+            let socket = socket2::SockRef::from(&tcp_stream);
+            // Get the MSS and divide it by 2 to ensure we can at least fill half the MSS
+            let mss = socket.mss().unwrap_or(mtu as u32) / 2;
+            // Compute largest multiple of TCP MSS that is smaller of default MTU
+            let mut tgt = mss;
+            while (tgt + mss) < mtu as u32 {
+                tgt += mss;
+            }
+            mtu = (mtu as u32).min(tgt) as BatchSize;
+        }
+
         // Build the Tls object
         LinkUnicastTls {
             inner: UnsafeCell::new(socket),
@@ -106,12 +130,8 @@ impl LinkUnicastTls {
             write_mtx: AsyncMutex::new(()),
             read_mtx: AsyncMutex::new(()),
             auth_identifier,
+            mtu,
         }
-    }
-
-    #[cfg(target_family = "unix")]
-    fn get_socket(&self) -> &TlsStream<TcpStream> {
-        unsafe { &*self.inner.get() }
     }
 
     // NOTE: It is safe to suppress Clippy warning since no concurrent reads
@@ -188,29 +208,7 @@ impl LinkUnicastTrait for LinkUnicastTls {
 
     #[inline(always)]
     fn get_mtu(&self) -> BatchSize {
-        // See IETF RFC6691: https://datatracker.ietf.org/doc/rfc6691/
-        let header = match self.src_addr.ip() {
-            std::net::IpAddr::V4(_) => 40,
-            std::net::IpAddr::V6(_) => 60,
-        };
-        #[allow(unused_mut)] // mut is not needed when target_family != unix
-        let mut mtu = *TLS_DEFAULT_MTU - header;
-
-        // target limitation of socket2: https://docs.rs/socket2/latest/src/socket2/sys/unix.rs.html#1544
-        #[cfg(target_family = "unix")]
-        {
-            let socket = socket2::SockRef::from(self.get_socket().get_ref().0);
-            // Get the MSS and divide it by 2 to ensure we can at least fill half the MSS
-            let mss = socket.mss().unwrap_or(mtu as u32) / 2;
-            // Compute largest multiple of TCP MSS that is smaller of default MTU
-            let mut tgt = mss;
-            while (tgt + mss) < mtu as u32 {
-                tgt += mss;
-            }
-            mtu = (mtu as u32).min(tgt) as BatchSize;
-        }
-
-        mtu
+        self.mtu
     }
 
     #[inline(always)]

--- a/io/zenoh-transport/src/common/batch.rs
+++ b/io/zenoh-transport/src/common/batch.rs
@@ -120,14 +120,6 @@ impl BatchConfig {
                 .then_some(BatchHeader::new(BatchHeader::COMPRESSION))
         }
     }
-
-    pub fn max_buffer_size(&self) -> usize {
-        let mut len = self.mtu as usize;
-        if self.is_streamed {
-            len += BatchSize::BITS as usize / 8;
-        }
-        len
-    }
 }
 
 // Batch header
@@ -214,7 +206,7 @@ pub struct WBatch {
 impl WBatch {
     pub fn new(config: BatchConfig) -> Self {
         let mut batch = Self {
-            buffer: BBuf::with_capacity(config.max_buffer_size()),
+            buffer: BBuf::with_capacity(config.mtu as usize),
             codec: Zenoh080Batch::new(),
             config,
             #[cfg(feature = "stats")]

--- a/io/zenoh-transport/src/multicast/link.rs
+++ b/io/zenoh-transport/src/multicast/link.rs
@@ -73,9 +73,7 @@ impl TransportLinkMulticast {
                     .batch
                     .is_compression
                     .then_some(BBuf::with_capacity(
-                        lz4_flex::block::get_maximum_output_size(
-                            self.config.batch.max_buffer_size()
-                        ),
+                        lz4_flex::block::get_maximum_output_size(self.config.batch.mtu as usize),
                     )),
                 None
             ),
@@ -551,7 +549,7 @@ async fn rx_task(
     }
 
     // The pool of buffers
-    let mtu = link.inner.config.batch.max_buffer_size();
+    let mtu = link.inner.config.batch.mtu as usize;
     let mut n = rx_buffer_size / mtu;
     if rx_buffer_size % mtu != 0 {
         n += 1;

--- a/io/zenoh-transport/src/unicast/establishment/accept.rs
+++ b/io/zenoh-transport/src/unicast/establishment/accept.rs
@@ -163,6 +163,12 @@ impl<'a, 'b: 'a> AcceptFsm for &'a mut AcceptLink<'b> {
             .await
             .map_err(|e| (e, Some(close::reason::INVALID)))?;
 
+        tracing::trace!(
+            "Establishment Accept InitSyn: {}. Received: {:?}",
+            self.link,
+            msg
+        );
+
         let init_syn = match msg.body {
             TransportBody::InitSyn(init_syn) => init_syn,
             _ => {
@@ -362,7 +368,7 @@ impl<'a, 'b: 'a> AcceptFsm for &'a mut AcceptLink<'b> {
         let cookie: ZSlice = encrypted.into();
 
         // Send the message on the link
-        let message: TransportMessage = InitAck {
+        let msg: TransportMessage = InitAck {
             version: input.mine_version,
             whatami: input.mine_whatami,
             zid: input.mine_zid,
@@ -381,9 +387,15 @@ impl<'a, 'b: 'a> AcceptFsm for &'a mut AcceptLink<'b> {
 
         let _ = self
             .link
-            .send(&message)
+            .send(&msg)
             .await
             .map_err(|e| (e, Some(close::reason::GENERIC)))?;
+
+        tracing::trace!(
+            "Establishment Accept InitAck: {}. Sent: {:?}",
+            self.link,
+            msg
+        );
 
         let output = SendInitAckOut {
             cookie_nonce,
@@ -404,6 +416,12 @@ impl<'a, 'b: 'a> AcceptFsm for &'a mut AcceptLink<'b> {
             .recv()
             .await
             .map_err(|e| (e, Some(close::reason::INVALID)))?;
+
+        tracing::trace!(
+            "Establishment Accept OpenSyn: {}. Received: {:?}",
+            self.link,
+            msg
+        );
 
         let open_syn = match msg.body {
             TransportBody::OpenSyn(open_syn) => open_syn,
@@ -594,7 +612,7 @@ impl<'a, 'b: 'a> AcceptFsm for &'a mut AcceptLink<'b> {
         // Build OpenAck message
         let mine_initial_sn =
             compute_sn(input.mine_zid, input.other_zid, state.transport.resolution);
-        let open_ack = OpenAck {
+        let msg = OpenAck {
             lease: input.mine_lease,
             initial_sn: mine_initial_sn,
             ext_qos,
@@ -607,8 +625,13 @@ impl<'a, 'b: 'a> AcceptFsm for &'a mut AcceptLink<'b> {
         };
 
         // Do not send the OpenAck right now since we might still incur in MAX_LINKS error
+        tracing::trace!(
+            "Establishment Accept OpenAck: {}. Sent: {:?}",
+            self.link,
+            msg
+        );
 
-        let output = SendOpenAckOut { open_ack };
+        let output = SendOpenAckOut { open_ack: msg };
         Ok(output)
     }
 }

--- a/io/zenoh-transport/src/unicast/establishment/accept.rs
+++ b/io/zenoh-transport/src/unicast/establishment/accept.rs
@@ -769,7 +769,7 @@ pub(crate) async fn accept_link(link: LinkUnicast, manager: &TransportManager) -
         .await?;
 
     tracing::debug!(
-        "New transport link accepted from {} to {}: {}.",
+        "New transport link accepted from {} to {}: {}",
         osyn_out.other_zid,
         manager.config.zid,
         s_link,

--- a/io/zenoh-transport/src/unicast/establishment/open.rs
+++ b/io/zenoh-transport/src/unicast/establishment/open.rs
@@ -208,6 +208,8 @@ impl<'a, 'b: 'a> OpenFsm for &'a mut OpenLink<'b> {
         }
         .into();
 
+        tracing::trace!("Establishment Open InitSyn: {}. Sent: {:?}", link, msg);
+
         let _ = link
             .send(&msg)
             .await
@@ -228,6 +230,8 @@ impl<'a, 'b: 'a> OpenFsm for &'a mut OpenLink<'b> {
             .recv()
             .await
             .map_err(|e| (e, Some(close::reason::INVALID)))?;
+
+        tracing::trace!("Establishment Open InitAck: {}. Received: {:?}", link, msg);
 
         let init_ack = match msg.body {
             TransportBody::InitAck(init_ack) => init_ack,
@@ -414,7 +418,7 @@ impl<'a, 'b: 'a> OpenFsm for &'a mut OpenLink<'b> {
         // Build and send an OpenSyn message
         let mine_initial_sn =
             compute_sn(input.mine_zid, input.other_zid, state.transport.resolution);
-        let message: TransportMessage = OpenSyn {
+        let msg: TransportMessage = OpenSyn {
             lease: input.mine_lease,
             initial_sn: mine_initial_sn,
             cookie: input.other_cookie,
@@ -429,9 +433,11 @@ impl<'a, 'b: 'a> OpenFsm for &'a mut OpenLink<'b> {
         .into();
 
         let _ = link
-            .send(&message)
+            .send(&msg)
             .await
             .map_err(|e| (e, Some(close::reason::GENERIC)))?;
+
+        tracing::trace!("Establishment Open OpenSyn: {}. Sent: {:?}", link, msg);
 
         let output = SendOpenSynOut {
             mine_initial_sn,
@@ -453,6 +459,8 @@ impl<'a, 'b: 'a> OpenFsm for &'a mut OpenLink<'b> {
             .recv()
             .await
             .map_err(|e| (e, Some(close::reason::INVALID)))?;
+
+        tracing::trace!("Establishment Open OpenAck: {}. Received: {:?}", link, msg);
 
         let open_ack = match msg.body {
             TransportBody::OpenAck(open_ack) => open_ack,

--- a/io/zenoh-transport/src/unicast/link.rs
+++ b/io/zenoh-transport/src/unicast/link.rs
@@ -67,9 +67,7 @@ impl TransportLinkUnicast {
                     .batch
                     .is_compression
                     .then_some(BBuf::with_capacity(
-                        lz4_flex::block::get_maximum_output_size(
-                            self.config.batch.max_buffer_size()
-                        ),
+                        lz4_flex::block::get_maximum_output_size(self.config.batch.mtu as usize),
                     )),
                 None
             ),

--- a/io/zenoh-transport/src/unicast/lowlatency/link.rs
+++ b/io/zenoh-transport/src/unicast/lowlatency/link.rs
@@ -152,11 +152,7 @@ impl TransportUnicastLowlatency {
 
             // The pool of buffers
             let pool = {
-                let mtu = if is_streamed {
-                    link_rx.batch.mtu as usize
-                } else {
-                    link_rx.batch.max_buffer_size()
-                };
+                let mtu = link_rx.batch.mtu as usize;
                 let mut n = rx_buffer_size / mtu;
                 if rx_buffer_size % mtu != 0 {
                     n += 1;

--- a/io/zenoh-transport/src/unicast/universal/link.rs
+++ b/io/zenoh-transport/src/unicast/universal/link.rs
@@ -248,7 +248,7 @@ async fn rx_task(
     }
 
     // The pool of buffers
-    let mtu = link.batch.max_buffer_size();
+    let mtu = link.batch.mtu as usize;
     let mut n = rx_buffer_size / mtu;
     if rx_buffer_size % mtu != 0 {
         n += 1;

--- a/io/zenoh-transport/tests/unicast_compression.rs
+++ b/io/zenoh-transport/tests/unicast_compression.rs
@@ -51,8 +51,8 @@ mod tests {
 
     const MSG_COUNT: usize = 1_000;
     const MSG_SIZE_ALL: [usize; 2] = [1_024, 131_072];
-    const MSG_SIZE_LOWLATENCY: [usize; 2] = [1_024, 65000];
     const MSG_SIZE_NOFRAG: [usize; 1] = [1_024];
+    const MSG_SIZE_LOWLATENCY: [usize; 1] = MSG_SIZE_NOFRAG;
 
     // Transport Handler for the router
     struct SHRouter {

--- a/io/zenoh-transport/tests/unicast_transport.rs
+++ b/io/zenoh-transport/tests/unicast_transport.rs
@@ -232,13 +232,13 @@ const SLEEP_COUNT: Duration = Duration::from_millis(10);
 
 const MSG_COUNT: usize = 1_000;
 const MSG_SIZE_ALL: [usize; 2] = [1_024, 131_072];
-const MSG_SIZE_LOWLATENCY: [usize; 2] = [1_024, 65000];
 #[cfg(any(
     feature = "transport_tcp",
     feature = "transport_udp",
     feature = "transport_unixsock-stream",
 ))]
 const MSG_SIZE_NOFRAG: [usize; 1] = [1_024];
+const MSG_SIZE_LOWLATENCY: [usize; 1] = MSG_SIZE_NOFRAG;
 
 // Transport Handler for the router
 struct SHRouter {

--- a/zenoh/src/api/handlers/ring.rs
+++ b/zenoh/src/api/handlers/ring.rs
@@ -24,7 +24,7 @@ use zenoh_result::ZResult;
 use super::{callback::Callback, Dyn, IntoHandler};
 use crate::api::session::API_DATA_RECEPTION_CHANNEL_SIZE;
 
-/// A synchrounous ring channel with a limited size that allows users to keep the last N data.
+/// A synchronous ring channel with a limited size that allows users to keep the last N data.
 pub struct RingChannel {
     capacity: usize,
 }

--- a/zenoh/src/api/selector.rs
+++ b/zenoh/src/api/selector.rs
@@ -26,7 +26,7 @@ use super::{key_expr::KeyExpr, queryable::Query};
 
 /// A selector is the combination of a [Key Expression](crate::key_expr::KeyExpr), which defines the
 /// set of keys that are relevant to an operation, and a set of parameters
-/// with a few intendend uses:
+/// with a few intended uses:
 /// - specifying arguments to a queryable, allowing the passing of Remote Procedure Call parameters
 /// - filtering by value,
 /// - filtering by metadata, such as the timestamp of a value,


### PR DESCRIPTION
This PR retrieves the configured TCP MSS (Maximum Segment Size) for TCP-based stream (i.e. TCP and TLS) and uses the MSS value as advertised link MTU. This allows to choose the Zenoh frame size more wisely based on the reported information.