### PR TITLE
`Hello` should be clonable to make it compatible with zenoh-c API

### DIFF
--- a/commons/zenoh-config/src/wrappers.rs
+++ b/commons/zenoh-config/src/wrappers.rs
@@ -100,6 +100,7 @@ impl FromStr for ZenohId {
 }
 
 /// A zenoh Hello message.
+#[derive(Clone)]
 #[repr(transparent)]
 pub struct Hello(HelloProto);
 


### PR DESCRIPTION
The `Hello` structure is a parameter of callback and at this moment in zenoh-c API user should be able to take ownership of callback parameter passed to him by cloning.