### PR TITLE
Make `zenoh::session::ZenohId` stable

### DIFF
--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -187,17 +187,21 @@ pub mod key_expr {
 pub mod session {
     #[zenoh_macros::unstable]
     pub use zenoh_config::wrappers::EntityGlobalId;
-    pub use zenoh_config::wrappers::ZenohId;
+
+    #[zenoh_macros::unstable]
     pub use zenoh_protocol::core::EntityId;
 
     #[zenoh_macros::internal]
     pub use crate::api::session::{init, InitBuilder};
+
     pub use crate::api::{
         builders::publisher::{SessionDeleteBuilder, SessionPutBuilder},
         info::{PeersZenohIdBuilder, RoutersZenohIdBuilder, SessionInfo, ZenohIdBuilder},
         query::SessionGetBuilder,
         session::{open, OpenBuilder, Session, Undeclarable},
     };
+
+    pub use zenoh_config::wrappers::ZenohId;
 }
 
 /// Sample primitives

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -186,7 +186,8 @@ pub mod key_expr {
 /// Zenoh [`Session`] and associated types
 pub mod session {
     #[zenoh_macros::unstable]
-    pub use zenoh_config::wrappers::{EntityGlobalId, ZenohId};
+    pub use zenoh_config::wrappers::EntityGlobalId;
+    pub use zenoh_config::wrappers::ZenohId;
     pub use zenoh_protocol::core::EntityId;
 
     #[zenoh_macros::internal]

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -187,21 +187,18 @@ pub mod key_expr {
 pub mod session {
     #[zenoh_macros::unstable]
     pub use zenoh_config::wrappers::EntityGlobalId;
-
+    pub use zenoh_config::wrappers::ZenohId;
     #[zenoh_macros::unstable]
     pub use zenoh_protocol::core::EntityId;
 
     #[zenoh_macros::internal]
     pub use crate::api::session::{init, InitBuilder};
-
     pub use crate::api::{
         builders::publisher::{SessionDeleteBuilder, SessionPutBuilder},
         info::{PeersZenohIdBuilder, RoutersZenohIdBuilder, SessionInfo, ZenohIdBuilder},
         query::SessionGetBuilder,
         session::{open, OpenBuilder, Session, Undeclarable},
     };
-
-    pub use zenoh_config::wrappers::ZenohId;
 }
 
 /// Sample primitives


### PR DESCRIPTION
This also makes `zenoh::session::EntityId` unstable, which was stable for some reason.