### PR TITLE
feat(storage-manager): replication initial alignment

### DIFF
--- a/plugins/zenoh-plugin-storage-manager/src/replication/core.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replication/core.rs
@@ -43,8 +43,8 @@ use super::{
 use crate::{replication::aligner::AlignmentQuery, storages_mgt::LatestUpdates};
 
 kedefine!(
-    pub digest_key_expr_formatter: "@-digest/${zid:*}/${storage_ke:**}",
-    pub aligner_key_expr_formatter: "@zid/${zid:*}/${storage_ke:**}/aligner",
+    pub digest_key_expr_formatter: "@-digest/${zid:*}/${hash_configuration:*}",
+    pub aligner_key_expr_formatter: "@zid/${zid:*}/${hash_configuration:*}/aligner",
 );
 
 #[derive(Clone)]
@@ -69,16 +69,20 @@ impl Replication {
     ///
     /// [Log]: crate::replication::log::LogLatest
     pub(crate) fn spawn_digest_publisher(&self) -> JoinHandle<()> {
-        let zenoh_session = self.zenoh_session.clone();
-        let storage_key_expr = self.storage_key_expr.clone();
-        let replication_log = self.replication_log.clone();
-        let latest_updates = self.latest_updates.clone();
+        let replication = self.clone();
 
         tokio::task::spawn(async move {
+            let configuration = replication
+                .replication_log
+                .read()
+                .await
+                .configuration
+                .clone();
+
             let digest_key_put = match keformat!(
                 digest_key_expr_formatter::formatter(),
-                zid = zenoh_session.zid(),
-                storage_ke = storage_key_expr
+                zid = replication.zenoh_session.zid(),
+                hash_configuration = *configuration.fingerprint(),
             ) {
                 Ok(key) => key,
                 Err(e) => {
@@ -89,25 +93,14 @@ impl Replication {
                 }
             };
 
-            // Scope to not forget to release the lock.
-            let (publication_interval, propagation_delay, last_elapsed_interval) = {
-                let replication_log_guard = replication_log.read().await;
-                let configuration = replication_log_guard.configuration();
-                let last_elapsed_interval = match configuration.last_elapsed_interval() {
-                    Ok(idx) => idx,
-                    Err(e) => {
-                        tracing::error!(
-                            "Fatal error, call to `last_elapsed_interval` failed with: {e:?}"
-                        );
-                        return;
-                    }
-                };
-
-                (
-                    configuration.interval,
-                    configuration.propagation_delay,
-                    last_elapsed_interval,
-                )
+            let last_elapsed_interval = match configuration.last_elapsed_interval() {
+                Ok(idx) => idx,
+                Err(e) => {
+                    tracing::error!(
+                        "Fatal error, call to `last_elapsed_interval` failed with: {e:?}"
+                    );
+                    return;
+                }
             };
 
             // We have no control over when a replica is going to be started. The purpose is here
@@ -115,7 +108,7 @@ impl Replication {
             // at every interval (+ δ).
             let duration_until_next_interval = {
                 let millis_last_elapsed =
-                    *last_elapsed_interval as u128 * publication_interval.as_millis();
+                    *last_elapsed_interval as u128 * configuration.interval.as_millis();
 
                 if millis_last_elapsed > u64::MAX as u128 {
                     tracing::error!(
@@ -138,7 +131,7 @@ impl Replication {
                     };
 
                 Duration::from_millis(
-                    (publication_interval.as_millis() - (millis_since_now - millis_last_elapsed))
+                    (configuration.interval.as_millis() - (millis_since_now - millis_last_elapsed))
                         as u64,
                 )
             };
@@ -148,7 +141,7 @@ impl Replication {
             let mut events = HashMap::default();
 
             // Internal delay to avoid an "update storm".
-            let max_publication_delay = (publication_interval.as_millis() / 3) as u64;
+            let max_publication_delay = (configuration.interval.as_millis() / 3) as u64;
 
             let mut digest_update_start: Instant;
             let mut digest: Digest;
@@ -160,15 +153,15 @@ impl Replication {
                 // Except that we want to take into account the time it takes for a publication to
                 // reach this Zenoh node. Hence, we sleep for `propagation_delay` to, hopefully,
                 // catch the publications that are in transit.
-                tokio::time::sleep(propagation_delay).await;
+                tokio::time::sleep(configuration.propagation_delay).await;
 
                 {
-                    let mut latest_updates_guard = latest_updates.write().await;
+                    let mut latest_updates_guard = replication.latest_updates.write().await;
                     std::mem::swap(&mut events, &mut latest_updates_guard);
                 }
 
                 {
-                    let mut replication_guard = replication_log.write().await;
+                    let mut replication_guard = replication.replication_log.write().await;
                     replication_guard.update(events.drain().map(|(_, event)| event));
                     digest = match replication_guard.digest() {
                         Ok(digest) => digest,
@@ -194,7 +187,8 @@ impl Replication {
                 // buffer that, hopefully, has enough memory.
                 let buffer_capacity = serialization_buffer.capacity();
 
-                match zenoh_session
+                match replication
+                    .zenoh_session
                     .put(
                         &digest_key_put,
                         std::mem::replace(
@@ -209,17 +203,17 @@ impl Replication {
                 }
 
                 let digest_update_duration = digest_update_start.elapsed();
-                if digest_update_duration > publication_interval {
+                if digest_update_duration > configuration.interval {
                     tracing::warn!(
                         "The duration it took to update and publish the Digest is superior to the \
                          duration of an Interval ({} ms), we recommend increasing the duration of \
                          the latter. Digest update: {} ms (incl. delay: {} ms)",
-                        publication_interval.as_millis(),
+                        configuration.interval.as_millis(),
                         digest_update_duration.as_millis(),
-                        publication_delay + propagation_delay.as_millis() as u64
+                        publication_delay + configuration.propagation_delay.as_millis() as u64
                     );
                 } else {
-                    tokio::time::sleep(publication_interval - digest_update_duration).await;
+                    tokio::time::sleep(configuration.interval - digest_update_duration).await;
                 }
             }
         })
@@ -233,16 +227,20 @@ impl Replication {
     ///
     /// [DigestDiff]: super::digest::DigestDiff
     pub(crate) fn spawn_digest_subscriber(&self) -> JoinHandle<()> {
-        let zenoh_session = self.zenoh_session.clone();
-        let storage_key_expr = self.storage_key_expr.clone();
-        let replication_log = self.replication_log.clone();
         let replication = self.clone();
 
         tokio::task::spawn(async move {
+            let configuration = replication
+                .replication_log
+                .read()
+                .await
+                .configuration
+                .clone();
+
             let digest_key_sub = match keformat!(
                 digest_key_expr_formatter::formatter(),
                 zid = "*",
-                storage_ke = &storage_key_expr
+                hash_configuration = *configuration.fingerprint()
             ) {
                 Ok(key) => key,
                 Err(e) => {
@@ -257,7 +255,8 @@ impl Replication {
 
             let mut retry = 0;
             let subscriber = loop {
-                match zenoh_session
+                match replication
+                    .zenoh_session
                     .declare_subscriber(&digest_key_sub)
                     // NOTE: We need to explicitly set the locality to `Remote` as otherwise the
                     //       Digest subscriber will also receive the Digest published by its own
@@ -325,7 +324,7 @@ impl Replication {
 
                         tracing::debug!("Replication digest received");
 
-                        let digest = match replication_log.read().await.digest() {
+                        let digest = match replication.replication_log.read().await.digest() {
                             Ok(digest) => digest,
                             Err(e) => {
                                 tracing::error!(
@@ -340,7 +339,7 @@ impl Replication {
 
                             let replica_aligner_ke = match keformat!(
                                 aligner_key_expr_formatter::formatter(),
-                                storage_ke = &storage_key_expr,
+                                hash_configuration = *configuration.fingerprint(),
                                 zid = source_zid,
                             ) {
                                 Ok(key) => key,
@@ -373,15 +372,20 @@ impl Replication {
     /// responsible for fetching in the Replication Log or in the Storage the relevant information
     /// to send to the Replica such that it can align its own Storage.
     pub(crate) fn spawn_aligner_queryable(&self) -> JoinHandle<()> {
-        let zenoh_session = self.zenoh_session.clone();
-        let storage_key_expr = self.storage_key_expr.clone();
         let replication = self.clone();
 
         tokio::task::spawn(async move {
+            let configuration = replication
+                .replication_log
+                .read()
+                .await
+                .configuration
+                .clone();
+
             let aligner_ke = match keformat!(
                 aligner_key_expr_formatter::formatter(),
-                zid = zenoh_session.zid(),
-                storage_ke = storage_key_expr,
+                zid = replication.zenoh_session.zid(),
+                hash_configuration = *configuration.fingerprint(),
             ) {
                 Ok(ke) => ke,
                 Err(e) => {
@@ -395,7 +399,8 @@ impl Replication {
 
             let mut retry = 0;
             let queryable = loop {
-                match zenoh_session
+                match replication
+                    .zenoh_session
                     .declare_queryable(&aligner_ke)
                     .allowed_origin(Locality::Remote)
                     .await

--- a/plugins/zenoh-plugin-storage-manager/src/replication/service.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replication/service.rs
@@ -44,7 +44,7 @@ impl ReplicationService {
     ///    received.
     pub async fn spawn_start(
         zenoh_session: Arc<Session>,
-        storage_service: StorageService,
+        storage_service: &StorageService,
         storage_key_expr: OwnedKeyExpr,
         replication_log: Arc<RwLock<LogLatest>>,
         latest_updates: Arc<RwLock<LatestUpdates>>,
@@ -98,13 +98,15 @@ impl ReplicationService {
             );
         }
 
+        let storage = storage_service.storage.clone();
+
         tokio::task::spawn(async move {
             let replication = Replication {
                 zenoh_session,
                 replication_log,
                 storage_key_expr,
                 latest_updates,
-                storage: storage_service.storage.clone(),
+                storage,
             };
 
             let replication_service = Self {

--- a/plugins/zenoh-plugin-storage-manager/src/replication/service.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replication/service.rs
@@ -12,13 +12,13 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use tokio::{
     sync::{broadcast::Receiver, RwLock},
     task::JoinHandle,
 };
-use zenoh::{key_expr::OwnedKeyExpr, query::QueryTarget, sample::Locality, session::Session};
+use zenoh::{key_expr::OwnedKeyExpr, session::Session};
 
 use super::{core::Replication, LogLatest};
 use crate::storages_mgt::{LatestUpdates, StorageMessage, StorageService};
@@ -29,17 +29,22 @@ pub(crate) struct ReplicationService {
     aligner_queryable_handle: JoinHandle<()>,
 }
 
-pub(crate) const MAX_RETRY: usize = 2;
-pub(crate) const WAIT_PERIOD_SECS: u64 = 4;
-
 impl ReplicationService {
     /// Starts the `ReplicationService`, spawning multiple tasks.
     ///
+    /// # Initial alignment
+    ///
+    /// To optimise network resources, if the Storage is empty an "initial alignment" will be
+    /// performed: if a Replica is detected, a query will be made to retrieve the entire content of
+    /// its Storage.
+    ///
     /// # Tasks spawned
     ///
-    /// This function will spawn two tasks:
+    /// This function will spawn four long-lived tasks:
     /// 1. One to publish the [Digest].
-    /// 2. One to wait on the provided [Receiver] in order to stop the Replication Service,
+    /// 2. One to receive the [Digest] of other Replica.
+    /// 3. One to receive alignment queries of other Replica.
+    /// 4. One to wait on the provided [Receiver] in order to stop the Replication Service,
     ///    attempting to abort all the tasks that were spawned, once a Stop message has been
     ///    received.
     pub async fn spawn_start(
@@ -50,65 +55,27 @@ impl ReplicationService {
         latest_updates: Arc<RwLock<LatestUpdates>>,
         mut rx: Receiver<StorageMessage>,
     ) {
-        // We perform a "wait-try" policy because Zenoh needs some time to propagate the routing
-        // information and, here, we need to have the queryables propagated.
-        //
-        // 4 seconds is an arbitrary value.
-        let mut attempt = 0;
-        let mut received_reply = false;
-
-        while attempt < MAX_RETRY {
-            attempt += 1;
-            tokio::time::sleep(Duration::from_secs(WAIT_PERIOD_SECS)).await;
-
-            match zenoh_session
-                .get(&storage_key_expr)
-                // `BestMatching`, the default option for `target`, will try to minimise the storage
-                // that are queried and their distance while trying to maximise the key space
-                // covered.
-                //
-                // In other words, if there is a close and complete storage, it will only query this
-                // one.
-                .target(QueryTarget::BestMatching)
-                // The value `Remote` is self-explanatory but why it is needed deserves an
-                // explanation: we do not want to query the local database as the purpose is to get
-                // the data from other replicas (if there is one).
-                .allowed_destination(Locality::Remote)
-                .await
-            {
-                Ok(replies) => {
-                    while let Ok(reply) = replies.recv_async().await {
-                        received_reply = true;
-                        if let Ok(sample) = reply.into_result() {
-                            if let Err(e) = storage_service.process_sample(sample).await {
-                                tracing::error!("{e:?}");
-                            }
-                        }
-                    }
-                }
-                Err(e) => tracing::error!("Initial alignment Query failed with: {e:?}"),
-            }
-
-            if received_reply {
-                break;
-            }
-
-            tracing::debug!(
-                "Found no Queryable matching '{storage_key_expr}'. Attempt {attempt}/{MAX_RETRY}."
-            );
-        }
-
         let storage = storage_service.storage.clone();
 
-        tokio::task::spawn(async move {
-            let replication = Replication {
-                zenoh_session,
-                replication_log,
-                storage_key_expr,
-                latest_updates,
-                storage,
-            };
+        let replication = Replication {
+            zenoh_session,
+            replication_log,
+            storage_key_expr,
+            latest_updates,
+            storage,
+        };
 
+        if replication
+            .replication_log
+            .read()
+            .await
+            .intervals
+            .is_empty()
+        {
+            replication.initial_alignment().await;
+        }
+
+        tokio::task::spawn(async move {
             let replication_service = Self {
                 digest_publisher_handle: replication.spawn_digest_publisher(),
                 digest_subscriber_handle: replication.spawn_digest_subscriber(),
@@ -124,7 +91,7 @@ impl ReplicationService {
         });
     }
 
-    /// Stops all the tasks spawned by the `ReplicationService`.
+    /// Stops all the long-lived tasks spawned by the `ReplicationService`.
     pub fn stop(self) {
         self.digest_publisher_handle.abort();
         self.digest_subscriber_handle.abort();


### PR DESCRIPTION
These commits change the way a replicated Storage starts: if it is empty
and configured to be replicated, it will attempt to align with an active
and compatible (i.e. same configuration) Replica before anything.

The previous behaviour made a query on the key expression of the
Storage. Although, it could, in some cases, actually perform the same
initial alignment, it could not guarantee to only query a Storage that
was configured to be replicated.


⚠️  See individual commits for more details, they are meant to be reviewed separately.
⚠️ This PR is meant to be rebased (_not_ squashed).