### PR TITLE
feat(storage-manager): replication supports wildcard updates

### DIFF
--- a/plugins/zenoh-plugin-storage-manager/src/replication/classification.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replication/classification.rs
@@ -13,7 +13,7 @@
 //
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     ops::{Deref, Sub},
 };
 
@@ -74,7 +74,7 @@ impl Sub<u64> for IntervalIdx {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub(crate) struct Interval {
     pub(crate) fingerprint: Fingerprint,
-    pub(crate) sub_intervals: HashMap<SubIntervalIdx, SubInterval>,
+    pub(crate) sub_intervals: BTreeMap<SubIntervalIdx, SubInterval>,
 }
 
 impl<const N: usize> From<[(SubIntervalIdx, SubInterval); N]> for Interval {

--- a/plugins/zenoh-plugin-storage-manager/src/replication/configuration.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replication/configuration.rs
@@ -79,6 +79,10 @@ impl Configuration {
         }
     }
 
+    pub fn prefix(&self) -> Option<&OwnedKeyExpr> {
+        self.prefix.as_ref()
+    }
+
     /// Returns the [Fingerprint] of the `Configuration`.
     ///
     /// The fingerprint is the hash of all its fields, using the `xxhash_rust` crate.

--- a/plugins/zenoh-plugin-storage-manager/src/replication/core.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replication/core.rs
@@ -379,7 +379,7 @@ impl Replication {
                         };
 
                         if let Some(digest_diff) = digest.diff(other_digest) {
-                            tracing::debug!("Potential misalignment detected");
+                            tracing::debug!("Potential misalignment detected: {digest_diff:?}");
 
                             let replica_aligner_ke = match keformat!(
                                 aligner_key_expr_formatter::formatter(),
@@ -464,8 +464,6 @@ impl Replication {
                     tracing::debug!("Skipping query with empty Attachment");
                     continue;
                 }
-
-                tracing::trace!("Received Alignment Query");
 
                 let replication = replication.clone();
                 tokio::task::spawn(async move { replication.aligner(query).await });

--- a/plugins/zenoh-plugin-storage-manager/src/replication/core/aligner_query.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replication/core/aligner_query.rs
@@ -107,8 +107,8 @@ impl Replication {
                         .intervals
                         .get(&interval_idx)
                     {
-                        interval.sub_intervals.values().for_each(|sub_interval| {
-                            events_to_send.extend(sub_interval.events.values().map(Into::into));
+                        interval.sub_intervals().for_each(|sub_interval| {
+                            events_to_send.extend(sub_interval.events().map(Into::into));
                         });
                     }
 
@@ -256,12 +256,8 @@ impl Replication {
                 .for_each(|(interval_idx, sub_intervals)| {
                     if let Some(interval) = log.intervals.get(interval_idx) {
                         sub_intervals.iter().for_each(|sub_interval_idx| {
-                            if let Some(sub_interval) = interval.sub_intervals.get(sub_interval_idx)
-                            {
-                                sub_interval
-                                    .events
-                                    .values()
-                                    .for_each(|event| events.push(event.into()))
+                            if let Some(sub_interval) = interval.sub_interval_at(sub_interval_idx) {
+                                events.extend(sub_interval.events().map(Into::into));
                             }
                         });
                     }

--- a/plugins/zenoh-plugin-storage-manager/src/replication/core/aligner_reply.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replication/core/aligner_reply.rs
@@ -163,10 +163,10 @@ impl Replication {
                                 let diff = replica_sub_ivl
                                     .into_iter()
                                     .filter(|(sub_idx, sub_fp)| {
-                                        match interval.sub_intervals.get(sub_idx) {
+                                        match interval.sub_interval_at(sub_idx) {
                                             None => true,
                                             Some(sub_interval) => {
-                                                sub_interval.fingerprint != *sub_fp
+                                                sub_interval.fingerprint() != *sub_fp
                                             }
                                         }
                                     })

--- a/plugins/zenoh-plugin-storage-manager/src/replication/core/aligner_reply.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replication/core/aligner_reply.rs
@@ -15,18 +15,25 @@
 use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
+use tokio::sync::RwLockWriteGuard;
 use zenoh::{
-    key_expr::{format::keformat, OwnedKeyExpr},
+    internal::Value,
+    key_expr::{format::keformat, keyexpr_tree::IKeyExprTreeMut, OwnedKeyExpr},
     sample::{Sample, SampleKind},
     session::ZenohId,
+    Result as ZResult,
 };
 use zenoh_backend_traits::StorageInsertionResult;
 
-use crate::replication::{
-    classification::{EventRemoval, IntervalIdx, SubIntervalIdx},
-    core::{aligner_key_expr_formatter, aligner_query::AlignmentQuery, Replication},
-    digest::Fingerprint,
-    log::EventMetadata,
+use crate::{
+    replication::{
+        classification::{EventRemoval, IntervalIdx, SubIntervalIdx},
+        core::{aligner_key_expr_formatter, aligner_query::AlignmentQuery, Replication},
+        digest::Fingerprint,
+        log::{Action, EventMetadata},
+        Event, LogLatest,
+    },
+    storages_mgt::service::Update,
 };
 
 /// The `AlignmentReply` enumeration contains the possible information needed by a Replica to align
@@ -192,9 +199,14 @@ impl Replication {
                 let mut diff_events = Vec::default();
 
                 for replica_event in replica_events {
+                    tracing::trace!("Checking if < {replica_event:?} > is missing");
                     if let Some(missing_event_metadata) =
                         self.process_event_metadata(replica_event).await
                     {
+                        tracing::trace!(
+                            "Requesting: < {:?} >",
+                            missing_event_metadata.stripped_key
+                        );
                         diff_events.push(missing_event_metadata);
                     }
                 }
@@ -234,33 +246,32 @@ impl Replication {
             .latest_updates
             .read()
             .await
-            .get(&replica_event.stripped_key)
+            .get(&replica_event.log_key())
             .is_some_and(|latest_event| latest_event.timestamp >= replica_event.timestamp)
         {
             return None;
         }
 
+        let mut replication_log_guard = self.replication_log.write().await;
+        if !self
+            .needs_further_processing(&mut replication_log_guard, &replica_event)
+            .await
+        {
+            return None;
+        }
+
         match &replica_event.action {
-            SampleKind::Put => {
-                let replication_log_guard = self.replication_log.read().await;
-                if let Some(latest_event) =
-                    replication_log_guard.lookup(&replica_event.stripped_key)
-                {
-                    if latest_event.timestamp >= replica_event.timestamp {
-                        return None;
-                    }
-                }
-                return Some(replica_event);
-            }
-            SampleKind::Delete => {
-                let mut replication_log_guard = self.replication_log.write().await;
-                match replication_log_guard
-                    .remove_older(&replica_event.stripped_key, &replica_event.timestamp)
-                {
+            // To apply a Put or a WildcardPut we need the payload so we return here to indicate
+            // that we need to retrieve it from the Replica.
+            Action::Put | Action::WildcardPut(_) => return Some(replica_event),
+
+            // A Delete can be applied right away, we have all the information we need.
+            Action::Delete => {
+                match replication_log_guard.remove_older(&replica_event) {
                     EventRemoval::NotFound => {}
                     EventRemoval::KeptNewer => return None,
                     EventRemoval::RemovedOlder(older_event) => {
-                        if older_event.action == SampleKind::Put {
+                        if older_event.action == Action::Put {
                             // NOTE: In some of our backend implementation, a deletion on a
                             //       non-existing key will return an error. Given that we cannot
                             //       distinguish an error from a missing key, we will assume
@@ -269,6 +280,7 @@ impl Replication {
                             // FIXME: Once the behaviour described above is fixed, check for
                             //        errors.
                             let _ = self
+                                .storage_service
                                 .storage
                                 .lock()
                                 .await
@@ -277,12 +289,20 @@ impl Replication {
                         }
                     }
                 }
+            }
 
-                replication_log_guard.insert_event_unchecked(replica_event.clone().into());
+            Action::WildcardDelete(_) => {
+                self.apply_wildcard_update(
+                    &mut replication_log_guard,
+                    &replica_event,
+                    Value::empty(),
+                )
+                .await;
             }
         }
 
-        Some(replica_event)
+        replication_log_guard.insert_event_unchecked(replica_event.clone().into());
+        None
     }
 
     /// Processes the [EventMetadata] and [Sample] sent by the Replica, adding it to our Storage if
@@ -299,49 +319,469 @@ impl Replication {
     /// steps and the Replica goes straight to sending all its Replication Log and data in its
     /// Storage. Including for the deleted events.
     async fn process_event_retrieval(&self, replica_event: EventMetadata, sample: Sample) {
-        tracing::trace!("Processing `AlignmentReply::Retrieval`");
+        tracing::trace!("Processing `AlignmentReply::Retrieval` for < {replica_event:?} >");
 
         if self
             .latest_updates
             .read()
             .await
-            .get(&replica_event.stripped_key)
-            .is_some_and(|latest_event| latest_event.timestamp >= replica_event.timestamp)
+            .get(&replica_event.log_key())
+            .is_some_and(|latest_event| latest_event.timestamp() >= replica_event.timestamp())
         {
             return;
         }
 
         let mut replication_log_guard = self.replication_log.write().await;
-        match replication_log_guard
-            .remove_older(&replica_event.stripped_key, &replica_event.timestamp)
+
+        if !self
+            .needs_further_processing(&mut replication_log_guard, &replica_event)
+            .await
         {
-            EventRemoval::KeptNewer => return,
-            EventRemoval::RemovedOlder(_) | EventRemoval::NotFound => {}
+            return;
         }
 
-        // NOTE: This code can only be called with `action` set to `delete` on an initial
-        // alignment, in which case the Storage of the receiving Replica is empty => there
-        // is no need to actually call `storage.delete`.
-        //
-        // Outside of an initial alignment, the `delete` action will be performed at the
-        // step above, in `AlignmentReply::EventsMetadata`.
-        if replica_event.action == SampleKind::Put
+        // The Event is newer than what we have and is not overridden by a Wildcard Update, we
+        // need to process it.
+        replication_log_guard.remove_older(&replica_event);
+
+        match &replica_event.action {
+            // NOTE: This code can only be called with `action` set to `Delete` or `WildcardDelete`
+            // on an initial alignment, in which case the Storage of the receiving Replica is empty
+            // => there is no need to actually call `storage.delete`.
+            //
+            // Outside of an initial alignment, the `Delete` or `WildcardDelete` actions will be
+            // performed at the step above, in `AlignmentReply::EventsMetadata`.
+            Action::Delete => {}
+            Action::WildcardDelete(wildcard_delete_ke) => {
+                self.storage_service
+                    .register_wildcard_update(
+                        wildcard_delete_ke.clone(),
+                        SampleKind::Delete,
+                        replica_event.timestamp,
+                        zenoh::internal::Value::empty(),
+                    )
+                    .await;
+            }
+            Action::Put => {
+                if matches!(
+                    self.storage_service
+                        .storage
+                        .lock()
+                        .await
+                        .put(
+                            replica_event.stripped_key.clone(),
+                            sample.into(),
+                            replica_event.timestamp,
+                        )
+                        .await,
+                    Ok(StorageInsertionResult::Outdated) | Err(_)
+                ) {
+                    // NOTE: This is not necessarily an error: as we are not locking the
+                    // `latest_updates` more events on the same key expression can be received
+                    // before we have time to store this one.
+                    //
+                    // In that scenario the Storage should either return an error or `Outdated`.
+                    return;
+                }
+            }
+            Action::WildcardPut(_) => {
+                self.apply_wildcard_update(
+                    &mut replication_log_guard,
+                    &replica_event,
+                    sample.into(),
+                )
+                .await;
+            }
+        }
+
+        replication_log_guard.insert_event_unchecked(replica_event.into());
+    }
+
+    /// Returns `true` if the provided `replica_event` requires more processing.
+    ///
+    /// This method will:
+    /// - check if there is a Wildcard Update that overrides it or a more recent Event in the
+    ///   Replication Log,
+    /// - if there is a Wildcard Update that overrides it, apply the Wildcard Update and return
+    ///   `false` as a Wildcard Update is self-contained,
+    /// - if there is a more recent Event, return `false` as this Replica is up-to-date,
+    /// - if there is neither, return `true` as depending on where this method was called, different
+    ///   operation(s) need to be performed.
+    async fn needs_further_processing(
+        &self,
+        replication_log_guard: &mut RwLockWriteGuard<'_, LogLatest>,
+        replica_event: &EventMetadata,
+    ) -> bool {
+        // We received an EventMetadata, we need to check if we don't have:
+        // 1. a Wildcard Update that overrides it,
+        // 2. a more recent Event on that same key expression already in the Replication Log.
+        let Ok(maybe_wildcard_update) = self.is_overridden_by_wildcard_update(replica_event).await
+        else {
+            tracing::error!(
+                "Internal error attempting to prefix < {:?} > with < {:?} >",
+                replica_event.stripped_key,
+                self.storage_service.configuration.strip_prefix
+            );
+            return false;
+        };
+
+        let maybe_newer_event = replication_log_guard
+            .lookup(replica_event)
+            .and_then(|log_event| {
+                if log_event.timestamp < replica_event.timestamp {
+                    None
+                } else {
+                    Some(log_event)
+                }
+            })
+            .cloned();
+
+        match (maybe_wildcard_update, maybe_newer_event) {
+            // No Event in the Replication Log or Wildcard Update, we go on, we need to process it.
+            (None, None) => {}
+            // If the timestamp of the Event in the Replication Log for the same key expression has
+            // a greater Timestamp then we discard this EventMetadata.
+            (None, Some(_)) => return false,
+            // We have a Wildcard Update that overrides the Event -> we override it and we're done.
+            (Some((wildcard_ke, wildcard_update)), None) => {
+                self.store_event_overridden_by_wildcard_update(
+                    replication_log_guard,
+                    replica_event.clone(),
+                    wildcard_ke,
+                    wildcard_update,
+                )
+                .await;
+                return false;
+            }
+            // The Wildcard Update we have and the Event have the same Timestamp: that means that
+            // what we have in the Replication Log is the application of the Wildcard Update.
+            //
+            // We thus need to check one very specific case: if the `replica_event` we received is a
+            // Delete that came *before* a Wildcard Update Put and *after* the last non-wildcard
+            // update.
+            //
+            // With an example:
+            //
+            // We have:
+            // - Put "a = 1" @t0
+            // - Wildcard Update "** = 42" @t2 (hence we have in the Log "a = 42" @t2)
+            //
+            // We receive:
+            // - Delete "a" @t1 (@t0 < @t1 < @t2).
+            //
+            // Despite having @t2 > @t1, this earlier Event should actually lead to the deletion of
+            // "a" because a Wildcard Update should not revive a deleted Event.
+            //
+            // NOTE: Wildcard Delete needs separate processing, done in the `apply_wildcard_update`
+            // method.
+            (Some((_, wildcard_update)), Some(log_event))
+                if wildcard_update.timestamp() == log_event.timestamp()
+                    && replica_event.action == Action::Delete
+                    && log_event.timestamp_last_non_wildcard_update.is_some_and(
+                        |timestamp_non_wildcard| replica_event.timestamp > timestamp_non_wildcard,
+                    ) =>
+            {
+                if log_event.action == Action::Put {
+                    let _ = self
+                        .storage_service
+                        .storage
+                        .lock()
+                        .await
+                        .delete(replica_event.stripped_key.clone(), *log_event.timestamp())
+                        .await;
+                }
+
+                if let Some(mut removed_event) =
+                    replication_log_guard.remove_event(&(&log_event).into())
+                {
+                    removed_event.set_timestamp_and_action(
+                        replica_event.timestamp,
+                        replica_event.action.clone(),
+                    );
+
+                    replication_log_guard.insert_event_unchecked(removed_event);
+                    return false;
+                }
+            }
+            // The timestamp of the Wildcard Update is greater than that of the Event, we apply the
+            // Wildcard Update.
+            (Some((wildcard_ke, wildcard_update)), Some(log_event))
+                if wildcard_update.timestamp() > log_event.timestamp() =>
+            {
+                self.store_event_overridden_by_wildcard_update(
+                    replication_log_guard,
+                    replica_event.clone(),
+                    wildcard_ke,
+                    wildcard_update,
+                )
+                .await;
+                return false;
+            }
+            // The timestamp of the Event in the Replication Log is greater or equal to the Wildcard
+            // Update: we have nothing to do.
+            (Some((_, wildcard_update)), Some(log_event))
+                if log_event.timestamp() >= wildcard_update.timestamp() =>
+            {
+                return false;
+            }
+            (_, _) => unreachable!(),
+        }
+
+        true
+    }
+
+    /// Applies the Wildcard Update provided in the `replica_event`, unless there is a more recent
+    /// one already recorded in the Replication Log.
+    ///
+    /// ⚠️ This method does NOT insert the Wildcard Update in the Replication Log. It still needs
+    ///    to be added afterwards. This is why we only take a mutable reference on the Write lock.
+    ///    (We do not perform this operation to avoid code duplication in methods calling this one.)
+    ///
+    /// Applying a Wildcard Update involves several steps:
+    ///
+    /// - We need to override any Event present in the latest cache and in the Replication Log. That
+    ///   means we need to:
+    ///   (i)   remove them,
+    ///   (ii)  if needed, override or delete the data associated in the Storage,
+    ///   (iii) update their metadata (putting the timestamp and action of the Wildcard Update),
+    ///   (iv)  re-insert them.
+    ///
+    /// - We need to register the Wildcard Update such that the Storage is aware of it and can
+    ///   apply it on late-comers.
+    async fn apply_wildcard_update(
+        &self,
+        replication_log_guard: &mut RwLockWriteGuard<'_, LogLatest>,
+        replica_event: &EventMetadata,
+        value: Value,
+    ) {
+        let (wildcard_ke, wildcard_kind) = match &replica_event.action {
+            Action::Put | Action::Delete => unreachable!(),
+            Action::WildcardPut(wildcard_ke) => (wildcard_ke, SampleKind::Put),
+            Action::WildcardDelete(wildcard_ke) => (wildcard_ke, SampleKind::Delete),
+        };
+
+        if matches!(
+            replication_log_guard.remove_older(replica_event),
+            EventRemoval::KeptNewer
+        ) {
+            return;
+        }
+
+        // We lock the Cache until we are done processing this Wildcard Update to not let pass Event
+        // that should be overridden: the Wildcard Update will only be applied once on older Events
+        // and that time is now.
+        let mut latest_updates_guard = self.latest_updates.write().await;
+        let mut overridden_events =
+            crate::replication::core::remove_events_overridden_by_wildcard_update(
+                &mut latest_updates_guard,
+                self.storage_service.configuration.strip_prefix.as_ref(),
+                wildcard_ke,
+                replica_event.timestamp(),
+                wildcard_kind,
+            );
+
+        match replication_log_guard.remove_events_overridden_by_wildcard_update(
+            wildcard_ke,
+            replica_event.timestamp(),
+            wildcard_kind,
+        ) {
+            Ok(events) => overridden_events.extend(events),
+            Err(e) => {
+                tracing::error!("Skipping Wildcard Update < {wildcard_ke} >: {e:?}");
+                return;
+            }
+        };
+
+        for mut overridden_event in overridden_events {
+            let overridden_event_action = overridden_event.action();
+            tracing::trace!("Applying < {wildcard_ke:?} > on: < {overridden_event:?} >");
+            match (overridden_event_action, wildcard_kind) {
+                // The methods `remove_events_overridden_by_wildcard_update` will not remove deleted
+                // Events.
+                (Action::Delete, _) => {
+                    #[cfg(debug_assertions)]
+                    unreachable!()
+                }
+
+                (Action::Put, SampleKind::Put) => {
+                    if matches!(
+                        self.storage_service
+                            .storage
+                            .lock()
+                            .await
+                            .put(
+                                overridden_event.key_expr().clone(),
+                                value.clone(),
+                                replica_event.timestamp,
+                            )
+                            .await,
+                        Ok(StorageInsertionResult::Outdated) | Err(_)
+                    ) {
+                        continue;
+                    }
+                }
+                (Action::Put, SampleKind::Delete) => {
+                    if matches!(
+                        self.storage_service
+                            .storage
+                            .lock()
+                            .await
+                            .delete(
+                                overridden_event.key_expr().clone(),
+                                *overridden_event.timestamp(),
+                            )
+                            .await,
+                        Ok(StorageInsertionResult::Outdated)
+                    ) {
+                        continue;
+                    }
+                }
+
+                // We are overriding a Wildcard Update with another Wildcard Update, there is no
+                // need to touch the Storage or to reinsert the overridden Wildcard Update, the new
+                // one is enough.
+                (
+                    Action::WildcardPut(overridden_wildcard_ke)
+                    | Action::WildcardDelete(overridden_wildcard_ke),
+                    _,
+                ) => {
+                    // NOTE: If a Wildcard Update overrides another Wildcard Update, there is no
+                    // need to reinsert the previous Wildcard Update, that would lead to extra data
+                    // stored for no valid reason, since the newer Wildcard Update will always
+                    // "win".
+                    //
+                    // Example:
+                    // 1. z_put -k "test/replication/**" -v "1" @t_0
+                    // 2. z_put -k "test/**" -v 42 @t_1  (t_1 > t_0)
+                    //
+                    // 2. overrides 1., so we remove 1. from the `wildcard_updates` structure.
+                    let mut wildcard_puts_guard = self.storage_service.wildcard_puts.write().await;
+                    wildcard_puts_guard.remove(overridden_wildcard_ke);
+                    wildcard_puts_guard.prune();
+                    continue;
+                }
+            }
+
+            overridden_event
+                .set_timestamp_and_action(replica_event.timestamp, replica_event.action.clone());
+            replication_log_guard.insert_event_unchecked(overridden_event);
+        }
+
+        self.storage_service
+            .register_wildcard_update(
+                wildcard_ke.clone(),
+                (&replica_event.action).into(),
+                replica_event.timestamp,
+                value,
+            )
+            .await;
+    }
+
+    /// Checks if the provided `replica_event` is overridden by a Wildcard Update and, if so,
+    /// returns the associated [Update].
+    ///
+    /// If there is no Wildcard Update that overrides it, `None` is returned.
+    ///
+    /// # Errors
+    ///
+    /// This method will return an error if the stripped key of the `replica_event` is set to `None`
+    /// and this Storage was configured without any `strip_prefix`.
+    ///
+    /// This is a "fatal" error that cannot be recovered from.
+    async fn is_overridden_by_wildcard_update(
+        &self,
+        replica_event: &EventMetadata,
+    ) -> ZResult<Option<(OwnedKeyExpr, Update)>> {
+        let full_event_key_expr = match &replica_event.action {
+            Action::Put | Action::Delete => crate::prefix(
+                self.storage_service.configuration.strip_prefix.as_ref(),
+                replica_event.stripped_key.as_ref(),
+            )?,
+            Action::WildcardPut(wildcard_ke) | Action::WildcardDelete(wildcard_ke) => {
+                wildcard_ke.clone()
+            }
+        };
+
+        Ok(self
+            .storage_service
+            .overriding_wild_update(
+                &full_event_key_expr,
+                &replica_event.timestamp,
+                &replica_event.timestamp_last_non_wildcard_update,
+                &replica_event.action,
+            )
+            .await)
+    }
+
+    /// Stores in the Storage and/or the Replication Log the provided `replica_event` *that is being
+    /// overridden by the `wildcard_update`*.
+    ///
+    /// The `replica_event` was sent by a Replica during the alignment process. It is not associated
+    /// to any data in the Storage.
+    ///
+    /// A payload will be pushed to the Storage if the `wildcard_update` is a put.
+    //
+    // NOTE: There is no need to attempt to delete an event in the Storage if the `wildcard_update`
+    //       is a delete. Indeed, if the wildcard update is a delete then it is impossible to have
+    //       a previous event associated to the same key expression as, by definition of a wildcard
+    //       update, it would have been deleted.
+    async fn store_event_overridden_by_wildcard_update(
+        &self,
+        replication_log_guard: &mut RwLockWriteGuard<'_, LogLatest>,
+        replica_event: EventMetadata,
+        wildcard_ke: OwnedKeyExpr,
+        wildcard_update: Update,
+    ) {
+        let wildcard_timestamp = *wildcard_update.timestamp();
+
+        // A Wildcard Update overrides another Wildcard Update, we have nothing to do.
+        if matches!(
+            replica_event.action,
+            Action::WildcardPut(_) | Action::WildcardDelete(_)
+        ) {
+            return;
+        }
+
+        tracing::trace!(
+            "Overriding < {replica_event:?} > with < {wildcard_ke} {} >",
+            wildcard_timestamp
+        );
+
+        // Generate the action that will be used to override the metadata of the Event. We do it
+        // now to avoid having to clone the `wildcard_update` because we move it below.
+        let wildcard_action = match wildcard_update.kind() {
+            SampleKind::Put => Action::WildcardPut(wildcard_ke),
+            SampleKind::Delete => Action::WildcardDelete(wildcard_ke),
+        };
+
+        if wildcard_update.kind() == SampleKind::Put
             && matches!(
-                self.storage
+                self.storage_service
+                    .storage
                     .lock()
                     .await
                     .put(
                         replica_event.stripped_key.clone(),
-                        sample.into(),
-                        replica_event.timestamp,
+                        wildcard_update.into_value(),
+                        wildcard_timestamp
                     )
                     .await,
                 Ok(StorageInsertionResult::Outdated) | Err(_)
             )
         {
+            tracing::error!(
+                "Failed to insert Wildcard Put Update applied to < {:?} >",
+                replica_event.stripped_key
+            );
             return;
         }
 
-        replication_log_guard.insert_event_unchecked(replica_event.into());
+        // First create an Event with the metadata sent by the Replica: we want to keep the
+        // `timestamp_last_non_wildcard_update`.
+        let mut event: Event = replica_event.into();
+        // Then update the Event with the values of the Wildcard Update.
+        event.set_timestamp_and_action(wildcard_timestamp, wildcard_action);
+
+        replication_log_guard.insert_event(event);
     }
 }

--- a/plugins/zenoh-plugin-storage-manager/src/replication/log.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replication/log.rs
@@ -282,6 +282,8 @@ impl LogLatest {
             return;
         };
 
+        tracing::trace!("Inserting < {:?} > in Replication Log", event.key_expr());
+
         self.bloom_filter_event.set(event.key_expr());
 
         self.intervals

--- a/plugins/zenoh-plugin-storage-manager/src/replication/log.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replication/log.rs
@@ -16,7 +16,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 use bloomfilter::Bloom;
 use serde::{Deserialize, Serialize};
-use zenoh::{key_expr::OwnedKeyExpr, sample::SampleKind, time::Timestamp, Result};
+use zenoh::{key_expr::OwnedKeyExpr, sample::SampleKind, time::Timestamp, Result as ZResult};
 use zenoh_backend_traits::config::ReplicaConfig;
 
 use super::{
@@ -352,7 +352,7 @@ impl LogLatest {
     /// This method will return an error if the index of the last elapsed interval is superior to
     /// [u64::MAX]. In theory, this should not happen but if it does, **it is an error that cannot
     /// be recovered from (⚠️)**.
-    pub fn digest(&self) -> Result<Digest> {
+    pub fn digest(&self) -> ZResult<Digest> {
         let last_elapsed_interval = self.configuration.last_elapsed_interval()?;
 
         Ok(self.digest_from(last_elapsed_interval))

--- a/plugins/zenoh-plugin-storage-manager/src/replication/mod.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replication/mod.rs
@@ -33,5 +33,5 @@ mod digest;
 mod log;
 mod service;
 
-pub(crate) use log::{Event, LogLatest};
+pub(crate) use log::{Action, Event, LogLatest, LogLatestKey};
 pub(crate) use service::ReplicationService;

--- a/plugins/zenoh-plugin-storage-manager/src/replication/service.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replication/service.rs
@@ -49,20 +49,18 @@ impl ReplicationService {
     ///    received.
     pub async fn spawn_start(
         zenoh_session: Arc<Session>,
-        storage_service: &StorageService,
+        storage_service: Arc<StorageService>,
         storage_key_expr: OwnedKeyExpr,
         replication_log: Arc<RwLock<LogLatest>>,
         latest_updates: Arc<RwLock<LatestUpdates>>,
         mut rx: Receiver<StorageMessage>,
     ) {
-        let storage = storage_service.storage.clone();
-
         let replication = Replication {
             zenoh_session,
             replication_log,
             storage_key_expr,
             latest_updates,
-            storage,
+            storage_service,
         };
 
         if replication

--- a/plugins/zenoh-plugin-storage-manager/src/replication/tests/log.test.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replication/tests/log.test.rs
@@ -15,14 +15,14 @@
 use std::{collections::HashMap, str::FromStr, time::Duration};
 
 use uhlc::{Timestamp, HLC, NTP64};
-use zenoh::{key_expr::OwnedKeyExpr, sample::SampleKind};
+use zenoh::key_expr::OwnedKeyExpr;
 use zenoh_backend_traits::config::ReplicaConfig;
 
-use super::{Event, LogLatest};
+use super::{Event, EventMetadata, LogLatest};
 use crate::replication::{
     classification::{Interval, IntervalIdx, SubInterval, SubIntervalIdx},
     digest::{Digest, Fingerprint},
-    log::EventInsertion,
+    log::{Action, EventInsertion},
 };
 
 fn generate_timestamp_matching(
@@ -60,30 +60,30 @@ fn test_insert() {
     let event_10_0_0 = Event::new(
         Some(OwnedKeyExpr::from_str("10/0/0").unwrap()),
         generate_timestamp_matching(&log, &hlc, 10, 0, 0),
-        SampleKind::Put,
+        &Action::Put,
     );
-    assert!(!log.bloom_filter_event.check(event_10_0_0.key_expr()));
+    assert!(!log.bloom_filter_event.check(&event_10_0_0.log_key()));
     assert_eq!(
         EventInsertion::New(event_10_0_0.clone()),
         log.insert_event(Event::new(
             event_10_0_0.key_expr().clone(),
             *event_10_0_0.timestamp(),
-            SampleKind::Put
+            &Action::Put
         ))
     );
-    assert!(log.bloom_filter_event.check(event_10_0_0.key_expr()));
+    assert!(log.bloom_filter_event.check(&event_10_0_0.log_key()));
 
     let event_10_0_0_new = Event::new(
         event_10_0_0.key_expr().clone(),
         generate_timestamp_matching(&log, &hlc, 10, 0, 1),
-        SampleKind::Put,
+        &Action::Put,
     );
     assert_eq!(
         EventInsertion::ReplacedOlder(event_10_0_0.clone()),
         log.insert_event(Event::new(
             event_10_0_0_new.key_expr().clone(),
             *event_10_0_0_new.timestamp(),
-            SampleKind::Put
+            &Action::Put
         ))
     );
 
@@ -93,7 +93,7 @@ fn test_insert() {
         log.insert_event(Event::new(
             event_10_0_0_new.key_expr().clone(),
             *event_10_0_0_new.timestamp(),
-            SampleKind::Put
+            &Action::Put
         ))
     );
 
@@ -124,54 +124,54 @@ fn test_digest() {
     let event_warm_5_1_0 = Event::new(
         Some(OwnedKeyExpr::from_str("5/1/0").unwrap()),
         generate_timestamp_matching(&log, &hlc, 5, 1, 0),
-        SampleKind::Put,
+        &Action::Put,
     );
     assert_eq!(
         EventInsertion::New(event_warm_5_1_0.clone()),
         log.insert_event(Event::new(
             event_warm_5_1_0.key_expr().clone(),
             *event_warm_5_1_0.timestamp(),
-            SampleKind::Put
+            &Action::Put
         ))
     );
     let event_warm_6_2_0 = Event::new(
         Some(OwnedKeyExpr::from_str("6/2/0").unwrap()),
         generate_timestamp_matching(&log, &hlc, 6, 2, 0),
-        SampleKind::Put,
+        &Action::Put,
     );
     assert_eq!(
         EventInsertion::New(event_warm_6_2_0.clone()),
         log.insert_event(Event::new(
             event_warm_6_2_0.key_expr().clone(),
             *event_warm_6_2_0.timestamp(),
-            SampleKind::Put
+            &Action::Put
         ))
     );
     let event_warm_6_2_1 = Event::new(
         Some(OwnedKeyExpr::from_str("6/2/1").unwrap()),
         generate_timestamp_matching(&log, &hlc, 6, 2, 1),
-        SampleKind::Put,
+        &Action::Put,
     );
     assert_eq!(
         EventInsertion::New(event_warm_6_2_1.clone()),
         log.insert_event(Event::new(
             event_warm_6_2_1.key_expr().clone(),
             *event_warm_6_2_1.timestamp(),
-            SampleKind::Put
+            &Action::Put
         ))
     );
 
     let event_hot_10_4_1 = Event::new(
         Some(OwnedKeyExpr::from_str("10/4/1").unwrap()),
         generate_timestamp_matching(&log, &hlc, 10, 4, 1),
-        SampleKind::Put,
+        &Action::Put,
     );
     assert_eq!(
         EventInsertion::New(event_hot_10_4_1.clone()),
         log.insert_event(Event::new(
             event_hot_10_4_1.key_expr().clone(),
             *event_hot_10_4_1.timestamp(),
-            SampleKind::Put
+            &Action::Put
         ))
     );
 
@@ -179,14 +179,14 @@ fn test_digest() {
     let event_burning_11_0_0 = Event::new(
         Some(OwnedKeyExpr::from_str("11/0/0").unwrap()),
         generate_timestamp_matching(&log, &hlc, 11, 0, 42),
-        SampleKind::Put,
+        &Action::Put,
     );
     assert_eq!(
         EventInsertion::New(event_burning_11_0_0.clone()),
         log.insert_event(Event::new(
             event_burning_11_0_0.key_expr().clone(),
             *event_burning_11_0_0.timestamp(),
-            SampleKind::Put
+            &Action::Put
         ))
     );
 
@@ -217,53 +217,53 @@ fn test_digest() {
     let event_cold_0_0_0 = Event::new(
         Some(OwnedKeyExpr::from_str("0/0/0").unwrap()),
         generate_timestamp_matching(&log, &hlc, 0, 0, 0),
-        SampleKind::Put,
+        &Action::Put,
     );
     assert_eq!(
         EventInsertion::New(event_cold_0_0_0.clone()),
         log.insert_event(Event::new(
             event_cold_0_0_0.key_expr().clone(),
             *event_cold_0_0_0.timestamp(),
-            SampleKind::Put
+            &Action::Put
         ))
     );
     let event_cold_1_0_0 = Event::new(
         Some(OwnedKeyExpr::from_str("1/0/0").unwrap()),
         generate_timestamp_matching(&log, &hlc, 1, 0, 0),
-        SampleKind::Put,
+        &Action::Put,
     );
     assert_eq!(
         EventInsertion::New(event_cold_1_0_0.clone()),
         log.insert_event(Event::new(
             event_cold_1_0_0.key_expr().clone(),
             *event_cold_1_0_0.timestamp(),
-            SampleKind::Put
+            &Action::Put
         ))
     );
     let event_cold_2_0_0 = Event::new(
         Some(OwnedKeyExpr::from_str("2/0/0").unwrap()),
         generate_timestamp_matching(&log, &hlc, 2, 0, 0),
-        SampleKind::Put,
+        &Action::Put,
     );
     assert_eq!(
         EventInsertion::New(event_cold_2_0_0.clone()),
         log.insert_event(Event::new(
             event_cold_2_0_0.key_expr().clone(),
             *event_cold_2_0_0.timestamp(),
-            SampleKind::Put
+            &Action::Put
         ))
     );
     let event_cold_4_0_0 = Event::new(
         Some(OwnedKeyExpr::from_str("4/0/0").unwrap()),
         generate_timestamp_matching(&log, &hlc, 4, 0, 0),
-        SampleKind::Put,
+        &Action::Put,
     );
     assert_eq!(
         EventInsertion::New(event_cold_4_0_0.clone()),
         log.insert_event(Event::new(
             event_cold_4_0_0.key_expr().clone(),
             *event_cold_4_0_0.timestamp(),
-            SampleKind::Put
+            &Action::Put
         ))
     );
 
@@ -295,4 +295,110 @@ fn test_digest() {
         hot_era_fingerprints: HashMap::default(),
     };
     assert_eq!(expected_digest, log.digest_from(IntervalIdx(12)));
+}
+
+#[test]
+fn test_event() {
+    let hlc = HLC::default();
+
+    let ke = OwnedKeyExpr::from_str("test/key").unwrap();
+    let ts = hlc.new_timestamp();
+
+    let expected_event = Event {
+        metadata: EventMetadata {
+            stripped_key: Some(ke.clone()),
+            timestamp: ts,
+            timestamp_last_non_wildcard_update: Some(ts),
+            action: Action::Put,
+        },
+        fingerprint: Event::compute_fingerprint(&Some(ke.clone()), &ts),
+    };
+
+    let event = Event::new(Some(ke.clone()), ts, &Action::Put);
+
+    assert_eq!(expected_event, event);
+
+    let wildcard_ke = OwnedKeyExpr::from_str("test/key").unwrap();
+    let wildcard_ts = hlc.new_timestamp();
+
+    let expected_wildcard_event = Event {
+        metadata: EventMetadata {
+            stripped_key: Some(wildcard_ke.clone()),
+            timestamp: wildcard_ts,
+            timestamp_last_non_wildcard_update: None,
+            action: Action::WildcardPut(wildcard_ke.clone()),
+        },
+        fingerprint: Event::compute_fingerprint(&Some(wildcard_ke.clone()), &wildcard_ts),
+    };
+
+    let wildcard_event = Event::new(
+        Some(wildcard_ke.clone()),
+        wildcard_ts,
+        &Action::WildcardPut(wildcard_ke.clone()),
+    );
+
+    assert_eq!(expected_wildcard_event, wildcard_event);
+}
+
+#[test]
+fn test_convert_metadata_to_event() {
+    let hlc = HLC::default();
+
+    // Wildcard Update
+    let wildcard_timestamp = hlc.new_timestamp();
+    let wildcard_ke = OwnedKeyExpr::from_str("test/**").unwrap();
+
+    let event_metadata_wildcard = EventMetadata {
+        stripped_key: Some(wildcard_ke.clone()),
+        timestamp: wildcard_timestamp,
+        timestamp_last_non_wildcard_update: None,
+        action: Action::WildcardPut(wildcard_ke.clone()),
+    };
+
+    let expected_wildcard_event = Event::new(
+        Some(wildcard_ke.clone()),
+        wildcard_timestamp,
+        &Action::WildcardPut(wildcard_ke),
+    );
+
+    let converted_event: Event = event_metadata_wildcard.into();
+    assert_eq!(expected_wildcard_event, converted_event);
+
+    // PutOrDelete
+    let put_timestamp = hlc.new_timestamp();
+    let put_ke = OwnedKeyExpr::from_str("test/a").unwrap();
+
+    let event_metadata_put = EventMetadata {
+        stripped_key: Some(put_ke.clone()),
+        timestamp: put_timestamp,
+        timestamp_last_non_wildcard_update: Some(put_timestamp),
+        action: Action::Put,
+    };
+
+    let expected_put_event = Event::new(Some(put_ke.clone()), put_timestamp, &Action::Put);
+
+    let converted_event: Event = event_metadata_put.into();
+    assert_eq!(expected_put_event, converted_event);
+
+    // PutOrDelete overridden by Wildcard
+    let overridden_timestamp = hlc.new_timestamp();
+    let overridden_ke = OwnedKeyExpr::from_str("test/overridden").unwrap();
+
+    let event_metadata_put = EventMetadata {
+        stripped_key: Some(overridden_ke.clone()),
+        timestamp: overridden_timestamp,
+        timestamp_last_non_wildcard_update: Some(put_timestamp),
+        action: Action::Put,
+    };
+
+    let expected_put_event = Event {
+        metadata: event_metadata_put.clone(),
+        fingerprint: Event::compute_fingerprint(
+            &Some(overridden_ke.clone()),
+            &overridden_timestamp,
+        ),
+    };
+
+    let converted_event: Event = event_metadata_put.into();
+    assert_eq!(expected_put_event, converted_event);
 }

--- a/plugins/zenoh-plugin-storage-manager/src/storages_mgt/service.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/storages_mgt/service.rs
@@ -218,7 +218,7 @@ impl StorageService {
     // The storage should only simply save the key, sample pair while put and retrieve the same
     // during get the trimming during PUT and GET should be handled by the plugin
     pub(crate) async fn process_sample(&self, sample: Sample) -> ZResult<()> {
-        tracing::trace!("[STORAGE] Processing sample: {:?}", sample);
+        tracing::trace!("[STORAGE] Processing sample: {:?}", sample.key_expr());
 
         // A Sample, in theory, will not arrive to a Storage without a Timestamp. This check (which,
         // again, should never enter the `None` branch) ensures that the Storage Manager
@@ -253,12 +253,6 @@ impl StorageService {
                 tracing::trace!("Skipping Sample < {} > deleted later on", k);
                 continue;
             }
-
-            tracing::trace!(
-                "Sample `{:?}` identified as needed processing for key {}",
-                sample,
-                k
-            );
 
             // there might be the case that the actual update was outdated due to a wild card
             // update, but not stored yet in the storage. get the relevant wild

--- a/plugins/zenoh-plugin-storage-manager/src/storages_mgt/service.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/storages_mgt/service.rs
@@ -616,20 +616,13 @@ impl StorageService {
             Ok(entries) => {
                 for (k, _ts) in entries {
                     // @TODO: optimize adding back the prefix (possible inspiration from https://github.com/eclipse-zenoh/zenoh/blob/0.5.0-beta.9/backends/traits/src/utils.rs#L79)
-                    let full_key = match k {
-                        Some(key) => crate::prefix(prefix, &key),
-                        None => {
-                            let Some(prefix) = prefix else {
-                                // TODO Check if we have anything in place that would prevent such
-                                //      an error from happening.
-                                tracing::error!(
-                                    "Internal bug: empty key with no `strip_prefix` configured"
-                                );
-                                continue;
-                            };
-                            prefix.clone()
-                        }
+                    let Ok(full_key) = crate::prefix(prefix, k.as_ref()) else {
+                        tracing::error!(
+                            "Internal error: empty key with no `strip_prefix` configured"
+                        );
+                        continue;
                     };
+
                     if key_expr.intersects(&full_key.clone()) {
                         result.push(full_key);
                     }


### PR DESCRIPTION
This PR adds support for Wildcard updates (be it deletion or addition) when replicating storage.

⚠️  Commits are meant to be reviewed individually (once the PR is no longer a draft).
⚠️ This PR is meant to be rebased _not squashed_.