### PR TITLE
feat(ACL): Add liveliness token filters

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -225,6 +225,7 @@
   //       "messages": [
   //         "put", "delete", "declare_subscriber",
   //         "query", "reply", "declare_queryable",
+  //         "liveliness_token", "query_liveliness", "declare_liveliness_subscriber",
   //       ],
   //       "flows":["egress","ingress"],
   //       "permission": "allow",

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -225,7 +225,7 @@
   //       "messages": [
   //         "put", "delete", "declare_subscriber",
   //         "query", "reply", "declare_queryable",
-  //         "liveliness_token", "query_liveliness", "declare_liveliness_subscriber",
+  //         "liveliness_token", "liveliness_query", "declare_liveliness_subscriber",
   //       ],
   //       "flows":["egress","ingress"],
   //       "permission": "allow",

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -170,6 +170,9 @@ pub enum AclMessage {
     Query,
     DeclareQueryable,
     Reply,
+    LivelinessToken,
+    DeclareLivelinessSubscriber,
+    QueryLiveliness,
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, Hash, PartialEq)]

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -172,7 +172,7 @@ pub enum AclMessage {
     Reply,
     LivelinessToken,
     DeclareLivelinessSubscriber,
-    QueryLiveliness,
+    LivelinessQuery,
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, Hash, PartialEq)]

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -1458,7 +1458,9 @@ impl SessionInner {
                     primitives.send_interest(Interest {
                         id: sub_state.id,
                         mode: InterestMode::Final,
-                        options: InterestOptions::empty(),
+                        // Note: InterestMode::Final options are undefined in the current protocol specification,
+                        //       they are initialized here for internal use by local egress interceptors.
+                        options: InterestOptions::TOKENS,
                         wire_expr: None,
                         ext_qos: declare::ext::QoSType::DEFAULT,
                         ext_tstamp: None,

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -1252,7 +1252,9 @@ impl SessionInner {
                     primitives.send_interest(Interest {
                         id: pub_state.remote_id,
                         mode: InterestMode::Final,
-                        options: InterestOptions::empty(),
+                        // Note: InterestMode::Final options are undefined in the current protocol specification,
+                        //       they are initialized here for internal use by local egress interceptors.
+                        options: InterestOptions::SUBSCRIBERS,
                         wire_expr: None,
                         ext_qos: declare::ext::QoSType::DEFAULT,
                         ext_tstamp: None,

--- a/zenoh/src/net/routing/dispatcher/token.rs
+++ b/zenoh/src/net/routing/dispatcher/token.rs
@@ -156,6 +156,7 @@ pub(crate) fn undeclare_token(
     {
         tracing::debug!("{} Undeclare token {} ({})", face, id, res.expr());
     } else {
-        tracing::error!("{} Undeclare unknown token {}", face, id);
+        // NOTE: This is expected behavior if liveliness tokens are denied with ingress ACL interceptor.
+        tracing::debug!("{} Undeclare unknown token {}", face, id);
     }
 }

--- a/zenoh/src/net/routing/hat/client/interests.rs
+++ b/zenoh/src/net/routing/hat/client/interests.rs
@@ -212,7 +212,9 @@ impl HatInterestTrait for HatCode {
                                 Interest {
                                     id,
                                     mode: InterestMode::Final,
-                                    options: InterestOptions::empty(),
+                                    // Note: InterestMode::Final options are undefined in the current protocol specification,
+                                    //       they are initialized here for internal use by local egress interceptors.
+                                    options: interest.options,
                                     wire_expr: None,
                                     ext_qos: ext::QoSType::DECLARE,
                                     ext_tstamp: None,

--- a/zenoh/src/net/routing/hat/p2p_peer/interests.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/interests.rs
@@ -238,7 +238,9 @@ impl HatInterestTrait for HatCode {
                                 Interest {
                                     id,
                                     mode: InterestMode::Final,
-                                    options: InterestOptions::empty(),
+                                    // Note: InterestMode::Final options are undefined in the current protocol specification,
+                                    //       they are initialized here for internal use by local egress interceptors.
+                                    options: interest.options,
                                     wire_expr: None,
                                     ext_qos: ext::QoSType::DECLARE,
                                     ext_tstamp: None,

--- a/zenoh/src/net/routing/interceptor/access_control.rs
+++ b/zenoh/src/net/routing/interceptor/access_control.rs
@@ -386,7 +386,7 @@ impl InterceptorTrait for IngressAclEnforcer {
                 }
             }
             NetworkBody::Interest(Interest {
-                mode: InterestMode::Current | InterestMode::CurrentFuture,
+                mode: InterestMode::Future | InterestMode::CurrentFuture,
                 options,
                 ..
             }) if options.tokens() => {

--- a/zenoh/src/net/routing/interceptor/access_control.rs
+++ b/zenoh/src/net/routing/interceptor/access_control.rs
@@ -372,6 +372,18 @@ impl InterceptorTrait for IngressAclEnforcer {
                 }
             }
             NetworkBody::Interest(Interest { mode, options, .. })
+                if options.tokens() && mode.eq(&InterestMode::Current) =>
+            {
+                if self.action(
+                    AclMessage::QueryLiveliness,
+                    "Query Liveliness (ingress)",
+                    key_expr?,
+                ) == Permission::Deny
+                {
+                    return None;
+                }
+            }
+            NetworkBody::Interest(Interest { mode, options, .. })
                 if options.tokens()
                     && (mode.eq(&InterestMode::Future)
                         || mode.eq(&InterestMode::CurrentFuture)) =>
@@ -554,6 +566,18 @@ impl InterceptorTrait for EgressAclEnforcer {
                 if self.action(
                     AclMessage::LivelinessToken,
                     "Undeclare Liveliness Token (egress)",
+                    key_expr?,
+                ) == Permission::Deny
+                {
+                    return None;
+                }
+            }
+            NetworkBody::Interest(Interest { mode, options, .. })
+                if options.tokens() && mode.eq(&InterestMode::Current) =>
+            {
+                if self.action(
+                    AclMessage::QueryLiveliness,
+                    "Query Liveliness (egress)",
                     key_expr?,
                 ) == Permission::Deny
                 {

--- a/zenoh/src/net/routing/interceptor/access_control.rs
+++ b/zenoh/src/net/routing/interceptor/access_control.rs
@@ -375,8 +375,8 @@ impl InterceptorTrait for IngressAclEnforcer {
                 if options.tokens() && mode.eq(&InterestMode::Current) =>
             {
                 if self.action(
-                    AclMessage::QueryLiveliness,
-                    "Query Liveliness (ingress)",
+                    AclMessage::LivelinessQuery,
+                    "Liveliness Query (ingress)",
                     key_expr?,
                 ) == Permission::Deny
                 {
@@ -576,8 +576,8 @@ impl InterceptorTrait for EgressAclEnforcer {
                 if options.tokens() && mode.eq(&InterestMode::Current) =>
             {
                 if self.action(
-                    AclMessage::QueryLiveliness,
-                    "Query Liveliness (egress)",
+                    AclMessage::LivelinessQuery,
+                    "Liveliness Query (egress)",
                     key_expr?,
                 ) == Permission::Deny
                 {

--- a/zenoh/src/net/routing/interceptor/access_control.rs
+++ b/zenoh/src/net/routing/interceptor/access_control.rs
@@ -371,9 +371,11 @@ impl InterceptorTrait for IngressAclEnforcer {
                     }
                 }
             }
-            NetworkBody::Interest(Interest { mode, options, .. })
-                if options.tokens() && mode.eq(&InterestMode::Current) =>
-            {
+            NetworkBody::Interest(Interest {
+                mode: InterestMode::Current,
+                options,
+                ..
+            }) if options.tokens() => {
                 if self.action(
                     AclMessage::LivelinessQuery,
                     "Liveliness Query (ingress)",
@@ -383,11 +385,11 @@ impl InterceptorTrait for IngressAclEnforcer {
                     return None;
                 }
             }
-            NetworkBody::Interest(Interest { mode, options, .. })
-                if options.tokens()
-                    && (mode.eq(&InterestMode::Future)
-                        || mode.eq(&InterestMode::CurrentFuture)) =>
-            {
+            NetworkBody::Interest(Interest {
+                mode: InterestMode::Current | InterestMode::CurrentFuture,
+                options,
+                ..
+            }) if options.tokens() => {
                 if self.action(
                     AclMessage::DeclareLivelinessSubscriber,
                     "Declare Liveliness Subscriber (ingress)",
@@ -397,7 +399,10 @@ impl InterceptorTrait for IngressAclEnforcer {
                     return None;
                 }
             }
-            NetworkBody::Interest(Interest { mode, .. }) if mode.eq(&InterestMode::Final) => {
+            NetworkBody::Interest(Interest {
+                mode: InterestMode::Final,
+                ..
+            }) => {
                 // InterestMode::Final filtering diverges between ingress and egress:
                 // InterestMode::Final ingress is always allowed, it will be rejected by routing logic if its associated Interest was denied
             }
@@ -557,9 +562,11 @@ impl InterceptorTrait for EgressAclEnforcer {
                     return None;
                 }
             }
-            NetworkBody::Interest(Interest { mode, options, .. })
-                if options.tokens() && mode.eq(&InterestMode::Current) =>
-            {
+            NetworkBody::Interest(Interest {
+                mode: InterestMode::Current,
+                options,
+                ..
+            }) if options.tokens() => {
                 if self.action(
                     AclMessage::LivelinessQuery,
                     "Liveliness Query (egress)",
@@ -569,11 +576,11 @@ impl InterceptorTrait for EgressAclEnforcer {
                     return None;
                 }
             }
-            NetworkBody::Interest(Interest { mode, options, .. })
-                if options.tokens()
-                    && (mode.eq(&InterestMode::Future)
-                        || mode.eq(&InterestMode::CurrentFuture)) =>
-            {
+            NetworkBody::Interest(Interest {
+                mode: InterestMode::Future | InterestMode::CurrentFuture,
+                options,
+                ..
+            }) if options.tokens() => {
                 if self.action(
                     AclMessage::DeclareLivelinessSubscriber,
                     "Declare Liveliness Subscriber (egress)",
@@ -583,10 +590,13 @@ impl InterceptorTrait for EgressAclEnforcer {
                     return None;
                 }
             }
-            NetworkBody::Interest(Interest { mode, options, .. })
-                // options are set for InterestMode::Final for internal use only by egress interceptors
-                if mode.eq(&InterestMode::Final) && options.tokens() =>
-            {
+            NetworkBody::Interest(Interest {
+                mode: InterestMode::Final,
+                options,
+                ..
+            }) if options.tokens() => {
+                // Note: options are set for InterestMode::Final for internal use only by egress interceptors.
+
                 // InterestMode::Final filtering diverges between ingress and egress:
                 // in egress the keyexpr has to be provided in the RoutingContext
                 if self.action(

--- a/zenoh/src/net/routing/interceptor/authorization.rs
+++ b/zenoh/src/net/routing/interceptor/authorization.rs
@@ -190,7 +190,7 @@ struct ActionPolicy {
     reply: PermissionPolicy,
     liveliness_token: PermissionPolicy,
     declare_liveliness_sub: PermissionPolicy,
-    query_liveliness: PermissionPolicy,
+    liveliness_query: PermissionPolicy,
 }
 
 impl ActionPolicy {
@@ -204,7 +204,7 @@ impl ActionPolicy {
             AclMessage::DeclareQueryable => &self.declare_queryable,
             AclMessage::LivelinessToken => &self.liveliness_token,
             AclMessage::DeclareLivelinessSubscriber => &self.declare_liveliness_sub,
-            AclMessage::QueryLiveliness => &self.query_liveliness,
+            AclMessage::LivelinessQuery => &self.liveliness_query,
         }
     }
     fn action_mut(&mut self, action: AclMessage) -> &mut PermissionPolicy {
@@ -217,7 +217,7 @@ impl ActionPolicy {
             AclMessage::DeclareQueryable => &mut self.declare_queryable,
             AclMessage::LivelinessToken => &mut self.liveliness_token,
             AclMessage::DeclareLivelinessSubscriber => &mut self.declare_liveliness_sub,
-            AclMessage::QueryLiveliness => &mut self.query_liveliness,
+            AclMessage::LivelinessQuery => &mut self.liveliness_query,
         }
     }
 }

--- a/zenoh/src/net/routing/interceptor/authorization.rs
+++ b/zenoh/src/net/routing/interceptor/authorization.rs
@@ -188,6 +188,9 @@ struct ActionPolicy {
     declare_subscriber: PermissionPolicy,
     declare_queryable: PermissionPolicy,
     reply: PermissionPolicy,
+    liveliness_token: PermissionPolicy,
+    declare_liveliness_sub: PermissionPolicy,
+    query_liveliness: PermissionPolicy,
 }
 
 impl ActionPolicy {
@@ -199,6 +202,9 @@ impl ActionPolicy {
             AclMessage::Delete => &self.delete,
             AclMessage::DeclareSubscriber => &self.declare_subscriber,
             AclMessage::DeclareQueryable => &self.declare_queryable,
+            AclMessage::LivelinessToken => &self.liveliness_token,
+            AclMessage::DeclareLivelinessSubscriber => &self.declare_liveliness_sub,
+            AclMessage::QueryLiveliness => &self.query_liveliness,
         }
     }
     fn action_mut(&mut self, action: AclMessage) -> &mut PermissionPolicy {
@@ -209,6 +215,9 @@ impl ActionPolicy {
             AclMessage::Delete => &mut self.delete,
             AclMessage::DeclareSubscriber => &mut self.declare_subscriber,
             AclMessage::DeclareQueryable => &mut self.declare_queryable,
+            AclMessage::LivelinessToken => &mut self.liveliness_token,
+            AclMessage::DeclareLivelinessSubscriber => &mut self.declare_liveliness_sub,
+            AclMessage::QueryLiveliness => &mut self.query_liveliness,
         }
     }
 }


### PR DESCRIPTION
Adds liveliness filters to ACL.
The new message types are `["liveliness_token", "declare_liveliness_subscriber", "liveliness_query"]`. Delcaration filters also apply on their respective undeclarations.

Closes #1562