### PR TITLE
feat!: improve serialization efficiency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
- "half 2.4.1",
+ "half",
 ]
 
 [[package]]
@@ -1603,12 +1603,6 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
-
-[[package]]
-name = "half"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
@@ -1956,12 +1950,6 @@ checksum = "924e5d73ea28f59011fec52a0d12185d496a9b075d360657aed2a5707f701153"
 dependencies = [
  "nom",
 ]
-
-[[package]]
-name = "iter-read"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c397ca3ea05ad509c4ec451fea28b4771236a376ca1c69fd5143aae0cf8f93c4"
 
 [[package]]
 name = "itertools"
@@ -3650,29 +3638,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-pickle"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762ad136a26407c6a80825813600ceeab5e613660d93d79a41f0ec877171e71"
-dependencies = [
- "byteorder",
- "iter-read",
- "num-bigint",
- "num-traits",
- "serde",
-]
-
-[[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half 1.8.3",
- "serde",
 ]
 
 [[package]]
@@ -5424,8 +5389,6 @@ dependencies = [
  "rand 0.8.5",
  "rustc_version 0.4.1",
  "serde",
- "serde-pickle",
- "serde_cbor",
  "serde_json",
  "serde_yaml",
  "socket2 0.5.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,9 +154,7 @@ secrecy = { version = "0.8.0", features = ["serde", "alloc"] }
 serde = { version = "1.0.210", default-features = false, features = [
   "derive",
 ] } # Default features are disabled due to usage in no_std crates
-serde_cbor = "0.11.2"
 serde_json = "1.0.128"
-serde-pickle = "1.1.1"
 serde_yaml = "0.9.34"
 static_init = "1.0.3"
 stabby = "36.1.1"

--- a/ci/valgrind-check/src/pub_sub/bin/z_pub_sub.rs
+++ b/ci/valgrind-check/src/pub_sub/bin/z_pub_sub.rs
@@ -38,7 +38,7 @@ async fn main() {
                 sample.key_expr().as_str(),
                 sample
                     .payload()
-                    .deserialize::<String>()
+                    .try_deserialize::<String>()
                     .unwrap_or_else(|e| format!("{}", e))
             );
         })

--- a/ci/valgrind-check/src/queryable_get/bin/z_queryable_get.rs
+++ b/ci/valgrind-check/src/queryable_get/bin/z_queryable_get.rs
@@ -64,13 +64,13 @@ async fn main() {
                     sample.key_expr().as_str(),
                     sample
                         .payload()
-                        .deserialize::<String>()
+                        .try_deserialize::<String>()
                         .unwrap_or_else(|e| format!("{}", e))
                 ),
                 Err(err) => println!(
                     ">> Received (ERROR: '{}')",
                     err.payload()
-                        .deserialize::<String>()
+                        .try_deserialize::<String>()
                         .unwrap_or_else(|e| format!("{}", e))
                 ),
             }

--- a/commons/zenoh-buffers/src/zbuf.rs
+++ b/commons/zenoh-buffers/src/zbuf.rs
@@ -494,6 +494,11 @@ impl<'a> ZBufWriter<'a> {
         self.zslice_writer = zbuf.slices.last_mut().unwrap().writer();
         self.zslice_writer.as_mut().unwrap()
     }
+
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) {
+        self.zslice_writer().reserve(additional)
+    }
 }
 
 impl<'a> HasWriter for &'a mut ZBuf {

--- a/commons/zenoh-protocol/src/core/parameters.rs
+++ b/commons/zenoh-protocol/src/core/parameters.rs
@@ -374,6 +374,11 @@ impl<'s> From<Cow<'s, str>> for Parameters<'s> {
         }
     }
 }
