### PR TITLE
Add publisher delete and queryable reply messages to ACL

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -199,7 +199,7 @@
   //       /// Id has to be unique within the rule set
   //       "id": "rule1",
   //       "messages": [
-  //         "put", "query", "declare_subscriber", "declare_queryable"
+  //         "put", "query", "declare_subscriber", "declare_queryable", "reply"
   //       ],
   //       "flows":["egress","ingress"],
   //       "permission": "allow",
@@ -210,7 +210,7 @@
   //     {
   //       "id": "rule2",
   //       "messages": [
-  //         "put", "query", "declare_subscriber", "declare_queryable"
+  //         "put", "query", "declare_subscriber", "declare_queryable", "reply"
   //       ],
   //       "flows":["ingress"],
   //       "permission": "allow",

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -199,7 +199,8 @@
   //       /// Id has to be unique within the rule set
   //       "id": "rule1",
   //       "messages": [
-  //         "put", "query", "declare_subscriber", "declare_queryable", "reply"
+  //         "put", "delete", "declare_subscriber", 
+  //         "query", "reply", "declare_queryable",
   //       ],
   //       "flows":["egress","ingress"],
   //       "permission": "allow",
@@ -210,7 +211,8 @@
   //     {
   //       "id": "rule2",
   //       "messages": [
-  //         "put", "query", "declare_subscriber", "declare_queryable", "reply"
+  //         "put", "delete", "declare_subscriber", 
+  //         "query", "reply", "declare_queryable",
   //       ],
   //       "flows":["ingress"],
   //       "permission": "allow",

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -169,6 +169,7 @@ pub enum AclMessage {
     DeclareSubscriber,
     Query,
     DeclareQueryable,
+    Reply,
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, Hash, PartialEq)]

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -166,6 +166,7 @@ pub struct PolicyRule {
 #[serde(rename_all = "snake_case")]
 pub enum AclMessage {
     Put,
+    Delete,
     DeclareSubscriber,
     Query,
     DeclareQueryable,

--- a/zenoh/src/net/routing/dispatcher/queries.rs
+++ b/zenoh/src/net/routing/dispatcher/queries.rs
@@ -718,7 +718,7 @@ pub(crate) fn route_send_response(
                         ext_tstamp,
                         ext_respid,
                     },
-                    "".to_string(), // @TODO provide the proper key expression of the response for interceptors
+                    key_expr.to_string(),
                 ));
         }
         None => tracing::warn!(

--- a/zenoh/src/net/routing/dispatcher/queries.rs
+++ b/zenoh/src/net/routing/dispatcher/queries.rs
@@ -718,7 +718,7 @@ pub(crate) fn route_send_response(
                         ext_tstamp,
                         ext_respid,
                     },
-                    key_expr.to_string(),
+                    "".to_string(), // @TODO provide the proper key expression of the response for interceptors
                 ));
         }
         None => tracing::warn!(

--- a/zenoh/src/net/routing/interceptor/access_control.rs
+++ b/zenoh/src/net/routing/interceptor/access_control.rs
@@ -244,10 +244,8 @@ impl InterceptorTrait for IngressAclEnforcer {
                     return None;
                 }
             }
