### PR TITLE
feat!: make callback opaque

### DIFF
--- a/commons/zenoh-config/src/wrappers.rs
+++ b/commons/zenoh-config/src/wrappers.rs
@@ -100,6 +100,7 @@ impl FromStr for ZenohId {
 }
 
 /// A zenoh Hello message.
+#[derive(Clone, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct Hello(HelloProto);
 

--- a/zenoh-ext/src/lib.rs
+++ b/zenoh-ext/src/lib.rs
@@ -53,11 +53,13 @@ impl From<LivelinessSpace> for KeySpace {
 }
 
 pub trait ExtractSample {
-    fn extract(self) -> ZResult<Sample>;
+    fn extract(&self) -> ZResult<Sample>;
 }
 
 impl ExtractSample for Reply {
-    fn extract(self) -> ZResult<Sample> {
-        self.into_result().map_err(|e| zerror!("{:?}", e).into())
+    fn extract(&self) -> ZResult<Sample> {
+        self.result()
+            .cloned()
+            .map_err(|e| zerror!("{:?}", e).into())
     }
 }

--- a/zenoh-ext/src/querying_subscriber.rs
+++ b/zenoh-ext/src/querying_subscriber.rs
@@ -112,7 +112,7 @@ impl<'a, 'b, KeySpace> QueryingSubscriberBuilder<'a, 'b, KeySpace, DefaultHandle
         handler: Handler,
     ) -> QueryingSubscriberBuilder<'a, 'b, KeySpace, Handler>
     where
