### PR TITLE
reexporting methods from QoSBuilderTrait added

### DIFF
--- a/zenoh/src/api/query.rs
+++ b/zenoh/src/api/query.rs
@@ -228,6 +228,7 @@ impl<Handler> SampleBuilderTrait for SessionGetBuilder<'_, '_, Handler> {
     }
 }
 
+#[zenoh_macros::internal_trait]
 impl QoSBuilderTrait for SessionGetBuilder<'_, '_, DefaultHandler> {
     fn congestion_control(self, congestion_control: CongestionControl) -> Self {
         let qos = self.qos.congestion_control(congestion_control);

--- a/zenoh/src/api/queryable.rs
+++ b/zenoh/src/api/queryable.rs
@@ -329,6 +329,7 @@ impl<T> SampleBuilderTrait for ReplyBuilder<'_, '_, T> {
     }
 }
 
+#[zenoh_macros::internal_trait]
 impl<T> QoSBuilderTrait for ReplyBuilder<'_, '_, T> {
     fn congestion_control(self, congestion_control: CongestionControl) -> Self {
         let qos = self.qos.congestion_control(congestion_control);

--- a/zenoh/src/api/sample.rs
+++ b/zenoh/src/api/sample.rs
@@ -421,6 +421,7 @@ impl From<QoSBuilder> for QoS {
     }
 }
 
+#[zenoh_macros::internal_trait]
 impl QoSBuilderTrait for QoSBuilder {
     fn congestion_control(self, congestion_control: CongestionControl) -> Self {
         let mut inner = self.0.inner;


### PR DESCRIPTION
followup to https://github.com/eclipse-zenoh/zenoh/pull/1376