### PR TITLE
Add wait_before_close option

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -386,8 +386,11 @@
           /// Using CongestionControl::Block the caller is blocked until a batch is available and re-inserted into the queue.
           /// Using CongestionControl::Drop the message might be dropped, depending on conditions configured here.
           congestion_control: {
-            /// The maximum time in microseconds to wait for an available batch before dropping the message if still no batch is available.
+            /// The maximum time in microseconds to wait for an available batch before dropping a droppable message if still no batch is available.
             wait_before_drop: 1000,
+            /// The maximum time in microseconds to wait for an available batch before closing the transport session when sending a blocking message
+            /// if still no batch is available.
+            wait_before_close: 5000000,
           },
           /// Perform batching of messages if they are smaller of the batch_size
           batching: {

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -383,14 +383,18 @@
             background: 4,
           },
           /// Congestion occurs when the queue is empty (no available batch).
-          /// Using CongestionControl::Block the caller is blocked until a batch is available and re-inserted into the queue.
-          /// Using CongestionControl::Drop the message might be dropped, depending on conditions configured here.
           congestion_control: {
-            /// The maximum time in microseconds to wait for an available batch before dropping a droppable message if still no batch is available.
-            wait_before_drop: 1000,
-            /// The maximum time in microseconds to wait for an available batch before closing the transport session when sending a blocking message
-            /// if still no batch is available.
-            wait_before_close: 5000000,
+            /// Behavior pushing CongestionControl::Drop messages to the queue. 
+            drop: {
+              /// The maximum time in microseconds to wait for an available batch before dropping a droppable message if still no batch is available.
+              wait_before_drop: 1000,
+            }
+            /// Behavior pushing CongestionControl::Block messages to the queue. 
+            block: {
+              /// The maximum time in microseconds to wait for an available batch before closing the transport session when sending a blocking message
+              /// if still no batch is available.
+              wait_before_close: 5000000,
+            }
           },
           /// Perform batching of messages if they are smaller of the batch_size
           batching: {

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -388,7 +388,7 @@
             drop: {
               /// The maximum time in microseconds to wait for an available batch before dropping a droppable message if still no batch is available.
               wait_before_drop: 1000,
-            }
+            },
             /// Behavior pushing CongestionControl::Block messages to the queue. 
             block: {
               /// The maximum time in microseconds to wait for an available batch before closing the transport session when sending a blocking message

--- a/commons/zenoh-config/src/defaults.rs
+++ b/commons/zenoh-config/src/defaults.rs
@@ -244,6 +244,7 @@ impl Default for CongestionControlConf {
     fn default() -> Self {
         Self {
             wait_before_drop: 1000,
+            wait_before_close: 5000000,
         }
     }
 }

--- a/commons/zenoh-config/src/defaults.rs
+++ b/commons/zenoh-config/src/defaults.rs
@@ -240,10 +240,17 @@ impl Default for QueueSizeConf {
     }
 }
 
