### PR TITLE
Fix router to router key expressions mapping

### DIFF
--- a/zenoh/src/net/routing/hat/router/interests.rs
+++ b/zenoh/src/net/routing/hat/router/interests.rs
@@ -115,6 +115,6 @@ impl HatInterestTrait for HatCode {
 
 #[inline]
 pub(super) fn push_declaration_profile(tables: &Tables, face: &FaceState) -> bool {
-    face.whatami == WhatAmI::Client
-        || (face.whatami == WhatAmI::Peer && !hat!(tables).full_net(WhatAmI::Peer))
+    !(face.whatami == WhatAmI::Client
+        || (face.whatami == WhatAmI::Peer && !hat!(tables).full_net(WhatAmI::Peer)))
 }


### PR DESCRIPTION
Before this fix key expressions were always sent plain text between routers impacting performances.