### PR TITLE
Support `--cfg` flag in examples

### DIFF
--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -2,7 +2,8 @@
 //! See the code in ../examples/
 //! Check ../README.md for usage.
 //!
-use zenoh::config::Config;
+
+use zenoh::config::{Config, ValidatedMap};
 
 #[derive(clap::ValueEnum, Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum Wai {
@@ -20,6 +21,14 @@ pub struct CommonArgs {
     #[arg(short, long)]
     /// A configuration file.
     config: Option<String>,
+    #[arg(long)]
+    /// Allows arbitrary configuration changes as column-separated KEY:VALUE pairs, where:
+    ///   - KEY must be a valid config path.
+    ///   - VALUE must be a valid JSON5 string that can be deserialized to the expected type for the KEY field.
+    ///
+    /// Example: `--cfg='transport/unicast/max_links:2'`
+    #[arg(long)]
+    cfg: Vec<String>,
     #[arg(short, long)]
     /// The Zenoh session mode [default: peer].
     mode: Option<Wai>,
@@ -42,42 +51,54 @@ impl From<CommonArgs> for Config {
         (&value).into()
     }
 }
+
 impl From<&CommonArgs> for Config {
-    fn from(value: &CommonArgs) -> Self {
-        let mut config = match &value.config {
+    fn from(args: &CommonArgs) -> Self {
+        let mut config = match &args.config {
             Some(path) => Config::from_file(path).unwrap(),
             None => Config::default(),
         };
-        match value.mode {
+        match args.mode {
             Some(Wai::Peer) => config.set_mode(Some(zenoh::config::WhatAmI::Peer)),
             Some(Wai::Client) => config.set_mode(Some(zenoh::config::WhatAmI::Client)),
             Some(Wai::Router) => config.set_mode(Some(zenoh::config::WhatAmI::Router)),
             None => Ok(None),
         }
         .unwrap();
-        if !value.connect.is_empty() {
+        if !args.connect.is_empty() {
             config
                 .connect
                 .endpoints
-                .set(value.connect.iter().map(|v| v.parse().unwrap()).collect())
+                .set(args.connect.iter().map(|v| v.parse().unwrap()).collect())
                 .unwrap();
         }
-        if !value.listen.is_empty() {
+        if !args.listen.is_empty() {
             config
                 .listen
                 .endpoints
-                .set(value.listen.iter().map(|v| v.parse().unwrap()).collect())
+                .set(args.listen.iter().map(|v| v.parse().unwrap()).collect())
                 .unwrap();
         }
-        if value.no_multicast_scouting {
+        if args.no_multicast_scouting {
             config.scouting.multicast.set_enabled(Some(false)).unwrap();
         }
-        if value.enable_shm {
+        if args.enable_shm {
             #[cfg(feature = "shared-memory")]
             config.transport.shared_memory.set_enabled(true).unwrap();
             #[cfg(not(feature = "shared-memory"))]
             {
-                println!("enable-shm argument: SHM cannot be enabled, because Zenoh is compiled without shared-memory feature!");
+                eprintln!("`--enable-shm` argument: SHM cannot be enabled, because Zenoh is compiled without shared-memory feature!");
+                std::process::exit(-1);
+            }
+        }
+        for json in &args.cfg {
+            if let Some((key, value)) = json.split_once(':') {
+                if let Err(err) = config.insert_json5(key, value) {
+                    eprintln!("`--cfg` argument: could not parse `{json}`: {err}");
+                    std::process::exit(-1);
+                }
+            } else {
+                eprintln!("`--cfg` argument: expected KEY:VALUE pair, got {json}");
                 std::process::exit(-1);
             }
         }


### PR DESCRIPTION
Add `--cfg` flag to examples, similarly to `zenohd`.