### PR TITLE
refactor: use builder method for undeclaration on drop

### DIFF
--- a/zenoh-ext/src/querying_subscriber.rs
+++ b/zenoh-ext/src/querying_subscriber.rs
@@ -128,7 +128,7 @@ impl<'a, 'b, KeySpace> QueryingSubscriberBuilder<'a, 'b, KeySpace, DefaultHandle
     }
 }
 
-impl<'a, 'b, Handler> QueryingSubscriberBuilder<'a, 'b, crate::UserSpace, Handler> {
+impl<'b, Handler> QueryingSubscriberBuilder<'_, 'b, crate::UserSpace, Handler> {
     /// Change the subscription reliability.
     #[cfg(feature = "unstable")]
     #[deprecated(
@@ -207,7 +207,7 @@ impl<'a, 'b, Handler> QueryingSubscriberBuilder<'a, 'b, crate::UserSpace, Handle
     }
 }
 
-impl<'a, 'b, KeySpace, Handler> QueryingSubscriberBuilder<'a, 'b, KeySpace, Handler> {
+impl<KeySpace, Handler> QueryingSubscriberBuilder<'_, '_, KeySpace, Handler> {
     /// Change the timeout to be used for queries.
     #[inline]
     pub fn query_timeout(mut self, query_timeout: Duration) -> Self {
@@ -228,7 +228,7 @@ impl<'a, 'b, KeySpace, Handler> QueryingSubscriberBuilder<'a, 'b, KeySpace, Hand
     }
 }
 
-impl<'a, KeySpace, Handler> Resolvable for QueryingSubscriberBuilder<'a, '_, KeySpace, Handler>
+impl<KeySpace, Handler> Resolvable for QueryingSubscriberBuilder<'_, '_, KeySpace, Handler>
 where
     Handler: IntoHandler<'static, Sample>,
     Handler::Handler: Send,
@@ -285,7 +285,7 @@ where
     }
 }
 
-impl<'a, KeySpace, Handler> IntoFuture for QueryingSubscriberBuilder<'a, '_, KeySpace, Handler>
+impl<KeySpace, Handler> IntoFuture for QueryingSubscriberBuilder<'_, '_, KeySpace, Handler>
 where
     KeySpace: Into<crate::KeySpace> + Clone,
     Handler: IntoHandler<'static, Sample> + Send,
@@ -495,12 +495,10 @@ where
 }
 
 impl<
-        'a,
-        'b,
         Handler,
         Fetch: FnOnce(Box<dyn Fn(TryIntoSample) + Send + Sync>) -> ZResult<()>,
         TryIntoSample,
-    > FetchingSubscriberBuilder<'a, 'b, crate::UserSpace, Handler, Fetch, TryIntoSample>
+    > FetchingSubscriberBuilder<'_, '_, crate::UserSpace, Handler, Fetch, TryIntoSample>
 where
     TryIntoSample: ExtractSample,
 {
@@ -548,13 +546,11 @@ where
 }
 
 impl<
-        'a,
-        'b,
         KeySpace,
         Handler,
         Fetch: FnOnce(Box<dyn Fn(TryIntoSample) + Send + Sync>) -> ZResult<()>,
         TryIntoSample,
-    > FetchingSubscriberBuilder<'a, 'b, KeySpace, Handler, Fetch, TryIntoSample>
+    > FetchingSubscriberBuilder<'_, '_, KeySpace, Handler, Fetch, TryIntoSample>
 where
     TryIntoSample: ExtractSample,
 {
@@ -572,12 +568,11 @@ where
 }
 
 impl<
-        'a,
         KeySpace,
         Handler,
         Fetch: FnOnce(Box<dyn Fn(TryIntoSample) + Send + Sync>) -> ZResult<()>,
         TryIntoSample,
-    > Resolvable for FetchingSubscriberBuilder<'a, '_, KeySpace, Handler, Fetch, TryIntoSample>
+    > Resolvable for FetchingSubscriberBuilder<'_, '_, KeySpace, Handler, Fetch, TryIntoSample>
 where
     Handler: IntoHandler<'static, Sample>,
     Handler::Handler: Send,
@@ -604,12 +599,11 @@ where
 }
 
 impl<
-        'a,
         KeySpace,
         Handler,
         Fetch: FnOnce(Box<dyn Fn(TryIntoSample) + Send + Sync>) -> ZResult<()> + Send + Sync,
         TryIntoSample,
