### PR TITLE
Make `rustls`, `rustls-webpki` and `webpki-roots` optional

### DIFF
--- a/io/zenoh-link-commons/Cargo.toml
+++ b/io/zenoh-link-commons/Cargo.toml
@@ -26,14 +26,15 @@ version = { workspace = true }
 
 [features]
 compression = []
+tls = ["dep:rustls", "dep:rustls-webpki", "dep:webpki-roots"]
 
 [dependencies]
 async-trait = { workspace = true }
 base64 = { workspace = true, optional = true }
 flume = { workspace = true }
 futures = { workspace = true }
-rustls = { workspace = true }
-rustls-webpki = { workspace = true }
+rustls = { workspace = true, optional = true }
+rustls-webpki = { workspace = true, optional = true }
 serde = { workspace = true, features = ["default"] }
 tokio = { workspace = true, features = [
   "fs",

--- a/io/zenoh-link-commons/src/lib.rs
+++ b/io/zenoh-link-commons/src/lib.rs
@@ -21,6 +21,7 @@ extern crate alloc;
 
 mod listener;
 mod multicast;
+#[cfg(feature = "tls")]
 pub mod tls;
 mod unicast;
 

--- a/io/zenoh-links/zenoh-link-quic/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-quic/Cargo.toml
@@ -49,7 +49,7 @@ x509-parser = { workspace = true }
 zenoh-collections = { workspace = true }
 zenoh-config = { workspace = true }
 zenoh-core = { workspace = true }
-zenoh-link-commons = { workspace = true }
+zenoh-link-commons = { workspace = true, features = ["tls"] }
 zenoh-protocol = { workspace = true }
 zenoh-result = { workspace = true }
 zenoh-runtime = { workspace = true }

--- a/io/zenoh-links/zenoh-link-tls/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-tls/Cargo.toml
@@ -43,7 +43,7 @@ webpki-roots = { workspace = true }
 zenoh-collections = { workspace = true }
 zenoh-config = { workspace = true }
 zenoh-core = { workspace = true }
-zenoh-link-commons = { workspace = true }
+zenoh-link-commons = { workspace = true, features = ["tls"] }
 zenoh-protocol = { workspace = true }
 zenoh-result = { workspace = true }
 zenoh-runtime = { workspace = true }


### PR DESCRIPTION
In f36b228a18cb048e93751c2b58075d3d65e4b79c the `zenoh-link-commons` (used by `zenoh-link`) crate was made to depend on the aforementioned TLS crates. This is not necessary as the `tls` module is only used by `zenoh-link-tls` and `zenoh-link-quic`.