### PR TITLE
fix: starting rest plugin like any other plugin

### DIFF
--- a/plugins/zenoh-plugin-rest/src/lib.rs
+++ b/plugins/zenoh-plugin-rest/src/lib.rs
@@ -304,8 +304,6 @@ impl Plugin for RestPlugin {
         WORKER_THREAD_NUM.store(conf.work_thread_num, Ordering::SeqCst);
         MAX_BLOCK_THREAD_NUM.store(conf.max_block_thread_num, Ordering::SeqCst);
 
-        // spawn_runtime(run(runtime.clone(), conf.clone()));
-
         let task = run(runtime.clone(), conf.clone());
         let task =
             blockon_runtime(async { timeout(Duration::from_millis(1), spawn_runtime(task)).await });


### PR DESCRIPTION
Changing the way the rest plugin is started because it was causing deadlocks.

See this stack trace:

```
#0  syscall () at ../sysdeps/unix/sysv/linux/x86_64/syscall.S:38
#1  0x0000555559e1de43 in std::sys::pal::unix::futex::futex_wait () at library/std/src/sys/pal/unix/futex.rs:62
#2  std::sys::sync::mutex::futex::Mutex::lock_contended () at library/std/src/sys/sync/mutex/futex.rs:68
#3  0x0000555558058e55 in std::sys::sync::mutex::futex::Mutex::lock () at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/sys/sync/mutex/futex.rs:40
#4  std::sync::mutex::Mutex<zenoh::api::config::Config>::lock<zenoh::api::config::Config> (self=0x7ffff0018ec0) at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/sync/mutex.rs:317
#5  0x00005555580d0ecb in zenoh::api::config::Notifier<zenoh::api::config::Config>::lock_config (self=0x7ffff0019698) at src/api/config.rs:180
#6  0x00005555580d0e4e in zenoh::api::config::Notifier<zenoh::api::config::Config>::lock (self=0x7ffff0019698) at src/api/config.rs:169
#7  0x00005555576afe8f in zenoh::api::liveliness::Liveliness::get<zenoh::api::key_expr::KeyExpr> (self=0x7fffef5efd48, key_expr=...) at /home/gabrik/.cargo/git/checkouts/zenoh-cc237f2570fab813/965e905/zenoh/src/api/liveliness.rs:207
#8  0x000055555757ed53 in zenoh_ext::querying_subscriber::{impl#4}::wait::{closure#0}<zenoh_ext::LivelinessSpace, (flume::Sender<zenoh::api::sample::Sample>, flume::Receiver<zenoh::api::sample::Sample>)> (cb=...) at /home/gabrik/.cargo/git/checkouts/zenoh-cc237f2570fab813/965e905/zenoh-ext/src/querying_subscriber.rs:239
#9  0x000055555758b6e2 in zenoh_ext::querying_subscriber::run_fetch<zenoh_ext::querying_subscriber::{impl#4}::wait::{closure_env#0}<zenoh_ext::LivelinessSpace, (flume::Sender<zenoh::api::sample::Sample>, flume::Receiver<zenoh::api::sample::Sample>)>, zenoh::api::query::Reply> (fetch=..., handler=...) at /home/gabrik/.cargo/git/checkouts/zenoh-cc237f2570fab813/965e905/zenoh-ext/src/querying_subscriber.rs:876
#10 0x0000555557584a00 in zenoh_ext::querying_subscriber::FetchingSubscriber<flume::Receiver<zenoh::api::sample::Sample>>::new<flume::Receiver<zenoh::api::sample::Sample>, zenoh_ext::LivelinessSpace, (flume::Sender<zenoh::api::sample::Sample>, flume::Receiver<zenoh::api::sample::Sample>), zenoh_ext::querying_subscriber::{impl#4}::wait::{closure_env#0}<zenoh_ext::LivelinessSpace, (flume::Sender<zenoh::api::sample::Sample>, flume::Receiver<zenoh::api::sample::Sample>)>, zenoh::api::query::Reply> (conf=...) at /home/gabrik/.cargo/git/checkouts/zenoh-cc237f2570fab813/965e905/zenoh-ext/src/querying_subscriber.rs:684
#11 0x000055555757f59a in zenoh_ext::querying_subscriber::{impl#13}::wait<zenoh_ext::LivelinessSpace, (flume::Sender<zenoh::api::sample::Sample>, flume::Receiver<zenoh::api::sample::Sample>), zenoh_ext::querying_subscriber::{impl#4}::wait::{closure_env#0}<zenoh_ext::LivelinessSpace, (flume::Sender<zenoh::api::sample::Sample>, flume::Receiver<zenoh::api::sample::Sample>)>, zenoh::api::query::Reply> (self=...) at /home/gabrik/.cargo/git/checkouts/zenoh-cc237f2570fab813/965e905/zenoh-ext/src/querying_subscriber.rs:530
#12 0x000055555757e44b in zenoh_ext::querying_subscriber::{impl#4}::wait<zenoh_ext::LivelinessSpace, (flume::Sender<zenoh::api::sample::Sample>, flume::Receiver<zenoh::api::sample::Sample>)> (self=...) at /home/gabrik/.cargo/git/checkouts/zenoh-cc237f2570fab813/965e905/zenoh-ext/src/querying_subscriber.rs:223
#13 0x000055555757f449 in zenoh_ext::querying_subscriber::{impl#5}::into_future<zenoh_ext::LivelinessSpace, (flume::Sender<zenoh::api::sample::Sample>, flume::Receiver<zenoh::api::sample::Sample>)> (self=<error reading variable: Cannot access memory at address 0xd1>) at /home/gabrik/.cargo/git/checkouts/zenoh-cc237f2570fab813/965e905/zenoh-ext/src/querying_subscriber.rs:264
#14 0x000055555750c583 in zenoh_plugin_dds::{impl#5}::run::{async_fn#0} () at src/lib.rs:725
#15 0x00005555574f8f35 in zenoh_plugin_dds::run::{async_fn#0} () at src/lib.rs:282
#16 0x00005555575d1e18 in core::future::future::{impl#1}::poll<alloc::boxed::Box<zenoh_plugin_dds::run::{async_fn_env#0}, alloc::alloc::Global>> (self=..., cx=0x7fffef5fd720) at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/future/future.rs:123
#17 0x0000555557661d50 in tokio::runtime::task::core::{impl#6}::poll::{closure#0}<core::pin::Pin<alloc::boxed::Box<zenoh_plugin_dds::run::{async_fn_env#0}, alloc::alloc::Global>>, alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>> (ptr=0x7ffff0012e30) at /home/gabrik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/core.rs:331
#18 0x0000555557661185 in tokio::loom::std::unsafe_cell::UnsafeCell<tokio::runtime::task::core::Stage<core::pin::Pin<alloc::boxed::Box<zenoh_plugin_dds::run::{async_fn_env#0}, alloc::alloc::Global>>>>::with_mut<tokio::runtime::task::core::Stage<core::pin::Pin<alloc::boxed::Box<zenoh_plugin_dds::run::{async_fn_env#0}, alloc::alloc::Global>>>, core::task::poll::Poll<()>, tokio::runtime::task::core::{impl#6}::poll::{closure_env#0}<core::pin::Pin<alloc::boxed::Box<zenoh_plugin_dds::run::{async_fn_env#0}, alloc::alloc::Global>>, alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>>> (self=0x7ffff0012e30, f=...) at /home/gabrik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/loom/std/unsafe_cell.rs:16
#19 tokio::runtime::task::core::Core<core::pin::Pin<alloc::boxed::Box<zenoh_plugin_dds::run::{async_fn_env#0}, alloc::alloc::Global>>, alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>>::poll<core::pin::Pin<alloc::boxed::Box<zenoh_plugin_dds::run::{async_fn_env#0}, alloc::alloc::Global>>, alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>> (self=0x7ffff0012e20, cx=...) at /home/gabrik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/core.rs:320
#20 0x000055555759f27e in tokio::runtime::task::harness::poll_future::{closure#0}<core::pin::Pin<alloc::boxed::Box<zenoh_plugin_dds::run::{async_fn_env#0}, alloc::alloc::Global>>, alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>> () at /home/gabrik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/harness.rs:500
#21 0x00005555575abf11 in core::panic::unwind_safe::{impl#23}::call_once<core::task::poll::Poll<()>, tokio::runtime::task::harness::poll_future::{closure_env#0}<core::pin::Pin<alloc::boxed::Box<zenoh_plugin_dds::run::{async_fn_env#0}, alloc::alloc::Global>>, alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>>> (self=...) at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/panic/unwind_safe.rs:272
#22 0x00005555575c876a in std::panicking::try::do_call<core::panic::unwind_safe::AssertUnwindSafe<tokio::runtime::task::harness::poll_future::{closure_env#0}<core::pin::Pin<alloc::boxed::Box<zenoh_plugin_dds::run::{async_fn_env#0}, alloc::alloc::Global>>, alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>>>, core::task::poll::Poll<()>> (data=0x7fffef5fd858) at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:559
#23 0x00005555575d2d4b in __rust_try ()
#24 0x00005555575c6a96 in std::panicking::try<core::task::poll::Poll<()>, core::panic::unwind_safe::AssertUnwindSafe<tokio::runtime::task::harness::poll_future::{closure_env#0}<core::pin::Pin<alloc::boxed::Box<zenoh_plugin_dds::run::{async_fn_env#0}, alloc::alloc::Global>>, alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>>>> (f=...) at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:523
#25 0x000055555768532e in std::panic::catch_unwind<core::panic::unwind_safe::AssertUnwindSafe<tokio::runtime::task::harness::poll_future::{closure_env#0}<core::pin::Pin<alloc::boxed::Box<zenoh_plugin_dds::run::{async_fn_env#0}, alloc::alloc::Global>>, alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>>>, core::task::poll::Poll<()>> (f=<error reading variable: Cannot access memory at address 0xa1>) at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panic.rs:149
#26 0x000055555759ddd0 in tokio::runtime::task::harness::poll_future<core::pin::Pin<alloc::boxed::Box<zenoh_plugin_dds::run::{async_fn_env#0}, alloc::alloc::Global>>, alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>> (core=0x7ffff0012e20, cx=...) at /home/gabrik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/harness.rs:488
#27 0x00005555575a0cde in tokio::runtime::task::harness::Harness<core::pin::Pin<alloc::boxed::Box<zenoh_plugin_dds::run::{async_fn_env#0}, alloc::alloc::Global>>, alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>>::poll_inner<core::pin::Pin<alloc::boxed::Box<zenoh_plugin_dds::run::{async_fn_env#0}, alloc::alloc::Global>>, alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>> (self=0x7fffef5fdaa0) at /home/gabrik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/harness.rs:209
#28 0x00005555575a28d7 in tokio::runtime::task::harness::Harness<core::pin::Pin<alloc::boxed::Box<zenoh_plugin_dds::run::{async_fn_env#0}, alloc::alloc::Global>>, alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>>::poll<core::pin::Pin<alloc::boxed::Box<zenoh_plugin_dds::run::{async_fn_env#0}, alloc::alloc::Global>>, alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>> (self=...) at /home/gabrik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/harness.rs:154
#29 0x00005555576ae23d in tokio::runtime::task::raw::poll<core::pin::Pin<alloc::boxed::Box<zenoh_plugin_dds::run::{async_fn_env#0}, alloc::alloc::Global>>, alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>> (ptr=...) at /home/gabrik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/raw.rs:271
#30 0x0000555559d02807 in tokio::runtime::task::raw::RawTask::poll (self=...) at src/runtime/task/raw.rs:201
#31 0x0000555559d315f2 in tokio::runtime::task::LocalNotified<alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>>::run<alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>> (self=...) at src/runtime/task/mod.rs:436
#32 0x0000555559d0a01d in tokio::runtime::scheduler::multi_thread::worker::{impl#1}::run_task::{closure#0} () at src/runtime/scheduler/multi_thread/worker.rs:598
#33 0x0000555559d09e74 in tokio::runtime::coop::with_budget<core::result::Result<alloc::boxed::Box<tokio::runtime::scheduler::multi_thread::worker::Core, alloc::alloc::Global>, ()>, tokio::runtime::scheduler::multi_thread::worker::{impl#1}::run_task::{closure_env#0}> (budget=..., f=...) at src/runtime/coop.rs:107
#34 tokio::runtime::coop::budget<core::result::Result<alloc::boxed::Box<tokio::runtime::scheduler::multi_thread::worker::Core, alloc::alloc::Global>, ()>, tokio::runtime::scheduler::multi_thread::worker::{impl#1}::run_task::{closure_env#0}> (f=...) at src/runtime/coop.rs:73
#35 tokio::runtime::scheduler::multi_thread::worker::Context::run_task (self=0x7fffef5fe118, task=..., core=0x55555a15e150) at src/runtime/scheduler/multi_thread/worker.rs:597
#36 0x0000555559d09511 in tokio::runtime::scheduler::multi_thread::worker::Context::run (self=0x7fffef5fe118, core=0x55555a15e150) at src/runtime/scheduler/multi_thread/worker.rs:548
#37 0x0000555559d09169 in tokio::runtime::scheduler::multi_thread::worker::run::{closure#0}::{closure#0} () at src/runtime/scheduler/multi_thread/worker.rs:513
#38 0x0000555559d48340 in tokio::runtime::context::scoped::Scoped<tokio::runtime::scheduler::Context>::set<tokio::runtime::scheduler::Context, tokio::runtime::scheduler::multi_thread::worker::run::{closure#0}::{closure_env#0}, ()> (self=0x7fffef5ff888, t=0x7fffef5fe110, f=...) at src/runtime/context/scoped.rs:40
#39 0x0000555559d15a3b in tokio::runtime::context::set_scheduler::{closure#0}<(), tokio::runtime::scheduler::multi_thread::worker::run::{closure#0}::{closure_env#0}> (c=0x7fffef5ff860) at src/runtime/context.rs:180
#40 0x0000555559d3f380 in std::thread::local::LocalKey<tokio::runtime::context::Context>::try_with<tokio::runtime::context::Context, tokio::runtime::context::set_scheduler::{closure_env#0}<(), tokio::runtime::scheduler::multi_thread::worker::run::{closure#0}::{closure_env#0}>, ()> (self=0x555559fe8ec8, f=...) at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/thread/local.rs:286
#41 0x0000555559d3e7eb in std::thread::local::LocalKey<tokio::runtime::context::Context>::with<tokio::runtime::context::Context, tokio::runtime::context::set_scheduler::{closure_env#0}<(), tokio::runtime::scheduler::multi_thread::worker::run::{closure#0}::{closure_env#0}>, ()> (self=0x555559fe8ec8, f=<error reading variable: Cannot access memory at address 0x89>) at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/thread/local.rs:262
#42 0x0000555559d159b4 in tokio::runtime::context::set_scheduler<(), tokio::runtime::scheduler::multi_thread::worker::run::{closure#0}::{closure_env#0}> (v=0x7fffef5fe110, f=...) at src/runtime/context.rs:180
#43 0x0000555559d09071 in tokio::runtime::scheduler::multi_thread::worker::run::{closure#0} () at src/runtime/scheduler/multi_thread/worker.rs:508
#44 0x0000555559cf7028 in tokio::runtime::context::runtime::enter_runtime<tokio::runtime::scheduler::multi_thread::worker::run::{closure_env#0}, ()> (handle=0x7fffef5fe368, allow_block_in_place=true, f=...) at src/runtime/context/runtime.rs:65
#45 0x0000555559d08ded in tokio::runtime::scheduler::multi_thread::worker::run (worker=...) at src/runtime/scheduler/multi_thread/worker.rs:500
#46 0x0000555557a94d6b in tokio::runtime::scheduler::multi_thread::worker::block_in_place::{closure#0}::{closure#0}<zenoh_plugin_rest::blockon_runtime::{closure_env#0}<zenoh_plugin_rest::{impl#1}::start::{async_block_env#2}>, core::result::Result<core::result::Result<core::result::Result<(), alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync), alloc::alloc::Global>>, tokio::runtime::task::error::JoinError>, tokio::time::error::Elapsed>> () at /home/gabrik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/scheduler/multi_thread/worker.rs:441
#47 0x0000555557aff3c2 in tokio::runtime::blocking::task::{impl#2}::poll<tokio::runtime::scheduler::multi_thread::worker::block_in_place::{closure#0}::{closure_env#0}<zenoh_plugin_rest::blockon_runtime::{closure_env#0}<zenoh_plugin_rest::{impl#1}::start::{async_block_env#2}>, core::result::Result<core::result::Result<core::result::Result<(), alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync), alloc::alloc::Global>>, tokio::runtime::task::error::JoinError>, tokio::time::error::Elapsed>>, ()> (self=..., _cx=0x7fffef5fe560) at /home/gabrik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/blocking/task.rs:42
#48 0x0000555557b47390 in tokio::runtime::task::core::{impl#6}::poll::{closure#0}<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::block_in_place::{closure#0}::{closure_env#0}<zenoh_plugin_rest::blockon_runtime::{closure_env#0}<zenoh_plugin_rest::{impl#1}::start::{async_block_env#2}>, core::result::Result<core::result::Result<core::result::Result<(), alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync), alloc::alloc::Global>>, tokio::runtime::task::error::JoinError>, tokio::time::error::Elapsed>>>, tokio::runtime::blocking::schedule::BlockingSchedule> (ptr=0x7ffff00535b8) at /home/gabrik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/core.rs:331
#49 0x0000555557b466d5 in tokio::loom::std::unsafe_cell::UnsafeCell<tokio::runtime::task::core::Stage<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::block_in_place::{closure#0}::{closure_env#0}<zenoh_plugin_rest::blockon_runtime::{closure_env#0}<zenoh_plugin_rest::{impl#1}::start::{async_block_env#2}>, core::result::Result<core::result::Result<core::result::Result<(), alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync), alloc::alloc::Global>>, tokio::runtime::task::error::JoinError>, tokio::time::error::Elapsed>>>>>::with_mut<tokio::runtime::task::core::Stage<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::block_in_place::{closure#0}::{closure_env#0}<zenoh_plugin_rest::blockon_runtime::{closure_env#0}<zenoh_plugin_rest::{impl#1}::start::{async_block_env#2}>, core::result::Result<core::result::Result<core::result::Result<(), alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync), alloc::alloc::Global>>, tokio::runtime::task::error::JoinError>, tokio::time::error::Elapsed>>>>, core::task::poll::Poll<()>, tokio::runtime::task::core::{impl#6}::poll::{closure_env#0}<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::block_in_place::{closure#0}::{closure_env#0}<zenoh_plugin_rest::blockon_runtime::{closure_env#0}<zenoh_plugin_rest::{impl#1}::start::{async_block_env#2}>, core::result::Result<core::result::Result<core::result::Result<(), alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync), alloc::alloc::Global>>, tokio::runtime::task::error::JoinError>, tokio::time::error::Elapsed>>>, tokio::runtime::blocking::schedule::BlockingSchedule>> (self=0x7ffff00535b8, f=...) at /home/gabrik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/loom/std/unsafe_cell.rs:16
#50 tokio::runtime::task::core::Core<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::block_in_place::{closure#0}::{closure_env#0}<zenoh_plugin_rest::blockon_runtime::{closure_env#0}<zenoh_plugin_rest::{impl#1}::start::{async_block_env#2}>, core::result::Result<core::result::Result<core::result::Result<(), alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync), alloc::alloc::Global>>, tokio::runtime::task::error::JoinError>, tokio::time::error::Elapsed>>>, tokio::runtime::blocking::schedule::BlockingSchedule>::poll<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::block_in_place::{closure#0}::{closure_env#0}<zenoh_plugin_rest::blockon_runtime::{closure_env#0}<zenoh_plugin_rest::{impl#1}::start::{async_block_env#2}>, core::result::Result<core::result::Result<core::result::Result<(), alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync), alloc::alloc::Global>>, tokio::runtime::task::error::JoinError>, tokio::time::error::Elapsed>>>, tokio::runtime::blocking::schedule::BlockingSchedule> (self=0x7ffff00535a0, cx=...) at /home/gabrik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/core.rs:320
#51 0x0000555557b15cfe in tokio::runtime::task::harness::poll_future::{closure#0}<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::block_in_place::{closure#0}::{closure_env#0}<zenoh_plugin_rest::blockon_runtime::{closure_env#0}<zenoh_plugin_rest::{impl#1}::start::{async_block_env#2}>, core::result::Result<core::result::Result<core::result::Result<(), alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync), alloc::alloc::Global>>, tokio::runtime::task::error::JoinError>, tokio::time::error::Elapsed>>>, tokio::runtime::blocking::schedule::BlockingSchedule> () at /home/gabrik/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/harness.rs:500
#52 0x0000555557b4e2c1 in core::panic::unwind_safe::{impl#23}::call_once<core::task::poll::Poll<()>, tokio::runtime::task::harness::poll_future::{closure_env#0}<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::block_in_place::{closure#0}::{closure_env#0}<zenoh_plugin_rest::blockon_runtime::{closure_env#0}<zenoh_plugin_rest::{impl#1}::start::{async_block_env#2}>, core::result::Result<core::result::Result<core::result::Result<(), alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync), alloc::alloc::Global>>, tokio::runtime::task::error::JoinError>, tokio::time::error::Elapsed>>>, tokio::runtime::blocking::schedule::BlockingSchedule>> (self=...) at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/panic/unwind_safe.rs:272
#53 0x0000555557b05b6a in std::panicking::try::do_call<core::panic::unwind_safe::AssertUnwindSafe<tokio::runtime::task::harness::poll_future::{closure_env#0}<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::block_in_place::{closure#0}::{closure_env#0}<zenoh_plugin_rest::blockon_runtime::{closure_env#0}<zenoh_plugin_rest::{impl#1}::start::{async_block_env#2}>, core::result::Result<core::result::Result<core::result::Result<(), alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync), alloc::alloc::Global>>, tokio::runtime::task::error::JoinError>, tokio::time::error::Elapsed>>>, tokio::runtime::blocking::schedule::BlockingSchedule>>, core::task::poll::Poll<()>> (data=0x7fffef5fe698) at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:559
#54 0x0000555557b0c3bb in __rust_try ()
```


TL;DR;

the DDS plugin was stuck in getting a lock for the config, that was already locked by the rest one in the `blockon_runtime`, using `runtime_spawn` solved the issue.
