### PR TITLE
add empty gravestone values for Sample, Reply, ReplyError, Query and Hello

### DIFF
--- a/commons/zenoh-config/src/wrappers.rs
+++ b/commons/zenoh-config/src/wrappers.rs
@@ -119,6 +119,17 @@ impl Hello {
     pub fn whatami(&self) -> WhatAmI {
         self.0.whatami
     }
+
+    /// Constructs an empty Hello message.
+    #[zenoh_macros::internal]
+    pub fn empty() -> Self {
+        Hello(HelloProto {
+            version: zenoh_protocol::VERSION,
+            whatami: WhatAmI::default(),
+            zid: ZenohIdProto::default(),
+            locators: Vec::default(),
+        })
+    }
 }
 
 impl From<HelloProto> for Hello {

--- a/zenoh/src/api/query.rs
+++ b/zenoh/src/api/query.rs
@@ -84,6 +84,15 @@ impl ReplyError {
     pub fn encoding(&self) -> &Encoding {
         &self.encoding
     }
+
+    /// Constructs an uninitialized empty ReplyError.
+    #[zenoh_macros::internal]
+    pub fn empty() -> Self {
+        ReplyError {
+            payload: ZBytes::new(),
+            encoding: Encoding::default(),
+        }
+    }
 }
 
 impl Display for ReplyError {

--- a/zenoh/src/api/query.rs
+++ b/zenoh/src/api/query.rs
@@ -140,6 +140,15 @@ impl Reply {
     pub fn replier_id(&self) -> Option<ZenohId> {
         self.replier_id.map(Into::into)
     }
+
+    /// Constructs an uninitialized empty Reply.
+    #[zenoh_macros::internal]
+    pub unsafe fn empty() -> Self {
+        Reply {
+            result: Ok(Sample::empty()),
+            replier_id: None,
+        }
+    }
 }
 
 impl From<Reply> for Result<Sample, ReplyError> {

--- a/zenoh/src/api/queryable.rs
+++ b/zenoh/src/api/queryable.rs
@@ -200,6 +200,17 @@ impl Query {
     fn _accepts_any_replies(&self) -> ZResult<bool> {
         Ok(self.parameters().reply_key_expr_any())
     }
+
+    /// Constructs an empty Query without payload, nor attachment referencing the same inner query.
+    #[zenoh_macros::internal]
+    pub unsafe fn empty(&self) -> Self {
+        Query {
+            inner: self.inner.clone(),
+            eid: 0,
+            value: None,
+            attachment: None,
+        }
+    }
 }
 
 impl fmt::Debug for Query {

--- a/zenoh/src/api/sample.rs
+++ b/zenoh/src/api/sample.rs
@@ -409,6 +409,22 @@ impl Sample {
     pub fn attachment_mut(&mut self) -> Option<&mut ZBytes> {
         self.attachment.as_mut()
     }
+
+    /// Constructs an uninitialized empty Sample.
+    #[zenoh_macros::internal]
+    pub unsafe fn empty() -> Self {
+        Sample {
+            key_expr: KeyExpr::from_str_unchecked(""),
+            payload: ZBytes::new(),
+            kind: SampleKind::Put,
+            encoding: Encoding::default(),
+            timestamp: None,
+            qos: QoS::default(),
+            reliability: Reliability::default(),
+            source_info: SourceInfo::empty(),
+            attachment: None,
+        }
+    }
 }
 
 impl From<Sample> for Value {


### PR DESCRIPTION
add empty gravestone values for Sample, Reply, ReplyError, Query and Hello - required to support move operations in C++