-        Handler: IntoHandler<'static, Sample>,
+        Handler: IntoHandler<Sample>,
     {
         let QueryingSubscriberBuilder {
             session,
@@ -221,7 +221,7 @@ impl<'a, 'b, KeySpace, Handler> QueryingSubscriberBuilder<'a, 'b, KeySpace, Hand
 
 impl<'a, KeySpace, Handler> Resolvable for QueryingSubscriberBuilder<'a, '_, KeySpace, Handler>
 where
-    Handler: IntoHandler<'static, Sample>,
+    Handler: IntoHandler<Sample>,
     Handler::Handler: Send,
 {
     type To = ZResult<FetchingSubscriber<'a, Handler::Handler>>;
@@ -230,7 +230,7 @@ where
 impl<KeySpace, Handler> Wait for QueryingSubscriberBuilder<'_, '_, KeySpace, Handler>
 where
     KeySpace: Into<crate::KeySpace> + Clone,
-    Handler: IntoHandler<'static, Sample> + Send,
+    Handler: IntoHandler<Sample> + Send,
     Handler::Handler: Send,
 {
     fn wait(self) -> <Self as Resolvable>::To {
@@ -279,7 +279,7 @@ where
 impl<'a, KeySpace, Handler> IntoFuture for QueryingSubscriberBuilder<'a, '_, KeySpace, Handler>
 where
     KeySpace: Into<crate::KeySpace> + Clone,
-    Handler: IntoHandler<'static, Sample> + Send,
+    Handler: IntoHandler<Sample> + Send,
     Handler::Handler: Send,
 {
     type Output = <Self as Resolvable>::To;
@@ -470,7 +470,7 @@ where
         handler: Handler,
     ) -> FetchingSubscriberBuilder<'a, 'b, KeySpace, Handler, Fetch, TryIntoSample>
     where
-        Handler: IntoHandler<'static, Sample>,
+        Handler: IntoHandler<Sample>,
     {
         let FetchingSubscriberBuilder {
             session,
@@ -544,7 +544,7 @@ impl<
         TryIntoSample,
     > Resolvable for FetchingSubscriberBuilder<'a, '_, KeySpace, Handler, Fetch, TryIntoSample>
 where
-    Handler: IntoHandler<'static, Sample>,
+    Handler: IntoHandler<Sample>,
     Handler::Handler: Send,
     TryIntoSample: ExtractSample,
 {
@@ -559,7 +559,7 @@ impl<
     > Wait for FetchingSubscriberBuilder<'_, '_, KeySpace, Handler, Fetch, TryIntoSample>
 where
     KeySpace: Into<crate::KeySpace>,
-    Handler: IntoHandler<'static, Sample> + Send,
+    Handler: IntoHandler<Sample> + Send,
     Handler::Handler: Send,
     TryIntoSample: ExtractSample + Send + Sync,
 {
@@ -577,7 +577,7 @@ impl<
     > IntoFuture for FetchingSubscriberBuilder<'a, '_, KeySpace, Handler, Fetch, TryIntoSample>
 where
     KeySpace: Into<crate::KeySpace>,
-    Handler: IntoHandler<'static, Sample> + Send,
+    Handler: IntoHandler<Sample> + Send,
     Handler::Handler: Send,
     TryIntoSample: ExtractSample + Send + Sync,
 {
@@ -651,7 +651,7 @@ impl<'a, Handler> FetchingSubscriber<'a, Handler> {
     ) -> ZResult<Self>
     where
         KeySpace: Into<crate::KeySpace>,
-        InputHandler: IntoHandler<'static, Sample, Handler = Handler> + Send,
+        InputHandler: IntoHandler<Sample, Handler = Handler> + Send,
         TryIntoSample: ExtractSample + Send + Sync,
     {
         let session_id = conf.session.zid();

--- a/zenoh-ext/src/subscriber_ext.rs
+++ b/zenoh-ext/src/subscriber_ext.rs
@@ -80,7 +80,7 @@ pub trait SubscriberBuilderExt<'a, 'b, Handler> {
     /// # }
     /// ```
     fn fetching<
-        Fetch: FnOnce(Box<dyn Fn(TryIntoSample) + Send + Sync>) -> ZResult<()>,
+        Fetch: FnOnce(Box<dyn Fn(&TryIntoSample) + Send + Sync>) -> ZResult<()>,
         TryIntoSample,
     >(
         self,
@@ -158,7 +158,7 @@ impl<'a, 'b, Handler> SubscriberBuilderExt<'a, 'b, Handler> for SubscriberBuilde
     /// # }
     /// ```
     fn fetching<
-        Fetch: FnOnce(Box<dyn Fn(TryIntoSample) + Send + Sync>) -> ZResult<()>,
+        Fetch: FnOnce(Box<dyn Fn(&TryIntoSample) + Send + Sync>) -> ZResult<()>,
         TryIntoSample,
     >(
         self,
@@ -270,7 +270,7 @@ impl<'a, 'b, Handler> SubscriberBuilderExt<'a, 'b, Handler>
     /// # }
     /// ```
     fn fetching<
-        Fetch: FnOnce(Box<dyn Fn(TryIntoSample) + Send + Sync>) -> ZResult<()>,
+        Fetch: FnOnce(Box<dyn Fn(&TryIntoSample) + Send + Sync>) -> ZResult<()>,
         TryIntoSample,
     >(
         self,

--- a/zenoh/src/api/admin.rs
+++ b/zenoh/src/api/admin.rs
@@ -35,6 +35,7 @@ use super::{
     session::Session,
     subscriber::SubscriberKind,
 };
+use crate::handlers::Callback;
 
 lazy_static::lazy_static!(
     static ref KE_STARSTAR: &'static keyexpr = unsafe { keyexpr::from_str_unchecked("**") };
@@ -54,15 +55,15 @@ pub(crate) fn init(session: &Session) {
             &admin_key,
             true,
             Locality::SessionLocal,
-            Arc::new({
+            Callback::new(Arc::new({
                 let session = session.clone();
                 move |q| super::admin::on_admin_query(&session, q)
-            }),
+            })),
         );
     }
 }
 
-pub(crate) fn on_admin_query(session: &Session, query: Query) {
+pub(crate) fn on_admin_query(session: &Session, query: &Query) {
     fn reply_peer(own_zid: &keyexpr, query: &Query, peer: TransportPeer) {
         let zid = peer.zid.to_string();
         if let Ok(zid) = keyexpr::new(&zid) {

--- a/zenoh/src/api/admin.rs
+++ b/zenoh/src/api/admin.rs
@@ -110,14 +110,14 @@ pub(crate) fn on_admin_query(session: &Session, query: &Query) {
             .block_in_place(session.runtime.manager().get_transports_unicast())
         {
             if let Ok(peer) = transport.get_peer() {
-                reply_peer(own_zid, &query, peer);
+                reply_peer(own_zid, query, peer);
             }
         }
         for transport in zenoh_runtime::ZRuntime::Net
             .block_in_place(session.runtime.manager().get_transports_multicast())
         {
             for peer in transport.get_peers().unwrap_or_default() {
-                reply_peer(own_zid, &query, peer);
+                reply_peer(own_zid, query, peer);
             }
         }
     }

--- a/zenoh/src/api/handlers/callback.rs
+++ b/zenoh/src/api/handlers/callback.rs
@@ -31,6 +31,7 @@ enum CallbackInner<T> {
     Ring(RingChannelSender<T>),
 }
 
+/// Callback type used by zenoh entities.
 pub struct Callback<T>(CallbackInner<T>);
 
 impl<T> Clone for Callback<T> {
@@ -44,6 +45,7 @@ impl<T> Clone for Callback<T> {
 }
 
 impl<T> Callback<T> {
+    /// Instantiate a `Callback` from a callback function.
     pub fn new(cb: Arc<dyn Fn(&T) + Send + Sync>) -> Self {
         Self(CallbackInner::Dyn(cb))
     }
@@ -56,6 +58,7 @@ impl<T> Callback<T> {
         Self(CallbackInner::Ring(sender))
     }
 
+    /// Call the inner callback.
     #[inline]
     pub fn call(&self, arg: &T)
     where
@@ -72,6 +75,9 @@ impl<T> Callback<T> {
         }
     }
 
+    /// Call the inner callback, passing the argument by value instead of by reference.
+    ///
+    /// The underlying implementation may benefit of moving the argument instead of cloning it.
     #[inline]
     pub fn call_by_value(&self, arg: T) {
         match &self.0 {

--- a/zenoh/src/api/handlers/callback.rs
+++ b/zenoh/src/api/handlers/callback.rs
@@ -20,7 +20,7 @@ use super::{IntoHandler, RingChannelSender};
 
 /// A function that can transform a [`FnMut`]`(T)` to
 /// a [`Fn`]`(T)` with the help of a [`Mutex`](std::sync::Mutex).
-pub fn locked<T>(fnmut: impl FnMut(T)) -> impl Fn(T) {
+pub fn locked<T>(fnmut: impl FnMut(&T)) -> impl Fn(&T) {
     let lock = std::sync::Mutex::new(fnmut);
     move |x| zlock!(lock)(x)
 }
@@ -73,7 +73,7 @@ impl<T> Callback<T> {
     }
 
     #[inline]
-    pub(crate) fn call_by_value(&self, arg: T) {
+    pub fn call_by_value(&self, arg: T) {
         match &self.0 {
             CallbackInner::Dyn(cb) => cb(&arg),
             CallbackInner::Flume(tx) => {

--- a/zenoh/src/api/handlers/fifo.rs
+++ b/zenoh/src/api/handlers/fifo.rs
@@ -13,7 +13,10 @@
 //
 
 //! Callback handler trait.
-use super::{callback::Callback, Dyn, IntoHandler, API_DATA_RECEPTION_CHANNEL_SIZE};
+
+use std::sync::Arc;
+
+use super::{callback::Callback, IntoHandler, API_DATA_RECEPTION_CHANNEL_SIZE};
 
 /// The default handler in Zenoh is a FIFO queue.
 
@@ -34,27 +37,27 @@ impl Default for FifoChannel {
     }
 }
 
-impl<T: Send + 'static> IntoHandler<'static, T> for FifoChannel {
+impl<T: Send> IntoHandler<T> for FifoChannel {
     type Handler = flume::Receiver<T>;
 
-    fn into_handler(self) -> (Callback<'static, T>, Self::Handler) {
+    fn into_handler(self) -> (Callback<T>, Self::Handler) {
         flume::bounded(self.capacity).into_handler()
     }
 }
 
-impl<T: Send + Sync + 'static> IntoHandler<'static, T>
+impl<T: Clone + Send + Sync + 'static> IntoHandler<T>
     for (std::sync::mpsc::SyncSender<T>, std::sync::mpsc::Receiver<T>)
 {
     type Handler = std::sync::mpsc::Receiver<T>;
 
-    fn into_handler(self) -> (Callback<'static, T>, Self::Handler) {
+    fn into_handler(self) -> (Callback<T>, Self::Handler) {
         let (sender, receiver) = self;
         (
-            Dyn::new(move |t| {
-                if let Err(e) = sender.send(t) {
-                    tracing::error!("{}", e)
+            Callback::new(Arc::new(move |t| {
+                if let Err(error) = sender.send(t.clone()) {
+                    tracing::error!(%error)
                 }
-            }),
+            })),
             receiver,
         )
     }

--- a/zenoh/src/api/handlers/mod.rs
+++ b/zenoh/src/api/handlers/mod.rs
@@ -23,19 +23,16 @@ pub use ring::*;
 
 use crate::api::session::API_DATA_RECEPTION_CHANNEL_SIZE;
 
-/// An alias for `Arc<T>`.
-pub type Dyn<T> = std::sync::Arc<T>;
-
 /// A type that can be converted into a [`Callback`]-Handler pair.
 ///
 /// When Zenoh functions accept types that implement these, it intends to use the [`Callback`] as just that,
 /// while granting you access to the handler through the returned value via [`std::ops::Deref`] and [`std::ops::DerefMut`].
 ///
 /// Any closure that accepts `T` can be converted into a pair of itself and `()`.
-pub trait IntoHandler<'a, T> {
+pub trait IntoHandler<T> {
     type Handler;
 
-    fn into_handler(self) -> (Callback<'a, T>, Self::Handler);
+    fn into_handler(self) -> (Callback<T>, Self::Handler);
 }
 
 /// The default handler in Zenoh is a FIFO queue.
@@ -43,10 +40,10 @@ pub trait IntoHandler<'a, T> {
 #[derive(Default)]
 pub struct DefaultHandler(FifoChannel);
 
-impl<T: Send + 'static> IntoHandler<'static, T> for DefaultHandler {
-    type Handler = <FifoChannel as IntoHandler<'static, T>>::Handler;
+impl<T: Send> IntoHandler<T> for DefaultHandler {
+    type Handler = <FifoChannel as IntoHandler<T>>::Handler;
 
-    fn into_handler(self) -> (Callback<'static, T>, Self::Handler) {
+    fn into_handler(self) -> (Callback<T>, Self::Handler) {
         self.0.into_handler()
     }
 }

--- a/zenoh/src/api/liveliness.rs
+++ b/zenoh/src/api/liveliness.rs
@@ -542,7 +542,7 @@ impl<'a, 'b> LivelinessSubscriberBuilder<'a, 'b, DefaultHandler> {
     #[zenoh_macros::unstable]
     pub fn with<Handler>(self, handler: Handler) -> LivelinessSubscriberBuilder<'a, 'b, Handler>
     where
-        Handler: crate::handlers::IntoHandler<'static, Sample>,
+        Handler: crate::handlers::IntoHandler<Sample>,
     {
         let LivelinessSubscriberBuilder {
             session,
@@ -582,7 +582,7 @@ impl<Handler> LivelinessSubscriberBuilder<'_, '_, Handler> {
 #[zenoh_macros::unstable]
 impl<'a, Handler> Resolvable for LivelinessSubscriberBuilder<'a, '_, Handler>
 where
-    Handler: IntoHandler<'static, Sample> + Send,
+    Handler: IntoHandler<Sample> + Send,
     Handler::Handler: Send,
 {
     type To = ZResult<Subscriber<'a, Handler::Handler>>;
@@ -591,7 +591,7 @@ where
 #[zenoh_macros::unstable]
 impl<'a, Handler> Wait for LivelinessSubscriberBuilder<'a, '_, Handler>
 where
-    Handler: IntoHandler<'static, Sample> + Send,
+    Handler: IntoHandler<Sample> + Send,
     Handler::Handler: Send,
 {
     #[zenoh_macros::unstable]
@@ -623,7 +623,7 @@ where
 #[zenoh_macros::unstable]
 impl<'a, Handler> IntoFuture for LivelinessSubscriberBuilder<'a, '_, Handler>
 where
-    Handler: IntoHandler<'static, Sample> + Send,
+    Handler: IntoHandler<Sample> + Send,
     Handler::Handler: Send,
 {
     type Output = <Self as Resolvable>::To;
@@ -759,7 +759,7 @@ impl<'a, 'b> LivelinessGetBuilder<'a, 'b, DefaultHandler> {
     #[inline]
     pub fn with<Handler>(self, handler: Handler) -> LivelinessGetBuilder<'a, 'b, Handler>
     where
-        Handler: IntoHandler<'static, Reply>,
+        Handler: IntoHandler<Reply>,
     {
         let LivelinessGetBuilder {
             session,
@@ -787,7 +787,7 @@ impl<'a, 'b, Handler> LivelinessGetBuilder<'a, 'b, Handler> {
 
 impl<Handler> Resolvable for LivelinessGetBuilder<'_, '_, Handler>
 where
-    Handler: IntoHandler<'static, Reply> + Send,
+    Handler: IntoHandler<Reply> + Send,
     Handler::Handler: Send,
 {
     type To = ZResult<Handler::Handler>;
@@ -795,7 +795,7 @@ where
 
 impl<Handler> Wait for LivelinessGetBuilder<'_, '_, Handler>
 where
-    Handler: IntoHandler<'static, Reply> + Send,
+    Handler: IntoHandler<Reply> + Send,
     Handler::Handler: Send,
 {
     fn wait(self) -> <Self as Resolvable>::To {
@@ -808,7 +808,7 @@ where
 
 impl<Handler> IntoFuture for LivelinessGetBuilder<'_, '_, Handler>
 where
-    Handler: IntoHandler<'static, Reply> + Send,
+    Handler: IntoHandler<Reply> + Send,
     Handler::Handler: Send,
 {
     type Output = <Self as Resolvable>::To;

--- a/zenoh/src/api/liveliness.rs
+++ b/zenoh/src/api/liveliness.rs
@@ -31,6 +31,7 @@ use super::{
     subscriber::{Subscriber, SubscriberInner},
     Id,
 };
+use crate::handlers::Callback;
 
 /// A structure with functions to declare a
 /// [`LivelinessToken`](LivelinessToken), query
@@ -464,12 +465,9 @@ impl<'a, 'b> LivelinessSubscriberBuilder<'a, 'b, DefaultHandler> {
     /// ```
     #[inline]
     #[zenoh_macros::unstable]
-    pub fn callback<Callback>(
-        self,
-        callback: Callback,
-    ) -> LivelinessSubscriberBuilder<'a, 'b, Callback>
+    pub fn callback<F>(self, callback: F) -> LivelinessSubscriberBuilder<'a, 'b, Callback<Sample>>
     where
-        Callback: Fn(Sample) + Send + Sync + 'static,
+        F: Fn(&Sample) + Send + Sync + 'static,
     {
         let LivelinessSubscriberBuilder {
             session,
@@ -480,7 +478,7 @@ impl<'a, 'b> LivelinessSubscriberBuilder<'a, 'b, DefaultHandler> {
         LivelinessSubscriberBuilder {
             session,
             key_expr,
-            handler: callback,
+            handler: Callback::new(Arc::new(callback)),
             history,
         }
     }
@@ -508,12 +506,12 @@ impl<'a, 'b> LivelinessSubscriberBuilder<'a, 'b, DefaultHandler> {
     /// ```
     #[inline]
     #[zenoh_macros::unstable]
-    pub fn callback_mut<CallbackMut>(
+    pub fn callback_mut<F>(
         self,
-        callback: CallbackMut,
-    ) -> LivelinessSubscriberBuilder<'a, 'b, impl Fn(Sample) + Send + Sync + 'static>
+        callback: F,
+    ) -> LivelinessSubscriberBuilder<'a, 'b, Callback<Sample>>
     where
-        CallbackMut: FnMut(Sample) + Send + Sync + 'static,
+        F: FnMut(&Sample) + Send + Sync + 'static,
     {
         self.callback(locked(callback))
     }
@@ -686,9 +684,9 @@ impl<'a, 'b> LivelinessGetBuilder<'a, 'b, DefaultHandler> {
     /// # }
     /// ```
     #[inline]
-    pub fn callback<Callback>(self, callback: Callback) -> LivelinessGetBuilder<'a, 'b, Callback>
+    pub fn callback<F>(self, callback: F) -> LivelinessGetBuilder<'a, 'b, Callback<Reply>>
     where
-        Callback: Fn(Reply) + Send + Sync + 'static,
+        F: Fn(&Reply) + Send + Sync + 'static,
     {
         let LivelinessGetBuilder {
             session,
@@ -700,7 +698,7 @@ impl<'a, 'b> LivelinessGetBuilder<'a, 'b, DefaultHandler> {
             session,
             key_expr,
             timeout,
-            handler: callback,
+            handler: Callback::new(Arc::new(callback)),
         }
     }
 
@@ -726,12 +724,9 @@ impl<'a, 'b> LivelinessGetBuilder<'a, 'b, DefaultHandler> {
     /// # }
     /// ```
     #[inline]
-    pub fn callback_mut<CallbackMut>(
-        self,
-        callback: CallbackMut,
-    ) -> LivelinessGetBuilder<'a, 'b, impl Fn(Reply) + Send + Sync + 'static>
+    pub fn callback_mut<F>(self, callback: F) -> LivelinessGetBuilder<'a, 'b, Callback<Reply>>
     where
-        CallbackMut: FnMut(Reply) + Send + Sync + 'static,
+        F: FnMut(&Reply) + Send + Sync + 'static,
     {
         self.callback(locked(callback))
     }

--- a/zenoh/src/api/publisher.rs
+++ b/zenoh/src/api/publisher.rs
@@ -824,9 +824,9 @@ impl<'a> MatchingListenerBuilder<'a, DefaultHandler> {
     /// ```
     #[inline]
     #[zenoh_macros::unstable]
-    pub fn callback<Callback>(self, callback: Callback) -> MatchingListenerBuilder<'a, Callback>
+    pub fn callback<F>(self, callback: F) -> MatchingListenerBuilder<'a, Callback<MatchingStatus>>
     where
-        Callback: Fn(MatchingStatus) + Send + Sync + 'static,
+        F: Fn(&MatchingStatus) + Send + Sync + 'static,
     {
         let MatchingListenerBuilder {
             publisher,
@@ -834,7 +834,7 @@ impl<'a> MatchingListenerBuilder<'a, DefaultHandler> {
         } = self;
         MatchingListenerBuilder {
             publisher,
-            handler: callback,
+            handler: Callback::new(Arc::new(callback)),
         }
     }
 
@@ -858,12 +858,12 @@ impl<'a> MatchingListenerBuilder<'a, DefaultHandler> {
     /// ```
     #[inline]
     #[zenoh_macros::unstable]
-    pub fn callback_mut<CallbackMut>(
+    pub fn callback_mut<F>(
         self,
-        callback: CallbackMut,
-    ) -> MatchingListenerBuilder<'a, impl Fn(MatchingStatus) + Send + Sync + 'static>
+        callback: F,
+    ) -> MatchingListenerBuilder<'a, Callback<MatchingStatus>>
     where
-        CallbackMut: FnMut(MatchingStatus) + Send + Sync + 'static,
+        F: FnMut(&MatchingStatus) + Send + Sync + 'static,
     {
         self.callback(crate::api::handlers::locked(callback))
     }

--- a/zenoh/src/api/publisher.rs
+++ b/zenoh/src/api/publisher.rs
@@ -896,7 +896,7 @@ impl<'a> MatchingListenerBuilder<'a, DefaultHandler> {
     #[zenoh_macros::unstable]
     pub fn with<Handler>(self, handler: Handler) -> MatchingListenerBuilder<'a, Handler>
     where
-        Handler: IntoHandler<'static, MatchingStatus>,
+        Handler: IntoHandler<MatchingStatus>,
     {
         let MatchingListenerBuilder {
             publisher,
@@ -909,7 +909,7 @@ impl<'a> MatchingListenerBuilder<'a, DefaultHandler> {
 #[zenoh_macros::unstable]
 impl<'a, Handler> Resolvable for MatchingListenerBuilder<'a, Handler>
 where
-    Handler: IntoHandler<'static, MatchingStatus> + Send,
+    Handler: IntoHandler<MatchingStatus> + Send,
     Handler::Handler: Send,
 {
     type To = ZResult<MatchingListener<'a, Handler::Handler>>;
@@ -918,7 +918,7 @@ where
 #[zenoh_macros::unstable]
 impl<'a, Handler> Wait for MatchingListenerBuilder<'a, Handler>
 where
-    Handler: IntoHandler<'static, MatchingStatus> + Send,
+    Handler: IntoHandler<MatchingStatus> + Send,
     Handler::Handler: Send,
 {
     #[zenoh_macros::unstable]
@@ -943,7 +943,7 @@ where
 #[zenoh_macros::unstable]
 impl<'a, Handler> IntoFuture for MatchingListenerBuilder<'a, Handler>
 where
-    Handler: IntoHandler<'static, MatchingStatus> + Send,
+    Handler: IntoHandler<MatchingStatus> + Send,
     Handler::Handler: Send,
 {
     type Output = <Self as Resolvable>::To;
@@ -961,7 +961,7 @@ pub(crate) struct MatchingListenerState {
     pub(crate) current: std::sync::Mutex<bool>,
     pub(crate) key_expr: KeyExpr<'static>,
     pub(crate) destination: Locality,
-    pub(crate) callback: Callback<'static, MatchingStatus>,
+    pub(crate) callback: Callback<MatchingStatus>,
 }
 
 #[zenoh_macros::unstable]

--- a/zenoh/src/api/query.rs
+++ b/zenoh/src/api/query.rs
@@ -154,7 +154,7 @@ impl From<Reply> for Result<Sample, ReplyError> {
 
 #[cfg(feature = "unstable")]
 pub(crate) struct LivelinessQueryState {
-    pub(crate) callback: Callback<'static, Reply>,
+    pub(crate) callback: Callback<Reply>,
 }
 
 pub(crate) struct QueryState {
@@ -163,7 +163,7 @@ pub(crate) struct QueryState {
     pub(crate) parameters: Parameters<'static>,
     pub(crate) reception_mode: ConsolidationMode,
     pub(crate) replies: Option<HashMap<OwnedKeyExpr, Reply>>,
-    pub(crate) callback: Callback<'static, Reply>,
+    pub(crate) callback: Callback<Reply>,
 }
 
 impl QueryState {
@@ -362,7 +362,7 @@ impl<'a, 'b> SessionGetBuilder<'a, 'b, DefaultHandler> {
     #[inline]
     pub fn with<Handler>(self, handler: Handler) -> SessionGetBuilder<'a, 'b, Handler>
     where
-        Handler: IntoHandler<'static, Reply>,
+        Handler: IntoHandler<Reply>,
     {
         let SessionGetBuilder {
             session,
@@ -473,7 +473,7 @@ pub enum ReplyKeyExpr {
 
 impl<Handler> Resolvable for SessionGetBuilder<'_, '_, Handler>
 where
-    Handler: IntoHandler<'static, Reply> + Send,
+    Handler: IntoHandler<Reply> + Send,
     Handler::Handler: Send,
 {
     type To = ZResult<Handler::Handler>;
@@ -481,7 +481,7 @@ where
 
 impl<Handler> Wait for SessionGetBuilder<'_, '_, Handler>
 where
-    Handler: IntoHandler<'static, Reply> + Send,
+    Handler: IntoHandler<Reply> + Send,
     Handler::Handler: Send,
 {
     fn wait(self) -> <Self as Resolvable>::To {
@@ -511,7 +511,7 @@ where
 
 impl<Handler> IntoFuture for SessionGetBuilder<'_, '_, Handler>
 where
-    Handler: IntoHandler<'static, Reply> + Send,
+    Handler: IntoHandler<Reply> + Send,
     Handler::Handler: Send,
 {
     type Output = <Self as Resolvable>::To;

--- a/zenoh/src/api/queryable.rs
+++ b/zenoh/src/api/queryable.rs
@@ -51,7 +51,7 @@ use super::{
     value::Value,
     Id,
 };
-use crate::net::primitives::Primitives;
+use crate::{handlers::Callback, net::primitives::Primitives};
 
 pub(crate) struct QueryInner {
     pub(crate) key_expr: KeyExpr<'static>,
@@ -525,7 +525,7 @@ pub(crate) struct QueryableState {
     pub(crate) key_expr: WireExpr<'static>,
     pub(crate) complete: bool,
     pub(crate) origin: Locality,
-    pub(crate) callback: Arc<dyn Fn(Query) + Send + Sync>,
+    pub(crate) callback: Callback<Query>,
 }
 
 impl fmt::Debug for QueryableState {
@@ -739,7 +739,7 @@ impl<'a, 'b> QueryableBuilder<'a, 'b, DefaultHandler> {
     #[inline]
     pub fn with<Handler>(self, handler: Handler) -> QueryableBuilder<'a, 'b, Handler>
     where
-        Handler: IntoHandler<'static, Query>,
+        Handler: IntoHandler<Query>,
     {
         let QueryableBuilder {
             session,
@@ -888,7 +888,7 @@ impl<Handler> DerefMut for Queryable<'_, Handler> {
 
 impl<'a, Handler> Resolvable for QueryableBuilder<'a, '_, Handler>
 where
-    Handler: IntoHandler<'static, Query> + Send,
+    Handler: IntoHandler<Query> + Send,
     Handler::Handler: Send,
 {
     type To = ZResult<Queryable<'a, Handler::Handler>>;
@@ -896,7 +896,7 @@ where
 
 impl<'a, Handler> Wait for QueryableBuilder<'a, '_, Handler>
 where
-    Handler: IntoHandler<'static, Query> + Send,
+    Handler: IntoHandler<Query> + Send,
     Handler::Handler: Send,
 {
     fn wait(self) -> <Self as Resolvable>::To {
@@ -922,7 +922,7 @@ where
 
 impl<'a, Handler> IntoFuture for QueryableBuilder<'a, '_, Handler>
 where
-    Handler: IntoHandler<'static, Query> + Send,
+    Handler: IntoHandler<Query> + Send,
     Handler::Handler: Send,
 {
     type Output = <Self as Resolvable>::To;

--- a/zenoh/src/api/queryable.rs
+++ b/zenoh/src/api/queryable.rs
@@ -666,9 +666,9 @@ impl<'a, 'b> QueryableBuilder<'a, 'b, DefaultHandler> {
     /// # }
     /// ```
     #[inline]
-    pub fn callback<Callback>(self, callback: Callback) -> QueryableBuilder<'a, 'b, Callback>
+    pub fn callback<F>(self, callback: F) -> QueryableBuilder<'a, 'b, Callback<Query>>
     where
-        Callback: Fn(Query) + Send + Sync + 'static,
+        F: Fn(&Query) + Send + Sync + 'static,
     {
         let QueryableBuilder {
             session,
@@ -682,7 +682,7 @@ impl<'a, 'b> QueryableBuilder<'a, 'b, DefaultHandler> {
             key_expr,
             complete,
             origin,
-            handler: callback,
+            handler: Callback::new(Arc::new(callback)),
         }
     }
 
@@ -707,12 +707,9 @@ impl<'a, 'b> QueryableBuilder<'a, 'b, DefaultHandler> {
     /// # }
     /// ```
     #[inline]
-    pub fn callback_mut<CallbackMut>(
-        self,
-        callback: CallbackMut,
-    ) -> QueryableBuilder<'a, 'b, impl Fn(Query) + Send + Sync + 'static>
+    pub fn callback_mut<F>(self, callback: F) -> QueryableBuilder<'a, 'b, Callback<Query>>
     where
-        CallbackMut: FnMut(Query) + Send + Sync + 'static,
+        F: FnMut(&Query) + Send + Sync + 'static,
     {
         self.callback(locked(callback))
     }

--- a/zenoh/src/api/scouting.rs
+++ b/zenoh/src/api/scouting.rs
@@ -136,7 +136,7 @@ impl ScoutBuilder<DefaultHandler> {
     #[inline]
     pub fn with<Handler>(self, handler: Handler) -> ScoutBuilder<Handler>
     where
-        Handler: IntoHandler<'static, Hello>,
+        Handler: IntoHandler<Hello>,
     {
         let ScoutBuilder {
             what,
@@ -153,7 +153,7 @@ impl ScoutBuilder<DefaultHandler> {
 
 impl<Handler> Resolvable for ScoutBuilder<Handler>
 where
-    Handler: IntoHandler<'static, Hello> + Send,
+    Handler: IntoHandler<Hello> + Send,
     Handler::Handler: Send,
 {
     type To = ZResult<Scout<Handler::Handler>>;
@@ -161,7 +161,7 @@ where
 
 impl<Handler> Wait for ScoutBuilder<Handler>
 where
-    Handler: IntoHandler<'static, Hello> + Send,
+    Handler: IntoHandler<Hello> + Send,
     Handler::Handler: Send,
 {
     fn wait(self) -> <Self as Resolvable>::To {
@@ -172,7 +172,7 @@ where
 
 impl<Handler> IntoFuture for ScoutBuilder<Handler>
 where
-    Handler: IntoHandler<'static, Hello> + Send,
+    Handler: IntoHandler<Hello> + Send,
     Handler::Handler: Send,
 {
     type Output = <Self as Resolvable>::To;
@@ -295,7 +295,7 @@ impl<Receiver> Scout<Receiver> {
 fn _scout(
     what: WhatAmIMatcher,
     config: zenoh_config::Config,
-    callback: Callback<'static, Hello>,
+    callback: Callback<Hello>,
 ) -> ZResult<ScoutInner> {
     tracing::trace!("scout({}, {})", what, &config);
     let default_addr = SocketAddr::from(zenoh_config::defaults::scouting::multicast::address);
@@ -325,7 +325,7 @@ fn _scout(
                     let scout = Runtime::scout(&sockets, what, &addr, move |hello| {
                         let callback = callback.clone();
                         async move {
-                            callback(hello.into());
+                            callback.call_by_value(hello.into());
                             Loop::Continue
                         }
                     });

--- a/zenoh/src/api/subscriber.rs
+++ b/zenoh/src/api/subscriber.rs
@@ -40,7 +40,7 @@ pub(crate) struct SubscriberState {
     pub(crate) remote_id: Id,
     pub(crate) key_expr: KeyExpr<'static>,
     pub(crate) origin: Locality,
-    pub(crate) callback: Callback<'static, Sample>,
+    pub(crate) callback: Callback<Sample>,
 }
 
 impl fmt::Debug for SubscriberState {
@@ -307,7 +307,7 @@ impl<'a, 'b> SubscriberBuilder<'a, 'b, DefaultHandler> {
     #[inline]
     pub fn with<Handler>(self, handler: Handler) -> SubscriberBuilder<'a, 'b, Handler>
     where
-        Handler: IntoHandler<'static, Sample>,
+        Handler: IntoHandler<Sample>,
     {
         let SubscriberBuilder {
             session,
@@ -366,7 +366,7 @@ impl<'a, 'b, Handler> SubscriberBuilder<'a, 'b, Handler> {
 // Push mode
 impl<'a, Handler> Resolvable for SubscriberBuilder<'a, '_, Handler>
 where
-    Handler: IntoHandler<'static, Sample> + Send,
+    Handler: IntoHandler<Sample> + Send,
     Handler::Handler: Send,
 {
     type To = ZResult<Subscriber<'a, Handler::Handler>>;
@@ -374,7 +374,7 @@ where
 
 impl<'a, Handler> Wait for SubscriberBuilder<'a, '_, Handler>
 where
-    Handler: IntoHandler<'static, Sample> + Send,
+    Handler: IntoHandler<Sample> + Send,
     Handler::Handler: Send,
 {
     fn wait(self) -> <Self as Resolvable>::To {
@@ -407,7 +407,7 @@ where
 
 impl<'a, Handler> IntoFuture for SubscriberBuilder<'a, '_, Handler>
 where
-    Handler: IntoHandler<'static, Sample> + Send,
+    Handler: IntoHandler<Sample> + Send,
     Handler::Handler: Send,
 {
     type Output = <Self as Resolvable>::To;

--- a/zenoh/src/api/subscriber.rs
+++ b/zenoh/src/api/subscriber.rs
@@ -96,7 +96,7 @@ impl<'a> SubscriberInner<'a> {
     /// use zenoh::{prelude::*, sample::Sample};
     ///
     /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
-    /// # fn data_handler(_sample: Sample) { };
+    /// # fn data_handler(_sample: &Sample) { };
     /// let subscriber = session
     ///     .declare_subscriber("key/expression")
     ///     .callback(data_handler)

--- a/zenoh/src/api/subscriber.rs
+++ b/zenoh/src/api/subscriber.rs
@@ -232,9 +232,9 @@ impl<'a, 'b> SubscriberBuilder<'a, 'b, DefaultHandler> {
     /// # }
     /// ```
     #[inline]
-    pub fn callback<Callback>(self, callback: Callback) -> SubscriberBuilder<'a, 'b, Callback>
+    pub fn callback<F>(self, callback: F) -> SubscriberBuilder<'a, 'b, Callback<Sample>>
     where
-        Callback: Fn(Sample) + Send + Sync + 'static,
+        F: Fn(&Sample) + Send + Sync + 'static,
     {
         let SubscriberBuilder {
             session,
@@ -250,7 +250,7 @@ impl<'a, 'b> SubscriberBuilder<'a, 'b, DefaultHandler> {
             #[cfg(feature = "unstable")]
             reliability,
             origin,
-            handler: callback,
+            handler: Callback::new(Arc::new(callback)),
         }
     }
 
@@ -275,12 +275,9 @@ impl<'a, 'b> SubscriberBuilder<'a, 'b, DefaultHandler> {
     /// # }
     /// ```
     #[inline]
-    pub fn callback_mut<CallbackMut>(
-        self,
-        callback: CallbackMut,
-    ) -> SubscriberBuilder<'a, 'b, impl Fn(Sample) + Send + Sync + 'static>
+    pub fn callback_mut<F>(self, callback: F) -> SubscriberBuilder<'a, 'b, Callback<Sample>>
     where
-        CallbackMut: FnMut(Sample) + Send + Sync + 'static,
+        F: FnMut(&Sample) + Send + Sync + 'static,
     {
         self.callback(locked(callback))
     }


### PR DESCRIPTION
Use an enum hidden to use channel senders directly. It should improve performances, and may allow later to use async sender methods.