-    > IntoFuture for FetchingSubscriberBuilder<'a, '_, KeySpace, Handler, Fetch, TryIntoSample>
+    > IntoFuture for FetchingSubscriberBuilder<'_, '_, KeySpace, Handler, Fetch, TryIntoSample>
 where
     KeySpace: Into<crate::KeySpace>,
     Handler: IntoHandler<'static, Sample> + Send,

--- a/zenoh-ext/src/subscriber_ext.rs
+++ b/zenoh-ext/src/subscriber_ext.rs
@@ -173,6 +173,7 @@ impl<'a, 'b, Handler> SubscriberBuilderExt<'a, 'b, Handler> for SubscriberBuilde
             origin: self.origin,
             fetch,
             handler: self.handler,
+            undeclare_on_drop: true,
             phantom: std::marker::PhantomData,
         }
     }
@@ -219,6 +220,7 @@ impl<'a, 'b, Handler> SubscriberBuilderExt<'a, 'b, Handler> for SubscriberBuilde
             query_consolidation: QueryConsolidation::from(zenoh::query::ConsolidationMode::None),
             query_accept_replies: ReplyKeyExpr::default(),
             query_timeout: Duration::from_secs(10),
+            undeclare_on_drop: true,
             handler: self.handler,
         }
     }
@@ -282,6 +284,7 @@ impl<'a, 'b, Handler> SubscriberBuilderExt<'a, 'b, Handler>
             origin: Locality::default(),
             fetch,
             handler: self.handler,
+            undeclare_on_drop: true,
             phantom: std::marker::PhantomData,
         }
     }
@@ -327,6 +330,7 @@ impl<'a, 'b, Handler> SubscriberBuilderExt<'a, 'b, Handler>
             query_consolidation: QueryConsolidation::DEFAULT,
             query_accept_replies: ReplyKeyExpr::MatchingQuery,
             query_timeout: Duration::from_secs(10),
+            undeclare_on_drop: true,
             handler: self.handler,
         }
     }

--- a/zenoh/src/api/handlers/callback.rs
+++ b/zenoh/src/api/handlers/callback.rs
@@ -31,8 +31,6 @@ where
 {
     type Handler = ();
 
-    const BACKGROUND: bool = true;
-
     fn into_handler(self) -> (Callback<'a, T>, Self::Handler) {
         (Dyn::from(self), ())
     }
@@ -86,8 +84,6 @@ where
     DropFn: FnMut() + Send + Sync + 'static,
 {
     type Handler = ();
-
-    const BACKGROUND: bool = true;
 
     fn into_handler(self) -> (Callback<'a, Event>, Self::Handler) {
         (Dyn::from(move |evt| (self.callback)(evt)), ())

--- a/zenoh/src/api/handlers/callback.rs
+++ b/zenoh/src/api/handlers/callback.rs
@@ -36,6 +36,25 @@ where
     }
 }
 
+impl<'a, T, F, H> IntoHandler<'a, T> for (F, H)
+where
+    F: Fn(T) + Send + Sync + 'a,
+{
+    type Handler = H;
+
+    fn into_handler(self) -> (Callback<'a, T>, Self::Handler) {
+        (Dyn::from(self.0), self.1)
+    }
+}
+
+impl<'a, T, H> IntoHandler<'a, T> for (Callback<'static, T>, H) {
+    type Handler = H;
+
+    fn into_handler(self) -> (Callback<'a, T>, Self::Handler) {
+        self
+    }
+}
+
 impl<T: Send + 'static> IntoHandler<'static, T> for (flume::Sender<T>, flume::Receiver<T>) {
     type Handler = flume::Receiver<T>;
 

--- a/zenoh/src/api/handlers/mod.rs
+++ b/zenoh/src/api/handlers/mod.rs
@@ -35,12 +35,6 @@ pub type Dyn<T> = std::sync::Arc<T>;
 pub trait IntoHandler<'a, T> {
     type Handler;
 
-    /// If it makes sense to still run the callback in background
-    /// when the handler having been dropped.
-    /// This boolean may be used to determine if an entity declared
-    /// with the callback should be undeclared on drop.
-    const BACKGROUND: bool = false;
-
     fn into_handler(self) -> (Callback<'a, T>, Self::Handler);
 }
 

--- a/zenoh/src/api/liveliness.rs
+++ b/zenoh/src/api/liveliness.rs
@@ -575,7 +575,7 @@ where
 }
 
 #[zenoh_macros::unstable]
-impl<'a, Handler> Wait for LivelinessSubscriberBuilder<'a, '_, Handler>
+impl<Handler> Wait for LivelinessSubscriberBuilder<'_, '_, Handler>
 where
     Handler: IntoHandler<'static, Sample> + Send,
     Handler::Handler: Send,
@@ -610,7 +610,7 @@ where
 }
 
 #[zenoh_macros::unstable]
