### PR TITLE
Fix rust-cache invocation order in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,11 @@ jobs:
       - name: Clone this repository
         uses: actions/checkout@v4
 
-      - name: Setup rust-cache
-        uses: Swatinem/rust-cache@v2
-
       - name: Update Stable Rust toolchain
         run: rustup update stable
+
+      - name: Setup rust-cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Install latest cargo-deny
         uses: taiki-e/install-action@cargo-deny


### PR DESCRIPTION
Fix rust-cache invocation order in the CI workflow. See https://github.com/Swatinem/rust-cache/issues/9\#issuecomment-766755677.