### PR TITLE
refactor: remove state from entities

### DIFF
--- a/zenoh/src/api/admin.rs
+++ b/zenoh/src/api/admin.rs
@@ -45,7 +45,7 @@ lazy_static::lazy_static!(
 );
 
 pub(crate) fn init(session: WeakSession) {
-    if let Ok(own_zid) = keyexpr::new(&session.runtime.zid().to_string()) {
+    if let Ok(own_zid) = keyexpr::new(&session.zid().to_string()) {
         let admin_key = KeyExpr::from(*KE_PREFIX / own_zid / *KE_SESSION / *KE_STARSTAR)
             .to_wire(&session)
             .to_owned();
@@ -104,7 +104,7 @@ pub(crate) fn on_admin_query(session: &WeakSession, query: Query) {
         }
     }
 
-    if let Ok(own_zid) = keyexpr::new(&session.runtime.zid().to_string()) {
+    if let Ok(own_zid) = keyexpr::new(&session.zid().to_string()) {
         for transport in zenoh_runtime::ZRuntime::Net
             .block_in_place(session.runtime.manager().get_transports_unicast())
         {
@@ -155,7 +155,7 @@ impl TransportMulticastEventHandler for Handler {
         &self,
         peer: zenoh_transport::TransportPeer,
     ) -> ZResult<Arc<dyn TransportPeerEventHandler>> {
-        if let Ok(own_zid) = keyexpr::new(&self.session.runtime.zid().to_string()) {
+        if let Ok(own_zid) = keyexpr::new(&self.session.zid().to_string()) {
             if let Ok(zid) = keyexpr::new(&peer.zid.to_string()) {
                 let expr = WireExpr::from(
                     &(*KE_PREFIX / own_zid / *KE_SESSION / *KE_TRANSPORT_UNICAST / zid),

--- a/zenoh/src/api/builders/publisher.rs
+++ b/zenoh/src/api/builders/publisher.rs
@@ -333,8 +333,6 @@ impl<'a, 'b> PublisherBuilder<'a, 'b> {
     // internal function for performing the publication
     fn create_one_shot_publisher(self) -> ZResult<Publisher<'b>> {
         Ok(Publisher {
-            #[cfg(feature = "unstable")]
-            session_id: self.session.0.runtime.zid(),
             session: self.session.downgrade(),
             id: 0, // This is a one shot Publisher
             key_expr: self.key_expr?,
@@ -394,8 +392,6 @@ impl<'a, 'b> Wait for PublisherBuilder<'a, 'b> {
             .0
             .declare_publisher_inner(key_expr.clone(), self.destination)?;
         Ok(Publisher {
-            #[cfg(feature = "unstable")]
-            session_id: self.session.0.runtime.zid(),
             session: self.session.downgrade(),
             id,
             key_expr,

--- a/zenoh/src/api/liveliness.rs
+++ b/zenoh/src/api/liveliness.rs
@@ -597,10 +597,9 @@ where
             )
             .map(|sub_state| Subscriber {
                 inner: SubscriberInner {
-                    #[cfg(feature = "unstable")]
-                    session_id: session.zid(),
                     session: self.session.downgrade(),
-                    state: sub_state,
+                    id: sub_state.id,
+                    key_expr: sub_state.key_expr.clone(),
                     kind: SubscriberKind::LivelinessSubscriber,
                     undeclare_on_drop: self.undeclare_on_drop,
                 },

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -1077,11 +1077,14 @@ impl SessionInner {
             let mut state = zwrite!(self.state);
             state.queryables.clear();
             state.subscribers.clear();
-            state.matching_listeners.clear();
             state.liveliness_subscribers.clear();
             state.local_resources.clear();
             state.remote_resources.clear();
-            state.tokens.clear();
+            #[cfg(feature = "unstable")]
+            {
+                state.tokens.clear();
+                state.matching_listeners.clear();
+            }
             Ok(())
         })
     }


### PR DESCRIPTION
Entities having having a reference to their state prevented to drop their callback when closing the session.