### PR TITLE
Fix storage error when keyexpr equals the configured `strip_prefix`

### DIFF
--- a/plugins/zenoh-plugin-storage-manager/src/lib.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/lib.rs
@@ -443,12 +443,15 @@ pub fn strip_prefix(
                 );
             }
 
-            match key_expr.strip_prefix(prefix).as_slice() {
-                [stripped_key_expr] => {
-                    if stripped_key_expr.is_empty() {
-                        return Ok(None);
-                    }
+            // `key_expr.strip_prefix` returns empty vec if `key_expr == prefix`,
+            // but also returns empty vec if `prefix` is not a prefix to `key_expr`.
+            // First case needs to be handled before calling `key_expr.strip_prefix`
+            if key_expr.as_str().eq(prefix.as_str()) {
+                return Ok(None);
+            }
 
+            match key_expr.strip_prefix(prefix).as_slice() {
+                [stripped_key_expr] if !stripped_key_expr.is_empty() => {
                     OwnedKeyExpr::from_str(stripped_key_expr).map(Some)
                 }
                 _ => bail!("Failed to strip prefix < {} > from: {}", prefix, key_expr),


### PR DESCRIPTION
Following the changes in #1325, issue #1350 was identified. This PR fixes said issue.

Closes #1350.