### PR TITLE
Do not include zenoh_result::Error in Other AllocError

### DIFF
--- a/commons/zenoh-shm/src/api/provider/types.rs
+++ b/commons/zenoh-shm/src/api/provider/types.rs
@@ -26,12 +26,12 @@ pub enum ZAllocError {
     /// The provider is out of memory.
     OutOfMemory,
     /// Uncategorized allocation error.
-    Other(zenoh_result::Error),
+    Other,
 }
 
 impl From<zenoh_result::Error> for ZAllocError {
-    fn from(value: zenoh_result::Error) -> Self {
-        Self::Other(value)
+    fn from(_value: zenoh_result::Error) -> Self {
+        Self::Other
     }
 }
 


### PR DESCRIPTION
This reduces allocation result's size and fixes https://github.com/eclipse-zenoh/zenoh-c/issues/740