-impl Default for CongestionControlConf {
+impl Default for CongestionControlDropConf {
     fn default() -> Self {
         Self {
             wait_before_drop: 1000,
+        }
+    }
+}
+
+impl Default for CongestionControlBlockConf {
+    fn default() -> Self {
+        Self {
             wait_before_close: 5000000,
         }
     }

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -423,10 +423,10 @@ validated_struct::validator! {
                         /// Using CongestionControl::Drop the message might be dropped, depending on conditions configured here.
                         pub congestion_control: CongestionControlConf {
                             /// The maximum time in microseconds to wait for an available batch before dropping a droppable message if still no batch is available.
-                            wait_before_drop: u64,
+                            wait_before_drop: i64,
                             /// The maximum time in microseconds to wait for an available batch before closing the transport session when sending a blocking message
                             /// if still no batch is available.
-                            wait_before_close: u64,
+                            wait_before_close: i64,
                         },
                         pub batching: BatchingConf {
                             /// Perform adaptive batching of messages if they are smaller of the batch_size.

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -421,12 +421,20 @@ validated_struct::validator! {
                         /// Congestion occurs when the queue is empty (no available batch).
                         /// Using CongestionControl::Block the caller is blocked until a batch is available and re-inserted into the queue.
                         /// Using CongestionControl::Drop the message might be dropped, depending on conditions configured here.
-                        pub congestion_control: CongestionControlConf {
-                            /// The maximum time in microseconds to wait for an available batch before dropping a droppable message if still no batch is available.
-                            wait_before_drop: i64,
-                            /// The maximum time in microseconds to wait for an available batch before closing the transport session when sending a blocking message
-                            /// if still no batch is available.
-                            wait_before_close: i64,
+                        pub congestion_control: #[derive(Default)]
+                        CongestionControlConf {
+                            /// Behavior pushing CongestionControl::Drop messages to the queue.
+                            pub drop: CongestionControlDropConf {
+                                /// The maximum time in microseconds to wait for an available batch before dropping a droppable message
+                                /// if still no batch is available.
+                                wait_before_drop: i64,
+                            },
+                            /// Behavior pushing CongestionControl::Block messages to the queue.
+                            pub block: CongestionControlBlockConf {
+                                /// The maximum time in microseconds to wait for an available batch before closing the transport session
+                                /// when sending a blocking message if still no batch is available.
+                                wait_before_close: i64,
+                            },
                         },
                         pub batching: BatchingConf {
                             /// Perform adaptive batching of messages if they are smaller of the batch_size.

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -422,8 +422,11 @@ validated_struct::validator! {
                         /// Using CongestionControl::Block the caller is blocked until a batch is available and re-inserted into the queue.
                         /// Using CongestionControl::Drop the message might be dropped, depending on conditions configured here.
                         pub congestion_control: CongestionControlConf {
-                            /// The maximum time in microseconds to wait for an available batch before dropping the message if still no batch is available.
-                            pub wait_before_drop: u64,
+                            /// The maximum time in microseconds to wait for an available batch before dropping a droppable message if still no batch is available.
+                            wait_before_drop: u64,
+                            /// The maximum time in microseconds to wait for an available batch before closing the transport session when sending a blocking message
+                            /// if still no batch is available.
+                            wait_before_close: u64,
                         },
                         pub batching: BatchingConf {
                             /// Perform adaptive batching of messages if they are smaller of the batch_size.

--- a/io/zenoh-transport/src/common/pipeline.rs
+++ b/io/zenoh-transport/src/common/pipeline.rs
@@ -141,7 +141,7 @@ impl StageIn {
         &mut self,
         msg: &mut NetworkMessage,
         priority: Priority,
-        deadline_before_drop: Option<Option<Instant>>,
+        deadline: Option<Instant>,
     ) -> bool {
         // Lock the current serialization batch.
         let mut c_guard = self.mutex.current();
@@ -154,31 +154,22 @@ impl StageIn {
                         None => match self.s_ref.pull() {
                             Some(mut batch) => {
                                 batch.clear();
-                                self.s_out.atomic_backoff.first_write.store(LOCAL_EPOCH.elapsed().as_micros() as MicroSeconds, Ordering::Relaxed);
+                                self.s_out.atomic_backoff.first_write.store(
+                                    LOCAL_EPOCH.elapsed().as_micros() as MicroSeconds,
+                                    Ordering::Relaxed,
+                                );
                                 break batch;
                             }
                             None => {
                                 drop(c_guard);
-                                match deadline_before_drop {
-                                    Some(deadline) if !$fragment => {
-                                        // We are in the congestion scenario and message is droppable
-                                        // Wait for an available batch until deadline
-                                        if !deadline.map_or(false, |deadline| self.s_ref.wait_deadline(deadline)) {
-                                            // Still no available batch.
-                                            // Restore the sequence number and drop the message
-                                            $restore_sn;
-                                            return false
-                                        }
-                                    }
-                                    _ => {
-                                        // Block waiting for an available batch
-                                        if !self.s_ref.wait() {
-                                            // Some error prevented the queue to wait and give back an available batch
-                                            // Restore the sequence number and drop the message
-                                            $restore_sn;
-                                            return false;
-                                        }
-                                    }
+                                // Wait for an available batch until deadline
+                                if !deadline
+                                    .map_or(false, |deadline| self.s_ref.wait_deadline(deadline))
+                                {
+                                    // Still no available batch.
+                                    // Restore the sequence number and drop the message
+                                    $restore_sn;
+                                    return false;
                                 }
                                 c_guard = self.mutex.current();
                             }
@@ -513,6 +504,7 @@ pub(crate) struct TransmissionPipelineConf {
     pub(crate) batch: BatchConfig,
     pub(crate) queue_size: [usize; Priority::NUM],
     pub(crate) wait_before_drop: Duration,
+    pub(crate) wait_before_close: Duration,
     pub(crate) batching_enabled: bool,
     pub(crate) batching_time_limit: Duration,
 }
@@ -597,6 +589,7 @@ impl TransmissionPipeline {
             stage_in: stage_in.into_boxed_slice().into(),
             active: active.clone(),
             wait_before_drop: config.wait_before_drop,
+            wait_before_close: config.wait_before_close,
         };
         let consumer = TransmissionPipelineConsumer {
             stage_out: stage_out.into_boxed_slice(),
@@ -614,6 +607,7 @@ pub(crate) struct TransmissionPipelineProducer {
     stage_in: Arc<[Mutex<StageIn>]>,
     active: Arc<AtomicBool>,
     wait_before_drop: Duration,
+    wait_before_close: Duration,
 }
 
 impl TransmissionPipelineProducer {
@@ -627,18 +621,15 @@ impl TransmissionPipelineProducer {
             (0, Priority::DEFAULT)
         };
         // If message is droppable, compute a deadline after which the sample could be dropped
-        let deadline_before_drop = if msg.is_droppable() {
-            if self.wait_before_drop.is_zero() {
-                Some(None)
-            } else {
-                Some(Some(Instant::now() + self.wait_before_drop))
-            }
+        let wait_time = if msg.is_droppable() {
+            self.wait_before_drop
         } else {
-            None
+            self.wait_before_close
         };
+        let deadline = (!wait_time.is_zero()).then_some(Instant::now() + wait_time);
         // Lock the channel. We are the only one that will be writing on it.
         let mut queue = zlock!(self.stage_in[idx]);
-        queue.push_network_message(&mut msg, priority, deadline_before_drop)
+        queue.push_network_message(&mut msg, priority, deadline)
     }
 
     #[inline]
@@ -793,6 +784,7 @@ mod tests {
         queue_size: [1; Priority::NUM],
         batching_enabled: true,
         wait_before_drop: Duration::from_millis(1),
+        wait_before_close: Duration::from_secs(5),
         batching_time_limit: Duration::from_micros(1),
     };
 
@@ -806,6 +798,7 @@ mod tests {
         queue_size: [1; Priority::NUM],
         batching_enabled: true,
         wait_before_drop: Duration::from_millis(1),
+        wait_before_close: Duration::from_secs(5),
         batching_time_limit: Duration::from_micros(1),
     };
 

--- a/io/zenoh-transport/src/manager.rs
+++ b/io/zenoh-transport/src/manager.rs
@@ -41,6 +41,14 @@ use crate::multicast::manager::{
     TransportManagerStateMulticast,
 };
 
+fn duration_from_i64us(us: i64) -> Duration {
+    if us >= 0 {
+        Duration::from_micros(us as u64)
+    } else {
+        Duration::MAX
+    }
+}
+
 /// # Examples
 /// ```
 /// use std::sync::Arc;
@@ -251,10 +259,10 @@ impl TransportManagerBuilder {
         ));
         self = self.defrag_buff_size(*link.rx().max_message_size());
         self = self.link_rx_buffer_size(*link.rx().buffer_size());
-        self = self.wait_before_drop(Duration::from_micros(
+        self = self.wait_before_drop(duration_from_i64us(
             *link.tx().queue().congestion_control().wait_before_drop(),
         ));
-        self = self.wait_before_close(Duration::from_micros(
+        self = self.wait_before_close(duration_from_i64us(
             *link.tx().queue().congestion_control().wait_before_close(),
         ));
         self = self.queue_size(link.tx().queue().size().clone());
@@ -363,8 +371,8 @@ impl Default for TransportManagerBuilder {
             resolution: Resolution::default(),
             batch_size: BatchSize::MAX,
             batching_enabled: true,
-            wait_before_drop: Duration::from_micros(wait_before_drop),
-            wait_before_close: Duration::from_micros(wait_before_close),
+            wait_before_drop: duration_from_i64us(wait_before_drop),
+            wait_before_close: duration_from_i64us(wait_before_close),
             queue_size: queue.size,
             batching_time_limit: Duration::from_millis(backoff),
             defrag_buff_size: *link_rx.max_message_size(),

--- a/io/zenoh-transport/src/manager.rs
+++ b/io/zenoh-transport/src/manager.rs
@@ -260,10 +260,20 @@ impl TransportManagerBuilder {
         self = self.defrag_buff_size(*link.rx().max_message_size());
         self = self.link_rx_buffer_size(*link.rx().buffer_size());
         self = self.wait_before_drop(duration_from_i64us(
-            *link.tx().queue().congestion_control().wait_before_drop(),
+            *link
+                .tx()
+                .queue()
+                .congestion_control()
+                .drop()
+                .wait_before_drop(),
         ));
         self = self.wait_before_close(duration_from_i64us(
-            *link.tx().queue().congestion_control().wait_before_close(),
+            *link
+                .tx()
+                .queue()
+                .congestion_control()
+                .block()
+                .wait_before_close(),
         ));
         self = self.queue_size(link.tx().queue().size().clone());
         self = self.tx_threads(*link.tx().threads());
@@ -362,8 +372,8 @@ impl Default for TransportManagerBuilder {
         let link_rx = LinkRxConf::default();
         let queue = QueueConf::default();
         let backoff = *queue.batching().time_limit();
-        let wait_before_drop = *queue.congestion_control().wait_before_drop();
-        let wait_before_close = *queue.congestion_control().wait_before_close();
+        let wait_before_drop = *queue.congestion_control().drop().wait_before_drop();
+        let wait_before_close = *queue.congestion_control().block().wait_before_close();
         Self {
             version: VERSION,
             zid: ZenohIdProto::rand(),

--- a/io/zenoh-transport/src/multicast/link.rs
+++ b/io/zenoh-transport/src/multicast/link.rs
@@ -309,6 +309,7 @@ impl TransportLinkMulticastUniversal {
                 batch: self.link.config.batch,
                 queue_size: self.transport.manager.config.queue_size,
                 wait_before_drop: self.transport.manager.config.wait_before_drop,
+                wait_before_close: self.transport.manager.config.wait_before_close,
                 batching_enabled: self.transport.manager.config.batching,
                 batching_time_limit: self.transport.manager.config.queue_backoff,
             };

--- a/io/zenoh-transport/src/unicast/universal/link.rs
+++ b/io/zenoh-transport/src/unicast/universal/link.rs
@@ -63,6 +63,7 @@ impl TransportLinkUnicastUniversal {
             },
             queue_size: transport.manager.config.queue_size,
             wait_before_drop: transport.manager.config.wait_before_drop,
+            wait_before_close: transport.manager.config.wait_before_close,
             batching_enabled: transport.manager.config.batching,
             batching_time_limit: transport.manager.config.queue_backoff,
         };


### PR DESCRIPTION
Add a `wait_before_close` transport option that allows to configure the maximum time in microseconds to wait for an available batch before closing the transport session when sending a `CongestionControl::Block` message.
The default value has been set to 5 seconds.
`-1` can be set to restore the original behavior.

To clarify the difference between `CongestionControl::Drop` and `CongestionControl::Block` with the new behavior:
- `CongestionControl::Drop`
  - Option name: `congestion_control/drop/wait_before_drop`
  - Default wait time 1 ms
  - On timeout: drop message
- `CongestionControl::Block`
  - Option name: `congestion_control/block/wait_before_close`
  - Default wait time 5 s
  - On timeout: close transport session
  
Being able to set a different wait time for each message would be ideal but this is for another PR.