### PR TITLE
Add ZBytes::slices

### DIFF
--- a/examples/examples/z_bytes.rs
+++ b/examples/examples/z_bytes.rs
@@ -33,7 +33,8 @@ fn main() {
     // Corresponding encoding to be used in operations like `.put()`, `.reply()`, etc.
     // let encoding = Encoding::ZENOH_STRING;
 
-    // Cow
+    // Cow<str>
+    // See [`zenoh::bytes::ZBytes`] documentation for zero-copy behaviour.
     let input = Cow::from("test");
     let payload = ZBytes::from(&input);
     let output: Cow<str> = payload.deserialize().unwrap();
@@ -45,6 +46,15 @@ fn main() {
     let input: Vec<u8> = vec![1, 2, 3, 4];
     let payload = ZBytes::from(&input);
     let output: Vec<u8> = payload.into();
+    assert_eq!(input, output);
+    // Corresponding encoding to be used in operations like `.put()`, `.reply()`, etc.
+    // let encoding = Encoding::ZENOH_BYTES;
+
+    // Cow<[u8]>
+    // See [`zenoh::bytes::ZBytes`] documentation for zero-copy behaviour.
+    let input = Cow::from(vec![1, 2, 3, 4]);
+    let payload = ZBytes::from(&input);
+    let output: Cow<[u8]> = payload.into();
     assert_eq!(input, output);
     // Corresponding encoding to be used in operations like `.put()`, `.reply()`, etc.
     // let encoding = Encoding::ZENOH_BYTES;
@@ -79,6 +89,13 @@ fn main() {
     let payload = ZBytes::from_iter(input.iter());
     for (idx, value) in payload.iter::<i32>().enumerate() {
         assert_eq!(input[idx], value.unwrap());
+    }
+
+    // Iterator RAW
+    let input: [i32; 4] = [1, 2, 3, 4];
+    let payload = ZBytes::from_iter(input.iter());
+    for slice in payload.iter_raw() {
+        println!("{:02x?}", slice);
     }
 
     // HashMap

--- a/examples/examples/z_bytes.rs
+++ b/examples/examples/z_bytes.rs
@@ -94,7 +94,7 @@ fn main() {
     // Iterator RAW
     let input: [i32; 4] = [1, 2, 3, 4];
     let payload = ZBytes::from_iter(input.iter());
-    for slice in payload.iter_raw() {
+    for slice in payload.slices() {
         println!("{:02x?}", slice);
     }
 

--- a/zenoh/src/api/bytes.rs
+++ b/zenoh/src/api/bytes.rs
@@ -264,7 +264,7 @@ impl ZBytes {
 
     /// Get a [`ZBytesWriter`] implementing [`std::io::Write`] trait.
     ///
-    /// See [`ZBytesWriter`] on how to chain the serialization of differnt types into a single [`ZBytes`].
+    /// See [`ZBytesWriter`] on how to chain the serialization of different types into a single [`ZBytes`].
     pub fn writer(&mut self) -> ZBytesWriter<'_> {
         ZBytesWriter(self.0.writer())
     }
@@ -449,7 +449,7 @@ impl ZBytes {
     /// ```
     ///
     /// If you want to be sure that no copy is performed at all, then you should use [`ZBytes::slices`].
-    /// Please note that in this case data may not be contiguous in memory and it is the responsability of the user to properly parse the raw slices.
+    /// Please note that in this case data may not be contiguous in memory and it is the responsibility of the user to properly parse the raw slices.
     pub fn into<'a, T>(&'a self) -> T
     where
         ZSerde: Deserialize<T, Input<'a> = &'a ZBytes, Error = Infallible>,

--- a/zenoh/src/api/bytes.rs
+++ b/zenoh/src/api/bytes.rs
@@ -187,7 +187,7 @@ pub trait Deserialize<T> {
 ///
 /// **NOTE 2:** `ZBytes` may store data in non-contiguous regions of memory.
 /// The typical case for `ZBytes` to store data in different memory regions is when data is received fragmented from the network.
-/// The user then can decided to use [`ZBytes::deserialize`], [`ZBytes::reader`], [`ZBytes::into`], or [`ZBytes::iter_raw`] depending
+/// The user then can decided to use [`ZBytes::deserialize`], [`ZBytes::reader`], [`ZBytes::into`], or [`ZBytes::slices`] depending
 /// on their needs.
 ///
 /// To directly access raw data as contiguous slice it is preferred to convert `ZBytes` into a [`std::borrow::Cow<[u8]>`].
@@ -215,7 +215,7 @@ pub trait Deserialize<T> {
 ///
 /// let buf: Vec<u8> = vec![0, 1, 2, 3];
 /// let bytes = ZBytes::from(buf.clone());
-/// for slice in bytes.iter_raw() {
+/// for slice in bytes.slices() {
 ///     println!("{:02x?}", slice);
 /// }
 /// ```
@@ -298,7 +298,7 @@ impl ZBytes {
     /// Please note that no guarantee is provided on the internal memory layout of [`ZBytes`].
     /// The only provided guarantee is on the bytes order that is preserved.
     ///
-    /// Please note that [`ZBytes::iter`] will perform deserialization while iterating while [`ZBytes::iter_raw`] will not.
+    /// Please note that [`ZBytes::iter`] will perform deserialization while iterating while [`ZBytes::slices`] will not.
     ///
     /// ```rust
     /// use std::io::Write;
@@ -312,19 +312,19 @@ impl ZBytes {
     /// writer.write(&buf2);
     ///
     /// // Print the raw content
-    /// for slice in zbs.iter_raw() {
+    /// for slice in zbs.slices() {
     ///     println!("{:02x?}", slice);
     /// }
     ///
     /// // Concatenate input in a single vector
     /// let buf: Vec<u8> = buf1.into_iter().chain(buf2.into_iter()).collect();
     /// // Concatenate raw bytes in a single vector
-    /// let out: Vec<u8> = zbs.iter_raw().fold(Vec::new(), |mut b, x| { b.extend_from_slice(x); b });
+    /// let out: Vec<u8> = zbs.slices().fold(Vec::new(), |mut b, x| { b.extend_from_slice(x); b });
     /// // The previous line is the equivalent of
     /// // let out: Vec<u8> = zbs.into();
     /// assert_eq!(buf, out);
     /// ```
-    pub fn iter_raw(&self) -> impl Iterator<Item = &[u8]> {
+    pub fn slices(&self) -> impl Iterator<Item = &[u8]> {
         self.0.slices()
     }
 

--- a/zenoh/src/api/bytes.rs
+++ b/zenoh/src/api/bytes.rs
@@ -192,7 +192,7 @@ pub trait Deserialize<T> {
 ///
 /// To directly access raw data as contiguous slice it is preferred to convert `ZBytes` into a [`std::borrow::Cow<[u8]>`].
 /// If `ZBytes` contains all the data in a single memory location, this is guaranteed to be zero-copy. This is the common case for small messages.
-/// If `ZBytes` contains data scattered in differnt memory regions, this operation will do an allocation and a copy. This is the common case for large messages.
+/// If `ZBytes` contains data scattered in different memory regions, this operation will do an allocation and a copy. This is the common case for large messages.
 ///
 /// Example:
 /// ```rust


### PR DESCRIPTION
This PR adds a way to iterate over the raw byte slices of a `ZBytes`.
This PR also improves `ZBytes` documentation