### PR TITLE
Hide `zenoh_config` internals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5350,6 +5350,7 @@ dependencies = [
  "tracing",
  "uhlc",
  "unwrap-infallible",
+ "validated_struct",
  "vec_map",
  "zenoh-buffers",
  "zenoh-codec",
@@ -5413,7 +5414,6 @@ version = "1.0.0-dev"
 name = "zenoh-config"
 version = "1.0.0-dev"
 dependencies = [
- "flume",
  "json5",
  "num_cpus",
  "secrecy",
@@ -5479,6 +5479,7 @@ dependencies = [
  "tokio",
  "tracing",
  "zenoh",
+ "zenoh-config",
  "zenoh-macros",
  "zenoh-util",
 ]
@@ -5491,6 +5492,7 @@ dependencies = [
  "futures",
  "tokio",
  "zenoh",
+ "zenoh-config",
  "zenoh-ext",
 ]
 
@@ -5987,6 +5989,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "zenoh",
+ "zenoh-config",
  "zenoh-util",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5332,6 +5332,7 @@ dependencies = [
  "futures",
  "git-version",
  "itertools 0.13.0",
+ "json5",
  "lazy_static",
  "once_cell",
  "paste",

--- a/commons/zenoh-config/Cargo.toml
+++ b/commons/zenoh-config/Cargo.toml
@@ -28,7 +28,6 @@ internal = []
 
 [dependencies]
 tracing = { workspace = true }
-flume = { workspace = true }
 json5 = { workspace = true }
 num_cpus = { workspace = true }
 serde = { workspace = true, features = ["default"] }

--- a/commons/zenoh-config/src/defaults.rs
+++ b/commons/zenoh-config/src/defaults.rs
@@ -13,8 +13,6 @@
 //
 use super::*;
 
-pub const ENV: &str = "ZENOH_CONFIG";
-
 macro_rules! mode_accessor {
     ($type:ty) => {
         #[inline]

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -737,12 +737,6 @@ impl std::fmt::Display for ConfigOpenErr {
 }
 impl std::error::Error for ConfigOpenErr {}
 impl Config {
-    pub fn from_env() -> ZResult<Self> {
-        let path = std::env::var(defaults::ENV)
-            .map_err(|e| zerror!("Invalid ENV variable ({}): {}", defaults::ENV, e))?;
-        Self::from_file(path.as_str())
-    }
-
     pub fn from_file<P: AsRef<Path>>(path: P) -> ZResult<Self> {
         let path = path.as_ref();
         let mut config = Self::_from_file(path)?;

--- a/commons/zenoh-macros/src/lib.rs
+++ b/commons/zenoh-macros/src/lib.rs
@@ -195,8 +195,7 @@ pub fn unstable_config(args: TokenStream, tokens: TokenStream) -> TokenStream {
         Err(err) => return err.into_compile_error().into(),
     };
 
-    let feature_gate: Attribute =
-        parse_quote!(#[cfg(any(feature = "unstable", feature = "unstable_config"))]);
+    let feature_gate: Attribute = parse_quote!(#[cfg(feature = "unstable_config")]);
     attrs.push(feature_gate);
 
     TokenStream::from(item.to_token_stream())

--- a/commons/zenoh-macros/src/lib.rs
+++ b/commons/zenoh-macros/src/lib.rs
@@ -181,6 +181,27 @@ pub fn unstable(attr: TokenStream, tokens: TokenStream) -> TokenStream {
     TokenStream::from(item.to_token_stream())
 }
 
+// FIXME(fuzzypixelz): refactor `unstable` macro to accept arguments
+#[proc_macro_attribute]
+pub fn unstable_config(args: TokenStream, tokens: TokenStream) -> TokenStream {
+    let tokens = unstable_doc(args, tokens);
+    let mut item = match parse_annotable_item!(tokens) {
+        Ok(item) => item,
+        Err(err) => return err.into_compile_error().into(),
+    };
+
+    let attrs = match item.attributes_mut() {
+        Ok(attrs) => attrs,
+        Err(err) => return err.into_compile_error().into(),
+    };
+
+    let feature_gate: Attribute =
+        parse_quote!(#[cfg(any(feature = "unstable", feature = "unstable_config"))]);
+    attrs.push(feature_gate);
+
+    TokenStream::from(item.to_token_stream())
+}
+
 #[proc_macro_attribute]
 /// Adds a `#[cfg(feature = "internal")]` and `#[doc(hidden)]` attributes to the item.
 pub fn internal(_attr: TokenStream, tokens: TokenStream) -> TokenStream {

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -3,7 +3,7 @@
 //! Check ../README.md for usage.
 //!
 
-use zenoh::config::Config;
+use zenoh::{config::WhatAmI, Config};
 
 #[derive(clap::ValueEnum, Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum Wai {
@@ -59,9 +59,9 @@ impl From<&CommonArgs> for Config {
             None => Config::default(),
         };
         match args.mode {
-            Some(Wai::Peer) => config.set_mode(Some(zenoh::config::WhatAmI::Peer)),
-            Some(Wai::Client) => config.set_mode(Some(zenoh::config::WhatAmI::Client)),
-            Some(Wai::Router) => config.set_mode(Some(zenoh::config::WhatAmI::Router)),
+            Some(Wai::Peer) => config.set_mode(Some(WhatAmI::Peer)),
+            Some(Wai::Client) => config.set_mode(Some(WhatAmI::Client)),
+            Some(Wai::Router) => config.set_mode(Some(WhatAmI::Router)),
             None => Ok(None),
         }
         .unwrap();

--- a/zenoh-ext/Cargo.toml
+++ b/zenoh-ext/Cargo.toml
@@ -50,6 +50,7 @@ zenoh-macros = { workspace = true }
 
 [dev-dependencies]
 zenoh = { workspace = true, features = ["unstable"], default-features = true }
+zenoh-config = { workspace = true }
 
 [package.metadata.docs.rs]
 features = ["unstable"]

--- a/zenoh-ext/examples/Cargo.toml
+++ b/zenoh-ext/examples/Cargo.toml
@@ -39,6 +39,7 @@ clap = { workspace = true, features = ["derive"] }
 zenoh-ext = { workspace = true }
 
 [dev-dependencies]
+zenoh-config = { workspace = true }
 
 [[example]]
 name = "z_query_sub"

--- a/zenoh-ext/examples/examples/z_pub_cache.rs
+++ b/zenoh-ext/examples/examples/z_pub_cache.rs
@@ -14,10 +14,8 @@
 use std::time::Duration;
 
 use clap::{arg, Parser};
-use zenoh::{
-    config::{Config, ModeDependentValue},
-    key_expr::KeyExpr,
-};
+use zenoh::{config::Config, key_expr::KeyExpr};
+use zenoh_config::ModeDependentValue;
 use zenoh_ext::*;
 use zenoh_ext_examples::CommonArgs;
 

--- a/zenoh-ext/examples/src/lib.rs
+++ b/zenoh-ext/examples/src/lib.rs
@@ -2,7 +2,7 @@
 //! See the code in ../examples/
 //! Check ../README.md for usage.
 //!
-use zenoh::config::Config;
+use zenoh::{config::WhatAmI, Config};
 
 #[derive(clap::ValueEnum, Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum Wai {
@@ -43,9 +43,9 @@ impl From<&CommonArgs> for Config {
             None => Config::default(),
         };
         match value.mode {
-            Some(Wai::Peer) => config.set_mode(Some(zenoh::config::WhatAmI::Peer)),
-            Some(Wai::Client) => config.set_mode(Some(zenoh::config::WhatAmI::Client)),
-            Some(Wai::Router) => config.set_mode(Some(zenoh::config::WhatAmI::Router)),
+            Some(Wai::Peer) => config.set_mode(Some(WhatAmI::Peer)),
+            Some(Wai::Client) => config.set_mode(Some(WhatAmI::Client)),
+            Some(Wai::Router) => config.set_mode(Some(WhatAmI::Router)),
             None => Ok(None),
         }
         .unwrap();

--- a/zenoh-ext/src/querying_subscriber.rs
+++ b/zenoh-ext/src/querying_subscriber.rs
@@ -633,7 +633,7 @@ where
 /// use zenoh::Wait;
 /// use zenoh_ext::*;
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let subscriber = session
 ///     .declare_subscriber("key/expr")
 ///     .fetching( |cb| {
@@ -777,7 +777,7 @@ impl<Handler> FetchingSubscriber<Handler> {
     /// use zenoh::Wait;
     /// use zenoh_ext::*;
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let mut subscriber = session
     ///     .declare_subscriber("key/expr")
     ///     .fetching( |cb| {
@@ -855,7 +855,7 @@ impl Drop for RepliesHandler {
 /// # use zenoh::Wait;
 /// # use zenoh_ext::*;
 /// #
-/// # let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// # let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// # let mut fetching_subscriber = session
 /// #     .declare_subscriber("key/expr")
 /// #     .fetching( |cb| {

--- a/zenoh-ext/src/session_ext.rs
+++ b/zenoh-ext/src/session_ext.rs
@@ -18,14 +18,16 @@ use super::PublicationCacheBuilder;
 
 /// Some extensions to the [`zenoh::Session`](zenoh::Session)
 pub trait SessionExt<'s, 'a> {
+    // REVIEW(fuzzypixelz): this doc test is the only one to use the programmatic configuration API..
     /// Examples:
     /// ```
     /// # #[tokio::main]
     /// # async fn main() {
-    /// use zenoh::config::ModeDependentValue::Unique;
     /// use zenoh_ext::SessionExt;
+    /// use zenoh_config::ModeDependentValue::Unique;
     ///
-    /// let mut config = zenoh::config::default();
+    ///
+    /// let mut config = zenoh::Config::default();
     /// config.timestamping.set_enabled(Some(Unique(true)));
     /// let session = zenoh::open(config).await.unwrap();
     /// let publication_cache = session.declare_publication_cache("key/expression").await.unwrap();

--- a/zenoh-ext/src/subscriber_ext.rs
+++ b/zenoh-ext/src/subscriber_ext.rs
@@ -63,7 +63,7 @@ pub trait SubscriberBuilderExt<'a, 'b, Handler> {
     /// use zenoh::Wait;
     /// use zenoh_ext::*;
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let subscriber = session
     ///     .declare_subscriber("key/expr")
     ///     .fetching( |cb| {
@@ -106,7 +106,7 @@ pub trait SubscriberBuilderExt<'a, 'b, Handler> {
     /// # async fn main() {
     /// use zenoh_ext::*;
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let subscriber = session
     ///     .declare_subscriber("key/expr")
     ///     .querying()
@@ -140,7 +140,7 @@ impl<'a, 'b, Handler> SubscriberBuilderExt<'a, 'b, Handler> for SubscriberBuilde
     /// use zenoh::Wait;
     /// use zenoh_ext::*;
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let subscriber = session
     ///     .declare_subscriber("key/expr")
     ///     .fetching( |cb| {
@@ -195,7 +195,7 @@ impl<'a, 'b, Handler> SubscriberBuilderExt<'a, 'b, Handler> for SubscriberBuilde
     /// # async fn main() {
     /// use zenoh_ext::*;
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let subscriber = session
     ///     .declare_subscriber("key/expr")
     ///     .querying()
@@ -249,7 +249,7 @@ impl<'a, 'b, Handler> SubscriberBuilderExt<'a, 'b, Handler>
     /// use zenoh::Wait;
     /// use zenoh_ext::*;
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let subscriber = session
     ///     .liveliness()
     ///     .declare_subscriber("key/expr")
@@ -307,7 +307,7 @@ impl<'a, 'b, Handler> SubscriberBuilderExt<'a, 'b, Handler>
     /// # async fn main() {
     /// use zenoh_ext::*;
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let subscriber = session
     ///     .liveliness()
     ///     .declare_subscriber("key/expr")

--- a/zenoh-ext/tests/liveliness.rs
+++ b/zenoh-ext/tests/liveliness.rs
@@ -12,11 +12,8 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-use zenoh::{
-    config::{self, EndPoint, WhatAmI},
-    sample::SampleKind,
-    Wait,
-};
+use zenoh::{sample::SampleKind, Wait};
+use zenoh_config::{EndPoint, WhatAmI};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_liveliness_querying_subscriber_clique() {
@@ -36,7 +33,7 @@ async fn test_liveliness_querying_subscriber_clique() {
     zenoh_util::init_log_from_env_or("error");
 
     let peer1 = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![PEER1_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -49,7 +46,7 @@ async fn test_liveliness_querying_subscriber_clique() {
     };
 
     let peer2 = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![PEER1_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -114,7 +111,7 @@ async fn test_liveliness_querying_subscriber_brokered() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -127,7 +124,7 @@ async fn test_liveliness_querying_subscriber_brokered() {
     };
 
     let client1 = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -140,7 +137,7 @@ async fn test_liveliness_querying_subscriber_brokered() {
     };
 
     let client2 = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -153,7 +150,7 @@ async fn test_liveliness_querying_subscriber_brokered() {
     };
 
     let client3 = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -220,7 +217,7 @@ async fn test_liveliness_fetching_subscriber_clique() {
     zenoh_util::init_log_from_env_or("error");
 
     let peer1 = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![PEER1_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -233,7 +230,7 @@ async fn test_liveliness_fetching_subscriber_clique() {
     };
 
     let peer2 = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![PEER1_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -302,7 +299,7 @@ async fn test_liveliness_fetching_subscriber_brokered() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -315,7 +312,7 @@ async fn test_liveliness_fetching_subscriber_brokered() {
     };
 
     let client1 = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -328,7 +325,7 @@ async fn test_liveliness_fetching_subscriber_brokered() {
     };
 
     let client2 = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -341,7 +338,7 @@ async fn test_liveliness_fetching_subscriber_brokered() {
     };
 
     let client3 = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -110,7 +110,6 @@ zenoh-util = { workspace = true }
 zenoh-runtime = { workspace = true }
 zenoh-task = { workspace = true }
 once_cell = { workspace = true }
-validated_struct = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -76,6 +76,7 @@ flume = { workspace = true }
 futures = { workspace = true }
 git-version = { workspace = true }
 itertools = { workspace = true }
+json5 = { workspace = true }
 lazy_static = { workspace = true }
 tracing = { workspace = true }
 paste = { workspace = true }

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -63,7 +63,7 @@ transport_udp = ["zenoh-transport/transport_udp"]
 transport_unixsock-stream = ["zenoh-transport/transport_unixsock-stream"]
 transport_ws = ["zenoh-transport/transport_ws"]
 transport_vsock = ["zenoh-transport/transport_vsock"]
-unstable = ["zenoh-keyexpr/unstable"]
+unstable = ["unstable_config", "zenoh-keyexpr/unstable"]
 unstable_config = []
 
 [dependencies]

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -64,6 +64,7 @@ transport_unixsock-stream = ["zenoh-transport/transport_unixsock-stream"]
 transport_ws = ["zenoh-transport/transport_ws"]
 transport_vsock = ["zenoh-transport/transport_vsock"]
 unstable = ["zenoh-keyexpr/unstable"]
+unstable_config = []
 
 [dependencies]
 tokio = { workspace = true, features = ["rt", "macros", "time"] }
@@ -108,6 +109,7 @@ zenoh-util = { workspace = true }
 zenoh-runtime = { workspace = true }
 zenoh-task = { workspace = true }
 once_cell = { workspace = true }
+validated_struct = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/zenoh/src/api/builders/publisher.rs
+++ b/zenoh/src/api/builders/publisher.rs
@@ -61,7 +61,7 @@ pub struct PublicationBuilderDelete;
 /// # async fn main() {
 /// use zenoh::{bytes::Encoding, qos::CongestionControl};
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// session
 ///     .put("key/expression", "payload")
 ///     .encoding(Encoding::TEXT_PLAIN)
@@ -253,7 +253,7 @@ impl IntoFuture for PublicationBuilder<PublisherBuilder<'_, '_>, PublicationBuil
 /// # async fn main() {
 /// use zenoh::qos::CongestionControl;
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let publisher = session
 ///     .declare_publisher("key/expression")
 ///     .congestion_control(CongestionControl::Block)

--- a/zenoh/src/api/config.rs
+++ b/zenoh/src/api/config.rs
@@ -31,18 +31,17 @@ impl Config {
     }
 
     pub fn insert_json5(&mut self, key: &str, value: &str) -> Result<(), InsertionError> {
-        <zenoh_config::Config as validated_struct::ValidatedMap>::insert_json5(
-            &mut self.0,
-            key,
-            value,
-        )
-        .map_err(InsertionError)
+        self.0.insert_json5(key, value).map_err(InsertionError)
     }
 
     #[zenoh_macros::unstable]
     pub fn get<'a>(&'a self, key: &str) -> Result<&'a dyn Any, LookupError> {
-        <zenoh_config::Config as validated_struct::ValidatedMap>::get(&self.0, key)
-            .map_err(LookupError)
+        self.0.get(key).map_err(LookupError)
+    }
+
+    #[zenoh_macros::unstable]
+    pub fn get_json(&self, key: &str) -> Result<String, LookupError> {
+        self.0.get_json(key).map_err(LookupError)
     }
 
     #[zenoh_macros::unstable]

--- a/zenoh/src/api/config.rs
+++ b/zenoh/src/api/config.rs
@@ -38,11 +38,13 @@ impl Config {
         .map_err(InsertionError)
     }
 
+    #[zenoh_macros::unstable]
     pub fn get<'a>(&'a self, key: &str) -> Result<&'a dyn Any, LookupError> {
         <zenoh_config::Config as validated_struct::ValidatedMap>::get(&self.0, key)
             .map_err(LookupError)
     }
 
+    #[zenoh_macros::unstable]
     pub fn remove<K: AsRef<str>>(&mut self, key: K) -> ZResult<()> {
         self.0.remove(key)
     }
@@ -98,9 +100,11 @@ struct NotifierInner<T> {
     inner: Mutex<T>,
     subscribers: Mutex<Vec<flume::Sender<Notification>>>,
 }
+
 pub struct Notifier<T> {
     inner: Arc<NotifierInner<T>>,
 }
+
 impl<T> Clone for Notifier<T> {
     fn clone(&self) -> Self {
         Self {
@@ -108,6 +112,7 @@ impl<T> Clone for Notifier<T> {
         }
     }
 }
+
 impl Notifier<Config> {
     pub fn new(inner: Config) -> Self {
         Notifier {

--- a/zenoh/src/api/config.rs
+++ b/zenoh/src/api/config.rs
@@ -43,7 +43,7 @@ impl Config {
     /// environment variable.
     pub fn from_env() -> ZResult<Self> {
         let path = env::var(Self::DEFAULT_CONFIG_PATH_ENV)?;
-        Ok(Config(zenoh_config::Config::from_file(Path::new(&path)?)?))
+        Ok(Config(zenoh_config::Config::from_file(Path::new(&path))?))
     }
 
     /// Load configuration from the file at `path`.
@@ -55,7 +55,7 @@ impl Config {
     pub fn from_json5(input: &str) -> ZResult<Config> {
         match zenoh_config::Config::from_deserializer(&mut json5::Deserializer::from_str(input)?) {
             Ok(config) => Ok(Config(config)),
-            Err(Ok(config)) => {
+            Err(Ok(_)) => {
                 Err(zerror!("The config was correctly deserialized yet it's invalid").into())
             }
             Err(Err(err)) => Err(err.into()),

--- a/zenoh/src/api/config.rs
+++ b/zenoh/src/api/config.rs
@@ -1,0 +1,200 @@
+use std::{
+    any::Any,
+    error::Error,
+    fmt,
+    ops::{self, Deref},
+    path::Path,
+    sync::{Arc, Mutex, MutexGuard},
+};
+
+use zenoh_result::ZResult;
+
+/// Zenoh configuration.
+///
+/// Most options are optional as a way to keep defaults flexible. Some of the options have different
+/// default values depending on the rest of the configuration.
+///
+/// To construct a configuration, we advise that you use a configuration file (JSON, JSON5 and YAML
+/// are currently supported, please use the proper extension for your format as the deserializer
+/// will be picked according to it).
+#[derive(Default, Debug, Clone)]
+pub struct Config(pub(crate) zenoh_config::Config);
+
+impl Config {
+    pub fn from_env() -> ZResult<Self> {
+        Ok(Config(zenoh_config::Config::from_env()?))
+    }
+
+    pub fn from_file<P: AsRef<Path>>(path: P) -> ZResult<Self> {
+        Ok(Config(zenoh_config::Config::from_file(path)?))
+    }
+
+    pub fn insert_json5(&mut self, key: &str, value: &str) -> Result<(), InsertionError> {
+        <zenoh_config::Config as validated_struct::ValidatedMap>::insert_json5(
+            &mut self.0,
+            key,
+            value,
+        )
+        .map_err(InsertionError)
+    }
+
+    pub fn get<'a>(&'a self, key: &str) -> Result<&'a dyn Any, LookupError> {
+        <zenoh_config::Config as validated_struct::ValidatedMap>::get(&self.0, key)
+            .map_err(LookupError)
+    }
+
+    pub fn remove<K: AsRef<str>>(&mut self, key: K) -> ZResult<()> {
+        self.0.remove(key)
+    }
+}
+
+#[derive(Debug)]
+pub struct InsertionError(validated_struct::InsertionError);
+
+impl fmt::Display for InsertionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", &self.0)
+    }
+}
+
+impl Error for InsertionError {}
+
+#[derive(Debug)]
+pub struct LookupError(validated_struct::GetError);
+
+impl fmt::Display for LookupError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", &self.0)
+    }
+}
+
+impl Error for LookupError {}
+
+#[zenoh_macros::unstable_config]
+impl std::ops::Deref for Config {
+    type Target = zenoh_config::Config;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[zenoh_macros::unstable_config]
+impl std::ops::DerefMut for Config {
+    fn deref_mut(&mut self) -> &mut <Self as std::ops::Deref>::Target {
+        &mut self.0
+    }
+}
+
+impl fmt::Display for Config {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", &self.0)
+    }
+}
+
+pub type Notification = Arc<str>;
+
+struct NotifierInner<T> {
+    inner: Mutex<T>,
+    subscribers: Mutex<Vec<flume::Sender<Notification>>>,
+}
+pub struct Notifier<T> {
+    inner: Arc<NotifierInner<T>>,
+}
+impl<T> Clone for Notifier<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+impl Notifier<Config> {
+    pub fn new(inner: Config) -> Self {
+        Notifier {
+            inner: Arc::new(NotifierInner {
+                inner: Mutex::new(inner),
+                subscribers: Mutex::new(Vec::new()),
+            }),
+        }
+    }
+
+    pub fn subscribe(&self) -> flume::Receiver<Notification> {
+        let (tx, rx) = flume::unbounded();
+        self.lock_subscribers().push(tx);
+        rx
+    }
+
+    pub fn notify<K: AsRef<str>>(&self, key: K) {
+        let key = key.as_ref();
+        let key: Arc<str> = Arc::from(key);
+        let mut marked = Vec::new();
+        let mut subscribers = self.lock_subscribers();
+
+        for (i, sub) in subscribers.iter().enumerate() {
+            if sub.send(key.clone()).is_err() {
+                marked.push(i)
+            }
+        }
+
+        for i in marked.into_iter().rev() {
+            subscribers.swap_remove(i);
+        }
+    }
+
+    pub fn lock(&self) -> MutexGuard<Config> {
+        self.lock_config()
+    }
+
+    fn lock_subscribers(&self) -> MutexGuard<Vec<flume::Sender<Notification>>> {
+        self.inner
+            .subscribers
+            .lock()
+            .expect("acquiring Notifier's subscribers Mutex should not fail")
+    }
+
+    fn lock_config(&self) -> MutexGuard<Config> {
+        self.inner
+            .inner
+            .lock()
+            .expect("acquiring Notifier's Config Mutex should not fail")
+    }
+
+    pub fn remove<K: AsRef<str>>(&self, key: K) -> ZResult<()> {
+        self.lock_config().remove(key.as_ref())?;
+        self.notify(key);
+        Ok(())
+    }
+
+    pub fn insert_json5(&self, key: &str, value: &str) -> Result<(), InsertionError> {
+        self.lock_config().insert_json5(key, value)
+    }
+
+    pub fn get<'a>(&'a self, key: &str) -> Result<LookupGuard<'a, Config>, LookupError> {
+        let config = self.lock_config();
+        // SAFETY: MutexGuard pins the mutex behind which the value is held.
+        let subref = config.get(key.as_ref())? as *const _;
+        Ok(LookupGuard {
+            _guard: config,
+            subref,
+        })
+    }
+}
+
+pub struct LookupGuard<'a, T> {
+    _guard: MutexGuard<'a, T>,
+    subref: *const dyn Any,
+}
+
+impl<'a, T> ops::Deref for LookupGuard<'a, T> {
+    type Target = dyn Any;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.subref }
+    }
+}
+
+impl<'a, T> AsRef<dyn Any> for LookupGuard<'a, T> {
+    fn as_ref(&self) -> &dyn Any {
+        self.deref()
+    }
+}

--- a/zenoh/src/api/config.rs
+++ b/zenoh/src/api/config.rs
@@ -12,11 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use std::{
-    any::Any,
-    env,
-    error::Error,
-    fmt,
-    ops::{self, Deref},
+    env, fmt,
     path::Path,
     sync::{Arc, Mutex, MutexGuard},
 };
@@ -193,24 +189,5 @@ impl Notifier<Config> {
 
     pub fn insert_json5(&self, key: &str, value: &str) -> ZResult<()> {
         self.lock_config().insert_json5(key, value)
-    }
-}
-
-pub struct LookupGuard<'a, T> {
-    _guard: MutexGuard<'a, T>,
-    subref: *const dyn Any,
-}
-
-impl<'a, T> ops::Deref for LookupGuard<'a, T> {
-    type Target = dyn Any;
-
-    fn deref(&self) -> &Self::Target {
-        unsafe { &*self.subref }
-    }
-}
-
-impl<'a, T> AsRef<dyn Any> for LookupGuard<'a, T> {
-    fn as_ref(&self) -> &dyn Any {
-        self.deref()
     }
 }

--- a/zenoh/src/api/config.rs
+++ b/zenoh/src/api/config.rs
@@ -36,7 +36,7 @@ use zenoh_result::ZResult;
 pub struct Config(pub(crate) zenoh_config::Config);
 
 impl Config {
-    /// Default envrionment variable containing the file path used in [`Config::from_env`].
+    /// Default environment variable containing the file path used in [`Config::from_env`].
     pub const DEFAULT_CONFIG_PATH_ENV: &'static str = "ZENOH_CONFIG";
 
     /// Load configuration from the file path specified in the [`Self::DEFAULT_CONFIG_PATH_ENV`]

--- a/zenoh/src/api/config.rs
+++ b/zenoh/src/api/config.rs
@@ -56,7 +56,7 @@ impl Config {
         match zenoh_config::Config::from_deserializer(&mut json5::Deserializer::from_str(input)?) {
             Ok(config) => Ok(Config(config)),
             Err(Ok(_)) => {
-                Err(zerror!("The config was correctly deserialized yet it's invalid").into())
+                Err(zerror!("The config was correctly deserialized but it is invalid").into())
             }
             Err(Err(err)) => Err(err.into()),
         }

--- a/zenoh/src/api/info.rs
+++ b/zenoh/src/api/info.rs
@@ -29,7 +29,7 @@ use crate::net::runtime::Runtime;
 /// # #[tokio::main]
 /// # async fn main() {
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let zid = session.info().zid().await;
 /// # }
 /// ```
@@ -66,7 +66,7 @@ impl<'a> IntoFuture for ZenohIdBuilder<'a> {
 /// # #[tokio::main]
 /// # async fn main() {
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let mut routers_zid = session.info().routers_zid().await;
 /// while let Some(router_zid) = routers_zid.next() {}
 /// # }
@@ -113,7 +113,7 @@ impl<'a> IntoFuture for RoutersZenohIdBuilder<'a> {
 /// # #[tokio::main]
 /// # async fn main() {
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let zid = session.info().zid().await;
 /// let mut peers_zid = session.info().peers_zid().await;
 /// while let Some(peer_zid) = peers_zid.next() {}
@@ -161,7 +161,7 @@ impl<'a> IntoFuture for PeersZenohIdBuilder<'a> {
 /// # #[tokio::main]
 /// # async fn main() {
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let info = session.info();
 /// let zid = info.zid().await;
 /// # }
@@ -178,7 +178,7 @@ impl SessionInfo {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let zid = session.info().zid().await;
     /// # }
     /// ```
@@ -196,7 +196,7 @@ impl SessionInfo {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let mut routers_zid = session.info().routers_zid().await;
     /// while let Some(router_zid) = routers_zid.next() {}
     /// # }
@@ -214,7 +214,7 @@ impl SessionInfo {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let mut peers_zid = session.info().peers_zid().await;
     /// while let Some(peer_zid) = peers_zid.next() {}
     /// # }

--- a/zenoh/src/api/key_expr.rs
+++ b/zenoh/src/api/key_expr.rs
@@ -567,7 +567,7 @@ impl<'a> UndeclarableSealed<&'a Session> for KeyExpr<'a> {
 /// # #[tokio::main]
 /// # async fn main() {
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let key_expr = session.declare_keyexpr("key/expression").await.unwrap();
 /// session.undeclare(key_expr).await.unwrap();
 /// # }

--- a/zenoh/src/api/liveliness.rs
+++ b/zenoh/src/api/liveliness.rs
@@ -52,7 +52,7 @@ use crate::api::session::WeakSession;
 /// # #[tokio::main]
 /// # async fn main() {
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let liveliness = session
 ///     .liveliness()
 ///     .declare_token("key/expression")
@@ -66,7 +66,7 @@ use crate::api::session::WeakSession;
 /// # #[tokio::main]
 /// # async fn main() {
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let replies = session.liveliness().get("key/**").await.unwrap();
 /// while let Ok(reply) = replies.recv_async().await {
 ///     if let Ok(sample) = reply.result() {
@@ -82,7 +82,7 @@ use crate::api::session::WeakSession;
 /// # async fn main() {
 /// use zenoh::sample::SampleKind;
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let subscriber = session.liveliness().declare_subscriber("key/**").await.unwrap();
 /// while let Ok(sample) = subscriber.recv_async().await {
 ///     match sample.kind() {
@@ -110,7 +110,7 @@ impl<'a> Liveliness<'a> {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let liveliness = session
     ///     .liveliness()
     ///     .declare_token("key/expression")
@@ -145,7 +145,7 @@ impl<'a> Liveliness<'a> {
     /// # async fn main() {
     /// use zenoh::sample::SampleKind;
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let subscriber = session.liveliness().declare_subscriber("key/expression").await.unwrap();
     /// while let Ok(sample) = subscriber.recv_async().await {
     ///     match sample.kind() {
@@ -184,7 +184,7 @@ impl<'a> Liveliness<'a> {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let replies = session.liveliness().get("key/expression").await.unwrap();
     /// while let Ok(reply) = replies.recv_async().await {
     ///     if let Ok(sample) = reply.result() {
@@ -223,7 +223,7 @@ impl<'a> Liveliness<'a> {
 /// # #[tokio::main]
 /// # async fn main() {
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let liveliness = session
 ///     .liveliness()
 ///     .declare_token("key/expression")
@@ -295,7 +295,7 @@ pub(crate) struct LivelinessTokenState {
 /// # #[tokio::main]
 /// # async fn main() {
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let liveliness = session
 ///     .liveliness()
 ///     .declare_token("key/expression")
@@ -318,7 +318,7 @@ pub struct LivelinessToken {
 /// # #[tokio::main]
 /// # async fn main() {
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let liveliness = session
 ///     .liveliness()
 ///     .declare_token("key/expression")
@@ -363,7 +363,7 @@ impl LivelinessToken {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let liveliness = session
     ///     .liveliness()
     ///     .declare_token("key/expression")
@@ -412,7 +412,7 @@ impl Drop for LivelinessToken {
 /// # #[tokio::main]
 /// # async fn main() {
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let subscriber = session
 ///     .liveliness()
 ///     .declare_subscriber("key/expression")
@@ -446,7 +446,7 @@ impl<'a, 'b> LivelinessSubscriberBuilder<'a, 'b, DefaultHandler> {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let subscriber = session
     ///     .liveliness()
     ///     .declare_subscriber("key/expression")
@@ -480,7 +480,7 @@ impl<'a, 'b> LivelinessSubscriberBuilder<'a, 'b, DefaultHandler> {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let mut n = 0;
     /// let subscriber = session
     ///     .liveliness()
@@ -509,7 +509,7 @@ impl<'a, 'b> LivelinessSubscriberBuilder<'a, 'b, DefaultHandler> {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let subscriber = session
     ///     .liveliness()
     ///     .declare_subscriber("key/expression")
@@ -631,7 +631,7 @@ where
 /// # async fn main() {
 /// # use std::convert::TryFrom;
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let tokens = session
 ///     .liveliness()
 ///     .get("key/expression")
@@ -662,7 +662,7 @@ impl<'a, 'b> LivelinessGetBuilder<'a, 'b, DefaultHandler> {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let queryable = session
     ///     .liveliness()
     ///     .get("key/expression")
@@ -689,7 +689,7 @@ impl<'a, 'b> LivelinessGetBuilder<'a, 'b, DefaultHandler> {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let mut n = 0;
     /// let queryable = session
     ///     .liveliness()
@@ -717,7 +717,7 @@ impl<'a, 'b> LivelinessGetBuilder<'a, 'b, DefaultHandler> {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let replies = session
     ///     .liveliness()
     ///     .get("key/expression")

--- a/zenoh/src/api/mod.rs
+++ b/zenoh/src/api/mod.rs
@@ -17,6 +17,7 @@ pub(crate) type Id = u32;
 pub(crate) mod admin;
 pub(crate) mod builders;
 pub(crate) mod bytes;
+pub(crate) mod config;
 pub(crate) mod encoding;
 pub(crate) mod handlers;
 pub(crate) mod info;

--- a/zenoh/src/api/publisher.rs
+++ b/zenoh/src/api/publisher.rs
@@ -75,7 +75,7 @@ impl fmt::Debug for PublisherState {
 /// # #[tokio::main]
 /// # async fn main() {
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let publisher = session.declare_publisher("key/expression").await.unwrap();
 /// publisher.put("value").await.unwrap();
 /// # }
@@ -89,7 +89,7 @@ impl fmt::Debug for PublisherState {
 /// # async fn main() {
 /// use futures::StreamExt;
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let mut subscriber = session.declare_subscriber("key/expression").await.unwrap();
 /// let publisher = session.declare_publisher("another/key/expression").await.unwrap();
 /// subscriber.stream().map(Ok).forward(publisher).await.unwrap();
@@ -120,7 +120,7 @@ impl<'a> Publisher<'a> {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let publisher = session.declare_publisher("key/expression")
     ///     .await
     ///     .unwrap();
@@ -173,7 +173,7 @@ impl<'a> Publisher<'a> {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let publisher = session.declare_publisher("key/expression").await.unwrap();
     /// publisher.put("value").await.unwrap();
     /// # }
@@ -203,7 +203,7 @@ impl<'a> Publisher<'a> {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let publisher = session.declare_publisher("key/expression").await.unwrap();
     /// publisher.delete().await.unwrap();
     /// # }
@@ -229,7 +229,7 @@ impl<'a> Publisher<'a> {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let publisher = session.declare_publisher("key/expression").await.unwrap();
     /// let matching_subscribers: bool = publisher
     ///     .matching_status()
@@ -256,7 +256,7 @@ impl<'a> Publisher<'a> {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let publisher = session.declare_publisher("key/expression").await.unwrap();
     /// let matching_listener = publisher.matching_listener().await.unwrap();
     /// while let Ok(matching_status) = matching_listener.recv_async().await {
@@ -284,7 +284,7 @@ impl<'a> Publisher<'a> {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let publisher = session.declare_publisher("key/expression").await.unwrap();
     /// publisher.undeclare().await.unwrap();
     /// # }
@@ -322,7 +322,7 @@ impl<'a> UndeclarableSealed<()> for Publisher<'a> {
 /// # #[tokio::main]
 /// # async fn main() {
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let publisher = session.declare_publisher("key/expression").await.unwrap();
 /// publisher.undeclare().await.unwrap();
 /// # }
@@ -503,7 +503,7 @@ impl TryFrom<ProtocolPriority> for Priority {
 /// # #[tokio::main]
 /// # async fn main() {
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let publisher = session.declare_publisher("key/expression").await.unwrap();
 /// let matching_status = publisher.matching_status().await.unwrap();
 /// # }
@@ -523,7 +523,7 @@ impl MatchingStatus {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let publisher = session.declare_publisher("key/expression").await.unwrap();
     /// let matching_subscribers: bool = publisher
     ///     .matching_status()
@@ -555,7 +555,7 @@ impl<'a, 'b> MatchingListenerBuilder<'a, 'b, DefaultHandler> {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let publisher = session.declare_publisher("key/expression").await.unwrap();
     /// let matching_listener = publisher
     ///     .matching_listener()
@@ -587,7 +587,7 @@ impl<'a, 'b> MatchingListenerBuilder<'a, 'b, DefaultHandler> {
     /// # async fn main() {
     ///
     /// let mut n = 0;
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let publisher = session.declare_publisher("key/expression").await.unwrap();
     /// let matching_listener = publisher
     ///     .matching_listener()
@@ -615,7 +615,7 @@ impl<'a, 'b> MatchingListenerBuilder<'a, 'b, DefaultHandler> {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let publisher = session.declare_publisher("key/expression").await.unwrap();
     /// let matching_listener = publisher
     ///     .matching_listener()
@@ -754,7 +754,7 @@ pub(crate) struct MatchingListenerInner {
 /// # #[tokio::main]
 /// # async fn main() {
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let publisher = session.declare_publisher("key/expression").await.unwrap();
 /// let matching_listener = publisher.matching_listener().await.unwrap();
 /// while let Ok(matching_status) = matching_listener.recv_async().await {
@@ -781,7 +781,7 @@ impl<Handler> MatchingListener<Handler> {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let publisher = session.declare_publisher("key/expression").await.unwrap();
     /// let matching_listener = publisher.matching_listener().await.unwrap();
     /// matching_listener.undeclare().await.unwrap();
@@ -856,10 +856,7 @@ impl<Handler> IntoFuture for MatchingListenerUndeclaration<Handler> {
 
 #[cfg(test)]
 mod tests {
-    use zenoh_config::Config;
-    use zenoh_core::Wait;
-
-    use crate::api::sample::SampleKind;
+    use crate::{sample::SampleKind, Config, Wait};
 
     #[cfg(feature = "internal")]
     #[test]

--- a/zenoh/src/api/query.rs
+++ b/zenoh/src/api/query.rs
@@ -180,7 +180,7 @@ impl QueryState {
 /// # async fn main() {
 /// use zenoh::{query::{ConsolidationMode, QueryTarget}};
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let replies = session
 ///     .get("key/expression?value>1")
 ///     .target(QueryTarget::All)
@@ -266,7 +266,7 @@ impl<'a, 'b> SessionGetBuilder<'a, 'b, DefaultHandler> {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let queryable = session
     ///     .get("key/expression")
     ///     .callback(|reply| {println!("Received {:?}", reply.result());})
@@ -292,7 +292,7 @@ impl<'a, 'b> SessionGetBuilder<'a, 'b, DefaultHandler> {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let mut n = 0;
     /// let queryable = session
     ///     .get("key/expression")
@@ -319,7 +319,7 @@ impl<'a, 'b> SessionGetBuilder<'a, 'b, DefaultHandler> {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let replies = session
     ///     .get("key/expression")
     ///     .with(flume::bounded(32))

--- a/zenoh/src/api/queryable.rs
+++ b/zenoh/src/api/queryable.rs
@@ -558,7 +558,7 @@ pub(crate) struct QueryableInner {
 /// # #[tokio::main]
 /// # async fn main() {
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let queryable = session.declare_queryable("key/expression").await.unwrap();
 /// queryable.undeclare().await.unwrap();
 /// # }
@@ -592,7 +592,7 @@ impl<Handler> IntoFuture for QueryableUndeclaration<Handler> {
 /// # #[tokio::main]
 /// # async fn main() {
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let queryable = session.declare_queryable("key/expression").await.unwrap();
 /// # }
 /// ```
@@ -621,7 +621,7 @@ impl<'a, 'b> QueryableBuilder<'a, 'b, DefaultHandler> {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let queryable = session
     ///     .declare_queryable("key/expression")
     ///     .callback(|query| {println!(">> Handling query '{}'", query.selector());})
@@ -650,7 +650,7 @@ impl<'a, 'b> QueryableBuilder<'a, 'b, DefaultHandler> {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let mut n = 0;
     /// let queryable = session
     ///     .declare_queryable("key/expression")
@@ -677,7 +677,7 @@ impl<'a, 'b> QueryableBuilder<'a, 'b, DefaultHandler> {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let queryable = session
     ///     .declare_queryable("key/expression")
     ///     .with(flume::bounded(32))
@@ -759,7 +759,7 @@ impl<Handler> QueryableBuilder<'_, '_, Handler> {
 /// # async fn main() {
 /// use futures::prelude::*;
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let (tx, rx) = flume::bounded(32);
 /// session
 ///     .declare_queryable("key/expression")
@@ -781,7 +781,7 @@ impl<Handler> QueryableBuilder<'_, '_, Handler> {
 /// # #[tokio::main]
 /// # async fn main() {
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let queryable = session
 ///     .declare_queryable("key/expression")
 ///     .with(flume::bounded(32))
@@ -811,7 +811,7 @@ impl<Handler> Queryable<Handler> {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let queryable = session.declare_queryable("key/expression")
     ///     .await
     ///     .unwrap();
@@ -848,7 +848,7 @@ impl<Handler> Queryable<Handler> {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let queryable = session.declare_queryable("key/expression")
     ///     .await
     ///     .unwrap();

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -77,7 +77,6 @@ use super::{
         SessionPutBuilder,
     },
     bytes::ZBytes,
-    config::Notifier,
     encoding::Encoding,
     handlers::{Callback, DefaultHandler},
     info::SessionInfo,
@@ -654,7 +653,8 @@ impl Session {
     /// let _ = session.config().insert_json5("connect/endpoints", r#"["tcp/127.0.0.1/7447"]"#);
     /// # }
     /// ```
-    pub fn config(&self) -> &Notifier<Config> {
+    #[zenoh_macros::unstable]
+    pub fn config(&self) -> &crate::config::Notifier<Config> {
         self.0.runtime.config()
     }
 

--- a/zenoh/src/api/subscriber.rs
+++ b/zenoh/src/api/subscriber.rs
@@ -69,7 +69,7 @@ pub(crate) struct SubscriberInner {
 /// # #[tokio::main]
 /// # async fn main() {
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let subscriber = session
 ///     .declare_subscriber("key/expression")
 ///     .await
@@ -106,7 +106,7 @@ impl<Handler> IntoFuture for SubscriberUndeclaration<Handler> {
 /// # #[tokio::main]
 /// # async fn main() {
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let subscriber = session
 ///     .declare_subscriber("key/expression")
 ///     .await
@@ -156,7 +156,7 @@ impl<'a, 'b> SubscriberBuilder<'a, 'b, DefaultHandler> {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let subscriber = session
     ///     .declare_subscriber("key/expression")
     ///     .callback(|sample| { println!("Received: {} {:?}", sample.key_expr(), sample.payload()); })
@@ -185,7 +185,7 @@ impl<'a, 'b> SubscriberBuilder<'a, 'b, DefaultHandler> {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let mut n = 0;
     /// let subscriber = session
     ///     .declare_subscriber("key/expression")
@@ -212,7 +212,7 @@ impl<'a, 'b> SubscriberBuilder<'a, 'b, DefaultHandler> {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let subscriber = session
     ///     .declare_subscriber("key/expression")
     ///     .with(flume::bounded(32))
@@ -364,7 +364,7 @@ where
 /// # #[tokio::main]
 /// # async fn main() {
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// session
 ///     .declare_subscriber("key/expression")
 ///     .callback(|sample| { println!("Received: {} {:?}", sample.key_expr(), sample.payload()) })
@@ -379,7 +379,7 @@ where
 /// # #[tokio::main]
 /// # async fn main() {
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let subscriber = session
 ///     .declare_subscriber("key/expression")
 ///     .with(flume::bounded(32))
@@ -406,7 +406,7 @@ impl<Handler> Subscriber<Handler> {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let subscriber = session.declare_subscriber("key/expression")
     ///     .await
     ///     .unwrap();
@@ -448,7 +448,7 @@ impl<Handler> Subscriber<Handler> {
     /// # #[tokio::main]
     /// # async fn main() {
     ///
-    /// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+    /// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
     /// let subscriber = session.declare_subscriber("key/expression")
     ///     .await
     ///     .unwrap();

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -353,7 +353,10 @@ pub mod time {
 pub mod config {
     pub use zenoh_config::{WhatAmI, WhatAmIMatcher};
 
-    pub use crate::api::config::{Config, InsertionError, LookupError, LookupGuard, Notifier};
+    pub use crate::api::config::{Config, InsertionError};
+
+    #[zenoh_macros::unstable]
+    pub use crate::api::config::{LookupError, LookupGuard, Notifier};
 }
 
 #[cfg(all(

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -353,9 +353,9 @@ pub mod time {
 pub mod config {
     pub use zenoh_config::{WhatAmI, WhatAmIMatcher};
 
-    pub use crate::api::config::{Config, InsertionError};
+    pub use crate::api::config::Config;
     #[zenoh_macros::unstable]
-    pub use crate::api::config::{LookupError, LookupGuard, Notifier};
+    pub use crate::api::config::Notifier;
 }
 
 #[cfg(all(

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -37,7 +37,7 @@
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!     let session = zenoh::open(zenoh::config::default()).await.unwrap();
+//!     let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 //!     session.put("key/expression", "value").await.unwrap();
 //!     session.close().await.unwrap();
 //! }
@@ -50,7 +50,7 @@
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!     let session = zenoh::open(zenoh::config::default()).await.unwrap();
+//!     let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 //!     let subscriber = session.declare_subscriber("key/expression").await.unwrap();
 //!     while let Ok(sample) = subscriber.recv_async().await {
 //!         println!("Received: {:?}", sample);
@@ -66,7 +66,7 @@
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!     let session = zenoh::open(zenoh::config::default()).await.unwrap();
+//!     let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 //!     let replies = session.get("key/expression").await.unwrap();
 //!     while let Ok(reply) = replies.recv_async().await {
 //!         println!(">> Received {:?}", reply.result());
@@ -296,7 +296,7 @@ pub mod scouting {
 /// # #[tokio::main]
 /// # async fn main() {
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let liveliness = session
 ///     .liveliness()
 ///     .declare_token("key/expression")
@@ -310,7 +310,7 @@ pub mod scouting {
 /// # #[tokio::main]
 /// # async fn main() {
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let replies = session.liveliness().get("key/**").await.unwrap();
 /// while let Ok(reply) = replies.recv_async().await {
 ///     if let Ok(sample) = reply.result() {
@@ -326,7 +326,7 @@ pub mod scouting {
 /// # async fn main() {
 /// use zenoh::sample::SampleKind;
 ///
-/// let session = zenoh::open(zenoh::config::peer()).await.unwrap();
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
 /// let subscriber = session.liveliness().declare_subscriber("key/**").await.unwrap();
 /// while let Ok(sample) = subscriber.recv_async().await {
 ///     match sample.kind() {
@@ -351,11 +351,9 @@ pub mod time {
 
 /// Configuration to pass to [`open`] and [`scout`] functions and associated constants
 pub mod config {
-    // pub use zenoh_config::{
-    //     client, default, peer, Config, EndPoint, Locator, ModeDependentValue, PermissionsConf,
-    //     PluginLoad, ValidatedMap, ZenohId,
-    // };
-    pub use zenoh_config::*;
+    pub use zenoh_config::{WhatAmI, WhatAmIMatcher};
+
+    pub use crate::api::config::{Config, InsertionError, LookupError, LookupGuard, Notifier};
 }
 
 #[cfg(all(

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -354,7 +354,6 @@ pub mod config {
     pub use zenoh_config::{WhatAmI, WhatAmIMatcher};
 
     pub use crate::api::config::{Config, InsertionError};
-
     #[zenoh_macros::unstable]
     pub use crate::api::config::{LookupError, LookupGuard, Notifier};
 }

--- a/zenoh/src/net/routing/hat/linkstate_peer/mod.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/mod.rs
@@ -180,7 +180,8 @@ pub(crate) struct HatCode {}
 
 impl HatBaseTrait for HatCode {
     fn init(&self, tables: &mut Tables, runtime: Runtime) {
-        let config = runtime.config().lock();
+        let config_guard = runtime.config().lock();
+        let config = &config_guard.0;
         let whatami = tables.whatami;
         let gossip = unwrap_or_default!(config.scouting().gossip().enabled());
         let gossip_multihop = unwrap_or_default!(config.scouting().gossip().multihop());
@@ -194,7 +195,7 @@ impl HatBaseTrait for HatCode {
             unwrap_or_default!(config.routing().peer().mode()) == *"linkstate";
         let router_peers_failover_brokering =
             unwrap_or_default!(config.routing().router().peers_failover_brokering());
-        drop(config);
+        drop(config_guard);
 
         hat_mut!(tables).linkstatepeers_net = Some(Network::new(
             "[Peers network]".to_string(),

--- a/zenoh/src/net/routing/hat/p2p_peer/mod.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/mod.rs
@@ -107,7 +107,8 @@ pub(crate) struct HatCode {}
 
 impl HatBaseTrait for HatCode {
     fn init(&self, tables: &mut Tables, runtime: Runtime) {
-        let config = runtime.config().lock();
+        let config_guard = runtime.config().lock();
+        let config = &config_guard.0;
         let whatami = tables.whatami;
         let gossip = unwrap_or_default!(config.scouting().gossip().enabled());
         let gossip_multihop = unwrap_or_default!(config.scouting().gossip().multihop());
@@ -118,7 +119,7 @@ impl HatBaseTrait for HatCode {
         };
         let router_peers_failover_brokering =
             unwrap_or_default!(config.routing().router().peers_failover_brokering());
-        drop(config);
+        drop(config_guard);
 
         hat_mut!(tables).gossip = Some(Network::new(
             "[Gossip]".to_string(),

--- a/zenoh/src/net/routing/hat/router/mod.rs
+++ b/zenoh/src/net/routing/hat/router/mod.rs
@@ -307,7 +307,8 @@ pub(crate) struct HatCode {}
 
 impl HatBaseTrait for HatCode {
     fn init(&self, tables: &mut Tables, runtime: Runtime) {
-        let config = runtime.config().lock();
+        let config_guard = runtime.config().lock();
+        let config = &config_guard.0;
         let whatami = tables.whatami;
         let gossip = unwrap_or_default!(config.scouting().gossip().enabled());
         let gossip_multihop = unwrap_or_default!(config.scouting().gossip().multihop());
@@ -322,7 +323,7 @@ impl HatBaseTrait for HatCode {
             unwrap_or_default!(config.routing().peer().mode()) == *"linkstate";
         let router_peers_failover_brokering =
             unwrap_or_default!(config.routing().router().peers_failover_brokering());
-        drop(config);
+        drop(config_guard);
 
         if router_full_linkstate | gossip {
             hat_mut!(tables).routers_net = Some(Network::new(

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -157,7 +157,7 @@ impl AdminSpace {
     pub async fn start(runtime: &Runtime, version: String) {
         let zid_str = runtime.state.zid.to_string();
         let whatami_str = runtime.state.whatami.to_str();
-        let mut config = runtime.config().lock();
+        let config = &mut runtime.config().lock().0;
         let root_key: OwnedKeyExpr = format!("@/{zid_str}/{whatami_str}").try_into().unwrap();
 
         let mut handlers: HashMap<_, Handler> = HashMap::new();
@@ -374,7 +374,7 @@ impl Primitives for AdminSpace {
     fn send_push(&self, msg: Push, _reliability: Reliability) {
         trace!("recv Push {:?}", msg);
         {
-            let conf = self.context.runtime.state.config.lock();
+            let conf = &self.context.runtime.state.config.lock().0;
             if !conf.adminspace.permissions().write {
                 tracing::error!(
                     "Received PUT on '{}' but adminspace.permissions.write=false in configuration",
@@ -435,7 +435,7 @@ impl Primitives for AdminSpace {
             RequestBody::Query(query) => {
                 let primitives = zlock!(self.primitives).as_ref().unwrap().clone();
                 {
-                    let conf = self.context.runtime.state.config.lock();
+                    let conf = &self.context.runtime.state.config.lock().0;
                     if !conf.adminspace.permissions().read {
                         tracing::error!(
                         "Received GET on '{}' but adminspace.permissions.read=false in configuration",
@@ -602,7 +602,7 @@ fn local_data(context: &AdminContext, query: Query) {
     let mut json = json!({
         "zid": context.runtime.state.zid,
         "version": context.version,
-        "metadata": context.runtime.config().lock().metadata(),
+        "metadata": context.runtime.config().lock().0.metadata(),
         "locators": locators,
         "sessions": transports,
         "plugins": plugins,

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -36,7 +36,7 @@ use futures::{stream::StreamExt, Future};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use uhlc::{HLCBuilder, HLC};
-use zenoh_config::wrappers::ZenohId;
+use zenoh_config::{unwrap_or_default, ModeDependent, ZenohId};
 use zenoh_link::{EndPoint, Link};
 use zenoh_plugin_trait::{PluginStartArgs, StructVersion};
 use zenoh_protocol::{
@@ -61,10 +61,7 @@ use super::{primitives::DeMux, routing, routing::router::Router};
 use crate::api::loader::{load_plugins, start_plugins};
 #[cfg(feature = "plugins")]
 use crate::api::plugins::PluginsManager;
-use crate::{
-    config::{unwrap_or_default, Config, ModeDependent, Notifier},
-    GIT_VERSION, LONG_VERSION,
-};
+use crate::{config::Notifier, Config, GIT_VERSION, LONG_VERSION};
 
 pub(crate) struct RuntimeState {
     zid: ZenohId,
@@ -93,7 +90,7 @@ impl WeakRuntime {
 }
 
 pub struct RuntimeBuilder {
-    config: Config,
+    config: zenoh_config::Config,
     #[cfg(feature = "plugins")]
     plugins_manager: Option<PluginsManager>,
     #[cfg(feature = "shared-memory")]
@@ -103,7 +100,7 @@ pub struct RuntimeBuilder {
 impl RuntimeBuilder {
     pub fn new(config: Config) -> Self {
         Self {
-            config,
+            config: config.0,
             #[cfg(feature = "plugins")]
             plugins_manager: None,
             #[cfg(feature = "shared-memory")]
@@ -166,7 +163,7 @@ impl RuntimeBuilder {
         // Admin space creation flag
         let start_admin_space = *config.adminspace.enabled();
 
-        let config = Notifier::new(config);
+        let config = Notifier::new(crate::config::Config(config));
         let runtime = Runtime {
             state: Arc::new(RuntimeState {
                 zid: zid.into(),

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -61,7 +61,10 @@ use super::{primitives::DeMux, routing, routing::router::Router};
 use crate::api::loader::{load_plugins, start_plugins};
 #[cfg(feature = "plugins")]
 use crate::api::plugins::PluginsManager;
-use crate::{config::Notifier, Config, GIT_VERSION, LONG_VERSION};
+use crate::{
+    api::config::{Config, Notifier},
+    GIT_VERSION, LONG_VERSION,
+};
 
 pub(crate) struct RuntimeState {
     zid: ZenohId,

--- a/zenoh/tests/acl.rs
+++ b/zenoh/tests/acl.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-#![cfg(any(feature = "unstable", feature = "unstable_config"))]
+#![cfg(feature = "unstable_config")]
 #![cfg(target_family = "unix")]
 mod test {
     use std::{

--- a/zenoh/tests/authentication.rs
+++ b/zenoh/tests/authentication.rs
@@ -11,6 +11,9 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
+
+#![cfg(any(feature = "unstable", feature = "unstable_config"))]
+
 mod test {
     use std::{
         fs,
@@ -21,11 +24,8 @@ mod test {
 
     use once_cell::sync::Lazy;
     use tokio::runtime::Handle;
-    use zenoh::{
-        config,
-        config::{EndPoint, WhatAmI},
-        Config, Session,
-    };
+    use zenoh::{config::WhatAmI, Config, Session};
+    use zenoh_config::{EndPoint, ModeDependentValue};
     use zenoh_core::{zlock, ztimeout};
 
     const TIMEOUT: Duration = Duration::from_secs(60);
@@ -270,7 +270,7 @@ client2name:client2passwd";
 
     async fn get_basic_router_config_tls(port: u16, lowlatency: bool) -> Config {
         let cert_path = TESTFILES_PATH.to_string_lossy();
-        let mut config = config::default();
+        let mut config = zenoh::Config::default();
         config.set_mode(Some(WhatAmI::Router)).unwrap();
         config
             .listen
@@ -323,7 +323,7 @@ client2name:client2passwd";
     }
     async fn get_basic_router_config_quic(port: u16) -> Config {
         let cert_path = TESTFILES_PATH.to_string_lossy();
-        let mut config = config::default();
+        let mut config = zenoh::Config::default();
         config.set_mode(Some(WhatAmI::Router)).unwrap();
         config
             .listen
@@ -369,7 +369,7 @@ client2name:client2passwd";
     }
 
     async fn get_basic_router_config_usrpswd(port: u16) -> Config {
-        let mut config = config::default();
+        let mut config = zenoh::Config::default();
         config.set_mode(Some(WhatAmI::Router)).unwrap();
         config
             .listen
@@ -408,7 +408,7 @@ client2name:client2passwd";
 
     async fn get_basic_router_config_quic_usrpswd(port: u16) -> Config {
         let cert_path = TESTFILES_PATH.to_string_lossy();
-        let mut config = config::default();
+        let mut config = zenoh::Config::default();
         config.set_mode(Some(WhatAmI::Router)).unwrap();
         config
             .listen
@@ -474,9 +474,16 @@ client2name:client2passwd";
     async fn get_client_sessions_tls(port: u16, lowlatency: bool) -> (Session, Session) {
         let cert_path = TESTFILES_PATH.to_string_lossy();
         println!("Opening client sessions");
-        let mut config = config::client([format!("tls/127.0.0.1:{}", port)
+        let mut config = zenoh::Config::default();
+        config.set_mode(Some(WhatAmI::Client)).unwrap();
+        config
+            .connect
+            .set_endpoints(ModeDependentValue::Unique(vec![format!(
+                "tls/127.0.0.1:{port}"
+            )
             .parse::<EndPoint>()
-            .unwrap()]);
+            .unwrap()]))
+            .unwrap();
         config
             .insert_json5(
                 "transport",
@@ -520,9 +527,16 @@ client2name:client2passwd";
             .unwrap();
         let s01 = ztimeout!(zenoh::open(config)).unwrap();
 
-        let mut config = config::client([format!("tls/127.0.0.1:{}", port)
+        let mut config = zenoh::Config::default();
+        config.set_mode(Some(WhatAmI::Client)).unwrap();
+        config
+            .connect
+            .set_endpoints(ModeDependentValue::Unique(vec![format!(
+                "tls/127.0.0.1:{port}"
+            )
             .parse::<EndPoint>()
-            .unwrap()]);
+            .unwrap()]))
+            .unwrap();
         config
             .insert_json5(
                 "transport",
@@ -571,9 +585,16 @@ client2name:client2passwd";
     async fn get_client_sessions_quic(port: u16) -> (Session, Session) {
         let cert_path = TESTFILES_PATH.to_string_lossy();
         println!("Opening client sessions");
-        let mut config = config::client([format!("quic/127.0.0.1:{}", port)
+        let mut config = zenoh::Config::default();
+        config.set_mode(Some(WhatAmI::Client)).unwrap();
+        config
+            .connect
+            .set_endpoints(ModeDependentValue::Unique(vec![format!(
+                "quic/127.0.0.1:{port}"
+            )
             .parse::<EndPoint>()
-            .unwrap()]);
+            .unwrap()]))
+            .unwrap();
         config
             .insert_json5(
                 "transport",
@@ -609,9 +630,16 @@ client2name:client2passwd";
             .set_root_ca_certificate(Some(format!("{}/ca.pem", cert_path)))
             .unwrap();
         let s01 = ztimeout!(zenoh::open(config)).unwrap();
-        let mut config = config::client([format!("quic/127.0.0.1:{}", port)
+        let mut config = zenoh::Config::default();
+        config.set_mode(Some(WhatAmI::Client)).unwrap();
+        config
+            .connect
+            .set_endpoints(ModeDependentValue::Unique(vec![format!(
+                "quic/127.0.0.1:{port}"
+            )
             .parse::<EndPoint>()
-            .unwrap()]);
+            .unwrap()]))
+            .unwrap();
         config
             .insert_json5(
                 "transport",
@@ -652,8 +680,16 @@ client2name:client2passwd";
 
     async fn get_client_sessions_usrpswd(port: u16) -> (Session, Session) {
         println!("Opening client sessions");
-        let mut config =
-            config::client([format!("tcp/127.0.0.1:{port}").parse::<EndPoint>().unwrap()]);
+        let mut config = zenoh::Config::default();
+        config.set_mode(Some(WhatAmI::Client)).unwrap();
+        config
+            .connect
+            .set_endpoints(ModeDependentValue::Unique(vec![format!(
+                "tcp/127.0.0.1:{port}"
+            )
+            .parse::<EndPoint>()
+            .unwrap()]))
+            .unwrap();
         config
             .insert_json5(
                 "transport",
@@ -668,8 +704,16 @@ client2name:client2passwd";
             )
             .unwrap();
         let s01 = ztimeout!(zenoh::open(config)).unwrap();
-        let mut config =
-            config::client([format!("tcp/127.0.0.1:{port}").parse::<EndPoint>().unwrap()]);
+        let mut config = zenoh::Config::default();
+        config.set_mode(Some(WhatAmI::Client)).unwrap();
+        config
+            .connect
+            .set_endpoints(ModeDependentValue::Unique(vec![format!(
+                "tcp/127.0.0.1:{port}"
+            )
+            .parse::<EndPoint>()
+            .unwrap()]))
+            .unwrap();
         config
             .insert_json5(
                 "transport",
@@ -690,9 +734,16 @@ client2name:client2passwd";
     async fn get_client_sessions_quic_usrpswd(port: u16) -> (Session, Session) {
         let cert_path = TESTFILES_PATH.to_string_lossy();
         println!("Opening client sessions");
-        let mut config = config::client([format!("quic/127.0.0.1:{port}")
+        let mut config = zenoh::Config::default();
+        config.set_mode(Some(WhatAmI::Client)).unwrap();
+        config
+            .connect
+            .set_endpoints(ModeDependentValue::Unique(vec![format!(
+                "quic/127.0.0.1:{port}"
+            )
             .parse::<EndPoint>()
-            .unwrap()]);
+            .unwrap()]))
+            .unwrap();
         config
             .insert_json5(
                 "transport",
@@ -735,9 +786,16 @@ client2name:client2passwd";
             .unwrap();
         let s01 = ztimeout!(zenoh::open(config)).unwrap();
 
-        let mut config = config::client([format!("quic/127.0.0.1:{}", port)
+        let mut config = zenoh::Config::default();
+        config.set_mode(Some(WhatAmI::Client)).unwrap();
+        config
+            .connect
+            .set_endpoints(ModeDependentValue::Unique(vec![format!(
+                "quic/127.0.0.1:{port}"
+            )
             .parse::<EndPoint>()
-            .unwrap()]);
+            .unwrap()]))
+            .unwrap();
         config
             .insert_json5(
                 "transport",

--- a/zenoh/tests/authentication.rs
+++ b/zenoh/tests/authentication.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-#![cfg(any(feature = "unstable", feature = "unstable_config"))]
+#![cfg(feature = "unstable_config")]
 
 mod test {
     use std::{

--- a/zenoh/tests/connection_retry.rs
+++ b/zenoh/tests/connection_retry.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-#![cfg(any(feature = "unstable", feature = "unstable_config"))]
+#![cfg(feature = "unstable_config")]
 
 use zenoh::{Config, Wait};
 use zenoh_config::{ConnectionRetryConf, EndPoint, ModeDependent};

--- a/zenoh/tests/connection_retry.rs
+++ b/zenoh/tests/connection_retry.rs
@@ -11,10 +11,11 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use zenoh::{
-    config::{ConnectionRetryConf, EndPoint, ModeDependent},
-    Config, Wait,
-};
+
+#![cfg(any(feature = "unstable", feature = "unstable_config"))]
+
+use zenoh::{Config, Wait};
+use zenoh_config::{ConnectionRetryConf, EndPoint, ModeDependent};
 
 #[test]
 fn retry_config_overriding() {
@@ -157,7 +158,7 @@ fn retry_config_infinite_period() {
         .unwrap();
 
     let endpoint: EndPoint = "tcp/[::]:0".parse().unwrap();
-    let retry_config = zenoh_config::get_retry_config(&config, Some(&endpoint), true);
+    let retry_config = &config.get_retry_config(Some(&endpoint), true);
 
     let mut period = retry_config.period();
 

--- a/zenoh/tests/events.rs
+++ b/zenoh/tests/events.rs
@@ -11,15 +11,18 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
+
+#![cfg(any(feature = "unstable", feature = "unstable_config"))]
+
 use std::time::Duration;
 
-use zenoh::{config, query::Reply, sample::SampleKind, Session};
+use zenoh::{query::Reply, sample::SampleKind, Session};
 use zenoh_core::ztimeout;
 
 const TIMEOUT: Duration = Duration::from_secs(10);
 
 async fn open_session(listen: &[&str], connect: &[&str]) -> Session {
-    let mut config = config::peer();
+    let mut config = zenoh::Config::default();
     config
         .listen
         .endpoints

--- a/zenoh/tests/events.rs
+++ b/zenoh/tests/events.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-#![cfg(any(feature = "unstable", feature = "unstable_config"))]
+#![cfg(feature = "unstable_config")]
 
 use std::time::Duration;
 

--- a/zenoh/tests/interceptors.rs
+++ b/zenoh/tests/interceptors.rs
@@ -11,6 +11,8 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
+
+#![cfg(any(feature = "unstable", feature = "unstable_config"))]
 #![cfg(unix)]
 
 use std::{
@@ -21,11 +23,8 @@ use std::{
     },
 };
 
-use zenoh::{
-    config::{DownsamplingItemConf, DownsamplingRuleConf, InterceptorFlow},
-    key_expr::KeyExpr,
-    Config, Wait,
-};
+use zenoh::{key_expr::KeyExpr, Config, Wait};
+use zenoh_config::{DownsamplingItemConf, DownsamplingRuleConf, InterceptorFlow};
 
 // Tokio's time granularity on different platforms
 #[cfg(target_os = "windows")]

--- a/zenoh/tests/interceptors.rs
+++ b/zenoh/tests/interceptors.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-#![cfg(any(feature = "unstable", feature = "unstable_config"))]
+#![cfg(feature = "unstable_config")]
 #![cfg(unix)]
 
 use std::{

--- a/zenoh/tests/liveliness.rs
+++ b/zenoh/tests/liveliness.rs
@@ -371,7 +371,7 @@ async fn test_liveliness_query_local() {
 async fn test_liveliness_subscriber_double_client_before() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -383,7 +383,7 @@ async fn test_liveliness_subscriber_double_client_before() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -396,7 +396,7 @@ async fn test_liveliness_subscriber_double_client_before() {
     };
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -412,7 +412,7 @@ async fn test_liveliness_subscriber_double_client_before() {
     tokio::time::sleep(SLEEP).await;
 
     let client_sub = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -466,7 +466,7 @@ async fn test_liveliness_subscriber_double_client_before() {
 async fn test_liveliness_subscriber_double_client_middle() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -478,7 +478,7 @@ async fn test_liveliness_subscriber_double_client_middle() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -491,7 +491,7 @@ async fn test_liveliness_subscriber_double_client_middle() {
     };
 
     let client_sub = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -510,7 +510,7 @@ async fn test_liveliness_subscriber_double_client_middle() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -564,7 +564,7 @@ async fn test_liveliness_subscriber_double_client_middle() {
 async fn test_liveliness_subscriber_double_client_after() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -576,7 +576,7 @@ async fn test_liveliness_subscriber_double_client_after() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -589,7 +589,7 @@ async fn test_liveliness_subscriber_double_client_after() {
     };
 
     let client_sub = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -613,7 +613,7 @@ async fn test_liveliness_subscriber_double_client_after() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -664,7 +664,7 @@ async fn test_liveliness_subscriber_double_client_after() {
 async fn test_liveliness_subscriber_double_client_history_before() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -676,7 +676,7 @@ async fn test_liveliness_subscriber_double_client_history_before() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -689,7 +689,7 @@ async fn test_liveliness_subscriber_double_client_history_before() {
     };
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -705,7 +705,7 @@ async fn test_liveliness_subscriber_double_client_history_before() {
     tokio::time::sleep(SLEEP).await;
 
     let client_sub = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -767,7 +767,7 @@ async fn test_liveliness_subscriber_double_client_history_before() {
 async fn test_liveliness_subscriber_double_client_history_middle() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -779,7 +779,7 @@ async fn test_liveliness_subscriber_double_client_history_middle() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -792,7 +792,7 @@ async fn test_liveliness_subscriber_double_client_history_middle() {
     };
 
     let client_sub = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -812,7 +812,7 @@ async fn test_liveliness_subscriber_double_client_history_middle() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -870,7 +870,7 @@ async fn test_liveliness_subscriber_double_client_history_middle() {
 async fn test_liveliness_subscriber_double_client_history_after() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -882,7 +882,7 @@ async fn test_liveliness_subscriber_double_client_history_after() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -895,7 +895,7 @@ async fn test_liveliness_subscriber_double_client_history_after() {
     };
 
     let client_sub = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -921,7 +921,7 @@ async fn test_liveliness_subscriber_double_client_history_after() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -976,7 +976,7 @@ async fn test_liveliness_subscriber_double_client_history_after() {
 async fn test_liveliness_subscriber_double_peer_before() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -988,7 +988,7 @@ async fn test_liveliness_subscriber_double_peer_before() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1001,7 +1001,7 @@ async fn test_liveliness_subscriber_double_peer_before() {
     };
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1017,7 +1017,7 @@ async fn test_liveliness_subscriber_double_peer_before() {
     tokio::time::sleep(SLEEP).await;
 
     let peer_sub = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1065,7 +1065,7 @@ async fn test_liveliness_subscriber_double_peer_before() {
 async fn test_liveliness_subscriber_double_peer_middle() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -1077,7 +1077,7 @@ async fn test_liveliness_subscriber_double_peer_middle() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1090,7 +1090,7 @@ async fn test_liveliness_subscriber_double_peer_middle() {
     };
 
     let peer_sub = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1106,7 +1106,7 @@ async fn test_liveliness_subscriber_double_peer_middle() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1157,7 +1157,7 @@ async fn test_liveliness_subscriber_double_peer_middle() {
 async fn test_liveliness_subscriber_double_peer_after() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -1169,7 +1169,7 @@ async fn test_liveliness_subscriber_double_peer_after() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1182,7 +1182,7 @@ async fn test_liveliness_subscriber_double_peer_after() {
     };
 
     let peer_sub = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1200,7 +1200,7 @@ async fn test_liveliness_subscriber_double_peer_after() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1251,7 +1251,7 @@ async fn test_liveliness_subscriber_double_peer_after() {
 async fn test_liveliness_subscriber_double_peer_history_before() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -1263,7 +1263,7 @@ async fn test_liveliness_subscriber_double_peer_history_before() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1276,7 +1276,7 @@ async fn test_liveliness_subscriber_double_peer_history_before() {
     };
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1292,7 +1292,7 @@ async fn test_liveliness_subscriber_double_peer_history_before() {
     tokio::time::sleep(SLEEP).await;
 
     let peer_sub = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1354,7 +1354,7 @@ async fn test_liveliness_subscriber_double_peer_history_before() {
 async fn test_liveliness_subscriber_double_peer_history_middle() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -1366,7 +1366,7 @@ async fn test_liveliness_subscriber_double_peer_history_middle() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1379,7 +1379,7 @@ async fn test_liveliness_subscriber_double_peer_history_middle() {
     };
 
     let peer_sub = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1399,7 +1399,7 @@ async fn test_liveliness_subscriber_double_peer_history_middle() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1457,7 +1457,7 @@ async fn test_liveliness_subscriber_double_peer_history_middle() {
 async fn test_liveliness_subscriber_double_peer_history_after() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -1469,7 +1469,7 @@ async fn test_liveliness_subscriber_double_peer_history_after() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1482,7 +1482,7 @@ async fn test_liveliness_subscriber_double_peer_history_after() {
     };
 
     let peer_sub = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1508,7 +1508,7 @@ async fn test_liveliness_subscriber_double_peer_history_after() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1563,7 +1563,7 @@ async fn test_liveliness_subscriber_double_peer_history_after() {
 async fn test_liveliness_subscriber_double_router_before() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -1576,7 +1576,7 @@ async fn test_liveliness_subscriber_double_router_before() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1589,7 +1589,7 @@ async fn test_liveliness_subscriber_double_router_before() {
     };
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1605,7 +1605,7 @@ async fn test_liveliness_subscriber_double_router_before() {
     tokio::time::sleep(SLEEP).await;
 
     let router_sub = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_SUB_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1663,7 +1663,7 @@ async fn test_liveliness_subscriber_double_router_before() {
 async fn test_liveliness_subscriber_double_router_middle() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -1676,7 +1676,7 @@ async fn test_liveliness_subscriber_double_router_middle() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1689,7 +1689,7 @@ async fn test_liveliness_subscriber_double_router_middle() {
     };
 
     let router_sub = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_SUB_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1712,7 +1712,7 @@ async fn test_liveliness_subscriber_double_router_middle() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1766,7 +1766,7 @@ async fn test_liveliness_subscriber_double_router_middle() {
 async fn test_liveliness_subscriber_double_router_after() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -1779,7 +1779,7 @@ async fn test_liveliness_subscriber_double_router_after() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1792,7 +1792,7 @@ async fn test_liveliness_subscriber_double_router_after() {
     };
 
     let router_sub = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_SUB_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1820,7 +1820,7 @@ async fn test_liveliness_subscriber_double_router_after() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1871,7 +1871,7 @@ async fn test_liveliness_subscriber_double_router_after() {
 async fn test_liveliness_subscriber_double_router_history_before() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -1884,7 +1884,7 @@ async fn test_liveliness_subscriber_double_router_history_before() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1897,7 +1897,7 @@ async fn test_liveliness_subscriber_double_router_history_before() {
     };
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1913,7 +1913,7 @@ async fn test_liveliness_subscriber_double_router_history_before() {
     tokio::time::sleep(SLEEP).await;
 
     let router_sub = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_SUB_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1979,7 +1979,7 @@ async fn test_liveliness_subscriber_double_router_history_before() {
 async fn test_liveliness_subscriber_double_router_history_middle() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -1992,7 +1992,7 @@ async fn test_liveliness_subscriber_double_router_history_middle() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2005,7 +2005,7 @@ async fn test_liveliness_subscriber_double_router_history_middle() {
     };
 
     let router_sub = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_SUB_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2029,7 +2029,7 @@ async fn test_liveliness_subscriber_double_router_history_middle() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2087,7 +2087,7 @@ async fn test_liveliness_subscriber_double_router_history_middle() {
 async fn test_liveliness_subscriber_double_router_history_after() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -2100,7 +2100,7 @@ async fn test_liveliness_subscriber_double_router_history_after() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2113,7 +2113,7 @@ async fn test_liveliness_subscriber_double_router_history_after() {
     };
 
     let router_sub = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_SUB_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2143,7 +2143,7 @@ async fn test_liveliness_subscriber_double_router_history_after() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2198,7 +2198,7 @@ async fn test_liveliness_subscriber_double_router_history_after() {
 async fn test_liveliness_subscriber_double_clientviapeer_before() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -2211,7 +2211,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_before() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2224,7 +2224,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_before() {
     };
 
     let peer_dummy = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![PEER_DUMMY_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2241,7 +2241,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_before() {
     };
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2257,7 +2257,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_before() {
     tokio::time::sleep(SLEEP).await;
 
     let client_sub = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![PEER_DUMMY_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2312,7 +2312,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_before() {
 async fn test_liveliness_subscriber_double_clientviapeer_middle() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -2325,7 +2325,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_middle() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2338,7 +2338,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_middle() {
     };
 
     let peer_dummy = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![PEER_DUMMY_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2355,7 +2355,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_middle() {
     };
 
     let client_sub = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![PEER_DUMMY_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2374,7 +2374,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_middle() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2429,7 +2429,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_middle() {
 async fn test_liveliness_subscriber_double_clientviapeer_after() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -2442,7 +2442,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_after() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2455,7 +2455,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_after() {
     };
 
     let peer_dummy = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![PEER_DUMMY_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2472,7 +2472,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_after() {
     };
 
     let client_sub = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![PEER_DUMMY_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2496,7 +2496,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_after() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2548,7 +2548,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_after() {
 async fn test_liveliness_subscriber_double_clientviapeer_history_before() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -2562,7 +2562,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_before() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2575,7 +2575,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_before() {
     };
 
     let peer_dummy = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![PEER_DUMMY_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2592,7 +2592,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_before() {
     };
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2608,7 +2608,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_before() {
     tokio::time::sleep(SLEEP).await;
 
     let client_sub = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![PEER_DUMMY_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2671,7 +2671,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_before() {
 async fn test_liveliness_subscriber_double_clientviapeer_history_middle() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -2685,7 +2685,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_middle() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2698,7 +2698,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_middle() {
     };
 
     let peer_dummy = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![PEER_DUMMY_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2715,7 +2715,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_middle() {
     };
 
     let client_sub = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![PEER_DUMMY_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2735,7 +2735,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_middle() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2794,7 +2794,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_middle() {
 async fn test_liveliness_subscriber_double_clientviapeer_history_after() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -2808,7 +2808,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_after() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2821,7 +2821,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_after() {
     };
 
     let peer_dummy = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![PEER_DUMMY_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2838,7 +2838,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_after() {
     };
 
     let client_sub = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![PEER_DUMMY_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2864,7 +2864,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_after() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2920,7 +2920,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_after() {
 async fn test_liveliness_subget_client_before() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -2932,7 +2932,7 @@ async fn test_liveliness_subget_client_before() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2945,7 +2945,7 @@ async fn test_liveliness_subget_client_before() {
     };
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2961,7 +2961,7 @@ async fn test_liveliness_subget_client_before() {
     tokio::time::sleep(SLEEP).await;
 
     let client_subget = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3013,7 +3013,7 @@ async fn test_liveliness_subget_client_before() {
 async fn test_liveliness_subget_client_middle() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -3025,7 +3025,7 @@ async fn test_liveliness_subget_client_middle() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3038,7 +3038,7 @@ async fn test_liveliness_subget_client_middle() {
     };
 
     let client_subget = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3059,7 +3059,7 @@ async fn test_liveliness_subget_client_middle() {
     assert!(sub.try_recv().is_err());
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3111,7 +3111,7 @@ async fn test_liveliness_subget_client_middle() {
 async fn test_liveliness_subget_client_history_before() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -3123,7 +3123,7 @@ async fn test_liveliness_subget_client_history_before() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3136,7 +3136,7 @@ async fn test_liveliness_subget_client_history_before() {
     };
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3152,7 +3152,7 @@ async fn test_liveliness_subget_client_history_before() {
     tokio::time::sleep(SLEEP).await;
 
     let client_subget = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3208,7 +3208,7 @@ async fn test_liveliness_subget_client_history_before() {
 async fn test_liveliness_subget_client_history_middle() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -3220,7 +3220,7 @@ async fn test_liveliness_subget_client_history_middle() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3233,7 +3233,7 @@ async fn test_liveliness_subget_client_history_middle() {
     };
 
     let client_subget = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3255,7 +3255,7 @@ async fn test_liveliness_subget_client_history_middle() {
     assert!(sub.try_recv().is_err());
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3311,7 +3311,7 @@ async fn test_liveliness_subget_client_history_middle() {
 async fn test_liveliness_subget_peer_before() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -3323,7 +3323,7 @@ async fn test_liveliness_subget_peer_before() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3336,7 +3336,7 @@ async fn test_liveliness_subget_peer_before() {
     };
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3352,7 +3352,7 @@ async fn test_liveliness_subget_peer_before() {
     tokio::time::sleep(SLEEP).await;
 
     let peer_subget = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3404,7 +3404,7 @@ async fn test_liveliness_subget_peer_before() {
 async fn test_liveliness_subget_peer_middle() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -3416,7 +3416,7 @@ async fn test_liveliness_subget_peer_middle() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3429,7 +3429,7 @@ async fn test_liveliness_subget_peer_middle() {
     };
 
     let peer_subget = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3450,7 +3450,7 @@ async fn test_liveliness_subget_peer_middle() {
     assert!(sub.try_recv().is_err());
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3502,7 +3502,7 @@ async fn test_liveliness_subget_peer_middle() {
 async fn test_liveliness_subget_peer_history_before() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -3514,7 +3514,7 @@ async fn test_liveliness_subget_peer_history_before() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3527,7 +3527,7 @@ async fn test_liveliness_subget_peer_history_before() {
     };
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3543,7 +3543,7 @@ async fn test_liveliness_subget_peer_history_before() {
     tokio::time::sleep(SLEEP).await;
 
     let peer_subget = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3599,7 +3599,7 @@ async fn test_liveliness_subget_peer_history_before() {
 async fn test_liveliness_subget_peer_history_middle() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -3611,7 +3611,7 @@ async fn test_liveliness_subget_peer_history_middle() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3624,7 +3624,7 @@ async fn test_liveliness_subget_peer_history_middle() {
     };
 
     let peer_subget = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3646,7 +3646,7 @@ async fn test_liveliness_subget_peer_history_middle() {
     assert!(sub.try_recv().is_err());
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3702,7 +3702,7 @@ async fn test_liveliness_subget_peer_history_middle() {
 async fn test_liveliness_subget_router_before() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -3715,7 +3715,7 @@ async fn test_liveliness_subget_router_before() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3728,7 +3728,7 @@ async fn test_liveliness_subget_router_before() {
     };
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3744,7 +3744,7 @@ async fn test_liveliness_subget_router_before() {
     tokio::time::sleep(SLEEP).await;
 
     let router_subget = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_SUBGET_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3800,7 +3800,7 @@ async fn test_liveliness_subget_router_before() {
 async fn test_liveliness_subget_router_middle() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -3813,7 +3813,7 @@ async fn test_liveliness_subget_router_middle() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3826,7 +3826,7 @@ async fn test_liveliness_subget_router_middle() {
     };
 
     let router_subget = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_SUBGET_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3851,7 +3851,7 @@ async fn test_liveliness_subget_router_middle() {
     assert!(sub.try_recv().is_err());
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3903,7 +3903,7 @@ async fn test_liveliness_subget_router_middle() {
 async fn test_liveliness_subget_router_history_before() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -3916,7 +3916,7 @@ async fn test_liveliness_subget_router_history_before() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3929,7 +3929,7 @@ async fn test_liveliness_subget_router_history_before() {
     };
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3945,7 +3945,7 @@ async fn test_liveliness_subget_router_history_before() {
     tokio::time::sleep(SLEEP).await;
 
     let router_subget = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_SUBGET_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -4005,7 +4005,7 @@ async fn test_liveliness_subget_router_history_before() {
 async fn test_liveliness_subget_router_history_middle() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -4018,7 +4018,7 @@ async fn test_liveliness_subget_router_history_middle() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -4031,7 +4031,7 @@ async fn test_liveliness_subget_router_history_middle() {
     };
 
     let router_subget = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_SUBGET_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -4057,7 +4057,7 @@ async fn test_liveliness_subget_router_history_middle() {
     assert!(sub.try_recv().is_err());
 
     let client_tok = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])

--- a/zenoh/tests/liveliness.rs
+++ b/zenoh/tests/liveliness.rs
@@ -19,9 +19,8 @@ use zenoh_core::ztimeout;
 async fn test_liveliness_subscriber_clique() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
-    use zenoh_config::WhatAmI;
-    use zenoh_link::EndPoint;
+    use zenoh::{config::WhatAmI, sample::SampleKind};
+    use zenoh_config::EndPoint;
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
     const PEER1_ENDPOINT: &str = "tcp/localhost:47447";
@@ -30,10 +29,10 @@ async fn test_liveliness_subscriber_clique() {
     zenoh_util::init_log_from_env_or("error");
 
     let peer1 = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
-            .set(vec![PEER1_ENDPOINT.parse::<config::EndPoint>().unwrap()])
+            .set(vec![PEER1_ENDPOINT.parse::<EndPoint>().unwrap()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Peer));
@@ -43,7 +42,7 @@ async fn test_liveliness_subscriber_clique() {
     };
 
     let peer2 = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![PEER1_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -83,7 +82,7 @@ async fn test_liveliness_subscriber_clique() {
 async fn test_liveliness_query_clique() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
     const TIMEOUT: Duration = Duration::from_secs(60);
@@ -94,7 +93,7 @@ async fn test_liveliness_query_clique() {
     zenoh_util::init_log_from_env_or("error");
 
     let peer1 = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![PEER1_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -107,7 +106,7 @@ async fn test_liveliness_query_clique() {
     };
 
     let peer2 = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![PEER1_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -140,7 +139,7 @@ async fn test_liveliness_query_clique() {
 async fn test_liveliness_subscriber_brokered() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
 
@@ -152,7 +151,7 @@ async fn test_liveliness_subscriber_brokered() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -165,7 +164,7 @@ async fn test_liveliness_subscriber_brokered() {
     };
 
     let client1 = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -178,7 +177,7 @@ async fn test_liveliness_subscriber_brokered() {
     };
 
     let client2 = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -219,7 +218,7 @@ async fn test_liveliness_subscriber_brokered() {
 async fn test_liveliness_query_brokered() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     use zenoh_link::EndPoint;
     const TIMEOUT: Duration = Duration::from_secs(60);
@@ -230,7 +229,7 @@ async fn test_liveliness_query_brokered() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -243,7 +242,7 @@ async fn test_liveliness_query_brokered() {
     };
 
     let client1 = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -256,7 +255,7 @@ async fn test_liveliness_query_brokered() {
     };
 
     let client2 = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -290,7 +289,7 @@ async fn test_liveliness_query_brokered() {
 async fn test_liveliness_subscriber_local() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
+    use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
@@ -299,7 +298,7 @@ async fn test_liveliness_subscriber_local() {
     zenoh_util::init_log_from_env_or("error");
 
     let peer = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Peer));
         let s = ztimeout!(zenoh::open(c)).unwrap();
@@ -333,8 +332,7 @@ async fn test_liveliness_subscriber_local() {
 async fn test_liveliness_query_local() {
     use std::time::Duration;
 
-    use zenoh::{config, sample::SampleKind};
-    use zenoh_config::WhatAmI;
+    use zenoh::{config::WhatAmI, sample::SampleKind};
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/query/local";
@@ -342,7 +340,7 @@ async fn test_liveliness_query_local() {
     zenoh_util::init_log_from_env_or("error");
 
     let peer = {
-        let mut c = config::default();
+        let mut c = zenoh::Config::default();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Peer));
         let s = ztimeout!(zenoh::open(c)).unwrap();

--- a/zenoh/tests/matching.rs
+++ b/zenoh/tests/matching.rs
@@ -12,10 +12,12 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 #![cfg(feature = "unstable")]
-use std::{str::FromStr, time::Duration};
+
+use std::time::Duration;
 
 use flume::RecvTimeoutError;
-use zenoh::{config, config::Locator, sample::Locality, Result as ZResult, Session};
+use zenoh::{sample::Locality, Result as ZResult, Session};
+use zenoh_config::{ModeDependentValue, WhatAmI};
 use zenoh_core::ztimeout;
 
 const TIMEOUT: Duration = Duration::from_secs(60);
@@ -23,7 +25,7 @@ const RECV_TIMEOUT: Duration = Duration::from_secs(1);
 
 async fn create_session_pair(locator: &str) -> (Session, Session) {
     let config1 = {
-        let mut config = config::peer();
+        let mut config = zenoh::Config::default();
         config.scouting.multicast.set_enabled(Some(false)).unwrap();
         config
             .listen
@@ -32,7 +34,12 @@ async fn create_session_pair(locator: &str) -> (Session, Session) {
             .unwrap();
         config
     };
-    let config2 = config::client([Locator::from_str(locator).unwrap()]);
+    let mut config2 = zenoh::Config::default();
+    config2.set_mode(Some(WhatAmI::Client)).unwrap();
+    config2
+        .connect
+        .set_endpoints(ModeDependentValue::Unique(vec![locator.parse().unwrap()]))
+        .unwrap();
 
     let session1 = ztimeout!(zenoh::open(config1)).unwrap();
     let session2 = ztimeout!(zenoh::open(config2)).unwrap();
@@ -95,8 +102,8 @@ async fn zenoh_matching_status_any() -> ZResult<()> {
 async fn zenoh_matching_status_remote() -> ZResult<()> {
     zenoh_util::init_log_from_env_or("error");
 
-    let session1 = ztimeout!(zenoh::open(config::peer())).unwrap();
-    let session2 = ztimeout!(zenoh::open(config::peer())).unwrap();
+    let session1 = ztimeout!(zenoh::open(zenoh::Config::default())).unwrap();
+    let session2 = ztimeout!(zenoh::open(zenoh::Config::default())).unwrap();
 
     let publisher1 = ztimeout!(session1
         .declare_publisher("zenoh_matching_status_remote_test")
@@ -150,8 +157,8 @@ async fn zenoh_matching_status_remote() -> ZResult<()> {
 async fn zenoh_matching_status_local() -> ZResult<()> {
     zenoh_util::init_log_from_env_or("error");
 
-    let session1 = ztimeout!(zenoh::open(zenoh::config::peer())).unwrap();
-    let session2 = ztimeout!(zenoh::open(zenoh::config::peer())).unwrap();
+    let session1 = ztimeout!(zenoh::open(zenoh::Config::default())).unwrap();
+    let session2 = ztimeout!(zenoh::open(zenoh::Config::default())).unwrap();
 
     let publisher1 = ztimeout!(session1
         .declare_publisher("zenoh_matching_status_local_test")

--- a/zenoh/tests/open_time.rs
+++ b/zenoh/tests/open_time.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-#![cfg(any(feature = "unstable", feature = "unstable_config"))]
+#![cfg(feature = "unstable_config")]
 #![allow(unused)]
 use std::{
     future::IntoFuture,

--- a/zenoh/tests/open_time.rs
+++ b/zenoh/tests/open_time.rs
@@ -11,6 +11,8 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
+
+#![cfg(any(feature = "unstable", feature = "unstable_config"))]
 #![allow(unused)]
 use std::{
     future::IntoFuture,
@@ -37,7 +39,7 @@ async fn time_open(
     lowlatency: bool,
 ) {
     /* [ROUTER] */
-    let mut router_config = Config::default();
+    let mut router_config = zenoh::Config::default();
     router_config.set_mode(Some(WhatAmI::Router)).unwrap();
     router_config
         .listen
@@ -67,7 +69,7 @@ async fn time_open(
     );
 
     /* [APP] */
-    let mut app_config = Config::default();
+    let mut app_config = zenoh::Config::default();
     app_config.set_mode(Some(connect_mode)).unwrap();
     app_config
         .connect

--- a/zenoh/tests/qos.rs
+++ b/zenoh/tests/qos.rs
@@ -24,8 +24,8 @@ const SLEEP: Duration = Duration::from_secs(1);
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn qos_pubsub() {
-    let session1 = ztimeout!(zenoh::open(zenoh_config::peer())).unwrap();
-    let session2 = ztimeout!(zenoh::open(zenoh_config::peer())).unwrap();
+    let session1 = ztimeout!(zenoh::open(zenoh::Config::default())).unwrap();
+    let session2 = ztimeout!(zenoh::open(zenoh::Config::default())).unwrap();
 
     let publisher1 = ztimeout!(session1
         .declare_publisher("test/qos")

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-#![cfg(any(feature = "unstable", feature = "unstable_config"))]
+#![cfg(feature = "unstable_config")]
 
 use std::{
     sync::{

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -11,6 +11,9 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
+
+#![cfg(any(feature = "unstable", feature = "unstable_config"))]
+
 use std::{
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -20,11 +23,8 @@ use std::{
 };
 
 use tokio_util::sync::CancellationToken;
-use zenoh::{
-    config::{ModeDependentValue, WhatAmI, WhatAmIMatcher},
-    qos::CongestionControl,
-    Config, Result, Session,
-};
+use zenoh::{config::WhatAmI, qos::CongestionControl, Config, Result, Session};
+use zenoh_config::{ModeDependentValue, WhatAmIMatcher};
 use zenoh_core::ztimeout;
 use zenoh_result::bail;
 

--- a/zenoh/tests/session.rs
+++ b/zenoh/tests/session.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-#![cfg(any(feature = "unstable", feature = "unstable_config"))]
+#![cfg(feature = "unstable_config")]
 
 use std::{
     sync::{

--- a/zenoh/tests/session.rs
+++ b/zenoh/tests/session.rs
@@ -11,6 +11,9 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
+
+#![cfg(any(feature = "unstable", feature = "unstable_config"))]
+
 use std::{
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -23,7 +26,7 @@ use std::{
 use zenoh::internal::runtime::{Runtime, RuntimeBuilder};
 #[cfg(feature = "unstable")]
 use zenoh::pubsub::Reliability;
-use zenoh::{config, key_expr::KeyExpr, qos::CongestionControl, sample::SampleKind, Session};
+use zenoh::{key_expr::KeyExpr, qos::CongestionControl, sample::SampleKind, Session};
 use zenoh_core::ztimeout;
 #[cfg(not(feature = "unstable"))]
 use zenoh_protocol::core::Reliability;
@@ -36,7 +39,7 @@ const MSG_SIZE: [usize; 2] = [1_024, 100_000];
 
 async fn open_session_unicast(endpoints: &[&str]) -> (Session, Session) {
     // Open the sessions
-    let mut config = config::peer();
+    let mut config = zenoh::Config::default();
     config
         .listen
         .endpoints
@@ -51,7 +54,7 @@ async fn open_session_unicast(endpoints: &[&str]) -> (Session, Session) {
     println!("[  ][01a] Opening peer01 session: {:?}", endpoints);
     let peer01 = ztimeout!(zenoh::open(config)).unwrap();
 
-    let mut config = config::peer();
+    let mut config = zenoh::Config::default();
     config
         .connect
         .endpoints
@@ -71,7 +74,7 @@ async fn open_session_unicast(endpoints: &[&str]) -> (Session, Session) {
 
 async fn open_session_multicast(endpoint01: &str, endpoint02: &str) -> (Session, Session) {
     // Open the sessions
-    let mut config = config::peer();
+    let mut config = zenoh::Config::default();
     config
         .listen
         .endpoints
@@ -81,7 +84,7 @@ async fn open_session_multicast(endpoint01: &str, endpoint02: &str) -> (Session,
     println!("[  ][01a] Opening peer01 session: {}", endpoint01);
     let peer01 = ztimeout!(zenoh::open(config)).unwrap();
 
-    let mut config = config::peer();
+    let mut config = zenoh::Config::default();
     config
         .listen
         .endpoints
@@ -286,7 +289,7 @@ async fn zenoh_session_multicast() {
 #[cfg(feature = "internal")]
 async fn open_session_unicast_runtime(endpoints: &[&str]) -> (Runtime, Runtime) {
     // Open the sessions
-    let mut config = config::peer();
+    let mut config = zenoh::Config::default();
     config
         .listen
         .endpoints
@@ -302,7 +305,7 @@ async fn open_session_unicast_runtime(endpoints: &[&str]) -> (Runtime, Runtime) 
     let mut r1 = RuntimeBuilder::new(config).build().await.unwrap();
     r1.start().await.unwrap();
 
-    let mut config = config::peer();
+    let mut config = zenoh::Config::default();
     config
         .connect
         .endpoints

--- a/zenoh/tests/shm.rs
+++ b/zenoh/tests/shm.rs
@@ -21,7 +21,6 @@ use std::{
 };
 
 use zenoh::{
-    config,
     pubsub::Reliability,
     qos::CongestionControl,
     shm::{
@@ -40,7 +39,7 @@ const MSG_SIZE: [usize; 2] = [1_024, 100_000];
 
 async fn open_session_unicast(endpoints: &[&str]) -> (Session, Session) {
     // Open the sessions
-    let mut config = config::peer();
+    let mut config = zenoh::Config::default();
     config
         .listen
         .endpoints
@@ -55,7 +54,7 @@ async fn open_session_unicast(endpoints: &[&str]) -> (Session, Session) {
     println!("[  ][01a] Opening peer01 session: {:?}", endpoints);
     let peer01 = ztimeout!(zenoh::open(config)).unwrap();
 
-    let mut config = config::peer();
+    let mut config = zenoh::Config::default();
     config
         .connect
         .endpoints
@@ -75,7 +74,7 @@ async fn open_session_unicast(endpoints: &[&str]) -> (Session, Session) {
 
 async fn open_session_multicast(endpoint01: &str, endpoint02: &str) -> (Session, Session) {
     // Open the sessions
-    let mut config = config::peer();
+    let mut config = zenoh::Config::default();
     config
         .listen
         .endpoints
@@ -85,7 +84,7 @@ async fn open_session_multicast(endpoint01: &str, endpoint02: &str) -> (Session,
     println!("[  ][01a] Opening peer01 session: {}", endpoint01);
     let peer01 = ztimeout!(zenoh::open(config)).unwrap();
 
-    let mut config = config::peer();
+    let mut config = zenoh::Config::default();
     config
         .listen
         .endpoints

--- a/zenoh/tests/unicity.rs
+++ b/zenoh/tests/unicity.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-#![cfg(any(feature = "unstable", feature = "unstable_config"))]
+#![cfg(feature = "unstable_config")]
 
 use std::{
     sync::{

--- a/zenoh/tests/unicity.rs
+++ b/zenoh/tests/unicity.rs
@@ -11,6 +11,9 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
+
+#![cfg(any(feature = "unstable", feature = "unstable_config"))]
+
 use std::{
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -20,13 +23,8 @@ use std::{
 };
 
 use tokio::runtime::Handle;
-use zenoh::{
-    config,
-    config::{EndPoint, WhatAmI},
-    key_expr::KeyExpr,
-    qos::CongestionControl,
-    Session,
-};
+use zenoh::{config::WhatAmI, key_expr::KeyExpr, qos::CongestionControl, Session};
+use zenoh_config::{EndPoint, ModeDependentValue};
 use zenoh_core::ztimeout;
 
 const TIMEOUT: Duration = Duration::from_secs(60);
@@ -36,7 +34,7 @@ const MSG_SIZE: [usize; 2] = [1_024, 100_000];
 
 async fn open_p2p_sessions() -> (Session, Session, Session) {
     // Open the sessions
-    let mut config = config::peer();
+    let mut config = zenoh::Config::default();
     config
         .listen
         .endpoints
@@ -46,7 +44,7 @@ async fn open_p2p_sessions() -> (Session, Session, Session) {
     println!("[  ][01a] Opening s01 session");
     let s01 = ztimeout!(zenoh::open(config)).unwrap();
 
-    let mut config = config::peer();
+    let mut config = zenoh::Config::default();
     config
         .listen
         .endpoints
@@ -61,7 +59,7 @@ async fn open_p2p_sessions() -> (Session, Session, Session) {
     println!("[  ][02a] Opening s02 session");
     let s02 = ztimeout!(zenoh::open(config)).unwrap();
 
-    let mut config = config::peer();
+    let mut config = zenoh::Config::default();
     config
         .connect
         .endpoints
@@ -79,7 +77,7 @@ async fn open_p2p_sessions() -> (Session, Session, Session) {
 
 async fn open_router_session() -> Session {
     // Open the sessions
-    let mut config = config::default();
+    let mut config = zenoh::Config::default();
     config.set_mode(Some(WhatAmI::Router)).unwrap();
     config
         .listen
@@ -98,15 +96,36 @@ async fn close_router_session(s: Session) {
 
 async fn open_client_sessions() -> (Session, Session, Session) {
     // Open the sessions
-    let config = config::client(["tcp/127.0.0.1:37447".parse::<EndPoint>().unwrap()]);
+    let mut config = zenoh::Config::default();
+    config.set_mode(Some(WhatAmI::Client)).unwrap();
+    config
+        .connect
+        .set_endpoints(ModeDependentValue::Unique(vec!["tcp/127.0.0.1:37447"
+            .parse::<EndPoint>()
+            .unwrap()]))
+        .unwrap();
     println!("[  ][01a] Opening s01 session");
     let s01 = ztimeout!(zenoh::open(config)).unwrap();
 
-    let config = config::client(["tcp/127.0.0.1:37447".parse::<EndPoint>().unwrap()]);
+    let mut config = zenoh::Config::default();
+    config.set_mode(Some(WhatAmI::Client)).unwrap();
+    config
+        .connect
+        .set_endpoints(ModeDependentValue::Unique(vec!["tcp/127.0.0.1:37447"
+            .parse::<EndPoint>()
+            .unwrap()]))
+        .unwrap();
     println!("[  ][02a] Opening s02 session");
     let s02 = ztimeout!(zenoh::open(config)).unwrap();
 
-    let config = config::client(["tcp/127.0.0.1:37447".parse::<EndPoint>().unwrap()]);
+    let mut config = zenoh::Config::default();
+    config.set_mode(Some(WhatAmI::Client)).unwrap();
+    config
+        .connect
+        .set_endpoints(ModeDependentValue::Unique(vec!["tcp/127.0.0.1:37447"
+            .parse::<EndPoint>()
+            .unwrap()]))
+        .unwrap();
     println!("[  ][03a] Opening s03 session");
     let s03 = ztimeout!(zenoh::open(config)).unwrap();
 

--- a/zenohd/Cargo.toml
+++ b/zenohd/Cargo.toml
@@ -43,6 +43,7 @@ tracing-subscriber = {workspace = true}
 tracing-loki = {workspace = true, optional = true }
 url = {workspace = true, optional = true }
 zenoh = { workspace = true, features = ["unstable", "internal", "plugins"] }
+zenoh-config = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true, features = ["default"] }

--- a/zenohd/src/main.rs
+++ b/zenohd/src/main.rs
@@ -17,10 +17,8 @@ use git_version::git_version;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 #[cfg(feature = "loki")]
 use url::Url;
-use zenoh::{
-    config::{Config, EndPoint, ModeDependentValue, PermissionsConf, WhatAmI},
-    Result,
-};
+use zenoh::{config::WhatAmI, Config, Result};
+use zenoh_config::{EndPoint, ModeDependentValue, PermissionsConf};
 use zenoh_util::LibSearchDirs;
 
 #[cfg(feature = "loki")]


### PR DESCRIPTION
Addresses #1417 and #1304 with the following changes:

- Replace `zenoh::Config` with `zenoh::config::Config` leaving `zenoh_config::Config` unchanged.
- Add a new `zenoh_config::Config` with the following public items:
  - `Default`, `Debug`, `Clone` and `Default` impls
  - `Deref<Target = InternalConfig>` and `DerefMut<Target = InternalConfig>` impls with `cfg(feature = "unstable_config")`]
  - `from_env`, `from_file`, `insert_json5`, `get` and `remove`
- Reduce `zenoh::config` to the following public items:
  - `Config`
  - `InsertionError`
  - `LookupError`
  - `LookupGuard`
  - `WhatAmI` (for `zenoh::scout`)
  - `WhatAmIMatcher` (for `zenoh::scout`)
  - `Notifier` (for `zenoh::Session::config`)
  - `Notification` (for `zenoh::config::Notifier`)
- Move `Notifier` to the zenoh crate with the following API:
  - `new` (**not sure about this one**)
  - `subscribe`
  - `notify`
  - `lock`
  - `remove`
  - `insert_json5`
  - `get`

Older code using the `zenoh_config::Config` API will still compile provided that items such as `ModeDependentValue` are imported from `zenoh_config`.

<hr>

I believe the `Config` API changes is ready to be propagated to bindings. Here are CI runs to know what's going wrong:

- cc @wyfo https://github.com/eclipse-zenoh/zenoh-python/actions/runs/10886444693/job/30245908828
- cc @sashacmc https://github.com/eclipse-zenoh/zenoh-c/actions/runs/10886423431/job/30245904074
- cc @DariusIMP https://github.com/eclipse-zenoh/zenoh-java/actions/runs/10899780569
- cc @DariusIMP https://github.com/eclipse-zenoh/zenoh-kotlin/actions/runs/10886495298