### PR TITLE
Bug/liveliness duplicate

### DIFF
--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -11,6 +11,8 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
+#[cfg(feature = "unstable")]
+use std::collections::hash_map::Entry;
 use std::{
     collections::HashMap,
     convert::TryInto,
@@ -2312,9 +2314,8 @@ impl Primitives for Session {
 
                                     (query.callback)(reply);
                                 }
-                            } else {
-                                state.remote_tokens.insert(m.id, key_expr.clone());
-
+                            } else if let Entry::Vacant(e) = state.remote_tokens.entry(m.id) {
+                                e.insert(key_expr.clone());
                                 drop(state);
 
                                 self.execute_subscriber_callbacks(

--- a/zenoh/src/net/routing/hat/client/token.rs
+++ b/zenoh/src/net/routing/hat/client/token.rs
@@ -339,6 +339,7 @@ pub(crate) fn declare_token_interest(
                 for src_face in tables
                     .faces
                     .values()
+                    .filter(|f| mode.future() || f.whatami == WhatAmI::Client)
                     .cloned()
                     .collect::<Vec<Arc<FaceState>>>()
                 {
@@ -370,6 +371,7 @@ pub(crate) fn declare_token_interest(
             for src_face in tables
                 .faces
                 .values()
+                .filter(|f| mode.future() || f.whatami == WhatAmI::Client)
                 .cloned()
                 .collect::<Vec<Arc<FaceState>>>()
             {

--- a/zenoh/src/net/routing/hat/client/token.rs
+++ b/zenoh/src/net/routing/hat/client/token.rs
@@ -285,6 +285,21 @@ pub(super) fn token_new_face(
     }
 }
 
+#[inline]
+fn make_token_id(res: &Arc<Resource>, face: &mut Arc<FaceState>, mode: InterestMode) -> u32 {
+    if mode.future() {
+        if let Some(id) = face_hat!(face).local_tokens.get(res) {
+            *id
+        } else {
+            let id = face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst);
+            face_hat_mut!(face).local_tokens.insert(res.clone(), id);
+            id
+        }
+    } else {
+        0
+    }
+}
+
 pub(crate) fn declare_token_interest(
     tables: &mut Tables,
     face: &mut Arc<FaceState>,
@@ -304,13 +319,7 @@ pub(crate) fn declare_token_interest(
                         .values()
                         .any(|token| token.context.is_some() && token.matches(res))
                 }) {
-                    let id = if mode.future() {
-                        let id = face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst);
-                        face_hat_mut!(face).local_tokens.insert((*res).clone(), id);
-                        id
-                    } else {
-                        0
-                    };
+                    let id = make_token_id(res, face, mode);
                     let wire_expr = Resource::decl_key(res, face, true);
                     send_declare(
                         &face.primitives,
@@ -335,13 +344,7 @@ pub(crate) fn declare_token_interest(
                 {
                     for token in face_hat!(src_face).remote_tokens.values() {
                         if token.context.is_some() && token.matches(res) {
-                            let id = if mode.future() {
-                                let id = face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst);
-                                face_hat_mut!(face).local_tokens.insert(token.clone(), id);
-                                id
-                            } else {
-                                0
-                            };
+                            let id = make_token_id(token, face, mode);
                             let wire_expr = Resource::decl_key(token, face, true);
                             send_declare(
                                 &face.primitives,
@@ -371,13 +374,7 @@ pub(crate) fn declare_token_interest(
                 .collect::<Vec<Arc<FaceState>>>()
             {
                 for token in face_hat!(src_face).remote_tokens.values() {
-                    let id = if mode.future() {
-                        let id = face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst);
-                        face_hat_mut!(face).local_tokens.insert(token.clone(), id);
-                        id
-                    } else {
-                        0
-                    };
+                    let id = make_token_id(token, face, mode);
                     let wire_expr = Resource::decl_key(token, face, true);
                     send_declare(
                         &face.primitives,

--- a/zenoh/src/net/routing/hat/client/token.rs
+++ b/zenoh/src/net/routing/hat/client/token.rs
@@ -339,7 +339,7 @@ pub(crate) fn declare_token_interest(
                 for src_face in tables
                     .faces
                     .values()
-                    .filter(|f| mode.future() || f.whatami == WhatAmI::Client)
+                    .filter(|f| f.whatami == WhatAmI::Client)
                     .cloned()
                     .collect::<Vec<Arc<FaceState>>>()
                 {
@@ -371,7 +371,7 @@ pub(crate) fn declare_token_interest(
             for src_face in tables
                 .faces
                 .values()
-                .filter(|f| mode.future() || f.whatami == WhatAmI::Client)
+                .filter(|f| f.whatami == WhatAmI::Client)
                 .cloned()
                 .collect::<Vec<Arc<FaceState>>>()
             {

--- a/zenoh/src/net/routing/hat/linkstate_peer/queries.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/queries.rs
@@ -738,6 +738,28 @@ lazy_static::lazy_static! {
     static ref EMPTY_ROUTE: Arc<QueryTargetQablSet> = Arc::new(Vec::new());
 }
 
+#[inline]
+fn make_qabl_id(
+    res: &Arc<Resource>,
+    face: &mut Arc<FaceState>,
+    mode: InterestMode,
+    info: QueryableInfoType,
+) -> u32 {
+    if mode.future() {
+        if let Some((id, _)) = face_hat!(face).local_qabls.get(res) {
+            *id
+        } else {
+            let id = face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst);
+            face_hat_mut!(face)
+                .local_qabls
+                .insert(res.clone(), (id, info));
+            id
+        }
+    } else {
+        0
+    }
+}
+
 pub(super) fn declare_qabl_interest(
     tables: &mut Tables,
     face: &mut Arc<FaceState>,
@@ -758,15 +780,7 @@ pub(super) fn declare_qabl_interest(
                             || remote_linkstatepeer_qabls(tables, qabl))
                 }) {
                     let info = local_qabl_info(tables, res, face);
-                    let id = if mode.future() {
-                        let id = face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst);
-                        face_hat_mut!(face)
-                            .local_qabls
-                            .insert((*res).clone(), (id, info));
-                        id
-                    } else {
-                        0
-                    };
+                    let id = make_qabl_id(res, face, mode, info);
                     let wire_expr = Resource::decl_key(res, face, face.whatami != WhatAmI::Client);
                     send_declare(
                         &face.primitives,
@@ -794,15 +808,7 @@ pub(super) fn declare_qabl_interest(
                             || remote_linkstatepeer_qabls(tables, qabl))
                     {
                         let info = local_qabl_info(tables, qabl, face);
-                        let id = if mode.future() {
-                            let id = face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst);
-                            face_hat_mut!(face)
-                                .local_qabls
-                                .insert(qabl.clone(), (id, info));
-                            id
-                        } else {
-                            0
-                        };
+                        let id = make_qabl_id(qabl, face, mode, info);
                         let key_expr =
                             Resource::decl_key(qabl, face, face.whatami != WhatAmI::Client);
                         send_declare(
@@ -831,15 +837,7 @@ pub(super) fn declare_qabl_interest(
                     && (remote_simple_qabls(qabl, face) || remote_linkstatepeer_qabls(tables, qabl))
                 {
                     let info = local_qabl_info(tables, qabl, face);
-                    let id = if mode.future() {
-                        let id = face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst);
-                        face_hat_mut!(face)
-                            .local_qabls
-                            .insert(qabl.clone(), (id, info));
-                        id
-                    } else {
-                        0
-                    };
+                    let id = make_qabl_id(qabl, face, mode, info);
                     let key_expr = Resource::decl_key(qabl, face, face.whatami != WhatAmI::Client);
                     send_declare(
                         &face.primitives,

--- a/zenoh/src/net/routing/hat/linkstate_peer/token.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/token.rs
@@ -633,6 +633,21 @@ pub(super) fn token_tree_change(tables: &mut Tables, new_clildren: &[Vec<NodeInd
     }
 }
 
+#[inline]
+fn make_token_id(res: &Arc<Resource>, face: &mut Arc<FaceState>, mode: InterestMode) -> u32 {
+    if mode.future() {
+        if let Some(id) = face_hat!(face).local_tokens.get(res) {
+            *id
+        } else {
+            let id = face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst);
+            face_hat_mut!(face).local_tokens.insert(res.clone(), id);
+            id
+        }
+    } else {
+        0
+    }
+}
+
 pub(crate) fn declare_token_interest(
     tables: &mut Tables,
     face: &mut Arc<FaceState>,
@@ -652,13 +667,7 @@ pub(crate) fn declare_token_interest(
                         && (remote_simple_tokens(tables, token, face)
                             || remote_linkstatepeer_tokens(tables, token))
                 }) {
-                    let id = if mode.future() {
-                        let id = face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst);
-                        face_hat_mut!(face).local_tokens.insert((*res).clone(), id);
-                        id
-                    } else {
-                        0
-                    };
+                    let id = make_token_id(res, face, mode);
                     let wire_expr = Resource::decl_key(res, face, face.whatami != WhatAmI::Client);
                     send_declare(
                         &face.primitives,
@@ -681,13 +690,7 @@ pub(crate) fn declare_token_interest(
                         && (remote_simple_tokens(tables, token, face)
                             || remote_linkstatepeer_tokens(tables, token))
                     {
-                        let id = if mode.future() {
-                            let id = face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst);
-                            face_hat_mut!(face).local_tokens.insert(token.clone(), id);
-                            id
-                        } else {
-                            0
-                        };
+                        let id = make_token_id(token, face, mode);
                         let wire_expr =
                             Resource::decl_key(token, face, face.whatami != WhatAmI::Client);
                         send_declare(
@@ -712,13 +715,7 @@ pub(crate) fn declare_token_interest(
                     && (remote_simple_tokens(tables, token, face)
                         || remote_linkstatepeer_tokens(tables, token))
                 {
-                    let id = if mode.future() {
-                        let id = face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst);
-                        face_hat_mut!(face).local_tokens.insert(token.clone(), id);
-                        id
-                    } else {
-                        0
-                    };
+                    let id = make_token_id(token, face, mode);
                     let wire_expr =
                         Resource::decl_key(token, face, face.whatami != WhatAmI::Client);
                     send_declare(

--- a/zenoh/src/net/routing/hat/p2p_peer/token.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/token.rs
@@ -475,7 +475,7 @@ pub(crate) fn declare_token_interest(
                 for src_face in tables
                     .faces
                     .values()
-                    .filter(|f| mode.future() || f.whatami != WhatAmI::Router)
+                    .filter(|f| f.whatami != WhatAmI::Router)
                     .cloned()
                     .collect::<Vec<Arc<FaceState>>>()
                 {
@@ -508,7 +508,7 @@ pub(crate) fn declare_token_interest(
             for src_face in tables
                 .faces
                 .values()
-                .filter(|f| mode.future() || f.whatami != WhatAmI::Router)
+                .filter(|f| f.whatami != WhatAmI::Router)
                 .cloned()
                 .collect::<Vec<Arc<FaceState>>>()
             {

--- a/zenoh/src/net/routing/hat/p2p_peer/token.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/token.rs
@@ -475,6 +475,7 @@ pub(crate) fn declare_token_interest(
                 for src_face in tables
                     .faces
                     .values()
+                    .filter(|f| mode.future() || f.whatami != WhatAmI::Router)
                     .cloned()
                     .collect::<Vec<Arc<FaceState>>>()
                 {
@@ -507,6 +508,7 @@ pub(crate) fn declare_token_interest(
             for src_face in tables
                 .faces
                 .values()
+                .filter(|f| mode.future() || f.whatami != WhatAmI::Router)
                 .cloned()
                 .collect::<Vec<Arc<FaceState>>>()
             {


### PR DESCRIPTION
This PR fixes several issues occurring when multiple Liveliness subs or liveliness subs and liveliness get with intersecting key expressions with or without history. The issues were mainly token duplicates or missed token undeclares.