### PR TITLE
chore: update release.yml for required labels

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -14,12 +14,22 @@
 
 changelog:
   categories:
+    - title: Breaking changes 💥
+      labels:
+        - breaking-change
     - title: New features 🎉
       labels:
         - enhancement
+        - new feature
     - title: Bug fixes 🐞
       labels:
         - bug
+    - title: Documentation 📝
+      labels:
+        - documentation
+    - title: Dependencies 👷
+      labels:
+        - dependencies
     - title: Other changes
       labels:
         - "*"


### PR DESCRIPTION
Update `release.yml` to account for the required labels in PRs and better categorize automatically generated release notes.