### PR TITLE
feat!: make callback an opaque type

### DIFF
--- a/zenoh/src/api/admin.rs
+++ b/zenoh/src/api/admin.rs
@@ -34,7 +34,7 @@ use super::{
     sample::{DataInfo, Locality, SampleKind},
     subscriber::SubscriberKind,
 };
-use crate::api::session::WeakSession;
+use crate::{api::session::WeakSession, handlers::Callback};
 
 lazy_static::lazy_static!(
     static ref KE_STARSTAR: &'static keyexpr = unsafe { keyexpr::from_str_unchecked("**") };
@@ -54,10 +54,10 @@ pub(crate) fn init(session: WeakSession) {
             &admin_key,
             true,
             Locality::SessionLocal,
-            Arc::new({
+            Callback::new(Arc::new({
                 let session = session.clone();
                 move |q| on_admin_query(&session, q)
-            }),
+            })),
         );
     }
 }

--- a/zenoh/src/api/handlers/mod.rs
+++ b/zenoh/src/api/handlers/mod.rs
@@ -23,19 +23,16 @@ pub use ring::*;
 
 use crate::api::session::API_DATA_RECEPTION_CHANNEL_SIZE;
 
-/// An alias for `Arc<T>`.
-pub type Dyn<T> = std::sync::Arc<T>;
-
 /// A type that can be converted into a [`Callback`]-Handler pair.
 ///
 /// When Zenoh functions accept types that implement these, it intends to use the [`Callback`] as just that,
 /// while granting you access to the handler through the returned value via [`std::ops::Deref`] and [`std::ops::DerefMut`].
 ///
 /// Any closure that accepts `T` can be converted into a pair of itself and `()`.
