### PR TITLE
Fix erroneous parsing of `backend_search_dirs`

### DIFF
--- a/plugins/zenoh-backend-traits/src/config.rs
+++ b/plugins/zenoh-backend-traits/src/config.rs
@@ -164,6 +164,8 @@ impl<S: Into<String> + AsRef<str>, V: AsObject> TryFrom<(S, &V)> for PluginConfi
                 })
             })
             .unwrap_or(Ok(true))?;
+        // TODO(fuzzypixelz): refactor this function's interface to get access to the configuration
+        // source, this we can support spec syntax in the lib search dir.
         let backend_search_dirs = match value.get("backend_search_dirs") {
             Some(serde_json::Value::String(path)) => LibSearchDirs::from_paths(&[path.clone()]),
             Some(serde_json::Value::Array(paths)) => {
@@ -174,7 +176,7 @@ impl<S: Into<String> + AsRef<str>, V: AsObject> TryFrom<(S, &V)> for PluginConfi
                     };
                     specs.push(path.clone());
                 }
-                LibSearchDirs::from_specs(&specs)?
+                LibSearchDirs::from_paths(&specs)
             }
             None => LibSearchDirs::default(),
             _ => bail!("`backend_search_dirs` field of {}'s configuration must be a string or array of strings", name.as_ref())


### PR DESCRIPTION
The `backend_search_dirs` configuration option was badly parsed because we went from raw JSON to `serde_json::Value` and tried to parse said value as raw JSON.

To properly clean this the code needs to be reworked to avoid deserializing the raw JSON before it hits the `LibSearchDirs` deserializer.

cc @gabrik