### PR TITLE
Hide `UndeclarableInner::undeclare_inner`

### DIFF
--- a/zenoh/src/api/key_expr.rs
+++ b/zenoh/src/api/key_expr.rs
@@ -25,7 +25,7 @@ use zenoh_protocol::{
 };
 use zenoh_result::ZResult;
 
-use super::session::{Session, UndeclarableInner};
+use super::session::{Session, UndeclarableSealed};
 use crate::net::primitives::Primitives;
 
 #[derive(Clone, Debug)]
@@ -549,7 +549,7 @@ impl<'a> KeyExpr<'a> {
     }
 }
 
-impl<'a> UndeclarableInner<&'a Session, KeyExprUndeclaration<'a>> for KeyExpr<'a> {
+impl<'a> UndeclarableSealed<&'a Session, KeyExprUndeclaration<'a>> for KeyExpr<'a> {
     fn undeclare_inner(self, session: &'a Session) -> KeyExprUndeclaration<'a> {
         KeyExprUndeclaration {
             session,

--- a/zenoh/src/api/key_expr.rs
+++ b/zenoh/src/api/key_expr.rs
@@ -25,7 +25,7 @@ use zenoh_protocol::{
 };
 use zenoh_result::ZResult;
 
-use super::session::{Session, Undeclarable};
+use super::session::{Session, UndeclarableInner};
 use crate::net::primitives::Primitives;
 
 #[derive(Clone, Debug)]
@@ -549,7 +549,7 @@ impl<'a> KeyExpr<'a> {
     }
 }
 
-impl<'a> Undeclarable<&'a Session, KeyExprUndeclaration<'a>> for KeyExpr<'a> {
+impl<'a> UndeclarableInner<&'a Session, KeyExprUndeclaration<'a>> for KeyExpr<'a> {
     fn undeclare_inner(self, session: &'a Session) -> KeyExprUndeclaration<'a> {
         KeyExprUndeclaration {
             session,

--- a/zenoh/src/api/liveliness.rs
+++ b/zenoh/src/api/liveliness.rs
@@ -27,7 +27,7 @@ use super::{
     key_expr::KeyExpr,
     query::Reply,
     sample::{Locality, Sample},
-    session::{Session, SessionRef, UndeclarableInner},
+    session::{Session, SessionRef, UndeclarableSealed},
     subscriber::{Subscriber, SubscriberInner},
     Id,
 };
@@ -386,7 +386,7 @@ impl<'a> LivelinessToken<'a> {
     /// ```
     #[inline]
     pub fn undeclare(self) -> impl Resolve<ZResult<()>> + 'a {
-        UndeclarableInner::undeclare_inner(self, ())
+        UndeclarableSealed::undeclare_inner(self, ())
     }
 
     /// Keep this liveliness token in background, until the session is closed.
@@ -401,7 +401,7 @@ impl<'a> LivelinessToken<'a> {
 }
 
 #[zenoh_macros::unstable]
-impl<'a> UndeclarableInner<(), LivelinessTokenUndeclaration<'a>> for LivelinessToken<'a> {
+impl<'a> UndeclarableSealed<(), LivelinessTokenUndeclaration<'a>> for LivelinessToken<'a> {
     fn undeclare_inner(self, _: ()) -> LivelinessTokenUndeclaration<'a> {
         LivelinessTokenUndeclaration { token: self }
     }

--- a/zenoh/src/api/liveliness.rs
+++ b/zenoh/src/api/liveliness.rs
@@ -27,7 +27,7 @@ use super::{
     key_expr::KeyExpr,
     query::Reply,
     sample::{Locality, Sample},
-    session::{Session, SessionRef, Undeclarable},
+    session::{Session, SessionRef, UndeclarableInner},
     subscriber::{Subscriber, SubscriberInner},
     Id,
 };
@@ -386,7 +386,7 @@ impl<'a> LivelinessToken<'a> {
     /// ```
     #[inline]
     pub fn undeclare(self) -> impl Resolve<ZResult<()>> + 'a {
-        Undeclarable::undeclare_inner(self, ())
+        UndeclarableInner::undeclare_inner(self, ())
     }
 
     /// Keep this liveliness token in background, until the session is closed.
@@ -401,7 +401,7 @@ impl<'a> LivelinessToken<'a> {
 }
 
 #[zenoh_macros::unstable]
-impl<'a> Undeclarable<(), LivelinessTokenUndeclaration<'a>> for LivelinessToken<'a> {
+impl<'a> UndeclarableInner<(), LivelinessTokenUndeclaration<'a>> for LivelinessToken<'a> {
     fn undeclare_inner(self, _: ()) -> LivelinessTokenUndeclaration<'a> {
         LivelinessTokenUndeclaration { token: self }
     }

--- a/zenoh/src/api/publisher.rs
+++ b/zenoh/src/api/publisher.rs
@@ -51,7 +51,7 @@ use super::{
     encoding::Encoding,
     key_expr::KeyExpr,
     sample::{DataInfo, Locality, QoS, Sample, SampleFields, SampleKind},
-    session::{SessionRef, UndeclarableInner},
+    session::{SessionRef, UndeclarableSealed},
 };
 use crate::{
     api::{subscriber::SubscriberKind, Id},
@@ -361,7 +361,7 @@ impl<'a> Publisher<'a> {
     /// # }
     /// ```
     pub fn undeclare(self) -> impl Resolve<ZResult<()>> + 'a {
-        UndeclarableInner::undeclare_inner(self, ())
+        UndeclarableSealed::undeclare_inner(self, ())
     }
 
     #[cfg(feature = "unstable")]
@@ -462,7 +462,7 @@ impl PublisherDeclarations for std::sync::Arc<Publisher<'static>> {
     }
 }
 
-impl<'a> UndeclarableInner<(), PublisherUndeclaration<'a>> for Publisher<'a> {
+impl<'a> UndeclarableSealed<(), PublisherUndeclaration<'a>> for Publisher<'a> {
     fn undeclare_inner(self, _: ()) -> PublisherUndeclaration<'a> {
         PublisherUndeclaration { publisher: self }
     }
@@ -974,12 +974,12 @@ pub(crate) struct MatchingListenerInner<'a> {
 impl<'a> MatchingListenerInner<'a> {
     #[inline]
     pub fn undeclare(self) -> MatchingListenerUndeclaration<'a> {
-        UndeclarableInner::undeclare_inner(self, ())
+        UndeclarableSealed::undeclare_inner(self, ())
     }
 }
 
 #[zenoh_macros::unstable]
-impl<'a> UndeclarableInner<(), MatchingListenerUndeclaration<'a>> for MatchingListenerInner<'a> {
+impl<'a> UndeclarableSealed<(), MatchingListenerUndeclaration<'a>> for MatchingListenerInner<'a> {
     fn undeclare_inner(self, _: ()) -> MatchingListenerUndeclaration<'a> {
         MatchingListenerUndeclaration { subscriber: self }
     }
@@ -1046,9 +1046,9 @@ impl<'a, Receiver> MatchingListener<'a, Receiver> {
 }
 
 #[zenoh_macros::unstable]
-impl<'a, T> UndeclarableInner<(), MatchingListenerUndeclaration<'a>> for MatchingListener<'a, T> {
+impl<'a, T> UndeclarableSealed<(), MatchingListenerUndeclaration<'a>> for MatchingListener<'a, T> {
     fn undeclare_inner(self, _: ()) -> MatchingListenerUndeclaration<'a> {
-        UndeclarableInner::undeclare_inner(self.listener, ())
+        UndeclarableSealed::undeclare_inner(self.listener, ())
     }
 }
 

--- a/zenoh/src/api/publisher.rs
+++ b/zenoh/src/api/publisher.rs
@@ -51,7 +51,7 @@ use super::{
     encoding::Encoding,
     key_expr::KeyExpr,
     sample::{DataInfo, Locality, QoS, Sample, SampleFields, SampleKind},
-    session::{SessionRef, Undeclarable},
+    session::{SessionRef, UndeclarableInner},
 };
 use crate::{
     api::{subscriber::SubscriberKind, Id},
@@ -361,7 +361,7 @@ impl<'a> Publisher<'a> {
     /// # }
     /// ```
     pub fn undeclare(self) -> impl Resolve<ZResult<()>> + 'a {
-        Undeclarable::undeclare_inner(self, ())
+        UndeclarableInner::undeclare_inner(self, ())
     }
 
     #[cfg(feature = "unstable")]
@@ -462,7 +462,7 @@ impl PublisherDeclarations for std::sync::Arc<Publisher<'static>> {
     }
 }
 
