### PR TITLE
Fix bug declaring/undeclaring tokens with the same key

### DIFF
--- a/zenoh/src/api/liveliness.rs
+++ b/zenoh/src/api/liveliness.rs
@@ -276,7 +276,6 @@ impl IntoFuture for LivelinessTokenBuilder<'_, '_> {
 #[derive(Debug)]
 pub(crate) struct LivelinessTokenState {
     pub(crate) id: Id,
-    pub(crate) key_expr: KeyExpr<'static>,
 }
 
 /// A token whose liveliness is tied to the Zenoh [`Session`](Session).

--- a/zenoh/src/api/liveliness.rs
+++ b/zenoh/src/api/liveliness.rs
@@ -254,9 +254,9 @@ impl Wait for LivelinessTokenBuilder<'_, '_> {
         session
             .0
             .declare_liveliness_inner(&key_expr)
-            .map(|tok_state| LivelinessToken {
+            .map(|id| LivelinessToken {
                 session: self.session.downgrade(),
-                state: tok_state,
+                id,
                 undeclare_on_drop: true,
             })
     }
@@ -270,12 +270,6 @@ impl IntoFuture for LivelinessTokenBuilder<'_, '_> {
     fn into_future(self) -> Self::IntoFuture {
         std::future::ready(self.wait())
     }
-}
-
-#[zenoh_macros::unstable]
-#[derive(Debug)]
-pub(crate) struct LivelinessTokenState {
-    pub(crate) id: Id,
 }
 
 /// A token whose liveliness is tied to the Zenoh [`Session`](Session).
@@ -307,7 +301,7 @@ pub(crate) struct LivelinessTokenState {
 #[derive(Debug)]
 pub struct LivelinessToken {
     session: WeakSession,
-    state: Arc<LivelinessTokenState>,
+    id: Id,
     undeclare_on_drop: bool,
 }
 
@@ -381,7 +375,7 @@ impl LivelinessToken {
     fn undeclare_impl(&mut self) -> ZResult<()> {
         // set the flag first to avoid double panic if this function panic
         self.undeclare_on_drop = false;
-        self.session.undeclare_liveliness(self.state.id)
+        self.session.undeclare_liveliness(self.id)
     }
 }
 

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -71,7 +71,7 @@ use zenoh_task::TaskController;
 use crate::api::selector::ZenohParameters;
 #[cfg(feature = "unstable")]
 use crate::api::{
-    liveliness::{Liveliness, LivelinessTokenState},
+    liveliness::Liveliness,
     publisher::Publisher,
     publisher::{MatchingListenerState, MatchingStatus},
     query::LivelinessQueryState,
@@ -137,8 +137,6 @@ pub(crate) struct SessionState {
     pub(crate) liveliness_subscribers: HashMap<Id, Arc<SubscriberState>>,
     pub(crate) queryables: HashMap<Id, Arc<QueryableState>>,
     #[cfg(feature = "unstable")]
-    pub(crate) tokens: HashMap<Id, Arc<LivelinessTokenState>>,
-    #[cfg(feature = "unstable")]
     pub(crate) matching_listeners: HashMap<Id, Arc<MatchingListenerState>>,
     pub(crate) queries: HashMap<RequestId, QueryState>,
     #[cfg(feature = "unstable")]
@@ -169,8 +167,6 @@ impl SessionState {
             subscribers: HashMap::new(),
             liveliness_subscribers: HashMap::new(),
             queryables: HashMap::new(),
-            #[cfg(feature = "unstable")]
-            tokens: HashMap::new(),
             #[cfg(feature = "unstable")]
             matching_listeners: HashMap::new(),
             queries: HashMap::new(),
@@ -1110,7 +1106,6 @@ impl SessionInner {
                 // anyway, it doesn't really matter, and this code will be cleaned up when the APIs
                 // will be stabilized.
                 let mut state = zwrite!(self.state);
-                let _tokens = std::mem::take(&mut state.tokens);
                 let _matching_listeners = std::mem::take(&mut state.matching_listeners);
                 drop(state);
             }
@@ -1548,18 +1543,10 @@ impl SessionInner {
     }
 
     #[zenoh_macros::unstable]
-    pub(crate) fn declare_liveliness_inner(
-        &self,
-        key_expr: &KeyExpr,
-    ) -> ZResult<Arc<LivelinessTokenState>> {
-        let mut state = zwrite!(self.state);
+    pub(crate) fn declare_liveliness_inner(&self, key_expr: &KeyExpr) -> ZResult<Id> {
         tracing::trace!("declare_liveliness({:?})", key_expr);
         let id = self.runtime.next_id();
-        let tok_state = Arc::new(LivelinessTokenState { id });
-
-        state.tokens.insert(tok_state.id, tok_state.clone());
-        let primitives = state.primitives()?;
-        drop(state);
+        let primitives = zread!(self.state).primitives()?;
         primitives.send_declare(Declare {
             interest_id: None,
             ext_qos: declare::ext::QoSType::DECLARE,
@@ -1570,7 +1557,7 @@ impl SessionInner {
                 wire_expr: key_expr.to_wire(self).to_owned(),
             }),
         });
-        Ok(tok_state)
+        Ok(id)
     }
 
     #[cfg(feature = "unstable")]
@@ -1676,27 +1663,21 @@ impl SessionInner {
 
     #[zenoh_macros::unstable]
     pub(crate) fn undeclare_liveliness(&self, tid: Id) -> ZResult<()> {
-        let mut state = zwrite!(self.state);
-        let Ok(primitives) = state.primitives() else {
+        let Ok(primitives) = zread!(self.state).primitives() else {
             return Ok(());
         };
-        if let Some(tok_state) = state.tokens.remove(&tid) {
-            trace!("undeclare_liveliness({:?})", tok_state);
-            drop(state);
-            primitives.send_declare(Declare {
-                interest_id: None,
-                ext_qos: ext::QoSType::DECLARE,
-                ext_tstamp: None,
-                ext_nodeid: ext::NodeIdType::DEFAULT,
-                body: DeclareBody::UndeclareToken(UndeclareToken {
-                    id: tok_state.id,
-                    ext_wire_expr: WireExprType::null(),
-                }),
-            });
-            Ok(())
-        } else {
-            Err(zerror!("Unable to find liveliness token").into())
-        }
+        trace!("undeclare_liveliness({:?})", tid);
+        primitives.send_declare(Declare {
+            interest_id: None,
+            ext_qos: ext::QoSType::DECLARE,
+            ext_tstamp: None,
+            ext_nodeid: ext::NodeIdType::DEFAULT,
+            body: DeclareBody::UndeclareToken(UndeclareToken {
+                id: tid,
+                ext_wire_expr: WireExprType::null(),
+            }),
+        });
+        Ok(())
     }
 
     #[zenoh_macros::unstable]


### PR DESCRIPTION
There was 2 possible paths here: 
1. Change `declare_liveliness_inner` to manage twin tokens (similar to subscribers).
2. Change `undeclare_liveliness_inner` to manage twin tokens independently.

Since the plan to have a routing less client is dead, the twin management in `Session` does not make much sense any more as it is also performed in routing. It just adds complexity for few or inexistent benefit.
So I opted for path 2.