### PR TITLE
fallible serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4821,6 +4821,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "unwrap-infallible"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "151ac09978d3c2862c4e39b557f4eceee2cc72150bc4cb4f16abf061b6e381fb"
+
+[[package]]
 name = "unzip-n"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5588,6 +5594,7 @@ dependencies = [
  "serde",
  "tokio",
  "tracing",
+ "unwrap-infallible",
  "zenoh",
  "zenoh-config",
  "zenoh-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,6 +177,7 @@ thread-priority = "1.1.0"
 typenum = "1.17.0"
 uhlc = { version = "0.8.0", default-features = false } # Default features are disabled due to usage in no_std crates
 unzip-n = "0.1.2"
+unwrap-infallible = "0.1.5"
 url = "2.5.2"
 urlencoding = "2.1.3"
 uuid = { version = "1.10.0", default-features = false, features = [

--- a/zenoh-ext/Cargo.toml
+++ b/zenoh-ext/Cargo.toml
@@ -45,6 +45,7 @@ futures = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true, features = ["default"] }
 leb128 = { workspace = true }
+unwrap-infallible = { workspace = true }
 zenoh = { workspace = true, default-features = false }
 zenoh-macros = { workspace = true }
 

--- a/zenoh-ext/src/lib.rs
+++ b/zenoh-ext/src/lib.rs
@@ -26,8 +26,8 @@ mod subscriber_ext;
 #[cfg(feature = "internal")]
 pub use crate::serialization::VarInt;
 pub use crate::serialization::{
-    z_deserialize, z_serialize, Deserialize, Serialize, ZDeserializeError, ZDeserializer,
-    ZReadIter, ZSerializer,
+    z_deserialize, z_serialize, z_try_serialize, Deserialize, TrySerialize, ZDeserializeError,
+    ZDeserializer, ZReadIter, ZSerializeError, ZSerializer,
 };
 #[cfg(feature = "unstable")]
 pub use crate::{

--- a/zenoh-ext/src/serialization.rs
+++ b/zenoh-ext/src/serialization.rs
@@ -189,7 +189,7 @@ pub fn z_serialize<T: Serialize + ?Sized>(t: &T) -> ZBytes {
 ///
 /// ```rust
 /// use zenoh_ext::*;
-/// let zbytes = z_try_serialize(&CString::new(b"Invalid utf8: \xff");
+/// let zbytes = z_try_serialize(&std::ffi::CString::new(b"Invalid utf8 \xF0").unwrap());
 /// assert!(zbytes.is_err());
 /// ```
 ///

--- a/zenoh-ext/src/serialization.rs
+++ b/zenoh-ext/src/serialization.rs
@@ -189,7 +189,7 @@ pub fn z_serialize<T: Serialize + ?Sized>(t: &T) -> ZBytes {
 ///
 /// ```rust
 /// use zenoh_ext::*;
-/// let zbytes = z_try_serialize(&CString::new("new(b"Invalid utf8: \xff");
+/// let zbytes = z_try_serialize(&CString::new(b"Invalid utf8: \xff");
 /// assert!(zbytes.is_err());
 /// ```
 ///

--- a/zenoh-ext/src/serialization.rs
+++ b/zenoh-ext/src/serialization.rs
@@ -78,7 +78,7 @@ pub trait TrySerialize {
     }
 }
 
-/// Infallible serialization implementation. Implemeted automatically for types
+/// Infallible serialization implementation. Implemented automatically for types
 /// that implement `TrySerialize<Error = Infallible>`.
 /// Can be implemented manually when necessary, e.g. in case when the type already
 /// have automatic implementation of `TrySerialize` with the error type not `Infallible`.


### PR DESCRIPTION
- `z_try_serialize` function added
- trait `TrySerialize` added. The trait `Serialize` remains for infallible serialization
   - For basic types and containers which allows infallible serialization this trait is implemeted as `TrySerialize<Error = Infallible>`
   - The `Serialize` trait is implemeted automatically for all types which implements `TrySerialize<Error = Infallible>`
   - It's possible to implement `Serialize` explicitly for types which already implements `TrySerialize<Error = ZSerializeError>` or any other error. This is necessary for e.g. `HashMap`
 - fallible serialization of `CString` added: in demonstration purpose and may be for future use in zenoh-c