-impl<'a> Undeclarable<(), PublisherUndeclaration<'a>> for Publisher<'a> {
+impl<'a> UndeclarableInner<(), PublisherUndeclaration<'a>> for Publisher<'a> {
     fn undeclare_inner(self, _: ()) -> PublisherUndeclaration<'a> {
         PublisherUndeclaration { publisher: self }
     }
@@ -974,12 +974,12 @@ pub(crate) struct MatchingListenerInner<'a> {
 impl<'a> MatchingListenerInner<'a> {
     #[inline]
     pub fn undeclare(self) -> MatchingListenerUndeclaration<'a> {
-        Undeclarable::undeclare_inner(self, ())
+        UndeclarableInner::undeclare_inner(self, ())
     }
 }
 
 #[zenoh_macros::unstable]
-impl<'a> Undeclarable<(), MatchingListenerUndeclaration<'a>> for MatchingListenerInner<'a> {
+impl<'a> UndeclarableInner<(), MatchingListenerUndeclaration<'a>> for MatchingListenerInner<'a> {
     fn undeclare_inner(self, _: ()) -> MatchingListenerUndeclaration<'a> {
         MatchingListenerUndeclaration { subscriber: self }
     }
@@ -1046,9 +1046,9 @@ impl<'a, Receiver> MatchingListener<'a, Receiver> {
 }
 
 #[zenoh_macros::unstable]
