### PR TITLE
Select links based on message Priority & Reliability

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -331,6 +331,11 @@
       /// The supported protocols are: ["tcp" , "udp", "tls", "quic", "ws", "unixsock-stream", "vsock"]
       /// For example, to only enable "tls" and "quic":
       //   protocols: ["tls", "quic"],
+      ///
+      /// Endpoints accept a "priorities" metadata value in the form of a Rust-style half-open range
+      /// (e.g. `2..4` signifies priorities 2 and 3). This value is used to select the link used
+      /// for transmission based on the priority of the message in question.
+      ///
       /// Configure the zenoh TX parameters of a link
       tx: {
         /// The resolution in bits to be used for the message sequence numbers.

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -330,11 +330,16 @@
       /// If not configured, all the supported protocols are automatically whitelisted.
       /// The supported protocols are: ["tcp" , "udp", "tls", "quic", "ws", "unixsock-stream", "vsock"]
       /// For example, to only enable "tls" and "quic":
-      //   protocols: ["tls", "quic"],
+      ///   protocols: ["tls", "quic"],
       ///
-      /// Endpoints accept a "priorities" metadata value in the form of a Rust-style half-open range
-      /// (e.g. `2..4` signifies priorities 2 and 3). This value is used to select the link used
-      /// for transmission based on the priority of the message in question.
+      /// ## Endpoint metadata
+      ///
+      /// **priorities**: a Rust-style half-open range (e.g. `2..4` signifies priorities 2 and 3).
+      /// This value is used to select the link used for transmission based on the Priority of the
+      /// message in question.
+      ///
+      /// **reliability**: either "best_effort" or "reliable". This value is used to select the link
+      /// used for transmission based on the Reliability of the message in question.
       ///
       /// Configure the zenoh TX parameters of a link
       tx: {
@@ -392,7 +397,7 @@
             enabled: true,
             /// The maximum time limit (in ms) a message should be retained for batching when back-pressure happens.
             time_limit: 1,
-          }
+          },
         },
       },
       /// Configure the zenoh RX parameters of a link