-impl<'a, Handler> IntoFuture for LivelinessSubscriberBuilder<'a, '_, Handler>
+impl<Handler> IntoFuture for LivelinessSubscriberBuilder<'_, '_, Handler>
 where
     Handler: IntoHandler<'static, Sample> + Send,
     Handler::Handler: Send,
@@ -750,7 +750,7 @@ impl<'a, 'b> LivelinessGetBuilder<'a, 'b, DefaultHandler> {
     }
 }
 
-impl<'a, 'b, Handler> LivelinessGetBuilder<'a, 'b, Handler> {
+impl<Handler> LivelinessGetBuilder<'_, '_, Handler> {
     /// Set query timeout.
     #[inline]
     pub fn timeout(mut self, timeout: Duration) -> Self {

--- a/zenoh/src/api/publisher.rs
+++ b/zenoh/src/api/publisher.rs
@@ -756,7 +756,7 @@ impl<Handler> MatchingListenerBuilder<'_, '_, Handler> {
 }
 
 #[zenoh_macros::unstable]
-impl<'a, 'b, Handler> Resolvable for MatchingListenerBuilder<'a, 'b, Handler>
+impl<Handler> Resolvable for MatchingListenerBuilder<'_, '_, Handler>
 where
     Handler: IntoHandler<'static, MatchingStatus> + Send,
     Handler::Handler: Send,
@@ -765,7 +765,7 @@ where
 }
 
 #[zenoh_macros::unstable]
-impl<'a, 'b, Handler> Wait for MatchingListenerBuilder<'a, 'b, Handler>
+impl<Handler> Wait for MatchingListenerBuilder<'_, '_, Handler>
 where
     Handler: IntoHandler<'static, MatchingStatus> + Send,
     Handler::Handler: Send,
@@ -791,7 +791,7 @@ where
 }
 
 #[zenoh_macros::unstable]
-impl<'a, 'b, Handler> IntoFuture for MatchingListenerBuilder<'a, 'b, Handler>
+impl<Handler> IntoFuture for MatchingListenerBuilder<'_, '_, Handler>
 where
     Handler: IntoHandler<'static, MatchingStatus> + Send,
     Handler::Handler: Send,

--- a/zenoh/src/api/publisher.rs
+++ b/zenoh/src/api/publisher.rs
@@ -741,6 +741,7 @@ impl<'a, 'b> MatchingListenerBuilder<'a, 'b, DefaultHandler> {
     }
 }
 
