### PR TITLE
Reliability is exported in zenoh::qos

### DIFF
--- a/zenoh-ext/src/querying_subscriber.rs
+++ b/zenoh-ext/src/querying_subscriber.rs
@@ -21,7 +21,7 @@ use std::{
 };
 
 #[cfg(feature = "unstable")]
-use zenoh::pubsub::Reliability;
+use zenoh::qos::Reliability;
 use zenoh::{
     handlers::{locked, Callback, DefaultHandler, IntoHandler},
     internal::zlock,

--- a/zenoh/src/api/subscriber.rs
+++ b/zenoh/src/api/subscriber.rs
@@ -21,10 +21,11 @@ use tracing::error;
 use zenoh_core::{Resolvable, Wait};
 use zenoh_result::ZResult;
 #[cfg(feature = "unstable")]
-use {zenoh_config::wrappers::EntityGlobalId, zenoh_protocol::core::EntityGlobalIdProto};
+use {
+    crate::qos::Reliability, zenoh_config::wrappers::EntityGlobalId,
+    zenoh_protocol::core::EntityGlobalIdProto,
+};
 
-#[cfg(feature = "unstable")]
-use crate::pubsub::Reliability;
 use crate::{
     api::{
         handlers::{locked, Callback, DefaultHandler, IntoHandler},

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -229,9 +229,6 @@ pub mod bytes {
 /// Pub/sub primitives
 pub mod pubsub {
     #[zenoh_macros::unstable]
-    pub use zenoh_protocol::core::Reliability;
-
-    #[zenoh_macros::unstable]
     pub use crate::api::publisher::{
         MatchingListener, MatchingListenerBuilder, MatchingListenerUndeclaration, MatchingStatus,
     };
@@ -276,6 +273,8 @@ pub mod handlers {
 /// Quality of service primitives
 pub mod qos {
     pub use zenoh_protocol::core::CongestionControl;
+    #[zenoh_macros::unstable]
+    pub use zenoh_protocol::core::Reliability;
 
     pub use crate::api::publisher::Priority;
 }

--- a/zenoh/tests/session.rs
+++ b/zenoh/tests/session.rs
@@ -25,7 +25,7 @@ use std::{
 #[cfg(feature = "internal")]
 use zenoh::internal::runtime::{Runtime, RuntimeBuilder};
 #[cfg(feature = "unstable")]
-use zenoh::pubsub::Reliability;
+use zenoh::qos::Reliability;
 use zenoh::{key_expr::KeyExpr, qos::CongestionControl, sample::SampleKind, Session};
 use zenoh_core::ztimeout;
 #[cfg(not(feature = "unstable"))]

--- a/zenoh/tests/shm.rs
+++ b/zenoh/tests/shm.rs
@@ -21,8 +21,7 @@ use std::{
 };
 
 use zenoh::{
-    pubsub::Reliability,
-    qos::CongestionControl,
+    qos::{CongestionControl, Reliability},
     shm::{
         zshm, BlockOn, GarbageCollect, PosixShmProviderBackend, ShmProviderBuilder,
         POSIX_PROTOCOL_ID,


### PR DESCRIPTION
Move zenoh::pubsub::Reliability to zenoh::qos::Reliability.