### PR TITLE
fix(serial-reopening): bug that prevented the serial link to be reused after closing a session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4381,7 +4381,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 
@@ -5042,9 +5042,9 @@ checksum = "6a5cbf750400958819fb6178eaa83bee5cd9c29a26a40cc241df8c70fdd46984"
 
 [[package]]
 name = "z-serial"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1f288ec253cd9add72c2cf8c24d6525a3d81481b0407a4d53c23c16c871c38c"
+checksum = "1660dfc9f90480610f94c285a9a967b49cd2f57b3b1267d9bd7fd5d4f57c36c8"
 dependencies = [
  "cobs",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4381,7 +4381,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 
@@ -5043,7 +5043,7 @@ checksum = "6a5cbf750400958819fb6178eaa83bee5cd9c29a26a40cc241df8c70fdd46984"
 [[package]]
 name = "z-serial"
 version = "0.2.3"
-source = "git+https://github.com/ZettaScaleLabs/z-serial/?branch=feat/state-machine#bb00ed07424987d3fa983732741e0a1aaba24411"
+source = "git+https://github.com/ZettaScaleLabs/z-serial/?branch=feat/state-machine#d7496e671215ee04316bcb1f4b31b437d1ee87af"
 dependencies = [
  "cobs",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4381,7 +4381,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 
@@ -5043,8 +5043,7 @@ checksum = "6a5cbf750400958819fb6178eaa83bee5cd9c29a26a40cc241df8c70fdd46984"
 [[package]]
 name = "z-serial"
 version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f113597c6b880587004169f14bc010e4b440981ab2ad669779d3654f9b1c4af1"
+source = "git+https://github.com/ZettaScaleLabs/z-serial/?branch=feat/state-machine#2262076d24689965cd0422386c1cf491b4281605"
 dependencies = [
  "cobs",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5043,7 +5043,7 @@ checksum = "6a5cbf750400958819fb6178eaa83bee5cd9c29a26a40cc241df8c70fdd46984"
 [[package]]
 name = "z-serial"
 version = "0.2.3"
-source = "git+https://github.com/ZettaScaleLabs/z-serial/?branch=feat/state-machine#2262076d24689965cd0422386c1cf491b4281605"
+source = "git+https://github.com/ZettaScaleLabs/z-serial/?branch=feat/state-machine#43b978efa780b5b8150eaac96949f8545166f918"
 dependencies = [
  "cobs",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5043,7 +5043,7 @@ checksum = "6a5cbf750400958819fb6178eaa83bee5cd9c29a26a40cc241df8c70fdd46984"
 [[package]]
 name = "z-serial"
 version = "0.2.3"
-source = "git+https://github.com/ZettaScaleLabs/z-serial/?branch=feat/state-machine#43b978efa780b5b8150eaac96949f8545166f918"
+source = "git+https://github.com/ZettaScaleLabs/z-serial/?branch=feat/state-machine#bb00ed07424987d3fa983732741e0a1aaba24411"
 dependencies = [
  "cobs",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4381,7 +4381,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 
@@ -5042,8 +5042,9 @@ checksum = "6a5cbf750400958819fb6178eaa83bee5cd9c29a26a40cc241df8c70fdd46984"
 
 [[package]]
 name = "z-serial"
-version = "0.2.3"
-source = "git+https://github.com/ZettaScaleLabs/z-serial/?branch=feat/state-machine#d7496e671215ee04316bcb1f4b31b437d1ee87af"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1f288ec253cd9add72c2cf8c24d6525a3d81481b0407a4d53c23c16c871c38c"
 dependencies = [
  "cobs",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,6 +223,9 @@ zenoh = { version = "1.0.0-dev", path = "zenoh", default-features = false }
 zenoh-runtime = { version = "1.0.0-dev", path = "commons/zenoh-runtime" }
 zenoh-task = { version = "1.0.0-dev", path = "commons/zenoh-task" }
 
+[patch.crates-io]
+z-serial = { git = "https://github.com/ZettaScaleLabs/z-serial/", branch = "feat/state-machine" }
+
 [profile.dev]
 debug = true
 opt-level = 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,7 +187,7 @@ vec_map = "0.8.2"
 webpki-roots = "0.26.5"
 winapi = { version = "0.3.9", features = ["iphlpapi", "winerror"] }
 x509-parser = "0.16.0"
-z-serial = "0.2.3"
+z-serial = "0.3.0"
 either = "1.13.0"
 prost = "0.13.2"
 tls-listener = { version = "0.10.2", features = ["rustls-ring"] }
@@ -222,9 +222,6 @@ zenoh-link-commons = { version = "1.0.0-dev", path = "io/zenoh-link-commons" }
 zenoh = { version = "1.0.0-dev", path = "zenoh", default-features = false }
 zenoh-runtime = { version = "1.0.0-dev", path = "commons/zenoh-runtime" }
 zenoh-task = { version = "1.0.0-dev", path = "commons/zenoh-task" }
-
-[patch.crates-io]
-z-serial = { git = "https://github.com/ZettaScaleLabs/z-serial/", branch = "feat/state-machine" }
 
 [profile.dev]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,7 +187,7 @@ vec_map = "0.8.2"
 webpki-roots = "0.26.5"
 winapi = { version = "0.3.9", features = ["iphlpapi", "winerror"] }
 x509-parser = "0.16.0"
-z-serial = "0.3.0"
+z-serial = "0.3.1"
 either = "1.13.0"
 prost = "0.13.2"
 tls-listener = { version = "0.10.2", features = ["rustls-ring"] }

--- a/io/zenoh-links/zenoh-link-serial/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-serial/src/lib.rs
@@ -38,6 +38,8 @@ const DEFAULT_BAUDRATE: u32 = 9_600;
 
 const DEFAULT_EXCLUSIVE: bool = true;
 
+const DEFAULT_TIMEOUT: u64 = 50_000;
+
 pub const SERIAL_LOCATOR_PREFIX: &str = "serial";
 
 const SERIAL_MTU_LIMIT: BatchSize = SERIAL_MAX_MTU;
@@ -94,6 +96,14 @@ pub fn get_exclusive(endpoint: &EndPoint) -> bool {
     }
 }
 
+pub fn get_timeout(endpoint: &EndPoint) -> u64 {
+    if let Some(tout) = endpoint.config().get(config::TIMEOUT_RAW) {
+        u64::from_str(tout).unwrap_or(DEFAULT_TIMEOUT)
+    } else {
+        DEFAULT_TIMEOUT
+    }
+}
+
 pub fn get_unix_path_as_string(address: Address<'_>) -> String {
     address.as_str().to_owned()
 }
@@ -101,4 +111,5 @@ pub fn get_unix_path_as_string(address: Address<'_>) -> String {
 pub mod config {
     pub const PORT_BAUD_RATE_RAW: &str = "baudrate";
     pub const PORT_EXCLUSIVE_RAW: &str = "exclusive";
+    pub const TIMEOUT_RAW: &str = "tout";
 }

--- a/io/zenoh-links/zenoh-link-serial/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-serial/src/lib.rs
@@ -40,6 +40,8 @@ const DEFAULT_EXCLUSIVE: bool = true;
 
 const DEFAULT_TIMEOUT: u64 = 50_000;
 
+const DEFAULT_RELEASE_ON_CLOSE: bool = true;
+
 pub const SERIAL_LOCATOR_PREFIX: &str = "serial";
 
 const SERIAL_MTU_LIMIT: BatchSize = SERIAL_MAX_MTU;
@@ -104,6 +106,14 @@ pub fn get_timeout(endpoint: &EndPoint) -> u64 {
     }
 }
 
+pub fn get_release_on_close(endpoint: &EndPoint) -> bool {
+    if let Some(release_on_close) = endpoint.config().get(config::RELEASE_ON_CLOSE) {
+        bool::from_str(release_on_close).unwrap_or(DEFAULT_RELEASE_ON_CLOSE)
+    } else {
+        DEFAULT_RELEASE_ON_CLOSE
+    }
+}
+
 pub fn get_unix_path_as_string(address: Address<'_>) -> String {
     address.as_str().to_owned()
 }
@@ -112,4 +122,5 @@ pub mod config {
     pub const PORT_BAUD_RATE_RAW: &str = "baudrate";
     pub const PORT_EXCLUSIVE_RAW: &str = "exclusive";
     pub const TIMEOUT_RAW: &str = "tout";
+    pub const RELEASE_ON_CLOSE: &str = "release_on_close";
 }

--- a/io/zenoh-links/zenoh-link-serial/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-serial/src/unicast.rs
@@ -405,6 +405,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastSerial {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn accept_read_task(
     link: Arc<LinkUnicastSerial>,
     token: CancellationToken,
@@ -415,6 +416,7 @@ async fn accept_read_task(
     exclusive: bool,
     release_on_close: bool,
 ) -> ZResult<()> {
+    #[allow(clippy::too_many_arguments)]
     async fn receive(
         link: Arc<LinkUnicastSerial>,
         src_path: String,

--- a/io/zenoh-links/zenoh-link-serial/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-serial/src/unicast.rs
@@ -423,6 +423,8 @@ async fn accept_read_task(
         exclusive: bool,
         release_on_close: bool,
     ) -> ZResult<Arc<LinkUnicastSerial>> {
+        tokio::time::sleep(Duration::from_micros(*SERIAL_ACCEPT_THROTTLE_TIME)).await;
+
         while is_connected.load(Ordering::Acquire) {
             // The serial is already connected to nothing.
             tokio::time::sleep(Duration::from_micros(*SERIAL_ACCEPT_THROTTLE_TIME)).await;

--- a/io/zenoh-links/zenoh-link-serial/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-serial/src/unicast.rs
@@ -479,7 +479,7 @@ async fn accept_read_task(
                             continue;
                         }
                         Err(e) =>  {
-                            tracing::warn!("{}. Hint: Is the serial cable connected?", e);
+                            tracing::debug!("{}. Hint: Is the serial cable connected?", e);
                             tokio::time::sleep(Duration::from_micros(*SERIAL_ACCEPT_THROTTLE_TIME)).await;
                             continue;
 

--- a/io/zenoh-links/zenoh-link-serial/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-serial/src/unicast.rs
@@ -433,13 +433,11 @@ async fn accept_read_task(
         tracing::trace!("Creating Serial listener on device {src_path:?}, with baudrate {baud_rate} and exclusive set as {exclusive}");
         if release_on_close {
             let port = ZSerial::new(src_path.clone(), baud_rate, exclusive).map_err(|e| {
-                let e = zerror!(
+                zerror!(
                     "Can not create a new Serial link bound to {:?}: {}",
                     src_path,
                     e
                 );
-                tracing::warn!("{}", e);
-                e
             })?;
 
             link.set_port(port);
@@ -474,7 +472,7 @@ async fn accept_read_task(
                         Ok(link) => {
                             // Communicate the new link to the initial transport manager
                             if let Err(e) = manager.send_async(LinkUnicast(link.clone())).await {
-                                tracing::error!("{}-{}: {}", file!(), line!(), e)
+                                tracing::debug!("{}-{}: {}", file!(), line!(), e)
                             }
 
                             // Ensure the creation of this link is only once

--- a/io/zenoh-links/zenoh-link-serial/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-serial/src/unicast.rs
@@ -437,7 +437,7 @@ async fn accept_read_task(
                     "Can not create a new Serial link bound to {:?}: {}",
                     src_path,
                     e
-                );
+                )
             })?;
 
             link.set_port(port);

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -41,8 +41,7 @@ default = [
   "transport_tls",
   "transport_udp",
   "transport_unixsock-stream",
-  "transport_ws",
-  "transport_serial"
+  "transport_ws"
 ]
 internal = ["zenoh-keyexpr/internal", "zenoh-config/internal"]
 plugins = []

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -42,6 +42,7 @@ default = [
   "transport_udp",
   "transport_unixsock-stream",
   "transport_ws",
+  "transport_serial"
 ]
 internal = ["zenoh-keyexpr/internal", "zenoh-config/internal"]
 plugins = []


### PR DESCRIPTION
Fixing a bug that prevented the serial link to be reused after closing a session.

Serial link remains 1-to-1 and exclusive, meaning that if a session is opened on a serial device no other sessions can use it.
once the first session closes, then another session can connect to the serial listener.