### PR TITLE
Remove closing from hat trait

### DIFF
--- a/io/zenoh-transport/src/lib.rs
+++ b/io/zenoh-transport/src/lib.rs
@@ -82,7 +82,6 @@ impl TransportEventHandler for DummyTransportEventHandler {
 /*************************************/
 pub trait TransportMulticastEventHandler: Send + Sync {
     fn new_peer(&self, peer: TransportPeer) -> ZResult<Arc<dyn TransportPeerEventHandler>>;
-    fn closing(&self);
     fn closed(&self);
     fn as_any(&self) -> &dyn Any;
 }
@@ -95,7 +94,6 @@ impl TransportMulticastEventHandler for DummyTransportMulticastEventHandler {
     fn new_peer(&self, _peer: TransportPeer) -> ZResult<Arc<dyn TransportPeerEventHandler>> {
         Ok(Arc::new(DummyTransportPeerEventHandler))
     }
-    fn closing(&self) {}
     fn closed(&self) {}
     fn as_any(&self) -> &dyn Any {
         self
@@ -121,7 +119,6 @@ pub trait TransportPeerEventHandler: Send + Sync {
     fn handle_message(&self, msg: NetworkMessage) -> ZResult<()>;
     fn new_link(&self, src: Link);
     fn del_link(&self, link: Link);
-    fn closing(&self);
     fn closed(&self);
     fn as_any(&self) -> &dyn Any;
 }
@@ -137,7 +134,6 @@ impl TransportPeerEventHandler for DummyTransportPeerEventHandler {
 
     fn new_link(&self, _link: Link) {}
     fn del_link(&self, _link: Link) {}
-    fn closing(&self) {}
     fn closed(&self) {}
 
     fn as_any(&self) -> &dyn Any {

--- a/io/zenoh-transport/src/multicast/transport.rs
+++ b/io/zenoh-transport/src/multicast/transport.rs
@@ -178,11 +178,7 @@ impl TransportMulticastInner {
     pub(super) async fn delete(&self) -> ZResult<()> {
         tracing::debug!("Closing multicast transport on {:?}", self.locator);
 
-        // Notify the callback that we are going to close the transport
         let callback = zwrite!(self.callback).take();
-        if let Some(cb) = callback.as_ref() {
-            cb.closing();
-        }
 
         // Delete the transport on the manager
         let _ = self.manager.del_transport_multicast(&self.locator).await;
@@ -441,7 +437,6 @@ impl TransportMulticastInner {
 
             // TODO(yuyuan): Unify the termination
             peer.token.cancel();
-            peer.handler.closing();
             drop(guard);
             peer.handler.closed();
         }

--- a/io/zenoh-transport/src/unicast/lowlatency/transport.rs
+++ b/io/zenoh-transport/src/unicast/lowlatency/transport.rs
@@ -117,12 +117,7 @@ impl TransportUnicastLowlatency {
         // to avoid concurrent new_transport and closing/closed notifications
         let mut a_guard = self.get_alive().await;
         *a_guard = false;
-
-        // Notify the callback that we are going to close the transport
         let callback = zwrite!(self.callback).take();
-        if let Some(cb) = callback.as_ref() {
-            cb.closing();
-        }
 
         // Delete the transport on the manager
         let _ = self.manager.del_transport_unicast(&self.config.zid).await;

--- a/io/zenoh-transport/src/unicast/universal/transport.rs
+++ b/io/zenoh-transport/src/unicast/universal/transport.rs
@@ -129,12 +129,7 @@ impl TransportUnicastUniversal {
         // to avoid concurrent new_transport and closing/closed notifications
         let mut a_guard = self.get_alive().await;
         *a_guard = false;
-
-        // Notify the callback that we are going to close the transport
         let callback = zwrite!(self.callback).take();
-        if let Some(cb) = callback.as_ref() {
-            cb.closing();
-        }
 
         // Delete the transport on the manager
         let _ = self.manager.del_transport_unicast(&self.config.zid).await;

--- a/io/zenoh-transport/tests/endpoints.rs
+++ b/io/zenoh-transport/tests/endpoints.rs
@@ -62,7 +62,6 @@ impl TransportPeerEventHandler for SC {
     }
     fn new_link(&self, _link: Link) {}
     fn del_link(&self, _link: Link) {}
-    fn closing(&self) {}
     fn closed(&self) {}
 
     fn as_any(&self) -> &dyn Any {

--- a/io/zenoh-transport/tests/multicast_compression.rs
+++ b/io/zenoh-transport/tests/multicast_compression.rs
@@ -111,7 +111,6 @@ mod tests {
                 count: self.count.clone(),
             }))
         }
-        fn closing(&self) {}
         fn closed(&self) {}
 
         fn as_any(&self) -> &dyn Any {
@@ -127,7 +126,6 @@ mod tests {
 
         fn new_link(&self, _link: Link) {}
         fn del_link(&self, _link: Link) {}
-        fn closing(&self) {}
         fn closed(&self) {}
 
         fn as_any(&self) -> &dyn Any {

--- a/io/zenoh-transport/tests/multicast_transport.rs
+++ b/io/zenoh-transport/tests/multicast_transport.rs
@@ -110,7 +110,6 @@ mod tests {
                 count: self.count.clone(),
             }))
         }
-        fn closing(&self) {}
         fn closed(&self) {}
 
         fn as_any(&self) -> &dyn Any {
@@ -126,7 +125,6 @@ mod tests {
 
         fn new_link(&self, _link: Link) {}
         fn del_link(&self, _link: Link) {}
-        fn closing(&self) {}
         fn closed(&self) {}
 
         fn as_any(&self) -> &dyn Any {

--- a/io/zenoh-transport/tests/transport_whitelist.rs
+++ b/io/zenoh-transport/tests/transport_whitelist.rs
@@ -58,7 +58,6 @@ impl TransportPeerEventHandler for SCRouter {
 
     fn new_link(&self, _link: Link) {}
     fn del_link(&self, _link: Link) {}
-    fn closing(&self) {}
     fn closed(&self) {}
 
     fn as_any(&self) -> &dyn Any {

--- a/io/zenoh-transport/tests/unicast_authenticator.rs
+++ b/io/zenoh-transport/tests/unicast_authenticator.rs
@@ -70,7 +70,6 @@ impl TransportPeerEventHandler for MHRouterAuthenticator {
     }
     fn new_link(&self, _link: Link) {}
     fn del_link(&self, _link: Link) {}
-    fn closing(&self) {}
     fn closed(&self) {}
 
     fn as_any(&self) -> &dyn Any {

--- a/io/zenoh-transport/tests/unicast_compression.rs
+++ b/io/zenoh-transport/tests/unicast_compression.rs
@@ -110,7 +110,6 @@ mod tests {
 
         fn new_link(&self, _link: Link) {}
         fn del_link(&self, _link: Link) {}
-        fn closing(&self) {}
         fn closed(&self) {}
 
         fn as_any(&self) -> &dyn Any {
@@ -150,7 +149,6 @@ mod tests {
 
         fn new_link(&self, _link: Link) {}
         fn del_link(&self, _link: Link) {}
-        fn closing(&self) {}
         fn closed(&self) {}
 
         fn as_any(&self) -> &dyn Any {

--- a/io/zenoh-transport/tests/unicast_concurrent.rs
+++ b/io/zenoh-transport/tests/unicast_concurrent.rs
@@ -98,7 +98,6 @@ impl TransportPeerEventHandler for MHPeer {
 
     fn new_link(&self, _link: Link) {}
     fn del_link(&self, _link: Link) {}
-    fn closing(&self) {}
     fn closed(&self) {}
 
     fn as_any(&self) -> &dyn Any {

--- a/io/zenoh-transport/tests/unicast_intermittent.rs
+++ b/io/zenoh-transport/tests/unicast_intermittent.rs
@@ -138,7 +138,6 @@ impl TransportPeerEventHandler for SCClient {
 
     fn new_link(&self, _link: Link) {}
     fn del_link(&self, _link: Link) {}
-    fn closing(&self) {}
     fn closed(&self) {}
 
     fn as_any(&self) -> &dyn Any {

--- a/io/zenoh-transport/tests/unicast_priorities.rs
+++ b/io/zenoh-transport/tests/unicast_priorities.rs
@@ -133,7 +133,6 @@ impl TransportPeerEventHandler for SCRouter {
 
     fn new_link(&self, _link: Link) {}
     fn del_link(&self, _link: Link) {}
-    fn closing(&self) {}
     fn closed(&self) {}
 
     fn as_any(&self) -> &dyn Any {
@@ -183,7 +182,6 @@ impl TransportPeerEventHandler for SCClient {
 
     fn new_link(&self, _link: Link) {}
     fn del_link(&self, _link: Link) {}
-    fn closing(&self) {}
     fn closed(&self) {}
 
     fn as_any(&self) -> &dyn Any {

--- a/io/zenoh-transport/tests/unicast_shm.rs
+++ b/io/zenoh-transport/tests/unicast_shm.rs
@@ -141,7 +141,6 @@ mod tests {
 
         fn new_link(&self, _link: Link) {}
         fn del_link(&self, _link: Link) {}
-        fn closing(&self) {}
         fn closed(&self) {}
 
         fn as_any(&self) -> &dyn Any {

--- a/io/zenoh-transport/tests/unicast_simultaneous.rs
+++ b/io/zenoh-transport/tests/unicast_simultaneous.rs
@@ -126,7 +126,6 @@ mod tests {
 
         fn new_link(&self, _link: Link) {}
         fn del_link(&self, _link: Link) {}
-        fn closing(&self) {}
         fn closed(&self) {}
 
         fn as_any(&self) -> &dyn Any {

--- a/io/zenoh-transport/tests/unicast_transport.rs
+++ b/io/zenoh-transport/tests/unicast_transport.rs
@@ -296,7 +296,6 @@ impl TransportPeerEventHandler for SCRouter {
 
     fn new_link(&self, _link: Link) {}
     fn del_link(&self, _link: Link) {}
-    fn closing(&self) {}
     fn closed(&self) {}
 
     fn as_any(&self) -> &dyn Any {
@@ -336,7 +335,6 @@ impl TransportPeerEventHandler for SCClient {
 
     fn new_link(&self, _link: Link) {}
     fn del_link(&self, _link: Link) {}
-    fn closing(&self) {}
     fn closed(&self) {}
 
     fn as_any(&self) -> &dyn Any {

--- a/zenoh/src/api/admin.rs
+++ b/zenoh/src/api/admin.rs
@@ -187,8 +187,6 @@ impl TransportMulticastEventHandler for Handler {
         }
     }
 
-    fn closing(&self) {}
-
     fn closed(&self) {}
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -249,8 +247,6 @@ impl TransportPeerEventHandler for PeerHandler {
             None,
         );
     }
-
-    fn closing(&self) {}
 
     fn closed(&self) {
         let info = DataInfo {

--- a/zenoh/src/net/primitives/demux.rs
+++ b/zenoh/src/net/primitives/demux.rs
@@ -100,8 +100,6 @@ impl TransportPeerEventHandler for DeMux {
 
     fn del_link(&self, _link: Link) {}
 
-    fn closing(&self) {}
-
     fn closed(&self) {
         self.face.send_close();
     }

--- a/zenoh/src/net/primitives/demux.rs
+++ b/zenoh/src/net/primitives/demux.rs
@@ -100,24 +100,11 @@ impl TransportPeerEventHandler for DeMux {
 
     fn del_link(&self, _link: Link) {}
 
-    fn closing(&self) {
-        self.face.send_close();
-        if let Some(transport) = self.transport.as_ref() {
-            let mut declares = vec![];
-            let ctrl_lock = zlock!(self.face.tables.ctrl_lock);
-            let mut tables = zwrite!(self.face.tables.tables);
-            let _ = ctrl_lock.closing(&mut tables, &self.face.tables, transport, &mut |p, m| {
-                declares.push((p.clone(), m))
-            });
-            drop(tables);
-            drop(ctrl_lock);
-            for (p, m) in declares {
-                p.send_declare(m);
-            }
-        }
-    }
+    fn closing(&self) {}
 
-    fn closed(&self) {}
+    fn closed(&self) {
+        self.face.send_close();
+    }
 
     fn as_any(&self) -> &dyn Any {
         self

--- a/zenoh/src/net/primitives/mux.rs
+++ b/zenoh/src/net/primitives/mux.rs
@@ -200,9 +200,7 @@ impl Primitives for Mux {
         }
     }
 
-    fn send_close(&self) {
-        // self.handler.closing().await;
-    }
+    fn send_close(&self) {}
 }
 
 impl EPrimitives for Mux {
@@ -530,9 +528,7 @@ impl Primitives for McastMux {
         }
     }
 
-    fn send_close(&self) {
-        // self.handler.closing().await;
-    }
+    fn send_close(&self) {}
 }
 
 impl EPrimitives for McastMux {

--- a/zenoh/src/net/routing/hat/client/mod.rs
+++ b/zenoh/src/net/routing/hat/client/mod.rs
@@ -130,6 +130,7 @@ impl HatBaseTrait for HatCode {
     fn close_face(
         &self,
         tables: &TablesLock,
+        _tables_ref: &Arc<TablesLock>,
         face: &mut Arc<FaceState>,
         send_declare: &mut SendDeclare,
     ) {
@@ -258,16 +259,6 @@ impl HatBaseTrait for HatCode {
         _routing_context: NodeId,
     ) -> NodeId {
         0
-    }
-
-    fn closing(
-        &self,
-        _tables: &mut Tables,
-        _tables_ref: &Arc<TablesLock>,
-        _transport: &TransportUnicast,
-        _send_declare: &mut SendDeclare,
-    ) -> ZResult<()> {
-        Ok(())
     }
 
     #[inline]

--- a/zenoh/src/net/routing/hat/mod.rs
+++ b/zenoh/src/net/routing/hat/mod.rs
@@ -131,17 +131,10 @@ pub(crate) trait HatBaseTrait {
 
     fn info(&self, tables: &Tables, kind: WhatAmI) -> String;
 
-    fn closing(
-        &self,
-        tables: &mut Tables,
-        tables_ref: &Arc<TablesLock>,
-        transport: &TransportUnicast,
-        send_declare: &mut SendDeclare,
-    ) -> ZResult<()>;
-
     fn close_face(
         &self,
         tables: &TablesLock,
+        tables_ref: &Arc<TablesLock>,
         face: &mut Arc<FaceState>,
         send_declare: &mut SendDeclare,
     );

--- a/zenoh/src/net/routing/hat/router/mod.rs
+++ b/zenoh/src/net/routing/hat/router/mod.rs
@@ -430,6 +430,7 @@ impl HatBaseTrait for HatCode {
     fn close_face(
         &self,
         tables: &TablesLock,
+        tables_ref: &Arc<TablesLock>,
         face: &mut Arc<FaceState>,
         send_declare: &mut SendDeclare,
     ) {
@@ -536,6 +537,84 @@ impl HatBaseTrait for HatCode {
             Resource::clean(&mut res);
         }
         wtables.faces.remove(&face.id);
+
+        match face.whatami {
+            WhatAmI::Router => {
+                for (_, removed_node) in hat_mut!(wtables)
+                    .routers_net
+                    .as_mut()
+                    .unwrap()
+                    .remove_link(&face.zid)
+                {
+                    pubsub_remove_node(
+                        &mut wtables,
+                        &removed_node.zid,
+                        WhatAmI::Router,
+                        send_declare,
+                    );
+                    queries_remove_node(
+                        &mut wtables,
+                        &removed_node.zid,
+                        WhatAmI::Router,
+                        send_declare,
+                    );
+                    token_remove_node(
+                        &mut wtables,
+                        &removed_node.zid,
+                        WhatAmI::Router,
+                        send_declare,
+                    );
+                }
+
+                if hat!(wtables).full_net(WhatAmI::Peer) {
+                    hat_mut!(wtables).shared_nodes = shared_nodes(
+                        hat!(wtables).routers_net.as_ref().unwrap(),
+                        hat!(wtables).linkstatepeers_net.as_ref().unwrap(),
+                    );
+                }
+
+                hat_mut!(wtables).schedule_compute_trees(tables_ref.clone(), WhatAmI::Router);
+            }
+            WhatAmI::Peer => {
+                if hat!(wtables).full_net(WhatAmI::Peer) {
+                    for (_, removed_node) in hat_mut!(wtables)
+                        .linkstatepeers_net
+                        .as_mut()
+                        .unwrap()
+                        .remove_link(&face.zid)
+                    {
+                        pubsub_remove_node(
+                            &mut wtables,
+                            &removed_node.zid,
+                            WhatAmI::Peer,
+                            send_declare,
+                        );
+                        queries_remove_node(
+                            &mut wtables,
+                            &removed_node.zid,
+                            WhatAmI::Peer,
+                            send_declare,
+                        );
+                        token_remove_node(
+                            &mut wtables,
+                            &removed_node.zid,
+                            WhatAmI::Peer,
+                            send_declare,
+                        );
+                    }
+
+                    hat_mut!(wtables).shared_nodes = shared_nodes(
+                        hat!(wtables).routers_net.as_ref().unwrap(),
+                        hat!(wtables).linkstatepeers_net.as_ref().unwrap(),
+                    );
+
+                    hat_mut!(wtables).schedule_compute_trees(tables_ref.clone(), WhatAmI::Peer);
+                } else if let Some(net) = hat_mut!(wtables).linkstatepeers_net.as_mut() {
+                    net.remove_link(&face.zid);
+                }
+            }
+            _ => (),
+        };
         drop(wtables);
     }
 
@@ -687,100 +766,6 @@ impl HatBaseTrait for HatCode {
             }
             _ => 0,
         }
-    }
-
-    fn closing(
-        &self,
-        tables: &mut Tables,
-        tables_ref: &Arc<TablesLock>,
-        transport: &TransportUnicast,
-        send_declare: &mut SendDeclare,
-    ) -> ZResult<()> {
-        match (transport.get_zid(), transport.get_whatami()) {
-            (Ok(zid), Ok(whatami)) => {
-                match whatami {
-                    WhatAmI::Router => {
-                        for (_, removed_node) in hat_mut!(tables)
-                            .routers_net
-                            .as_mut()
-                            .unwrap()
-                            .remove_link(&zid)
-                        {
-                            pubsub_remove_node(
-                                tables,
-                                &removed_node.zid,
-                                WhatAmI::Router,
-                                send_declare,
-                            );
-                            queries_remove_node(
-                                tables,
-                                &removed_node.zid,
-                                WhatAmI::Router,
-                                send_declare,
-                            );
-                            token_remove_node(
-                                tables,
-                                &removed_node.zid,
-                                WhatAmI::Router,
-                                send_declare,
-                            );
-                        }
-
-                        if hat!(tables).full_net(WhatAmI::Peer) {
-                            hat_mut!(tables).shared_nodes = shared_nodes(
-                                hat!(tables).routers_net.as_ref().unwrap(),
-                                hat!(tables).linkstatepeers_net.as_ref().unwrap(),
-                            );
-                        }
-
-                        hat_mut!(tables)
-                            .schedule_compute_trees(tables_ref.clone(), WhatAmI::Router);
-                    }
-                    WhatAmI::Peer => {
-                        if hat!(tables).full_net(WhatAmI::Peer) {
-                            for (_, removed_node) in hat_mut!(tables)
-                                .linkstatepeers_net
-                                .as_mut()
-                                .unwrap()
-                                .remove_link(&zid)
-                            {
-                                pubsub_remove_node(
-                                    tables,
-                                    &removed_node.zid,
-                                    WhatAmI::Peer,
-                                    send_declare,
-                                );
-                                queries_remove_node(
-                                    tables,
-                                    &removed_node.zid,
-                                    WhatAmI::Peer,
-                                    send_declare,
-                                );
-                                token_remove_node(
-                                    tables,
-                                    &removed_node.zid,
-                                    WhatAmI::Peer,
-                                    send_declare,
-                                );
-                            }
-
-                            hat_mut!(tables).shared_nodes = shared_nodes(
-                                hat!(tables).routers_net.as_ref().unwrap(),
-                                hat!(tables).linkstatepeers_net.as_ref().unwrap(),
-                            );
-
-                            hat_mut!(tables)
-                                .schedule_compute_trees(tables_ref.clone(), WhatAmI::Peer);
-                        } else if let Some(net) = hat_mut!(tables).linkstatepeers_net.as_mut() {
-                            net.remove_link(&zid);
-                        }
-                    }
-                    _ => (),
-                };
-            }
-            (_, _) => tracing::error!("Closed transport in session closing!"),
-        }
-        Ok(())
     }
 
     #[inline]

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -457,13 +457,6 @@ impl TransportPeerEventHandler for RuntimeSession {
         }
     }
 
-    fn closing(&self) {
-        self.main_handler.closing();
-        for handler in &self.slave_handlers {
-            handler.closing();
-        }
-    }
-
     fn closed(&self) {
         self.main_handler.closed();
         Runtime::closed_session(self);
@@ -500,12 +493,6 @@ impl TransportMulticastEventHandler for RuntimeMulticastGroup {
         }))
     }
 
-    fn closing(&self) {
-        for handler in &self.slave_handlers {
-            handler.closed();
-        }
-    }
-
     fn closed(&self) {
         for handler in &self.slave_handlers {
             handler.closed();
@@ -538,13 +525,6 @@ impl TransportPeerEventHandler for RuntimeMulticastSession {
         self.main_handler.del_link(link.clone());
         for handler in &self.slave_handlers {
             handler.del_link(link.clone());
-        }
-    }
-
-    fn closing(&self) {
-        self.main_handler.closing();
-        for handler in &self.slave_handlers {
-            handler.closing();
         }
     }
 

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -459,7 +459,6 @@ impl TransportPeerEventHandler for RuntimeSession {
 
     fn closing(&self) {
         self.main_handler.closing();
-        Runtime::closing_session(self);
         for handler in &self.slave_handlers {
             handler.closing();
         }
@@ -467,6 +466,7 @@ impl TransportPeerEventHandler for RuntimeSession {
 
     fn closed(&self) {
         self.main_handler.closed();
+        Runtime::closed_session(self);
         for handler in &self.slave_handlers {
             handler.closed();
         }

--- a/zenoh/src/net/runtime/orchestrator.rs
+++ b/zenoh/src/net/runtime/orchestrator.rs
@@ -1180,7 +1180,7 @@ impl Runtime {
         }
     }
 
-    pub(super) fn closing_session(session: &RuntimeSession) {
+    pub(super) fn closed_session(session: &RuntimeSession) {
         if session.runtime.is_closed() {
             return;
         }


### PR DESCRIPTION
The closing function has been removed from the hat trait.
All face closing related code has been moved from the 'closing' phase of transport closing to the 'closed' phase of transport closing. This avoids receiving messages from a face after cleaning occurred and so avoids error logs.