### PR TITLE
Add `live-run` input to `bump-crates`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,7 @@ jobs:
       - uses: eclipse-zenoh/ci/bump-crates@main
         with:
           repo: ${{ github.repository }}
+          live-run: ${{ inputs.live-run || false }}
           version: ${{ steps.create-release-branch.outputs.version }}
           branch: ${{ steps.create-release-branch.outputs.branch }}
           bump-deps-pattern: zenoh.*


### PR DESCRIPTION
See https://github.com/eclipse-zenoh/ci/pull/239/.