### PR TITLE
feat!: bind callback subscriber/queryable to session lifetime

### DIFF
--- a/examples/examples/z_sub_thr.rs
+++ b/examples/examples/z_sub_thr.rs
@@ -87,9 +87,7 @@ fn main() {
             }
         })
         .wait()
-        .unwrap()
-        // Make the subscriber run in background, until the session is closed.
-        .background();
+        .unwrap();
 
     println!("Press CTRL-C to quit...");
     std::thread::park();

--- a/zenoh/src/api/key_expr.rs
+++ b/zenoh/src/api/key_expr.rs
@@ -551,7 +551,7 @@ impl<'a> KeyExpr<'a> {
 
 impl<'a> UndeclarableSealed<&'a Session> for KeyExpr<'a> {
     type Undeclaration = KeyExprUndeclaration<'a>;
-    
+
     fn undeclare_inner(self, session: &'a Session) -> Self::Undeclaration {
         KeyExprUndeclaration {
             session,

--- a/zenoh/src/api/key_expr.rs
+++ b/zenoh/src/api/key_expr.rs
@@ -551,6 +551,7 @@ impl<'a> KeyExpr<'a> {
 
 impl<'a> UndeclarableSealed<&'a Session> for KeyExpr<'a> {
     type Undeclaration = KeyExprUndeclaration<'a>;
+    
     fn undeclare_inner(self, session: &'a Session) -> Self::Undeclaration {
         KeyExprUndeclaration {
             session,

--- a/zenoh/src/api/key_expr.rs
+++ b/zenoh/src/api/key_expr.rs
@@ -549,8 +549,9 @@ impl<'a> KeyExpr<'a> {
     }
 }
 
-impl<'a> UndeclarableSealed<&'a Session, KeyExprUndeclaration<'a>> for KeyExpr<'a> {
-    fn undeclare_inner(self, session: &'a Session) -> KeyExprUndeclaration<'a> {
+impl<'a> UndeclarableSealed<&'a Session> for KeyExpr<'a> {
+    type Undeclaration = KeyExprUndeclaration<'a>;
+    fn undeclare_inner(self, session: &'a Session) -> Self::Undeclaration {
         KeyExprUndeclaration {
             session,
             expr: self,

--- a/zenoh/src/api/liveliness.rs
+++ b/zenoh/src/api/liveliness.rs
@@ -385,6 +385,7 @@ impl<'a> LivelinessToken<'a> {
     }
 
     fn undeclare_impl(&mut self) -> ZResult<()> {
+        // set the flag first to avoid double panic if this function panic
         self.undeclare_on_drop = false;
         match self.session.upgrade() {
             Some(session) => session.undeclare_liveliness(self.state.id),
@@ -581,6 +582,7 @@ where
                     session: session.into(),
                     state: sub_state,
                     kind: SubscriberKind::LivelinessSubscriber,
+                    // `size_of::<Handler::Handler>() == 0` means callback-only subscriber
                     undeclare_on_drop: size_of::<Handler::Handler>() > 0,
                 },
                 handler,

--- a/zenoh/src/api/publisher.rs
+++ b/zenoh/src/api/publisher.rs
@@ -366,6 +366,7 @@ impl<'a> Publisher<'a> {
     }
 
     fn undeclare_impl(&mut self) -> ZResult<()> {
+        // set the flag first to avoid double panic if this function panic
         self.undeclare_on_drop = false;
         #[cfg(feature = "unstable")]
         {

--- a/zenoh/src/api/queryable.rs
+++ b/zenoh/src/api/queryable.rs
@@ -755,7 +755,7 @@ impl<'a, 'b, Handler> QueryableBuilder<'a, 'b, Handler> {
 /// let (tx, rx) = flume::bounded(32);
 /// session
 ///     .declare_queryable("key/expression")
-///     .callback(|query| tx.send(query).unwrap())
+///     .callback(move |query| tx.send(query).unwrap())
 ///     .await
 ///     .unwrap();
 /// // queryable run in background until the session is closed

--- a/zenoh/src/api/queryable.rs
+++ b/zenoh/src/api/queryable.rs
@@ -760,7 +760,7 @@ impl<'a, 'b, Handler> QueryableBuilder<'a, 'b, Handler> {
 ///     .unwrap();
 /// // queryable run in background until the session is closed
 /// tokio::spawn(async move {
-///     while let Ok(query) = rx.recv().await {
+///     while let Ok(query) = rx.recv_async().await {
 ///         println!(">> Handling query '{}'", query.selector());
 ///         query.reply("key/expression", "value").await.unwrap();
 ///     }

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -191,13 +191,15 @@ pub mod session {
     pub use zenoh_config::wrappers::{EntityGlobalId, ZenohId};
     pub use zenoh_protocol::core::EntityId;
 
+    #[zenoh_macros::unstable]
+    pub use crate::api::session::SessionRef;
     #[zenoh_macros::internal]
     pub use crate::api::session::{init, InitBuilder};
     pub use crate::api::{
         builders::publisher::{SessionDeleteBuilder, SessionPutBuilder},
         info::{PeersZenohIdBuilder, RoutersZenohIdBuilder, SessionInfo, ZenohIdBuilder},
         query::SessionGetBuilder,
-        session::{open, OpenBuilder, Session, SessionDeclarations, SessionRef, Undeclarable},
+        session::{open, OpenBuilder, Session, SessionDeclarations, Undeclarable},
     };
 }
 


### PR DESCRIPTION
To determine if the entity is callback-only, the only elegant way I've found is the rule "handler is ZST means callback-only". Unless users starts writing fancy implementations, it should be correct 100% of the time.

Session entities now uses weak references, except publishers because it would impact performances. Weak references also solves the issue of mass undeclarations before closing the session (when the session is an `Arc`), except for publishers.

`Undeclarable` trait has been refactored a little bit to better match its use in the code.