### PR TITLE
Optimize RoutingContext keyexpr for Query and Response messages

### DIFF
--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -2799,13 +2799,13 @@ impl crate::net::primitives::EPrimitives for Session {
     }
 
     #[inline]
-    fn send_request(&self, ctx: crate::net::routing::RoutingContext<Request>) {
-        (self as &dyn Primitives).send_request(ctx.msg)
+    fn send_request(&self, msg: Request) {
+        (self as &dyn Primitives).send_request(msg)
     }
 
     #[inline]
-    fn send_response(&self, ctx: crate::net::routing::RoutingContext<Response>) {
-        (self as &dyn Primitives).send_response(ctx.msg)
+    fn send_response(&self, msg: Response) {
+        (self as &dyn Primitives).send_response(msg)
     }
 
     #[inline]

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -2809,8 +2809,8 @@ impl crate::net::primitives::EPrimitives for Session {
     }
 
     #[inline]
-    fn send_response_final(&self, ctx: crate::net::routing::RoutingContext<ResponseFinal>) {
-        (self as &dyn Primitives).send_response_final(ctx.msg)
+    fn send_response_final(&self, msg: ResponseFinal) {
+        (self as &dyn Primitives).send_response_final(msg)
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/zenoh/src/net/primitives/mod.rs
+++ b/zenoh/src/net/primitives/mod.rs
@@ -49,9 +49,9 @@ pub(crate) trait EPrimitives: Send + Sync {
 
     fn send_push(&self, msg: Push);
 
-    fn send_request(&self, ctx: RoutingContext<Request>);
+    fn send_request(&self, msg: Request);
 
-    fn send_response(&self, ctx: RoutingContext<Response>);
+    fn send_response(&self, msg: Response);
 
     fn send_response_final(&self, ctx: RoutingContext<ResponseFinal>);
 }
@@ -82,9 +82,9 @@ impl EPrimitives for DummyPrimitives {
 
     fn send_push(&self, _msg: Push) {}
 
-    fn send_request(&self, _ctx: RoutingContext<Request>) {}
+    fn send_request(&self, _ctx: Request) {}
 
-    fn send_response(&self, _ctx: RoutingContext<Response>) {}
+    fn send_response(&self, _ctx: Response) {}
 
     fn send_response_final(&self, _ctx: RoutingContext<ResponseFinal>) {}
 

--- a/zenoh/src/net/primitives/mod.rs
+++ b/zenoh/src/net/primitives/mod.rs
@@ -53,7 +53,7 @@ pub(crate) trait EPrimitives: Send + Sync {
 
     fn send_response(&self, msg: Response);
 
-    fn send_response_final(&self, ctx: RoutingContext<ResponseFinal>);
+    fn send_response_final(&self, msg: ResponseFinal);
 }
 
 #[derive(Default)]
@@ -86,7 +86,7 @@ impl EPrimitives for DummyPrimitives {
 
     fn send_response(&self, _msg: Response) {}
 
-    fn send_response_final(&self, _ctx: RoutingContext<ResponseFinal>) {}
+    fn send_response_final(&self, _msg: ResponseFinal) {}
 
     fn as_any(&self) -> &dyn Any {
         self

--- a/zenoh/src/net/primitives/mod.rs
+++ b/zenoh/src/net/primitives/mod.rs
@@ -82,9 +82,9 @@ impl EPrimitives for DummyPrimitives {
 
     fn send_push(&self, _msg: Push) {}
 
-    fn send_request(&self, _ctx: Request) {}
+    fn send_request(&self, _msg: Request) {}
 
-    fn send_response(&self, _ctx: Response) {}
+    fn send_response(&self, _msg: Response) {}
 
     fn send_response_final(&self, _ctx: RoutingContext<ResponseFinal>) {}
 

--- a/zenoh/src/net/primitives/mux.rs
+++ b/zenoh/src/net/primitives/mux.rs
@@ -271,53 +271,51 @@ impl EPrimitives for Mux {
         }
     }
 
-    fn send_request(&self, ctx: RoutingContext<Request>) {
-        let ctx = RoutingContext {
-            msg: NetworkMessage {
-                body: NetworkBody::Request(ctx.msg),
-                #[cfg(feature = "stats")]
-                size: None,
-            },
-            inface: ctx.inface,
-            outface: ctx.outface,
-            prefix: ctx.prefix,
-            full_expr: ctx.full_expr,
+    fn send_request(&self, msg: Request) {
+        let msg = NetworkMessage {
+            body: NetworkBody::Request(msg),
+            #[cfg(feature = "stats")]
+            size: None,
         };
-        let prefix = ctx
-            .wire_expr()
-            .and_then(|we| (!we.has_suffix()).then(|| ctx.prefix()))
-            .flatten()
-            .cloned();
-        let cache = prefix
-            .as_ref()
-            .and_then(|p| p.get_egress_cache(ctx.outface.get().unwrap()));
-        if let Some(ctx) = self.interceptor.intercept(ctx, cache) {
-            let _ = self.handler.schedule(ctx.msg);
+        if self.interceptor.interceptors.is_empty() {
+            let _ = self.handler.schedule(msg);
+        } else if let Some(face) = self.face.get().and_then(|f| f.upgrade()) {
+            let ctx = RoutingContext::new_out(msg, face.clone());
+            let prefix = ctx
+                .wire_expr()
+                .and_then(|we| (!we.has_suffix()).then(|| ctx.prefix()))
+                .flatten()
+                .cloned();
+            let cache = prefix.as_ref().and_then(|p| p.get_egress_cache(&face));
+            if let Some(ctx) = self.interceptor.intercept(ctx, cache) {
+                let _ = self.handler.schedule(ctx.msg);
+            }
+        } else {
+            tracing::error!("Uninitialized multiplexer!");
         }
     }
 
-    fn send_response(&self, ctx: RoutingContext<Response>) {
-        let ctx = RoutingContext {
-            msg: NetworkMessage {
-                body: NetworkBody::Response(ctx.msg),
-                #[cfg(feature = "stats")]
-                size: None,
-            },
-            inface: ctx.inface,
-            outface: ctx.outface,
-            prefix: ctx.prefix,
-            full_expr: ctx.full_expr,
+    fn send_response(&self, msg: Response) {
+        let msg = NetworkMessage {
+            body: NetworkBody::Response(msg),
+            #[cfg(feature = "stats")]
+            size: None,
         };
-        let prefix = ctx
-            .wire_expr()
-            .and_then(|we| (!we.has_suffix()).then(|| ctx.prefix()))
-            .flatten()
-            .cloned();
-        let cache = prefix
-            .as_ref()
-            .and_then(|p| p.get_egress_cache(ctx.outface.get().unwrap()));
-        if let Some(ctx) = self.interceptor.intercept(ctx, cache) {
-            let _ = self.handler.schedule(ctx.msg);
+        if self.interceptor.interceptors.is_empty() {
+            let _ = self.handler.schedule(msg);
+        } else if let Some(face) = self.face.get().and_then(|f| f.upgrade()) {
+            let ctx = RoutingContext::new_out(msg, face.clone());
+            let prefix = ctx
+                .wire_expr()
+                .and_then(|we| (!we.has_suffix()).then(|| ctx.prefix()))
+                .flatten()
+                .cloned();
+            let cache = prefix.as_ref().and_then(|p| p.get_egress_cache(&face));
+            if let Some(ctx) = self.interceptor.intercept(ctx, cache) {
+                let _ = self.handler.schedule(ctx.msg);
+            }
+        } else {
+            tracing::error!("Uninitialized multiplexer!");
         }
     }
 
@@ -592,53 +590,51 @@ impl EPrimitives for McastMux {
         }
     }
 
-    fn send_request(&self, ctx: RoutingContext<Request>) {
-        let ctx = RoutingContext {
-            msg: NetworkMessage {
-                body: NetworkBody::Request(ctx.msg),
-                #[cfg(feature = "stats")]
-                size: None,
-            },
-            inface: ctx.inface,
-            outface: ctx.outface,
-            prefix: ctx.prefix,
-            full_expr: ctx.full_expr,
+    fn send_request(&self, msg: Request) {
+        let msg = NetworkMessage {
+            body: NetworkBody::Request(msg),
+            #[cfg(feature = "stats")]
+            size: None,
         };
-        let prefix = ctx
-            .wire_expr()
-            .and_then(|we| (!we.has_suffix()).then(|| ctx.prefix()))
-            .flatten()
-            .cloned();
-        let cache = prefix
-            .as_ref()
-            .and_then(|p| p.get_egress_cache(ctx.outface.get().unwrap()));
-        if let Some(ctx) = self.interceptor.intercept(ctx, cache) {
-            let _ = self.handler.schedule(ctx.msg);
+        if self.interceptor.interceptors.is_empty() {
+            let _ = self.handler.schedule(msg);
+        } else if let Some(face) = self.face.get() {
+            let ctx = RoutingContext::new_out(msg, face.clone());
+            let prefix = ctx
+                .wire_expr()
+                .and_then(|we| (!we.has_suffix()).then(|| ctx.prefix()))
+                .flatten()
+                .cloned();
+            let cache = prefix.as_ref().and_then(|p| p.get_egress_cache(face));
+            if let Some(ctx) = self.interceptor.intercept(ctx, cache) {
+                let _ = self.handler.schedule(ctx.msg);
+            }
+        } else {
+            tracing::error!("Uninitialized multiplexer!");
         }
     }
 
-    fn send_response(&self, ctx: RoutingContext<Response>) {
-        let ctx = RoutingContext {
-            msg: NetworkMessage {
-                body: NetworkBody::Response(ctx.msg),
-                #[cfg(feature = "stats")]
-                size: None,
-            },
-            inface: ctx.inface,
-            outface: ctx.outface,
-            prefix: ctx.prefix,
-            full_expr: ctx.full_expr,
+    fn send_response(&self, msg: Response) {
+        let msg = NetworkMessage {
+            body: NetworkBody::Response(msg),
+            #[cfg(feature = "stats")]
+            size: None,
         };
-        let prefix = ctx
-            .wire_expr()
-            .and_then(|we| (!we.has_suffix()).then(|| ctx.prefix()))
-            .flatten()
-            .cloned();
-        let cache = prefix
-            .as_ref()
-            .and_then(|p| p.get_egress_cache(ctx.outface.get().unwrap()));
-        if let Some(ctx) = self.interceptor.intercept(ctx, cache) {
-            let _ = self.handler.schedule(ctx.msg);
+        if self.interceptor.interceptors.is_empty() {
+            let _ = self.handler.schedule(msg);
+        } else if let Some(face) = self.face.get() {
+            let ctx = RoutingContext::new_out(msg, face.clone());
+            let prefix = ctx
+                .wire_expr()
+                .and_then(|we| (!we.has_suffix()).then(|| ctx.prefix()))
+                .flatten()
+                .cloned();
+            let cache = prefix.as_ref().and_then(|p| p.get_egress_cache(face));
+            if let Some(ctx) = self.interceptor.intercept(ctx, cache) {
+                let _ = self.handler.schedule(ctx.msg);
+            }
+        } else {
+            tracing::error!("Uninitialized multiplexer!");
         }
     }
 

--- a/zenoh/src/net/routing/dispatcher/queries.rs
+++ b/zenoh/src/net/routing/dispatcher/queries.rs
@@ -43,10 +43,7 @@ use super::{
     resource::{QueryRoute, QueryRoutes, QueryTargetQablSet, Resource},
     tables::{NodeId, RoutingExpr, Tables, TablesLock},
 };
-use crate::net::routing::{
-    hat::{HatTrait, SendDeclare},
-    RoutingContext,
-};
+use crate::net::routing::hat::{HatTrait, SendDeclare};
 
 pub(crate) struct Query {
     src_face: Arc<FaceState>,
@@ -600,16 +597,11 @@ pub fn route_query(
                         face,
                         qid
                     );
-                    face.primitives
-                        .clone()
-                        .send_response_final(RoutingContext::with_expr(
-                            ResponseFinal {
-                                rid: qid,
-                                ext_qos: response::ext::QoSType::RESPONSE_FINAL,
-                                ext_tstamp: None,
-                            },
-                            expr.full_expr().to_string(),
-                        ));
+                    face.primitives.clone().send_response_final(ResponseFinal {
+                        rid: qid,
+                        ext_qos: response::ext::QoSType::RESPONSE_FINAL,
+                        ext_tstamp: None,
+                    });
                 } else {
                     for ((outface, key_expr, context), qid) in route.values() {
                         QueryCleanup::spawn_query_clean_up_task(outface, tables_ref, *qid, timeout);
@@ -637,16 +629,11 @@ pub fn route_query(
             } else {
                 tracing::debug!("Send final reply {}:{} (not master)", face, qid);
                 drop(rtables);
-                face.primitives
-                    .clone()
-                    .send_response_final(RoutingContext::with_expr(
-                        ResponseFinal {
-                            rid: qid,
-                            ext_qos: response::ext::QoSType::RESPONSE_FINAL,
-                            ext_tstamp: None,
-                        },
-                        expr.full_expr().to_string(),
-                    ));
+                face.primitives.clone().send_response_final(ResponseFinal {
+                    rid: qid,
+                    ext_qos: response::ext::QoSType::RESPONSE_FINAL,
+                    ext_tstamp: None,
+                });
             }
         }
         None => {
@@ -656,16 +643,11 @@ pub fn route_query(
                 expr.scope,
             );
             drop(rtables);
-            face.primitives
-                .clone()
-                .send_response_final(RoutingContext::with_expr(
-                    ResponseFinal {
-                        rid: qid,
-                        ext_qos: response::ext::QoSType::RESPONSE_FINAL,
-                        ext_tstamp: None,
-                    },
-                    "".to_string(),
-                ));
+            face.primitives.clone().send_response_final(ResponseFinal {
+                rid: qid,
+                ext_qos: response::ext::QoSType::RESPONSE_FINAL,
+                ext_tstamp: None,
+            });
         }
     }
 }
@@ -763,13 +745,10 @@ pub(crate) fn finalize_pending_query(query: (Arc<Query>, CancellationToken)) {
             .src_face
             .primitives
             .clone()
-            .send_response_final(RoutingContext::with_expr(
-                ResponseFinal {
-                    rid: query.src_qid,
-                    ext_qos: response::ext::QoSType::RESPONSE_FINAL,
-                    ext_tstamp: None,
-                },
-                "".to_string(),
-            ));
+            .send_response_final(ResponseFinal {
+                rid: query.src_qid,
+                ext_qos: response::ext::QoSType::RESPONSE_FINAL,
+                ext_tstamp: None,
+            });
     }
 }

--- a/zenoh/src/net/routing/dispatcher/queries.rs
+++ b/zenoh/src/net/routing/dispatcher/queries.rs
@@ -621,20 +621,17 @@ pub fn route_query(
                         }
 
                         tracing::trace!("Propagate query {}:{} to {}", face, qid, outface);
-                        outface.primitives.send_request(RoutingContext::with_expr(
-                            Request {
-                                id: *qid,
-                                wire_expr: key_expr.into(),
-                                ext_qos,
-                                ext_tstamp,
-                                ext_nodeid: ext::NodeIdType { node_id: *context },
-                                ext_target,
-                                ext_budget,
-                                ext_timeout,
-                                payload: body.clone(),
-                            },
-                            expr.full_expr().to_string(),
-                        ));
+                        outface.primitives.send_request(Request {
+                            id: *qid,
+                            wire_expr: key_expr.into(),
+                            ext_qos,
+                            ext_tstamp,
+                            ext_nodeid: ext::NodeIdType { node_id: *context },
+                            ext_target,
+                            ext_budget,
+                            ext_timeout,
+                            payload: body.clone(),
+                        });
                     }
                 }
             } else {
@@ -705,21 +702,14 @@ pub(crate) fn route_send_response(
                 inc_res_stats!(query.src_face, tx, admin, body)
             }
 
-            query
-                .src_face
-                .primitives
-                .clone()
-                .send_response(RoutingContext::with_expr(
-                    Response {
-                        rid: query.src_qid,
-                        wire_expr: key_expr.to_owned(),
-                        payload: body,
-                        ext_qos,
-                        ext_tstamp,
-                        ext_respid,
-                    },
-                    "".to_string(), // @TODO provide the proper key expression of the response for interceptors
-                ));
+            query.src_face.primitives.send_response(Response {
+                rid: query.src_qid,
+                wire_expr: key_expr.to_owned(),
+                payload: body,
+                ext_qos,
+                ext_tstamp,
+                ext_respid,
+            });
         }
         None => tracing::warn!(
             "Route reply {}:{} from {}: Query not found!",

--- a/zenoh/src/net/routing/interceptor/access_control.rs
+++ b/zenoh/src/net/routing/interceptor/access_control.rs
@@ -360,11 +360,8 @@ impl InterceptorTrait for EgressAclEnforcer {
                     return None;
                 }
             }
-            NetworkBody::Response(Response { wire_expr, .. }) => {
-                // @TODO: Remove wire_expr usage when issue #1255 is implemented
-                if self.action(AclMessage::Reply, "Reply (egress)", wire_expr.as_str())
-                    == Permission::Deny
-                {
+            NetworkBody::Response(Response { .. }) => {
+                if self.action(AclMessage::Reply, "Reply (egress)", key_expr?) == Permission::Deny {
                     return None;
                 }
             }

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -531,8 +531,8 @@ impl crate::net::primitives::EPrimitives for AdminSpace {
     }
 
     #[inline]
-    fn send_response_final(&self, ctx: crate::net::routing::RoutingContext<ResponseFinal>) {
-        (self as &dyn Primitives).send_response_final(ctx.msg)
+    fn send_response_final(&self, msg: ResponseFinal) {
+        (self as &dyn Primitives).send_response_final(msg)
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -512,13 +512,13 @@ impl crate::net::primitives::EPrimitives for AdminSpace {
     }
 
     #[inline]
-    fn send_request(&self, ctx: crate::net::routing::RoutingContext<Request>) {
-        (self as &dyn Primitives).send_request(ctx.msg)
+    fn send_request(&self, msg: Request) {
+        (self as &dyn Primitives).send_request(msg)
     }
 
     #[inline]
-    fn send_response(&self, ctx: crate::net::routing::RoutingContext<Response>) {
-        (self as &dyn Primitives).send_response(ctx.msg)
+    fn send_response(&self, msg: Response) {
+        (self as &dyn Primitives).send_response(msg)
     }
 
     #[inline]

--- a/zenoh/src/net/tests/tables.rs
+++ b/zenoh/src/net/tests/tables.rs
@@ -567,9 +567,13 @@ impl EPrimitives for ClientPrimitives {
         *zlock!(self.data) = Some(msg.wire_expr.to_owned());
     }
 
-    fn send_request(&self, _ctx: RoutingContext<zenoh_protocol::network::Request>) {}
+    fn send_request(&self, msg: zenoh_protocol::network::Request) {
+        *zlock!(self.data) = Some(msg.wire_expr.to_owned());
+    }
 
-    fn send_response(&self, _ctx: RoutingContext<zenoh_protocol::network::Response>) {}
+    fn send_response(&self, msg: zenoh_protocol::network::Response) {
+        *zlock!(self.data) = Some(msg.wire_expr.to_owned());
+    }
 
     fn send_response_final(&self, _ctx: RoutingContext<zenoh_protocol::network::ResponseFinal>) {}
 

--- a/zenoh/src/net/tests/tables.rs
+++ b/zenoh/src/net/tests/tables.rs
@@ -575,7 +575,7 @@ impl EPrimitives for ClientPrimitives {
         *zlock!(self.data) = Some(msg.wire_expr.to_owned());
     }
 
-    fn send_response_final(&self, _ctx: RoutingContext<zenoh_protocol::network::ResponseFinal>) {}
+    fn send_response_final(&self, _msg: zenoh_protocol::network::ResponseFinal) {}
 
     fn as_any(&self) -> &dyn std::any::Any {
         self


### PR DESCRIPTION
This PR replicates Push egress routing logic for Query, Response and ResponseFinal messages. Skips allocation of `String` for the `RoutingContext` on the critical path of each message, which should improve performance.

Also includes fix to flaky Authentication lowlatency transport test (See issue #1267).

Closes #1255