### PR TITLE
Do not trigger transport error in case of SHM buffer invalidation

### DIFF
--- a/io/zenoh-transport/src/multicast/rx.rs
+++ b/io/zenoh-transport/src/multicast/rx.rs
@@ -13,6 +13,8 @@
 //
 use std::sync::MutexGuard;
 
+#[cfg(feature = "shared-memory")]
+use tracing::error;
 use zenoh_core::{zlock, zread};
 use zenoh_protocol::{
     core::{Locator, Priority, Reliability},
@@ -44,7 +46,10 @@ impl TransportMulticastInner {
         #[cfg(feature = "shared-memory")]
         {
             if self.manager.config.multicast.is_shm {
-                crate::shm::map_zmsg_to_shmbuf(&mut msg, &self.manager.shmr)?;
+                if let Err(e) = crate::shm::map_zmsg_to_shmbuf(&mut msg, &self.manager.shmr) {
+                    error!("Error receiving SHM buffer: {e}");
+                    return Ok(());
+                }
             }
         }
 

--- a/io/zenoh-transport/src/shm.rs
+++ b/io/zenoh-transport/src/shm.rs
@@ -332,7 +332,7 @@ pub fn map_zslice_to_shmbuf(zslice: &mut ZSlice, shmr: &ShmReader) -> ZResult<()
     let shmbinfo: ShmBufInfo = codec.read(&mut reader).map_err(|e| zerror!("{:?}", e))?;
 
     // Try to mount shmbuf and replace the content of the slice with mounted buf
-    // NOTE: SHM buffer read error is not a hard error becuse we do not want to
+    // NOTE: SHM buffer read error is not a hard error because we do not want to
     // loose all the data in the whole ZBuf above. In case of error we just
     // replace current ZSlice with an empty one
     *zslice = match shmr.read_shmbuf(&shmbinfo) {

--- a/io/zenoh-transport/src/unicast/lowlatency/rx.rs
+++ b/io/zenoh-transport/src/unicast/lowlatency/rx.rs
@@ -11,6 +11,8 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
+#[cfg(feature = "shared-memory")]
+use tracing::error;
 use zenoh_buffers::{
     reader::{HasReader, Reader},
     ZSlice,
@@ -37,7 +39,10 @@ impl TransportUnicastLowlatency {
             #[cfg(feature = "shared-memory")]
             {
                 if self.config.shm.is_some() {
-                    crate::shm::map_zmsg_to_shmbuf(&mut msg, &self.manager.shmr)?;
+                    if let Err(e) = crate::shm::map_zmsg_to_shmbuf(&mut msg, &self.manager.shmr) {
+                        error!("Error receiving SHM buffer: {e}");
+                        return Ok(());
+                    }
                 }
             }
             callback.handle_message(msg)

--- a/io/zenoh-transport/src/unicast/universal/rx.rs
+++ b/io/zenoh-transport/src/unicast/universal/rx.rs
@@ -13,6 +13,8 @@
 //
 use std::sync::MutexGuard;
 
+#[cfg(feature = "shared-memory")]
+use tracing::error;
 use zenoh_core::{zlock, zread};
 use zenoh_link::Link;
 use zenoh_protocol::{
@@ -45,7 +47,10 @@ impl TransportUnicastUniversal {
         #[cfg(feature = "shared-memory")]
         {
             if self.config.shm.is_some() {
-                crate::shm::map_zmsg_to_shmbuf(&mut msg, &self.manager.shmr)?;
+                if let Err(e) = crate::shm::map_zmsg_to_shmbuf(&mut msg, &self.manager.shmr) {
+                    error!("Error receiving SHM buffer: {e}");
+                    return Ok(());
+                }
             }
         }
         callback.handle_message(msg)


### PR DESCRIPTION
The core problem is that our RX task goes down with an error if it receives invalidated SHM buffer. And SHM buffer invalidation is not a hard error, but a case that could happen, so we shouldn't fail our transport because of it