### PR TITLE
Close TLS and Quic links on certificate expiration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5664,6 +5664,7 @@ dependencies = [
  "rustls",
  "rustls-webpki",
  "serde",
+ "time 0.3.36",
  "tokio",
  "tokio-util",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5689,6 +5689,7 @@ dependencies = [
  "rustls-pki-types",
  "rustls-webpki",
  "secrecy",
+ "time 0.3.36",
  "tokio",
  "tokio-util",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5745,6 +5745,7 @@ dependencies = [
  "rustls-webpki",
  "secrecy",
  "socket2 0.5.7",
+ "time 0.3.36",
  "tls-listener",
  "tokio",
  "tokio-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,6 +167,7 @@ socket2 = { version = "0.5.7", features = ["all"] }
 stop-token = "0.7.0"
 syn = "2.0"
 tide = "0.16.0"
+time = "0.3.36"
 token-cell = { version = "1.5.0", default-features = false }
 tokio = { version = "1.40.0", default-features = false } # Default features are disabled due to some crates' requirements
 tokio-util = "0.7.12"

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -466,6 +466,10 @@
         // This could be dangerous because your CA can have signed a server cert for foo.com, that's later being used to host a server at baz.com. If you wan't your
         // ca to verify that the server at baz.com is actually baz.com, let this be true (default).
         verify_name_on_connect: true,
+        // Whether or not to close links when remote certificates expires.
+        // If set to true, links that require certificates (tls/quic) will automatically disconnect when the time of expiration of the remote certificate chain is reached
+        // note that mTLS (client authentication) is required for a listener to disconnect a client on expiration
+        close_link_on_expiration: false,
       },
     },
     /// Shared memory configuration.

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -483,6 +483,7 @@ validated_struct::validator! {
                     connect_private_key: Option<String>,
                     connect_certificate: Option<String>,
                     verify_name_on_connect: Option<bool>,
+                    close_link_on_expiration: Option<bool>,
                     // Skip serializing field because they contain secrets
                     #[serde(skip_serializing)]
                     root_ca_certificate_base64: Option<SecretValue>,

--- a/io/zenoh-link-commons/Cargo.toml
+++ b/io/zenoh-link-commons/Cargo.toml
@@ -35,6 +35,7 @@ futures = { workspace = true }
 rustls = { workspace = true, optional = true }
 rustls-webpki = { workspace = true, optional = true }
 serde = { workspace = true, features = ["default"] }
+time = { workspace = true }
 tokio = { workspace = true, features = [
   "fs",
   "io-util",

--- a/io/zenoh-link-commons/src/tls.rs
+++ b/io/zenoh-link-commons/src/tls.rs
@@ -135,6 +135,12 @@ pub mod expiration {
         const MAX_EXPIRATION_SLEEP_DURATION: tokio::time::Duration =
             tokio::time::Duration::from_secs(600);
 
+        tracing::trace!(
+            "Expiration task started for link {} => {}",
+            expiration_info.src_locator,
+            expiration_info.dst_locator,
+        );
+
         loop {
             let now = OffsetDateTime::now_utc();
             if expiration_info.expiration_time <= now {

--- a/io/zenoh-link-commons/src/tls.rs
+++ b/io/zenoh-link-commons/src/tls.rs
@@ -146,6 +146,12 @@ pub mod expiration {
         expiration_time: OffsetDateTime,
         token: CancellationToken,
     ) {
+        tracing::trace!(
+            "Expiration task started for {} link {:?} => {:?}",
+            link_type.to_uppercase(),
+            src_addr,
+            dst_addr,
+        );
         tokio::select! {
             _ = token.cancelled() => {},
             _ = sleep_until_date(expiration_time) => {

--- a/io/zenoh-link-commons/src/tls.rs
+++ b/io/zenoh-link-commons/src/tls.rs
@@ -107,7 +107,7 @@ pub mod expiration {
             link: Weak<dyn LinkUnicastTrait>,
             src_addr: SocketAddr,
             dst_addr: SocketAddr,
-            link_type: String,
+            link_type: &'static str,
             expiration_time: OffsetDateTime,
         ) -> Self {
             let token = CancellationToken::new();
@@ -142,7 +142,7 @@ pub mod expiration {
         link: Weak<dyn LinkUnicastTrait>,
         src_addr: SocketAddr,
         dst_addr: SocketAddr,
-        link_type: String,
+        link_type: &'static str,
         expiration_time: OffsetDateTime,
         token: CancellationToken,
     ) {

--- a/io/zenoh-link-commons/src/tls.rs
+++ b/io/zenoh-link-commons/src/tls.rs
@@ -1,5 +1,6 @@
-use crate::LinkUnicastTrait;
 use alloc::vec::Vec;
+use std::{collections::BTreeMap, sync::Weak};
+
 use rustls::{
     client::{
         danger::{ServerCertVerified, ServerCertVerifier},
@@ -10,12 +11,13 @@ use rustls::{
     server::ParsedCertificate,
     RootCertStore,
 };
-use std::{collections::BTreeMap, sync::Weak};
 use time::OffsetDateTime;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use webpki::ALL_VERIFICATION_ALGS;
 use zenoh_protocol::core::Locator;
+
+use crate::LinkUnicastTrait;
 
 impl ServerCertVerifier for WebPkiVerifierAnyServerName {
     /// Will verify the certificate is valid in the following ways:

--- a/io/zenoh-link-commons/src/tls.rs
+++ b/io/zenoh-link-commons/src/tls.rs
@@ -1,5 +1,5 @@
+use crate::LinkUnicastTrait;
 use alloc::vec::Vec;
-
 use rustls::{
     client::{
         danger::{ServerCertVerified, ServerCertVerifier},
@@ -10,7 +10,12 @@ use rustls::{
     server::ParsedCertificate,
     RootCertStore,
 };
+use std::{collections::BTreeMap, sync::Weak};
+use time::OffsetDateTime;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 use webpki::ALL_VERIFICATION_ALGS;
+use zenoh_protocol::core::Locator;
 
 impl ServerCertVerifier for WebPkiVerifierAnyServerName {
     /// Will verify the certificate is valid in the following ways:
@@ -86,3 +91,119 @@ impl WebPkiVerifierAnyServerName {
         Self { roots }
     }
 }
+
+pub struct LinkCertExpirationManager {
+    pub token: CancellationToken,
+    pub tx: NewLinkExpirationSender,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl Drop for LinkCertExpirationManager {
+    fn drop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            zenoh_runtime::ZRuntime::Acceptor.block_in_place(async {
+                self.token.cancel();
+                let _ = handle.await;
+            })
+        }
+    }
+}
+
+impl LinkCertExpirationManager {
+    pub fn new(token: CancellationToken) -> Self {
+        let (tx, rx) = flume::bounded::<(OffsetDateTime, LinkCertExpirationInfo)>(1);
+        let handle = zenoh_runtime::ZRuntime::Acceptor.spawn(expiration_task(token.clone(), rx));
+        Self {
+            token,
+            handle: Some(handle),
+            tx,
+        }
+    }
+}
+
+async fn expiration_task(
+    token: CancellationToken,
+    rx: flume::Receiver<(OffsetDateTime, LinkCertExpirationInfo)>,
+) {
+    // TODO: Maybe expose this as a locator parameter?
+    const PERIODIC_SLEEP_DURATION: tokio::time::Duration = tokio::time::Duration::from_secs(600);
+    let mut link_expiration_map: BTreeMap<OffsetDateTime, Vec<LinkCertExpirationInfo>> =
+        BTreeMap::new();
+    let mut next_wakeup_instant: tokio::time::Instant;
+
+    loop {
+        next_wakeup_instant = tokio::time::Instant::now() + PERIODIC_SLEEP_DURATION;
+
+        if let Some((&next_expiration_time, links_to_close)) = link_expiration_map.first_key_value()
+        {
+            let now = OffsetDateTime::now_utc();
+            if next_expiration_time <= now {
+                // Close links
+                // NOTE: after closing links, transports are reopened with cert chains that expire instantly.
+                //       It's not an issue, but maybe we should add some throttling before closing the links...
+                for link_info in links_to_close {
+                    if let Some(link) = link_info.link.upgrade() {
+                        tracing::warn!(
+                            "Closing link {} => {} : remote certificate chain expired",
+                            link_info.src_locator,
+                            link_info.dst_locator,
+                        );
+                        if let Err(e) = link.close().await {
+                            tracing::error!(
+                                "Error closing link {} => {} : {}",
+                                link_info.src_locator,
+                                link_info.dst_locator,
+                                e
+                            )
+                        }
+                    }
+                }
+                link_expiration_map.remove(&next_expiration_time);
+                // loop again to check the next deadline
+                continue;
+            } else {
+                // next sleep duration is the minimum between PERIODIC_SLEEP_DURATION and the duration till next expiration
+                // this mitigates the unsoundness of using `tokio::time::sleep_until` with long durations
+                let next_expiration_duration = std::time::Duration::from_secs_f32(
+                    (next_expiration_time - now).as_seconds_f32(),
+                );
+                next_wakeup_instant = tokio::time::Instant::now()
+                    + tokio::time::Duration::min(PERIODIC_SLEEP_DURATION, next_expiration_duration);
+            }
+        }
+
+        tokio::select! {
+            _ = token.cancelled() => break,
+
+            _ = tokio::time::sleep_until(next_wakeup_instant) => {},
+
+            Ok(new_link) = rx.recv_async() => {
+                link_expiration_map.entry(new_link.0).or_default().push(new_link.1);
+            },
+            // if channel was closed, do nothing: we don't expect more links to be created,
+            // but it's not a reason to stop this task
+        }
+    }
+}
+
+pub struct LinkCertExpirationInfo {
+    link: Weak<dyn LinkUnicastTrait>,
+    src_locator: Locator,
+    dst_locator: Locator,
+}
+
+impl LinkCertExpirationInfo {
+    pub fn new(
+        link: Weak<dyn LinkUnicastTrait>,
+        src_locator: &Locator,
+        dst_locator: &Locator,
+    ) -> Self {
+        Self {
+            link,
+            src_locator: src_locator.clone(),
+            dst_locator: dst_locator.clone(),
+        }
+    }
+}
+
+pub type NewLinkExpirationSender = flume::Sender<(OffsetDateTime, LinkCertExpirationInfo)>;

--- a/io/zenoh-link-commons/src/tls.rs
+++ b/io/zenoh-link-commons/src/tls.rs
@@ -156,7 +156,7 @@ pub mod expiration {
                 }
                 break;
             }
-            // next sleep duration is the minimum between PERIODIC_SLEEP_DURATION and the duration till next expiration
+            // next sleep duration is the minimum between MAX_EXPIRATION_SLEEP_DURATION and the duration till next expiration
             // this mitigates the unsoundness of using `tokio::time::sleep_until` with long durations
             let next_expiration_duration = std::time::Duration::from_secs_f32(
                 (expiration_info.expiration_time - now).as_seconds_f32(),

--- a/io/zenoh-links/zenoh-link-quic/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-quic/Cargo.toml
@@ -33,6 +33,7 @@ rustls-pemfile = { workspace = true }
 rustls-pki-types = { workspace = true }
 rustls-webpki = { workspace = true }
 secrecy = { workspace = true }
+time = { workspace = true }
 tokio = { workspace = true, features = [
   "fs",
   "io-util",

--- a/io/zenoh-links/zenoh-link-quic/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/lib.rs
@@ -112,4 +112,7 @@ pub mod config {
 
     pub const TLS_VERIFY_NAME_ON_CONNECT: &str = "verify_name_on_connect";
     pub const TLS_VERIFY_NAME_ON_CONNECT_DEFAULT: bool = true;
+
+    pub const TLS_CLOSE_LINK_ON_EXPIRATION: &str = "close_link_on_expiration";
+    pub const TLS_CLOSE_LINK_ON_EXPIRATION_DEFAULT: bool = false;
 }

--- a/io/zenoh-links/zenoh-link-quic/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/unicast.rs
@@ -273,11 +273,6 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastQuic {
             let mut maybe_expiration_manager = None;
             if client_crypto.tls_close_link_on_expiration {
                 // setup expiration manager
-                tracing::trace!(
-                    "Expiration task started for QUIC link {:?} => {:?}",
-                    src_addr,
-                    dst_addr,
-                );
                 maybe_expiration_manager = Some(LinkCertExpirationManager::new(
                     weak_link.clone(),
                     src_addr,
@@ -467,11 +462,6 @@ async fn accept_task(
                             if tls_close_link_on_expiration {
                                 if let Some(certchain_expiration_time) = maybe_expiration_time {
                                     // setup expiration manager
-                                    tracing::trace!(
-                                        "Expiration task started for QUIC link {:?} => {:?}",
-                                        src_addr,
-                                        dst_addr,
-                                    );
                                     maybe_expiration_manager = Some(LinkCertExpirationManager::new(
                                         weak_link.clone(),
                                         src_addr,

--- a/io/zenoh-links/zenoh-link-quic/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/unicast.rs
@@ -270,10 +270,10 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastQuic {
             get_cert_chain_expiration(&quic_conn)?.expect("server should have certificate chain");
 
         let link = Arc::<LinkUnicastQuic>::new_cyclic(|weak_link| {
-            let mut maybe_expiration_manager = None;
+            let mut expiration_manager = None;
             if client_crypto.tls_close_link_on_expiration {
                 // setup expiration manager
-                maybe_expiration_manager = Some(LinkCertExpirationManager::new(
+                expiration_manager = Some(LinkCertExpirationManager::new(
                     weak_link.clone(),
                     src_addr,
                     dst_addr,
@@ -288,7 +288,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastQuic {
                 send,
                 recv,
                 auth_id.into(),
-                maybe_expiration_manager,
+                expiration_manager,
             )
         });
 
@@ -458,11 +458,11 @@ async fn accept_task(
                         tracing::debug!("Accepted QUIC connection on {:?}: {:?}", src_addr, dst_addr);
                         // Create the new link object
                         let link = Arc::<LinkUnicastQuic>::new_cyclic(|weak_link| {
-                            let mut maybe_expiration_manager = None;
+                            let mut expiration_manager = None;
                             if tls_close_link_on_expiration {
                                 if let Some(certchain_expiration_time) = maybe_expiration_time {
                                     // setup expiration manager
-                                    maybe_expiration_manager = Some(LinkCertExpirationManager::new(
+                                    expiration_manager = Some(LinkCertExpirationManager::new(
                                         weak_link.clone(),
                                         src_addr,
                                         dst_addr,
@@ -484,7 +484,7 @@ async fn accept_task(
                                 send,
                                 recv,
                                 auth_id.into(),
-                                maybe_expiration_manager,
+                                expiration_manager,
                             )
                         });
 

--- a/io/zenoh-links/zenoh-link-quic/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/unicast.rs
@@ -97,9 +97,11 @@ impl LinkUnicastTrait for LinkUnicastQuic {
                 // expiration_task is closing link, return its returned ZResult to Transport
                 return expiration_manager.wait_for_expiration_task().await;
             }
-            // cancel the expiration task
+            // cancel the expiration task and close link
             expiration_manager.cancel_expiration_task();
+            let res = self.close().await;
             let _ = expiration_manager.wait_for_expiration_task().await;
+            return res;
         }
         self.close().await
     }

--- a/io/zenoh-links/zenoh-link-quic/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/unicast.rs
@@ -277,7 +277,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastQuic {
                     weak_link.clone(),
                     src_addr,
                     dst_addr,
-                    QUIC_LOCATOR_PREFIX.to_string(),
+                    QUIC_LOCATOR_PREFIX,
                     certchain_expiration_time,
                 ))
             }
@@ -466,7 +466,7 @@ async fn accept_task(
                                         weak_link.clone(),
                                         src_addr,
                                         dst_addr,
-                                        QUIC_LOCATOR_PREFIX.to_string(),
+                                        QUIC_LOCATOR_PREFIX,
                                         certchain_expiration_time,
                                     ));
                                 } else {

--- a/io/zenoh-links/zenoh-link-quic/src/utils.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/utils.rs
@@ -141,12 +141,21 @@ impl ConfigurationInspector<ZenohConfig> for TlsConfigurator {
             false => ps.push((TLS_VERIFY_NAME_ON_CONNECT, "false")),
         };
 
+        match c
+            .close_link_on_expiration()
+            .unwrap_or(TLS_CLOSE_LINK_ON_EXPIRATION_DEFAULT)
+        {
+            true => ps.push((TLS_CLOSE_LINK_ON_EXPIRATION, "true")),
+            false => ps.push((TLS_CLOSE_LINK_ON_EXPIRATION, "false")),
+        }
+
         Ok(parameters::from_iter(ps.drain(..)))
     }
 }
 
 pub(crate) struct TlsServerConfig {
     pub(crate) server_config: ServerConfig,
+    pub(crate) tls_close_link_on_expiration: bool,
 }
 
 impl TlsServerConfig {
@@ -156,6 +165,12 @@ impl TlsServerConfig {
                 .parse()
                 .map_err(|_| zerror!("Unknown enable mTLS argument: {}", s))?,
             None => false,
+        };
+        let tls_close_link_on_expiration: bool = match config.get(TLS_CLOSE_LINK_ON_EXPIRATION) {
+            Some(s) => s
+                .parse()
+                .map_err(|_| zerror!("Unknown close on expiration argument: {}", s))?,
+            None => TLS_CLOSE_LINK_ON_EXPIRATION_DEFAULT,
         };
         let tls_server_private_key = TlsServerConfig::load_tls_private_key(config).await?;
         let tls_server_certificate = TlsServerConfig::load_tls_certificate(config).await?;
@@ -215,7 +230,10 @@ impl TlsServerConfig {
                 .with_single_cert(certs, keys.remove(0))
                 .map_err(|e| zerror!(e))?
         };
-        Ok(TlsServerConfig { server_config: sc })
+        Ok(TlsServerConfig {
+            server_config: sc,
+            tls_close_link_on_expiration,
+        })
     }
 
     async fn load_tls_private_key(config: &Config<'_>) -> ZResult<Vec<u8>> {
@@ -241,6 +259,7 @@ impl TlsServerConfig {
 
 pub(crate) struct TlsClientConfig {
     pub(crate) client_config: ClientConfig,
+    pub(crate) tls_close_link_on_expiration: bool,
 }
 
 impl TlsClientConfig {
@@ -263,6 +282,13 @@ impl TlsClientConfig {
                 s
             }
             None => false,
+        };
+
+        let tls_close_link_on_expiration: bool = match config.get(TLS_CLOSE_LINK_ON_EXPIRATION) {
+            Some(s) => s
+                .parse()
+                .map_err(|_| zerror!("Unknown close on expiration argument: {}", s))?,
+            None => TLS_CLOSE_LINK_ON_EXPIRATION_DEFAULT,
         };
 
         // Allows mixed user-generated CA and webPKI CA
@@ -351,7 +377,10 @@ impl TlsClientConfig {
                     .with_no_client_auth()
             }
         };
-        Ok(TlsClientConfig { client_config: cc })
+        Ok(TlsClientConfig {
+            client_config: cc,
+            tls_close_link_on_expiration,
+        })
     }
 
     async fn load_tls_private_key(config: &Config<'_>) -> ZResult<Vec<u8>> {

--- a/io/zenoh-links/zenoh-link-tls/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-tls/Cargo.toml
@@ -36,6 +36,7 @@ socket2 = { workspace = true }
 tokio = { workspace = true, features = ["fs", "io-util", "net", "sync"] }
 tokio-rustls = { workspace = true }
 tokio-util = { workspace = true, features = ["rt"] }
+time = { workspace = true }
 tracing = { workspace = true }
 x509-parser = { workspace = true }
 webpki-roots = { workspace = true }

--- a/io/zenoh-links/zenoh-link-tls/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/lib.rs
@@ -109,6 +109,9 @@ pub mod config {
     pub const TLS_VERIFY_NAME_ON_CONNECT: &str = "verify_name_on_connect";
     pub const TLS_VERIFY_NAME_ON_CONNECT_DEFAULT: bool = true;
 
+    pub const TLS_CLOSE_LINK_ON_EXPIRATION: &str = "close_link_on_expiration";
+    pub const TLS_CLOSE_LINK_ON_EXPIRATION_DEFAULT: bool = false;
+
     /// The time duration in milliseconds to wait for the TLS handshake to complete.
     pub const TLS_HANDSHAKE_TIMEOUT_MS: &str = "tls_handshake_timeout_ms";
     pub const TLS_HANDSHAKE_TIMEOUT_MS_DEFAULT: u64 = 10_000;

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -313,7 +313,7 @@ impl LinkManagerUnicastTls {
                     for link in links_to_close {
                         if let Some(link) = link.upgrade() {
                             tracing::warn!(
-                                "Closing link {} => {} : remote certificate expired",
+                                "Closing link {} => {} : remote certificate chain expired",
                                 link.src_locator,
                                 link.dst_locator,
                             );

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -349,13 +349,12 @@ impl LinkManagerUnicastTls {
 
                 _ = tokio::time::sleep_until(next_wakeup_instant) => {},
 
-                maybe_new_link = rx.recv() => {
+                maybe_new_link = rx.recv(), if !rx.is_closed() => {
                     if let Some(new_link) = maybe_new_link {
                         link_expiration_map.entry(new_link.0).or_default().push(new_link.1);
                     }
                     // else channel was closed, do nothing: we don't expect more links to be created,
                     // but it's not a reason to stop this task
-                    // FIXME: after this case, this branch of the select will instantly resolve in every loop...
                 },
             }
         }

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -346,7 +346,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastTls {
                     weak_link.clone(),
                     src_addr,
                     dst_addr,
-                    TLS_LOCATOR_PREFIX.to_string(),
+                    TLS_LOCATOR_PREFIX,
                     certchain_expiration_time,
                 ))
             }
@@ -484,7 +484,7 @@ async fn accept_task(
                                         weak_link.clone(),
                                         src_addr,
                                         dst_addr,
-                                        TLS_LOCATOR_PREFIX.to_string(),
+                                        TLS_LOCATOR_PREFIX,
                                         certchain_expiration_time,
                                     ));
                                 } else {

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -339,10 +339,10 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastTls {
         let tls_stream = TlsStream::Client(tls_stream);
 
         let link = Arc::<LinkUnicastTls>::new_cyclic(|weak_link| {
-            let mut maybe_expiration_manager = None;
+            let mut expiration_manager = None;
             if client_config.tls_close_link_on_expiration {
                 // setup expiration manager
-                maybe_expiration_manager = Some(LinkCertExpirationManager::new(
+                expiration_manager = Some(LinkCertExpirationManager::new(
                     weak_link.clone(),
                     src_addr,
                     dst_addr,
@@ -355,7 +355,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastTls {
                 dst_addr,
                 src_addr,
                 auth_identifier.into(),
-                maybe_expiration_manager,
+                expiration_manager,
             )
         });
 
@@ -476,11 +476,11 @@ async fn accept_task(
                         tracing::debug!("Accepted TLS connection on {:?}: {:?}", src_addr, dst_addr);
                         // Create the new link object
                         let link = Arc::<LinkUnicastTls>::new_cyclic(|weak_link| {
-                            let mut maybe_expiration_manager = None;
+                            let mut expiration_manager = None;
                             if tls_close_link_on_expiration {
                                 if let Some(certchain_expiration_time) = maybe_expiration_time {
                                     // setup expiration manager
-                                    maybe_expiration_manager = Some(LinkCertExpirationManager::new(
+                                    expiration_manager = Some(LinkCertExpirationManager::new(
                                         weak_link.clone(),
                                         src_addr,
                                         dst_addr,
@@ -498,7 +498,7 @@ async fn accept_task(
                                 dst_addr,
                                 src_addr,
                                 auth_identifier.into(),
-                                maybe_expiration_manager,
+                                expiration_manager,
                             )
                         });
 

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -342,11 +342,6 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastTls {
             let mut maybe_expiration_manager = None;
             if client_config.tls_close_link_on_expiration {
                 // setup expiration manager
-                tracing::trace!(
-                    "Expiration task started for TLS link {:?} => {:?}",
-                    src_addr,
-                    dst_addr,
-                );
                 maybe_expiration_manager = Some(LinkCertExpirationManager::new(
                     weak_link.clone(),
                     src_addr,
@@ -485,11 +480,6 @@ async fn accept_task(
                             if tls_close_link_on_expiration {
                                 if let Some(certchain_expiration_time) = maybe_expiration_time {
                                     // setup expiration manager
-                                    tracing::trace!(
-                                        "Expiration task started for TLS link {:?} => {:?}",
-                                        src_addr,
-                                        dst_addr,
-                                    );
                                     maybe_expiration_manager = Some(LinkCertExpirationManager::new(
                                         weak_link.clone(),
                                         src_addr,

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -171,9 +171,11 @@ impl LinkUnicastTrait for LinkUnicastTls {
                 // expiration_task is closing link, return its returned ZResult to Transport
                 return expiration_manager.wait_for_expiration_task().await;
             }
-            // cancel the expiration task
+            // cancel the expiration task and close link
             expiration_manager.cancel_expiration_task();
+            let res = self.close().await;
             let _ = expiration_manager.wait_for_expiration_task().await;
+            return res;
         }
         self.close().await
     }


### PR DESCRIPTION
Quic and TLS links currently do not close when remote certificate expires. This PR makes instances monitor the expiration of the remote certificate chain, closing the link at the moment of expiration.

This is configurable via the `transport.link.tls.close_link_on_expiration` key in the config file. It is set by default to `false` to maintain the old behavior as default.