+#[zenoh_macros::unstable]
 impl<Handler> MatchingListenerBuilder<'_, '_, Handler> {
     /// Set whether the matching listener will be undeclared when dropped.
     ///

--- a/zenoh/src/api/query.rs
+++ b/zenoh/src/api/query.rs
@@ -285,7 +285,7 @@ impl<'a, 'b> SessionGetBuilder<'a, 'b, DefaultHandler> {
     /// Receive the replies for this query with a mutable callback.
     ///
     /// Using this guarantees that your callback will never be called concurrently.
-    /// If your callback is also accepted by the [`callback`](crate::session::SessionGetBuilder::callback) method, we suggest you use it instead of `callback_mut`
+    /// If your callback is also accepted by the [`callback`](crate::session::SessionGetBuilder::callback) method, we suggest you use it instead of `callback_mut`.
     ///
     /// # Examples
     /// ```

--- a/zenoh/src/api/queryable.rs
+++ b/zenoh/src/api/queryable.rs
@@ -606,10 +606,17 @@ pub struct QueryableBuilder<'a, 'b, Handler> {
     pub(crate) complete: bool,
     pub(crate) origin: Locality,
     pub(crate) handler: Handler,
+    pub(crate) undeclare_on_drop: bool,
 }
 
 impl<'a, 'b> QueryableBuilder<'a, 'b, DefaultHandler> {
-    /// Receive the queries for this Queryable with a callback.
+    /// Receive the queries for this queryable with a callback.
+    ///
+    /// Queryable will not be undeclared when dropped, with the callback running
+    /// in background until the session is closed.
+    ///
+    /// It is in fact just a convenient shortcut for
+    /// `.with(my_callback).undeclare_on_drop(false)`.
     ///
     /// # Examples
     /// ```
@@ -629,13 +636,16 @@ impl<'a, 'b> QueryableBuilder<'a, 'b, DefaultHandler> {
     where
         Callback: Fn(Query) + Send + Sync + 'static,
     {
-        self.with(callback)
+        self.with(callback).undeclare_on_drop(false)
     }
 
     /// Receive the queries for this Queryable with a mutable callback.
     ///
     /// Using this guarantees that your callback will never be called concurrently.
-    /// If your callback is also accepted by the [`callback`](QueryableBuilder::callback) method, we suggest you use it instead of `callback_mut`
+    /// If your callback is also accepted by the [`callback`](QueryableBuilder::callback) method, we suggest you use it instead of `callback_mut`.
+    ///
+    /// Queryable will not be undeclared when dropped, with the callback running
+    /// in background until the session is closed.
     ///
     /// # Examples
     /// ```
@@ -691,6 +701,7 @@ impl<'a, 'b> QueryableBuilder<'a, 'b, DefaultHandler> {
             complete,
             origin,
             handler: _,
+            undeclare_on_drop,
         } = self;
         QueryableBuilder {
             session,
@@ -698,7 +709,17 @@ impl<'a, 'b> QueryableBuilder<'a, 'b, DefaultHandler> {
             complete,
             origin,
             handler,
+            undeclare_on_drop,
         }
+    }
+}
+
+impl<'a, 'b, Handler> QueryableBuilder<'a, 'b, Handler> {
+    /// Change queryable completeness.
+    #[inline]
+    pub fn complete(mut self, complete: bool) -> Self {
+        self.complete = complete;
+        self
     }
 
     /// Restrict the matching queries that will be receive by this [`Queryable`]
@@ -709,12 +730,16 @@ impl<'a, 'b> QueryableBuilder<'a, 'b, DefaultHandler> {
         self.origin = origin;
         self
     }
-}
-impl<'a, 'b, Handler> QueryableBuilder<'a, 'b, Handler> {
-    /// Change queryable completeness.
+
+    /// Set whether the queryable will be undeclared when dropped.
+    ///
+    /// The method is usually used in combination with a callback like in
+    /// [`callback`](Self::callback) method, or a channel sender.
+    /// Be careful when using it, as queryables not undeclared will consume
+    /// resources until the session is closed.
     #[inline]
-    pub fn complete(mut self, complete: bool) -> Self {
-        self.complete = complete;
+    pub fn undeclare_on_drop(mut self, undeclare_on_drop: bool) -> Self {
+        self.undeclare_on_drop = undeclare_on_drop;
         self
     }
 }
@@ -909,7 +934,7 @@ where
                     session_id: session.zid(),
                     session: self.session.downgrade(),
                     state: qable_state,
-                    undeclare_on_drop: !Handler::BACKGROUND,
+                    undeclare_on_drop: self.undeclare_on_drop,
                 },
                 handler: receiver,
             })

--- a/zenoh/src/api/queryable.rs
+++ b/zenoh/src/api/queryable.rs
@@ -714,7 +714,7 @@ impl<'a, 'b> QueryableBuilder<'a, 'b, DefaultHandler> {
     }
 }
 
