### PR TITLE
chore: Update jsonschema to 0.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2012,9 +2012,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.19.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14a655181740aa66dfcb182daca1bc8109fda5c7c0399c4f30dcb155ab0d32a6"
+checksum = "f2eef4e82b548e08ac880d307c8e8838b45f497a08d3202f3b26c9debaed8058"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ http-types = "2.12.0"
 humantime = "2.1.0"
 itertools = "0.13.0"
 json5 = "0.4.1"
-jsonschema = { version = "0.19.1", default-features = false }
+jsonschema = { version = "0.20", default-features = false }
 keyed-set = "1.0.0"
 lazy_static = "1.5.0"
 libc = "0.2.158"

--- a/plugins/zenoh-plugin-rest/build.rs
+++ b/plugins/zenoh-plugin-rest/build.rs
@@ -27,10 +27,10 @@ fn main() {
     );
 
     let schema = serde_json::to_value(schema_for!(Config)).unwrap();
-    let schema = jsonschema::JSONSchema::compile(&schema).unwrap();
+    let validator = jsonschema::validator_for(&schema).unwrap();
     let config = std::fs::read_to_string("config.json5").unwrap();
     let config: serde_json::Value = serde_json::from_str(&config).unwrap();
-    if let Err(es) = schema.validate(&config) {
+    if let Err(es) = validator.validate(&config) {
         let es = es.map(|e| format!("{}", e)).collect::<Vec<_>>().join("\n");
         panic!("config.json5 schema validation error: {}", es);
     };

--- a/plugins/zenoh-plugin-storage-manager/build.rs
+++ b/plugins/zenoh-plugin-storage-manager/build.rs
@@ -23,10 +23,10 @@ fn main() {
     );
 
     let schema = serde_json::to_value(schema_for!(PluginConfig)).unwrap();
-    let schema = jsonschema::JSONSchema::compile(&schema).unwrap();
+    let validator = jsonschema::validator_for(&schema).unwrap();
     let config = std::fs::read_to_string("config.json5").unwrap();
     let config: serde_json::Value = serde_json::from_str(&config).unwrap();
-    if let Err(es) = schema.validate(&config) {
+    if let Err(es) = validator.validate(&config) {
         let es = es.map(|e| format!("{}", e)).collect::<Vec<_>>().join("\n");
         panic!("config.json5 schema validation error: {}", es);
     };


### PR DESCRIPTION
I've been updating the public API in `jsonschema` and I am here to update the version & add usage of the new API instead of the deprecated one. 