### PR TITLE
fix: getting reference instead of value in PluginsManager::declare_static_plugin

### DIFF
--- a/plugins/zenoh-plugin-storage-manager/src/lib.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/lib.rs
@@ -126,9 +126,8 @@ impl StorageRuntimeInner {
         } = config;
         let lib_loader = LibLoader::new(backend_search_dirs);
 
-        let plugins_manager =
-            PluginsManager::dynamic(lib_loader.clone(), BACKEND_LIB_PREFIX)
-                .declare_static_plugin::<MemoryBackend, &str>(MEMORY_BACKEND_NAME, true);
+        let mut plugins_manager = PluginsManager::dynamic(lib_loader.clone(), BACKEND_LIB_PREFIX);
+        plugins_manager.declare_static_plugin::<MemoryBackend, &str>(MEMORY_BACKEND_NAME, true);
 
         let session = Arc::new(zenoh::session::init(runtime.clone()).wait()?);
 

--- a/plugins/zenoh-plugin-trait/src/manager.rs
+++ b/plugins/zenoh-plugin-trait/src/manager.rs
@@ -132,10 +132,10 @@ impl<StartArgs: PluginStartArgs + 'static, Instance: PluginInstance + 'static>
         P: Plugin<StartArgs = StartArgs, Instance = Instance> + Send + Sync,
         S: Into<String>,
     >(
-        mut self,
+        &mut self,
         id: S,
         required: bool,
-    ) -> Self {
+    ) {
         let id = id.into();
         let plugin_loader: StaticPlugin<StartArgs, Instance, P> =
             StaticPlugin::new(id.clone(), required);
@@ -152,7 +152,6 @@ impl<StartArgs: PluginStartArgs + 'static, Instance: PluginInstance + 'static>
             self.plugins.last().unwrap().id(),
             self.plugins.last().unwrap().name()
         );
-        self
     }
 
     /// Add dynamic plugin to the manager by name, automatically prepending the default library prefix


### PR DESCRIPTION
Taking reference instead of value, as the inner `Vec` can still be updated.

Sister PRs:

- [x] DDS Bridge - https://github.com/eclipse-zenoh/zenoh-plugin-dds/pull/333
- [x] MQTT Bridge - https://github.com/eclipse-zenoh/zenoh-plugin-mqtt/pull/206
- [x] ROS2 Bridge - https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/pull/258
- [x] ROS1 Bridge - https://github.com/eclipse-zenoh/zenoh-plugin-ros1/pull/158