-pub trait IntoHandler<'a, T> {
+pub trait IntoHandler<T> {
     type Handler;
 
-    fn into_handler(self) -> (Callback<'a, T>, Self::Handler);
+    fn into_handler(self) -> (Callback<T>, Self::Handler);
 }
 
 /// The default handler in Zenoh is a FIFO queue.
@@ -43,10 +40,10 @@ pub trait IntoHandler<'a, T> {
 #[derive(Default)]
 pub struct DefaultHandler(FifoChannel);
 
-impl<T: Send + 'static> IntoHandler<'static, T> for DefaultHandler {
-    type Handler = <FifoChannel as IntoHandler<'static, T>>::Handler;
+impl<T: Send + 'static> IntoHandler<T> for DefaultHandler {
+    type Handler = <FifoChannel as IntoHandler<T>>::Handler;
 
-    fn into_handler(self) -> (Callback<'static, T>, Self::Handler) {
+    fn into_handler(self) -> (Callback<T>, Self::Handler) {
         self.0.into_handler()
     }
 }

--- a/zenoh/src/api/handlers/ring.rs
+++ b/zenoh/src/api/handlers/ring.rs
@@ -21,8 +21,10 @@ use std::{
 use zenoh_collections::RingBuffer;
 use zenoh_result::ZResult;
 
-use super::{callback::Callback, Dyn, IntoHandler};
-use crate::api::session::API_DATA_RECEPTION_CHANNEL_SIZE;
+use crate::api::{
+    handlers::{callback::Callback, IntoHandler},
+    session::API_DATA_RECEPTION_CHANNEL_SIZE,
+};
 
 /// A synchronous ring channel with a limited size that allows users to keep the last N data.
 pub struct RingChannel {
@@ -140,10 +142,10 @@ impl<T> RingChannelHandler<T> {
     }
 }
 
-impl<T: Send + 'static> IntoHandler<'static, T> for RingChannel {
+impl<T: Send + 'static> IntoHandler<T> for RingChannel {
     type Handler = RingChannelHandler<T>;
 
-    fn into_handler(self) -> (Callback<'static, T>, Self::Handler) {
+    fn into_handler(self) -> (Callback<T>, Self::Handler) {
         let (sender, receiver) = flume::bounded(1);
         let inner = Arc::new(RingChannelInner {
             ring: std::sync::Mutex::new(RingBuffer::new(self.capacity)),
@@ -153,7 +155,7 @@ impl<T: Send + 'static> IntoHandler<'static, T> for RingChannel {
             ring: Arc::downgrade(&inner),
         };
         (
-            Dyn::new(move |t| match inner.ring.lock() {
+            Callback::new(Arc::new(move |t| match inner.ring.lock() {
                 Ok(mut g) => {
                     // Eventually drop the oldest element.
                     g.push_force(t);
@@ -161,7 +163,7 @@ impl<T: Send + 'static> IntoHandler<'static, T> for RingChannel {
                     let _ = sender.try_send(());
                 }
                 Err(e) => tracing::error!("{}", e),
-            }),
+            })),
             receiver,
         )
     }

--- a/zenoh/src/api/liveliness.rs
+++ b/zenoh/src/api/liveliness.rs
@@ -525,7 +525,7 @@ impl<'a, 'b> LivelinessSubscriberBuilder<'a, 'b, DefaultHandler> {
     #[zenoh_macros::unstable]
     pub fn with<Handler>(self, handler: Handler) -> LivelinessSubscriberBuilder<'a, 'b, Handler>
     where
-        Handler: crate::handlers::IntoHandler<'static, Sample>,
+        Handler: crate::handlers::IntoHandler<Sample>,
     {
         let LivelinessSubscriberBuilder {
             session,
@@ -568,7 +568,7 @@ impl<Handler> LivelinessSubscriberBuilder<'_, '_, Handler> {
 #[zenoh_macros::unstable]
 impl<'a, Handler> Resolvable for LivelinessSubscriberBuilder<'a, '_, Handler>
 where
-    Handler: IntoHandler<'static, Sample> + Send,
+    Handler: IntoHandler<Sample> + Send,
     Handler::Handler: Send,
 {
     type To = ZResult<Subscriber<Handler::Handler>>;
@@ -577,7 +577,7 @@ where
 #[zenoh_macros::unstable]
 impl<Handler> Wait for LivelinessSubscriberBuilder<'_, '_, Handler>
 where
-    Handler: IntoHandler<'static, Sample> + Send,
+    Handler: IntoHandler<Sample> + Send,
     Handler::Handler: Send,
 {
     #[zenoh_macros::unstable]
@@ -612,7 +612,7 @@ where
 #[zenoh_macros::unstable]
 impl<Handler> IntoFuture for LivelinessSubscriberBuilder<'_, '_, Handler>
 where
-    Handler: IntoHandler<'static, Sample> + Send,
+    Handler: IntoHandler<Sample> + Send,
     Handler::Handler: Send,
 {
     type Output = <Self as Resolvable>::To;
@@ -733,7 +733,7 @@ impl<'a, 'b> LivelinessGetBuilder<'a, 'b, DefaultHandler> {
     #[inline]
     pub fn with<Handler>(self, handler: Handler) -> LivelinessGetBuilder<'a, 'b, Handler>
     where
-        Handler: IntoHandler<'static, Reply>,
+        Handler: IntoHandler<Reply>,
     {
         let LivelinessGetBuilder {
             session,
@@ -761,7 +761,7 @@ impl<Handler> LivelinessGetBuilder<'_, '_, Handler> {
 
 impl<Handler> Resolvable for LivelinessGetBuilder<'_, '_, Handler>
 where
-    Handler: IntoHandler<'static, Reply> + Send,
+    Handler: IntoHandler<Reply> + Send,
     Handler::Handler: Send,
 {
     type To = ZResult<Handler::Handler>;
@@ -769,7 +769,7 @@ where
 
 impl<Handler> Wait for LivelinessGetBuilder<'_, '_, Handler>
 where
-    Handler: IntoHandler<'static, Reply> + Send,
+    Handler: IntoHandler<Reply> + Send,
     Handler::Handler: Send,
 {
     fn wait(self) -> <Self as Resolvable>::To {
@@ -783,7 +783,7 @@ where
 
 impl<Handler> IntoFuture for LivelinessGetBuilder<'_, '_, Handler>
 where
-    Handler: IntoHandler<'static, Reply> + Send,
+    Handler: IntoHandler<Reply> + Send,
     Handler::Handler: Send,
 {
     type Output = <Self as Resolvable>::To;

--- a/zenoh/src/api/publisher.rs
+++ b/zenoh/src/api/publisher.rs
@@ -726,7 +726,7 @@ impl<'a, 'b> MatchingListenerBuilder<'a, 'b, DefaultHandler> {
     #[zenoh_macros::unstable]
     pub fn with<Handler>(self, handler: Handler) -> MatchingListenerBuilder<'a, 'b, Handler>
     where
-        Handler: IntoHandler<'static, MatchingStatus>,
+        Handler: IntoHandler<MatchingStatus>,
     {
         let MatchingListenerBuilder {
             publisher,
@@ -759,7 +759,7 @@ impl<Handler> MatchingListenerBuilder<'_, '_, Handler> {
 #[zenoh_macros::unstable]
 impl<Handler> Resolvable for MatchingListenerBuilder<'_, '_, Handler>
 where
-    Handler: IntoHandler<'static, MatchingStatus> + Send,
+    Handler: IntoHandler<MatchingStatus> + Send,
     Handler::Handler: Send,
 {
     type To = ZResult<MatchingListener<Handler::Handler>>;
@@ -768,7 +768,7 @@ where
 #[zenoh_macros::unstable]
 impl<Handler> Wait for MatchingListenerBuilder<'_, '_, Handler>
 where
-    Handler: IntoHandler<'static, MatchingStatus> + Send,
+    Handler: IntoHandler<MatchingStatus> + Send,
     Handler::Handler: Send,
 {
     #[zenoh_macros::unstable]
@@ -794,7 +794,7 @@ where
 #[zenoh_macros::unstable]
 impl<Handler> IntoFuture for MatchingListenerBuilder<'_, '_, Handler>
 where
-    Handler: IntoHandler<'static, MatchingStatus> + Send,
+    Handler: IntoHandler<MatchingStatus> + Send,
     Handler::Handler: Send,
 {
     type Output = <Self as Resolvable>::To;
@@ -812,7 +812,7 @@ pub(crate) struct MatchingListenerState {
     pub(crate) current: Mutex<bool>,
     pub(crate) key_expr: KeyExpr<'static>,
     pub(crate) destination: Locality,
-    pub(crate) callback: Callback<'static, MatchingStatus>,
+    pub(crate) callback: Callback<MatchingStatus>,
 }
 
 #[zenoh_macros::unstable]

--- a/zenoh/src/api/query.rs
+++ b/zenoh/src/api/query.rs
@@ -154,7 +154,7 @@ impl From<Reply> for Result<Sample, ReplyError> {
 
 #[cfg(feature = "unstable")]
 pub(crate) struct LivelinessQueryState {
-    pub(crate) callback: Callback<'static, Reply>,
+    pub(crate) callback: Callback<Reply>,
 }
 
 pub(crate) struct QueryState {
@@ -163,7 +163,7 @@ pub(crate) struct QueryState {
     pub(crate) parameters: Parameters<'static>,
     pub(crate) reception_mode: ConsolidationMode,
     pub(crate) replies: Option<HashMap<OwnedKeyExpr, Reply>>,
-    pub(crate) callback: Callback<'static, Reply>,
+    pub(crate) callback: Callback<Reply>,
 }
 
 impl QueryState {
@@ -333,7 +333,7 @@ impl<'a, 'b> SessionGetBuilder<'a, 'b, DefaultHandler> {
     #[inline]
     pub fn with<Handler>(self, handler: Handler) -> SessionGetBuilder<'a, 'b, Handler>
     where
-        Handler: IntoHandler<'static, Reply>,
+        Handler: IntoHandler<Reply>,
     {
         let SessionGetBuilder {
             session,
@@ -444,7 +444,7 @@ pub enum ReplyKeyExpr {
 
 impl<Handler> Resolvable for SessionGetBuilder<'_, '_, Handler>
 where
-    Handler: IntoHandler<'static, Reply> + Send,
+    Handler: IntoHandler<Reply> + Send,
     Handler::Handler: Send,
 {
     type To = ZResult<Handler::Handler>;
@@ -452,7 +452,7 @@ where
 
 impl<Handler> Wait for SessionGetBuilder<'_, '_, Handler>
 where
-    Handler: IntoHandler<'static, Reply> + Send,
+    Handler: IntoHandler<Reply> + Send,
     Handler::Handler: Send,
 {
     fn wait(self) -> <Self as Resolvable>::To {
@@ -483,7 +483,7 @@ where
 
 impl<Handler> IntoFuture for SessionGetBuilder<'_, '_, Handler>
 where
-    Handler: IntoHandler<'static, Reply> + Send,
+    Handler: IntoHandler<Reply> + Send,
     Handler::Handler: Send,
 {
     type Output = <Self as Resolvable>::To;

--- a/zenoh/src/api/queryable.rs
+++ b/zenoh/src/api/queryable.rs
@@ -53,6 +53,7 @@ use crate::{
         value::Value,
         Id,
     },
+    handlers::Callback,
     net::primitives::Primitives,
     Session,
 };
@@ -530,7 +531,7 @@ pub(crate) struct QueryableState {
     pub(crate) key_expr: WireExpr<'static>,
     pub(crate) complete: bool,
     pub(crate) origin: Locality,
-    pub(crate) callback: Arc<dyn Fn(Query) + Send + Sync>,
+    pub(crate) callback: Callback<Query>,
 }
 
 impl fmt::Debug for QueryableState {
@@ -693,7 +694,7 @@ impl<'a, 'b> QueryableBuilder<'a, 'b, DefaultHandler> {
     #[inline]
     pub fn with<Handler>(self, handler: Handler) -> QueryableBuilder<'a, 'b, Handler>
     where
-        Handler: IntoHandler<'static, Query>,
+        Handler: IntoHandler<Query>,
     {
         let QueryableBuilder {
             session,
@@ -906,7 +907,7 @@ impl<Handler> DerefMut for Queryable<Handler> {
 
 impl<Handler> Resolvable for QueryableBuilder<'_, '_, Handler>
 where
-    Handler: IntoHandler<'static, Query> + Send,
+    Handler: IntoHandler<Query> + Send,
     Handler::Handler: Send,
 {
     type To = ZResult<Queryable<Handler::Handler>>;
@@ -914,7 +915,7 @@ where
 
 impl<Handler> Wait for QueryableBuilder<'_, '_, Handler>
 where
-    Handler: IntoHandler<'static, Query> + Send,
+    Handler: IntoHandler<Query> + Send,
     Handler::Handler: Send,
 {
     fn wait(self) -> <Self as Resolvable>::To {
@@ -943,7 +944,7 @@ where
 
 impl<Handler> IntoFuture for QueryableBuilder<'_, '_, Handler>
 where
-    Handler: IntoHandler<'static, Query> + Send,
+    Handler: IntoHandler<Query> + Send,
     Handler::Handler: Send,
 {
     type Output = <Self as Resolvable>::To;

--- a/zenoh/src/api/scouting.rs
+++ b/zenoh/src/api/scouting.rs
@@ -127,7 +127,7 @@ impl ScoutBuilder<DefaultHandler> {
     #[inline]
     pub fn with<Handler>(self, handler: Handler) -> ScoutBuilder<Handler>
     where
-        Handler: IntoHandler<'static, Hello>,
+        Handler: IntoHandler<Hello>,
     {
         let ScoutBuilder {
             what,
@@ -144,7 +144,7 @@ impl ScoutBuilder<DefaultHandler> {
 
 impl<Handler> Resolvable for ScoutBuilder<Handler>
 where
-    Handler: IntoHandler<'static, Hello> + Send,
+    Handler: IntoHandler<Hello> + Send,
     Handler::Handler: Send,
 {
     type To = ZResult<Scout<Handler::Handler>>;
@@ -152,7 +152,7 @@ where
 
 impl<Handler> Wait for ScoutBuilder<Handler>
 where
-    Handler: IntoHandler<'static, Hello> + Send,
+    Handler: IntoHandler<Hello> + Send,
     Handler::Handler: Send,
 {
     fn wait(self) -> <Self as Resolvable>::To {
@@ -163,7 +163,7 @@ where
 
 impl<Handler> IntoFuture for ScoutBuilder<Handler>
 where
-    Handler: IntoHandler<'static, Hello> + Send,
+    Handler: IntoHandler<Hello> + Send,
     Handler::Handler: Send,
 {
     type Output = <Self as Resolvable>::To;
@@ -286,7 +286,7 @@ impl<Receiver> Scout<Receiver> {
 fn _scout(
     what: WhatAmIMatcher,
     config: zenoh_config::Config,
-    callback: Callback<'static, Hello>,
+    callback: Callback<Hello>,
 ) -> ZResult<ScoutInner> {
     tracing::trace!("scout({}, {})", what, &config);
     let default_addr = SocketAddr::from(zenoh_config::defaults::scouting::multicast::address);
@@ -316,7 +316,7 @@ fn _scout(
                     let scout = Runtime::scout(&sockets, what, &addr, move |hello| {
                         let callback = callback.clone();
                         async move {
-                            callback(hello.into());
+                            callback.call(hello.into());
                             Loop::Continue
                         }
                     });

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -1227,7 +1227,7 @@ impl SessionInner {
         self: &Arc<Self>,
         key_expr: &KeyExpr,
         origin: Locality,
-        callback: Callback<'static, Sample>,
+        callback: Callback<Sample>,
     ) -> ZResult<Arc<SubscriberState>> {
         let mut state = zwrite!(self.state);
         tracing::trace!("declare_subscriber({:?})", key_expr);
@@ -1433,7 +1433,7 @@ impl SessionInner {
         key_expr: &WireExpr,
         complete: bool,
         origin: Locality,
-        callback: Callback<'static, Query>,
+        callback: Callback<Query>,
     ) -> ZResult<Arc<QueryableState>> {
         let mut state = zwrite!(self.state);
         tracing::trace!("declare_queryable({:?})", key_expr);
@@ -1531,7 +1531,7 @@ impl SessionInner {
         key_expr: &KeyExpr,
         origin: Locality,
         history: bool,
-        callback: Callback<'static, Sample>,
+        callback: Callback<Sample>,
     ) -> ZResult<Arc<SubscriberState>> {
         let mut state = zwrite!(self.state);
         trace!("declare_liveliness_subscriber({:?})", key_expr);
@@ -1625,7 +1625,7 @@ impl SessionInner {
     pub(crate) fn declare_matches_listener_inner(
         &self,
         publisher: &Publisher,
-        callback: Callback<'static, MatchingStatus>,
+        callback: Callback<MatchingStatus>,
     ) -> ZResult<Arc<MatchingListenerState>> {
         let mut state = zwrite!(self.state);
         let id = self.runtime.next_id();
@@ -1647,7 +1647,9 @@ impl SessionInner {
                     .unwrap_or(true)
                 {
                     *current = true;
-                    (listener_state.callback)(MatchingStatus { matching: true });
+                    listener_state
+                        .callback
+                        .call(MatchingStatus { matching: true });
                 }
             }
             Err(e) => tracing::error!("Error trying to acquire MathginListener lock: {}", e),
@@ -1712,7 +1714,7 @@ impl SessionInner {
                                             if status.matching_subscribers() {
                                                 *current = true;
                                                 let callback = msub.callback.clone();
-                                                (callback)(status)
+                                                callback.call(status)
                                             }
                                         }
                                     }
@@ -1750,7 +1752,7 @@ impl SessionInner {
                                             if !status.matching_subscribers() {
                                                 *current = false;
                                                 let callback = msub.callback.clone();
-                                                (callback)(status)
+                                                callback.call(status)
                                             }
                                         }
                                     }
@@ -1834,26 +1836,22 @@ impl SessionInner {
             }
         };
         drop(state);
+        let mut sample = info.clone().into_sample(
+            // SAFETY: the keyexpr is valid
+            unsafe { KeyExpr::from_str_unchecked("dummy") },
+            payload,
+            #[cfg(feature = "unstable")]
+            reliability,
+            attachment,
+        );
         let zenoh_collections::single_or_vec::IntoIter { drain, last } = callbacks.into_iter();
         for (cb, key_expr) in drain {
-            let sample = info.clone().into_sample(
-                key_expr,
-                payload.clone(),
-                #[cfg(feature = "unstable")]
-                reliability,
-                attachment.clone(),
-            );
-            cb(sample);
+            sample.key_expr = key_expr;
+            cb.call(sample.clone());
         }
         if let Some((cb, key_expr)) = last {
-            let sample = info.into_sample(
-                key_expr,
-                payload,
-                #[cfg(feature = "unstable")]
-                reliability,
-                attachment.clone(),
-            );
-            cb(sample);
+            sample.key_expr = key_expr;
+            cb.call(sample);
         }
     }
 
@@ -1870,7 +1868,7 @@ impl SessionInner {
         value: Option<Value>,
         attachment: Option<ZBytes>,
         #[cfg(feature = "unstable")] source: SourceInfo,
-        callback: Callback<'static, Reply>,
+        callback: Callback<Reply>,
     ) -> ZResult<()> {
         tracing::trace!(
             "get({}, {:?}, {:?})",
@@ -1906,10 +1904,10 @@ impl SessionInner {
                                 tracing::debug!("Timeout on query {}! Send error and close.", qid);
                                 if query.reception_mode == ConsolidationMode::Latest {
                                     for (_, reply) in query.replies.unwrap().into_iter() {
-                                        (query.callback)(reply);
+                                        query.callback.call(reply);
                                     }
                                 }
-                                (query.callback)(Reply {
+                                query.callback.call(Reply {
                                     result: Err(Value::new("Timeout", Encoding::ZENOH_STRING).into()),
                                     #[cfg(feature = "unstable")]
                                     replier_id: Some(zid.into()),
@@ -1992,7 +1990,7 @@ impl SessionInner {
         self: &Arc<Self>,
         key_expr: &KeyExpr<'_>,
         timeout: Duration,
-        callback: Callback<'static, Reply>,
+        callback: Callback<Reply>,
     ) -> ZResult<()> {
         tracing::trace!("liveliness.get({}, {:?})", key_expr, timeout);
         let mut state = zwrite!(self.state);
@@ -2009,7 +2007,7 @@ impl SessionInner {
                             if let Some(query) = state.liveliness_queries.remove(&id) {
                                 std::mem::drop(state);
                                 tracing::debug!("Timeout on liveliness query {}! Send error and close.", id);
-                                (query.callback)(Reply {
+                                query.callback.call(Reply {
                                     result: Err(Value::new("Timeout", Encoding::ZENOH_STRING).into()),
                                     #[cfg(feature = "unstable")]
                                     replier_id: Some(zid.into()),
@@ -2084,7 +2082,7 @@ impl SessionInner {
                                 }
                         )
                         .map(|(id, qable)| (*id, qable.callback.clone()))
-                        .collect::<Vec<(u32, Arc<dyn Fn(Query) + Send + Sync>)>>();
+                        .collect::<Vec<(u32, Callback<Query>)>>();
                     (primitives, key_expr.into_owned(), queryables)
                 }
                 Err(err) => {
@@ -2107,16 +2105,18 @@ impl SessionInner {
                 primitives
             },
         });
-        for (eid, callback) in queryables {
-            callback(Query {
-                inner: query_inner.clone(),
-                eid,
-                value: body.as_ref().map(|b| Value {
-                    payload: b.payload.clone().into(),
-                    encoding: b.encoding.clone().into(),
-                }),
-                attachment: attachment.clone(),
-            });
+        let mut query = Query {
+            inner: query_inner,
+            eid: 0,
+            value: body.map(|b| Value {
+                payload: b.payload.into(),
+                encoding: b.encoding.into(),
+            }),
+            attachment,
+        };
+        for (eid, cb) in queryables {
+            query.eid = eid;
+            cb.call(query.clone());
         }
     }
 }
@@ -2228,7 +2228,7 @@ impl Primitives for WeakSession {
                                         replier_id: None,
                                     };
 
-                                    (query.callback)(reply);
+                                    query.callback.call(reply);
                                 }
                             } else {
                                 state.remote_tokens.insert(m.id, key_expr.clone());
@@ -2405,7 +2405,7 @@ impl Primitives for WeakSession {
                             #[cfg(feature = "unstable")]
                             replier_id: e.ext_sinfo.map(|info| info.id.zid),
                         };
-                        callback(new_reply);
+                        callback.call(new_reply);
                     }
                     None => {
                         tracing::warn!("Received ReplyData for unknown Query: {}", msg.rid);
@@ -2575,7 +2575,7 @@ impl Primitives for WeakSession {
                             };
                         std::mem::drop(state);
                         if let Some((callback, new_reply)) = callback {
-                            callback(new_reply);
+                            callback.call(new_reply);
                         }
                     }
                     None => {
@@ -2597,7 +2597,7 @@ impl Primitives for WeakSession {
                     std::mem::drop(state);
                     if query.reception_mode == ConsolidationMode::Latest {
                         for (_, reply) in query.replies.unwrap().into_iter() {
-                            (query.callback)(reply);
+                            query.callback.call(reply);
                         }
                     }
                     trace!("Close query {}", msg.rid);

--- a/zenoh/src/api/subscriber.rs
+++ b/zenoh/src/api/subscriber.rs
@@ -45,7 +45,7 @@ pub(crate) struct SubscriberState {
     pub(crate) remote_id: Id,
     pub(crate) key_expr: KeyExpr<'static>,
     pub(crate) origin: Locality,
-    pub(crate) callback: Callback<'static, Sample>,
+    pub(crate) callback: Callback<Sample>,
 }
 
 impl fmt::Debug for SubscriberState {
@@ -233,7 +233,7 @@ impl<'a, 'b> SubscriberBuilder<'a, 'b, DefaultHandler> {
     #[inline]
     pub fn with<Handler>(self, handler: Handler) -> SubscriberBuilder<'a, 'b, Handler>
     where
-        Handler: IntoHandler<'static, Sample>,
+        Handler: IntoHandler<Sample>,
     {
         let SubscriberBuilder {
             session,
@@ -311,7 +311,7 @@ impl<Handler> SubscriberBuilder<'_, '_, Handler> {
 // Push mode
 impl<Handler> Resolvable for SubscriberBuilder<'_, '_, Handler>
 where
-    Handler: IntoHandler<'static, Sample> + Send,
+    Handler: IntoHandler<Sample> + Send,
     Handler::Handler: Send,
 {
     type To = ZResult<Subscriber<Handler::Handler>>;
@@ -319,7 +319,7 @@ where
 
 impl<Handler> Wait for SubscriberBuilder<'_, '_, Handler>
 where
-    Handler: IntoHandler<'static, Sample> + Send,
+    Handler: IntoHandler<Sample> + Send,
     Handler::Handler: Send,
 {
     fn wait(self) -> <Self as Resolvable>::To {
@@ -345,7 +345,7 @@ where
 
 impl<Handler> IntoFuture for SubscriberBuilder<'_, '_, Handler>
 where
-    Handler: IntoHandler<'static, Sample> + Send,
+    Handler: IntoHandler<Sample> + Send,
     Handler::Handler: Send,
 {
     type Output = <Self as Resolvable>::To;


### PR DESCRIPTION
It may allow special case for channel handlers later, in order to use async methods, or change the return type of the callback in order to support async callbacks.

For the record I've tested quickly with an enum inside `Callback`, and there was a sensitive cost in performance of 1% when using callbacks.