### PR TITLE
Rename `KeyExpr::from_boxed_string_unchecked` to `KeyExpr::from_boxed_str_unchecked`

### DIFF
--- a/commons/zenoh-keyexpr/src/key_expr/owned.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/owned.rs
@@ -71,13 +71,13 @@ impl OwnedKeyExpr {
     /// Key Expressions must follow some rules to be accepted by a Zenoh network.
     /// Messages addressed with invalid key expressions will be dropped.
     pub unsafe fn from_string_unchecked(s: String) -> Self {
-        Self::from_boxed_string_unchecked(s.into_boxed_str())
+        Self::from_boxed_str_unchecked(s.into_boxed_str())
     }
     /// Constructs an OwnedKeyExpr without checking [`keyexpr`]'s invariants
     /// # Safety
     /// Key Expressions must follow some rules to be accepted by a Zenoh network.
     /// Messages addressed with invalid key expressions will be dropped.
-    pub unsafe fn from_boxed_string_unchecked(s: Box<str>) -> Self {
+    pub unsafe fn from_boxed_str_unchecked(s: Box<str>) -> Self {
         OwnedKeyExpr(s.into())
     }
 }

--- a/zenoh/src/api/key_expr.rs
+++ b/zenoh/src/api/key_expr.rs
@@ -81,10 +81,10 @@ impl KeyExpr<'static> {
     /// # Safety
     /// Key Expressions must follow some rules to be accepted by a Zenoh network.
     /// Messages addressed with invalid key expressions will be dropped.
-    pub unsafe fn from_boxed_string_unchecked(s: Box<str>) -> Self {
-        Self(KeyExprInner::Owned(
-            OwnedKeyExpr::from_boxed_string_unchecked(s),
-        ))
+    pub unsafe fn from_boxed_str_unchecked(s: Box<str>) -> Self {
+        Self(KeyExprInner::Owned(OwnedKeyExpr::from_boxed_str_unchecked(
+            s,
+        )))
     }
 }
 impl<'a> KeyExpr<'a> {

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -337,7 +337,7 @@ pub(crate) enum Resource {
 impl Resource {
     pub(crate) fn new(name: Box<str>) -> Self {
         if keyexpr::new(name.as_ref()).is_ok() {
-            Self::for_keyexpr(unsafe { OwnedKeyExpr::from_boxed_string_unchecked(name) })
+            Self::for_keyexpr(unsafe { OwnedKeyExpr::from_boxed_str_unchecked(name) })
         } else {
             Self::Prefix { prefix: name }
         }


### PR DESCRIPTION
A `Box<str>` implies `boxed_str` and not `boxed_string` (that would be `Box<String>` which doesn't make sense).

An `std` example of this is [`std::string::String::into_boxed_str`](https://doc.rust-lang.org/std/string/struct.String.html#method.into_boxed_str).