### PR TITLE
feat!: renaming of TLS configuration parameters

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -445,7 +445,7 @@
         // if set to false zenoh will disregard the common names of the certificates when verifying servers.
         // This could be dangerous because your CA can have signed a server cert for foo.com, that's later being used to host a server at baz.com. If you wan't your
         // ca to verify that the server at baz.com is actually baz.com, let this be true (default).
-        verify_name_on_connect: null,
+        verify_name_on_connect: true,
       },
     },
     /// Shared memory configuration.

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -431,20 +431,21 @@
         /// or the client's keys and certificates, depending on the node's mode. If not specified
         /// on router mode then the default WebPKI certificates are used instead.
         root_ca_certificate: null,
-        /// Path to the TLS server private key
-        server_private_key: null,
-        /// Path to the TLS server public certificate
-        server_certificate: null,
-        /// Client authentication, if true enables mTLS (mutual authentication)
-        client_auth: false,
-        /// Path to the TLS client private key
-        client_private_key: null,
-        /// Path to the TLS client public certificate
-        client_certificate: null,
-        // Whether or not to use server name verification, if set to false zenoh will disregard the common names of the certificates when verifying servers.
+        /// Path to the TLS listening side private key
+        listen_private_key: null,
+        /// Path to the TLS listening side public certificate
+        listen_certificate: null,
+        ///  Enables mTLS (mutual authentication), client authentication
+        enable_mtls: false,
+        /// Path to the TLS connecting side private key
+        connect_private_key: null,
+        /// Path to the TLS client connecting side certificate
+        connect_certificate: null,
+        // Whether or not to verify the mathching between hostname/dns and certificate when connecting,
+        // if set to false zenoh will disregard the common names of the certificates when verifying servers.
         // This could be dangerous because your CA can have signed a server cert for foo.com, that's later being used to host a server at baz.com. If you wan't your
         // ca to verify that the server at baz.com is actually baz.com, let this be true (default).
-        server_name_verification: null,
+        verify_name_on_connect: null,
       },
     },
     /// Shared memory configuration.

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -441,7 +441,7 @@
         connect_private_key: null,
         /// Path to the TLS client connecting side certificate
         connect_certificate: null,
-        // Whether or not to verify the mathching between hostname/dns and certificate when connecting,
+        // Whether or not to verify the matching between hostname/dns and certificate when connecting,
         // if set to false zenoh will disregard the common names of the certificates when verifying servers.
         // This could be dangerous because your CA can have signed a server cert for foo.com, that's later being used to host a server at baz.com. If you wan't your
         // ca to verify that the server at baz.com is actually baz.com, let this be true (default).

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -439,7 +439,7 @@
         enable_mtls: false,
         /// Path to the TLS connecting side private key
         connect_private_key: null,
