### PR TITLE
feat: use builder method instead of handler type for undeclaration on drop

### DIFF
--- a/zenoh/src/api/publisher.rs
+++ b/zenoh/src/api/publisher.rs
@@ -12,11 +12,12 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
+#[cfg(feature = "unstable")]
+use std::mem::size_of;
 use std::{
     convert::TryFrom,
     fmt,
     future::{IntoFuture, Ready},
-    mem::size_of,
     pin::Pin,
     task::{Context, Poll},
 };

--- a/zenoh/src/api/queryable.rs
+++ b/zenoh/src/api/queryable.rs
@@ -14,7 +14,6 @@
 use std::{
     fmt,
     future::{IntoFuture, Ready},
-    mem::size_of,
     ops::{Deref, DerefMut},
     sync::Arc,
 };
@@ -604,6 +603,7 @@ pub struct QueryableBuilder<'a, 'b, Handler> {
     pub(crate) complete: bool,
     pub(crate) origin: Locality,
     pub(crate) handler: Handler,
+    pub(crate) undeclare_on_drop: bool,
 }
 
 impl<'a, 'b> QueryableBuilder<'a, 'b, DefaultHandler> {
@@ -634,6 +634,7 @@ impl<'a, 'b> QueryableBuilder<'a, 'b, DefaultHandler> {
             complete,
             origin,
             handler: _,
+            undeclare_on_drop: _,
         } = self;
         QueryableBuilder {
             session,
@@ -641,6 +642,7 @@ impl<'a, 'b> QueryableBuilder<'a, 'b, DefaultHandler> {
             complete,
             origin,
             handler: callback,
+            undeclare_on_drop: false,
         }
     }
 
@@ -705,6 +707,7 @@ impl<'a, 'b> QueryableBuilder<'a, 'b, DefaultHandler> {
             complete,
             origin,
             handler: _,
+            undeclare_on_drop: _,
         } = self;
         QueryableBuilder {
             session,
@@ -712,6 +715,7 @@ impl<'a, 'b> QueryableBuilder<'a, 'b, DefaultHandler> {
             complete,
             origin,
             handler,
+            undeclare_on_drop: true,
         }
     }
 
@@ -927,8 +931,7 @@ where
                     session_id: session.zid(),
                     session: self.session.downgrade(),
                     state: qable_state,
-                    // `size_of::<Handler::Handler>() == 0` means callback-only queryable
-                    undeclare_on_drop: size_of::<Handler::Handler>() > 0,
+                    undeclare_on_drop: self.undeclare_on_drop,
                 },
                 handler: receiver,
             })

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -412,11 +412,11 @@ impl fmt::Debug for SessionInner {
 
 /// The entrypoint of the zenoh API.
 ///
-/// Zenoh session is instantiated using [`zenoh::open`] and it can be used to declare various
+/// Zenoh session is instantiated using [`zenoh::open`](crate::open) and it can be used to declare various
 /// entities like publishers, subscribers, or querybables, as well as issuing queries.
 ///
 /// Session is an `Arc`-like type, it can be cloned, and it is closed when the last instance
-/// is dropped (see [`Session::closed`]).
+/// is dropped (see [`Session::close`]).
 ///
 /// # Examples
 /// ```
@@ -573,7 +573,7 @@ impl Session {
     ///
     ///
     /// # Examples
-    /// ```no-run
+    /// ```no_run
     /// # #[tokio::main]
     /// # async fn main() {
     /// use zenoh::prelude::*;

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -425,7 +425,7 @@ impl fmt::Debug for SessionInner {
 /// use zenoh::prelude::*;
 ///
 /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
-/// session.put("key/expression", "value").res().await.unwrap();
+/// session.put("key/expression", "value").await.unwrap();
 /// # }
 pub struct Session(pub(crate) Arc<SessionInner>);
 

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -564,7 +564,7 @@ impl Session {
     /// entity after session closing is a no-op. Session state can be checked with
     /// [`Session::is_closed`].
     ///
-    /// Session are automatically closed when all of its instances are dropped, same as `Arc`.
+    /// Session are automatically closed when all its instances are dropped, same as `Arc`.
     /// You may still want to use this function to handle errors or close the session
     /// asynchronously.
     /// <br>

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -412,7 +412,7 @@ impl fmt::Debug for SessionInner {
 
 /// The entrypoint of the zenoh API.
 ///
-/// Zenoh session is instantiated using [`zenoh::open`], and can be used to declares various
+/// Zenoh session is instantiated using [`zenoh::open`] and it can be used to declare various
 /// entities like publishers, subscribers, or querybables, as well as issuing queries.
 ///
 /// Session is an `Arc`-like type, it can be cloned, and it is closed when the last instance

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -573,7 +573,7 @@ impl Session {
     ///
     ///
     /// # Examples
-    /// ```
+    /// ```no-run
     /// # #[tokio::main]
     /// # async fn main() {
     /// use zenoh::prelude::*;

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -413,7 +413,7 @@ impl fmt::Debug for SessionInner {
 /// The entrypoint of the zenoh API.
 ///
 /// Zenoh session is instantiated using [`zenoh::open`], and can be used to declares various
-/// entities like publishers, subscribers, or querybables, as well as making queries.
+/// entities like publishers, subscribers, or querybables, as well as issuing queries.
 ///
 /// Session is an `Arc`-like type, it can be cloned, and it is closed when the last instance
 /// is dropped (see [`Session::closed`]).

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -740,6 +740,7 @@ impl Session {
             reliability: Reliability::DEFAULT,
             origin: Locality::default(),
             handler: DefaultHandler::default(),
+            undeclare_on_drop: true,
         }
     }
 
@@ -784,6 +785,7 @@ impl Session {
             complete: false,
             origin: Locality::default(),
             handler: DefaultHandler::default(),
+            undeclare_on_drop: true,
         }
     }
 


### PR DESCRIPTION
Based on #1369, should be merged after