### PR TITLE
Fix keyexpr_tree lifetime

### DIFF
--- a/commons/zenoh-keyexpr/src/keyexpr_tree/traits/mod.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/traits/mod.rs
@@ -27,7 +27,7 @@ pub trait IKeyExprTree<'a, Weight> {
     /// Accesses the node at `key` if it exists, treating KEs as if they were completely verbatim keys.
     ///
     /// Returns `None` if `key` is not present in the KeTree.
-    fn node(&'a self, key: &keyexpr) -> Option<&Self::Node>;
+    fn node(&'a self, key: &keyexpr) -> Option<&'a Self::Node>;
 
     /// Returns a reference to the weight of the node at `key` if it exists.
     fn weight_at(&'a self, key: &keyexpr) -> Option<&'a Weight> {


### PR DESCRIPTION
Apply change as suggested by rustdoc.

```
~/zenoh (main) $ cargo +nightly rustdoc --package zenoh --features unstable,shared-memory -- --cfg doc_auto_cfg
warning: elided lifetime has a name
  --> commons/zenoh-keyexpr/src/keyexpr_tree/traits/mod.rs:30:48
   |
21 | pub trait IKeyExprTree<'a, Weight> {
   |                        -- lifetime `'a` declared here
...
30 |     fn node(&'a self, key: &keyexpr) -> Option<&Self::Node>;
   |                                                ^ this elided lifetime gets resolved as `'a`
   |
   = note: `#[warn(elided_named_lifetimes)]` on by default
```