### PR TITLE
Support bytes::Bytes for ZBytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,9 +648,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "cache-padded"
@@ -5382,6 +5382,7 @@ dependencies = [
  "ahash",
  "async-trait",
  "base64 0.22.1",
+ "bytes",
  "event-listener 5.3.1",
  "flume",
  "form_urlencoded",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ async-std = { version = "=1.12.0", default-features = false } # Default features
 async-trait = "0.1.60"
 base64 = "0.22.1"
 bincode = "1.3.3"
+bytes = "1.6.1"
 clap = { version = "4.4.11", features = ["derive"] }
 console-subscriber = "0.3.0"
 const_format = "0.2.30"

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -71,6 +71,7 @@ tokio-util = { workspace = true }
 ahash = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
+bytes = { workspace = true }
 event-listener = { workspace = true }
 flume = { workspace = true }
 form_urlencoded = { workspace = true }

--- a/zenoh/src/api/bytes.rs
+++ b/zenoh/src/api/bytes.rs
@@ -1930,6 +1930,40 @@ impl TryFrom<&mut ZBytes> for serde_yaml::Value {
     }
 }
 
+// Bytes
+impl Serialize<bytes::Bytes> for ZSerde {
+    type Output = ZBytes;
+
+    fn serialize(self, t: bytes::Bytes) -> Self::Output {
+        Self.serialize(&t)
+    }
+}
+
+impl Serialize<&bytes::Bytes> for ZSerde {
+    type Output = ZBytes;
+
+    fn serialize(self, t: &bytes::Bytes) -> Self::Output {
+        ZBytes::from(t.as_ref())
+    }
+}
+
+impl Serialize<&mut bytes::Bytes> for ZSerde {
+    type Output = ZBytes;
+
+    fn serialize(self, t: &mut bytes::Bytes) -> Self::Output {
+        ZBytes::from(t.as_ref())
+    }
+}
+
+impl Deserialize<bytes::Bytes> for ZSerde {
+    type Input<'a> = &'a ZBytes;
+    type Error = Infallible;
+
+    fn deserialize(self, v: Self::Input<'_>) -> Result<bytes::Bytes, Self::Error> {
+        Ok(bytes::Bytes::from(v.into::<Vec<u8>>()))
+    }
+}
+
 // CBOR
 impl Serialize<serde_cbor::Value> for ZSerde {
     type Output = Result<ZBytes, serde_cbor::Error>;
@@ -3167,6 +3201,10 @@ mod tests {
         // Parameters
         serialize_deserialize!(Parameters, Parameters::from(""));
         serialize_deserialize!(Parameters, Parameters::from("a=1;b=2;c3"));
+
+        // Bytes
+        serialize_deserialize!(bytes::Bytes, bytes::Bytes::from(vec![1, 2, 3, 4]));
+        serialize_deserialize!(bytes::Bytes, bytes::Bytes::from("Hello World"));
 
         // Tuple
         serialize_deserialize!((usize, usize), (0, 1));


### PR DESCRIPTION
Since uProtocol UPayload is [using bytes::Bytes](https://github.com/eclipse-uprotocol/up-rust/blob/1ac1c060240a47512afa8e63ea8d3952b54e3a01/src/communication.rs#L252), I think it will be good if we can support the transformation in ZBytes.