-impl<'a, T> Undeclarable<(), MatchingListenerUndeclaration<'a>> for MatchingListener<'a, T> {
+impl<'a, T> UndeclarableInner<(), MatchingListenerUndeclaration<'a>> for MatchingListener<'a, T> {
     fn undeclare_inner(self, _: ()) -> MatchingListenerUndeclaration<'a> {
-        Undeclarable::undeclare_inner(self.listener, ())
+        UndeclarableInner::undeclare_inner(self.listener, ())
     }
 }
 

--- a/zenoh/src/api/queryable.rs
+++ b/zenoh/src/api/queryable.rs
@@ -47,7 +47,7 @@ use super::{
     publisher::Priority,
     sample::{Locality, QoSBuilder, Sample, SampleKind},
     selector::Selector,
-    session::{SessionRef, Undeclarable},
+    session::{SessionRef, UndeclarableInner},
     value::Value,
     Id,
 };
@@ -567,7 +567,7 @@ pub(crate) struct CallbackQueryable<'a> {
     undeclare_on_drop: bool,
 }
 
-impl<'a> Undeclarable<(), QueryableUndeclaration<'a>> for CallbackQueryable<'a> {
+impl<'a> UndeclarableInner<(), QueryableUndeclaration<'a>> for CallbackQueryable<'a> {
     fn undeclare_inner(self, _: ()) -> QueryableUndeclaration<'a> {
         QueryableUndeclaration { queryable: self }
     }
@@ -848,7 +848,7 @@ impl<'a, Handler> Queryable<'a, Handler> {
 
     #[inline]
     pub fn undeclare(self) -> impl Resolve<ZResult<()>> + 'a {
-        Undeclarable::undeclare_inner(self, ())
+        UndeclarableInner::undeclare_inner(self, ())
     }
 
     /// Make the queryable run in background, until the session is closed.
@@ -862,9 +862,9 @@ impl<'a, Handler> Queryable<'a, Handler> {
     }
 }
 
-impl<'a, T> Undeclarable<(), QueryableUndeclaration<'a>> for Queryable<'a, T> {
+impl<'a, T> UndeclarableInner<(), QueryableUndeclaration<'a>> for Queryable<'a, T> {
     fn undeclare_inner(self, _: ()) -> QueryableUndeclaration<'a> {
-        Undeclarable::undeclare_inner(self.queryable, ())
+        UndeclarableInner::undeclare_inner(self.queryable, ())
     }
 }
 

--- a/zenoh/src/api/queryable.rs
+++ b/zenoh/src/api/queryable.rs
@@ -47,7 +47,7 @@ use super::{
     publisher::Priority,
     sample::{Locality, QoSBuilder, Sample, SampleKind},
     selector::Selector,
-    session::{SessionRef, UndeclarableInner},
+    session::{SessionRef, UndeclarableSealed},
     value::Value,
     Id,
 };
@@ -567,7 +567,7 @@ pub(crate) struct CallbackQueryable<'a> {
     undeclare_on_drop: bool,
 }
 
