### PR TITLE
Fix QoS extensions naming

### DIFF
--- a/commons/zenoh-codec/src/transport/init.rs
+++ b/commons/zenoh-codec/src/transport/init.rs
@@ -45,7 +45,7 @@ where
             resolution,
             batch_size,
             ext_qos,
-            ext_qos_optimized,
+            ext_qos_link,
             #[cfg(feature = "shared-memory")]
             ext_shm,
             ext_auth,
@@ -60,7 +60,7 @@ where
             header |= flag::S;
         }
         let mut n_exts = (ext_qos.is_some() as u8)
-            + (ext_qos_optimized.is_some() as u8)
+            + (ext_qos_link.is_some() as u8)
             + (ext_auth.is_some() as u8)
             + (ext_mlink.is_some() as u8)
             + (ext_lowlatency.is_some() as u8)
@@ -100,9 +100,9 @@ where
             n_exts -= 1;
             self.write(&mut *writer, (qos, n_exts != 0))?;
         }
-        if let Some(qos_optimized) = ext_qos_optimized.as_ref() {
+        if let Some(qos_link) = ext_qos_link.as_ref() {
             n_exts -= 1;
-            self.write(&mut *writer, (qos_optimized, n_exts != 0))?;
+            self.write(&mut *writer, (qos_link, n_exts != 0))?;
         }
         #[cfg(feature = "shared-memory")]
         if let Some(shm) = ext_shm.as_ref() {
@@ -179,7 +179,7 @@ where
 
         // Extensions
         let mut ext_qos = None;
-        let mut ext_qos_optimized = None;
+        let mut ext_qos_link = None;
         #[cfg(feature = "shared-memory")]
         let mut ext_shm = None;
         let mut ext_auth = None;
@@ -197,9 +197,9 @@ where
                     ext_qos = Some(q);
                     has_ext = ext;
                 }
-                ext::QoSOptimized::ID => {
-                    let (q, ext): (ext::QoSOptimized, bool) = eodec.read(&mut *reader)?;
-                    ext_qos_optimized = Some(q);
+                ext::QoSLink::ID => {
+                    let (q, ext): (ext::QoSLink, bool) = eodec.read(&mut *reader)?;
+                    ext_qos_link = Some(q);
                     has_ext = ext;
                 }
                 #[cfg(feature = "shared-memory")]
@@ -241,7 +241,7 @@ where
             resolution,
             batch_size,
             ext_qos,
-            ext_qos_optimized,
+            ext_qos_link,
             #[cfg(feature = "shared-memory")]
             ext_shm,
             ext_auth,
@@ -268,7 +268,7 @@ where
             batch_size,
             cookie,
             ext_qos,
-            ext_qos_optimized,
+            ext_qos_link,
             #[cfg(feature = "shared-memory")]
             ext_shm,
             ext_auth,
@@ -283,7 +283,7 @@ where
             header |= flag::S;
         }
         let mut n_exts = (ext_qos.is_some() as u8)
-            + (ext_qos_optimized.is_some() as u8)
+            + (ext_qos_link.is_some() as u8)
             + (ext_auth.is_some() as u8)
             + (ext_mlink.is_some() as u8)
             + (ext_lowlatency.is_some() as u8)
@@ -326,9 +326,9 @@ where
             n_exts -= 1;
             self.write(&mut *writer, (qos, n_exts != 0))?;
         }
