### PR TITLE
Fix argument parsing and warning logs for TLS and QUIC links

### DIFF
--- a/io/zenoh-links/zenoh-link-quic/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/lib.rs
@@ -109,6 +109,7 @@ pub mod config {
     pub const TLS_CONNECT_CERTIFICATE_BASE64: &str = "connect_certificate_base64";
 
     pub const TLS_ENABLE_MTLS: &str = "enable_mtls";
+    pub const TLS_ENABLE_MTLS_DEFAULT: bool = false;
 
     pub const TLS_VERIFY_NAME_ON_CONNECT: &str = "verify_name_on_connect";
     pub const TLS_VERIFY_NAME_ON_CONNECT_DEFAULT: bool = true;

--- a/io/zenoh-links/zenoh-link-quic/src/utils.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/utils.rs
@@ -164,7 +164,7 @@ impl TlsServerConfig {
             Some(s) => s
                 .parse()
                 .map_err(|_| zerror!("Unknown enable mTLS argument: {}", s))?,
-            None => false,
+            None => TLS_ENABLE_MTLS_DEFAULT,
         };
         let tls_close_link_on_expiration: bool = match config.get(TLS_CLOSE_LINK_ON_EXPIRATION) {
             Some(s) => s
@@ -268,21 +268,18 @@ impl TlsClientConfig {
             Some(s) => s
                 .parse()
                 .map_err(|_| zerror!("Unknown enable mTLS argument: {}", s))?,
-            None => false,
+            None => TLS_ENABLE_MTLS_DEFAULT,
         };
 
         let tls_server_name_verification: bool = match config.get(TLS_VERIFY_NAME_ON_CONNECT) {
-            Some(s) => {
-                let s: bool = s
-                    .parse()
-                    .map_err(|_| zerror!("Unknown server name verification argument: {}", s))?;
-                if s {
-                    tracing::warn!("Skipping name verification of servers");
-                }
-                s
-            }
-            None => false,
+            Some(s) => s
+                .parse()
+                .map_err(|_| zerror!("Unknown server name verification argument: {}", s))?,
+            None => TLS_VERIFY_NAME_ON_CONNECT_DEFAULT,
         };
+        if !tls_server_name_verification {
+            tracing::warn!("Skipping name verification of QUIC server");
+        }
 
         let tls_close_link_on_expiration: bool = match config.get(TLS_CLOSE_LINK_ON_EXPIRATION) {
             Some(s) => s

--- a/io/zenoh-links/zenoh-link-tls/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/lib.rs
@@ -105,6 +105,7 @@ pub mod config {
     pub const TLS_CONNECT_CERTIFICATE_BASE64: &str = "connect_certificate_base64";
 
     pub const TLS_ENABLE_MTLS: &str = "enable_mtls";
+    pub const TLS_ENABLE_MTLS_DEFAULT: bool = false;
 
     pub const TLS_VERIFY_NAME_ON_CONNECT: &str = "verify_name_on_connect";
     pub const TLS_VERIFY_NAME_ON_CONNECT_DEFAULT: bool = true;

--- a/io/zenoh-links/zenoh-link-tls/src/utils.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/utils.rs
@@ -168,7 +168,7 @@ impl TlsServerConfig {
             Some(s) => s
                 .parse()
                 .map_err(|_| zerror!("Unknown enable mTLS argument: {}", s))?,
-            None => false,
+            None => TLS_ENABLE_MTLS_DEFAULT,
         };
         let tls_close_link_on_expiration: bool = match config.get(TLS_CLOSE_LINK_ON_EXPIRATION) {
             Some(s) => s
@@ -282,21 +282,18 @@ impl TlsClientConfig {
             Some(s) => s
                 .parse()
                 .map_err(|_| zerror!("Unknown enable mTLS auth argument: {}", s))?,
-            None => false,
+            None => TLS_ENABLE_MTLS_DEFAULT,
         };
 
         let tls_server_name_verification: bool = match config.get(TLS_VERIFY_NAME_ON_CONNECT) {
-            Some(s) => {
-                let s: bool = s
-                    .parse()
-                    .map_err(|_| zerror!("Unknown server name verification argument: {}", s))?;
-                if s {
-                    tracing::warn!("Skipping name verification of servers");
-                }
-                s
-            }
-            None => false,
+            Some(s) => s
+                .parse()
+                .map_err(|_| zerror!("Unknown server name verification argument: {}", s))?,
+            None => TLS_VERIFY_NAME_ON_CONNECT_DEFAULT,
         };
+        if !tls_server_name_verification {
+            tracing::warn!("Skipping name verification of TLS server");
+        }
 
         let tls_close_link_on_expiration: bool = match config.get(TLS_CLOSE_LINK_ON_EXPIRATION) {
             Some(s) => s


### PR DESCRIPTION
Fixes the following issues:
- Warning should be logged when servername verification is disabled by client, but it was logged when enabled.
- `TLS_VERIFY_NAME_ON_CONNECT` was set to `false` when not provided, but the default value should be `TLS_VERIFY_NAME_ON_CONNECT_DEFAULT` which is set to `true`.
- Default value for `TLS_ENABLE_MTLS` was hardcoded instead of using a constant.