### PR TITLE
zenoh::config::default() restored

### DIFF
--- a/examples/examples/z_delete.rs
+++ b/examples/examples/z_delete.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use clap::Parser;
-use zenoh::{key_expr::KeyExpr, Config};
+use zenoh::{config::Config, key_expr::KeyExpr};
 use zenoh_examples::CommonArgs;
 
 #[tokio::main]

--- a/examples/examples/z_forward.rs
+++ b/examples/examples/z_forward.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use clap::Parser;
-use zenoh::{key_expr::KeyExpr, Config};
+use zenoh::{config::Config, key_expr::KeyExpr};
 use zenoh_examples::CommonArgs;
 use zenoh_ext::SubscriberForward;
 

--- a/examples/examples/z_get.rs
+++ b/examples/examples/z_get.rs
@@ -15,8 +15,8 @@ use std::time::Duration;
 
 use clap::Parser;
 use zenoh::{
+    config::Config,
     query::{QueryTarget, Selector},
-    Config,
 };
 use zenoh_examples::CommonArgs;
 

--- a/examples/examples/z_info.rs
+++ b/examples/examples/z_info.rs
@@ -43,7 +43,7 @@ struct Args {
     common: CommonArgs,
 }
 
-fn parse_args() -> zenoh::Config {
+fn parse_args() -> zenoh::config::Config {
     let args = Args::parse();
     args.common.into()
 }

--- a/examples/examples/z_ping.rs
+++ b/examples/examples/z_ping.rs
@@ -14,7 +14,7 @@
 use std::time::{Duration, Instant};
 
 use clap::Parser;
-use zenoh::{bytes::ZBytes, key_expr::keyexpr, qos::CongestionControl, Config, Wait};
+use zenoh::{bytes::ZBytes, config::Config, key_expr::keyexpr, qos::CongestionControl, Wait};
 use zenoh_examples::CommonArgs;
 
 fn main() {

--- a/examples/examples/z_pong.rs
+++ b/examples/examples/z_pong.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use clap::Parser;
-use zenoh::{key_expr::keyexpr, qos::CongestionControl, Config, Wait};
+use zenoh::{config::Config, key_expr::keyexpr, qos::CongestionControl, Wait};
 use zenoh_examples::CommonArgs;
 
 fn main() {

--- a/examples/examples/z_pub.rs
+++ b/examples/examples/z_pub.rs
@@ -14,7 +14,7 @@
 use std::time::Duration;
 
 use clap::Parser;
-use zenoh::{bytes::Encoding, key_expr::KeyExpr, Config};
+use zenoh::{bytes::Encoding, config::Config, key_expr::KeyExpr};
 use zenoh_examples::CommonArgs;
 
 #[tokio::main]

--- a/examples/examples/z_pull.rs
+++ b/examples/examples/z_pull.rs
@@ -14,7 +14,7 @@
 use std::time::Duration;
 
 use clap::Parser;
-use zenoh::{handlers::RingChannel, key_expr::KeyExpr, Config};
+use zenoh::{config::Config, handlers::RingChannel, key_expr::KeyExpr};
 use zenoh_examples::CommonArgs;
 
 #[tokio::main]

--- a/examples/examples/z_put.rs
+++ b/examples/examples/z_put.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use clap::Parser;
-use zenoh::{key_expr::KeyExpr, Config};
+use zenoh::{config::Config, key_expr::KeyExpr};
 use zenoh_examples::CommonArgs;
 
 #[tokio::main]

--- a/examples/examples/z_put_float.rs
+++ b/examples/examples/z_put_float.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use clap::Parser;
-use zenoh::{key_expr::KeyExpr, Config};
+use zenoh::{config::Config, key_expr::KeyExpr};
 use zenoh_examples::CommonArgs;
 use zenoh_ext::z_serialize;
 

--- a/examples/examples/z_queryable.rs
+++ b/examples/examples/z_queryable.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use clap::Parser;
-use zenoh::{key_expr::KeyExpr, Config};
+use zenoh::{config::Config, key_expr::KeyExpr};
 use zenoh_examples::CommonArgs;
 
 #[tokio::main]

--- a/examples/examples/z_scout.rs
+++ b/examples/examples/z_scout.rs
@@ -11,7 +11,10 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use zenoh::{config::WhatAmI, scout, Config};
+use zenoh::{
+    config::{Config, WhatAmI},
+    scout,
+};
 
 #[tokio::main]
 async fn main() {

--- a/examples/examples/z_storage.rs
+++ b/examples/examples/z_storage.rs
@@ -18,9 +18,9 @@ use std::collections::HashMap;
 use clap::Parser;
 use futures::select;
 use zenoh::{
+    config::Config,
     key_expr::{keyexpr, KeyExpr},
     sample::{Sample, SampleKind},
-    Config,
 };
 use zenoh_examples::CommonArgs;
 

--- a/examples/examples/z_sub.rs
+++ b/examples/examples/z_sub.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use clap::Parser;
-use zenoh::{key_expr::KeyExpr, Config};
+use zenoh::{config::Config, key_expr::KeyExpr};
 use zenoh_examples::CommonArgs;
 
 #[tokio::main]

--- a/examples/examples/z_sub_thr.rs
+++ b/examples/examples/z_sub_thr.rs
@@ -14,7 +14,7 @@
 use std::time::Instant;
 
 use clap::Parser;
-use zenoh::{Config, Wait};
+use zenoh::{config::Config, Wait};
 use zenoh_examples::CommonArgs;
 
 struct Stats {

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -3,7 +3,7 @@
 //! Check ../README.md for usage.
 //!
 
-use zenoh::{config::WhatAmI, Config};
+use zenoh::config::{Config, WhatAmI};
 
 #[derive(clap::ValueEnum, Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum Wai {

--- a/plugins/zenoh-plugin-storage-manager/tests/operations.rs
+++ b/plugins/zenoh-plugin-storage-manager/tests/operations.rs
@@ -20,7 +20,8 @@ use std::{str::FromStr, thread::sleep};
 
 use tokio::runtime::Runtime;
 use zenoh::{
-    internal::zasync_executor_init, query::Reply, sample::Sample, time::Timestamp, Config, Session,
+    config::Config, internal::zasync_executor_init, query::Reply, sample::Sample, time::Timestamp,
+    Session,
 };
 use zenoh_plugin_trait::Plugin;
 

--- a/plugins/zenoh-plugin-storage-manager/tests/wildcard.rs
+++ b/plugins/zenoh-plugin-storage-manager/tests/wildcard.rs
@@ -21,7 +21,8 @@ use std::{str::FromStr, thread::sleep};
 // use std::collections::HashMap;
 use tokio::runtime::Runtime;
 use zenoh::{
-    internal::zasync_executor_init, query::Reply, sample::Sample, time::Timestamp, Config, Session,
+    config::Config, internal::zasync_executor_init, query::Reply, sample::Sample, time::Timestamp,
+    Session,
 };
 use zenoh_plugin_trait::Plugin;
 

--- a/zenoh-ext/examples/examples/z_member.rs
+++ b/zenoh-ext/examples/examples/z_member.rs
@@ -14,7 +14,7 @@
 use std::{sync::Arc, time::Duration};
 
 use futures::StreamExt;
-use zenoh::Config;
+use zenoh::config::Config;
 use zenoh_ext::group::*;
 
 #[tokio::main]

--- a/zenoh-ext/examples/src/lib.rs
+++ b/zenoh-ext/examples/src/lib.rs
@@ -2,7 +2,7 @@
 //! See the code in ../examples/
 //! Check ../README.md for usage.
 //!
-use zenoh::{config::WhatAmI, Config};
+use zenoh::config::{Config, WhatAmI};
 
 #[derive(clap::ValueEnum, Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum Wai {

--- a/zenoh-ext/tests/liveliness.rs
+++ b/zenoh-ext/tests/liveliness.rs
@@ -36,7 +36,7 @@ async fn test_liveliness_querying_subscriber_clique() {
     zenoh_util::init_log_from_env_or("error");
 
     let peer1 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![PEER1_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -49,7 +49,7 @@ async fn test_liveliness_querying_subscriber_clique() {
     };
 
     let peer2 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![PEER1_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -114,7 +114,7 @@ async fn test_liveliness_querying_subscriber_brokered() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -127,7 +127,7 @@ async fn test_liveliness_querying_subscriber_brokered() {
     };
 
     let client1 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -140,7 +140,7 @@ async fn test_liveliness_querying_subscriber_brokered() {
     };
 
     let client2 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -153,7 +153,7 @@ async fn test_liveliness_querying_subscriber_brokered() {
     };
 
     let client3 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -220,7 +220,7 @@ async fn test_liveliness_fetching_subscriber_clique() {
     zenoh_util::init_log_from_env_or("error");
 
     let peer1 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![PEER1_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -233,7 +233,7 @@ async fn test_liveliness_fetching_subscriber_clique() {
     };
 
     let peer2 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![PEER1_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -302,7 +302,7 @@ async fn test_liveliness_fetching_subscriber_brokered() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -315,7 +315,7 @@ async fn test_liveliness_fetching_subscriber_brokered() {
     };
 
     let client1 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -328,7 +328,7 @@ async fn test_liveliness_fetching_subscriber_brokered() {
     };
 
     let client2 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -341,7 +341,7 @@ async fn test_liveliness_fetching_subscriber_brokered() {
     };
 
     let client3 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])

--- a/zenoh/src/api/config.rs
+++ b/zenoh/src/api/config.rs
@@ -91,6 +91,11 @@ impl Config {
     }
 }
 
+/// Default configuration. Same as [`Config::default`]
+pub fn default() -> Config {
+    Config::default()
+}
+
 #[zenoh_macros::internal_config]
 impl std::ops::Deref for Config {
     type Target = zenoh_config::Config;

--- a/zenoh/src/api/publisher.rs
+++ b/zenoh/src/api/publisher.rs
@@ -860,7 +860,7 @@ impl<Handler> IntoFuture for MatchingListenerUndeclaration<Handler> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{sample::SampleKind, Config, Wait};
+    use crate::{config::Config, sample::SampleKind, Wait};
 
     #[cfg(feature = "internal")]
     #[test]

--- a/zenoh/src/api/scouting.rs
+++ b/zenoh/src/api/scouting.rs
@@ -28,8 +28,8 @@ use zenoh_task::TerminatableTask;
 
 use crate::{
     api::handlers::{locked, Callback, DefaultHandler, IntoHandler},
+    config::Config,
     net::runtime::{orchestrator::Loop, Runtime},
-    Config,
 };
 
 /// A builder for initializing a [`Scout`].

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -101,12 +101,12 @@ use super::{
 #[cfg(feature = "unstable")]
 use crate::api::selector::ZenohParameters;
 use crate::{
+    config::Config,
     net::{
         primitives::Primitives,
         routing::dispatcher::face::Face,
         runtime::{Runtime, RuntimeBuilder},
     },
-    Config,
 };
 
 zconfigurable! {

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -349,9 +349,9 @@ pub mod time {
 pub mod config {
     pub use zenoh_config::{EndPoint, Locator, WhatAmI, WhatAmIMatcher, ZenohId};
 
-    pub use crate::api::config::Config;
     #[zenoh_macros::unstable]
     pub use crate::api::config::Notifier;
+    pub use crate::api::config::{default, Config};
 }
 
 #[cfg(all(

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -119,7 +119,6 @@ pub use zenoh_util::{init_log_from_env_or, try_init_log_from_env};
 
 #[doc(inline)]
 pub use crate::{
-    config::Config,
     scouting::scout,
     session::{open, Session},
 };

--- a/zenoh/tests/acl.rs
+++ b/zenoh/tests/acl.rs
@@ -21,7 +21,11 @@ mod test {
     };
 
     use tokio::runtime::Handle;
-    use zenoh::{config::WhatAmI, sample::SampleKind, Config, Session};
+    use zenoh::{
+        config::{Config, WhatAmI},
+        sample::SampleKind,
+        Session,
+    };
     use zenoh_config::{EndPoint, ModeDependentValue};
     use zenoh_core::{zlock, ztimeout};
 
@@ -75,7 +79,7 @@ mod test {
 
     async fn get_client_sessions(port: u16) -> (Session, Session) {
         println!("Opening client sessions");
-        let mut config = zenoh::Config::default();
+        let mut config = zenoh::config::default();
         config.set_mode(Some(WhatAmI::Client)).unwrap();
         config
             .connect
@@ -88,7 +92,7 @@ mod test {
 
         let s01 = ztimeout!(zenoh::open(config)).unwrap();
 
-        let mut config = zenoh::Config::default();
+        let mut config = zenoh::config::default();
         config.set_mode(Some(WhatAmI::Client)).unwrap();
         config
             .connect

--- a/zenoh/tests/authentication.rs
+++ b/zenoh/tests/authentication.rs
@@ -24,7 +24,10 @@ mod test {
 
     use once_cell::sync::Lazy;
     use tokio::runtime::Handle;
-    use zenoh::{config::WhatAmI, Config, Session};
+    use zenoh::{
+        config::{Config, WhatAmI},
+        Session,
+    };
     use zenoh_config::{EndPoint, ModeDependentValue};
     use zenoh_core::{zlock, ztimeout};
 
@@ -270,7 +273,7 @@ client2name:client2passwd";
 
     async fn get_basic_router_config_tls(port: u16, lowlatency: bool) -> Config {
         let cert_path = TESTFILES_PATH.to_string_lossy();
-        let mut config = zenoh::Config::default();
+        let mut config = zenoh::config::default();
         config.set_mode(Some(WhatAmI::Router)).unwrap();
         config
             .listen
@@ -323,7 +326,7 @@ client2name:client2passwd";
     }
     async fn get_basic_router_config_quic(port: u16) -> Config {
         let cert_path = TESTFILES_PATH.to_string_lossy();
-        let mut config = zenoh::Config::default();
+        let mut config = zenoh::config::default();
         config.set_mode(Some(WhatAmI::Router)).unwrap();
         config
             .listen
@@ -369,7 +372,7 @@ client2name:client2passwd";
     }
 
     async fn get_basic_router_config_usrpswd(port: u16) -> Config {
-        let mut config = zenoh::Config::default();
+        let mut config = zenoh::config::default();
         config.set_mode(Some(WhatAmI::Router)).unwrap();
         config
             .listen
@@ -408,7 +411,7 @@ client2name:client2passwd";
 
     async fn get_basic_router_config_quic_usrpswd(port: u16) -> Config {
         let cert_path = TESTFILES_PATH.to_string_lossy();
-        let mut config = zenoh::Config::default();
+        let mut config = zenoh::config::default();
         config.set_mode(Some(WhatAmI::Router)).unwrap();
         config
             .listen
@@ -474,7 +477,7 @@ client2name:client2passwd";
     async fn get_client_sessions_tls(port: u16, lowlatency: bool) -> (Session, Session) {
         let cert_path = TESTFILES_PATH.to_string_lossy();
         println!("Opening client sessions");
-        let mut config = zenoh::Config::default();
+        let mut config = zenoh::config::default();
         config.set_mode(Some(WhatAmI::Client)).unwrap();
         config
             .connect
@@ -527,7 +530,7 @@ client2name:client2passwd";
             .unwrap();
         let s01 = ztimeout!(zenoh::open(config)).unwrap();
 
-        let mut config = zenoh::Config::default();
+        let mut config = zenoh::config::default();
         config.set_mode(Some(WhatAmI::Client)).unwrap();
         config
             .connect
@@ -585,7 +588,7 @@ client2name:client2passwd";
     async fn get_client_sessions_quic(port: u16) -> (Session, Session) {
         let cert_path = TESTFILES_PATH.to_string_lossy();
         println!("Opening client sessions");
-        let mut config = zenoh::Config::default();
+        let mut config = zenoh::config::default();
         config.set_mode(Some(WhatAmI::Client)).unwrap();
         config
             .connect
@@ -630,7 +633,7 @@ client2name:client2passwd";
             .set_root_ca_certificate(Some(format!("{}/ca.pem", cert_path)))
             .unwrap();
         let s01 = ztimeout!(zenoh::open(config)).unwrap();
-        let mut config = zenoh::Config::default();
+        let mut config = zenoh::config::default();
         config.set_mode(Some(WhatAmI::Client)).unwrap();
         config
             .connect
@@ -680,7 +683,7 @@ client2name:client2passwd";
 
     async fn get_client_sessions_usrpswd(port: u16) -> (Session, Session) {
         println!("Opening client sessions");
-        let mut config = zenoh::Config::default();
+        let mut config = zenoh::config::default();
         config.set_mode(Some(WhatAmI::Client)).unwrap();
         config
             .connect
@@ -704,7 +707,7 @@ client2name:client2passwd";
             )
             .unwrap();
         let s01 = ztimeout!(zenoh::open(config)).unwrap();
-        let mut config = zenoh::Config::default();
+        let mut config = zenoh::config::default();
         config.set_mode(Some(WhatAmI::Client)).unwrap();
         config
             .connect
@@ -734,7 +737,7 @@ client2name:client2passwd";
     async fn get_client_sessions_quic_usrpswd(port: u16) -> (Session, Session) {
         let cert_path = TESTFILES_PATH.to_string_lossy();
         println!("Opening client sessions");
-        let mut config = zenoh::Config::default();
+        let mut config = zenoh::config::default();
         config.set_mode(Some(WhatAmI::Client)).unwrap();
         config
             .connect
@@ -786,7 +789,7 @@ client2name:client2passwd";
             .unwrap();
         let s01 = ztimeout!(zenoh::open(config)).unwrap();
 
-        let mut config = zenoh::Config::default();
+        let mut config = zenoh::config::default();
         config.set_mode(Some(WhatAmI::Client)).unwrap();
         config
             .connect

--- a/zenoh/tests/connection_retry.rs
+++ b/zenoh/tests/connection_retry.rs
@@ -14,7 +14,7 @@
 
 #![cfg(feature = "internal_config")]
 
-use zenoh::{Config, Wait};
+use zenoh::{config::Config, Wait};
 use zenoh_config::{ConnectionRetryConf, EndPoint, ModeDependent};
 
 #[test]

--- a/zenoh/tests/events.rs
+++ b/zenoh/tests/events.rs
@@ -22,7 +22,7 @@ use zenoh_core::ztimeout;
 const TIMEOUT: Duration = Duration::from_secs(10);
 
 async fn open_session(listen: &[&str], connect: &[&str]) -> Session {
-    let mut config = zenoh::Config::default();
+    let mut config = zenoh::config::default();
     config
         .listen
         .endpoints

--- a/zenoh/tests/handler.rs
+++ b/zenoh/tests/handler.rs
@@ -13,7 +13,7 @@
 //
 use std::{thread, time::Duration};
 
-use zenoh::{handlers::RingChannel, Config, Wait};
+use zenoh::{config::Config, handlers::RingChannel, Wait};
 
 #[test]
 fn pubsub_with_ringbuffer() {

--- a/zenoh/tests/interceptors.rs
+++ b/zenoh/tests/interceptors.rs
@@ -23,7 +23,7 @@ use std::{
     },
 };
 
-use zenoh::{key_expr::KeyExpr, Config, Wait};
+use zenoh::{config::Config, key_expr::KeyExpr, Wait};
 use zenoh_config::{DownsamplingItemConf, DownsamplingRuleConf, InterceptorFlow};
 
 // Tokio's time granularity on different platforms

--- a/zenoh/tests/liveliness.rs
+++ b/zenoh/tests/liveliness.rs
@@ -29,7 +29,7 @@ async fn test_liveliness_subscriber_clique() {
     zenoh_util::init_log_from_env_or("error");
 
     let peer1 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![PEER1_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -42,7 +42,7 @@ async fn test_liveliness_subscriber_clique() {
     };
 
     let peer2 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![PEER1_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -93,7 +93,7 @@ async fn test_liveliness_query_clique() {
     zenoh_util::init_log_from_env_or("error");
 
     let peer1 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![PEER1_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -106,7 +106,7 @@ async fn test_liveliness_query_clique() {
     };
 
     let peer2 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![PEER1_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -151,7 +151,7 @@ async fn test_liveliness_subscriber_brokered() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -164,7 +164,7 @@ async fn test_liveliness_subscriber_brokered() {
     };
 
     let client1 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -177,7 +177,7 @@ async fn test_liveliness_subscriber_brokered() {
     };
 
     let client2 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -229,7 +229,7 @@ async fn test_liveliness_query_brokered() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -242,7 +242,7 @@ async fn test_liveliness_query_brokered() {
     };
 
     let client1 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -255,7 +255,7 @@ async fn test_liveliness_query_brokered() {
     };
 
     let client2 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -298,7 +298,7 @@ async fn test_liveliness_subscriber_local() {
     zenoh_util::init_log_from_env_or("error");
 
     let peer = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Peer));
         let s = ztimeout!(zenoh::open(c)).unwrap();
@@ -340,7 +340,7 @@ async fn test_liveliness_query_local() {
     zenoh_util::init_log_from_env_or("error");
 
     let peer = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Peer));
         let s = ztimeout!(zenoh::open(c)).unwrap();
@@ -377,7 +377,7 @@ async fn test_liveliness_after_close() {
     zenoh_util::init_log_from_env_or("error");
 
     let peer1 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![PEER1_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -390,7 +390,7 @@ async fn test_liveliness_after_close() {
     };
 
     let peer2 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![PEER1_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -439,7 +439,7 @@ async fn test_liveliness_subscriber_double_client_before() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -452,7 +452,7 @@ async fn test_liveliness_subscriber_double_client_before() {
     };
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -468,7 +468,7 @@ async fn test_liveliness_subscriber_double_client_before() {
     tokio::time::sleep(SLEEP).await;
 
     let client_sub = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -534,7 +534,7 @@ async fn test_liveliness_subscriber_double_client_middle() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -547,7 +547,7 @@ async fn test_liveliness_subscriber_double_client_middle() {
     };
 
     let client_sub = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -566,7 +566,7 @@ async fn test_liveliness_subscriber_double_client_middle() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -632,7 +632,7 @@ async fn test_liveliness_subscriber_double_client_after() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -645,7 +645,7 @@ async fn test_liveliness_subscriber_double_client_after() {
     };
 
     let client_sub = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -669,7 +669,7 @@ async fn test_liveliness_subscriber_double_client_after() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -732,7 +732,7 @@ async fn test_liveliness_subscriber_double_client_history_before() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -745,7 +745,7 @@ async fn test_liveliness_subscriber_double_client_history_before() {
     };
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -761,7 +761,7 @@ async fn test_liveliness_subscriber_double_client_history_before() {
     tokio::time::sleep(SLEEP).await;
 
     let client_sub = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -835,7 +835,7 @@ async fn test_liveliness_subscriber_double_client_history_middle() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -848,7 +848,7 @@ async fn test_liveliness_subscriber_double_client_history_middle() {
     };
 
     let client_sub = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -868,7 +868,7 @@ async fn test_liveliness_subscriber_double_client_history_middle() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -938,7 +938,7 @@ async fn test_liveliness_subscriber_double_client_history_after() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -951,7 +951,7 @@ async fn test_liveliness_subscriber_double_client_history_after() {
     };
 
     let client_sub = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -977,7 +977,7 @@ async fn test_liveliness_subscriber_double_client_history_after() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1044,7 +1044,7 @@ async fn test_liveliness_subscriber_double_peer_before() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1057,7 +1057,7 @@ async fn test_liveliness_subscriber_double_peer_before() {
     };
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1073,7 +1073,7 @@ async fn test_liveliness_subscriber_double_peer_before() {
     tokio::time::sleep(SLEEP).await;
 
     let peer_sub = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1133,7 +1133,7 @@ async fn test_liveliness_subscriber_double_peer_middle() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1146,7 +1146,7 @@ async fn test_liveliness_subscriber_double_peer_middle() {
     };
 
     let peer_sub = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1162,7 +1162,7 @@ async fn test_liveliness_subscriber_double_peer_middle() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1225,7 +1225,7 @@ async fn test_liveliness_subscriber_double_peer_after() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1238,7 +1238,7 @@ async fn test_liveliness_subscriber_double_peer_after() {
     };
 
     let peer_sub = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1256,7 +1256,7 @@ async fn test_liveliness_subscriber_double_peer_after() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1319,7 +1319,7 @@ async fn test_liveliness_subscriber_double_peer_history_before() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1332,7 +1332,7 @@ async fn test_liveliness_subscriber_double_peer_history_before() {
     };
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1348,7 +1348,7 @@ async fn test_liveliness_subscriber_double_peer_history_before() {
     tokio::time::sleep(SLEEP).await;
 
     let peer_sub = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1422,7 +1422,7 @@ async fn test_liveliness_subscriber_double_peer_history_middle() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1435,7 +1435,7 @@ async fn test_liveliness_subscriber_double_peer_history_middle() {
     };
 
     let peer_sub = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1455,7 +1455,7 @@ async fn test_liveliness_subscriber_double_peer_history_middle() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1525,7 +1525,7 @@ async fn test_liveliness_subscriber_double_peer_history_after() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1538,7 +1538,7 @@ async fn test_liveliness_subscriber_double_peer_history_after() {
     };
 
     let peer_sub = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1564,7 +1564,7 @@ async fn test_liveliness_subscriber_double_peer_history_after() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1632,7 +1632,7 @@ async fn test_liveliness_subscriber_double_router_before() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1645,7 +1645,7 @@ async fn test_liveliness_subscriber_double_router_before() {
     };
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1661,7 +1661,7 @@ async fn test_liveliness_subscriber_double_router_before() {
     tokio::time::sleep(SLEEP).await;
 
     let router_sub = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_SUB_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1732,7 +1732,7 @@ async fn test_liveliness_subscriber_double_router_middle() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1745,7 +1745,7 @@ async fn test_liveliness_subscriber_double_router_middle() {
     };
 
     let router_sub = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_SUB_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1768,7 +1768,7 @@ async fn test_liveliness_subscriber_double_router_middle() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1835,7 +1835,7 @@ async fn test_liveliness_subscriber_double_router_after() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1848,7 +1848,7 @@ async fn test_liveliness_subscriber_double_router_after() {
     };
 
     let router_sub = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_SUB_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1876,7 +1876,7 @@ async fn test_liveliness_subscriber_double_router_after() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1940,7 +1940,7 @@ async fn test_liveliness_subscriber_double_router_history_before() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1953,7 +1953,7 @@ async fn test_liveliness_subscriber_double_router_history_before() {
     };
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -1969,7 +1969,7 @@ async fn test_liveliness_subscriber_double_router_history_before() {
     tokio::time::sleep(SLEEP).await;
 
     let router_sub = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_SUB_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2048,7 +2048,7 @@ async fn test_liveliness_subscriber_double_router_history_middle() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2061,7 +2061,7 @@ async fn test_liveliness_subscriber_double_router_history_middle() {
     };
 
     let router_sub = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_SUB_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2085,7 +2085,7 @@ async fn test_liveliness_subscriber_double_router_history_middle() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2156,7 +2156,7 @@ async fn test_liveliness_subscriber_double_router_history_after() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2169,7 +2169,7 @@ async fn test_liveliness_subscriber_double_router_history_after() {
     };
 
     let router_sub = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_SUB_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2199,7 +2199,7 @@ async fn test_liveliness_subscriber_double_router_history_after() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2267,7 +2267,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_before() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2280,7 +2280,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_before() {
     };
 
     let peer_dummy = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![PEER_DUMMY_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2297,7 +2297,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_before() {
     };
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2313,7 +2313,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_before() {
     tokio::time::sleep(SLEEP).await;
 
     let client_sub = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![PEER_DUMMY_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2381,7 +2381,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_middle() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2394,7 +2394,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_middle() {
     };
 
     let peer_dummy = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![PEER_DUMMY_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2411,7 +2411,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_middle() {
     };
 
     let client_sub = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![PEER_DUMMY_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2430,7 +2430,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_middle() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2498,7 +2498,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_after() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2511,7 +2511,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_after() {
     };
 
     let peer_dummy = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![PEER_DUMMY_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2528,7 +2528,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_after() {
     };
 
     let client_sub = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![PEER_DUMMY_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2552,7 +2552,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_after() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2618,7 +2618,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_before() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2631,7 +2631,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_before() {
     };
 
     let peer_dummy = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![PEER_DUMMY_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2648,7 +2648,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_before() {
     };
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2664,7 +2664,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_before() {
     tokio::time::sleep(SLEEP).await;
 
     let client_sub = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![PEER_DUMMY_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2741,7 +2741,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_middle() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2754,7 +2754,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_middle() {
     };
 
     let peer_dummy = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![PEER_DUMMY_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2771,7 +2771,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_middle() {
     };
 
     let client_sub = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![PEER_DUMMY_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2791,7 +2791,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_middle() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2864,7 +2864,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_after() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2877,7 +2877,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_after() {
     };
 
     let peer_dummy = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![PEER_DUMMY_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2894,7 +2894,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_after() {
     };
 
     let client_sub = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![PEER_DUMMY_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2920,7 +2920,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_after() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -2988,7 +2988,7 @@ async fn test_liveliness_subget_client_before() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3001,7 +3001,7 @@ async fn test_liveliness_subget_client_before() {
     };
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3017,7 +3017,7 @@ async fn test_liveliness_subget_client_before() {
     tokio::time::sleep(SLEEP).await;
 
     let client_subget = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3081,7 +3081,7 @@ async fn test_liveliness_subget_client_middle() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3094,7 +3094,7 @@ async fn test_liveliness_subget_client_middle() {
     };
 
     let client_subget = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3115,7 +3115,7 @@ async fn test_liveliness_subget_client_middle() {
     assert!(sub.try_recv().is_err());
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3179,7 +3179,7 @@ async fn test_liveliness_subget_client_history_before() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3192,7 +3192,7 @@ async fn test_liveliness_subget_client_history_before() {
     };
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3208,7 +3208,7 @@ async fn test_liveliness_subget_client_history_before() {
     tokio::time::sleep(SLEEP).await;
 
     let client_subget = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3276,7 +3276,7 @@ async fn test_liveliness_subget_client_history_middle() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3289,7 +3289,7 @@ async fn test_liveliness_subget_client_history_middle() {
     };
 
     let client_subget = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3311,7 +3311,7 @@ async fn test_liveliness_subget_client_history_middle() {
     assert!(sub.try_recv().is_err());
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3379,7 +3379,7 @@ async fn test_liveliness_subget_peer_before() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3392,7 +3392,7 @@ async fn test_liveliness_subget_peer_before() {
     };
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3408,7 +3408,7 @@ async fn test_liveliness_subget_peer_before() {
     tokio::time::sleep(SLEEP).await;
 
     let peer_subget = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3472,7 +3472,7 @@ async fn test_liveliness_subget_peer_middle() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3485,7 +3485,7 @@ async fn test_liveliness_subget_peer_middle() {
     };
 
     let peer_subget = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3506,7 +3506,7 @@ async fn test_liveliness_subget_peer_middle() {
     assert!(sub.try_recv().is_err());
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3570,7 +3570,7 @@ async fn test_liveliness_subget_peer_history_before() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3583,7 +3583,7 @@ async fn test_liveliness_subget_peer_history_before() {
     };
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3599,7 +3599,7 @@ async fn test_liveliness_subget_peer_history_before() {
     tokio::time::sleep(SLEEP).await;
 
     let peer_subget = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3667,7 +3667,7 @@ async fn test_liveliness_subget_peer_history_middle() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3680,7 +3680,7 @@ async fn test_liveliness_subget_peer_history_middle() {
     };
 
     let peer_subget = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3702,7 +3702,7 @@ async fn test_liveliness_subget_peer_history_middle() {
     assert!(sub.try_recv().is_err());
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3771,7 +3771,7 @@ async fn test_liveliness_subget_router_before() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3784,7 +3784,7 @@ async fn test_liveliness_subget_router_before() {
     };
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3800,7 +3800,7 @@ async fn test_liveliness_subget_router_before() {
     tokio::time::sleep(SLEEP).await;
 
     let router_subget = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_SUBGET_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3869,7 +3869,7 @@ async fn test_liveliness_subget_router_middle() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3882,7 +3882,7 @@ async fn test_liveliness_subget_router_middle() {
     };
 
     let router_subget = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_SUBGET_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3907,7 +3907,7 @@ async fn test_liveliness_subget_router_middle() {
     assert!(sub.try_recv().is_err());
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3972,7 +3972,7 @@ async fn test_liveliness_subget_router_history_before() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -3985,7 +3985,7 @@ async fn test_liveliness_subget_router_history_before() {
     };
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -4001,7 +4001,7 @@ async fn test_liveliness_subget_router_history_before() {
     tokio::time::sleep(SLEEP).await;
 
     let router_subget = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_SUBGET_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -4074,7 +4074,7 @@ async fn test_liveliness_subget_router_history_middle() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -4087,7 +4087,7 @@ async fn test_liveliness_subget_router_history_middle() {
     };
 
     let router_subget = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_SUBGET_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -4113,7 +4113,7 @@ async fn test_liveliness_subget_router_history_middle() {
     assert!(sub.try_recv().is_err());
 
     let client_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -4178,7 +4178,7 @@ async fn test_liveliness_regression_1() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -4191,7 +4191,7 @@ async fn test_liveliness_regression_1() {
     };
 
     let peer_tok = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![PEER_TOK_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -4211,7 +4211,7 @@ async fn test_liveliness_regression_1() {
     tokio::time::sleep(SLEEP).await;
 
     let peer_sub = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![
@@ -4262,7 +4262,7 @@ async fn test_liveliness_regression_2() {
     zenoh_util::init_log_from_env_or("error");
 
     let peer_tok1 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![PEER_TOK1_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -4278,7 +4278,7 @@ async fn test_liveliness_regression_2() {
     tokio::time::sleep(SLEEP).await;
 
     let peer_sub = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![PEER_SUB_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -4300,7 +4300,7 @@ async fn test_liveliness_regression_2() {
     assert!(sub.try_recv().is_err());
 
     let peer_tok2 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![
@@ -4356,7 +4356,7 @@ async fn test_liveliness_regression_2_history() {
     zenoh_util::init_log_from_env_or("error");
 
     let peer_tok1 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![PEER_TOK1_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -4372,7 +4372,7 @@ async fn test_liveliness_regression_2_history() {
     tokio::time::sleep(SLEEP).await;
 
     let peer_sub = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![PEER_SUB_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -4401,7 +4401,7 @@ async fn test_liveliness_regression_2_history() {
     assert!(sub.try_recv().is_err());
 
     let peer_tok2 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![
@@ -4457,7 +4457,7 @@ async fn test_liveliness_regression_3() {
     zenoh_util::init_log_from_env_or("error");
 
     let router = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -4470,7 +4470,7 @@ async fn test_liveliness_regression_3() {
     };
 
     let peer_tok1 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.listen
             .endpoints
             .set(vec![PEER_TOK_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -4490,7 +4490,7 @@ async fn test_liveliness_regression_3() {
     tokio::time::sleep(SLEEP).await;
 
     let client_tok2 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
@@ -4506,7 +4506,7 @@ async fn test_liveliness_regression_3() {
     tokio::time::sleep(SLEEP).await;
 
     let peer_sub = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.connect
             .endpoints
             .set(vec![
@@ -4568,7 +4568,7 @@ async fn test_liveliness_issue_1470() {
     zenoh_util::init_log_from_env_or("error");
 
     let router0 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.set_id(ZenohId::from_str("a0").unwrap()).unwrap();
         c.listen
             .endpoints
@@ -4586,7 +4586,7 @@ async fn test_liveliness_issue_1470() {
     tokio::time::sleep(SLEEP).await;
 
     let router1 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.set_id(ZenohId::from_str("a1").unwrap()).unwrap();
         c.listen
             .endpoints
@@ -4608,7 +4608,7 @@ async fn test_liveliness_issue_1470() {
     tokio::time::sleep(SLEEP).await;
 
     let peer = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.set_id(ZenohId::from_str("b").unwrap()).unwrap();
         c.listen
             .endpoints
@@ -4630,7 +4630,7 @@ async fn test_liveliness_issue_1470() {
     tokio::time::sleep(SLEEP).await;
 
     let client0 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.set_id(ZenohId::from_str("c0").unwrap()).unwrap();
         c.connect
             .endpoints
@@ -4676,7 +4676,7 @@ async fn test_liveliness_issue_1470() {
     client0.close().await.unwrap();
 
     let client1 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh::config::default();
         c.set_id(ZenohId::from_str("c1").unwrap()).unwrap();
         c.connect
             .endpoints

--- a/zenoh/tests/matching.rs
+++ b/zenoh/tests/matching.rs
@@ -25,7 +25,7 @@ const RECV_TIMEOUT: Duration = Duration::from_secs(1);
 
 async fn create_session_pair(locator: &str) -> (Session, Session) {
     let config1 = {
-        let mut config = zenoh::Config::default();
+        let mut config = zenoh::config::default();
         config.scouting.multicast.set_enabled(Some(false)).unwrap();
         config
             .listen
@@ -34,7 +34,7 @@ async fn create_session_pair(locator: &str) -> (Session, Session) {
             .unwrap();
         config
     };
-    let mut config2 = zenoh::Config::default();
+    let mut config2 = zenoh::config::default();
     config2.set_mode(Some(WhatAmI::Client)).unwrap();
     config2
         .connect
@@ -102,8 +102,8 @@ async fn zenoh_matching_status_any() -> ZResult<()> {
 async fn zenoh_matching_status_remote() -> ZResult<()> {
     zenoh_util::init_log_from_env_or("error");
 
-    let session1 = ztimeout!(zenoh::open(zenoh::Config::default())).unwrap();
-    let session2 = ztimeout!(zenoh::open(zenoh::Config::default())).unwrap();
+    let session1 = ztimeout!(zenoh::open(zenoh::config::default())).unwrap();
+    let session2 = ztimeout!(zenoh::open(zenoh::config::default())).unwrap();
 
     let publisher1 = ztimeout!(session1
         .declare_publisher("zenoh_matching_status_remote_test")
@@ -157,8 +157,8 @@ async fn zenoh_matching_status_remote() -> ZResult<()> {
 async fn zenoh_matching_status_local() -> ZResult<()> {
     zenoh_util::init_log_from_env_or("error");
 
-    let session1 = ztimeout!(zenoh::open(zenoh::Config::default())).unwrap();
-    let session2 = ztimeout!(zenoh::open(zenoh::Config::default())).unwrap();
+    let session1 = ztimeout!(zenoh::open(zenoh::config::default())).unwrap();
+    let session2 = ztimeout!(zenoh::open(zenoh::config::default())).unwrap();
 
     let publisher1 = ztimeout!(session1
         .declare_publisher("zenoh_matching_status_local_test")

--- a/zenoh/tests/open_time.rs
+++ b/zenoh/tests/open_time.rs
@@ -39,7 +39,7 @@ async fn time_open(
     lowlatency: bool,
 ) {
     /* [ROUTER] */
-    let mut router_config = zenoh::Config::default();
+    let mut router_config = zenoh::config::default();
     router_config.set_mode(Some(WhatAmI::Router)).unwrap();
     router_config
         .listen
@@ -69,7 +69,7 @@ async fn time_open(
     );
 
     /* [APP] */
-    let mut app_config = zenoh::Config::default();
+    let mut app_config = zenoh::config::default();
     app_config.set_mode(Some(connect_mode)).unwrap();
     app_config
         .connect

--- a/zenoh/tests/qos.rs
+++ b/zenoh/tests/qos.rs
@@ -24,8 +24,8 @@ const SLEEP: Duration = Duration::from_secs(1);
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn qos_pubsub() {
-    let session1 = ztimeout!(zenoh::open(zenoh::Config::default())).unwrap();
-    let session2 = ztimeout!(zenoh::open(zenoh::Config::default())).unwrap();
+    let session1 = ztimeout!(zenoh::open(zenoh::config::default())).unwrap();
+    let session2 = ztimeout!(zenoh::open(zenoh::config::default())).unwrap();
 
     let publisher1 = ztimeout!(session1
         .declare_publisher("test/qos")

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -23,7 +23,11 @@ use std::{
 };
 
 use tokio_util::sync::CancellationToken;
-use zenoh::{config::WhatAmI, qos::CongestionControl, Config, Result, Session};
+use zenoh::{
+    config::{Config, WhatAmI},
+    qos::CongestionControl,
+    Result, Session,
+};
 use zenoh_config::{ModeDependentValue, WhatAmIMatcher};
 use zenoh_core::ztimeout;
 use zenoh_result::bail;

--- a/zenoh/tests/session.rs
+++ b/zenoh/tests/session.rs
@@ -39,7 +39,7 @@ const MSG_SIZE: [usize; 2] = [1_024, 100_000];
 
 async fn open_session_unicast(endpoints: &[&str]) -> (Session, Session) {
     // Open the sessions
-    let mut config = zenoh::Config::default();
+    let mut config = zenoh::config::default();
     config
         .listen
         .endpoints

--- a/zenoh/tests/session.rs
+++ b/zenoh/tests/session.rs
@@ -54,7 +54,7 @@ async fn open_session_unicast(endpoints: &[&str]) -> (Session, Session) {
     println!("[  ][01a] Opening peer01 session: {:?}", endpoints);
     let peer01 = ztimeout!(zenoh::open(config)).unwrap();
 
-    let mut config = zenoh::Config::default();
+    let mut config = zenoh::config::default();
     config
         .connect
         .endpoints
@@ -74,7 +74,7 @@ async fn open_session_unicast(endpoints: &[&str]) -> (Session, Session) {
 
 async fn open_session_multicast(endpoint01: &str, endpoint02: &str) -> (Session, Session) {
     // Open the sessions
-    let mut config = zenoh::Config::default();
+    let mut config = zenoh::config::default();
     config
         .listen
         .endpoints
@@ -84,7 +84,7 @@ async fn open_session_multicast(endpoint01: &str, endpoint02: &str) -> (Session,
     println!("[  ][01a] Opening peer01 session: {}", endpoint01);
     let peer01 = ztimeout!(zenoh::open(config)).unwrap();
 
-    let mut config = zenoh::Config::default();
+    let mut config = zenoh::config::default();
     config
         .listen
         .endpoints
@@ -289,7 +289,7 @@ async fn zenoh_session_multicast() {
 #[cfg(feature = "internal")]
 async fn open_session_unicast_runtime(endpoints: &[&str]) -> (Runtime, Runtime) {
     // Open the sessions
-    let mut config = zenoh::Config::default();
+    let mut config = zenoh::config::default();
     config
         .listen
         .endpoints
@@ -305,7 +305,7 @@ async fn open_session_unicast_runtime(endpoints: &[&str]) -> (Runtime, Runtime) 
     let mut r1 = RuntimeBuilder::new(config).build().await.unwrap();
     r1.start().await.unwrap();
 
-    let mut config = zenoh::Config::default();
+    let mut config = zenoh::config::default();
     config
         .connect
         .endpoints

--- a/zenoh/tests/unicity.rs
+++ b/zenoh/tests/unicity.rs
@@ -34,7 +34,7 @@ const MSG_SIZE: [usize; 2] = [1_024, 100_000];
 
 async fn open_p2p_sessions() -> (Session, Session, Session) {
     // Open the sessions
-    let mut config = zenoh::Config::default();
+    let mut config = zenoh::config::default();
     config
         .listen
         .endpoints
@@ -44,7 +44,7 @@ async fn open_p2p_sessions() -> (Session, Session, Session) {
     println!("[  ][01a] Opening s01 session");
     let s01 = ztimeout!(zenoh::open(config)).unwrap();
 
-    let mut config = zenoh::Config::default();
+    let mut config = zenoh::config::default();
     config
         .listen
         .endpoints
@@ -59,7 +59,7 @@ async fn open_p2p_sessions() -> (Session, Session, Session) {
     println!("[  ][02a] Opening s02 session");
     let s02 = ztimeout!(zenoh::open(config)).unwrap();
 
-    let mut config = zenoh::Config::default();
+    let mut config = zenoh::config::default();
     config
         .connect
         .endpoints
@@ -77,7 +77,7 @@ async fn open_p2p_sessions() -> (Session, Session, Session) {
 
 async fn open_router_session() -> Session {
     // Open the sessions
-    let mut config = zenoh::Config::default();
+    let mut config = zenoh::config::default();
     config.set_mode(Some(WhatAmI::Router)).unwrap();
     config
         .listen
@@ -96,7 +96,7 @@ async fn close_router_session(s: Session) {
 
 async fn open_client_sessions() -> (Session, Session, Session) {
     // Open the sessions
-    let mut config = zenoh::Config::default();
+    let mut config = zenoh::config::default();
     config.set_mode(Some(WhatAmI::Client)).unwrap();
     config
         .connect
@@ -107,7 +107,7 @@ async fn open_client_sessions() -> (Session, Session, Session) {
     println!("[  ][01a] Opening s01 session");
     let s01 = ztimeout!(zenoh::open(config)).unwrap();
 
-    let mut config = zenoh::Config::default();
+    let mut config = zenoh::config::default();
     config.set_mode(Some(WhatAmI::Client)).unwrap();
     config
         .connect
@@ -118,7 +118,7 @@ async fn open_client_sessions() -> (Session, Session, Session) {
     println!("[  ][02a] Opening s02 session");
     let s02 = ztimeout!(zenoh::open(config)).unwrap();
 
-    let mut config = zenoh::Config::default();
+    let mut config = zenoh::config::default();
     config.set_mode(Some(WhatAmI::Client)).unwrap();
     config
         .connect

--- a/zenohd/src/main.rs
+++ b/zenohd/src/main.rs
@@ -17,7 +17,10 @@ use git_version::git_version;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 #[cfg(feature = "loki")]
 use url::Url;
-use zenoh::{config::WhatAmI, Config, Result};
+use zenoh::{
+    config::{Config, WhatAmI},
+    Result,
+};
 use zenoh_config::{EndPoint, ModeDependentValue, PermissionsConf};
 use zenoh_util::LibSearchDirs;
 


### PR DESCRIPTION
it was removed on cleaning up type leaks on inport zenoh_config::*, restored now