### PR TITLE
Fix config rexport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2098,7 +2098,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if 1.0.0",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3869,6 +3869,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4687,7 +4697,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 
@@ -5108,7 +5118,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/commons/zenoh-macros/src/lib.rs
+++ b/commons/zenoh-macros/src/lib.rs
@@ -183,7 +183,7 @@ pub fn unstable(attr: TokenStream, tokens: TokenStream) -> TokenStream {
 
 // FIXME(fuzzypixelz): refactor `unstable` macro to accept arguments
 #[proc_macro_attribute]
-pub fn unstable_config(args: TokenStream, tokens: TokenStream) -> TokenStream {
+pub fn internal_config(args: TokenStream, tokens: TokenStream) -> TokenStream {
     let tokens = unstable_doc(args, tokens);
     let mut item = match parse_annotable_item!(tokens) {
         Ok(item) => item,
@@ -195,7 +195,7 @@ pub fn unstable_config(args: TokenStream, tokens: TokenStream) -> TokenStream {
         Err(err) => return err.into_compile_error().into(),
     };
 
-    let feature_gate: Attribute = parse_quote!(#[cfg(feature = "unstable_config")]);
+    let feature_gate: Attribute = parse_quote!(#[cfg(feature = "internal_config")]);
     attrs.push(feature_gate);
 
     TokenStream::from(item.to_token_stream())

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -64,8 +64,8 @@ transport_udp = ["zenoh-transport/transport_udp"]
 transport_unixsock-stream = ["zenoh-transport/transport_unixsock-stream"]
 transport_ws = ["zenoh-transport/transport_ws"]
 transport_vsock = ["zenoh-transport/transport_vsock"]
-unstable = ["unstable_config", "zenoh-keyexpr/unstable"]
-unstable_config = []
+unstable = ["internal_config", "zenoh-keyexpr/unstable"]
+internal_config = []
 
 [dependencies]
 tokio = { workspace = true, features = ["rt", "macros", "time"] }

--- a/zenoh/src/api/config.rs
+++ b/zenoh/src/api/config.rs
@@ -91,7 +91,7 @@ impl Config {
     }
 }
 
-#[zenoh_macros::unstable_config]
+#[zenoh_macros::internal_config]
 impl std::ops::Deref for Config {
     type Target = zenoh_config::Config;
 
@@ -100,7 +100,7 @@ impl std::ops::Deref for Config {
     }
 }
 
-#[zenoh_macros::unstable_config]
+#[zenoh_macros::internal_config]
 impl std::ops::DerefMut for Config {
     fn deref_mut(&mut self) -> &mut <Self as std::ops::Deref>::Target {
         &mut self.0

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -352,10 +352,6 @@ pub mod time {
 /// Configuration to pass to [`open`] and [`scout`] functions and associated constants
 pub mod config {
     pub use zenoh_config::{EndPoint, Locator, WhatAmI, WhatAmIMatcher, ZenohId};
-    #[zenoh_macros::unstable_config]
-    pub use zenoh_config::{
-        ModeDependentValue, PermissionsConf, PluginsConfig, SecretValue, ValidatedMap,
-    };
 
     pub use crate::api::config::Config;
     #[zenoh_macros::unstable]

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -186,7 +186,7 @@ pub mod key_expr {
 /// Zenoh [`Session`] and associated types
 pub mod session {
     #[zenoh_macros::unstable]
-    pub use zenoh_config::wrappers::{EntityGlobalId, ZenohId};
+    pub use zenoh_config::wrappers::EntityGlobalId;
     pub use zenoh_protocol::core::EntityId;
 
     #[zenoh_macros::internal]
@@ -351,7 +351,11 @@ pub mod time {
 
 /// Configuration to pass to [`open`] and [`scout`] functions and associated constants
 pub mod config {
-    pub use zenoh_config::{WhatAmI, WhatAmIMatcher};
+    pub use zenoh_config::{EndPoint, Locator, WhatAmI, WhatAmIMatcher, ZenohId};
+    #[zenoh_macros::unstable_config]
+    pub use zenoh_config::{
+        ModeDependentValue, PermissionsConf, PluginsConfig, SecretValue, ValidatedMap,
+    };
 
     pub use crate::api::config::Config;
     #[zenoh_macros::unstable]

--- a/zenoh/tests/acl.rs
+++ b/zenoh/tests/acl.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-#![cfg(feature = "unstable_config")]
+#![cfg(feature = "internal_config")]
 #![cfg(target_family = "unix")]
 mod test {
     use std::{

--- a/zenoh/tests/authentication.rs
+++ b/zenoh/tests/authentication.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-#![cfg(feature = "unstable_config")]
+#![cfg(feature = "internal_config")]
 
 mod test {
     use std::{

--- a/zenoh/tests/connection_retry.rs
+++ b/zenoh/tests/connection_retry.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-#![cfg(feature = "unstable_config")]
+#![cfg(feature = "internal_config")]
 
 use zenoh::{Config, Wait};
 use zenoh_config::{ConnectionRetryConf, EndPoint, ModeDependent};

--- a/zenoh/tests/events.rs
+++ b/zenoh/tests/events.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-#![cfg(feature = "unstable_config")]
+#![cfg(feature = "internal_config")]
 
 use std::time::Duration;
 

--- a/zenoh/tests/interceptors.rs
+++ b/zenoh/tests/interceptors.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-#![cfg(feature = "unstable_config")]
+#![cfg(feature = "internal_config")]
 #![cfg(unix)]
 
 use std::{

--- a/zenoh/tests/open_time.rs
+++ b/zenoh/tests/open_time.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-#![cfg(feature = "unstable_config")]
+#![cfg(feature = "internal_config")]
 #![allow(unused)]
 use std::{
     future::IntoFuture,

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-#![cfg(feature = "unstable_config")]
+#![cfg(feature = "internal_config")]
 
 use std::{
     sync::{

--- a/zenoh/tests/session.rs
+++ b/zenoh/tests/session.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-#![cfg(feature = "unstable_config")]
+#![cfg(feature = "internal_config")]
 
 use std::{
     sync::{

--- a/zenoh/tests/unicity.rs
+++ b/zenoh/tests/unicity.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-#![cfg(feature = "unstable_config")]
+#![cfg(feature = "internal_config")]
 
 use std::{
     sync::{


### PR DESCRIPTION
Rexport some config type under unstable_config feature.
Some type was erroneously removed by https://github.com/eclipse-zenoh/zenoh/pull/1419.