### PR TITLE
Don't close multicast transport on OS error 55

### DIFF
--- a/io/zenoh-links/zenoh-link-udp/src/multicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/multicast.rs
@@ -90,10 +90,11 @@ impl LinkMulticastTrait for LinkMulticastUdp {
             std::io::Result::Err(e) => {
                 if let Some(55) = e.raw_os_error() {
                     // No buffer space available
-                    tracing::trace!("{}", e);
+                    tracing::trace!("Write error on UDP link {}: {}", self, e);
                     Ok(0)
                 } else {
                     let e = zerror!("Write error on UDP link {}: {}", self, e);
+                    tracing::trace!("{}", e);
                     Err(e.into())
                 }
             }

--- a/io/zenoh-links/zenoh-link-udp/src/multicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/multicast.rs
@@ -88,6 +88,13 @@ impl LinkMulticastTrait for LinkMulticastUdp {
         {
             Ok(size) => Ok(size),
             std::io::Result::Err(e) => {
+                #[cfg(not(target_os = "macos"))]
+                {
+                    let e = zerror!("Write error on UDP link {}: {}", self, e);
+                    tracing::trace!("{}", e);
+                    Err(e.into())
+                }
+                #[cfg(target_os = "macos")]
                 if let Some(55) = e.raw_os_error() {
                     // No buffer space available
                     tracing::trace!("Write error on UDP link {}: {}", self, e);


### PR DESCRIPTION
When sending high throughput through multicast transport the following could occur:
```
TX task failed: Write error on UDP link 192.168.0.1:51381 => 224.0.0.1:17511: No buffer space available (os error 55) at io/zenoh-links/zenoh-link-udp/src/multicast.rs:88.
Closing multicast transport on udp/224.0.0.1:17511
```
Now Zenoh logs and ignores the error.