-impl<'a> UndeclarableInner<(), QueryableUndeclaration<'a>> for CallbackQueryable<'a> {
+impl<'a> UndeclarableSealed<(), QueryableUndeclaration<'a>> for CallbackQueryable<'a> {
     fn undeclare_inner(self, _: ()) -> QueryableUndeclaration<'a> {
         QueryableUndeclaration { queryable: self }
     }
@@ -848,7 +848,7 @@ impl<'a, Handler> Queryable<'a, Handler> {
 
     #[inline]
     pub fn undeclare(self) -> impl Resolve<ZResult<()>> + 'a {
-        UndeclarableInner::undeclare_inner(self, ())
+        UndeclarableSealed::undeclare_inner(self, ())
     }
 
     /// Make the queryable run in background, until the session is closed.
@@ -862,9 +862,9 @@ impl<'a, Handler> Queryable<'a, Handler> {
     }
 }
 
-impl<'a, T> UndeclarableInner<(), QueryableUndeclaration<'a>> for Queryable<'a, T> {
+impl<'a, T> UndeclarableSealed<(), QueryableUndeclaration<'a>> for Queryable<'a, T> {
     fn undeclare_inner(self, _: ()) -> QueryableUndeclaration<'a> {
-        UndeclarableInner::undeclare_inner(self.queryable, ())
+        UndeclarableSealed::undeclare_inner(self.queryable, ())
     }
 }
 

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -449,17 +449,17 @@ impl fmt::Debug for SessionRef<'_> {
     }
 }
 
-pub(crate) trait UndeclarableInner<S, O, T = ZResult<()>>
+pub(crate) trait UndeclarableSealed<S, O, T = ZResult<()>>
 where
     O: Resolve<T> + Send,
 {
     fn undeclare_inner(self, session: S) -> O;
 }
 
-impl<'a, O, T, G> UndeclarableInner<&'a Session, O, T> for G
+impl<'a, O, T, G> UndeclarableSealed<&'a Session, O, T> for G
 where
     O: Resolve<T> + Send,
-    G: UndeclarableInner<(), O, T>,
+    G: UndeclarableSealed<(), O, T>,
 {
     fn undeclare_inner(self, _: &'a Session) -> O {
         self.undeclare_inner(())
@@ -470,7 +470,7 @@ where
 // care about the `private_bounds` lint in this particular case.
 #[allow(private_bounds)]
 /// A trait implemented by types that can be undeclared.
-pub trait Undeclarable<S, O, T>: UndeclarableInner<S, O, T>
+pub trait Undeclarable<S, O, T>: UndeclarableSealed<S, O, T>
 where
     O: Resolve<T> + Send,
 {
@@ -479,7 +479,7 @@ where
 impl<S, O, T, U> Undeclarable<S, O, T> for U
 where
     O: Resolve<T> + Send,
-    U: UndeclarableInner<S, O, T>,
+    U: UndeclarableSealed<S, O, T>,
 {
 }
 
@@ -639,7 +639,7 @@ impl Session {
         O: Resolve<ZResult<()>>,
         T: Undeclarable<&'a Self, O, ZResult<()>>,
     {
-        UndeclarableInner::undeclare_inner(decl, self)
+        UndeclarableSealed::undeclare_inner(decl, self)
     }
 
     /// Get the current configuration of the zenoh [`Session`](Session).

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -449,22 +449,38 @@ impl fmt::Debug for SessionRef<'_> {
     }
 }
 
-/// A trait implemented by types that can be undeclared.
-pub trait Undeclarable<S, O, T = ZResult<()>>
+pub(crate) trait UndeclarableInner<S, O, T = ZResult<()>>
 where
     O: Resolve<T> + Send,
 {
     fn undeclare_inner(self, session: S) -> O;
 }
 
-impl<'a, O, T, G> Undeclarable<&'a Session, O, T> for G
+impl<'a, O, T, G> UndeclarableInner<&'a Session, O, T> for G
 where
     O: Resolve<T> + Send,
-    G: Undeclarable<(), O, T>,
+    G: UndeclarableInner<(), O, T>,
 {
     fn undeclare_inner(self, _: &'a Session) -> O {
         self.undeclare_inner(())
     }
+}
+
+// NOTE: `UndeclarableInner` is only pub(crate) to hide the `undeclare_inner` method. So we don't
+// care about the `private_bounds` lint in this particular case.
+#[allow(private_bounds)]
+/// A trait implemented by types that can be undeclared.
+pub trait Undeclarable<S, O, T>: UndeclarableInner<S, O, T>
+where
+    O: Resolve<T> + Send,
+{
+}
+
+impl<S, O, T, U> Undeclarable<S, O, T> for U
+where
+    O: Resolve<T> + Send,
+    U: UndeclarableInner<S, O, T>,
+{
 }
 
 /// A zenoh session.
@@ -623,7 +639,7 @@ impl Session {
         O: Resolve<ZResult<()>>,
         T: Undeclarable<&'a Self, O, ZResult<()>>,
     {
-        Undeclarable::undeclare_inner(decl, self)
+        UndeclarableInner::undeclare_inner(decl, self)
     }
 
     /// Get the current configuration of the zenoh [`Session`](Session).

--- a/zenoh/src/api/subscriber.rs
+++ b/zenoh/src/api/subscriber.rs
@@ -29,7 +29,7 @@ use super::{
     handlers::{locked, Callback, DefaultHandler, IntoHandler},
     key_expr::KeyExpr,
     sample::{Locality, Sample},
-    session::{SessionRef, UndeclarableInner},
+    session::{SessionRef, UndeclarableSealed},
     Id,
 };
 
@@ -105,11 +105,11 @@ impl<'a> SubscriberInner<'a> {
     /// ```
     #[inline]
     pub fn undeclare(self) -> SubscriberUndeclaration<'a> {
-        UndeclarableInner::undeclare_inner(self, ())
+        UndeclarableSealed::undeclare_inner(self, ())
     }
 }
 
-impl<'a> UndeclarableInner<(), SubscriberUndeclaration<'a>> for SubscriberInner<'a> {
+impl<'a> UndeclarableSealed<(), SubscriberUndeclaration<'a>> for SubscriberInner<'a> {
     fn undeclare_inner(self, _: ()) -> SubscriberUndeclaration<'a> {
         SubscriberUndeclaration { subscriber: self }
     }
@@ -521,9 +521,9 @@ impl<'a, Handler> Subscriber<'a, Handler> {
     }
 }
 
