### PR TITLE
Optimize link selection metadata

### DIFF
--- a/commons/zenoh-protocol/src/core/endpoint.rs
+++ b/commons/zenoh-protocol/src/core/endpoint.rs
@@ -187,8 +187,8 @@ impl fmt::Debug for AddressMut<'_> {
 pub struct Metadata<'a>(pub(super) &'a str);
 
 impl<'a> Metadata<'a> {
-    pub const RELIABILITY: &'static str = "reliability";
-    pub const PRIORITIES: &'static str = "priorities";
+    pub const RELIABILITY: &'static str = "rel";
+    pub const PRIORITIES: &'static str = "prio";
 
     pub fn as_str(&self) -> &'a str {
         self.0

--- a/io/zenoh-link-commons/src/lib.rs
+++ b/io/zenoh-link-commons/src/lib.rs
@@ -117,7 +117,7 @@ impl Link {
         let mut locator = locator.clone();
         let mut metadata = locator.metadata_mut();
         reliability
-            .map(|r| metadata.insert(Metadata::RELIABILITY, r.as_str()))
+            .map(|r| metadata.insert(Metadata::RELIABILITY, r.to_string()))
             .transpose()
             .expect("adding `reliability` to Locator metadata should not fail");
         priorities


### PR DESCRIPTION
This reduces the size of metadata fields used in link selection as they can substantially increase the size of HELLO messages.

The abbreviations "rel" and "prio" are used for "priorities" and "reliability" respectively. Furthermore, the numbers 0 and 1 are used to denote "best_effort" and "reliable" reliabilities.