### PR TITLE
refactor(storage-manager): implement cache for `History::Latest`

### DIFF
--- a/plugins/zenoh-backend-example/src/lib.rs
+++ b/plugins/zenoh-backend-example/src/lib.rs
@@ -62,7 +62,6 @@ impl Volume for ExampleBackend {
         Capability {
             persistence: Persistence::Volatile,
             history: History::Latest,
-            read_cost: 0,
         }
     }
     async fn create_storage(&self, _props: StorageConfig) -> ZResult<Box<dyn Storage>> {

--- a/plugins/zenoh-backend-traits/src/lib.rs
+++ b/plugins/zenoh-backend-traits/src/lib.rs
@@ -53,12 +53,11 @@
 //!     }
 //!
 //!     fn get_capability(&self) -> Capability {
-//!         // This operation is used to confirm if the volume indeed supports  
+//!         // This operation is used to confirm if the volume indeed supports
 //!         // the capabilities requested by the configuration
 //!         Capability{
 //!             persistence: Persistence::Volatile,
 //!             history: History::Latest,
-//!             read_cost: 0,
 //!         }
 //!     }
 //!
@@ -145,10 +144,6 @@ const FEATURES: &str =
 pub struct Capability {
     pub persistence: Persistence,
     pub history: History,
-    /// `read_cost` is a parameter that hels the storage manager take a decision on optimizing database roundtrips
-    /// If the `read_cost` is higher than a given threshold, the storage manger will maintain a cache with the keys present in the database
-    /// This is a placeholder, not actually utilised in the current implementation
-    pub read_cost: u32,
 }
 
 /// Persistence is the guarantee expected from a storage in case of failures
@@ -185,7 +180,6 @@ pub struct StoredData {
 }
 
 /// Trait to be implemented by a Backend.
-///
 #[async_trait]
 pub trait Volume: Send + Sync {
     /// Returns the status that will be sent as a reply to a query

--- a/plugins/zenoh-plugin-storage-manager/src/memory_backend/mod.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/memory_backend/mod.rs
@@ -53,7 +53,6 @@ impl Volume for MemoryBackend {
         Capability {
             persistence: Persistence::Volatile,
             history: History::Latest,
-            read_cost: 0,
         }
     }
 


### PR DESCRIPTION
The changes introduced in #1367 were actually redundant (and incomplete): the method `is_latest` was checking that a received Sample was more recent than what is currently stored.

This commit removes the redundant checks and implements a correct caching strategy by leveraging both approaches. The changes consist mostly in:
1. Changing the outer test by continuing early if the Sample is detected as deleted. This allows lowering the overall indentation of the `process_sample` method by one level.
2. Modifying the behaviour of the `is_latest` method to check the cache first and only query the Storage if there is a cache miss.

To help make potential concurrency issues visible, the method `is_latest` was renamed to `guard_cache_if_latest` as the lock on the Cache should only be released when the Sample has been processed *and* the Cache updated.

Additionally, the cache is filled at initialisation.

The `read_cost` configuration parameter was removed as it was not used and made obsolete with this change.

* plugins/zenoh-backend-example/src/lib.rs:
* plugins/zenoh-backend-traits/src/lib.rs:
* plugins/zenoh-plugin-storage-manager/src/memory_backend/mod.rs: removed the obsolete `read_cost` parameter.

* plugins/zenoh-plugin-storage-manager/src/storages_mgt/mod.rs:
  - Populate the Cache at initialisation.
  - Updated the call to `StorageService::start` to also pass the Cache.

* plugins/zenoh-plugin-storage-manager/src/storages_mgt/service.rs
  - Updated the call to `StorageService::start` to also pass the Cache.
  - "Reversed" the logic when checking if a Sample is deleted: if it is continue to the next one. This allows reducing the indentation level.
  - Keep the guard over the cache if a Sample is more recent and only release it once it has been updated (after the Sample has been successfully processed).