### PR TITLE
Fix Clippy errors from Rust 1.82.0

### DIFF
--- a/commons/zenoh-buffers/src/lib.rs
+++ b/commons/zenoh-buffers/src/lib.rs
@@ -59,17 +59,21 @@ macro_rules! unsafe_slice_mut {
 #[cfg(all(not(test), not(feature = "test")))]
 #[macro_export]
 macro_rules! unsafe_slice {
-    ($s:expr,$r:expr) => {
-        unsafe { $s.get_unchecked($r) }
-    };
+    ($s:expr,$r:expr) => {{
+        let slice = &*$s;
+        let index = $r;
+        unsafe { slice.get_unchecked(index) }
+    }};
 }
 
 #[cfg(all(not(test), not(feature = "test")))]
 #[macro_export]
 macro_rules! unsafe_slice_mut {
-    ($s:expr,$r:expr) => {
-        unsafe { $s.get_unchecked_mut($r) }
-    };
+    ($s:expr,$r:expr) => {{
+        let slice = &mut *$s;
+        let index = $r;
+        unsafe { slice.get_unchecked_mut(index) }
+    }};
 }
 
 pub mod buffer {

--- a/commons/zenoh-keyexpr/src/key_expr/format/support.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/format/support.rs
@@ -246,7 +246,11 @@ impl<'s> IKeFormatStorage<'s> for Vec<Segment<'s>> {
         constructor: IterativeConstructor<Self, Self::PartialConstruct, Self::ConstructionError>,
         segment: Segment<'s>,
     ) -> IterativeConstructor<Self, Self::PartialConstruct, Self::ConstructionError> {
-        let IterativeConstructor::Complete(mut this) = constructor else {
+        // NOTE(fuzzypixelz): Rust 1.82.0 can detect that this pattern is irrefutable but that's not
+        // necessarily the case for prior versions. Thus we silence this lint to keep the MSRV minimal.
+        #[allow(irrefutable_let_patterns)]
+        let IterativeConstructor::Complete(mut this) = constructor
+        else {
             unsafe { core::hint::unreachable_unchecked() }
         };
         this.push(segment);


### PR DESCRIPTION
It is possible to preview unreleased rust versions like so:

```
RUSTUP_DIST_SERVER=https://dev-static.rust-lang.org rustup install 1.82.0
```