--- a/commons/zenoh-protocol/src/core/mod.rs
+++ b/commons/zenoh-protocol/src/core/mod.rs
@@ -409,10 +409,10 @@ impl Reliability {
 
     /// Returns `true` is `self` implies `other`.
     pub fn implies(self, other: Self) -> bool {
-        match (self, other) {
-            (Reliability::Reliable, Reliability::BestEffort) => false,
-            _ => true,
-        }
+        !matches!(
+            (self, other),
+            (Reliability::Reliable, Reliability::BestEffort)
+        )
     }
 
     #[cfg(feature = "test")]

--- a/commons/zenoh-protocol/src/core/mod.rs
+++ b/commons/zenoh-protocol/src/core/mod.rs
@@ -324,8 +324,14 @@ impl PriorityRange {
         Ok(Self { start, end })
     }
 
-    pub fn includes(&self, priority: Priority) -> bool {
+    /// Returns `true` if `priority` is a member of `self`.
+    pub fn contains(&self, priority: Priority) -> bool {
         self.start <= (priority as u8) && (priority as u8) < self.end
+    }
+
+    /// Returns `true` if `self` is a superset of `other`.
+    pub fn includes(&self, other: PriorityRange) -> bool {
+        self.start <= other.start && other.end <= self.end
     }
 
     pub fn len(&self) -> usize {

--- a/commons/zenoh-protocol/src/core/mod.rs
+++ b/commons/zenoh-protocol/src/core/mod.rs
@@ -19,10 +19,11 @@ use alloc::{
 };
 use core::{
     convert::{From, TryFrom, TryInto},
-    fmt,
+    fmt::{self, Display},
     hash::Hash,
     str::FromStr,
 };
+use std::error::Error;
 
 use serde::Serialize;
 pub use uhlc::{Timestamp, NTP64};
@@ -406,6 +407,14 @@ pub enum Reliability {
 impl Reliability {
     pub const DEFAULT: Self = Self::BestEffort;
 
+    /// Returns `true` is `self` implies `other`.
+    pub fn implies(self, other: Self) -> bool {
+        match (self, other) {
+            (Reliability::Reliable, Reliability::BestEffort) => false,
+            _ => true,
+        }
+    }
+
     #[cfg(feature = "test")]
     pub fn rand() -> Self {
         use rand::Rng;
@@ -426,6 +435,46 @@ impl From<bool> for Reliability {
             Reliability::Reliable
         } else {
             Reliability::BestEffort
+        }
+    }
+}
+
+impl From<Reliability> for bool {
+    fn from(value: Reliability) -> Self {
+        match value {
+            Reliability::BestEffort => false,
+            Reliability::Reliable => true,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct InvalidReliability {
+    found: String,
+}
+
+impl Display for InvalidReliability {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "invalid Reliability string, expected `best_effort` or `reliable` but found {}",
+            self.found
+        )
+    }
+}
+
+impl Error for InvalidReliability {}
+
+impl FromStr for Reliability {
+    type Err = InvalidReliability;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "reliable" => Ok(Reliability::Reliable),
+            "best_effort" => Ok(Reliability::BestEffort),
+            other => Err(InvalidReliability {
+                found: other.to_string(),
+            }),
         }
     }
 }

--- a/commons/zenoh-protocol/src/transport/init.rs
+++ b/commons/zenoh-protocol/src/transport/init.rs
@@ -126,13 +126,13 @@ pub struct InitSyn {
 // Extensions
 pub mod ext {
     use crate::{
-        common::{ZExtUnit, ZExtZBuf},
-        zextunit, zextzbuf,
+        common::{ZExtUnit, ZExtZ64, ZExtZBuf},
+        zextunit, zextz64, zextzbuf,
     };
 
     /// # QoS extension
     /// Used to negotiate the use of QoS
-    pub type QoS = zextunit!(0x1, false);
+    pub type QoS = zextz64!(0x1, false);
 
     /// # Shm extension
     /// Used as challenge for probing shared memory capabilities
@@ -161,7 +161,7 @@ impl InitSyn {
     pub fn rand() -> Self {
         use rand::Rng;
 
-        use crate::common::{ZExtUnit, ZExtZBuf};
+        use crate::common::{ZExtUnit, ZExtZ64, ZExtZBuf};
 
         let mut rng = rand::thread_rng();
 
@@ -170,7 +170,7 @@ impl InitSyn {
         let zid = ZenohIdProto::default();
         let resolution = Resolution::rand();
         let batch_size: BatchSize = rng.gen();
-        let ext_qos = rng.gen_bool(0.5).then_some(ZExtUnit::rand());
+        let ext_qos = rng.gen_bool(0.5).then_some(ZExtZ64::rand());
         #[cfg(feature = "shared-memory")]
         let ext_shm = rng.gen_bool(0.5).then_some(ZExtZBuf::rand());
         let ext_auth = rng.gen_bool(0.5).then_some(ZExtZBuf::rand());
@@ -217,7 +217,7 @@ impl InitAck {
     pub fn rand() -> Self {
         use rand::Rng;
 
-        use crate::common::{ZExtUnit, ZExtZBuf};
+        use crate::common::{ZExtUnit, ZExtZ64, ZExtZBuf};
 
         let mut rng = rand::thread_rng();
 
@@ -231,7 +231,7 @@ impl InitAck {
         };
         let batch_size: BatchSize = rng.gen();
         let cookie = ZSlice::rand(64);
-        let ext_qos = rng.gen_bool(0.5).then_some(ZExtUnit::rand());
+        let ext_qos = rng.gen_bool(0.5).then_some(ZExtZ64::rand());
         #[cfg(feature = "shared-memory")]
         let ext_shm = rng.gen_bool(0.5).then_some(ZExtZBuf::rand());
         let ext_auth = rng.gen_bool(0.5).then_some(ZExtZBuf::rand());

--- a/io/zenoh-link-commons/src/lib.rs
+++ b/io/zenoh-link-commons/src/lib.rs
@@ -33,7 +33,10 @@ pub use listener::*;
 pub use multicast::*;
 use serde::Serialize;
 pub use unicast::*;
-use zenoh_protocol::{core::Locator, transport::BatchSize};
+use zenoh_protocol::{
+    core::{Locator, PriorityRange, Reliability},
+    transport::BatchSize,
+};
 use zenoh_result::ZResult;
 
 /*************************************/
@@ -48,10 +51,11 @@ pub struct Link {
     pub dst: Locator,
     pub group: Option<Locator>,
     pub mtu: BatchSize,
-    pub is_reliable: bool,
     pub is_streamed: bool,
     pub interfaces: Vec<String>,
     pub auth_identifier: LinkAuthId,
+    pub priorities: Option<PriorityRange>,
+    pub reliability: Reliability,
 }
 
 #[async_trait]
@@ -70,45 +74,37 @@ impl fmt::Display for Link {
     }
 }
 
-impl From<&LinkUnicast> for Link {
-    fn from(link: &LinkUnicast) -> Link {
+impl Link {
+    pub fn new_unicast(
+        link: &LinkUnicast,
+        priorities: Option<PriorityRange>,
+        reliability: Reliability,
+    ) -> Self {
         Link {
             src: link.get_src().to_owned(),
             dst: link.get_dst().to_owned(),
             group: None,
             mtu: link.get_mtu(),
-            is_reliable: link.is_reliable(),
             is_streamed: link.is_streamed(),
             interfaces: link.get_interface_names(),
             auth_identifier: link.get_auth_id().clone(),
+            priorities,
+            reliability,
         }
     }
-}
 
-impl From<LinkUnicast> for Link {
-    fn from(link: LinkUnicast) -> Link {
-        Link::from(&link)
-    }
-}
-
-impl From<&LinkMulticast> for Link {
-    fn from(link: &LinkMulticast) -> Link {
+    pub fn new_multicast(link: &LinkMulticast) -> Self {
         Link {
             src: link.get_src().to_owned(),
             dst: link.get_dst().to_owned(),
             group: Some(link.get_dst().to_owned()),
             mtu: link.get_mtu(),
-            is_reliable: link.is_reliable(),
             is_streamed: false,
             interfaces: vec![],
             auth_identifier: LinkAuthId::default(),
+            priorities: None,
+            reliability: Reliability::from(link.is_reliable()),
         }
-    }
-}
-
-impl From<LinkMulticast> for Link {
-    fn from(link: LinkMulticast) -> Link {
-        Link::from(&link)
     }
 }
 

--- a/io/zenoh-link-commons/src/unicast.rs
+++ b/io/zenoh-link-commons/src/unicast.rs
@@ -36,7 +36,18 @@ pub trait LinkManagerUnicastTrait: Send + Sync {
     async fn get_listeners(&self) -> Vec<EndPoint>;
     async fn get_locators(&self) -> Vec<Locator>;
 }
-pub type NewLinkChannelSender = flume::Sender<LinkUnicast>;
+pub type NewLinkChannelSender = flume::Sender<NewLinkUnicast>;
+
+/// Notification of a new inbound connection.
+///
+/// Link implementations should preserve the metadata sections of [`NewLinkUnicast::endpoint`].
+pub struct NewLinkUnicast {
+    /// The link created in response to a new inbound connection.
+    pub link: LinkUnicast,
+    /// Endpoint of the listener.
+    pub endpoint: EndPoint,
+}
+
 pub trait ConstructibleLinkManagerUnicast<T>: Sized {
     fn new(new_link_sender: NewLinkChannelSender, config: T) -> ZResult<Self>;
 }

--- a/io/zenoh-links/zenoh-link-quic/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/unicast.rs
@@ -27,7 +27,7 @@ use x509_parser::prelude::*;
 use zenoh_core::zasynclock;
 use zenoh_link_commons::{
     get_ip_interface_names, LinkAuthId, LinkAuthType, LinkManagerUnicastTrait, LinkUnicast,
-    LinkUnicastTrait, ListenersUnicastIP, NewLinkChannelSender,
+    LinkUnicastTrait, ListenersUnicastIP, NewLinkChannelSender, NewLinkUnicast,
 };
 use zenoh_protocol::{
     core::{EndPoint, Locator},
@@ -332,11 +332,14 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastQuic {
 
         // Spawn the accept loop for the listener
         let token = self.listeners.token.child_token();
-        let c_token = token.clone();
 
-        let c_manager = self.manager.clone();
+        let task = {
+            let token = token.clone();
+            let manager = self.manager.clone();
+            let endpoint = endpoint.clone();
 
-        let task = async move { accept_task(quic_endpoint, c_token, c_manager).await };
+            async move { accept_task(endpoint, quic_endpoint, token, manager).await }
+        };
 
         // Initialize the QuicAcceptor
         let locator = endpoint.to_locator();
@@ -364,7 +367,8 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastQuic {
 }
 
 async fn accept_task(
-    endpoint: quinn::Endpoint,
+    endpoint: EndPoint,
+    quic_endpoint: quinn::Endpoint,
     token: CancellationToken,
     manager: NewLinkChannelSender,
 ) -> ZResult<()> {
@@ -382,7 +386,7 @@ async fn accept_task(
         Ok(conn)
     }
 
-    let src_addr = endpoint
+    let src_addr = quic_endpoint
         .local_addr()
         .map_err(|e| zerror!("Can not accept QUIC connections: {}", e))?;
 
@@ -393,7 +397,7 @@ async fn accept_task(
         tokio::select! {
             _ = token.cancelled() => break,
 
-            res = accept(endpoint.accept()) => {
+            res = accept(quic_endpoint.accept()) => {
                 match res {
                     Ok(quic_conn) => {
                         // Get the bideractional streams. Note that we don't allow unidirectional streams.
@@ -429,7 +433,7 @@ async fn accept_task(
                         ));
 
                         // Communicate the new link to the initial transport manager
-                        if let Err(e) = manager.send_async(LinkUnicast(link)).await {
+                        if let Err(e) = manager.send_async(NewLinkUnicast { link: LinkUnicast(link), endpoint: endpoint.clone() }).await {
                             tracing::error!("{}-{}: {}", file!(), line!(), e)
                         }
 

--- a/io/zenoh-transport/src/manager.rs
+++ b/io/zenoh-transport/src/manager.rs
@@ -419,8 +419,8 @@ impl TransportManager {
                     loop {
                         tokio::select! {
                                 res = new_unicast_link_receiver.recv_async() => {
-                                    if let Ok(link) = res {
-                                        this.handle_new_link_unicast(link).await;
+                                    if let Ok(new_link) = res {
+                                        this.handle_new_link_unicast(new_link).await;
                                     }
                                 }
                                 _ = cancellation_token.cancelled() => { break; }

--- a/io/zenoh-transport/src/multicast/link.rs
+++ b/io/zenoh-transport/src/multicast/link.rs
@@ -21,7 +21,7 @@ use std::{
 use tokio::task::JoinHandle;
 use zenoh_buffers::{BBuf, ZSlice, ZSliceBuffer};
 use zenoh_core::{zcondfeat, zlock};
-use zenoh_link::{Link, LinkMulticast, Locator};
+use zenoh_link::{LinkMulticast, Locator};
 use zenoh_protocol::{
     core::{Bits, Priority, Resolution, WhatAmI, ZenohIdProto},
     transport::{BatchSize, Close, Join, PrioritySn, TransportMessage, TransportSn},
@@ -123,18 +123,6 @@ impl fmt::Debug for TransportLinkMulticast {
             .field("link", &self.link)
             .field("config", &self.config)
             .finish()
-    }
-}
-
-impl From<&TransportLinkMulticast> for Link {
-    fn from(link: &TransportLinkMulticast) -> Self {
-        Link::from(&link.link)
-    }
-}
-
-impl From<TransportLinkMulticast> for Link {
-    fn from(link: TransportLinkMulticast) -> Self {
-        Link::from(link.link)
     }
 }
 

--- a/io/zenoh-transport/src/multicast/mod.rs
+++ b/io/zenoh-transport/src/multicast/mod.rs
@@ -92,7 +92,7 @@ impl TransportMulticast {
     #[inline(always)]
     pub fn get_link(&self) -> ZResult<Link> {
         let transport = self.get_transport()?;
-        Ok(transport.get_link().into())
+        Ok(Link::new_multicast(&transport.get_link().link))
     }
 
     #[inline(always)]

--- a/io/zenoh-transport/src/multicast/transport.rs
+++ b/io/zenoh-transport/src/multicast/transport.rs
@@ -333,7 +333,7 @@ impl TransportMulticastInner {
     /*               PEER                */
     /*************************************/
     pub(super) fn new_peer(&self, locator: &Locator, join: Join) -> ZResult<()> {
-        let mut link = Link::from(self.get_link());
+        let mut link = Link::new_multicast(&self.get_link().link);
         link.dst = locator.clone();
 
         let is_shm = zcondfeat!("shared-memory", join.ext_shm.is_some(), false);
@@ -452,7 +452,7 @@ impl TransportMulticastInner {
         zread!(self.peers)
             .values()
             .map(|p| {
-                let mut link = Link::from(self.get_link());
+                let mut link = Link::new_multicast(&self.get_link().link);
                 link.dst = p.locator.clone();
 
                 TransportPeer {

--- a/io/zenoh-transport/src/unicast/establishment/accept.rs
+++ b/io/zenoh-transport/src/unicast/establishment/accept.rs
@@ -786,7 +786,11 @@ pub(crate) async fn accept_link(
             is_compression: state.link.ext_compression.is_compression(),
         },
         priorities: state.transport.ext_qos.priorities(),
-        reliability: Reliability::from(link.link.is_reliable()),
+        reliability: state
+            .transport
+            .ext_qos
+            .reliability()
+            .unwrap_or_else(|| Reliability::from(link.link.is_reliable())),
     };
     let a_link = link.reconfigure(a_config);
     let s_link = format!("{:?}", a_link);

--- a/io/zenoh-transport/src/unicast/establishment/accept.rs
+++ b/io/zenoh-transport/src/unicast/establishment/accept.rs
@@ -20,9 +20,9 @@ use zenoh_buffers::{reader::HasReader, writer::HasWriter, ZSlice};
 use zenoh_codec::{RCodec, WCodec, Zenoh080};
 use zenoh_core::{zasynclock, zcondfeat, zerror};
 use zenoh_crypto::{BlockCipher, PseudoRng};
-use zenoh_link::LinkUnicast;
+use zenoh_link::{EndPoint, LinkUnicast};
 use zenoh_protocol::{
-    core::{Field, Resolution, WhatAmI, ZenohIdProto},
+    core::{Field, Reliability, Resolution, WhatAmI, ZenohIdProto},
     transport::{
         batch_size,
         close::{self, Close},
@@ -55,7 +55,7 @@ pub(super) type AcceptError = (zenoh_result::Error, Option<u8>);
 struct StateTransport {
     batch_size: BatchSize,
     resolution: Resolution,
-    ext_qos: ext::qos::StateAccept,
+    ext_qos: ext::qos::QoS,
     #[cfg(feature = "transport_multilink")]
     ext_mlink: ext::multilink::StateAccept,
     #[cfg(feature = "shared-memory")]
@@ -636,17 +636,24 @@ impl<'a, 'b: 'a> AcceptFsm for &'a mut AcceptLink<'b> {
     }
 }
 
-pub(crate) async fn accept_link(link: LinkUnicast, manager: &TransportManager) -> ZResult<()> {
+pub(crate) async fn accept_link(
+    endpoint: EndPoint,
+    link: LinkUnicast,
+    manager: &TransportManager,
+) -> ZResult<()> {
+    let direction = TransportLinkUnicastDirection::Inbound;
     let mtu = link.get_mtu();
     let is_streamed = link.is_streamed();
     let config = TransportLinkUnicastConfig {
-        direction: TransportLinkUnicastDirection::Inbound,
+        direction,
         batch: BatchConfig {
             mtu,
             is_streamed,
             #[cfg(feature = "transport_compression")]
             is_compression: false,
         },
+        priorities: None,
+        reliability: Reliability::from(link.is_reliable()),
     };
     let mut link = TransportLinkUnicast::new(link, config);
     let mut fsm = AcceptLink {
@@ -689,7 +696,7 @@ pub(crate) async fn accept_link(link: LinkUnicast, manager: &TransportManager) -
             transport: StateTransport {
                 batch_size: manager.config.batch_size.min(batch_size::UNICAST).min(mtu),
                 resolution: manager.config.resolution,
-                ext_qos: ext::qos::StateAccept::new(manager.config.unicast.is_qos),
+                ext_qos: ext::qos::QoS::new(manager.config.unicast.is_qos, &endpoint)?,
                 #[cfg(feature = "transport_multilink")]
                 ext_mlink: manager
                     .state
@@ -757,7 +764,7 @@ pub(crate) async fn accept_link(link: LinkUnicast, manager: &TransportManager) -
         whatami: osyn_out.other_whatami,
         sn_resolution: state.transport.resolution.get(Field::FrameSN),
         tx_initial_sn: oack_out.open_ack.initial_sn,
-        is_qos: state.transport.ext_qos.is_qos(),
+        is_qos: state.transport.ext_qos.is_enabled(),
         #[cfg(feature = "transport_multilink")]
         multilink: state.transport.ext_mlink.multilink(),
         #[cfg(feature = "shared-memory")]
@@ -771,13 +778,15 @@ pub(crate) async fn accept_link(link: LinkUnicast, manager: &TransportManager) -
     };
 
     let a_config = TransportLinkUnicastConfig {
-        direction: TransportLinkUnicastDirection::Inbound,
+        direction,
         batch: BatchConfig {
             mtu: state.transport.batch_size,
             is_streamed,
             #[cfg(feature = "transport_compression")]
             is_compression: state.link.ext_compression.is_compression(),
         },
+        priorities: state.transport.ext_qos.priorities(),
+        reliability: Reliability::from(link.link.is_reliable()),
     };
     let a_link = link.reconfigure(a_config);
     let s_link = format!("{:?}", a_link);

--- a/io/zenoh-transport/src/unicast/establishment/cookie.rs
+++ b/io/zenoh-transport/src/unicast/establishment/cookie.rs
@@ -34,7 +34,7 @@ pub(crate) struct Cookie {
     pub(crate) batch_size: BatchSize,
     pub(crate) nonce: u64,
     // Extensions
-    pub(crate) ext_qos: ext::qos::StateAccept,
+    pub(crate) ext_qos: ext::qos::QoS,
     #[cfg(feature = "transport_multilink")]
     pub(crate) ext_mlink: ext::multilink::StateAccept,
     #[cfg(feature = "shared-memory")]
@@ -90,7 +90,7 @@ where
         let batch_size: BatchSize = self.read(&mut *reader)?;
         let nonce: u64 = self.read(&mut *reader)?;
         // Extensions
-        let ext_qos: ext::qos::StateAccept = self.read(&mut *reader)?;
+        let ext_qos: ext::qos::QoS = self.read(&mut *reader)?;
         #[cfg(feature = "transport_multilink")]
         let ext_mlink: ext::multilink::StateAccept = self.read(&mut *reader)?;
         #[cfg(feature = "shared-memory")]
@@ -178,7 +178,7 @@ impl Cookie {
             resolution: Resolution::rand(),
             batch_size: rng.gen(),
             nonce: rng.gen(),
-            ext_qos: ext::qos::StateAccept::rand(),
+            ext_qos: ext::qos::QoS::rand(),
             #[cfg(feature = "transport_multilink")]
             ext_mlink: ext::multilink::StateAccept::rand(),
             #[cfg(feature = "shared-memory")]

--- a/io/zenoh-transport/src/unicast/establishment/ext/qos.rs
+++ b/io/zenoh-transport/src/unicast/establishment/ext/qos.rs
@@ -481,9 +481,8 @@ mod tests {
             priorities: Some(PriorityRange::new(2, 3).unwrap()),
         };
 
-        match test_priority_range_negotiation(qos_open, qos_accept).await {
-            Ok(()) => panic!("expected `Err(_)`, got `Ok(())`"),
-            Err(_) => {}
-        };
+        if let Ok(()) = test_priority_range_negotiation(qos_open, qos_accept).await {
+            panic!("expected `Err(_)`, got `Ok(())`")
+        }
     }
 }

--- a/io/zenoh-transport/src/unicast/establishment/ext/qos.rs
+++ b/io/zenoh-transport/src/unicast/establishment/ext/qos.rs
@@ -237,7 +237,7 @@ impl<'a> OpenFsm for &'a QoSFsm<'a> {
                     self_qos
                 } else {
                     return Err(zerror!(
-                        "The PriorityRange set in InitAck is not a superset of my PriorityRange"
+                        "The PriorityRange received in InitAck is not a superset of my PriorityRange"
                     )
                     .into());
                 }
@@ -309,7 +309,7 @@ impl<'a> AcceptFsm for &'a QoSFsm<'a> {
                     other_qos
                 } else {
                     return Err(zerror!(
-                        "The PriorityRange set in InitSyn is not a subset of my PriorityRange"
+                        "The PriorityRange received in InitSyn is not a subset of my PriorityRange"
                     )
                     .into());
                 }

--- a/io/zenoh-transport/src/unicast/establishment/ext/qos.rs
+++ b/io/zenoh-transport/src/unicast/establishment/ext/qos.rs
@@ -352,9 +352,8 @@ mod tests {
     use zenoh_protocol::core::PriorityRange;
     use zenoh_result::ZResult;
 
-    use crate::unicast::establishment::{AcceptFsm, OpenFsm};
-
     use super::{QoS, QoSFsm};
+    use crate::unicast::establishment::{AcceptFsm, OpenFsm};
 
     async fn test_priority_range_negotiation(
         qos_open: &mut QoS,

--- a/io/zenoh-transport/src/unicast/establishment/open.rs
+++ b/io/zenoh-transport/src/unicast/establishment/open.rs
@@ -671,7 +671,11 @@ pub(crate) async fn open_link(
             is_compression: state.link.ext_compression.is_compression(),
         },
         priorities: state.transport.ext_qos.priorities(),
-        reliability: Reliability::from(link.link.is_reliable()),
+        reliability: state
+            .transport
+            .ext_qos
+            .reliability()
+            .unwrap_or_else(|| Reliability::from(link.link.is_reliable())),
     };
     let o_link = link.reconfigure(o_config);
     let s_link = format!("{:?}", o_link);

--- a/io/zenoh-transport/src/unicast/link.rs
+++ b/io/zenoh-transport/src/unicast/link.rs
@@ -82,7 +82,7 @@ impl TransportLinkUnicast {
     pub(crate) fn rx(&self) -> TransportLinkUnicastRx {
         TransportLinkUnicastRx {
             link: self.link.clone(),
-            config: self.config.clone(),
+            config: self.config,
         }
     }
 

--- a/io/zenoh-transport/src/unicast/lowlatency/link.rs
+++ b/io/zenoh-transport/src/unicast/lowlatency/link.rs
@@ -152,7 +152,7 @@ impl TransportUnicastLowlatency {
 
             // The pool of buffers
             let pool = {
-                let mtu = link_rx.batch.mtu as usize;
+                let mtu = link_rx.config.batch.mtu as usize;
                 let mut n = rx_buffer_size / mtu;
                 if rx_buffer_size % mtu != 0 {
                     n += 1;

--- a/io/zenoh-transport/src/unicast/universal/link.rs
+++ b/io/zenoh-transport/src/unicast/universal/link.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use zenoh_buffers::ZSliceBuffer;
+use zenoh_link::Link;
 use zenoh_protocol::transport::{KeepAlive, TransportMessage};
 use zenoh_result::{zerror, ZResult};
 use zenoh_sync::{RecyclingObject, RecyclingObjectPool};
@@ -113,6 +114,8 @@ impl TransportLinkUnicastUniversal {
     }
 
     pub(super) fn start_rx(&mut self, transport: TransportUnicastUniversal, lease: Duration) {
+        let priorities = self.link.config.priorities;
+        let reliability = self.link.config.reliability;
         let mut rx = self.link.rx();
         let token = self.token.clone();
         let task = async move {
@@ -133,8 +136,12 @@ impl TransportLinkUnicastUniversal {
                 // Spawn a task to avoid a deadlock waiting for this same task
                 // to finish in the close() joining its handle
                 // WARN: Must be spawned on RX
-                zenoh_runtime::ZRuntime::RX
-                    .spawn(async move { transport.del_link((&rx.link).into()).await });
+
+                zenoh_runtime::ZRuntime::RX.spawn(async move {
+                    transport
+                        .del_link(Link::new_unicast(&rx.link, priorities, reliability))
+                        .await
+                });
 
                 // // WARN: This ZRuntime blocks
                 // zenoh_runtime::ZRuntime::Net
@@ -248,14 +255,14 @@ async fn rx_task(
     }
 
     // The pool of buffers
-    let mtu = link.batch.mtu as usize;
+    let mtu = link.config.batch.mtu as usize;
     let mut n = rx_buffer_size / mtu;
     if rx_buffer_size % mtu != 0 {
         n += 1;
     }
 
     let pool = RecyclingObjectPool::new(n, || vec![0_u8; mtu].into_boxed_slice());
-    let l = (&link.link).into();
+    let l = Link::new_unicast(&link.link, link.config.priorities, link.config.reliability);
 
     loop {
         tokio::select! {

--- a/io/zenoh-transport/src/unicast/universal/tx.rs
+++ b/io/zenoh-transport/src/unicast/universal/tx.rs
@@ -25,12 +25,12 @@ impl TransportUnicastUniversal {
     /// Returns the index of the best matching [`Reliability`]-[`PriorityRange`] pair.
     ///
     /// The result is either:
-    /// 1. A "full match" where the link matches both `reliability` and `priority`. In case of
-    ///    multiple candidates, the link with the smaller range is selected.
-    /// 2. A "partial match" where the link match `reliability` and **not** `priority`.
-    /// 3. An "any match" where any available link is selected.
+    /// 1. A "full match" where the pair matches both `reliability` and `priority`. In case of
+    ///    multiple candidates, the pair with the smaller range is selected.
+    /// 2. A "partial match" where the pair match `reliability` and **not** `priority`.
+    /// 3. An "any match" where any available pair is selected.
     ///
-    /// If `transport_links` is empty then [`None`] is returned.
+    /// If `elements` is empty then [`None`] is returned.
     fn select(
         elements: impl Iterator<Item = (Reliability, Option<PriorityRange>)>,
         reliability: Reliability,

--- a/io/zenoh-transport/src/unicast/universal/tx.rs
+++ b/io/zenoh-transport/src/unicast/universal/tx.rs
@@ -38,7 +38,7 @@ impl TransportUnicastUniversal {
                     .link
                     .config
                     .priorities
-                    .and_then(|range| range.includes(msg.priority()).then_some(range));
+                    .and_then(|range| range.contains(msg.priority()).then_some(range));
 
                 match (reliability, priorities) {
                     (true, Some(priorities)) => {


### PR DESCRIPTION
The goal of this pull request is to enable users to choose the link on which a message is sent as a function of the message's Priority & Reliability.

Supersedes #1324 and #1356.
