### PR TITLE
fix: update check-labels triggers

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -2,6 +2,7 @@ name: Check required labels
 
 on:
   pull_request_target:
+    types: [opened, synchronize, reopened, labeled]
     branches: ["**"]
 
 jobs:


### PR DESCRIPTION
Besides the default (opened, synchronize, reopened), check-labels workflow should run when the PR is labeled