### PR TITLE
refactor(storage-manager): move prefix related functions in crate

### DIFF
--- a/plugins/zenoh-plugin-storage-manager/src/replica/mod.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replica/mod.rs
@@ -94,10 +94,7 @@ impl Replica {
                         }
                     } else {
                         result.push((
-                            StorageService::get_prefixed(
-                                &storage_config.strip_prefix,
-                                &entry.0.unwrap().into(),
-                            ),
+                            crate::prefix(storage_config.strip_prefix.as_ref(), &entry.0.unwrap()),
                             entry.1,
                         ));
                     }


### PR DESCRIPTION
This change is motivated by the refactor of the Replication feature. In order to exchange metadata that can be processed by all Replicas, the key expressions associated with the data stored must be prefixed (when sent) and stripped (when received).

This commit exposes two functions, at the `zenoh-plugin-storage-manager` crate, that perform these operations.

The objective is to reuse these functions in the Replication refactor and, as we intend to move the Replication in its own crate, exposing them at the crate level makes it easier to then import them.

* plugins/zenoh-plugin-storage-manager/src/lib.rs:
  - moved there the `strip_prefix` function,
  - moved there the `get_prefixed` function and renamed it to `prefix`.
* plugins/zenoh-plugin-storage-manager/src/replica/mod.rs: updated the call to the previously named `get_prefixed` function.
* plugins/zenoh-plugin-storage-manager/src/replica/storage.rs:
  - removed the `strip_prefix` method,
  - removed the `prefix` function,
  - updated the call to `strip_prefix` and `get_prefixed`.