-            NetworkBody::Response(Response { wire_expr, .. }) => {
-                // @TODO: Remove wire_expr usage when issue #1255 is implemented
-                if self.action(AclMessage::Reply, "Reply (ingress)", wire_expr.as_str())
-                    == Permission::Deny
+            NetworkBody::Response(Response { .. }) => {
+                if self.action(AclMessage::Reply, "Reply (ingress)", key_expr?) == Permission::Deny
                 {
                     return None;
                 }

--- a/zenoh/src/net/routing/interceptor/access_control.rs
+++ b/zenoh/src/net/routing/interceptor/access_control.rs
@@ -235,6 +235,21 @@ impl InterceptorTrait for IngressAclEnforcer {
             .or_else(|| ctx.full_expr());
 
         match &ctx.msg.body {
+            NetworkBody::Request(Request {
+                payload: RequestBody::Query(_),
+                ..
+            }) => {
+                if self.action(AclMessage::Query, "Query (ingress)", key_expr?) == Permission::Deny
+                {
+                    return None;
+                }
+            }
+            NetworkBody::Response(Response { .. }) => {
+                if self.action(AclMessage::Reply, "Reply (ingress)", key_expr?) == Permission::Deny
+                {
+                    return None;
+                }
+            }
             NetworkBody::Push(Push {
                 payload: PushBody::Put(_),
                 ..
@@ -249,15 +264,6 @@ impl InterceptorTrait for IngressAclEnforcer {
             }) => {
                 if self.action(AclMessage::Delete, "Delete (ingress)", key_expr?)
                     == Permission::Deny
-                {
-                    return None;
-                }
-            }
-            NetworkBody::Request(Request {
-                payload: RequestBody::Query(_),
-                ..
-            }) => {
-                if self.action(AclMessage::Query, "Query (ingress)", key_expr?) == Permission::Deny
                 {
                     return None;
                 }
@@ -284,12 +290,6 @@ impl InterceptorTrait for IngressAclEnforcer {
                     "Declare Queryable (ingress)",
                     key_expr?,
                 ) == Permission::Deny
-                {
-                    return None;
-                }
-            }
-            NetworkBody::Response(Response { .. }) => {
-                if self.action(AclMessage::Reply, "Reply (ingress)", key_expr?) == Permission::Deny
                 {
                     return None;
                 }
@@ -352,6 +352,19 @@ impl InterceptorTrait for EgressAclEnforcer {
             .or_else(|| ctx.full_expr());
 
         match &ctx.msg.body {
+            NetworkBody::Request(Request {
+                payload: RequestBody::Query(_),
+                ..
+            }) => {
+                if self.action(AclMessage::Query, "Query (egress)", key_expr?) == Permission::Deny {
+                    return None;
+                }
+            }
+            NetworkBody::Response(Response { .. }) => {
+                if self.action(AclMessage::Reply, "Reply (egress)", key_expr?) == Permission::Deny {
+                    return None;
+                }
+            }
             NetworkBody::Push(Push {
                 payload: PushBody::Put(_),
                 ..
@@ -366,14 +379,6 @@ impl InterceptorTrait for EgressAclEnforcer {
             }) => {
                 if self.action(AclMessage::Delete, "Delete (egress)", key_expr?) == Permission::Deny
                 {
-                    return None;
-                }
-            }
-            NetworkBody::Request(Request {
-                payload: RequestBody::Query(_),
-                ..
-            }) => {
-                if self.action(AclMessage::Query, "Query (egress)", key_expr?) == Permission::Deny {
                     return None;
                 }
             }
@@ -400,11 +405,6 @@ impl InterceptorTrait for EgressAclEnforcer {
                     key_expr?,
                 ) == Permission::Deny
                 {
-                    return None;
-                }
-            }
-            NetworkBody::Response(Response { .. }) => {
-                if self.action(AclMessage::Reply, "Reply (egress)", key_expr?) == Permission::Deny {
                     return None;
                 }
             }

--- a/zenoh/src/net/routing/interceptor/access_control.rs
+++ b/zenoh/src/net/routing/interceptor/access_control.rs
@@ -278,7 +278,7 @@ impl InterceptorTrait for IngressAclEnforcer {
                     return None;
                 }
             }
-            NetworkBody::Response(_) => {
+            NetworkBody::Response(Response { .. }) => {
                 if self.action(AclMessage::Reply, "Reply (ingress)", key_expr?) == Permission::Deny
                 {
                     return None;
@@ -353,7 +353,7 @@ impl InterceptorTrait for EgressAclEnforcer {
                     return None;
                 }
             }
-            NetworkBody::Response(_) => {
+            NetworkBody::Response(Response { .. }) => {
                 if self.action(AclMessage::Reply, "Reply (egress)", key_expr?) == Permission::Deny {
                     return None;
                 }

--- a/zenoh/src/net/routing/interceptor/access_control.rs
+++ b/zenoh/src/net/routing/interceptor/access_control.rs
@@ -278,6 +278,12 @@ impl InterceptorTrait for IngressAclEnforcer {
                     return None;
                 }
             }
+            NetworkBody::Response(_) => {
+                if self.action(AclMessage::Reply, "Reply (ingress)", key_expr?) == Permission::Deny
+                {
+                    return None;
+                }
+            }
             _ => {}
         }
         Some(ctx)
@@ -344,6 +350,11 @@ impl InterceptorTrait for EgressAclEnforcer {
                     key_expr?,
                 ) == Permission::Deny
                 {
+                    return None;
+                }
+            }
+            NetworkBody::Response(_) => {
+                if self.action(AclMessage::Reply, "Reply (egress)", key_expr?) == Permission::Deny {
                     return None;
                 }
             }

--- a/zenoh/src/net/routing/interceptor/access_control.rs
+++ b/zenoh/src/net/routing/interceptor/access_control.rs
@@ -26,7 +26,7 @@ use zenoh_config::{
 };
 use zenoh_protocol::{
     core::ZenohIdProto,
-    network::{Declare, DeclareBody, NetworkBody, NetworkMessage, Push, Request},
+    network::{Declare, DeclareBody, NetworkBody, NetworkMessage, Push, Request, Response},
     zenoh::{PushBody, RequestBody},
 };
 use zenoh_result::ZResult;
@@ -284,7 +284,43 @@ impl InterceptorTrait for IngressAclEnforcer {
                     return None;
                 }
             }
-            _ => {}
+            // Unfiltered Delete messages
+            NetworkBody::Push(Push {
+                payload: PushBody::Del(_),
+                ..
+            }) => {}
+            // Unfiltered Declare messages
+            NetworkBody::Declare(Declare {
+                body: DeclareBody::DeclareKeyExpr(_),
+                ..
+            })
+            | NetworkBody::Declare(Declare {
+                body: DeclareBody::DeclareFinal(_),
+                ..
+            })
+            | NetworkBody::Declare(Declare {
+                body: DeclareBody::DeclareToken(_),
+                ..
+            }) => {}
+            // Unfiltered Undeclare messages
+            NetworkBody::Declare(Declare {
+                body: DeclareBody::UndeclareKeyExpr(_),
+                ..
+            })
+            | NetworkBody::Declare(Declare {
+                body: DeclareBody::UndeclareToken(_),
+                ..
+            })
+            | NetworkBody::Declare(Declare {
+                body: DeclareBody::UndeclareQueryable(_),
+                ..
+            })
+            | NetworkBody::Declare(Declare {
+                body: DeclareBody::UndeclareSubscriber(_),
+                ..
+            }) => {}
+            // Unfiltered remaining message types
+            NetworkBody::Interest(_) | NetworkBody::OAM(_) | NetworkBody::ResponseFinal(_) => {}
         }
         Some(ctx)
     }
@@ -358,7 +394,43 @@ impl InterceptorTrait for EgressAclEnforcer {
                     return None;
                 }
             }
-            _ => {}
+            // Unfiltered Delete messages
+            NetworkBody::Push(Push {
+                payload: PushBody::Del(_),
+                ..
+            }) => {}
+            // Unfiltered Declare messages
+            NetworkBody::Declare(Declare {
+                body: DeclareBody::DeclareKeyExpr(_),
+                ..
+            })
+            | NetworkBody::Declare(Declare {
+                body: DeclareBody::DeclareFinal(_),
+                ..
+            })
+            | NetworkBody::Declare(Declare {
+                body: DeclareBody::DeclareToken(_),
+                ..
+            }) => {}
+            // Unfiltered Undeclare messages
+            NetworkBody::Declare(Declare {
+                body: DeclareBody::UndeclareKeyExpr(_),
+                ..
+            })
+            | NetworkBody::Declare(Declare {
+                body: DeclareBody::UndeclareToken(_),
+                ..
+            })
+            | NetworkBody::Declare(Declare {
+                body: DeclareBody::UndeclareQueryable(_),
+                ..
+            })
+            | NetworkBody::Declare(Declare {
+                body: DeclareBody::UndeclareSubscriber(_),
+                ..
+            }) => {}
+            // Unfiltered remaining message types
+            NetworkBody::Interest(_) | NetworkBody::OAM(_) | NetworkBody::ResponseFinal(_) => {}
         }
         Some(ctx)
     }

--- a/zenoh/src/net/routing/interceptor/access_control.rs
+++ b/zenoh/src/net/routing/interceptor/access_control.rs
@@ -244,8 +244,10 @@ impl InterceptorTrait for IngressAclEnforcer {
                     return None;
                 }
             }
-            NetworkBody::Response(Response { .. }) => {
-                if self.action(AclMessage::Reply, "Reply (ingress)", key_expr?) == Permission::Deny
+            NetworkBody::Response(Response { wire_expr, .. }) => {
+                // @TODO: Remove wire_expr usage when issue #1255 is implemented
+                if self.action(AclMessage::Reply, "Reply (ingress)", wire_expr.as_str())
+                    == Permission::Deny
                 {
                     return None;
                 }
@@ -360,8 +362,11 @@ impl InterceptorTrait for EgressAclEnforcer {
                     return None;
                 }
             }
-            NetworkBody::Response(Response { .. }) => {
-                if self.action(AclMessage::Reply, "Reply (egress)", key_expr?) == Permission::Deny {
+            NetworkBody::Response(Response { wire_expr, .. }) => {
+                // @TODO: Remove wire_expr usage when issue #1255 is implemented
+                if self.action(AclMessage::Reply, "Reply (egress)", wire_expr.as_str())
+                    == Permission::Deny
+                {
                     return None;
                 }
             }

--- a/zenoh/src/net/routing/interceptor/access_control.rs
+++ b/zenoh/src/net/routing/interceptor/access_control.rs
@@ -243,6 +243,16 @@ impl InterceptorTrait for IngressAclEnforcer {
                     return None;
                 }
             }
+            NetworkBody::Push(Push {
+                payload: PushBody::Del(_),
+                ..
+            }) => {
+                if self.action(AclMessage::Delete, "Delete (ingress)", key_expr?)
+                    == Permission::Deny
+                {
+                    return None;
+                }
+            }
             NetworkBody::Request(Request {
                 payload: RequestBody::Query(_),
                 ..
@@ -284,11 +294,6 @@ impl InterceptorTrait for IngressAclEnforcer {
                     return None;
                 }
             }
-            // Unfiltered Delete messages
-            NetworkBody::Push(Push {
-                payload: PushBody::Del(_),
-                ..
-            }) => {}
             // Unfiltered Declare messages
             NetworkBody::Declare(Declare {
                 body: DeclareBody::DeclareKeyExpr(_),
@@ -355,6 +360,15 @@ impl InterceptorTrait for EgressAclEnforcer {
                     return None;
                 }
             }
+            NetworkBody::Push(Push {
+                payload: PushBody::Del(_),
+                ..
+            }) => {
+                if self.action(AclMessage::Delete, "Delete (egress)", key_expr?) == Permission::Deny
+                {
+                    return None;
+                }
+            }
             NetworkBody::Request(Request {
                 payload: RequestBody::Query(_),
                 ..
@@ -394,11 +408,6 @@ impl InterceptorTrait for EgressAclEnforcer {
                     return None;
                 }
             }
-            // Unfiltered Delete messages
-            NetworkBody::Push(Push {
-                payload: PushBody::Del(_),
-                ..
-            }) => {}
             // Unfiltered Declare messages
             NetworkBody::Declare(Declare {
                 body: DeclareBody::DeclareKeyExpr(_),

--- a/zenoh/src/net/routing/interceptor/authorization.rs
+++ b/zenoh/src/net/routing/interceptor/authorization.rs
@@ -186,6 +186,7 @@ struct ActionPolicy {
     put: PermissionPolicy,
     declare_subscriber: PermissionPolicy,
     declare_queryable: PermissionPolicy,
+    reply: PermissionPolicy,
 }
 
 impl ActionPolicy {
@@ -195,6 +196,7 @@ impl ActionPolicy {
             AclMessage::Put => &self.put,
             AclMessage::DeclareSubscriber => &self.declare_subscriber,
             AclMessage::DeclareQueryable => &self.declare_queryable,
+            AclMessage::Reply => &self.reply,
         }
     }
     fn action_mut(&mut self, action: AclMessage) -> &mut PermissionPolicy {
@@ -203,6 +205,7 @@ impl ActionPolicy {
             AclMessage::Put => &mut self.put,
             AclMessage::DeclareSubscriber => &mut self.declare_subscriber,
             AclMessage::DeclareQueryable => &mut self.declare_queryable,
+            AclMessage::Reply => &mut self.reply,
         }
     }
 }

--- a/zenoh/src/net/routing/interceptor/authorization.rs
+++ b/zenoh/src/net/routing/interceptor/authorization.rs
@@ -194,21 +194,21 @@ impl ActionPolicy {
     fn action(&self, action: AclMessage) -> &PermissionPolicy {
         match action {
             AclMessage::Query => &self.query,
+            AclMessage::Reply => &self.reply,
             AclMessage::Put => &self.put,
             AclMessage::Delete => &self.delete,
             AclMessage::DeclareSubscriber => &self.declare_subscriber,
             AclMessage::DeclareQueryable => &self.declare_queryable,
-            AclMessage::Reply => &self.reply,
         }
     }
     fn action_mut(&mut self, action: AclMessage) -> &mut PermissionPolicy {
         match action {
             AclMessage::Query => &mut self.query,
+            AclMessage::Reply => &mut self.reply,
             AclMessage::Put => &mut self.put,
             AclMessage::Delete => &mut self.delete,
             AclMessage::DeclareSubscriber => &mut self.declare_subscriber,
             AclMessage::DeclareQueryable => &mut self.declare_queryable,
-            AclMessage::Reply => &mut self.reply,
         }
     }
 }

--- a/zenoh/src/net/routing/interceptor/authorization.rs
+++ b/zenoh/src/net/routing/interceptor/authorization.rs
@@ -184,6 +184,7 @@ impl PermissionPolicy {
 struct ActionPolicy {
     query: PermissionPolicy,
     put: PermissionPolicy,
+    delete: PermissionPolicy,
     declare_subscriber: PermissionPolicy,
     declare_queryable: PermissionPolicy,
     reply: PermissionPolicy,
@@ -194,6 +195,7 @@ impl ActionPolicy {
         match action {
             AclMessage::Query => &self.query,
             AclMessage::Put => &self.put,
+            AclMessage::Delete => &self.delete,
             AclMessage::DeclareSubscriber => &self.declare_subscriber,
             AclMessage::DeclareQueryable => &self.declare_queryable,
             AclMessage::Reply => &self.reply,
@@ -203,6 +205,7 @@ impl ActionPolicy {
         match action {
             AclMessage::Query => &mut self.query,
             AclMessage::Put => &mut self.put,
+            AclMessage::Delete => &mut self.delete,
             AclMessage::DeclareSubscriber => &mut self.declare_subscriber,
             AclMessage::DeclareQueryable => &mut self.declare_queryable,
             AclMessage::Reply => &mut self.reply,

--- a/zenoh/tests/acl.rs
+++ b/zenoh/tests/acl.rs
@@ -140,7 +140,7 @@ mod test {
 
             publisher.delete().await.unwrap();
             tokio::time::sleep(SLEEP).await;
-            assert_ne!(*zlock!(deleted), true);
+            assert!(!(*zlock!(deleted)));
             ztimeout!(subscriber.undeclare()).unwrap();
         }
         close_sessions(sub_session, pub_session).await;
@@ -194,7 +194,7 @@ mod test {
 
             publisher.delete().await.unwrap();
             tokio::time::sleep(SLEEP).await;
-            assert_eq!(*zlock!(deleted), true);
+            assert!(*zlock!(deleted));
             ztimeout!(subscriber.undeclare()).unwrap();
         }
 
@@ -276,7 +276,7 @@ mod test {
 
             publisher.delete().await.unwrap();
             tokio::time::sleep(SLEEP).await;
-            assert_ne!(*zlock!(deleted), true);
+            assert!(!(*zlock!(deleted)));
             ztimeout!(subscriber.undeclare()).unwrap();
         }
         close_sessions(sub_session, pub_session).await;
@@ -357,7 +357,7 @@ mod test {
 
             publisher.delete().await.unwrap();
             tokio::time::sleep(SLEEP).await;
-            assert_eq!(*zlock!(deleted), true);
+            assert!(*zlock!(deleted));
             ztimeout!(subscriber.undeclare()).unwrap();
         }
         close_sessions(sub_session, pub_session).await;

--- a/zenoh/tests/authentication.rs
+++ b/zenoh/tests/authentication.rs
@@ -945,7 +945,8 @@ client2name:client2passwd";
                             "flows": ["egress", "ingress"],
                             "messages": [
                                 "query",
-                                "declare_queryable"
+                                "declare_queryable",
+                                "reply",
                             ],
                             "key_exprs": [
                                 "test/demo"
@@ -1030,7 +1031,8 @@ client2name:client2passwd";
                             "flows": ["egress"],
                             "messages": [
                                 "query",
-                                "declare_queryable"
+                                "declare_queryable",
+                                "reply"
                             ],
                             "key_exprs": [
                                 "test/demo"
@@ -1256,7 +1258,8 @@ client2name:client2passwd";
                             "flows": ["egress", "ingress"],
                             "messages": [
                                 "query",
-                                "declare_queryable"
+                                "declare_queryable",
+                                "reply"
                             ],
                             "key_exprs": [
                                 "test/demo"
@@ -1342,7 +1345,8 @@ client2name:client2passwd";
                             "flows": ["egress"],
                             "messages": [
                                 "query",
-                                "declare_queryable"
+                                "declare_queryable",
+                                "reply"
                             ],
                             "key_exprs": [
                                 "test/demo"
@@ -1568,7 +1572,8 @@ client2name:client2passwd";
                             "flows": ["ingress", "egress"],
                             "messages": [
                                 "query",
-                                "declare_queryable"
+                                "declare_queryable",
+                                "reply"
                             ],
                             "key_exprs": [
                                 "test/demo"
@@ -1654,7 +1659,8 @@ client2name:client2passwd";
                             "flows": ["egress"],
                             "messages": [
                                 "query",
-                                "declare_queryable"
+                                "declare_queryable",
+                                "reply"
                             ],
                             "key_exprs": [
                                 "test/demo"


### PR DESCRIPTION
Adds filtering of publisher delete and queryable reply messages to ACL.
Example of ACL rules with delete and reply messages:
```json
{
  "access_control":
    {
      "enabled": true,
      "default_permission": "deny",
      "rules":
      [
        {
          "id": "allow queryables",
          "permission": "allow",
          "flows": ["ingress", "egress"],
          "messages": [
            "query",
            "reply",
            "declare_queryable"
          ],
          "key_exprs": [
            "**"
          ]
        },
        {
          "id": "allow delete",
          "permission": "allow",
          "flows": ["ingress", "egress"],
          "messages": [
            "delete",
          ],
          "key_exprs": [
            "**"
          ]
        },
      ],
      // rest of ACL config
    }
}
```
