### PR TITLE
Routing renaming

### DIFF
--- a/zenoh/src/net/routing/hat/client/mod.rs
+++ b/zenoh/src/net/routing/hat/client/mod.rs
@@ -23,7 +23,7 @@ use std::{
     sync::{atomic::AtomicU32, Arc},
 };
 
-use token::{token_new_face, undeclare_client_token};
+use token::{token_new_face, undeclare_simple_token};
 use zenoh_config::WhatAmI;
 use zenoh_protocol::network::{
     declare::{queryable::ext::QueryableInfoType, QueryableId, SubscriberId, TokenId},
@@ -36,8 +36,8 @@ use zenoh_transport::unicast::TransportUnicast;
 
 use self::{
     interests::interests_new_face,
-    pubsub::{pubsub_new_face, undeclare_client_subscription},
-    queries::{queries_new_face, undeclare_client_queryable},
+    pubsub::{pubsub_new_face, undeclare_simple_subscription},
+    queries::{queries_new_face, undeclare_simple_queryable},
 };
 use super::{
     super::dispatcher::{
@@ -163,7 +163,7 @@ impl HatBaseTrait for HatCode {
         let mut subs_matches = vec![];
         for (_id, mut res) in hat_face.remote_subs.drain() {
             get_mut_unchecked(&mut res).session_ctxs.remove(&face.id);
-            undeclare_client_subscription(&mut wtables, &mut face_clone, &mut res, send_declare);
+            undeclare_simple_subscription(&mut wtables, &mut face_clone, &mut res, send_declare);
 
             if res.context.is_some() {
                 for match_ in &res.context().matches {
@@ -185,7 +185,7 @@ impl HatBaseTrait for HatCode {
         let mut qabls_matches = vec![];
         for (_id, mut res) in hat_face.remote_qabls.drain() {
             get_mut_unchecked(&mut res).session_ctxs.remove(&face.id);
-            undeclare_client_queryable(&mut wtables, &mut face_clone, &mut res, send_declare);
+            undeclare_simple_queryable(&mut wtables, &mut face_clone, &mut res, send_declare);
 
             if res.context.is_some() {
                 for match_ in &res.context().matches {
@@ -206,7 +206,7 @@ impl HatBaseTrait for HatCode {
 
         for (_id, mut res) in hat_face.remote_tokens.drain() {
             get_mut_unchecked(&mut res).session_ctxs.remove(&face.id);
-            undeclare_client_token(&mut wtables, &mut face_clone, &mut res, send_declare);
+            undeclare_simple_token(&mut wtables, &mut face_clone, &mut res, send_declare);
         }
         drop(wtables);
 

--- a/zenoh/src/net/routing/hat/linkstate_peer/mod.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/mod.rs
@@ -24,7 +24,7 @@ use std::{
     time::Duration,
 };
 
-use token::{token_remove_node, undeclare_client_token};
+use token::{token_remove_node, undeclare_simple_token};
 use zenoh_config::{unwrap_or_default, ModeDependent, WhatAmI, WhatAmIMatcher};
 use zenoh_protocol::{
     common::ZExtBody,
@@ -43,8 +43,8 @@ use zenoh_transport::unicast::TransportUnicast;
 
 use self::{
     network::Network,
-    pubsub::{pubsub_remove_node, undeclare_client_subscription},
-    queries::{queries_remove_node, undeclare_client_queryable},
+    pubsub::{pubsub_remove_node, undeclare_simple_subscription},
+    queries::{queries_remove_node, undeclare_simple_queryable},
 };
 use super::{
     super::dispatcher::{
@@ -117,17 +117,17 @@ macro_rules! face_hat_mut {
 use face_hat_mut;
 
 struct HatTables {
-    peer_subs: HashSet<Arc<Resource>>,
-    peer_tokens: HashSet<Arc<Resource>>,
-    peer_qabls: HashSet<Arc<Resource>>,
-    peers_net: Option<Network>,
-    peers_trees_task: Option<TerminatableTask>,
+    linkstatepeer_subs: HashSet<Arc<Resource>>,
+    linkstatepeer_tokens: HashSet<Arc<Resource>>,
+    linkstatepeer_qabls: HashSet<Arc<Resource>>,
+    linkstatepeers_net: Option<Network>,
+    linkstatepeers_trees_task: Option<TerminatableTask>,
 }
 
 impl Drop for HatTables {
     fn drop(&mut self) {
-        if self.peers_trees_task.is_some() {
-            let task = self.peers_trees_task.take().unwrap();
+        if self.linkstatepeers_trees_task.is_some() {
+            let task = self.linkstatepeers_trees_task.take().unwrap();
             task.terminate(Duration::from_secs(10));
         }
     }
@@ -136,16 +136,16 @@ impl Drop for HatTables {
 impl HatTables {
     fn new() -> Self {
         Self {
-            peer_subs: HashSet::new(),
-            peer_tokens: HashSet::new(),
-            peer_qabls: HashSet::new(),
-            peers_net: None,
-            peers_trees_task: None,
+            linkstatepeer_subs: HashSet::new(),
+            linkstatepeer_tokens: HashSet::new(),
+            linkstatepeer_qabls: HashSet::new(),
+            linkstatepeers_net: None,
+            linkstatepeers_trees_task: None,
         }
     }
 
     fn schedule_compute_trees(&mut self, tables_ref: Arc<TablesLock>) {
-        if self.peers_trees_task.is_none() {
+        if self.linkstatepeers_trees_task.is_none() {
             let task = TerminatableTask::spawn(
                 zenoh_runtime::ZRuntime::Net,
                 async move {
@@ -156,7 +156,11 @@ impl HatTables {
                     let mut tables = zwrite!(tables_ref.tables);
 
                     tracing::trace!("Compute trees");
-                    let new_children = hat_mut!(tables).peers_net.as_mut().unwrap().compute_trees();
+                    let new_children = hat_mut!(tables)
+                        .linkstatepeers_net
+                        .as_mut()
+                        .unwrap()
+                        .compute_trees();
 
                     tracing::trace!("Compute routes");
                     pubsub::pubsub_tree_change(&mut tables, &new_children);
@@ -164,11 +168,11 @@ impl HatTables {
                     token::token_tree_change(&mut tables, &new_children);
 
                     tracing::trace!("Computations completed");
-                    hat_mut!(tables).peers_trees_task = None;
+                    hat_mut!(tables).linkstatepeers_trees_task = None;
                 },
                 TerminatableTask::create_cancellation_token(),
             );
-            self.peers_trees_task = Some(task);
+            self.linkstatepeers_trees_task = Some(task);
         }
     }
 }
@@ -193,7 +197,7 @@ impl HatBaseTrait for HatCode {
             unwrap_or_default!(config.routing().router().peers_failover_brokering());
         drop(config);
 
-        hat_mut!(tables).peers_net = Some(Network::new(
+        hat_mut!(tables).linkstatepeers_net = Some(Network::new(
             "[Peers network]".to_string(),
             tables.zid,
             runtime,
@@ -237,7 +241,7 @@ impl HatBaseTrait for HatCode {
         _send_declare: &mut SendDeclare,
     ) -> ZResult<()> {
         let link_id = if face.state.whatami != WhatAmI::Client {
-            if let Some(net) = hat_mut!(tables).peers_net.as_mut() {
+            if let Some(net) = hat_mut!(tables).linkstatepeers_net.as_mut() {
                 net.add_link(transport.clone())
             } else {
                 0
@@ -290,7 +294,7 @@ impl HatBaseTrait for HatCode {
         let mut subs_matches = vec![];
         for (_id, mut res) in hat_face.remote_subs.drain() {
             get_mut_unchecked(&mut res).session_ctxs.remove(&face.id);
-            undeclare_client_subscription(&mut wtables, &mut face_clone, &mut res, send_declare);
+            undeclare_simple_subscription(&mut wtables, &mut face_clone, &mut res, send_declare);
 
             if res.context.is_some() {
                 for match_ in &res.context().matches {
@@ -312,7 +316,7 @@ impl HatBaseTrait for HatCode {
         let mut qabls_matches = vec![];
         for (_, mut res) in hat_face.remote_qabls.drain() {
             get_mut_unchecked(&mut res).session_ctxs.remove(&face.id);
-            undeclare_client_queryable(&mut wtables, &mut face_clone, &mut res, send_declare);
+            undeclare_simple_queryable(&mut wtables, &mut face_clone, &mut res, send_declare);
 
             if res.context.is_some() {
                 for match_ in &res.context().matches {
@@ -333,7 +337,7 @@ impl HatBaseTrait for HatCode {
 
         for (_id, mut res) in hat_face.remote_tokens.drain() {
             get_mut_unchecked(&mut res).session_ctxs.remove(&face.id);
-            undeclare_client_token(&mut wtables, &mut face_clone, &mut res, send_declare);
+            undeclare_simple_token(&mut wtables, &mut face_clone, &mut res, send_declare);
         }
         drop(wtables);
 
@@ -385,7 +389,7 @@ impl HatBaseTrait for HatCode {
 
                     let whatami = transport.get_whatami()?;
                     if whatami != WhatAmI::Client {
-                        if let Some(net) = hat_mut!(tables).peers_net.as_mut() {
+                        if let Some(net) = hat_mut!(tables).linkstatepeers_net.as_mut() {
                             let changes = net.link_states(list.link_states, zid);
 
                             for (_, removed_node) in changes.removed_nodes {
@@ -412,7 +416,7 @@ impl HatBaseTrait for HatCode {
         routing_context: NodeId,
     ) -> NodeId {
         hat!(tables)
-            .peers_net
+            .linkstatepeers_net
             .as_ref()
             .unwrap()
             .get_local_context(routing_context, face_hat!(face).link_id)
@@ -429,7 +433,7 @@ impl HatBaseTrait for HatCode {
             (Ok(zid), Ok(whatami)) => {
                 if whatami != WhatAmI::Client {
                     for (_, removed_node) in hat_mut!(tables)
-                        .peers_net
+                        .linkstatepeers_net
                         .as_mut()
                         .unwrap()
                         .remove_link(&zid)
@@ -470,7 +474,7 @@ impl HatBaseTrait for HatCode {
     fn info(&self, tables: &Tables, kind: WhatAmI) -> String {
         match kind {
             WhatAmI::Peer => hat!(tables)
-                .peers_net
+                .linkstatepeers_net
                 .as_ref()
                 .map(|net| net.dot())
                 .unwrap_or_else(|| "graph {}".to_string()),
@@ -480,17 +484,17 @@ impl HatBaseTrait for HatCode {
 }
 
 struct HatContext {
-    peer_subs: HashSet<ZenohIdProto>,
-    peer_qabls: HashMap<ZenohIdProto, QueryableInfoType>,
-    peer_tokens: HashSet<ZenohIdProto>,
+    linkstatepeer_subs: HashSet<ZenohIdProto>,
+    linkstatepeer_qabls: HashMap<ZenohIdProto, QueryableInfoType>,
+    linkstatepeer_tokens: HashSet<ZenohIdProto>,
 }
 
 impl HatContext {
     fn new() -> Self {
         Self {
-            peer_subs: HashSet::new(),
-            peer_qabls: HashMap::new(),
-            peer_tokens: HashSet::new(),
+            linkstatepeer_subs: HashSet::new(),
+            linkstatepeer_qabls: HashMap::new(),
+            linkstatepeer_tokens: HashSet::new(),
         }
     }
 }
@@ -525,7 +529,7 @@ impl HatFace {
 
 fn get_peer(tables: &Tables, face: &Arc<FaceState>, nodeid: NodeId) -> Option<ZenohIdProto> {
     match hat!(tables)
-        .peers_net
+        .linkstatepeers_net
         .as_ref()
         .unwrap()
         .get_link(face_hat!(face).link_id)
@@ -555,7 +559,7 @@ impl HatTrait for HatCode {}
 #[inline]
 fn get_routes_entries(tables: &Tables) -> RoutesIndexes {
     let indexes = hat!(tables)
-        .peers_net
+        .linkstatepeers_net
         .as_ref()
         .unwrap()
         .graph

--- a/zenoh/src/net/routing/hat/p2p_peer/mod.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/mod.rs
@@ -23,7 +23,7 @@ use std::{
     sync::{atomic::AtomicU32, Arc},
 };
 
-use token::{token_new_face, undeclare_client_token};
+use token::{token_new_face, undeclare_simple_token};
 use zenoh_config::{unwrap_or_default, ModeDependent, WhatAmI, WhatAmIMatcher};
 use zenoh_protocol::{
     common::ZExtBody,
@@ -45,8 +45,8 @@ use zenoh_transport::unicast::TransportUnicast;
 use self::{
     gossip::Network,
     interests::interests_new_face,
-    pubsub::{pubsub_new_face, undeclare_client_subscription},
-    queries::{queries_new_face, undeclare_client_queryable},
+    pubsub::{pubsub_new_face, undeclare_simple_subscription},
+    queries::{queries_new_face, undeclare_simple_queryable},
 };
 use super::{
     super::dispatcher::{
@@ -237,7 +237,7 @@ impl HatBaseTrait for HatCode {
         let mut subs_matches = vec![];
         for (_id, mut res) in hat_face.remote_subs.drain() {
             get_mut_unchecked(&mut res).session_ctxs.remove(&face.id);
-            undeclare_client_subscription(&mut wtables, &mut face_clone, &mut res, send_declare);
+            undeclare_simple_subscription(&mut wtables, &mut face_clone, &mut res, send_declare);
 
             if res.context.is_some() {
                 for match_ in &res.context().matches {
@@ -259,7 +259,7 @@ impl HatBaseTrait for HatCode {
         let mut qabls_matches = vec![];
         for (_id, mut res) in hat_face.remote_qabls.drain() {
             get_mut_unchecked(&mut res).session_ctxs.remove(&face.id);
-            undeclare_client_queryable(&mut wtables, &mut face_clone, &mut res, send_declare);
+            undeclare_simple_queryable(&mut wtables, &mut face_clone, &mut res, send_declare);
 
             if res.context.is_some() {
                 for match_ in &res.context().matches {
@@ -280,7 +280,7 @@ impl HatBaseTrait for HatCode {
 
         for (_id, mut res) in hat_face.remote_tokens.drain() {
             get_mut_unchecked(&mut res).session_ctxs.remove(&face.id);
-            undeclare_client_token(&mut wtables, &mut face_clone, &mut res, send_declare);
+            undeclare_simple_token(&mut wtables, &mut face_clone, &mut res, send_declare);
         }
         drop(wtables);
 

--- a/zenoh/src/net/routing/hat/p2p_peer/pubsub.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/pubsub.rs
@@ -145,7 +145,7 @@ fn propagate_simple_subscription(
     }
 }
 
-fn register_client_subscription(
+fn register_simple_subscription(
     _tables: &mut Tables,
     face: &mut Arc<FaceState>,
     id: SubscriberId,
@@ -173,7 +173,7 @@ fn register_client_subscription(
     face_hat_mut!(face).remote_subs.insert(id, res.clone());
 }
 
-fn declare_client_subscription(
+fn declare_simple_subscription(
     tables: &mut Tables,
     face: &mut Arc<FaceState>,
     id: SubscriberId,
@@ -181,7 +181,7 @@ fn declare_client_subscription(
     sub_info: &SubscriberInfo,
     send_declare: &mut SendDeclare,
 ) {
-    register_client_subscription(tables, face, id, res, sub_info);
+    register_simple_subscription(tables, face, id, res, sub_info);
 
     propagate_simple_subscription(tables, res, sub_info, face, send_declare);
     // This introduced a buffer overflow on windows
@@ -285,7 +285,7 @@ fn propagate_forget_simple_subscription(
     }
 }
 
-pub(super) fn undeclare_client_subscription(
+pub(super) fn undeclare_simple_subscription(
     tables: &mut Tables,
     face: &mut Arc<FaceState>,
     res: &mut Arc<Resource>,
@@ -355,14 +355,14 @@ pub(super) fn undeclare_client_subscription(
     }
 }
 
-fn forget_client_subscription(
+fn forget_simple_subscription(
     tables: &mut Tables,
     face: &mut Arc<FaceState>,
     id: SubscriberId,
     send_declare: &mut SendDeclare,
 ) -> Option<Arc<Resource>> {
     if let Some(mut res) = face_hat_mut!(face).remote_subs.remove(&id) {
-        undeclare_client_subscription(tables, face, &mut res, send_declare);
+        undeclare_simple_subscription(tables, face, &mut res, send_declare);
         Some(res)
     } else {
         None
@@ -545,7 +545,7 @@ impl HatPubSubTrait for HatCode {
         _node_id: NodeId,
         send_declare: &mut SendDeclare,
     ) {
-        declare_client_subscription(tables, face, id, res, sub_info, send_declare);
+        declare_simple_subscription(tables, face, id, res, sub_info, send_declare);
     }
 
     fn undeclare_subscription(
@@ -557,7 +557,7 @@ impl HatPubSubTrait for HatCode {
         _node_id: NodeId,
         send_declare: &mut SendDeclare,
     ) -> Option<Arc<Resource>> {
-        forget_client_subscription(tables, face, id, send_declare)
+        forget_simple_subscription(tables, face, id, send_declare)
     }
 
     fn get_subscriptions(&self, tables: &Tables) -> Vec<(Arc<Resource>, Sources)> {

--- a/zenoh/src/net/routing/hat/router/queries.rs
+++ b/zenoh/src/net/routing/hat/router/queries.rs
@@ -64,7 +64,7 @@ fn local_router_qabl_info(tables: &Tables, res: &Arc<Resource>) -> QueryableInfo
     let info = if hat!(tables).full_net(WhatAmI::Peer) {
         res.context.as_ref().and_then(|_| {
             res_hat!(res)
-                .peer_qabls
+                .linkstatepeer_qabls
                 .iter()
                 .fold(None, |accu, (zid, info)| {
                     if *zid != tables.zid {
@@ -152,7 +152,7 @@ fn local_qabl_info(
     };
     if res.context.is_some() && hat!(tables).full_net(WhatAmI::Peer) {
         info = res_hat!(res)
-            .peer_qabls
+            .linkstatepeer_qabls
             .iter()
             .fold(info, |accu, (zid, info)| {
                 if *zid != tables.zid {
@@ -363,7 +363,13 @@ fn register_router_queryable(
         // Propagate queryable to peers
         if face.is_none() || face.as_ref().unwrap().whatami != WhatAmI::Peer {
             let local_info = local_peer_qabl_info(tables, res);
-            register_peer_queryable(tables, face.as_deref_mut(), res, &local_info, tables.zid)
+            register_linkstatepeer_queryable(
+                tables,
+                face.as_deref_mut(),
+                res,
+                &local_info,
+                tables.zid,
+            )
         }
     }
 
@@ -382,19 +388,21 @@ fn declare_router_queryable(
     register_router_queryable(tables, Some(face), res, qabl_info, router, send_declare);
 }
 
-fn register_peer_queryable(
+fn register_linkstatepeer_queryable(
     tables: &mut Tables,
     face: Option<&mut Arc<FaceState>>,
     res: &mut Arc<Resource>,
     qabl_info: &QueryableInfoType,
     peer: ZenohIdProto,
 ) {
-    let current_info = res_hat!(res).peer_qabls.get(&peer);
+    let current_info = res_hat!(res).linkstatepeer_qabls.get(&peer);
     if current_info.is_none() || current_info.unwrap() != qabl_info {
         // Register peer queryable
         {
-            res_hat_mut!(res).peer_qabls.insert(peer, *qabl_info);
-            hat_mut!(tables).peer_qabls.insert(res.clone());
+            res_hat_mut!(res)
+                .linkstatepeer_qabls
+                .insert(peer, *qabl_info);
+            hat_mut!(tables).linkstatepeer_qabls.insert(res.clone());
         }
 
         // Propagate queryable to peers
@@ -402,7 +410,7 @@ fn register_peer_queryable(
     }
 }
 
-fn declare_peer_queryable(
+fn declare_linkstatepeer_queryable(
     tables: &mut Tables,
     face: &mut Arc<FaceState>,
     res: &mut Arc<Resource>,
@@ -411,13 +419,13 @@ fn declare_peer_queryable(
     send_declare: &mut SendDeclare,
 ) {
     let mut face = Some(face);
-    register_peer_queryable(tables, face.as_deref_mut(), res, qabl_info, peer);
+    register_linkstatepeer_queryable(tables, face.as_deref_mut(), res, qabl_info, peer);
     let local_info = local_router_qabl_info(tables, res);
     let zid = tables.zid;
     register_router_queryable(tables, face, res, &local_info, zid, send_declare);
 }
 
-fn register_client_queryable(
+fn register_simple_queryable(
     _tables: &mut Tables,
     face: &mut Arc<FaceState>,
     id: QueryableId,
@@ -437,7 +445,7 @@ fn register_client_queryable(
     face_hat_mut!(face).remote_qabls.insert(id, res.clone());
 }
 
-fn declare_client_queryable(
+fn declare_simple_queryable(
     tables: &mut Tables,
     face: &mut Arc<FaceState>,
     id: QueryableId,
@@ -445,7 +453,7 @@ fn declare_client_queryable(
     qabl_info: &QueryableInfoType,
     send_declare: &mut SendDeclare,
 ) {
-    register_client_queryable(tables, face, id, res, qabl_info);
+    register_simple_queryable(tables, face, id, res, qabl_info);
     let local_details = local_router_qabl_info(tables, res);
     let zid = tables.zid;
     register_router_queryable(tables, Some(face), res, &local_details, zid, send_declare);
@@ -461,16 +469,16 @@ fn remote_router_qabls(tables: &Tables, res: &Arc<Resource>) -> bool {
 }
 
 #[inline]
-fn remote_peer_qabls(tables: &Tables, res: &Arc<Resource>) -> bool {
+fn remote_linkstatepeer_qabls(tables: &Tables, res: &Arc<Resource>) -> bool {
     res.context.is_some()
         && res_hat!(res)
-            .peer_qabls
+            .linkstatepeer_qabls
             .keys()
             .any(|peer| peer != &tables.zid)
 }
 
 #[inline]
-fn client_qabls(res: &Arc<Resource>) -> Vec<Arc<FaceState>> {
+fn simple_qabls(res: &Arc<Resource>) -> Vec<Arc<FaceState>> {
     res.session_ctxs
         .values()
         .filter_map(|ctx| {
@@ -484,7 +492,7 @@ fn client_qabls(res: &Arc<Resource>) -> Vec<Arc<FaceState>> {
 }
 
 #[inline]
-fn remote_client_qabls(res: &Arc<Resource>, face: &Arc<FaceState>) -> bool {
+fn remote_simple_qabls(res: &Arc<Resource>, face: &Arc<FaceState>) -> bool {
     res.session_ctxs
         .values()
         .any(|ctx| ctx.face.id != face.id && ctx.qabl.is_some())
@@ -565,8 +573,8 @@ fn propagate_forget_simple_queryable(
             if !res.context().matches.iter().any(|m| {
                 m.upgrade().is_some_and(|m| {
                     m.context.is_some()
-                        && (remote_client_qabls(&m, &face)
-                            || remote_peer_qabls(tables, &m)
+                        && (remote_simple_qabls(&m, &face)
+                            || remote_linkstatepeer_qabls(tables, &m)
                             || remote_router_qabls(tables, &m))
                 })
             }) {
@@ -691,7 +699,7 @@ fn unregister_router_queryable(
             .retain(|qabl| !Arc::ptr_eq(qabl, res));
 
         if hat!(tables).full_net(WhatAmI::Peer) {
-            undeclare_peer_queryable(tables, None, res, &tables.zid.clone());
+            undeclare_linkstatepeer_queryable(tables, None, res, &tables.zid.clone());
         }
         propagate_forget_simple_queryable(tables, res, send_declare);
     }
@@ -722,41 +730,45 @@ fn forget_router_queryable(
     undeclare_router_queryable(tables, Some(face), res, router, send_declare);
 }
 
-fn unregister_peer_queryable(tables: &mut Tables, res: &mut Arc<Resource>, peer: &ZenohIdProto) {
-    res_hat_mut!(res).peer_qabls.remove(peer);
+fn unregister_linkstatepeer_queryable(
+    tables: &mut Tables,
+    res: &mut Arc<Resource>,
+    peer: &ZenohIdProto,
+) {
+    res_hat_mut!(res).linkstatepeer_qabls.remove(peer);
 
-    if res_hat!(res).peer_qabls.is_empty() {
+    if res_hat!(res).linkstatepeer_qabls.is_empty() {
         hat_mut!(tables)
-            .peer_qabls
+            .linkstatepeer_qabls
             .retain(|qabl| !Arc::ptr_eq(qabl, res));
     }
 }
 
-fn undeclare_peer_queryable(
+fn undeclare_linkstatepeer_queryable(
     tables: &mut Tables,
     face: Option<&Arc<FaceState>>,
     res: &mut Arc<Resource>,
     peer: &ZenohIdProto,
 ) {
-    if res_hat!(res).peer_qabls.contains_key(peer) {
-        unregister_peer_queryable(tables, res, peer);
+    if res_hat!(res).linkstatepeer_qabls.contains_key(peer) {
+        unregister_linkstatepeer_queryable(tables, res, peer);
         propagate_forget_sourced_queryable(tables, res, face, peer, WhatAmI::Peer);
     }
 }
 
-fn forget_peer_queryable(
+fn forget_linkstatepeer_queryable(
     tables: &mut Tables,
     face: &mut Arc<FaceState>,
     res: &mut Arc<Resource>,
     peer: &ZenohIdProto,
     send_declare: &mut SendDeclare,
 ) {
-    undeclare_peer_queryable(tables, Some(face), res, peer);
+    undeclare_linkstatepeer_queryable(tables, Some(face), res, peer);
 
-    let client_qabls = res.session_ctxs.values().any(|ctx| ctx.qabl.is_some());
-    let peer_qabls = remote_peer_qabls(tables, res);
+    let simple_qabls = res.session_ctxs.values().any(|ctx| ctx.qabl.is_some());
+    let linkstatepeer_qabls = remote_linkstatepeer_qabls(tables, res);
     let zid = tables.zid;
-    if !client_qabls && !peer_qabls {
+    if !simple_qabls && !linkstatepeer_qabls {
         undeclare_router_queryable(tables, None, res, &zid, send_declare);
     } else {
         let local_info = local_router_qabl_info(tables, res);
@@ -764,7 +776,7 @@ fn forget_peer_queryable(
     }
 }
 
-pub(super) fn undeclare_client_queryable(
+pub(super) fn undeclare_simple_queryable(
     tables: &mut Tables,
     face: &mut Arc<FaceState>,
     res: &mut Arc<Resource>,
@@ -779,11 +791,11 @@ pub(super) fn undeclare_client_queryable(
             get_mut_unchecked(ctx).qabl = None;
         }
 
-        let mut client_qabls = client_qabls(res);
+        let mut simple_qabls = simple_qabls(res);
         let router_qabls = remote_router_qabls(tables, res);
-        let peer_qabls = remote_peer_qabls(tables, res);
+        let linkstatepeer_qabls = remote_linkstatepeer_qabls(tables, res);
 
-        if client_qabls.is_empty() && !peer_qabls {
+        if simple_qabls.is_empty() && !linkstatepeer_qabls {
             undeclare_router_queryable(tables, None, res, &tables.zid.clone(), send_declare);
         } else {
             let local_info = local_router_qabl_info(tables, res);
@@ -791,8 +803,8 @@ pub(super) fn undeclare_client_queryable(
             propagate_forget_simple_queryable_to_peers(tables, res, send_declare);
         }
 
-        if client_qabls.len() == 1 && !router_qabls && !peer_qabls {
-            let mut face = &mut client_qabls[0];
+        if simple_qabls.len() == 1 && !router_qabls && !linkstatepeer_qabls {
+            let mut face = &mut simple_qabls[0];
             if let Some((id, _)) = face_hat_mut!(face).local_qabls.remove(res) {
                 send_declare(
                     &face.primitives,
@@ -820,8 +832,8 @@ pub(super) fn undeclare_client_queryable(
                 if !res.context().matches.iter().any(|m| {
                     m.upgrade().is_some_and(|m| {
                         m.context.is_some()
-                            && (remote_client_qabls(&m, face)
-                                || remote_peer_qabls(tables, &m)
+                            && (remote_simple_qabls(&m, face)
+                                || remote_linkstatepeer_qabls(tables, &m)
                                 || remote_router_qabls(tables, &m))
                     })
                 }) {
@@ -849,14 +861,14 @@ pub(super) fn undeclare_client_queryable(
     }
 }
 
-fn forget_client_queryable(
+fn forget_simple_queryable(
     tables: &mut Tables,
     face: &mut Arc<FaceState>,
     id: QueryableId,
     send_declare: &mut SendDeclare,
 ) -> Option<Arc<Resource>> {
     if let Some(mut res) = face_hat_mut!(face).remote_qabls.remove(&id) {
-        undeclare_client_queryable(tables, face, &mut res, send_declare);
+        undeclare_simple_queryable(tables, face, &mut res, send_declare);
         Some(res)
     } else {
         None
@@ -896,11 +908,11 @@ pub(super) fn queries_remove_node(
                 }
             }
             for mut res in qabls {
-                unregister_peer_queryable(tables, &mut res, node);
+                unregister_linkstatepeer_queryable(tables, &mut res, node);
 
-                let client_qabls = res.session_ctxs.values().any(|ctx| ctx.qabl.is_some());
-                let peer_qabls = remote_peer_qabls(tables, &res);
-                if !client_qabls && !peer_qabls {
+                let simple_qabls = res.session_ctxs.values().any(|ctx| ctx.qabl.is_some());
+                let linkstatepeer_qabls = remote_linkstatepeer_qabls(tables, &res);
+                if !simple_qabls && !linkstatepeer_qabls {
                     undeclare_router_queryable(
                         tables,
                         None,
@@ -953,7 +965,7 @@ pub(super) fn queries_linkstate_change(
                                 let forget = !HatTables::failover_brokering_to(links, dst_face.zid)
                                     && {
                                         let ctx_links = hat!(tables)
-                                            .peers_net
+                                            .linkstatepeers_net
                                             .as_ref()
                                             .map(|net| net.get_links(dst_face.zid))
                                             .unwrap_or_else(|| &[]);
@@ -1043,13 +1055,13 @@ pub(super) fn queries_tree_change(
 
                 let qabls_res = match net_type {
                     WhatAmI::Router => &hat!(tables).router_qabls,
-                    _ => &hat!(tables).peer_qabls,
+                    _ => &hat!(tables).linkstatepeer_qabls,
                 };
 
                 for res in qabls_res {
                     let qabls = match net_type {
                         WhatAmI::Router => &res_hat!(res).router_qabls,
-                        _ => &res_hat!(res).peer_qabls,
+                        _ => &res_hat!(res).linkstatepeer_qabls,
                     };
                     if let Some(qabl_info) = qabls.get(&tree_id) {
                         send_sourced_queryable_to_net_children(
@@ -1134,7 +1146,10 @@ pub(crate) fn declare_qabl_interest(
                     qabl.context.is_some()
                         && qabl.matches(res)
                         && (res_hat!(qabl).router_qabls.keys().any(|r| *r != tables.zid)
-                            || res_hat!(qabl).peer_qabls.keys().any(|r| *r != tables.zid)
+                            || res_hat!(qabl)
+                                .linkstatepeer_qabls
+                                .keys()
+                                .any(|r| *r != tables.zid)
                             || qabl.session_ctxs.values().any(|s| {
                                 s.face.id != face.id
                                     && s.qabl.is_some()
@@ -1179,7 +1194,10 @@ pub(crate) fn declare_qabl_interest(
                     if qabl.context.is_some()
                         && qabl.matches(res)
                         && (res_hat!(qabl).router_qabls.keys().any(|r| *r != tables.zid)
-                            || res_hat!(qabl).peer_qabls.keys().any(|r| *r != tables.zid)
+                            || res_hat!(qabl)
+                                .linkstatepeer_qabls
+                                .keys()
+                                .any(|r| *r != tables.zid)
                             || qabl.session_ctxs.values().any(|s| {
                                 s.qabl.is_some()
                                     && (s.face.whatami != WhatAmI::Peer
@@ -1221,8 +1239,8 @@ pub(crate) fn declare_qabl_interest(
         } else {
             for qabl in hat!(tables).router_qabls.iter() {
                 if qabl.context.is_some()
-                    && (remote_client_qabls(qabl, face)
-                        || remote_peer_qabls(tables, qabl)
+                    && (remote_simple_qabls(qabl, face)
+                        || remote_linkstatepeer_qabls(tables, qabl)
                         || remote_router_qabls(tables, qabl))
                 {
                     let info = local_qabl_info(tables, qabl, face);
@@ -1279,13 +1297,20 @@ impl HatQueriesTrait for HatCode {
             WhatAmI::Peer => {
                 if hat!(tables).full_net(WhatAmI::Peer) {
                     if let Some(peer) = get_peer(tables, face, node_id) {
-                        declare_peer_queryable(tables, face, res, qabl_info, peer, send_declare)
+                        declare_linkstatepeer_queryable(
+                            tables,
+                            face,
+                            res,
+                            qabl_info,
+                            peer,
+                            send_declare,
+                        )
                     }
                 } else {
-                    declare_client_queryable(tables, face, id, res, qabl_info, send_declare)
+                    declare_simple_queryable(tables, face, id, res, qabl_info, send_declare)
                 }
             }
-            _ => declare_client_queryable(tables, face, id, res, qabl_info, send_declare),
+            _ => declare_simple_queryable(tables, face, id, res, qabl_info, send_declare),
         }
     }
 
@@ -1315,7 +1340,13 @@ impl HatQueriesTrait for HatCode {
                 if hat!(tables).full_net(WhatAmI::Peer) {
                     if let Some(mut res) = res {
                         if let Some(peer) = get_peer(tables, face, node_id) {
-                            forget_peer_queryable(tables, face, &mut res, &peer, send_declare);
+                            forget_linkstatepeer_queryable(
+                                tables,
+                                face,
+                                &mut res,
+                                &peer,
+                                send_declare,
+                            );
                             Some(res)
                         } else {
                             None
@@ -1324,10 +1355,10 @@ impl HatQueriesTrait for HatCode {
                         None
                     }
                 } else {
-                    forget_client_queryable(tables, face, id, send_declare)
+                    forget_simple_queryable(tables, face, id, send_declare)
                 }
             }
-            _ => forget_client_queryable(tables, face, id, send_declare),
+            _ => forget_simple_queryable(tables, face, id, send_declare),
         }
     }
 
@@ -1344,7 +1375,7 @@ impl HatQueriesTrait for HatCode {
                     Sources {
                         routers: Vec::from_iter(res_hat!(s).router_qabls.keys().cloned()),
                         peers: if hat!(tables).full_net(WhatAmI::Peer) {
-                            Vec::from_iter(res_hat!(s).peer_qabls.keys().cloned())
+                            Vec::from_iter(res_hat!(s).linkstatepeer_qabls.keys().cloned())
                         } else {
                             s.session_ctxs
                                 .values()
@@ -1425,7 +1456,7 @@ impl HatQueriesTrait for HatCode {
             }
 
             if (master || source_type != WhatAmI::Router) && hat!(tables).full_net(WhatAmI::Peer) {
-                let net = hat!(tables).peers_net.as_ref().unwrap();
+                let net = hat!(tables).linkstatepeers_net.as_ref().unwrap();
                 let peer_source = match source_type {
                     WhatAmI::Peer => source,
                     _ => net.idx.index() as NodeId,
@@ -1436,7 +1467,7 @@ impl HatQueriesTrait for HatCode {
                     tables,
                     net,
                     peer_source,
-                    &res_hat!(mres).peer_qabls,
+                    &res_hat!(mres).linkstatepeer_qabls,
                     complete,
                 );
             }


### PR DESCRIPTION
Since introduction of p2p peers, some functions and fields containing the *client* word were referring to both clients and p2p peers and some functions and fields containing the *peer* word were referring to linkstate peers only. This was confusing and has been renamed. 
*client* has been replaced by *simple*. *simple* was already used at other places in the code and refers to declarations that do not identify a source node in a linkstate network (so clients and p2p peers) as opposed to *sourced* declarations that identify the source node in a linkstate network.
*peer* has been replaced by *linkstatepeer*.