### PR TITLE
Support for IPv6-only network interfaces

### DIFF
--- a/zenoh/src/net/runtime/orchestrator.rs
+++ b/zenoh/src/net/runtime/orchestrator.rs
@@ -535,7 +535,7 @@ impl Runtime {
         ifaces: &[IpAddr],
         multicast_ttl: u32,
     ) -> ZResult<UdpSocket> {
-        let socket = match Socket::new(Domain::IPV4, Type::DGRAM, None) {
+        let socket = match Socket::new(Domain::for_address(*sockaddr), Type::DGRAM, None) {
             Ok(socket) => socket,
             Err(err) => {
                 tracing::error!("Unable to create datagram socket: {}", err);
@@ -625,21 +625,22 @@ impl Runtime {
     }
 
     pub fn bind_ucast_port(addr: IpAddr, multicast_ttl: u32) -> ZResult<UdpSocket> {
-        let socket = match Socket::new(Domain::IPV4, Type::DGRAM, None) {
+        let sockaddr = || SocketAddr::new(addr, 0);
+        let socket = match Socket::new(Domain::for_address(sockaddr()), Type::DGRAM, None) {
             Ok(socket) => socket,
             Err(err) => {
                 tracing::warn!("Unable to create datagram socket: {}", err);
                 bail!(err=> "Unable to create datagram socket");
             }
         };
-        match socket.bind(&SocketAddr::new(addr, 0).into()) {
+        match socket.bind(&sockaddr().into()) {
             Ok(()) => {
                 #[allow(clippy::or_fun_call)]
                 let local_addr = socket
                     .local_addr()
-                    .unwrap_or(SocketAddr::new(addr, 0).into())
+                    .unwrap_or(sockaddr().into())
                     .as_socket()
-                    .unwrap_or(SocketAddr::new(addr, 0));
+                    .unwrap_or(sockaddr());
                 tracing::debug!("UDP port bound to {}", local_addr);
             }
             Err(err) => {


### PR DESCRIPTION
Substitutes the hardcoded Domain::IPV4 first parameter of some calls to Socket::new() by calls to Domain::for_address(), so that the domain is inferred from the address. This is necessary for network interfaces that are IPv6 only.
I ran into this issue while trying to run zenoh over thread, which is an IPv6 only technology.