### PR TITLE
Add `.private` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 cargo-timing*.html
 
 ci/valgrind-check/*.log
+
+# A folder to store intentionally untracked changes for a less cluttered git-status
+.private


### PR DESCRIPTION
A folder to store intentionally untracked changes for a less cluttered git-status.