+impl<'s> From<Parameters<'s>> for Cow<'s, str> {
+    fn from(value: Parameters<'s>) -> Self {
+        value.0
+    }
+}
 
 impl<'a> From<Parameters<'a>> for Cow<'_, Parameters<'a>> {
     fn from(props: Parameters<'a>) -> Self {

--- a/examples/examples/z_bytes.rs
+++ b/examples/examples/z_bytes.rs
@@ -21,7 +21,7 @@ fn main() {
     // Numeric: u8, u16, u32, u128, usize, i8, i16, i32, i128, isize, f32, f64
     let input = 1234_u32;
     let payload = ZBytes::from(input);
-    let output: u32 = payload.deserialize().unwrap();
+    let output: u32 = payload.try_deserialize().unwrap();
     assert_eq!(input, output);
     // Corresponding encoding to be used in operations like `.put()`, `.reply()`, etc.
     // let encoding = Encoding::ZENOH_UINT32;
@@ -29,7 +29,7 @@ fn main() {
     // String
     let input = String::from("test");
     let payload = ZBytes::from(&input);
-    let output: String = payload.deserialize().unwrap();
+    let output: String = payload.try_deserialize().unwrap();
     assert_eq!(input, output);
     // Corresponding encoding to be used in operations like `.put()`, `.reply()`, etc.
     // let encoding = Encoding::ZENOH_STRING;
@@ -38,7 +38,7 @@ fn main() {
     // See [`zenoh::bytes::ZBytes`] documentation for zero-copy behaviour.
     let input = Cow::from("test");
     let payload = ZBytes::from(&input);
-    let output: Cow<str> = payload.deserialize().unwrap();
+    let output: Cow<str> = payload.try_deserialize().unwrap();
     assert_eq!(input, output);
     // Corresponding encoding to be used in operations like `.put()`, `.reply()`, etc.
     // let encoding = Encoding::ZENOH_STRING;
@@ -46,10 +46,10 @@ fn main() {
     // Vec<u8>: The deserialization should be infallible
     let input: Vec<u8> = vec![1, 2, 3, 4];
     let payload = ZBytes::from(&input);
-    let output: Vec<u8> = payload.deserialize().unwrap();
+    let output: Vec<u8> = payload.try_deserialize().unwrap();
     assert_eq!(input, output);
     // Deserialization of Vec<u8> is infallible. See https://docs.rs/unwrap-infallible/latest/unwrap_infallible/.
-    let output: Vec<u8> = payload.deserialize().unwrap_infallible();
+    let output: Vec<u8> = payload.try_deserialize().unwrap_infallible();
     assert_eq!(input, output);
     // Since the deserialization of `Vec<u8>` is infallible, then `ZBytes` can be infallibly converted into a `Vec<u8>`.
     let output: Vec<u8> = payload.into();
@@ -61,10 +61,10 @@ fn main() {
     // See [`zenoh::bytes::ZBytes`] documentation for zero-copy behaviour.
     let input = Cow::from(vec![1, 2, 3, 4]);
     let payload = ZBytes::from(&input);
-    let output: Cow<[u8]> = payload.deserialize().unwrap();
+    let output: Cow<[u8]> = payload.try_deserialize().unwrap();
     assert_eq!(input, output);
     // Deserialization of `Cow<[u8]>` is infallible. See https://docs.rs/unwrap-infallible/latest/unwrap_infallible/.
-    let output: Cow<[u8]> = payload.deserialize().unwrap_infallible();
+    let output: Cow<[u8]> = payload.try_deserialize().unwrap_infallible();
     assert_eq!(input, output);
     // Since the deserialization of `Cow<[u8]>` is infallible, then `ZBytes` can be infallibly converted into a `Cow<[u8]>`.
     let output: Vec<u8> = payload.into();
@@ -74,7 +74,7 @@ fn main() {
 
     // Writer & Reader
     // serialization
-    let mut bytes = ZBytes::empty();
+    let mut bytes = ZBytes::new();
     let mut writer = bytes.writer();
     let i1 = 1234_u32;
     let i2 = String::from("test");
@@ -94,7 +94,7 @@ fn main() {
     // Tuple
     let input = (1234_u32, String::from("test"));
     let payload = ZBytes::serialize(input.clone());
-    let output: (u32, String) = payload.deserialize().unwrap();
+    let output: (u32, String) = payload.try_deserialize().unwrap();
     assert_eq!(input, output);
 
     // Iterator
@@ -116,7 +116,7 @@ fn main() {
     input.insert(0, String::from("abc"));
     input.insert(1, String::from("def"));
     let payload = ZBytes::from(input.clone());
-    let output = payload.deserialize::<HashMap<usize, String>>().unwrap();
+    let output = payload.try_deserialize::<HashMap<usize, String>>().unwrap();
     assert_eq!(input, output);
 
     // JSON
@@ -131,7 +131,7 @@ fn main() {
     }"#;
     let input: serde_json::Value = serde_json::from_str(data).unwrap();
     let payload = ZBytes::try_serialize(input.clone()).unwrap();
-    let output: serde_json::Value = payload.deserialize().unwrap();
+    let output: serde_json::Value = payload.try_deserialize().unwrap();
     assert_eq!(input, output);
     // Corresponding encoding to be used in operations like `.put()`, `.reply()`, etc.
     // let encoding = Encoding::APPLICATION_JSON;
@@ -146,7 +146,7 @@ fn main() {
     "#;
     let input: serde_yaml::Value = serde_yaml::from_str(data).unwrap();
     let payload = ZBytes::try_serialize(input.clone()).unwrap();
-    let output: serde_yaml::Value = payload.deserialize().unwrap();
+    let output: serde_yaml::Value = payload.try_deserialize().unwrap();
     assert_eq!(input, output);
     // Corresponding encoding to be used in operations like `.put()`, `.reply()`, etc.
     // let encoding = Encoding::APPLICATION_YAML;
@@ -166,7 +166,7 @@ fn main() {
     };
     let payload = ZBytes::from(input.encode_to_vec());
     let output =
-        EntityInfo::decode(Cursor::new(payload.deserialize::<Cow<[u8]>>().unwrap())).unwrap();
+        EntityInfo::decode(Cursor::new(payload.try_deserialize::<Cow<[u8]>>().unwrap())).unwrap();
     assert_eq!(input, output);
     // Corresponding encoding to be used in operations like `.put()`, `.reply()`, etc.
     // let encoding = Encoding::APPLICATION_PROTOBUF;

--- a/examples/examples/z_bytes_shm.rs
+++ b/examples/examples/z_bytes_shm.rs
@@ -62,7 +62,7 @@ fn main() {
     // branch to illustrate immutable access to SHM data
     {
         // deserialize ZBytes as an immutably borrowed zshm (ZBytes -> &zshm)
-        let borrowed_shm_buf: &zshm = payload.deserialize().unwrap();
+        let borrowed_shm_buf: &zshm = payload.try_deserialize().unwrap();
 
         // immutable API
         let _data: &[u8] = borrowed_shm_buf;

--- a/examples/examples/z_get.rs
+++ b/examples/examples/z_get.rs
@@ -49,7 +49,7 @@ async fn main() {
                 // Refer to z_bytes.rs to see how to deserialize different types of message
                 let payload = sample
                     .payload()
-                    .deserialize::<String>()
+                    .try_deserialize::<String>()
                     .unwrap_or_else(|e| format!("{}", e));
                 println!(
                     ">> Received ('{}': '{}')",
@@ -60,7 +60,7 @@ async fn main() {
             Err(err) => {
                 let payload = err
                     .payload()
-                    .deserialize::<String>()
+                    .try_deserialize::<String>()
                     .unwrap_or_else(|e| format!("{}", e));
                 println!(">> Received (ERROR: '{}')", payload);
             }

--- a/examples/examples/z_get_liveliness.rs
+++ b/examples/examples/z_get_liveliness.rs
@@ -40,7 +40,7 @@ async fn main() {
             Err(err) => {
                 let payload = err
                     .payload()
-                    .deserialize::<String>()
+                    .try_deserialize::<String>()
                     .unwrap_or_else(|e| format!("{}", e));
                 println!(">> Received (ERROR: '{}')", payload);
             }

--- a/examples/examples/z_get_shm.rs
+++ b/examples/examples/z_get_shm.rs
@@ -78,7 +78,7 @@ async fn main() {
         match reply.result() {
             Ok(sample) => {
                 print!(">> Received ('{}': ", sample.key_expr().as_str());
-                match sample.payload().deserialize::<&zshm>() {
+                match sample.payload().try_deserialize::<&zshm>() {
                     Ok(payload) => println!("'{}')", String::from_utf8_lossy(payload),),
                     Err(e) => println!("'Not a ShmBufInner: {:?}')", e),
                 }
@@ -86,7 +86,7 @@ async fn main() {
             Err(err) => {
                 let payload = err
                     .payload()
-                    .deserialize::<String>()
+                    .try_deserialize::<String>()
                     .unwrap_or_else(|e| format!("{}", e));
                 println!(">> Received (ERROR: '{}')", payload);
             }

--- a/examples/examples/z_pull.rs
+++ b/examples/examples/z_pull.rs
@@ -43,7 +43,7 @@ async fn main() {
             Ok(sample) => {
                 let payload = sample
                     .payload()
-                    .deserialize::<String>()
+                    .try_deserialize::<String>()
                     .unwrap_or_else(|e| format!("{}", e));
                 println!(
                     ">> [Subscriber] Pulled {} ('{}': '{}')... performing a computation of {:#?}",

--- a/examples/examples/z_queryable.rs
+++ b/examples/examples/z_queryable.rs
@@ -43,7 +43,7 @@ async fn main() {
             Some(query_payload) => {
                 // Refer to z_bytes.rs to see how to deserialize different types of message
                 let deserialized_payload = query_payload
-                    .deserialize::<String>()
+                    .try_deserialize::<String>()
                     .unwrap_or_else(|e| format!("{}", e));
                 println!(
                     ">> [Queryable ] Received Query '{}' with payload '{}'",

--- a/examples/examples/z_queryable_shm.rs
+++ b/examples/examples/z_queryable_shm.rs
@@ -144,7 +144,7 @@ fn handle_bytes(bytes: &ZBytes) -> (&str, String) {
 
         // if Zenoh is built with SHM support and with SHM API  we can detect the exact buffer type
         #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-        match bytes.deserialize::<&zshm>() {
+        match bytes.try_deserialize::<&zshm>() {
             Ok(_) => "SHM",
             Err(_) => "RAW",
         }
@@ -157,7 +157,7 @@ fn handle_bytes(bytes: &ZBytes) -> (&str, String) {
     //
     // Refer to z_bytes.rs to see how to deserialize different types of message
     let bytes_string = bytes
-        .deserialize::<String>()
+        .try_deserialize::<String>()
         .unwrap_or_else(|e| format!("{}", e));
 
     (bytes_type, bytes_string)

--- a/examples/examples/z_storage.rs
+++ b/examples/examples/z_storage.rs
@@ -51,7 +51,7 @@ async fn main() {
         select!(
             sample = subscriber.recv_async() => {
                 let sample = sample.unwrap();
-                let payload = sample.payload().deserialize::<String>().unwrap_or_else(|e| format!("{}", e));
+                let payload = sample.payload().try_deserialize::<String>().unwrap_or_else(|e| format!("{}", e));
                 println!(">> [Subscriber] Received {} ('{}': '{}')", sample.kind(), sample.key_expr().as_str(),payload);
                 match sample.kind() {
                     SampleKind::Delete => stored.remove(&sample.key_expr().to_string()),

--- a/examples/examples/z_sub.rs
+++ b/examples/examples/z_sub.rs
@@ -33,7 +33,7 @@ async fn main() {
         // Refer to z_bytes.rs to see how to deserialize different types of message
         let payload = sample
             .payload()
-            .deserialize::<String>()
+            .try_deserialize::<String>()
             .unwrap_or_else(|e| format!("{}", e));
 
         print!(
@@ -44,7 +44,7 @@ async fn main() {
         );
         if let Some(att) = sample.attachment() {
             let att = att
-                .deserialize::<String>()
+                .try_deserialize::<String>()
                 .unwrap_or_else(|e| format!("{}", e));
             print!(" ({})", att);
         }

--- a/examples/examples/z_sub_shm.rs
+++ b/examples/examples/z_sub_shm.rs
@@ -104,7 +104,7 @@ fn handle_bytes(bytes: &ZBytes) -> (&str, String) {
 
         // if Zenoh is built with SHM support and with SHM API  we can detect the exact buffer type
         #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-        match bytes.deserialize::<&zshm>() {
+        match bytes.try_deserialize::<&zshm>() {
             Ok(_) => "SHM",
             Err(_) => "RAW",
         }
@@ -117,7 +117,7 @@ fn handle_bytes(bytes: &ZBytes) -> (&str, String) {
     //
     // Refer to z_bytes.rs to see how to deserialize different types of message
     let bytes_string = bytes
-        .deserialize::<String>()
+        .try_deserialize::<String>()
         .unwrap_or_else(|e| format!("{}", e));
 
     (bytes_type, bytes_string)

--- a/plugins/zenoh-plugin-example/src/lib.rs
+++ b/plugins/zenoh-plugin-example/src/lib.rs
@@ -196,7 +196,7 @@ async fn run(runtime: Runtime, selector: KeyExpr<'_>, flag: Arc<AtomicBool>) {
             // on sample received by the Subscriber
             sample = sub.recv_async() => {
                 let sample = sample.unwrap();
-                let payload = sample.payload().deserialize::<Cow<str>>().unwrap_or_else(|e| Cow::from(e.to_string()));
+                let payload = sample.payload().try_deserialize::<Cow<str>>().unwrap_or_else(|e| Cow::from(e.to_string()));
                 info!("Received data ('{}': '{}')", sample.key_expr(), payload);
                 stored.insert(sample.key_expr().to_string(), sample);
             },

--- a/plugins/zenoh-plugin-storage-manager/src/replication/aligner.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replication/aligner.rs
@@ -89,7 +89,7 @@ impl Replication {
         };
 
         let alignment_query =
-            match bincode::deserialize::<AlignmentQuery>(&attachment.into::<Cow<[u8]>>()) {
+            match bincode::deserialize::<AlignmentQuery>(&attachment.deserialize::<Cow<[u8]>>()) {
                 Ok(alignment) => alignment,
                 Err(e) => {
                     tracing::error!(
@@ -368,7 +368,7 @@ impl Replication {
                                 continue;
                             }
                             Some(attachment) => match bincode::deserialize::<AlignmentReply>(
-                                &attachment.into::<Cow<[u8]>>(),
+                                &attachment.deserialize::<Cow<[u8]>>(),
                             ) {
                                 Err(e) => {
                                     tracing::error!(
@@ -655,7 +655,7 @@ async fn reply_to_query(query: &Query, reply: AlignmentReply, value: Option<Valu
             .attachment(attachment)
     } else {
         query
-            .reply(query.key_expr(), ZBytes::empty())
+            .reply(query.key_expr(), ZBytes::new())
             .attachment(attachment)
     };
 

--- a/plugins/zenoh-plugin-storage-manager/src/replication/core.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replication/core.rs
@@ -312,7 +312,7 @@ impl Replication {
                     // manner using the `span` we created just above.
                     async {
                         let other_digest = match bincode::deserialize::<Digest>(
-                            &sample.payload().into::<Cow<[u8]>>(),
+                            &sample.payload().deserialize::<Cow<[u8]>>(),
                         ) {
                             Ok(other_digest) => other_digest,
                             Err(e) => {

--- a/plugins/zenoh-plugin-storage-manager/src/storages_mgt/service.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/storages_mgt/service.rs
@@ -634,7 +634,7 @@ fn serialize_update(update: &Update) -> String {
         kind,
         data: StoredData { value, timestamp },
     } = update;
-    let zbuf: ZBuf = value.payload().into();
+    let zbuf: ZBuf = value.payload().deserialize();
 
     let result = (
         kind.to_string(),

--- a/plugins/zenoh-plugin-storage-manager/tests/operations.rs
+++ b/plugins/zenoh-plugin-storage-manager/tests/operations.rs
@@ -107,7 +107,10 @@ async fn test_updates_in_order() {
     // expects exactly one sample
     let data = get_data(&session, "operation/test/a").await;
     assert_eq!(data.len(), 1);
-    assert_eq!(data[0].payload().deserialize::<Cow<str>>().unwrap(), "1");
+    assert_eq!(
+        data[0].payload().try_deserialize::<Cow<str>>().unwrap(),
+        "1"
+    );
 
     put_data(
         &session,
@@ -122,7 +125,10 @@ async fn test_updates_in_order() {
     // expects exactly one sample
     let data = get_data(&session, "operation/test/b").await;
     assert_eq!(data.len(), 1);
-    assert_eq!(data[0].payload().deserialize::<Cow<str>>().unwrap(), "2");
+    assert_eq!(
+        data[0].payload().try_deserialize::<Cow<str>>().unwrap(),
+        "2"
+    );
 
     delete_data(
         &session,
@@ -140,7 +146,10 @@ async fn test_updates_in_order() {
     // expects exactly one sample
     let data = get_data(&session, "operation/test/b").await;
     assert_eq!(data.len(), 1);
-    assert_eq!(data[0].payload().deserialize::<Cow<str>>().unwrap(), "2");
+    assert_eq!(
+        data[0].payload().try_deserialize::<Cow<str>>().unwrap(),
+        "2"
+    );
     assert_eq!(data[0].key_expr().as_str(), "operation/test/b");
 
     drop(storage);

--- a/plugins/zenoh-plugin-storage-manager/tests/wildcard.rs
+++ b/plugins/zenoh-plugin-storage-manager/tests/wildcard.rs
@@ -120,7 +120,10 @@ async fn test_wild_card_in_order() {
     let data = get_data(&session, "wild/test/*").await;
     assert_eq!(data.len(), 1);
     assert_eq!(data[0].key_expr().as_str(), "wild/test/a");
-    assert_eq!(data[0].payload().deserialize::<Cow<str>>().unwrap(), "2");
+    assert_eq!(
+        data[0].payload().try_deserialize::<Cow<str>>().unwrap(),
+        "2"
+    );
 
     put_data(
         &session,
@@ -140,14 +143,14 @@ async fn test_wild_card_in_order() {
     assert!(["2", "3"].contains(
         &data[0]
             .payload()
-            .deserialize::<Cow<str>>()
+            .try_deserialize::<Cow<str>>()
             .unwrap()
             .as_ref()
     ));
     assert!(["2", "3"].contains(
         &data[1]
             .payload()
-            .deserialize::<Cow<str>>()
+            .try_deserialize::<Cow<str>>()
             .unwrap()
             .as_ref()
     ));
@@ -167,8 +170,14 @@ async fn test_wild_card_in_order() {
     assert_eq!(data.len(), 2);
     assert!(["wild/test/a", "wild/test/b"].contains(&data[0].key_expr().as_str()));
     assert!(["wild/test/a", "wild/test/b"].contains(&data[1].key_expr().as_str()));
-    assert_eq!(data[0].payload().deserialize::<Cow<str>>().unwrap(), "4");
-    assert_eq!(data[1].payload().deserialize::<Cow<str>>().unwrap(), "4");
+    assert_eq!(
+        data[0].payload().try_deserialize::<Cow<str>>().unwrap(),
+        "4"
+    );
+    assert_eq!(
+        data[1].payload().try_deserialize::<Cow<str>>().unwrap(),
+        "4"
+    );
 
     delete_data(
         &session,

--- a/zenoh-ext/examples/examples/z_query_sub.rs
+++ b/zenoh-ext/examples/examples/z_query_sub.rs
@@ -51,7 +51,7 @@ async fn main() {
     while let Ok(sample) = subscriber.recv_async().await {
         let payload = sample
             .payload()
-            .deserialize::<String>()
+            .try_deserialize::<String>()
             .unwrap_or_else(|e| format!("{}", e));
         println!(
             ">> [Subscriber] Received {} ('{}': '{}')",

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -32,25 +32,25 @@ maintenance = { status = "actively-developed" }
 auth_pubkey = ["zenoh-transport/auth_pubkey"]
 auth_usrpwd = ["zenoh-transport/auth_usrpwd"]
 default = [
-    "auth_pubkey",
-    "auth_usrpwd",
-    "transport_multilink",
-    "transport_compression",
-    "transport_quic",
-    "transport_tcp",
-    "transport_tls",
-    "transport_udp",
-    "transport_unixsock-stream",
-    "transport_ws",
+  "auth_pubkey",
+  "auth_usrpwd",
+  "transport_multilink",
+  "transport_compression",
+  "transport_quic",
+  "transport_tcp",
+  "transport_tls",
+  "transport_udp",
+  "transport_unixsock-stream",
+  "transport_ws",
 ]
 internal = ["zenoh-keyexpr/internal", "zenoh-config/internal"]
 plugins = []
 runtime_plugins = ["plugins"]
 shared-memory = [
-    "zenoh-shm",
-    "zenoh-protocol/shared-memory",
-    "zenoh-transport/shared-memory",
-    "zenoh-buffers/shared-memory",
+  "zenoh-shm",
+  "zenoh-protocol/shared-memory",
+  "zenoh-transport/shared-memory",
+  "zenoh-buffers/shared-memory",
 ]
 stats = ["zenoh-transport/stats", "zenoh-protocol/stats"]
 transport_multilink = ["zenoh-transport/transport_multilink"]
@@ -85,9 +85,7 @@ petgraph = { workspace = true }
 phf = { workspace = true }
 rand = { workspace = true, features = ["default"] }
 serde = { workspace = true, features = ["default"] }
-serde_cbor = { workspace = true }
 serde_json = { workspace = true }
-serde-pickle = { workspace = true }
 serde_yaml = { workspace = true }
 socket2 = { workspace = true }
 uhlc = { workspace = true, features = ["default"] }

--- a/zenoh/src/api/admin.rs
+++ b/zenoh/src/api/admin.rs
@@ -69,9 +69,9 @@ pub(crate) fn on_admin_query(session: &WeakSession, query: Query) {
             let key_expr = *KE_PREFIX / own_zid / *KE_SESSION / *KE_TRANSPORT_UNICAST / zid;
             if query.key_expr().intersects(&key_expr) {
                 if let Ok(value) = serde_json::value::to_value(peer.clone()) {
-                    match ZBytes::try_from(value) {
-                        Ok(zbuf) => {
-                            let _ = query.reply(key_expr, zbuf).wait();
+                    match ZBytes::try_serialize(value) {
+                        Ok(zbytes) => {
+                            let _ = query.reply(key_expr, zbytes).wait();
                         }
                         Err(e) => tracing::debug!("Admin query error: {}", e),
                     }
@@ -91,9 +91,9 @@ pub(crate) fn on_admin_query(session: &WeakSession, query: Query) {
                         / lid;
                     if query.key_expr().intersects(&key_expr) {
                         if let Ok(value) = serde_json::value::to_value(link) {
-                            match ZBytes::try_from(value) {
-                                Ok(zbuf) => {
-                                    let _ = query.reply(key_expr, zbuf).wait();
+                            match ZBytes::try_serialize(value) {
+                                Ok(zbytes) => {
+                                    let _ = query.reply(key_expr, zbytes).wait();
                                 }
                                 Err(e) => tracing::debug!("Admin query error: {}", e),
                             }

--- a/zenoh/src/api/builders/publisher.rs
+++ b/zenoh/src/api/builders/publisher.rs
@@ -228,7 +228,7 @@ impl Wait for PublicationBuilder<PublisherBuilder<'_, '_>, PublicationBuilderDel
     fn wait(self) -> <Self as Resolvable>::To {
         self.publisher.session.0.resolve_put(
             &self.publisher.key_expr?,
-            ZBytes::empty(),
+            ZBytes::new(),
             SampleKind::Delete,
             Encoding::ZENOH_BYTES,
             self.publisher.congestion_control,
@@ -459,7 +459,7 @@ impl Wait for PublicationBuilder<&Publisher<'_>, PublicationBuilderDelete> {
     fn wait(self) -> <Self as Resolvable>::To {
         self.publisher.session.resolve_put(
             &self.publisher.key_expr,
-            ZBytes::empty(),
+            ZBytes::new(),
             SampleKind::Delete,
             Encoding::ZENOH_BYTES,
             self.publisher.congestion_control,

--- a/zenoh/src/api/encoding.rs
+++ b/zenoh/src/api/encoding.rs
@@ -966,14 +966,6 @@ impl EncodingMapping for serde_yaml::Value {
     const ENCODING: Encoding = Encoding::APPLICATION_YAML;
 }
 
-impl EncodingMapping for serde_cbor::Value {
-    const ENCODING: Encoding = Encoding::APPLICATION_CBOR;
-}
-
-impl EncodingMapping for serde_pickle::Value {
-    const ENCODING: Encoding = Encoding::APPLICATION_PYTHON_SERIALIZED_OBJECT;
-}
-
 impl Encoding {
     #[zenoh_macros::internal]
     pub fn id(&self) -> EncodingId {

--- a/zenoh/src/api/query.rs
+++ b/zenoh/src/api/query.rs
@@ -14,6 +14,7 @@
 
 use std::{
     collections::HashMap,
+    convert::Infallible,
     error::Error,
     fmt::Display,
     future::{IntoFuture, Ready},
@@ -47,7 +48,7 @@ use super::{
 };
 #[cfg(feature = "unstable")]
 use super::{sample::SourceInfo, selector::ZenohParameters};
-use crate::bytes::OptionZBytes;
+use crate::bytes::{OptionZBytes, Serialize};
 
 /// The replies consolidation strategy to apply on replies to a [`get`](Session::get).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -382,12 +383,12 @@ impl<'a, 'b> SessionGetBuilder<'a, 'b, DefaultHandler> {
 }
 impl<'a, 'b, Handler> SessionGetBuilder<'a, 'b, Handler> {
     #[inline]
-    pub fn payload<IntoZBytes>(mut self, payload: IntoZBytes) -> Self
+    pub fn payload<'p, IntoZBytes>(mut self, payload: IntoZBytes) -> Self
     where
-        IntoZBytes: Into<ZBytes>,
+        IntoZBytes: Serialize<'p, Error = Infallible>,
     {
         let mut value = self.value.unwrap_or_default();
-        value.payload = payload.into();
+        value.payload = ZBytes::serialize(payload);
         self.value = Some(value);
         self
     }

--- a/zenoh/src/api/value.rs
+++ b/zenoh/src/api/value.rs
@@ -13,7 +13,11 @@
 //
 
 //! Value primitives.
+
+use std::convert::Infallible;
+
 use super::{bytes::ZBytes, encoding::Encoding};
+use crate::bytes::Serialize;
 
 /// A zenoh [`Value`] contains a `payload` and an [`Encoding`] that indicates how the payload's [`ZBytes`] should be interpreted.
 #[non_exhaustive]
@@ -25,20 +29,20 @@ pub struct Value {
 
 impl Value {
     /// Creates a new [`Value`] with specified [`ZBytes`] and  [`Encoding`].
-    pub fn new<T, E>(payload: T, encoding: E) -> Self
+    pub fn new<'a, T, E>(payload: T, encoding: E) -> Self
     where
-        T: Into<ZBytes>,
+        T: Serialize<'a, Error = Infallible>,
         E: Into<Encoding>,
     {
         Value {
-            payload: payload.into(),
+            payload: ZBytes::serialize(payload),
             encoding: encoding.into(),
         }
     }
     /// Creates an empty [`Value`].
     pub const fn empty() -> Self {
         Value {
-            payload: ZBytes::empty(),
+            payload: ZBytes::new(),
             encoding: Encoding::default(),
         }
     }

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -216,7 +216,7 @@ pub mod bytes {
     pub use crate::api::{
         bytes::{
             Deserialize, OptionZBytes, Serialize, ZBytes, ZBytesIterator, ZBytesReader,
-            ZBytesSliceIterator, ZBytesWriter, ZDeserializeError, ZSerde,
+            ZBytesSliceIterator, ZBytesWriter, ZDeserializeError,
         },
         encoding::Encoding,
     };

--- a/zenoh/tests/acl.rs
+++ b/zenoh/tests/acl.rs
@@ -141,7 +141,7 @@ mod test {
                 .callback(move |sample| {
                     if sample.kind() == SampleKind::Put {
                         let mut temp_value = zlock!(temp_recv_value);
-                        *temp_value = sample.payload().deserialize::<String>().unwrap();
+                        *temp_value = sample.payload().try_deserialize::<String>().unwrap();
                     } else if sample.kind() == SampleKind::Delete {
                         let mut deleted = zlock!(deleted_clone);
                         *deleted = true;
@@ -195,7 +195,7 @@ mod test {
                 .callback(move |sample| {
                     if sample.kind() == SampleKind::Put {
                         let mut temp_value = zlock!(temp_recv_value);
-                        *temp_value = sample.payload().deserialize::<String>().unwrap();
+                        *temp_value = sample.payload().try_deserialize::<String>().unwrap();
                     } else if sample.kind() == SampleKind::Delete {
                         let mut deleted = zlock!(deleted_clone);
                         *deleted = true;
@@ -277,7 +277,7 @@ mod test {
                 .callback(move |sample| {
                     if sample.kind() == SampleKind::Put {
                         let mut temp_value = zlock!(temp_recv_value);
-                        *temp_value = sample.payload().deserialize::<String>().unwrap();
+                        *temp_value = sample.payload().try_deserialize::<String>().unwrap();
                     } else if sample.kind() == SampleKind::Delete {
                         let mut deleted = zlock!(deleted_clone);
                         *deleted = true;
@@ -358,7 +358,7 @@ mod test {
                 .callback(move |sample| {
                     if sample.kind() == SampleKind::Put {
                         let mut temp_value = zlock!(temp_recv_value);
-                        *temp_value = sample.payload().deserialize::<String>().unwrap();
+                        *temp_value = sample.payload().try_deserialize::<String>().unwrap();
                     } else if sample.kind() == SampleKind::Delete {
                         let mut deleted = zlock!(deleted_clone);
                         *deleted = true;
@@ -436,7 +436,7 @@ mod test {
             while let Ok(reply) = ztimeout!(recv_reply.recv_async()) {
                 match reply.result() {
                     Ok(sample) => {
-                        received_value = sample.payload().deserialize::<String>().unwrap();
+                        received_value = sample.payload().try_deserialize::<String>().unwrap();
                         break;
                     }
                     Err(e) => println!("Error : {:?}", e),
@@ -490,7 +490,7 @@ mod test {
             while let Ok(reply) = ztimeout!(recv_reply.recv_async()) {
                 match reply.result() {
                     Ok(sample) => {
-                        received_value = sample.payload().deserialize::<String>().unwrap();
+                        received_value = sample.payload().try_deserialize::<String>().unwrap();
                         break;
                     }
                     Err(e) => println!("Error : {:?}", e),
@@ -571,7 +571,7 @@ mod test {
             while let Ok(reply) = ztimeout!(recv_reply.recv_async()) {
                 match reply.result() {
                     Ok(sample) => {
-                        received_value = sample.payload().deserialize::<String>().unwrap();
+                        received_value = sample.payload().try_deserialize::<String>().unwrap();
                         break;
                     }
                     Err(e) => println!("Error : {:?}", e),
@@ -650,7 +650,7 @@ mod test {
             while let Ok(reply) = ztimeout!(recv_reply.recv_async()) {
                 match reply.result() {
                     Ok(sample) => {
-                        received_value = sample.payload().deserialize::<String>().unwrap();
+                        received_value = sample.payload().try_deserialize::<String>().unwrap();
                         break;
                     }
                     Err(e) => println!("Error : {:?}", e),
@@ -718,7 +718,7 @@ mod test {
             while let Ok(reply) = ztimeout!(recv_reply.recv_async()) {
                 match reply.result() {
                     Ok(sample) => {
-                        received_value = sample.payload().deserialize::<String>().unwrap();
+                        received_value = sample.payload().try_deserialize::<String>().unwrap();
                         break;
                     }
                     Err(e) => println!("Error : {:?}", e),
@@ -792,7 +792,7 @@ mod test {
             while let Ok(reply) = ztimeout!(recv_reply.recv_async()) {
                 match reply.result() {
                     Ok(sample) => {
-                        received_value = sample.payload().deserialize::<String>().unwrap();
+                        received_value = sample.payload().try_deserialize::<String>().unwrap();
                         break;
                     }
                     Err(e) => println!("Error : {:?}", e),

--- a/zenoh/tests/attachments.rs
+++ b/zenoh/tests/attachments.rs
@@ -20,7 +20,7 @@ fn attachment_pubsub() {
     let _sub = zenoh
         .declare_subscriber("test/attachment")
         .callback(|sample| {
-            println!("{}", sample.payload().deserialize::<String>().unwrap());
+            println!("{}", sample.payload().try_deserialize::<String>().unwrap());
             for (k, v) in sample
                 .attachment()
                 .unwrap()
@@ -67,7 +67,7 @@ fn attachment_queries() {
         .callback(|query| {
             let s = query
                 .payload()
-                .map(|p| p.deserialize::<String>().unwrap())
+                .map(|p| p.try_deserialize::<String>().unwrap())
                 .unwrap_or_default();
             println!("Query value: {}", s);
 

--- a/zenoh/tests/authentication.rs
+++ b/zenoh/tests/authentication.rs
@@ -901,7 +901,7 @@ client2name:client2passwd";
                 .declare_subscriber(KEY_EXPR)
                 .callback(move |sample| {
                     let mut temp_value = zlock!(temp_recv_value);
-                    *temp_value = sample.payload().deserialize::<String>().unwrap();
+                    *temp_value = sample.payload().try_deserialize::<String>().unwrap();
                 })
                 .await
                 .unwrap();
@@ -969,7 +969,7 @@ client2name:client2passwd";
                     .declare_subscriber(KEY_EXPR)
                     .callback(move |sample| {
                         let mut temp_value = zlock!(temp_recv_value);
-                        *temp_value = sample.payload().deserialize::<String>().unwrap();
+                        *temp_value = sample.payload().try_deserialize::<String>().unwrap();
                     }))
                 .unwrap();
 
@@ -1052,13 +1052,13 @@ client2name:client2passwd";
             while let Ok(reply) = ztimeout!(recv_reply.recv_async()) {
                 match reply.result() {
                     Ok(sample) => {
-                        received_value = sample.payload().deserialize::<String>().unwrap();
+                        received_value = sample.payload().try_deserialize::<String>().unwrap();
                         break;
                     }
                     Err(e) => println!(
                         "Error : {}",
                         e.payload()
-                            .deserialize::<String>()
+                            .try_deserialize::<String>()
                             .unwrap_or_else(|e| format!("{}", e))
                     ),
                 }
@@ -1137,13 +1137,13 @@ client2name:client2passwd";
             while let Ok(reply) = ztimeout!(recv_reply.recv_async()) {
                 match reply.result() {
                     Ok(sample) => {
-                        received_value = sample.payload().deserialize::<String>().unwrap();
+                        received_value = sample.payload().try_deserialize::<String>().unwrap();
                         break;
                     }
                     Err(e) => println!(
                         "Error : {}",
                         e.payload()
-                            .deserialize::<String>()
+                            .try_deserialize::<String>()
                             .unwrap_or_else(|e| format!("{}", e))
                     ),
                 }
@@ -1211,7 +1211,7 @@ client2name:client2passwd";
                 .declare_subscriber(KEY_EXPR)
                 .callback(move |sample| {
                     let mut temp_value = zlock!(temp_recv_value);
-                    *temp_value = sample.payload().deserialize::<String>().unwrap();
+                    *temp_value = sample.payload().try_deserialize::<String>().unwrap();
                 })
                 .await
                 .unwrap();
@@ -1281,7 +1281,7 @@ client2name:client2passwd";
                     .declare_subscriber(KEY_EXPR)
                     .callback(move |sample| {
                         let mut temp_value = zlock!(temp_recv_value);
-                        *temp_value = sample.payload().deserialize::<String>().unwrap();
+                        *temp_value = sample.payload().try_deserialize::<String>().unwrap();
                     }))
                 .unwrap();
 
@@ -1365,13 +1365,13 @@ client2name:client2passwd";
             while let Ok(reply) = ztimeout!(recv_reply.recv_async()) {
                 match reply.result() {
                     Ok(sample) => {
-                        received_value = sample.payload().deserialize::<String>().unwrap();
+                        received_value = sample.payload().try_deserialize::<String>().unwrap();
                         break;
                     }
                     Err(e) => println!(
                         "Error : {}",
                         e.payload()
-                            .deserialize::<String>()
+                            .try_deserialize::<String>()
                             .unwrap_or_else(|e| format!("{}", e))
                     ),
                 }
@@ -1451,13 +1451,13 @@ client2name:client2passwd";
             while let Ok(reply) = ztimeout!(recv_reply.recv_async()) {
                 match reply.result() {
                     Ok(sample) => {
-                        received_value = sample.payload().deserialize::<String>().unwrap();
+                        received_value = sample.payload().try_deserialize::<String>().unwrap();
                         break;
                     }
                     Err(e) => println!(
                         "Error : {}",
                         e.payload()
-                            .deserialize::<String>()
+                            .try_deserialize::<String>()
                             .unwrap_or_else(|e| format!("{}", e))
                     ),
                 }
@@ -1526,7 +1526,7 @@ client2name:client2passwd";
                 .declare_subscriber(KEY_EXPR)
                 .callback(move |sample| {
                     let mut temp_value = zlock!(temp_recv_value);
-                    *temp_value = sample.payload().deserialize::<String>().unwrap();
+                    *temp_value = sample.payload().try_deserialize::<String>().unwrap();
                 })
                 .await
                 .unwrap();
@@ -1596,7 +1596,7 @@ client2name:client2passwd";
                     .declare_subscriber(KEY_EXPR)
                     .callback(move |sample| {
                         let mut temp_value = zlock!(temp_recv_value);
-                        *temp_value = sample.payload().deserialize::<String>().unwrap();
+                        *temp_value = sample.payload().try_deserialize::<String>().unwrap();
                     }))
                 .unwrap();
 
@@ -1680,13 +1680,13 @@ client2name:client2passwd";
             while let Ok(reply) = ztimeout!(recv_reply.recv_async()) {
                 match reply.result() {
                     Ok(sample) => {
-                        received_value = sample.payload().deserialize::<String>().unwrap();
+                        received_value = sample.payload().try_deserialize::<String>().unwrap();
                         break;
                     }
                     Err(e) => println!(
                         "Error : {}",
                         e.payload()
-                            .deserialize::<String>()
+                            .try_deserialize::<String>()
                             .unwrap_or_else(|e| format!("{}", e))
                     ),
                 }
@@ -1766,13 +1766,13 @@ client2name:client2passwd";
             while let Ok(reply) = ztimeout!(recv_reply.recv_async()) {
                 match reply.result() {
                     Ok(sample) => {
-                        received_value = sample.payload().deserialize::<String>().unwrap();
+                        received_value = sample.payload().try_deserialize::<String>().unwrap();
                         break;
                     }
                     Err(e) => println!(
                         "Error : {}",
                         e.payload()
-                            .deserialize::<String>()
+                            .try_deserialize::<String>()
                             .unwrap_or_else(|e| format!("{}", e))
                     ),
                 }
@@ -1843,7 +1843,7 @@ client2name:client2passwd";
                     .declare_subscriber(KEY_EXPR)
                     .callback(move |sample| {
                         let mut temp_value = zlock!(temp_recv_value);
-                        *temp_value = sample.payload().deserialize::<String>().unwrap();
+                        *temp_value = sample.payload().try_deserialize::<String>().unwrap();
                     }))
                 .unwrap();
 
@@ -1866,7 +1866,7 @@ client2name:client2passwd";
                     .declare_subscriber(KEY_EXPR)
                     .callback(move |sample| {
                         let mut temp_value = zlock!(temp_recv_value);
-                        *temp_value = sample.payload().deserialize::<String>().unwrap();
+                        *temp_value = sample.payload().try_deserialize::<String>().unwrap();
                     }))
                 .unwrap();
 
@@ -1939,7 +1939,7 @@ client2name:client2passwd";
                     .declare_subscriber(KEY_EXPR)
                     .callback(move |sample| {
                         let mut temp_value = zlock!(temp_recv_value);
-                        *temp_value = sample.payload().deserialize::<String>().unwrap();
+                        *temp_value = sample.payload().try_deserialize::<String>().unwrap();
                     }))
                 .unwrap();
 
@@ -1962,7 +1962,7 @@ client2name:client2passwd";
                     .declare_subscriber(KEY_EXPR)
                     .callback(move |sample| {
                         let mut temp_value = zlock!(temp_recv_value);
-                        *temp_value = sample.payload().deserialize::<String>().unwrap();
+                        *temp_value = sample.payload().try_deserialize::<String>().unwrap();
                     }))
                 .unwrap();
 

--- a/zenoh/tests/bytes.rs
+++ b/zenoh/tests/bytes.rs
@@ -53,7 +53,7 @@ fn shm_bytes_single_buf() {
     // branch to illustrate immutable access to SHM data
     {
         // deserialize ZBytes as an immutably borrowed zshm (ZBytes -> &zshm)
-        let borrowed_shm_buf: &zshm = payload.deserialize().unwrap();
+        let borrowed_shm_buf: &zshm = payload.try_deserialize().unwrap();
 
         // construct owned buffer from borrowed type (&zshm -> ZShm)
         let owned = borrowed_shm_buf.to_owned();

--- a/zenoh/tests/handler.rs
+++ b/zenoh/tests/handler.rs
@@ -35,7 +35,7 @@ fn pubsub_with_ringbuffer() {
             sub.recv()
                 .unwrap()
                 .payload()
-                .deserialize::<String>()
+                .try_deserialize::<String>()
                 .unwrap(),
             format!("put{i}")
         );
@@ -67,7 +67,11 @@ fn query_with_ringbuffer() {
     let query = queryable.recv().unwrap();
     // Only receive the latest query
     assert_eq!(
-        query.payload().unwrap().deserialize::<String>().unwrap(),
+        query
+            .payload()
+            .unwrap()
+            .try_deserialize::<String>()
+            .unwrap(),
         "query2"
     );
 }

--- a/zenoh/tests/shm.rs
+++ b/zenoh/tests/shm.rs
@@ -122,7 +122,7 @@ async fn test_session_pubsub(peer01: &Session, peer02: &Session, reliability: Re
             .declare_subscriber(&key_expr)
             .callback(move |sample| {
                 assert_eq!(sample.payload().len(), size);
-                let _ = sample.payload().deserialize::<&zshm>().unwrap();
+                let _ = sample.payload().try_deserialize::<&zshm>().unwrap();
                 c_msgs.fetch_add(1, Ordering::Relaxed);
             }))
         .unwrap();


### PR DESCRIPTION
Fixed-size objects are now written directly on the writer, instead of being wrapped first into a ZBytes.
Slice like objects are also written on the writer, but obviously prefixed by their size, like ZBytes.