### PR TITLE
Able to check Tokio Runtime is alive inside is_closed.

### DIFF
--- a/commons/zenoh-runtime/src/lib.rs
+++ b/commons/zenoh-runtime/src/lib.rs
@@ -129,12 +129,23 @@ impl ZRuntime {
     where
         F: Future<Output = R>,
     {
-        if let Ok(handle) = Handle::try_current() {
-            if handle.runtime_flavor() == RuntimeFlavor::CurrentThread {
-                panic!("Zenoh runtime doesn't support Tokio's current thread scheduler. Please use multi thread scheduler instead, e.g. a multi thread scheduler with one worker thread: `#[tokio::main(flavor = \"multi_thread\", worker_threads = 1)]`");
+        match Handle::try_current() {
+            Ok(handle) => {
+                if handle.runtime_flavor() == RuntimeFlavor::CurrentThread {
+                    panic!("Zenoh runtime doesn't support Tokio's current thread scheduler. Please use multi thread scheduler instead, e.g. a multi thread scheduler with one worker thread: `#[tokio::main(flavor = \"multi_thread\", worker_threads = 1)]`");
+                }
+            }
+            Err(e) => {
+                if e.is_thread_local_destroyed() {
+                    panic!("TLS inside Tokio is missing. You might call Zenoh API inside atexit, which should be avoided.");
+                }
             }
         }
         tokio::task::block_in_place(move || self.block_on(f))
+    }
+
+    pub fn is_alive() -> bool {
+        Handle::try_current().is_ok()
     }
 }
 

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -632,7 +632,11 @@ impl Session {
     /// assert!(session.is_closed());
     /// # }
     pub fn is_closed(&self) -> bool {
-        zread!(self.0.state).primitives.is_none()
+        if zenoh_runtime::ZRuntime::is_alive() {
+            zread!(self.0.state).primitives.is_none()
+        } else {
+            true
+        }
     }
 
     pub fn undeclare<'a, T>(&'a self, decl: T) -> impl Resolve<ZResult<()>> + 'a


### PR DESCRIPTION
The draft PR to deal with the issue
https://github.com/ZettaScaleLabs/rmw_zenoh/issues/26

Here is what we do:
1. Provide a clear panic log to tell developers not to use Zenoh API inside atexit.
2. Check Tokio Runtime availability inside `is_closed` API. This can help developers avoid calling Zenoh API in the wrong place.
