### PR TITLE
feat(zenoh_id): exposing into `[u8; 16]` & `to_le_bytes()`

### DIFF
--- a/commons/zenoh-config/src/wrappers.rs
+++ b/commons/zenoh-config/src/wrappers.rs
@@ -54,6 +54,15 @@ impl From<ZenohIdProto> for ZenohId {
     }
 }
 
+impl TryFrom<&[u8]> for ZenohId {
+    type Error = zenoh_result::Error;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        let proto: ZenohIdProto = value.try_into()?;
+        Ok(ZenohId::from(proto))
+    }
+}
+
 impl From<ZenohId> for ZenohIdProto {
     fn from(id: ZenohId) -> Self {
         id.0
@@ -69,6 +78,13 @@ impl From<ZenohId> for uhlc::ID {
 impl From<ZenohId> for OwnedKeyExpr {
     fn from(zid: ZenohId) -> Self {
         zid.0.into()
+    }
+}
+
+impl From<ZenohId> for [u8; ZenohIdProto::MAX_SIZE] {
+    fn from(value: ZenohId) -> Self {
+        let proto: ZenohIdProto = value.into();
+        proto.to_le_bytes()
     }
 }
 

--- a/commons/zenoh-config/src/wrappers.rs
+++ b/commons/zenoh-config/src/wrappers.rs
@@ -35,6 +35,10 @@ impl ZenohId {
     pub fn into_keyexpr(self) -> OwnedKeyExpr {
         self.into()
     }
+
+    pub fn to_le_bytes(self) -> [u8; uhlc::ID::MAX_SIZE] {
+        self.0.to_le_bytes()
+    }
 }
 
 impl fmt::Debug for ZenohId {
@@ -78,13 +82,6 @@ impl From<ZenohId> for uhlc::ID {
 impl From<ZenohId> for OwnedKeyExpr {
     fn from(zid: ZenohId) -> Self {
         zid.0.into()
-    }
-}
-
-impl From<ZenohId> for [u8; ZenohIdProto::MAX_SIZE] {
-    fn from(value: ZenohId) -> Self {
-        let proto: ZenohIdProto = value.into();
-        proto.to_le_bytes()
     }
 }
 


### PR DESCRIPTION
Allowing users to create a ZenohId from a slice, using TryFrom, and also allowing users to convert a ZenohId into `[u8; 16]`.

Related to https://github.com/eclipse-zenoh/zenoh-kotlin/pull/196. 