### PR TITLE
fix: typos

### DIFF
--- a/zenoh/src/api/handlers/ring.rs
+++ b/zenoh/src/api/handlers/ring.rs
@@ -24,7 +24,7 @@ use zenoh_result::ZResult;
 use super::{callback::Callback, Dyn, IntoHandler};
 use crate::api::session::API_DATA_RECEPTION_CHANNEL_SIZE;
 
-/// A synchrounous ring channel with a limited size that allows users to keep the last N data.
+/// A synchronous ring channel with a limited size that allows users to keep the last N data.
 pub struct RingChannel {
     capacity: usize,
 }

--- a/zenoh/src/api/selector.rs
+++ b/zenoh/src/api/selector.rs
@@ -26,7 +26,7 @@ use super::{key_expr::KeyExpr, queryable::Query};
 
 /// A selector is the combination of a [Key Expression](crate::key_expr::KeyExpr), which defines the
 /// set of keys that are relevant to an operation, and a set of parameters
-/// with a few intendend uses:
+/// with a few intended uses:
 /// - specifying arguments to a queryable, allowing the passing of Remote Procedure Call parameters
 /// - filtering by value,
 /// - filtering by metadata, such as the timestamp of a value,


### PR DESCRIPTION
* zenoh/src/api/handlers/ring.rs: synchrounous -> synchronous
* zenoh/src/api/selector.rs: intendend -> intended