### PR TITLE
fix: typos

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -307,7 +307,7 @@
       /// Configure the zenoh RX parameters of a link
       rx: {
         /// Receiving buffer size in bytes for each link
-        /// The default the rx_buffer_size value is the same as the default batch size: 65335.
+        /// The default the rx_buffer_size value is the same as the default batch size: 65535.
         /// For very high throughput scenarios, the rx_buffer_size can be increased to accommodate
         /// more in-flight data. This is particularly relevant when dealing with large messages.
         /// E.g. for 16MiB rx_buffer_size set the value to: 16777216.

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -411,7 +411,7 @@ validated_struct::validator! {
                 },
                 pub rx: LinkRxConf {
                     /// Receiving buffer size in bytes for each link
-                    /// The default the rx_buffer_size value is the same as the default batch size: 65335.
+                    /// The default the rx_buffer_size value is the same as the default batch size: 65535.
                     /// For very high throughput scenarios, the rx_buffer_size can be increased to accommodate
                     /// more in-flight data. This is particularly relevant when dealing with large messages.
                     /// E.g. for 16MiB rx_buffer_size set the value to: 16777216.


### PR DESCRIPTION
- zenoh/DEFAULT_CONFIG.json5: 65335 -> 65535
- zenoh/commons/zenoh-config/src/lib.rs: 65335 -> 65535

Signed-off-by: Brian Shih < brianshih1203@gmail.com >