### PR TITLE
Remove redundant `WhatAmI` tests in `HatBaseTrait::init`

### DIFF
--- a/zenoh/src/net/routing/hat/linkstate_peer/mod.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/mod.rs
@@ -190,8 +190,8 @@ impl HatBaseTrait for HatCode {
             WhatAmIMatcher::empty()
         };
 
-        let peer_full_linkstate = whatami != WhatAmI::Client
-            && unwrap_or_default!(config.routing().peer().mode()) == *"linkstate";
+        let peer_full_linkstate =
+            unwrap_or_default!(config.routing().peer().mode()) == *"linkstate";
         let router_peers_failover_brokering =
             unwrap_or_default!(config.routing().router().peers_failover_brokering());
         drop(config);

--- a/zenoh/src/net/routing/hat/router/mod.rs
+++ b/zenoh/src/net/routing/hat/router/mod.rs
@@ -320,9 +320,9 @@ impl HatBaseTrait for HatCode {
             WhatAmIMatcher::empty()
         };
 
-        let router_full_linkstate = whatami == WhatAmI::Router;
-        let peer_full_linkstate = whatami != WhatAmI::Client
-            && unwrap_or_default!(config.routing().peer().mode()) == *"linkstate";
+        let router_full_linkstate = true;
+        let peer_full_linkstate =
+            unwrap_or_default!(config.routing().peer().mode()) == *"linkstate";
         let router_peers_failover_brokering =
             unwrap_or_default!(config.routing().router().peers_failover_brokering());
         drop(config);


### PR DESCRIPTION
Router and Link-state Peer `HatCode::init` are only called if the `WhatAmI` matches the hat:

https://github.com/eclipse-zenoh/zenoh/blob/2d5ab7c48c47c4d957d653b14fc9140549721619/zenoh/src/net/routing/hat/mod.rs#L245-L257