-impl<'a, T> UndeclarableInner<(), SubscriberUndeclaration<'a>> for Subscriber<'a, T> {
+impl<'a, T> UndeclarableSealed<(), SubscriberUndeclaration<'a>> for Subscriber<'a, T> {
     fn undeclare_inner(self, _: ()) -> SubscriberUndeclaration<'a> {
-        UndeclarableInner::undeclare_inner(self.subscriber, ())
+        UndeclarableSealed::undeclare_inner(self.subscriber, ())
     }
 }
 

--- a/zenoh/src/api/subscriber.rs
+++ b/zenoh/src/api/subscriber.rs
@@ -29,7 +29,7 @@ use super::{
     handlers::{locked, Callback, DefaultHandler, IntoHandler},
     key_expr::KeyExpr,
     sample::{Locality, Sample},
-    session::{SessionRef, Undeclarable},
+    session::{SessionRef, UndeclarableInner},
     Id,
 };
 
@@ -105,11 +105,11 @@ impl<'a> SubscriberInner<'a> {
     /// ```
     #[inline]
     pub fn undeclare(self) -> SubscriberUndeclaration<'a> {
-        Undeclarable::undeclare_inner(self, ())
+        UndeclarableInner::undeclare_inner(self, ())
     }
 }
 
-impl<'a> Undeclarable<(), SubscriberUndeclaration<'a>> for SubscriberInner<'a> {
+impl<'a> UndeclarableInner<(), SubscriberUndeclaration<'a>> for SubscriberInner<'a> {
     fn undeclare_inner(self, _: ()) -> SubscriberUndeclaration<'a> {
         SubscriberUndeclaration { subscriber: self }
     }
@@ -521,9 +521,9 @@ impl<'a, Handler> Subscriber<'a, Handler> {
     }
 }
 
-impl<'a, T> Undeclarable<(), SubscriberUndeclaration<'a>> for Subscriber<'a, T> {
+impl<'a, T> UndeclarableInner<(), SubscriberUndeclaration<'a>> for Subscriber<'a, T> {
     fn undeclare_inner(self, _: ()) -> SubscriberUndeclaration<'a> {
-        Undeclarable::undeclare_inner(self.subscriber, ())
+        UndeclarableInner::undeclare_inner(self.subscriber, ())
     }
 }
 


### PR DESCRIPTION
The aim of this pull request is to remove `UndeclarableInner::undeclare_inner` from the public API.