### PR TITLE
feat: add local/remote sub cache to publisher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,7 @@ rustls-pemfile = "2.1.3"
 rustls-webpki = "0.102.8"
 rustls-pki-types = "1.8.0"
 schemars = { version = "0.8.21", features = ["either"] }
+scopeguard = "1.2.0"
 secrecy = { version = "0.8.0", features = ["serde", "alloc"] }
 serde = { version = "1.0.210", default-features = false, features = [
   "derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,6 @@ rustls-pemfile = "2.1.3"
 rustls-webpki = "0.102.8"
 rustls-pki-types = "1.8.0"
 schemars = { version = "0.8.21", features = ["either"] }
-scopeguard = "1.2.0"
 secrecy = { version = "0.8.0", features = ["serde", "alloc"] }
 serde = { version = "1.0.210", default-features = false, features = [
   "derive",

--- a/examples/examples/z_local_pub_sub_thr.rs
+++ b/examples/examples/z_local_pub_sub_thr.rs
@@ -1,0 +1,155 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+use std::{convert::TryInto, time::Instant};
+
+use clap::Parser;
+use zenoh::{
+    bytes::ZBytes,
+    qos::{CongestionControl, Priority},
+    Wait,
+};
+use zenoh_examples::CommonArgs;
+
+struct Stats {
+    round_count: usize,
+    round_size: usize,
+    finished_rounds: usize,
+    round_start: Instant,
+    global_start: Option<Instant>,
+}
+impl Stats {
+    fn new(round_size: usize) -> Self {
+        Stats {
+            round_count: 0,
+            round_size,
+            finished_rounds: 0,
+            round_start: Instant::now(),
+            global_start: None,
+        }
+    }
+    fn increment(&mut self) {
+        if self.round_count == 0 {
+            self.round_start = Instant::now();
+            if self.global_start.is_none() {
+                self.global_start = Some(self.round_start)
+            }
+            self.round_count += 1;
+        } else if self.round_count < self.round_size {
+            self.round_count += 1;
+        } else {
+            self.print_round();
+            self.finished_rounds += 1;
+            self.round_count = 0;
+        }
+    }
+    fn print_round(&self) {
+        let elapsed = self.round_start.elapsed().as_secs_f64();
+        let throughput = (self.round_size as f64) / elapsed;
+        println!("{throughput} msg/s");
+    }
+}
+impl Drop for Stats {
+    fn drop(&mut self) {
+        let Some(global_start) = self.global_start else {
+            return;
+        };
+        let elapsed = global_start.elapsed().as_secs_f64();
+        let total = self.round_size * self.finished_rounds + self.round_count;
+        let throughput = total as f64 / elapsed;
+        println!("Received {total} messages over {elapsed:.2}s: {throughput}msg/s");
+    }
+}
+
+fn main() {
+    // initiate logging
+    zenoh::init_log_from_env_or("error");
+    let args = Args::parse();
+
+    let session = zenoh::open(args.common).wait().unwrap();
+
+    let key_expr = "test/thr";
+
+    let mut stats = Stats::new(args.number);
+    session
+        .declare_subscriber(key_expr)
+        .callback_mut(move |_sample| {
+            stats.increment();
+            if stats.finished_rounds >= args.samples {
+                std::process::exit(0)
+            }
+        })
+        .background()
+        .wait()
+        .unwrap();
+
+    let mut prio = Priority::DEFAULT;
+    if let Some(p) = args.priority {
+        prio = p.try_into().unwrap();
+    }
+
+    let publisher = session
+        .declare_publisher(key_expr)
+        .congestion_control(CongestionControl::Block)
+        .priority(prio)
+        .express(args.express)
+        .wait()
+        .unwrap();
+
+    println!("Press CTRL-C to quit...");
+    let payload_size = args.payload_size;
+    let data: ZBytes = (0..payload_size)
+        .map(|i| (i % 10) as u8)
+        .collect::<Vec<u8>>()
+        .into();
+    let mut count: usize = 0;
+    let mut start = std::time::Instant::now();
+    loop {
+        publisher.put(data.clone()).wait().unwrap();
+
+        if args.print {
+            if count < args.number {
+                count += 1;
+            } else {
+                let thpt = count as f64 / start.elapsed().as_secs_f64();
+                println!("{thpt} msg/s");
+                count = 0;
+                start = std::time::Instant::now();
+            }
+        }
+    }
+}
+
+#[derive(Parser, Clone, PartialEq, Eq, Hash, Debug)]
+struct Args {
+    #[arg(short, long, default_value = "10")]
+    /// Number of throughput measurements.
+    samples: usize,
+    /// express for sending data
+    #[arg(long, default_value = "false")]
+    express: bool,
+    /// Priority for sending data
+    #[arg(short, long)]
+    priority: Option<u8>,
+    /// Print the statistics
+    #[arg(short = 't', long)]
+    print: bool,
+    /// Number of messages in each throughput measurements
+    #[arg(short, long, default_value = "10000000")]
+    number: usize,
+    /// Sets the size of the payload to publish
+    payload_size: usize,
+    #[command(flatten)]
+    common: CommonArgs,
+}

--- a/zenoh/src/api/builders/publisher.rs
+++ b/zenoh/src/api/builders/publisher.rs
@@ -473,8 +473,7 @@ impl Wait for PublisherBuilder<'_, '_> {
             .declare_publisher_inner(key_expr.clone(), self.destination)?;
         Ok(Publisher {
             session: self.session.downgrade(),
-            // TODO use constants here
-            cache: AtomicU64::new(0b11),
+            cache: AtomicU64::new(0),
             id,
             key_expr,
             encoding: self.encoding,

--- a/zenoh/src/api/builders/publisher.rs
+++ b/zenoh/src/api/builders/publisher.rs
@@ -473,7 +473,8 @@ impl Wait for PublisherBuilder<'_, '_> {
             .declare_publisher_inner(key_expr.clone(), self.destination)?;
         Ok(Publisher {
             session: self.session.downgrade(),
-            cache: AtomicU64::new(0),
+            // TODO use constants here
+            cache: AtomicU64::new(0b11),
             id,
             key_expr,
             encoding: self.encoding,

--- a/zenoh/src/api/publisher.rs
+++ b/zenoh/src/api/publisher.rs
@@ -77,6 +77,7 @@ impl fmt::Debug for PublisherState {
 pub(crate) struct PublisherCache(AtomicU64);
 
 impl PublisherCache {
+    #[inline(always)]
     pub(crate) fn with_cache<R>(&self, f: impl FnOnce(&mut PublisherCacheValue) -> R) -> R {
         let cached = self.0.load(Ordering::Relaxed);
         let mut to_cache = PublisherCacheValue(cached);
@@ -108,24 +109,29 @@ impl PublisherCacheValue {
     const NO_REMOTE: u64 = 0b01;
     const NO_LOCAL: u64 = 0b10;
 
+    #[inline(always)]
     pub(crate) fn match_subscription_version(&mut self, version: u64) {
         if self.0 >> Self::VERSION_SHIFT != version {
             self.0 = version << Self::VERSION_SHIFT;
         }
     }
 
+    #[inline(always)]
     pub(crate) fn has_remote_sub(&self) -> bool {
         self.0 & Self::NO_REMOTE == 0
     }
 
+    #[inline(always)]
     pub(crate) fn set_no_remote_sub(&mut self) {
         self.0 |= Self::NO_REMOTE;
     }
 
+    #[inline(always)]
     pub(crate) fn has_local_sub(&self) -> bool {
         self.0 & Self::NO_LOCAL == 0
     }
 
+    #[inline(always)]
     pub(crate) fn set_no_local_sub(&mut self) {
         self.0 |= Self::NO_LOCAL;
     }

--- a/zenoh/src/api/publisher.rs
+++ b/zenoh/src/api/publisher.rs
@@ -17,6 +17,7 @@ use std::{
     fmt,
     future::{IntoFuture, Ready},
     pin::Pin,
+    sync::atomic::AtomicU64,
     task::{Context, Poll},
 };
 
@@ -101,6 +102,7 @@ impl fmt::Debug for PublisherState {
 #[derive(Debug)]
 pub struct Publisher<'a> {
     pub(crate) session: WeakSession,
+    pub(crate) cache: AtomicU64,
     pub(crate) id: Id,
     pub(crate) key_expr: KeyExpr<'a>,
     pub(crate) encoding: Encoding,
@@ -391,6 +393,7 @@ impl Sink<Sample> for Publisher<'_> {
             ..
         } = item.into();
         self.session.resolve_put(
+            Some(&self.cache),
             &self.key_expr,
             payload,
             kind,

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -2176,7 +2176,7 @@ impl SessionInner {
                     ),
                     ext_tstamp: None,
                     ext_nodeid: push::ext::NodeIdType::DEFAULT,
-                    payload: match put.clone() {
+                    payload: match put {
                         Some(put) => PushBody::Put(Put {
                             timestamp,
                             encoding: put.encoding.into(),

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -2153,8 +2153,8 @@ impl SessionInner {
         #[cfg(feature = "unstable")] source_info: SourceInfo,
         attachment: Option<ZBytes>,
     ) -> ZResult<()> {
-        const REMOTE_TAG: u64 = 0b01;
-        const LOCAL_TAG: u64 = 0b10;
+        const NO_REMOTE_FLAG: u64 = 0b01;
+        const NO_LOCAL_FLAG: u64 = 0b10;
         const VERSION_SHIFT: u64 = 2;
         trace!("write({:?}, [...])", key_expr);
         let state = zread!(self.state);
@@ -2163,21 +2163,26 @@ impl SessionInner {
             .as_ref()
             .cloned()
             .ok_or(SessionClosedError)?;
-        let mut cached = REMOTE_TAG | LOCAL_TAG;
-        let mut to_cache = REMOTE_TAG | LOCAL_TAG;
+        let mut cached = 0;
+        let mut update_cache = None;
         if let Some(cache) = cache {
-            cached = cache.load(Ordering::Relaxed);
-            let version = cached >> VERSION_SHIFT;
+            let c = cache.load(Ordering::Relaxed);
+            let version = c >> VERSION_SHIFT;
             if version == state.subscription_version {
-                to_cache = cached;
+                cached = c;
             } else {
-                to_cache = (state.subscription_version << VERSION_SHIFT) | REMOTE_TAG | LOCAL_TAG;
+                cached = (state.subscription_version << VERSION_SHIFT);
             }
+            update_cache = Some(scopeguard::guard((), |_| {
+                if cached != c {
+                    let _ = cache.compare_exchange(c, cached, Ordering::Relaxed, Ordering::Relaxed);
+                }
+            }));
         }
         drop(state);
         let timestamp = timestamp.or_else(|| self.runtime.new_timestamp());
         let wire_expr = key_expr.to_wire(self);
-        if (to_cache & REMOTE_TAG) != 0 && destination != Locality::SessionLocal {
+        if (cached & NO_REMOTE_FLAG) == 0 && destination != Locality::SessionLocal {
             let remote = primitives.route_data(
                 Push {
                     wire_expr: wire_expr.to_owned(),
@@ -2219,10 +2224,10 @@ impl SessionInner {
                 Reliability::DEFAULT,
             );
             if !remote {
-                to_cache &= !REMOTE_TAG;
+                cached |= NO_REMOTE_FLAG
             }
         }
-        if (to_cache & LOCAL_TAG) != 0 && destination != Locality::Remote {
+        if (cached & NO_LOCAL_FLAG) == 0 && destination != Locality::Remote {
             let data_info = DataInfo {
                 kind,
                 encoding: Some(encoding),
@@ -2253,11 +2258,8 @@ impl SessionInner {
                 attachment,
             );
             if !local {
-                to_cache &= !LOCAL_TAG;
+                cached |= NO_LOCAL_FLAG;
             }
-        }
-        if let Some(cache) = cache.filter(|_| to_cache != cached) {
-            let _ = cache.compare_exchange(cached, to_cache, Ordering::Relaxed, Ordering::Relaxed);
         }
         Ok(())
     }
@@ -2565,10 +2567,10 @@ impl Primitives for WeakSession {
             }
             zenoh_protocol::network::DeclareBody::DeclareSubscriber(m) => {
                 trace!("recv DeclareSubscriber {} {:?}", m.id, m.wire_expr);
+                let mut state = zwrite!(self.state);
+                state.subscription_version += 1;
                 #[cfg(feature = "unstable")]
                 {
-                    let mut state = zwrite!(self.state);
-                    state.subscription_version += 1;
                     if state.primitives.is_none() {
                         return; // Session closing or closed
                     }

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -2153,8 +2153,8 @@ impl SessionInner {
         #[cfg(feature = "unstable")] source_info: SourceInfo,
         attachment: Option<ZBytes>,
     ) -> ZResult<()> {
-        const REMOTE_TAG: u64 = 0b01;
-        const LOCAL_TAG: u64 = 0b10;
+        const NO_REMOTE_FLAG: u64 = 0b01;
+        const NO_LOCAL_FLAG: u64 = 0b10;
         const VERSION_SHIFT: u64 = 2;
         trace!("write({:?}, [...])", key_expr);
         let state = zread!(self.state);
@@ -2163,21 +2163,26 @@ impl SessionInner {
             .as_ref()
             .cloned()
             .ok_or(SessionClosedError)?;
-        let mut cached = REMOTE_TAG | LOCAL_TAG;
-        let mut to_cache = REMOTE_TAG | LOCAL_TAG;
-        if let Some(cache) = cache {
-            cached = cache.load(Ordering::Relaxed);
-            let version = cached >> VERSION_SHIFT;
-            if version == state.subscription_version {
-                to_cache = cached;
-            } else {
-                to_cache = (state.subscription_version << VERSION_SHIFT) | REMOTE_TAG | LOCAL_TAG;
-            }
-        }
+        let version = state.subscription_version;
         drop(state);
+        let mut cached = 0;
+        let mut update_cache = None;
+        if let Some(cache) = cache {
+            let c = cache.load(Ordering::Relaxed);
+            if (c >> VERSION_SHIFT) == version {
+                cached = c;
+            } else {
+                cached = version << VERSION_SHIFT;
+            }
+            update_cache = Some(move |cached| {
+                if cached != c {
+                    let _ = cache.compare_exchange(c, cached, Ordering::Relaxed, Ordering::Relaxed);
+                }
+            });
+        }
         let timestamp = timestamp.or_else(|| self.runtime.new_timestamp());
         let wire_expr = key_expr.to_wire(self);
-        if (to_cache & REMOTE_TAG) != 0 && destination != Locality::SessionLocal {
+        if (cached & NO_REMOTE_FLAG) == 0 && destination != Locality::SessionLocal {
             let remote = primitives.route_data(
                 Push {
                     wire_expr: wire_expr.to_owned(),
@@ -2219,10 +2224,10 @@ impl SessionInner {
                 Reliability::DEFAULT,
             );
             if !remote {
-                to_cache &= !REMOTE_TAG;
+                cached |= NO_REMOTE_FLAG
             }
         }
-        if (to_cache & LOCAL_TAG) != 0 && destination != Locality::Remote {
+        if (cached & NO_LOCAL_FLAG) == 0 && destination != Locality::Remote {
             let data_info = DataInfo {
                 kind,
                 encoding: Some(encoding),
@@ -2253,11 +2258,11 @@ impl SessionInner {
                 attachment,
             );
             if !local {
-                to_cache &= !LOCAL_TAG;
+                cached |= NO_LOCAL_FLAG;
             }
         }
-        if let Some(cache) = cache.filter(|_| to_cache != cached) {
-            let _ = cache.compare_exchange(cached, to_cache, Ordering::Relaxed, Ordering::Relaxed);
+        if let Some(update) = update_cache {
+            update(cached);
         }
         Ok(())
     }
@@ -2565,10 +2570,10 @@ impl Primitives for WeakSession {
             }
             zenoh_protocol::network::DeclareBody::DeclareSubscriber(m) => {
                 trace!("recv DeclareSubscriber {} {:?}", m.id, m.wire_expr);
+                let mut state = zwrite!(self.state);
+                state.subscription_version += 1;
                 #[cfg(feature = "unstable")]
                 {
-                    let mut state = zwrite!(self.state);
-                    state.subscription_version += 1;
                     if state.primitives.is_none() {
                         return; // Session closing or closed
                     }

--- a/zenoh/src/net/routing/dispatcher/face.rs
+++ b/zenoh/src/net/routing/dispatcher/face.rs
@@ -213,6 +213,11 @@ impl Face {
             state: Arc::downgrade(&self.state),
         }
     }
+
+    #[inline]
+    pub fn route_data(&self, msg: Push, reliability: Reliability) -> bool {
+        route_data(&self.tables, &self.state, msg, reliability)
+    }
 }
 
 impl Primitives for Face {

--- a/zenoh/src/net/routing/dispatcher/pubsub.rs
+++ b/zenoh/src/net/routing/dispatcher/pubsub.rs
@@ -305,7 +305,7 @@ macro_rules! treat_timestamp {
                                     "Error treating timestamp for received Data ({}). Drop it!",
                                     e
                                 );
-                                return;
+                                return false;
                             } else {
                                 data.timestamp = Some(hlc.new_timestamp());
                                 tracing::error!(
@@ -393,104 +393,104 @@ pub fn route_data(
     face: &FaceState,
     mut msg: Push,
     reliability: Reliability,
-) {
+) -> bool {
     let tables = zread!(tables_ref.tables);
-    match tables
+    let Some(prefix) = tables
         .get_mapping(face, &msg.wire_expr.scope, msg.wire_expr.mapping)
         .cloned()
-    {
-        Some(prefix) => {
-            tracing::trace!(
-                "{} Route data for res {}{}",
-                face,
-                prefix.expr(),
-                msg.wire_expr.suffix.as_ref()
-            );
-            let mut expr = RoutingExpr::new(&prefix, msg.wire_expr.suffix.as_ref());
+    else {
+        tracing::error!(
+            "{} Route data with unknown scope {}!",
+            face,
+            msg.wire_expr.scope
+        );
+        return false;
+    };
+    tracing::trace!(
+        "{} Route data for res {}{}",
+        face,
+        prefix.expr(),
+        msg.wire_expr.suffix.as_ref()
+    );
+    let mut expr = RoutingExpr::new(&prefix, msg.wire_expr.suffix.as_ref());
 
-            #[cfg(feature = "stats")]
-            let admin = expr.full_expr().starts_with("@/");
-            #[cfg(feature = "stats")]
-            if !admin {
-                inc_stats!(face, rx, user, msg.payload)
-            } else {
-                inc_stats!(face, rx, admin, msg.payload)
-            }
+    #[cfg(feature = "stats")]
+    let admin = expr.full_expr().starts_with("@/");
+    #[cfg(feature = "stats")]
+    if !admin {
+        inc_stats!(face, rx, user, msg.payload)
+    } else {
+        inc_stats!(face, rx, admin, msg.payload)
+    }
+    let mut routed = false;
+    if tables.hat_code.ingress_filter(&tables, face, &mut expr) {
+        let res = Resource::get_resource(&prefix, expr.suffix);
 
-            if tables.hat_code.ingress_filter(&tables, face, &mut expr) {
-                let res = Resource::get_resource(&prefix, expr.suffix);
+        let route = get_data_route(&tables, face, &res, &mut expr, msg.ext_nodeid.node_id);
 
-                let route = get_data_route(&tables, face, &res, &mut expr, msg.ext_nodeid.node_id);
+        if !route.is_empty() {
+            treat_timestamp!(&tables.hlc, msg.payload, tables.drop_future_timestamp);
 
-                if !route.is_empty() {
-                    treat_timestamp!(&tables.hlc, msg.payload, tables.drop_future_timestamp);
-
-                    if route.len() == 1 {
-                        let (outface, key_expr, context) = route.values().next().unwrap();
-                        if tables
-                            .hat_code
-                            .egress_filter(&tables, face, outface, &mut expr)
-                        {
-                            drop(tables);
-                            #[cfg(feature = "stats")]
-                            if !admin {
-                                inc_stats!(face, tx, user, msg.payload)
-                            } else {
-                                inc_stats!(face, tx, admin, msg.payload)
-                            }
-
-                            outface.primitives.send_push(
-                                Push {
-                                    wire_expr: key_expr.into(),
-                                    ext_qos: msg.ext_qos,
-                                    ext_tstamp: msg.ext_tstamp,
-                                    ext_nodeid: ext::NodeIdType { node_id: *context },
-                                    payload: msg.payload,
-                                },
-                                reliability,
-                            )
-                        }
+            if route.len() == 1 {
+                let (outface, key_expr, context) = route.values().next().unwrap();
+                if tables
+                    .hat_code
+                    .egress_filter(&tables, face, outface, &mut expr)
+                {
+                    drop(tables);
+                    #[cfg(feature = "stats")]
+                    if !admin {
+                        inc_stats!(face, tx, user, msg.payload)
                     } else {
-                        let route = route
-                            .values()
-                            .filter(|(outface, _key_expr, _context)| {
-                                tables
-                                    .hat_code
-                                    .egress_filter(&tables, face, outface, &mut expr)
-                            })
-                            .cloned()
-                            .collect::<Vec<Direction>>();
+                        inc_stats!(face, tx, admin, msg.payload)
+                    }
 
-                        drop(tables);
-                        for (outface, key_expr, context) in route {
-                            #[cfg(feature = "stats")]
-                            if !admin {
-                                inc_stats!(face, tx, user, msg.payload)
-                            } else {
-                                inc_stats!(face, tx, admin, msg.payload)
-                            }
+                    outface.primitives.send_push(
+                        Push {
+                            wire_expr: key_expr.into(),
+                            ext_qos: msg.ext_qos,
+                            ext_tstamp: msg.ext_tstamp,
+                            ext_nodeid: ext::NodeIdType { node_id: *context },
+                            payload: msg.payload,
+                        },
+                        reliability,
+                    );
+                    routed = true;
+                } else {
+                    let route = route
+                        .values()
+                        .filter(|(outface, _key_expr, _context)| {
+                            tables
+                                .hat_code
+                                .egress_filter(&tables, face, outface, &mut expr)
+                        })
+                        .cloned()
+                        .collect::<Vec<Direction>>();
 
-                            outface.primitives.send_push(
-                                Push {
-                                    wire_expr: key_expr,
-                                    ext_qos: msg.ext_qos,
-                                    ext_tstamp: None,
-                                    ext_nodeid: ext::NodeIdType { node_id: context },
-                                    payload: msg.payload.clone(),
-                                },
-                                reliability,
-                            )
+                    drop(tables);
+                    for (outface, key_expr, context) in route {
+                        #[cfg(feature = "stats")]
+                        if !admin {
+                            inc_stats!(face, tx, user, msg.payload)
+                        } else {
+                            inc_stats!(face, tx, admin, msg.payload)
                         }
+
+                        outface.primitives.send_push(
+                            Push {
+                                wire_expr: key_expr,
+                                ext_qos: msg.ext_qos,
+                                ext_tstamp: None,
+                                ext_nodeid: ext::NodeIdType { node_id: context },
+                                payload: msg.payload.clone(),
+                            },
+                            reliability,
+                        );
+                        routed = true;
                     }
                 }
             }
         }
-        None => {
-            tracing::error!(
-                "{} Route data with unknown scope {}!",
-                face,
-                msg.wire_expr.scope
-            );
-        }
     }
+    routed
 }

--- a/zenoh/src/net/routing/dispatcher/pubsub.rs
+++ b/zenoh/src/net/routing/dispatcher/pubsub.rs
@@ -456,38 +456,38 @@ pub fn route_data(
                         reliability,
                     );
                     routed = true;
-                } else {
-                    let route = route
-                        .values()
-                        .filter(|(outface, _key_expr, _context)| {
-                            tables
-                                .hat_code
-                                .egress_filter(&tables, face, outface, &mut expr)
-                        })
-                        .cloned()
-                        .collect::<Vec<Direction>>();
+                }
+            } else {
+                let route = route
+                    .values()
+                    .filter(|(outface, _key_expr, _context)| {
+                        tables
+                            .hat_code
+                            .egress_filter(&tables, face, outface, &mut expr)
+                    })
+                    .cloned()
+                    .collect::<Vec<Direction>>();
 
-                    drop(tables);
-                    for (outface, key_expr, context) in route {
-                        #[cfg(feature = "stats")]
-                        if !admin {
-                            inc_stats!(face, tx, user, msg.payload)
-                        } else {
-                            inc_stats!(face, tx, admin, msg.payload)
-                        }
-
-                        outface.primitives.send_push(
-                            Push {
-                                wire_expr: key_expr,
-                                ext_qos: msg.ext_qos,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType { node_id: context },
-                                payload: msg.payload.clone(),
-                            },
-                            reliability,
-                        );
-                        routed = true;
+                drop(tables);
+                for (outface, key_expr, context) in route {
+                    #[cfg(feature = "stats")]
+                    if !admin {
+                        inc_stats!(face, tx, user, msg.payload)
+                    } else {
+                        inc_stats!(face, tx, admin, msg.payload)
                     }
+
+                    outface.primitives.send_push(
+                        Push {
+                            wire_expr: key_expr,
+                            ext_qos: msg.ext_qos,
+                            ext_tstamp: None,
+                            ext_nodeid: ext::NodeIdType { node_id: context },
+                            payload: msg.payload.clone(),
+                        },
+                        reliability,
+                    );
+                    routed = true;
                 }
             }
         }


### PR DESCRIPTION
Current `Publisher::put` workflow always try to check if there are both local and remote subscribers, and these operations are costly, e.g. more than 10% of the time spent in checking local subscribers. However, the information is known, at least can easily be retrieved, and it could be used to save a lot of CPU consumption in case of remote-only/local-only workflow.

The PR does it by adding a cache to the publisher, to store if there are no remote and/or no local subscribers, in order to shortcut the `put` workflow. The cache is an atomic integer, directly stored in the publisher, with one bit flag for each information. Both remote and local routing functions has been updated to return a boolean saying if there was a matching route/subscriber, in order to update the cache. 
Also, in order to reset the cache when there are new remote/local subscribers detected, the session keep a `subscription_version` integer field, incremented each time there is a new subscriber (at the same place where matching listener are notified). The version is also stored in the remaining bits of the cache, and if both don't match, the cache is reset with the current version. To not care about version rollover, a 64bit integer is used, which let 62bit used for the version (because of two bit flags) in the cache, so more than enough. 