-        if let Some(qos_optimized) = ext_qos_optimized.as_ref() {
+        if let Some(qos_link) = ext_qos_link.as_ref() {
             n_exts -= 1;
-            self.write(&mut *writer, (qos_optimized, n_exts != 0))?;
+            self.write(&mut *writer, (qos_link, n_exts != 0))?;
         }
         #[cfg(feature = "shared-memory")]
         if let Some(shm) = ext_shm.as_ref() {
@@ -408,7 +408,7 @@ where
 
         // Extensions
         let mut ext_qos = None;
-        let mut ext_qos_optimized = None;
+        let mut ext_qos_link = None;
         #[cfg(feature = "shared-memory")]
         let mut ext_shm = None;
         let mut ext_auth = None;
@@ -426,9 +426,9 @@ where
                     ext_qos = Some(q);
                     has_ext = ext;
                 }
-                ext::QoSOptimized::ID => {
-                    let (q, ext): (ext::QoSOptimized, bool) = eodec.read(&mut *reader)?;
-                    ext_qos_optimized = Some(q);
+                ext::QoSLink::ID => {
+                    let (q, ext): (ext::QoSLink, bool) = eodec.read(&mut *reader)?;
+                    ext_qos_link = Some(q);
                     has_ext = ext;
                 }
                 #[cfg(feature = "shared-memory")]
@@ -471,7 +471,7 @@ where
             batch_size,
             cookie,
             ext_qos,
-            ext_qos_optimized,
+            ext_qos_link,
             #[cfg(feature = "shared-memory")]
             ext_shm,
             ext_auth,

--- a/commons/zenoh-protocol/src/transport/init.rs
+++ b/commons/zenoh-protocol/src/transport/init.rs
@@ -172,8 +172,8 @@ impl InitSyn {
         let zid = ZenohIdProto::default();
         let resolution = Resolution::rand();
         let batch_size: BatchSize = rng.gen();
-        let ext_qos_link = rng.gen_bool(0.5).then_some(ZExtZ64::rand());
         let ext_qos = rng.gen_bool(0.5).then_some(ZExtUnit::rand());
+        let ext_qos_link = rng.gen_bool(0.5).then_some(ZExtZ64::rand());
         #[cfg(feature = "shared-memory")]
         let ext_shm = rng.gen_bool(0.5).then_some(ZExtZBuf::rand());
         let ext_auth = rng.gen_bool(0.5).then_some(ZExtZBuf::rand());

--- a/commons/zenoh-protocol/src/transport/init.rs
+++ b/commons/zenoh-protocol/src/transport/init.rs
@@ -115,7 +115,7 @@ pub struct InitSyn {
     pub resolution: Resolution,
     pub batch_size: BatchSize,
     pub ext_qos: Option<ext::QoS>,
-    pub ext_qos_optimized: Option<ext::QoSOptimized>,
+    pub ext_qos_link: Option<ext::QoSLink>,
     #[cfg(feature = "shared-memory")]
     pub ext_shm: Option<ext::Shm>,
     pub ext_auth: Option<ext::Auth>,
@@ -133,8 +133,8 @@ pub mod ext {
 
     /// # QoS extension
     /// Used to negotiate the use of QoS
-    pub type QoS = zextz64!(0x1, false);
-    pub type QoSOptimized = zextunit!(0x1, false);
+    pub type QoS = zextunit!(0x1, false);
+    pub type QoSLink = zextz64!(0x1, false);
 
     /// # Shm extension
     /// Used as challenge for probing shared memory capabilities
@@ -172,8 +172,8 @@ impl InitSyn {
         let zid = ZenohIdProto::default();
         let resolution = Resolution::rand();
         let batch_size: BatchSize = rng.gen();
-        let ext_qos = rng.gen_bool(0.5).then_some(ZExtZ64::rand());
-        let ext_qos_optimized = rng.gen_bool(0.5).then_some(ZExtUnit::rand());
+        let ext_qos_link = rng.gen_bool(0.5).then_some(ZExtZ64::rand());
+        let ext_qos = rng.gen_bool(0.5).then_some(ZExtUnit::rand());
         #[cfg(feature = "shared-memory")]
         let ext_shm = rng.gen_bool(0.5).then_some(ZExtZBuf::rand());
         let ext_auth = rng.gen_bool(0.5).then_some(ZExtZBuf::rand());
@@ -188,7 +188,7 @@ impl InitSyn {
             resolution,
             batch_size,
             ext_qos,
-            ext_qos_optimized,
+            ext_qos_link,
             #[cfg(feature = "shared-memory")]
             ext_shm,
             ext_auth,
@@ -208,7 +208,7 @@ pub struct InitAck {
     pub batch_size: BatchSize,
     pub cookie: ZSlice,
     pub ext_qos: Option<ext::QoS>,
-    pub ext_qos_optimized: Option<ext::QoSOptimized>,
+    pub ext_qos_link: Option<ext::QoSLink>,
     #[cfg(feature = "shared-memory")]
     pub ext_shm: Option<ext::Shm>,
     pub ext_auth: Option<ext::Auth>,
@@ -236,8 +236,8 @@ impl InitAck {
         };
         let batch_size: BatchSize = rng.gen();
         let cookie = ZSlice::rand(64);
-        let ext_qos = rng.gen_bool(0.5).then_some(ZExtZ64::rand());
-        let ext_qos_optimized = rng.gen_bool(0.5).then_some(ZExtUnit::rand());
+        let ext_qos = rng.gen_bool(0.5).then_some(ZExtUnit::rand());
+        let ext_qos_link = rng.gen_bool(0.5).then_some(ZExtZ64::rand());
         #[cfg(feature = "shared-memory")]
         let ext_shm = rng.gen_bool(0.5).then_some(ZExtZBuf::rand());
         let ext_auth = rng.gen_bool(0.5).then_some(ZExtZBuf::rand());
@@ -253,7 +253,7 @@ impl InitAck {
             batch_size,
             cookie,
             ext_qos,
-            ext_qos_optimized,
+            ext_qos_link,
             #[cfg(feature = "shared-memory")]
             ext_shm,
             ext_auth,

--- a/io/zenoh-transport/src/unicast/establishment/accept.rs
+++ b/io/zenoh-transport/src/unicast/establishment/accept.rs
@@ -226,7 +226,7 @@ impl<'a, 'b: 'a> AcceptFsm for &'a mut AcceptLink<'b> {
         self.ext_qos
             .recv_init_syn((
                 &mut state.transport.ext_qos,
-                (init_syn.ext_qos, init_syn.ext_qos_optimized),
+                (init_syn.ext_qos, init_syn.ext_qos_link),
             ))
             .await
             .map_err(|e| (e, Some(close::reason::GENERIC)))?;
@@ -287,7 +287,7 @@ impl<'a, 'b: 'a> AcceptFsm for &'a mut AcceptLink<'b> {
         let (mut state, input) = input;
 
         // Extension QoS
-        let (ext_qos, ext_qos_optimized) = self
+        let (ext_qos, ext_qos_link) = self
             .ext_qos
             .send_init_ack(&state.transport.ext_qos)
             .await
@@ -384,7 +384,7 @@ impl<'a, 'b: 'a> AcceptFsm for &'a mut AcceptLink<'b> {
             batch_size: state.transport.batch_size,
             cookie,
             ext_qos,
-            ext_qos_optimized,
+            ext_qos_link,
             #[cfg(feature = "shared-memory")]
             ext_shm,
             ext_auth,

--- a/io/zenoh-transport/src/unicast/establishment/open.rs
+++ b/io/zenoh-transport/src/unicast/establishment/open.rs
@@ -139,7 +139,7 @@ impl<'a, 'b: 'a> OpenFsm for &'a mut OpenLink<'b> {
         let (link, state, input) = input;
 
         // Extension QoS
-        let (ext_qos, ext_qos_optimized) = self
+        let (ext_qos, ext_qos_link) = self
             .ext_qos
             .send_init_syn(&state.transport.ext_qos)
             .await
@@ -199,7 +199,7 @@ impl<'a, 'b: 'a> OpenFsm for &'a mut OpenLink<'b> {
             batch_size: state.transport.batch_size,
             resolution: state.transport.resolution,
             ext_qos,
-            ext_qos_optimized,
+            ext_qos_link,
             #[cfg(feature = "shared-memory")]
             ext_shm,
             ext_auth,
@@ -305,7 +305,7 @@ impl<'a, 'b: 'a> OpenFsm for &'a mut OpenLink<'b> {
         self.ext_qos
             .recv_init_ack((
                 &mut state.transport.ext_qos,
-                (init_ack.ext_qos, init_ack.ext_qos_optimized),
+                (init_ack.ext_qos, init_ack.ext_qos_link),
             ))
             .await
             .map_err(|e| (e, Some(close::reason::GENERIC)))?;


### PR DESCRIPTION
Fix QoS extensions naming in light of updating zenoh-dissector.