### PR TITLE
Align naming style of `zenoh_config::defaults`

### DIFF
--- a/commons/zenoh-config/src/connection_retry.rs
+++ b/commons/zenoh-config/src/connection_retry.rs
@@ -16,14 +16,7 @@ use serde::{Deserialize, Serialize};
 use zenoh_core::zparse_default;
 use zenoh_protocol::core::{EndPoint, WhatAmI};
 
-use crate::{
-    defaults::{
-        self, DEFAULT_CONNECT_EXIT_ON_FAIL, DEFAULT_CONNECT_TIMEOUT_MS,
-        DEFAULT_LISTEN_EXIT_ON_FAIL, DEFAULT_LISTEN_TIMEOUT_MS,
-    },
-    mode_dependent::*,
-    Config,
-};
+use crate::{defaults, mode_dependent::*, Config};
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct ConnectionRetryModeDependentConf {
@@ -128,7 +121,7 @@ pub fn get_global_listener_timeout(config: &Config) -> std::time::Duration {
             .listen()
             .timeout_ms()
             .get(whatami)
-            .unwrap_or(DEFAULT_LISTEN_TIMEOUT_MS.get(whatami).unwrap()),
+            .unwrap_or(defaults::listen::timeout_ms.get(whatami).unwrap()),
     )
 }
 
@@ -139,7 +132,7 @@ pub fn get_global_connect_timeout(config: &Config) -> std::time::Duration {
             .connect()
             .timeout_ms()
             .get(whatami)
-            .unwrap_or(DEFAULT_CONNECT_TIMEOUT_MS.get(whatami).unwrap()),
+            .unwrap_or(defaults::connect::timeout_ms.get(whatami).unwrap()),
     )
 }
 
@@ -164,7 +157,7 @@ pub fn get_retry_config(
             .listen()
             .exit_on_failure()
             .get(whatami)
-            .unwrap_or(DEFAULT_LISTEN_EXIT_ON_FAIL.get(whatami).unwrap());
+            .unwrap_or(defaults::listen::exit_on_failure.get(whatami).unwrap());
     } else {
         retry = config
             .connect()
@@ -176,7 +169,7 @@ pub fn get_retry_config(
             .connect()
             .exit_on_failure()
             .get(whatami)
-            .unwrap_or(DEFAULT_CONNECT_EXIT_ON_FAIL.get(whatami).unwrap());
+            .unwrap_or(defaults::connect::exit_on_failure.get(whatami).unwrap());
     }
 
     let mut res = ConnectionRetryConf::new(whatami, exit_on_failure, retry, default_retry);

--- a/commons/zenoh-config/src/defaults.rs
+++ b/commons/zenoh-config/src/defaults.rs
@@ -34,6 +34,33 @@ pub const mode: WhatAmI = WhatAmI::Peer;
 
 #[allow(non_upper_case_globals)]
 #[allow(dead_code)]
+pub mod connect {
+    use super::{ModeDependentValue, ModeValues};
+
+    pub const timeout_ms: ModeDependentValue<i64> = ModeDependentValue::Dependent(ModeValues {
+        router: Some(-1),
+        peer: Some(-1),
+        client: Some(0),
+    });
+    pub const exit_on_failure: ModeDependentValue<bool> =
+        ModeDependentValue::Dependent(ModeValues {
+            router: Some(false),
+            peer: Some(false),
+            client: Some(true),
+        });
+}
+
+#[allow(non_upper_case_globals)]
+#[allow(dead_code)]
+pub mod listen {
+    use super::ModeDependentValue;
+
+    pub const timeout_ms: ModeDependentValue<i64> = ModeDependentValue::Unique(0);
+    pub const exit_on_failure: ModeDependentValue<bool> = ModeDependentValue::Unique(true);
+}
+
+#[allow(non_upper_case_globals)]
+#[allow(dead_code)]
 pub mod scouting {
     pub const timeout: u64 = 3000;
     pub const delay: u64 = 500;
@@ -260,23 +287,6 @@ impl Default for AclConfig {
         }
     }
 }
-
-pub const DEFAULT_CONNECT_TIMEOUT_MS: ModeDependentValue<i64> =
-    ModeDependentValue::Dependent(ModeValues {
-        client: Some(0),
-        peer: Some(-1),
-        router: Some(-1),
-    });
-
-pub const DEFAULT_CONNECT_EXIT_ON_FAIL: ModeDependentValue<bool> =
-    ModeDependentValue::Dependent(ModeValues {
-        client: Some(true),
-        peer: Some(false),
-        router: Some(false),
-    });
-
-pub const DEFAULT_LISTEN_TIMEOUT_MS: ModeDependentValue<i64> = ModeDependentValue::Unique(0);
-pub const DEFAULT_LISTEN_EXIT_ON_FAIL: ModeDependentValue<bool> = ModeDependentValue::Unique(true);
 
 impl Default for ConnectionRetryModeDependentConf {
     fn default() -> Self {


### PR DESCRIPTION
Addresses #1304.

Although this probably won't make it into the public API anymore.