-        /// Path to the TLS client connecting side certificate
+        /// Path to the TLS connecting side certificate
         connect_certificate: null,
         // Whether or not to verify the matching between hostname/dns and certificate when connecting,
         // if set to false zenoh will disregard the common names of the certificates when verifying servers.

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -463,23 +463,23 @@ validated_struct::validator! {
                 pub tls: #[derive(Default)]
                 TLSConf {
                     root_ca_certificate: Option<String>,
-                    server_private_key: Option<String>,
-                    server_certificate: Option<String>,
-                    client_auth: Option<bool>,
-                    client_private_key: Option<String>,
-                    client_certificate: Option<String>,
-                    server_name_verification: Option<bool>,
+                    listen_private_key: Option<String>,
+                    listen_certificate: Option<String>,
+                    enable_mtls: Option<bool>,
+                    connect_private_key: Option<String>,
+                    connect_certificate: Option<String>,
+                    verify_name_on_connect: Option<bool>,
                     // Skip serializing field because they contain secrets
                     #[serde(skip_serializing)]
                     root_ca_certificate_base64: Option<SecretValue>,
                     #[serde(skip_serializing)]
-                    server_private_key_base64:  Option<SecretValue>,
+                    listen_private_key_base64:  Option<SecretValue>,
                     #[serde(skip_serializing)]
-                    server_certificate_base64: Option<SecretValue>,
+                    listen_certificate_base64: Option<SecretValue>,
                     #[serde(skip_serializing)]
-                    client_private_key_base64 :  Option<SecretValue>,
+                    connect_private_key_base64 :  Option<SecretValue>,
                     #[serde(skip_serializing)]
-                    client_certificate_base64 :  Option<SecretValue>,
+                    connect_certificate_base64 :  Option<SecretValue>,
                 },
                 pub unixpipe: #[derive(Default)]
                 UnixPipeConf {

--- a/io/zenoh-links/zenoh-link-quic/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/lib.rs
@@ -111,5 +111,5 @@ pub mod config {
     pub const TLS_ENABLE_MTLS: &str = "enable_mtls";
 
     pub const TLS_VERIFY_NAME_ON_CONNECT: &str = "verify_name_on_connect";
-    pub const TLS_VERIFY_NAME_ON_CONNECT_DEFAULT: &str = "true";
+    pub const TLS_VERIFY_NAME_ON_CONNECT_DEFAULT: bool = true;
 }

--- a/io/zenoh-links/zenoh-link-quic/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/lib.rs
@@ -92,24 +92,24 @@ pub mod config {
     pub const TLS_ROOT_CA_CERTIFICATE_RAW: &str = "root_ca_certificate_raw";
     pub const TLS_ROOT_CA_CERTIFICATE_BASE64: &str = "root_ca_certificate_base64";
 
-    pub const TLS_SERVER_PRIVATE_KEY_FILE: &str = "server_private_key_file";
-    pub const TLS_SERVER_PRIVATE_KEY_RAW: &str = "server_private_key_raw";
-    pub const TLS_SERVER_PRIVATE_KEY_BASE64: &str = "server_private_key_base64";
+    pub const TLS_LISTEN_PRIVATE_KEY_FILE: &str = "listen_private_key_file";
+    pub const TLS_LISTEN_PRIVATE_KEY_RAW: &str = "listen_private_key_raw";
+    pub const TLS_LISTEN_PRIVATE_KEY_BASE64: &str = "listen_private_key_base64";
 
-    pub const TLS_SERVER_CERTIFICATE_FILE: &str = "server_certificate_file";
-    pub const TLS_SERVER_CERTIFICATE_RAW: &str = "server_certificate_raw";
-    pub const TLS_SERVER_CERTIFICATE_BASE64: &str = "server_certificate_base64";
+    pub const TLS_LISTEN_CERTIFICATE_FILE: &str = "listen_certificate_file";
+    pub const TLS_LISTEN_CERTIFICATE_RAW: &str = "listen_certificate_raw";
+    pub const TLS_LISTEN_CERTIFICATE_BASE64: &str = "listen_certificate_base64";
 
-    pub const TLS_CLIENT_PRIVATE_KEY_FILE: &str = "client_private_key_file";
-    pub const TLS_CLIENT_PRIVATE_KEY_RAW: &str = "client_private_key_raw";
-    pub const TLS_CLIENT_PRIVATE_KEY_BASE64: &str = "client_private_key_base64";
+    pub const TLS_CONNECT_PRIVATE_KEY_FILE: &str = "connect_private_key_file";
+    pub const TLS_CONNECT_PRIVATE_KEY_RAW: &str = "connect_private_key_raw";
+    pub const TLS_CONNECT_PRIVATE_KEY_BASE64: &str = "connect_private_key_base64";
 
-    pub const TLS_CLIENT_CERTIFICATE_FILE: &str = "client_certificate_file";
-    pub const TLS_CLIENT_CERTIFICATE_RAW: &str = "client_certificate_raw";
-    pub const TLS_CLIENT_CERTIFICATE_BASE64: &str = "client_certificate_base64";
+    pub const TLS_CONNECT_CERTIFICATE_FILE: &str = "connect_certificate_file";
+    pub const TLS_CONNECT_CERTIFICATE_RAW: &str = "connect_certificate_raw";
+    pub const TLS_CONNECT_CERTIFICATE_BASE64: &str = "connect_certificate_base64";
 
-    pub const TLS_CLIENT_AUTH: &str = "client_auth";
+    pub const TLS_ENABLE_MTLS: &str = "enable_mtls";
 
-    pub const TLS_SERVER_NAME_VERIFICATION: &str = "server_name_verification";
-    pub const TLS_SERVER_NAME_VERIFICATION_DEFAULT: &str = "true";
+    pub const TLS_VERIFY_NAME_ON_CONNECT: &str = "verify_name_on_connect";
+    pub const TLS_VERIFY_NAME_ON_CONNECT_DEFAULT: &str = "true";
 }

--- a/io/zenoh-links/zenoh-link-quic/src/utils.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/utils.rs
@@ -64,7 +64,7 @@ impl ConfigurationInspector<ZenohConfig> for TlsConfigurator {
 
         match (c.listen_private_key(), c.listen_private_key_base64()) {
             (Some(_), Some(_)) => {
-                bail!("Only one between 'server_private_key' and 'server_private_key_base64' can be present!")
+                bail!("Only one between 'listen_private_key' and 'listen_private_key_base64' can be present!")
             }
             (Some(server_private_key), None) => {
                 ps.push((TLS_LISTEN_PRIVATE_KEY_FILE, server_private_key));
@@ -80,7 +80,7 @@ impl ConfigurationInspector<ZenohConfig> for TlsConfigurator {
 
         match (c.listen_certificate(), c.listen_certificate_base64()) {
             (Some(_), Some(_)) => {
-                bail!("Only one between 'server_certificate' and 'server_certificate_base64' can be present!")
+                bail!("Only one between 'listen_certificate' and 'listen_certificate_base64' can be present!")
             }
             (Some(server_certificate), None) => {
                 ps.push((TLS_LISTEN_CERTIFICATE_FILE, server_certificate));
@@ -103,7 +103,7 @@ impl ConfigurationInspector<ZenohConfig> for TlsConfigurator {
 
         match (c.connect_private_key(), c.connect_private_key_base64()) {
             (Some(_), Some(_)) => {
-                bail!("Only one between 'client_private_key' and 'client_private_key_base64' can be present!")
+                bail!("Only one between 'connect_private_key' and 'connect_private_key_base64' can be present!")
             }
             (Some(client_private_key), None) => {
                 ps.push((TLS_CONNECT_PRIVATE_KEY_FILE, client_private_key));
@@ -154,7 +154,7 @@ impl TlsServerConfig {
         let tls_server_client_auth: bool = match config.get(TLS_ENABLE_MTLS) {
             Some(s) => s
                 .parse()
-                .map_err(|_| zerror!("Unknown client auth argument: {}", s))?,
+                .map_err(|_| zerror!("Unknown enable mTLS argument: {}", s))?,
             None => false,
         };
         let tls_server_private_key = TlsServerConfig::load_tls_private_key(config).await?;
@@ -203,7 +203,7 @@ impl TlsServerConfig {
             let root_cert_store = load_trust_anchors(config)?.map_or_else(
                 || {
                     Err(zerror!(
-                        "Missing root certificates while client authentication is enabled."
+                        "Missing root certificates while mTLS is enabled."
                     ))
                 },
                 Ok,
@@ -252,7 +252,7 @@ impl TlsClientConfig {
         let tls_client_server_auth: bool = match config.get(TLS_ENABLE_MTLS) {
             Some(s) => s
                 .parse()
-                .map_err(|_| zerror!("Unknown client auth argument: {}", s))?,
+                .map_err(|_| zerror!("Unknown enable mTLS argument: {}", s))?,
             None => false,
         };
 

--- a/io/zenoh-links/zenoh-link-quic/src/utils.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/utils.rs
@@ -133,12 +133,13 @@ impl ConfigurationInspector<ZenohConfig> for TlsConfigurator {
             _ => {}
         }
 
-        if let Some(server_name_verification) = c.verify_name_on_connect() {
-            match server_name_verification {
-                true => ps.push((TLS_VERIFY_NAME_ON_CONNECT, "true")),
-                false => ps.push((TLS_VERIFY_NAME_ON_CONNECT, "false")),
-            };
-        }
+        match c
+            .verify_name_on_connect()
+            .unwrap_or(TLS_VERIFY_NAME_ON_CONNECT_DEFAULT)
+        {
+            true => ps.push((TLS_VERIFY_NAME_ON_CONNECT, "true")),
+            false => ps.push((TLS_VERIFY_NAME_ON_CONNECT, "false")),
+        };
 
         Ok(parameters::from_iter(ps.drain(..)))
     }

--- a/io/zenoh-links/zenoh-link-quic/src/utils.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/utils.rs
@@ -201,11 +201,7 @@ impl TlsServerConfig {
 
         let sc = if tls_server_client_auth {
             let root_cert_store = load_trust_anchors(config)?.map_or_else(
-                || {
-                    Err(zerror!(
-                        "Missing root certificates while mTLS is enabled."
-                    ))
-                },
+                || Err(zerror!("Missing root certificates while mTLS is enabled.")),
                 Ok,
             )?;
             let client_auth = WebPkiClientVerifier::builder(root_cert_store.into()).build()?;

--- a/io/zenoh-links/zenoh-link-quic/src/utils.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/utils.rs
@@ -119,7 +119,7 @@ impl ConfigurationInspector<ZenohConfig> for TlsConfigurator {
 
         match (c.connect_certificate(), c.connect_certificate_base64()) {
             (Some(_), Some(_)) => {
-                bail!("Only one between 'client_certificate' and 'client_certificate_base64' can be present!")
+                bail!("Only one between 'connect_certificate' and 'connect_certificate_base64' can be present!")
             }
             (Some(client_certificate), None) => {
                 ps.push((TLS_CONNECT_CERTIFICATE_FILE, client_certificate));

--- a/io/zenoh-links/zenoh-link-tls/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/lib.rs
@@ -88,23 +88,23 @@ pub mod config {
     pub const TLS_ROOT_CA_CERTIFICATE_RAW: &str = "root_ca_certificate_raw";
     pub const TLS_ROOT_CA_CERTIFICATE_BASE64: &str = "root_ca_certificate_base64";
 
-    pub const TLS_SERVER_PRIVATE_KEY_FILE: &str = "server_private_key_file";
-    pub const TLS_SERVER_PRIVATE_KEY_RAW: &str = "server_private_key_raw";
-    pub const TLS_SERVER_PRIVATE_KEY_BASE_64: &str = "server_private_key_base64";
+    pub const TLS_LISTEN_PRIVATE_KEY_FILE: &str = "listen_private_key_file";
+    pub const TLS_LISTEN_PRIVATE_KEY_RAW: &str = "listen_private_key_raw";
+    pub const TLS_LISTEN_PRIVATE_KEY_BASE_64: &str = "listen_private_key_base64";
 
-    pub const TLS_SERVER_CERTIFICATE_FILE: &str = "server_certificate_file";
-    pub const TLS_SERVER_CERTIFICATE_RAW: &str = "server_certificate_raw";
-    pub const TLS_SERVER_CERTIFICATE_BASE64: &str = "server_certificate_base64";
+    pub const TLS_LISTEN_CERTIFICATE_FILE: &str = "listen_certificate_file";
+    pub const TLS_LISTEN_CERTIFICATE_RAW: &str = "listen_certificate_raw";
+    pub const TLS_LISTEN_CERTIFICATE_BASE64: &str = "listen_certificate_base64";
 
-    pub const TLS_CLIENT_PRIVATE_KEY_FILE: &str = "client_private_key_file";
-    pub const TLS_CLIENT_PRIVATE_KEY_RAW: &str = "client_private_key_raw";
-    pub const TLS_CLIENT_PRIVATE_KEY_BASE64: &str = "client_private_key_base64";
+    pub const TLS_CONNECT_PRIVATE_KEY_FILE: &str = "connect_private_key_file";
+    pub const TLS_CONNECT_PRIVATE_KEY_RAW: &str = "connect_private_key_raw";
+    pub const TLS_CONNECT_PRIVATE_KEY_BASE64: &str = "connect_private_key_base64";
 
-    pub const TLS_CLIENT_CERTIFICATE_FILE: &str = "client_certificate_file";
-    pub const TLS_CLIENT_CERTIFICATE_RAW: &str = "client_certificate_raw";
-    pub const TLS_CLIENT_CERTIFICATE_BASE64: &str = "client_certificate_base64";
+    pub const TLS_CONNECT_CERTIFICATE_FILE: &str = "connect_certificate_file";
+    pub const TLS_CONNECT_CERTIFICATE_RAW: &str = "connect_certificate_raw";
+    pub const TLS_CONNECT_CERTIFICATE_BASE64: &str = "connect_certificate_base64";
 
-    pub const TLS_CLIENT_AUTH: &str = "client_auth";
+    pub const TLS_ENABLE_MTLS: &str = "enable_mtls";
 
-    pub const TLS_SERVER_NAME_VERIFICATION: &str = "server_name_verification";
+    pub const TLS_VERIFY_NAME_ON_CONNECT: &str = "verify_name_on_connect";
 }

--- a/io/zenoh-links/zenoh-link-tls/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/lib.rs
@@ -107,4 +107,5 @@ pub mod config {
     pub const TLS_ENABLE_MTLS: &str = "enable_mtls";
 
     pub const TLS_VERIFY_NAME_ON_CONNECT: &str = "verify_name_on_connect";
+    pub const TLS_VERIFY_NAME_ON_CONNECT_DEFAULT: bool = true;
 }

--- a/io/zenoh-links/zenoh-link-tls/src/utils.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/utils.rs
@@ -121,7 +121,7 @@ impl ConfigurationInspector<ZenohConfig> for TlsConfigurator {
 
         match (c.connect_certificate(), c.connect_certificate_base64()) {
             (Some(_), Some(_)) => {
-                bail!("Only one between 'client_certificate' and 'client_certificate_base64' can be present!")
+                bail!("Only one between 'connect_certificate' and 'connect_certificate_base64' can be present!")
             }
             (Some(client_certificate), None) => {
                 ps.push((TLS_CONNECT_CERTIFICATE_FILE, client_certificate));

--- a/io/zenoh-links/zenoh-link-tls/src/utils.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/utils.rs
@@ -66,7 +66,7 @@ impl ConfigurationInspector<ZenohConfig> for TlsConfigurator {
 
         match (c.listen_private_key(), c.listen_private_key_base64()) {
             (Some(_), Some(_)) => {
-                bail!("Only one between 'server_private_key' and 'server_private_key_base64' can be present!")
+                bail!("Only one between 'listen_private_key' and 'listen_private_key' can be present!")
             }
             (Some(server_private_key), None) => {
                 ps.push((TLS_LISTEN_PRIVATE_KEY_FILE, server_private_key));
@@ -82,7 +82,7 @@ impl ConfigurationInspector<ZenohConfig> for TlsConfigurator {
 
         match (c.listen_certificate(), c.listen_certificate_base64()) {
             (Some(_), Some(_)) => {
-                bail!("Only one between 'server_certificate' and 'server_certificate_base64' can be present!")
+                bail!("Only one between 'listen_certificate' and 'listen_certificate_base64' can be present!")
             }
             (Some(server_certificate), None) => {
                 ps.push((TLS_LISTEN_CERTIFICATE_FILE, server_certificate));
@@ -105,7 +105,7 @@ impl ConfigurationInspector<ZenohConfig> for TlsConfigurator {
 
         match (c.connect_private_key(), c.connect_private_key_base64()) {
             (Some(_), Some(_)) => {
-                bail!("Only one between 'client_private_key' and 'client_private_key_base64' can be present!")
+                bail!("Only one between 'connect_private_key' and 'connect_private_key_base64' can be present!")
             }
             (Some(client_private_key), None) => {
                 ps.push((TLS_CONNECT_PRIVATE_KEY_FILE, client_private_key));
@@ -156,7 +156,7 @@ impl TlsServerConfig {
         let tls_server_client_auth: bool = match config.get(TLS_ENABLE_MTLS) {
             Some(s) => s
                 .parse()
-                .map_err(|_| zerror!("Unknown client auth argument: {}", s))?,
+                .map_err(|_| zerror!("Unknown enable mTLS argument: {}", s))?,
             None => false,
         };
         let tls_server_private_key = TlsServerConfig::load_tls_private_key(config).await?;
@@ -205,7 +205,7 @@ impl TlsServerConfig {
             let root_cert_store = load_trust_anchors(config)?.map_or_else(
                 || {
                     Err(zerror!(
-                        "Missing root certificates while client authentication is enabled."
+                        "Missing root certificates while mTLS is enabled."
                     ))
                 },
                 Ok,
@@ -254,7 +254,7 @@ impl TlsClientConfig {
         let tls_client_server_auth: bool = match config.get(TLS_ENABLE_MTLS) {
             Some(s) => s
                 .parse()
-                .map_err(|_| zerror!("Unknown client auth argument: {}", s))?,
+                .map_err(|_| zerror!("Unknown enable mTLS auth argument: {}", s))?,
             None => false,
         };
 

--- a/io/zenoh-links/zenoh-link-tls/src/utils.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/utils.rs
@@ -135,12 +135,13 @@ impl ConfigurationInspector<ZenohConfig> for TlsConfigurator {
             _ => {}
         }
 
-        if let Some(server_name_verification) = c.verify_name_on_connect() {
-            match server_name_verification {
-                true => ps.push((TLS_VERIFY_NAME_ON_CONNECT, "true")),
-                false => ps.push((TLS_VERIFY_NAME_ON_CONNECT, "false")),
-            };
-        }
+        match c
+            .verify_name_on_connect()
+            .unwrap_or(TLS_VERIFY_NAME_ON_CONNECT_DEFAULT)
+        {
+            true => ps.push((TLS_VERIFY_NAME_ON_CONNECT, "true")),
+            false => ps.push((TLS_VERIFY_NAME_ON_CONNECT, "false")),
+        };
 
         Ok(parameters::from_iter(ps.drain(..)))
     }

--- a/io/zenoh-links/zenoh-link-tls/src/utils.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/utils.rs
@@ -203,11 +203,7 @@ impl TlsServerConfig {
 
         let sc = if tls_server_client_auth {
             let root_cert_store = load_trust_anchors(config)?.map_or_else(
-                || {
-                    Err(zerror!(
-                        "Missing root certificates while mTLS is enabled."
-                    ))
-                },
+                || Err(zerror!("Missing root certificates while mTLS is enabled.")),
                 Ok,
             )?;
             let client_auth = WebPkiClientVerifier::builder(root_cert_store.into()).build()?;

--- a/io/zenoh-links/zenoh-link-tls/src/utils.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/utils.rs
@@ -64,81 +64,81 @@ impl ConfigurationInspector<ZenohConfig> for TlsConfigurator {
             _ => {}
         }
 
-        match (c.server_private_key(), c.server_private_key_base64()) {
+        match (c.listen_private_key(), c.listen_private_key_base64()) {
             (Some(_), Some(_)) => {
                 bail!("Only one between 'server_private_key' and 'server_private_key_base64' can be present!")
             }
             (Some(server_private_key), None) => {
-                ps.push((TLS_SERVER_PRIVATE_KEY_FILE, server_private_key));
+                ps.push((TLS_LISTEN_PRIVATE_KEY_FILE, server_private_key));
             }
             (None, Some(server_private_key)) => {
                 ps.push((
-                    TLS_SERVER_PRIVATE_KEY_BASE_64,
+                    TLS_LISTEN_PRIVATE_KEY_BASE_64,
                     server_private_key.expose_secret(),
                 ));
             }
             _ => {}
         }
 
-        match (c.server_certificate(), c.server_certificate_base64()) {
+        match (c.listen_certificate(), c.listen_certificate_base64()) {
             (Some(_), Some(_)) => {
                 bail!("Only one between 'server_certificate' and 'server_certificate_base64' can be present!")
             }
             (Some(server_certificate), None) => {
-                ps.push((TLS_SERVER_CERTIFICATE_FILE, server_certificate));
+                ps.push((TLS_LISTEN_CERTIFICATE_FILE, server_certificate));
             }
             (None, Some(server_certificate)) => {
                 ps.push((
-                    TLS_SERVER_CERTIFICATE_BASE64,
+                    TLS_LISTEN_CERTIFICATE_BASE64,
                     server_certificate.expose_secret(),
                 ));
             }
             _ => {}
         }
 
-        if let Some(client_auth) = c.client_auth() {
+        if let Some(client_auth) = c.enable_mtls() {
             match client_auth {
-                true => ps.push((TLS_CLIENT_AUTH, "true")),
-                false => ps.push((TLS_CLIENT_AUTH, "false")),
+                true => ps.push((TLS_ENABLE_MTLS, "true")),
+                false => ps.push((TLS_ENABLE_MTLS, "false")),
             };
         }
 
-        match (c.client_private_key(), c.client_private_key_base64()) {
+        match (c.connect_private_key(), c.connect_private_key_base64()) {
             (Some(_), Some(_)) => {
                 bail!("Only one between 'client_private_key' and 'client_private_key_base64' can be present!")
             }
             (Some(client_private_key), None) => {
-                ps.push((TLS_CLIENT_PRIVATE_KEY_FILE, client_private_key));
+                ps.push((TLS_CONNECT_PRIVATE_KEY_FILE, client_private_key));
             }
             (None, Some(client_private_key)) => {
                 ps.push((
-                    TLS_CLIENT_PRIVATE_KEY_BASE64,
+                    TLS_CONNECT_PRIVATE_KEY_BASE64,
                     client_private_key.expose_secret(),
                 ));
             }
             _ => {}
         }
 
-        match (c.client_certificate(), c.client_certificate_base64()) {
+        match (c.connect_certificate(), c.connect_certificate_base64()) {
             (Some(_), Some(_)) => {
                 bail!("Only one between 'client_certificate' and 'client_certificate_base64' can be present!")
             }
             (Some(client_certificate), None) => {
-                ps.push((TLS_CLIENT_CERTIFICATE_FILE, client_certificate));
+                ps.push((TLS_CONNECT_CERTIFICATE_FILE, client_certificate));
             }
             (None, Some(client_certificate)) => {
                 ps.push((
-                    TLS_CLIENT_CERTIFICATE_BASE64,
+                    TLS_CONNECT_CERTIFICATE_BASE64,
                     client_certificate.expose_secret(),
                 ));
             }
             _ => {}
         }
 
-        if let Some(server_name_verification) = c.server_name_verification() {
+        if let Some(server_name_verification) = c.verify_name_on_connect() {
             match server_name_verification {
-                true => ps.push((TLS_SERVER_NAME_VERIFICATION, "true")),
-                false => ps.push((TLS_SERVER_NAME_VERIFICATION, "false")),
+                true => ps.push((TLS_VERIFY_NAME_ON_CONNECT, "true")),
+                false => ps.push((TLS_VERIFY_NAME_ON_CONNECT, "false")),
             };
         }
 
@@ -152,7 +152,7 @@ pub(crate) struct TlsServerConfig {
 
 impl TlsServerConfig {
     pub async fn new(config: &Config<'_>) -> ZResult<TlsServerConfig> {
-        let tls_server_client_auth: bool = match config.get(TLS_CLIENT_AUTH) {
+        let tls_server_client_auth: bool = match config.get(TLS_ENABLE_MTLS) {
             Some(s) => s
                 .parse()
                 .map_err(|_| zerror!("Unknown client auth argument: {}", s))?,
@@ -226,9 +226,9 @@ impl TlsServerConfig {
     async fn load_tls_private_key(config: &Config<'_>) -> ZResult<Vec<u8>> {
         load_tls_key(
             config,
-            TLS_SERVER_PRIVATE_KEY_RAW,
-            TLS_SERVER_PRIVATE_KEY_FILE,
-            TLS_SERVER_PRIVATE_KEY_BASE_64,
+            TLS_LISTEN_PRIVATE_KEY_RAW,
+            TLS_LISTEN_PRIVATE_KEY_FILE,
+            TLS_LISTEN_PRIVATE_KEY_BASE_64,
         )
         .await
     }
@@ -236,9 +236,9 @@ impl TlsServerConfig {
     async fn load_tls_certificate(config: &Config<'_>) -> ZResult<Vec<u8>> {
         load_tls_certificate(
             config,
-            TLS_SERVER_CERTIFICATE_RAW,
-            TLS_SERVER_CERTIFICATE_FILE,
-            TLS_SERVER_CERTIFICATE_BASE64,
+            TLS_LISTEN_CERTIFICATE_RAW,
+            TLS_LISTEN_CERTIFICATE_FILE,
+            TLS_LISTEN_CERTIFICATE_BASE64,
         )
         .await
     }
@@ -250,14 +250,14 @@ pub(crate) struct TlsClientConfig {
 
 impl TlsClientConfig {
     pub async fn new(config: &Config<'_>) -> ZResult<TlsClientConfig> {
-        let tls_client_server_auth: bool = match config.get(TLS_CLIENT_AUTH) {
+        let tls_client_server_auth: bool = match config.get(TLS_ENABLE_MTLS) {
             Some(s) => s
                 .parse()
                 .map_err(|_| zerror!("Unknown client auth argument: {}", s))?,
             None => false,
         };
 
-        let tls_server_name_verification: bool = match config.get(TLS_SERVER_NAME_VERIFICATION) {
+        let tls_server_name_verification: bool = match config.get(TLS_VERIFY_NAME_ON_CONNECT) {
             Some(s) => {
                 let s: bool = s
                     .parse()
@@ -362,9 +362,9 @@ impl TlsClientConfig {
     async fn load_tls_private_key(config: &Config<'_>) -> ZResult<Vec<u8>> {
         load_tls_key(
             config,
-            TLS_CLIENT_PRIVATE_KEY_RAW,
-            TLS_CLIENT_PRIVATE_KEY_FILE,
-            TLS_CLIENT_PRIVATE_KEY_BASE64,
+            TLS_CONNECT_PRIVATE_KEY_RAW,
+            TLS_CONNECT_PRIVATE_KEY_FILE,
+            TLS_CONNECT_PRIVATE_KEY_BASE64,
         )
         .await
     }
@@ -372,9 +372,9 @@ impl TlsClientConfig {
     async fn load_tls_certificate(config: &Config<'_>) -> ZResult<Vec<u8>> {
         load_tls_certificate(
             config,
-            TLS_CLIENT_CERTIFICATE_RAW,
-            TLS_CLIENT_CERTIFICATE_FILE,
-            TLS_CLIENT_CERTIFICATE_BASE64,
+            TLS_CONNECT_CERTIFICATE_RAW,
+            TLS_CONNECT_CERTIFICATE_FILE,
+            TLS_CONNECT_CERTIFICATE_BASE64,
         )
         .await
     }

--- a/io/zenoh-transport/tests/endpoints.rs
+++ b/io/zenoh-transport/tests/endpoints.rs
@@ -319,8 +319,8 @@ AXVFFIgCSluyrolaD6CWD9MqOex4YOfJR2bNxI7lFvuK4AwjyUJzT1U1HXib17mM
         .config_mut()
         .extend_from_iter(
             [
-                (TLS_SERVER_CERTIFICATE_RAW, cert),
-                (TLS_SERVER_PRIVATE_KEY_RAW, key),
+                (TLS_LISTEN_CERTIFICATE_RAW, cert),
+                (TLS_LISTEN_PRIVATE_KEY_RAW, key),
             ]
             .iter()
             .copied(),
@@ -398,8 +398,8 @@ AXVFFIgCSluyrolaD6CWD9MqOex4YOfJR2bNxI7lFvuK4AwjyUJzT1U1HXib17mM
         .config_mut()
         .extend_from_iter(
             [
-                (TLS_SERVER_CERTIFICATE_RAW, cert),
-                (TLS_SERVER_PRIVATE_KEY_RAW, key),
+                (TLS_LISTEN_CERTIFICATE_RAW, cert),
+                (TLS_LISTEN_PRIVATE_KEY_RAW, key),
             ]
             .iter()
             .copied(),

--- a/io/zenoh-transport/tests/unicast_authenticator.rs
+++ b/io/zenoh-transport/tests/unicast_authenticator.rs
@@ -796,8 +796,8 @@ R+IdLiXcyIkg0m9N8I17p0ljCSkbrgGMD3bbePRTfg==
         .extend_from_iter(
             [
                 (TLS_ROOT_CA_CERTIFICATE_RAW, ca),
-                (TLS_SERVER_CERTIFICATE_RAW, cert),
-                (TLS_SERVER_PRIVATE_KEY_RAW, key),
+                (TLS_LISTEN_CERTIFICATE_RAW, cert),
+                (TLS_LISTEN_PRIVATE_KEY_RAW, key),
             ]
             .iter()
             .copied(),
@@ -896,8 +896,8 @@ R+IdLiXcyIkg0m9N8I17p0ljCSkbrgGMD3bbePRTfg==
         .extend_from_iter(
             [
                 (TLS_ROOT_CA_CERTIFICATE_RAW, ca),
-                (TLS_SERVER_CERTIFICATE_RAW, cert),
-                (TLS_SERVER_PRIVATE_KEY_RAW, key),
+                (TLS_LISTEN_CERTIFICATE_RAW, cert),
+                (TLS_LISTEN_PRIVATE_KEY_RAW, key),
             ]
             .iter()
             .copied(),

--- a/io/zenoh-transport/tests/unicast_multilink.rs
+++ b/io/zenoh-transport/tests/unicast_multilink.rs
@@ -615,8 +615,8 @@ R+IdLiXcyIkg0m9N8I17p0ljCSkbrgGMD3bbePRTfg==
             .extend_from_iter(
                 [
                     (TLS_ROOT_CA_CERTIFICATE_RAW, ca),
-                    (TLS_SERVER_PRIVATE_KEY_RAW, key),
-                    (TLS_SERVER_CERTIFICATE_RAW, cert),
+                    (TLS_LISTEN_PRIVATE_KEY_RAW, key),
+                    (TLS_LISTEN_CERTIFICATE_RAW, cert),
                 ]
                 .iter()
                 .copied(),
@@ -713,8 +713,8 @@ R+IdLiXcyIkg0m9N8I17p0ljCSkbrgGMD3bbePRTfg==
             .extend_from_iter(
                 [
                     (TLS_ROOT_CA_CERTIFICATE_RAW, ca),
-                    (TLS_SERVER_PRIVATE_KEY_RAW, key),
-                    (TLS_SERVER_CERTIFICATE_RAW, cert),
+                    (TLS_LISTEN_PRIVATE_KEY_RAW, key),
+                    (TLS_LISTEN_CERTIFICATE_RAW, cert),
                 ]
                 .iter()
                 .copied(),

--- a/io/zenoh-transport/tests/unicast_openclose.rs
+++ b/io/zenoh-transport/tests/unicast_openclose.rs
@@ -643,8 +643,8 @@ R+IdLiXcyIkg0m9N8I17p0ljCSkbrgGMD3bbePRTfg==
         .extend_from_iter(
             [
                 (TLS_ROOT_CA_CERTIFICATE_RAW, ca),
-                (TLS_SERVER_PRIVATE_KEY_RAW, key),
-                (TLS_SERVER_CERTIFICATE_RAW, cert),
+                (TLS_LISTEN_PRIVATE_KEY_RAW, key),
+                (TLS_LISTEN_CERTIFICATE_RAW, cert),
             ]
             .iter()
             .copied(),
@@ -741,8 +741,8 @@ R+IdLiXcyIkg0m9N8I17p0ljCSkbrgGMD3bbePRTfg==
         .extend_from_iter(
             [
                 (TLS_ROOT_CA_CERTIFICATE_RAW, ca),
-                (TLS_SERVER_PRIVATE_KEY_RAW, key),
-                (TLS_SERVER_CERTIFICATE_RAW, cert),
+                (TLS_LISTEN_PRIVATE_KEY_RAW, key),
+                (TLS_LISTEN_CERTIFICATE_RAW, cert),
             ]
             .iter()
             .copied(),

--- a/io/zenoh-transport/tests/unicast_time.rs
+++ b/io/zenoh-transport/tests/unicast_time.rs
@@ -401,8 +401,8 @@ R+IdLiXcyIkg0m9N8I17p0ljCSkbrgGMD3bbePRTfg==
         .extend_from_iter(
             [
                 (TLS_ROOT_CA_CERTIFICATE_RAW, ca),
-                (TLS_SERVER_PRIVATE_KEY_RAW, key),
-                (TLS_SERVER_CERTIFICATE_RAW, cert),
+                (TLS_LISTEN_PRIVATE_KEY_RAW, key),
+                (TLS_LISTEN_CERTIFICATE_RAW, cert),
             ]
             .iter()
             .copied(),
@@ -500,8 +500,8 @@ R+IdLiXcyIkg0m9N8I17p0ljCSkbrgGMD3bbePRTfg==
         .extend_from_iter(
             [
                 (TLS_ROOT_CA_CERTIFICATE_RAW, ca),
-                (TLS_SERVER_PRIVATE_KEY_RAW, key),
-                (TLS_SERVER_CERTIFICATE_RAW, cert),
+                (TLS_LISTEN_PRIVATE_KEY_RAW, key),
+                (TLS_LISTEN_CERTIFICATE_RAW, cert),
             ]
             .iter()
             .copied(),

--- a/io/zenoh-transport/tests/unicast_transport.rs
+++ b/io/zenoh-transport/tests/unicast_transport.rs
@@ -1009,8 +1009,8 @@ async fn transport_unicast_tls_only_server() {
         .extend_from_iter(
             [
                 (TLS_ROOT_CA_CERTIFICATE_RAW, SERVER_CA),
-                (TLS_SERVER_CERTIFICATE_RAW, SERVER_CERT),
-                (TLS_SERVER_PRIVATE_KEY_RAW, SERVER_KEY),
+                (TLS_LISTEN_CERTIFICATE_RAW, SERVER_CERT),
+                (TLS_LISTEN_PRIVATE_KEY_RAW, SERVER_KEY),
             ]
             .iter()
             .copied(),
@@ -1054,8 +1054,8 @@ async fn transport_unicast_quic_only_server() {
         .extend_from_iter(
             [
                 (TLS_ROOT_CA_CERTIFICATE_RAW, SERVER_CA),
-                (TLS_SERVER_CERTIFICATE_RAW, SERVER_CERT),
-                (TLS_SERVER_PRIVATE_KEY_RAW, SERVER_KEY),
+                (TLS_LISTEN_CERTIFICATE_RAW, SERVER_CERT),
+                (TLS_LISTEN_PRIVATE_KEY_RAW, SERVER_KEY),
             ]
             .iter()
             .copied(),
@@ -1102,9 +1102,9 @@ async fn transport_unicast_tls_only_mutual_success() {
         .extend_from_iter(
             [
                 (TLS_ROOT_CA_CERTIFICATE_RAW, SERVER_CA),
-                (TLS_CLIENT_CERTIFICATE_RAW, CLIENT_CERT),
-                (TLS_CLIENT_PRIVATE_KEY_RAW, CLIENT_KEY),
-                (TLS_CLIENT_AUTH, client_auth),
+                (TLS_CONNECT_CERTIFICATE_RAW, CLIENT_CERT),
+                (TLS_CONNECT_PRIVATE_KEY_RAW, CLIENT_KEY),
+                (TLS_ENABLE_MTLS, client_auth),
             ]
             .iter()
             .copied(),
@@ -1118,9 +1118,9 @@ async fn transport_unicast_tls_only_mutual_success() {
         .extend_from_iter(
             [
                 (TLS_ROOT_CA_CERTIFICATE_RAW, CLIENT_CA),
-                (TLS_SERVER_CERTIFICATE_RAW, SERVER_CERT),
-                (TLS_SERVER_PRIVATE_KEY_RAW, SERVER_KEY),
-                (TLS_CLIENT_AUTH, client_auth),
+                (TLS_LISTEN_CERTIFICATE_RAW, SERVER_CERT),
+                (TLS_LISTEN_PRIVATE_KEY_RAW, SERVER_KEY),
+                (TLS_ENABLE_MTLS, client_auth),
             ]
             .iter()
             .copied(),
@@ -1180,9 +1180,9 @@ async fn transport_unicast_tls_only_mutual_no_client_certs_failure() {
         .extend_from_iter(
             [
                 (TLS_ROOT_CA_CERTIFICATE_RAW, CLIENT_CA),
-                (TLS_SERVER_CERTIFICATE_RAW, SERVER_CERT),
-                (TLS_SERVER_PRIVATE_KEY_RAW, SERVER_KEY),
-                (TLS_CLIENT_AUTH, "true"),
+                (TLS_LISTEN_CERTIFICATE_RAW, SERVER_CERT),
+                (TLS_LISTEN_PRIVATE_KEY_RAW, SERVER_KEY),
+                (TLS_ENABLE_MTLS, "true"),
             ]
             .iter()
             .copied(),
@@ -1243,9 +1243,9 @@ fn transport_unicast_tls_only_mutual_wrong_client_certs_failure() {
                 // wrong certificates and keys. The SERVER_CA (cetificate authority) will not recognize
                 // these certificates as it is expecting to receive CLIENT_CERT and CLIENT_KEY from the
                 // client.
-                (TLS_CLIENT_CERTIFICATE_RAW, SERVER_CERT),
-                (TLS_CLIENT_PRIVATE_KEY_RAW, SERVER_KEY),
-                (TLS_CLIENT_AUTH, client_auth),
+                (TLS_CONNECT_CERTIFICATE_RAW, SERVER_CERT),
+                (TLS_CONNECT_PRIVATE_KEY_RAW, SERVER_KEY),
+                (TLS_ENABLE_MTLS, client_auth),
             ]
             .iter()
             .copied(),
@@ -1259,9 +1259,9 @@ fn transport_unicast_tls_only_mutual_wrong_client_certs_failure() {
         .extend_from_iter(
             [
                 (TLS_ROOT_CA_CERTIFICATE_RAW, CLIENT_CA),
-                (TLS_SERVER_CERTIFICATE_RAW, SERVER_CERT),
-                (TLS_SERVER_PRIVATE_KEY_RAW, SERVER_KEY),
-                (TLS_CLIENT_AUTH, client_auth),
+                (TLS_LISTEN_CERTIFICATE_RAW, SERVER_CERT),
+                (TLS_LISTEN_PRIVATE_KEY_RAW, SERVER_KEY),
+                (TLS_ENABLE_MTLS, client_auth),
             ]
             .iter()
             .copied(),
@@ -1318,9 +1318,9 @@ async fn transport_unicast_quic_only_mutual_success() {
         .extend_from_iter(
             [
                 (TLS_ROOT_CA_CERTIFICATE_RAW, SERVER_CA),
-                (TLS_CLIENT_CERTIFICATE_RAW, CLIENT_CERT),
-                (TLS_CLIENT_PRIVATE_KEY_RAW, CLIENT_KEY),
-                (TLS_CLIENT_AUTH, client_auth),
+                (TLS_CONNECT_CERTIFICATE_RAW, CLIENT_CERT),
+                (TLS_CONNECT_PRIVATE_KEY_RAW, CLIENT_KEY),
+                (TLS_ENABLE_MTLS, client_auth),
             ]
             .iter()
             .copied(),
@@ -1334,9 +1334,9 @@ async fn transport_unicast_quic_only_mutual_success() {
         .extend_from_iter(
             [
                 (TLS_ROOT_CA_CERTIFICATE_RAW, CLIENT_CA),
-                (TLS_SERVER_CERTIFICATE_RAW, SERVER_CERT),
-                (TLS_SERVER_PRIVATE_KEY_RAW, SERVER_KEY),
-                (TLS_CLIENT_AUTH, client_auth),
+                (TLS_LISTEN_CERTIFICATE_RAW, SERVER_CERT),
+                (TLS_LISTEN_PRIVATE_KEY_RAW, SERVER_KEY),
+                (TLS_ENABLE_MTLS, client_auth),
             ]
             .iter()
             .copied(),
@@ -1396,9 +1396,9 @@ async fn transport_unicast_quic_only_mutual_no_client_certs_failure() {
         .extend_from_iter(
             [
                 (TLS_ROOT_CA_CERTIFICATE_RAW, CLIENT_CA),
-                (TLS_SERVER_CERTIFICATE_RAW, SERVER_CERT),
-                (TLS_SERVER_PRIVATE_KEY_RAW, SERVER_KEY),
-                (TLS_CLIENT_AUTH, "true"),
+                (TLS_LISTEN_CERTIFICATE_RAW, SERVER_CERT),
+                (TLS_LISTEN_PRIVATE_KEY_RAW, SERVER_KEY),
+                (TLS_ENABLE_MTLS, "true"),
             ]
             .iter()
             .copied(),
@@ -1459,9 +1459,9 @@ fn transport_unicast_quic_only_mutual_wrong_client_certs_failure() {
                 // wrong certificates and keys. The SERVER_CA (cetificate authority) will not recognize
                 // these certificates as it is expecting to receive CLIENT_CERT and CLIENT_KEY from the
                 // client.
-                (TLS_CLIENT_CERTIFICATE_RAW, SERVER_CERT),
-                (TLS_CLIENT_PRIVATE_KEY_RAW, SERVER_KEY),
-                (TLS_CLIENT_AUTH, client_auth),
+                (TLS_CONNECT_CERTIFICATE_RAW, SERVER_CERT),
+                (TLS_CONNECT_PRIVATE_KEY_RAW, SERVER_KEY),
+                (TLS_ENABLE_MTLS, client_auth),
             ]
             .iter()
             .copied(),
@@ -1475,9 +1475,9 @@ fn transport_unicast_quic_only_mutual_wrong_client_certs_failure() {
         .extend_from_iter(
             [
                 (TLS_ROOT_CA_CERTIFICATE_RAW, CLIENT_CA),
-                (TLS_SERVER_CERTIFICATE_RAW, SERVER_CERT),
-                (TLS_SERVER_PRIVATE_KEY_RAW, SERVER_KEY),
-                (TLS_CLIENT_AUTH, client_auth),
+                (TLS_LISTEN_CERTIFICATE_RAW, SERVER_CERT),
+                (TLS_LISTEN_PRIVATE_KEY_RAW, SERVER_KEY),
+                (TLS_ENABLE_MTLS, client_auth),
             ]
             .iter()
             .copied(),

--- a/zenoh/tests/authentication.rs
+++ b/zenoh/tests/authentication.rs
@@ -287,8 +287,8 @@ client2name:client2passwd";
                             "tls"
                         ],
                         "tls": {
-                            "client_auth": true,
-                            "server_name_verification": false
+                            "enable_mtls": true,
+                            "verify_name_on_connect": false
                         },
                     },
                 }"#,
@@ -298,13 +298,13 @@ client2name:client2passwd";
             .transport
             .link
             .tls
-            .set_server_private_key(Some(format!("{}/serversidekey.pem", cert_path)))
+            .set_listen_private_key(Some(format!("{}/serversidekey.pem", cert_path)))
             .unwrap();
         config
             .transport
             .link
             .tls
-            .set_server_certificate(Some(format!("{}/serverside.pem", cert_path)))
+            .set_listen_certificate(Some(format!("{}/serverside.pem", cert_path)))
             .unwrap();
         config
             .transport
@@ -340,8 +340,8 @@ client2name:client2passwd";
                         "quic"
                     ],
                     "tls": {
-                        "client_auth": true,
-                        "server_name_verification": false
+                        "enable_mtls": true,
+                        "verify_name_on_connect": false
                     },
                     },  
                 }"#,
@@ -351,13 +351,13 @@ client2name:client2passwd";
             .transport
             .link
             .tls
-            .set_server_private_key(Some(format!("{}/serversidekey.pem", cert_path)))
+            .set_listen_private_key(Some(format!("{}/serversidekey.pem", cert_path)))
             .unwrap();
         config
             .transport
             .link
             .tls
-            .set_server_certificate(Some(format!("{}/serverside.pem", cert_path)))
+            .set_listen_certificate(Some(format!("{}/serverside.pem", cert_path)))
             .unwrap();
         config
             .transport
@@ -428,8 +428,8 @@ client2name:client2passwd";
                             "quic", "tcp"
                         ],
                         "tls": {
-                            "client_auth": true,
-                            "server_name_verification": false
+                            "enable_mtls": true,
+                            "verify_name_on_connect": false
                         },
                     },
                     "auth": {
@@ -454,13 +454,13 @@ client2name:client2passwd";
             .transport
             .link
             .tls
-            .set_server_private_key(Some(format!("{}/serversidekey.pem", cert_path)))
+            .set_listen_private_key(Some(format!("{}/serversidekey.pem", cert_path)))
             .unwrap();
         config
             .transport
             .link
             .tls
-            .set_server_certificate(Some(format!("{}/serverside.pem", cert_path)))
+            .set_listen_certificate(Some(format!("{}/serverside.pem", cert_path)))
             .unwrap();
         config
             .transport
@@ -493,8 +493,8 @@ client2name:client2passwd";
                             "tls"
                         ],
                         "tls": {
-                            "client_auth": true,
-                            "server_name_verification": false
+                            "enable_mtls": true,
+                            "verify_name_on_connect": false
                         }
                     }
                 }"#,
@@ -504,13 +504,13 @@ client2name:client2passwd";
             .transport
             .link
             .tls
-            .set_client_private_key(Some(format!("{}/clientsidekey.pem", cert_path)))
+            .set_connect_private_key(Some(format!("{}/clientsidekey.pem", cert_path)))
             .unwrap();
         config
             .transport
             .link
             .tls
-            .set_client_certificate(Some(format!("{}/clientside.pem", cert_path)))
+            .set_connect_certificate(Some(format!("{}/clientside.pem", cert_path)))
             .unwrap();
         config
             .transport
@@ -546,8 +546,8 @@ client2name:client2passwd";
                             "tls"
                         ],
                         "tls": {
-                            "client_auth": true,
-                            "server_name_verification": false
+                            "enable_mtls": true,
+                            "verify_name_on_connect": false
                         }
                     }
                 }"#,
@@ -557,13 +557,13 @@ client2name:client2passwd";
             .transport
             .link
             .tls
-            .set_client_private_key(Some(format!("{}/clientsidekey.pem", cert_path)))
+            .set_connect_private_key(Some(format!("{}/clientsidekey.pem", cert_path)))
             .unwrap();
         config
             .transport
             .link
             .tls
-            .set_client_certificate(Some(format!("{}/clientside.pem", cert_path)))
+            .set_connect_certificate(Some(format!("{}/clientside.pem", cert_path)))
             .unwrap();
         config
             .transport
@@ -604,8 +604,8 @@ client2name:client2passwd";
                             "quic"
                         ],
                         "tls": {
-                            "client_auth": true,
-                            "server_name_verification": false
+                            "enable_mtls": true,
+                            "verify_name_on_connect": false
                         }
                     }
                 }"#,
@@ -615,13 +615,13 @@ client2name:client2passwd";
             .transport
             .link
             .tls
-            .set_client_private_key(Some(format!("{}/clientsidekey.pem", cert_path)))
+            .set_connect_private_key(Some(format!("{}/clientsidekey.pem", cert_path)))
             .unwrap();
         config
             .transport
             .link
             .tls
-            .set_client_certificate(Some(format!("{}/clientside.pem", cert_path)))
+            .set_connect_certificate(Some(format!("{}/clientside.pem", cert_path)))
             .unwrap();
         config
             .transport
@@ -649,8 +649,8 @@ client2name:client2passwd";
                             "quic"
                         ],
                         "tls": {
-                            "client_auth": true,
-                            "server_name_verification": false
+                            "enable_mtls": true,
+                            "verify_name_on_connect": false
                         }
                     }
                 }"#,
@@ -660,13 +660,13 @@ client2name:client2passwd";
             .transport
             .link
             .tls
-            .set_client_private_key(Some(format!("{}/clientsidekey.pem", cert_path)))
+            .set_connect_private_key(Some(format!("{}/clientsidekey.pem", cert_path)))
             .unwrap();
         config
             .transport
             .link
             .tls
-            .set_client_certificate(Some(format!("{}/clientside.pem", cert_path)))
+            .set_connect_certificate(Some(format!("{}/clientside.pem", cert_path)))
             .unwrap();
         config
             .transport
@@ -753,8 +753,8 @@ client2name:client2passwd";
                             "quic"
                         ],
                         "tls": {
-                            "client_auth": true,
-                            "server_name_verification": false
+                            "enable_mtls": true,
+                            "verify_name_on_connect": false
                         }
                     },
                     "auth": {
@@ -770,13 +770,13 @@ client2name:client2passwd";
             .transport
             .link
             .tls
-            .set_client_private_key(Some(format!("{}/clientsidekey.pem", cert_path)))
+            .set_connect_private_key(Some(format!("{}/clientsidekey.pem", cert_path)))
             .unwrap();
         config
             .transport
             .link
             .tls
-            .set_client_certificate(Some(format!("{}/clientside.pem", cert_path)))
+            .set_connect_certificate(Some(format!("{}/clientside.pem", cert_path)))
             .unwrap();
         config
             .transport
@@ -805,8 +805,8 @@ client2name:client2passwd";
                             "quic"
                         ],
                         "tls": {
-                            "client_auth": true,
-                            "server_name_verification": false
+                            "enable_mtls": true,
+                            "verify_name_on_connect": false
                         }
                     },
                     "auth": {
@@ -822,13 +822,13 @@ client2name:client2passwd";
             .transport
             .link
             .tls
-            .set_client_private_key(Some(format!("{}/clientsidekey.pem", cert_path)))
+            .set_connect_private_key(Some(format!("{}/clientsidekey.pem", cert_path)))
             .unwrap();
         config
             .transport
             .link
             .tls
-            .set_client_certificate(Some(format!("{}/clientside.pem", cert_path)))
+            .set_connect_certificate(Some(format!("{}/clientside.pem", cert_path)))
             .unwrap();
         config
             .transport

--- a/zenoh/tests/open_time.rs
+++ b/zenoh/tests/open_time.rs
@@ -311,8 +311,8 @@ R+IdLiXcyIkg0m9N8I17p0ljCSkbrgGMD3bbePRTfg==
         .extend_from_iter(
             [
                 (TLS_ROOT_CA_CERTIFICATE_RAW, ca),
-                (TLS_SERVER_PRIVATE_KEY_RAW, key),
-                (TLS_SERVER_CERTIFICATE_RAW, cert),
+                (TLS_LISTEN_PRIVATE_KEY_RAW, key),
+                (TLS_LISTEN_CERTIFICATE_RAW, cert),
             ]
             .iter()
             .copied(),
@@ -410,8 +410,8 @@ R+IdLiXcyIkg0m9N8I17p0ljCSkbrgGMD3bbePRTfg==
         .extend_from_iter(
             [
                 (TLS_ROOT_CA_CERTIFICATE_RAW, ca),
-                (TLS_SERVER_PRIVATE_KEY_RAW, key),
-                (TLS_SERVER_CERTIFICATE_RAW, cert),
+                (TLS_LISTEN_PRIVATE_KEY_RAW, key),
+                (TLS_LISTEN_CERTIFICATE_RAW, cert),
             ]
             .iter()
             .copied(),


### PR DESCRIPTION
Names in TLS configuration can be improved, currently we have:
- `server_certificate` / `server_certificate` -> used when **listening** TLS/QUIC
- `client_certificate` / `client_private_key`  -> used when **connecting** TLS/QUIC
- `server_name_verification` / `client_auth` -> used configure behaviour in **connect**/**listen** 

 The concept of server and client are never mentioned in zenoh docs/configuration/examples, so it can be a bit misleading.

I suggest to rename: `server` => `listen` and `client` => `connect` for certificate/key,  `server_name_verification` => `verify_name_on_connect` and `client_auth` => `enable_mtls`

So this will make clear that if you want to **listen** TLS/QUIC you need a listen certificate, when you want to **connect** you need a connect certificate.

Summarizing this PR introduces the following changes:
- `server_certificate` / `server_private_key` -> `listen_certificate`/`listen_private_key`
- `client_certificate` / `client_private_key`  ->  `connect_certificate`/`connect_private_key`
- `server_name_verification` -> `verify_name_on_connect`
- `client_auth` -> `enable_mtls`

Sister PRs:
- https://github.com/atolab/zenoh-web/pull/70