-impl<'a, 'b, Handler> QueryableBuilder<'a, 'b, Handler> {
+impl<Handler> QueryableBuilder<'_, '_, Handler> {
     /// Change queryable completeness.
     #[inline]
     pub fn complete(mut self, complete: bool) -> Self {

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -736,6 +736,7 @@ impl Session {
             key_expr: TryIntoKeyExpr::try_into(key_expr).map_err(Into::into),
             origin: Locality::default(),
             handler: DefaultHandler::default(),
+            undeclare_on_drop: true,
         }
     }
 
@@ -779,6 +780,7 @@ impl Session {
             complete: false,
             origin: Locality::default(),
             handler: DefaultHandler::default(),
+            undeclare_on_drop: true,
         }
     }
 

--- a/zenoh/src/api/subscriber.rs
+++ b/zenoh/src/api/subscriber.rs
@@ -142,10 +142,21 @@ pub struct SubscriberBuilder<'a, 'b, Handler> {
     pub handler: Handler,
     #[cfg(not(feature = "unstable"))]
     pub(crate) handler: Handler,
+
+    #[cfg(feature = "unstable")]
+    pub undeclare_on_drop: bool,
+    #[cfg(not(feature = "unstable"))]
+    pub(crate) undeclare_on_drop: bool,
 }
 
 impl<'a, 'b> SubscriberBuilder<'a, 'b, DefaultHandler> {
     /// Receive the samples for this subscription with a callback.
+    ///
+    /// Subscriber will not be undeclared when dropped, with the callback running
+    /// in background until the session is closed.
+    ///
+    /// It is in fact just a convenient shortcut for
+    /// `.with(my_callback).undeclare_on_drop(false)`.
     ///
     /// # Examples
     /// ```
@@ -165,13 +176,16 @@ impl<'a, 'b> SubscriberBuilder<'a, 'b, DefaultHandler> {
     where
         Callback: Fn(Sample) + Send + Sync + 'static,
     {
-        self.with(callback)
+        self.with(callback).undeclare_on_drop(false)
     }
 
     /// Receive the samples for this subscription with a mutable callback.
     ///
     /// Using this guarantees that your callback will never be called concurrently.
-    /// If your callback is also accepted by the [`callback`](SubscriberBuilder::callback) method, we suggest you use it instead of `callback_mut`
+    /// If your callback is also accepted by the [`callback`](SubscriberBuilder::callback) method, we suggest you use it instead of `callback_mut`.
+    ///
+    /// Subscriber will not be undeclared when dropped, with the callback running
+    /// in background until the session is closed.
     ///
     /// # Examples
     /// ```
@@ -226,12 +240,14 @@ impl<'a, 'b> SubscriberBuilder<'a, 'b, DefaultHandler> {
             key_expr,
             origin,
             handler: _,
+            undeclare_on_drop,
         } = self;
         SubscriberBuilder {
             session,
             key_expr,
             origin,
             handler,
+            undeclare_on_drop,
         }
     }
 }
@@ -278,6 +294,18 @@ impl<'a, 'b, Handler> SubscriberBuilder<'a, 'b, Handler> {
         self.origin = origin;
         self
     }
+
+    /// Set whether the subscriber will be undeclared when dropped.
+    ///
+    /// The method is usually used in combination with a callback like in
+    /// [`callback`](Self::callback) method, or a channel sender.
+    /// Be careful when using it, as subscribers not undeclared will consume
+    /// resources until the session is closed.
+    #[inline]
+    pub fn undeclare_on_drop(mut self, undeclare_on_drop: bool) -> Self {
+        self.undeclare_on_drop = undeclare_on_drop;
+        self
+    }
 }
 
 // Push mode
@@ -308,7 +336,7 @@ where
                     session: session.downgrade(),
                     state: sub_state,
                     kind: SubscriberKind::Subscriber,
-                    undeclare_on_drop: !Handler::BACKGROUND,
+                    undeclare_on_drop: self.undeclare_on_drop,
                 },
                 handler: receiver,
             })

--- a/zenoh/src/api/subscriber.rs
+++ b/zenoh/src/api/subscriber.rs
@@ -252,7 +252,7 @@ impl<'a, 'b> SubscriberBuilder<'a, 'b, DefaultHandler> {
     }
 }
 
-impl<'a, 'b, Handler> SubscriberBuilder<'a, 'b, Handler> {
+impl<Handler> SubscriberBuilder<'_, '_, Handler> {
     /// Change the subscription reliability.
     #[cfg(feature = "unstable")]
     #[deprecated(
@@ -309,7 +309,7 @@ impl<'a, 'b, Handler> SubscriberBuilder<'a, 'b, Handler> {
 }
 
 // Push mode
-impl<'a, Handler> Resolvable for SubscriberBuilder<'a, '_, Handler>
+impl<Handler> Resolvable for SubscriberBuilder<'_, '_, Handler>
 where
     Handler: IntoHandler<'static, Sample> + Send,
     Handler::Handler: Send,
@@ -317,7 +317,7 @@ where
     type To = ZResult<Subscriber<Handler::Handler>>;
 }
 
-impl<'a, Handler> Wait for SubscriberBuilder<'a, '_, Handler>
+impl<Handler> Wait for SubscriberBuilder<'_, '_, Handler>
 where
     Handler: IntoHandler<'static, Sample> + Send,
     Handler::Handler: Send,
@@ -343,7 +343,7 @@ where
     }
 }
 
-impl<'a, Handler> IntoFuture for SubscriberBuilder<'a, '_, Handler>
+impl<Handler> IntoFuture for SubscriberBuilder<'_, '_, Handler>
 where
     Handler: IntoHandler<'static, Sample> + Send,
     Handler::Handler: Send,


### PR DESCRIPTION
The previous decided solution for undeclaration on drop "broke" the `FetchingSubscriber`, and using the associated constant doesn't make it easy to repair it. 

After a quick discussion with @kydos, it seems simpler and better to just expose an `undeclare_on_drop` builder method, having `callback` being just a shortcut for `.with(my_callback).undeclare_on_drop(false). This way, there is no hidden behavior, and it should be easier for the user to understand. And more importantly, it's way easier for the extensions and bindings to use it.