### PR TITLE
Add TCP buffer sizes configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5340,7 +5340,6 @@ dependencies = [
  "zenoh-link-commons",
  "zenoh-protocol",
  "zenoh-result",
- "zenoh-util",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5335,6 +5335,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "zenoh-config",
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -474,6 +474,12 @@
         // note that mTLS (client authentication) is required for a listener to disconnect a client on expiration
         close_link_on_expiration: false,
       },
+      /// Optional configration for TCP system buffers sizes. Applies to TCP and TLS links.
+      ///
+      /// Configure TCP read buffer size (bytes)
+      // tcp_rx_buffer: 123456,
+      /// Configure TCP write buffer size (bytes)
+      // tcp_tx_buffer: 123456,
     },
     /// Shared memory configuration.
     /// NOTE: shared memory can be used only if zenoh is compiled with "shared-memory" feature, otherwise

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -474,7 +474,7 @@
         // note that mTLS (client authentication) is required for a listener to disconnect a client on expiration
         close_link_on_expiration: false,
       },
-      /// Optional configration for TCP system buffers sizes. Applies to TCP and TLS links.
+      /// Optional configuration for TCP system buffers sizes. Applies to TCP and TLS links.
       ///
       /// Configure TCP read buffer size (bytes)
       // tcp_rx_buffer: 123456,

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -505,6 +505,10 @@ validated_struct::validator! {
                 UnixPipeConf {
                     file_access_mask: Option<u32>
                 },
+                /// Configure TCP read buffer size
+                pub tcp_rx_buffer: Option<u32>,
+                /// Configure TCP write buffer size
+                pub tcp_tx_buffer: Option<u32>,
             },
             pub shared_memory:
             ShmConf {

--- a/io/zenoh-link-commons/src/lib.rs
+++ b/io/zenoh-link-commons/src/lib.rs
@@ -45,8 +45,8 @@ use zenoh_result::ZResult;
 /*************************************/
 
 pub const BIND_INTERFACE: &str = "iface";
-pub const TCP_TX_BUFFER_SIZE: &str = "tcp_buffer_tx";
-pub const TCP_RX_BUFFER_SIZE: &str = "tcp_buffer_rx";
+pub const TCP_TX_BUFFER_SIZE: &str = "tcp_tx_buffer";
+pub const TCP_RX_BUFFER_SIZE: &str = "tcp_rx_buffer";
 
 #[derive(Clone, Debug, Serialize, Hash, PartialEq, Eq)]
 pub struct Link {

--- a/io/zenoh-link-commons/src/lib.rs
+++ b/io/zenoh-link-commons/src/lib.rs
@@ -45,6 +45,8 @@ use zenoh_result::ZResult;
 /*************************************/
 
 pub const BIND_INTERFACE: &str = "iface";
+pub const TCP_TX_BUFFER_SIZE: &str = "tcp_buffer_tx";
+pub const TCP_RX_BUFFER_SIZE: &str = "tcp_buffer_rx";
 
 #[derive(Clone, Debug, Serialize, Hash, PartialEq, Eq)]
 pub struct Link {

--- a/io/zenoh-link-commons/src/lib.rs
+++ b/io/zenoh-link-commons/src/lib.rs
@@ -21,6 +21,7 @@ extern crate alloc;
 
 mod listener;
 mod multicast;
+pub mod tcp;
 #[cfg(feature = "tls")]
 pub mod tls;
 mod unicast;

--- a/io/zenoh-link-commons/src/tcp.rs
+++ b/io/zenoh-link-commons/src/tcp.rs
@@ -1,0 +1,80 @@
+//
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+use std::net::SocketAddr;
+
+use tokio::net::{TcpListener, TcpSocket, TcpStream};
+use zenoh_result::{zerror, ZResult};
+
+pub struct TcpSocketUtils;
+
+impl TcpSocketUtils {
+    /// Build a new TCP listener bound to `addr` with the given configration parameters
+    pub fn listen(addr: &SocketAddr, iface: Option<&str>) -> ZResult<(TcpListener, SocketAddr)> {
+        let socket = match addr {
+            SocketAddr::V4(_) => TcpSocket::new_v4(),
+            SocketAddr::V6(_) => TcpSocket::new_v6(),
+        }?;
+
+        if let Some(iface) = iface {
+            zenoh_util::net::set_bind_to_device_tcp_socket(&socket, iface)?;
+        }
+
+        // Build a TcpListener from TcpSocket
+        // https://docs.rs/tokio/latest/tokio/net/struct.TcpSocket.html
+        socket.set_reuseaddr(true)?;
+        socket.bind(*addr).map_err(|e| zerror!("{}: {}", addr, e))?;
+        // backlog (the maximum number of pending connections are queued): 1024
+        let listener = socket
+            .listen(1024)
+            .map_err(|e| zerror!("{}: {}", addr, e))?;
+
+        let local_addr = listener
+            .local_addr()
+            .map_err(|e| zerror!("{}: {}", addr, e))?;
+
+        Ok((listener, local_addr))
+    }
+
+    /// Connect to a TCP socket address at `dst_addr` with the given configuration parameters
+    pub async fn connect(
+        dst_addr: &SocketAddr,
+        iface: Option<&str>,
+    ) -> ZResult<(TcpStream, SocketAddr, SocketAddr)> {
+        let socket = match dst_addr {
+            SocketAddr::V4(_) => TcpSocket::new_v4(),
+            SocketAddr::V6(_) => TcpSocket::new_v6(),
+        }?;
+
+        if let Some(iface) = iface {
+            zenoh_util::net::set_bind_to_device_tcp_socket(&socket, iface)?;
+        }
+
+        // Build a TcpStream from TcpSocket
+        // https://docs.rs/tokio/latest/tokio/net/struct.TcpSocket.html
+        let stream = socket
+            .connect(*dst_addr)
+            .await
+            .map_err(|e| zerror!("{}: {}", dst_addr, e))?;
+
+        let src_addr = stream
+            .local_addr()
+            .map_err(|e| zerror!("{}: {}", dst_addr, e))?;
+
+        let dst_addr = stream
+            .peer_addr()
+            .map_err(|e| zerror!("{}: {}", dst_addr, e))?;
+
+        Ok((stream, src_addr, dst_addr))
+    }
+}

--- a/io/zenoh-link-commons/src/tcp.rs
+++ b/io/zenoh-link-commons/src/tcp.rs
@@ -35,7 +35,7 @@ impl<'a> TcpSocketConfig<'a> {
         }
     }
 
-    /// Build a new TCPListener bound to `addr` with the given configration parameters
+    /// Build a new TCPListener bound to `addr` with the given configuration parameters
     pub fn new_listener(&self, addr: &SocketAddr) -> ZResult<(TcpListener, SocketAddr)> {
         let socket = self.socket_with_config(addr)?;
         // Build a TcpListener from TcpSocket

--- a/io/zenoh-link-commons/src/tcp.rs
+++ b/io/zenoh-link-commons/src/tcp.rs
@@ -16,20 +16,28 @@ use std::net::SocketAddr;
 use tokio::net::{TcpListener, TcpSocket, TcpStream};
 use zenoh_result::{zerror, ZResult};
 
-pub struct TcpSocketUtils;
+pub struct TcpSocketConfig<'a> {
+    tx_buffer_size: Option<u32>,
+    rx_buffer_size: Option<u32>,
+    iface: Option<&'a str>,
+}
 
-impl TcpSocketUtils {
-    /// Build a new TCP listener bound to `addr` with the given configration parameters
-    pub fn listen(addr: &SocketAddr, iface: Option<&str>) -> ZResult<(TcpListener, SocketAddr)> {
-        let socket = match addr {
-            SocketAddr::V4(_) => TcpSocket::new_v4(),
-            SocketAddr::V6(_) => TcpSocket::new_v6(),
-        }?;
-
-        if let Some(iface) = iface {
-            zenoh_util::net::set_bind_to_device_tcp_socket(&socket, iface)?;
+impl<'a> TcpSocketConfig<'a> {
+    pub fn new(
+        tx_buffer_size: Option<u32>,
+        rx_buffer_size: Option<u32>,
+        iface: Option<&'a str>,
+    ) -> Self {
+        Self {
+            tx_buffer_size,
+            rx_buffer_size,
+            iface,
         }
+    }
 
+    /// Build a new TCPListener bound to `addr` with the given configration parameters
+    pub fn new_listener(&self, addr: &SocketAddr) -> ZResult<(TcpListener, SocketAddr)> {
+        let socket = self.socket_with_config(addr)?;
         // Build a TcpListener from TcpSocket
         // https://docs.rs/tokio/latest/tokio/net/struct.TcpSocket.html
         socket.set_reuseaddr(true)?;
@@ -47,19 +55,11 @@ impl TcpSocketUtils {
     }
 
     /// Connect to a TCP socket address at `dst_addr` with the given configuration parameters
-    pub async fn connect(
+    pub async fn new_link(
+        &self,
         dst_addr: &SocketAddr,
-        iface: Option<&str>,
     ) -> ZResult<(TcpStream, SocketAddr, SocketAddr)> {
-        let socket = match dst_addr {
-            SocketAddr::V4(_) => TcpSocket::new_v4(),
-            SocketAddr::V6(_) => TcpSocket::new_v6(),
-        }?;
-
-        if let Some(iface) = iface {
-            zenoh_util::net::set_bind_to_device_tcp_socket(&socket, iface)?;
-        }
-
+        let socket = self.socket_with_config(dst_addr)?;
         // Build a TcpStream from TcpSocket
         // https://docs.rs/tokio/latest/tokio/net/struct.TcpSocket.html
         let stream = socket
@@ -76,5 +76,25 @@ impl TcpSocketUtils {
             .map_err(|e| zerror!("{}: {}", dst_addr, e))?;
 
         Ok((stream, src_addr, dst_addr))
+    }
+
+    /// Creates a TcpSocket with the provided config
+    fn socket_with_config(&self, addr: &SocketAddr) -> ZResult<TcpSocket> {
+        let socket = match addr {
+            SocketAddr::V4(_) => TcpSocket::new_v4(),
+            SocketAddr::V6(_) => TcpSocket::new_v6(),
+        }?;
+
+        if let Some(iface) = self.iface {
+            zenoh_util::net::set_bind_to_device_tcp_socket(&socket, iface)?;
+        }
+        if let Some(size) = self.tx_buffer_size {
+            socket.set_send_buffer_size(size)?;
+        }
+        if let Some(size) = self.rx_buffer_size {
+            socket.set_recv_buffer_size(size)?;
+        }
+
+        Ok(socket)
     }
 }

--- a/io/zenoh-link/src/lib.rs
+++ b/io/zenoh-link/src/lib.rs
@@ -34,7 +34,9 @@ use zenoh_link_serial::{LinkManagerUnicastSerial, SerialLocatorInspector, SERIAL
 #[cfg(feature = "transport_tcp")]
 pub use zenoh_link_tcp as tcp;
 #[cfg(feature = "transport_tcp")]
-use zenoh_link_tcp::{LinkManagerUnicastTcp, TcpLocatorInspector, TCP_LOCATOR_PREFIX};
+use zenoh_link_tcp::{
+    LinkManagerUnicastTcp, TcpConfigurator, TcpLocatorInspector, TCP_LOCATOR_PREFIX,
+};
 #[cfg(feature = "transport_tls")]
 pub use zenoh_link_tls as tls;
 #[cfg(feature = "transport_tls")]
@@ -172,6 +174,8 @@ impl LocatorInspector {
 }
 #[derive(Default)]
 pub struct LinkConfigurator {
+    #[cfg(feature = "transport_tcp")]
+    tcp_inspector: TcpConfigurator,
     #[cfg(feature = "transport_quic")]
     quic_inspector: QuicConfigurator,
     #[cfg(feature = "transport_tls")]
@@ -199,6 +203,13 @@ impl LinkConfigurator {
                 errors.insert(proto, e);
             }
         };
+        #[cfg(feature = "transport_tcp")]
+        {
+            insert_config(
+                TCP_LOCATOR_PREFIX.into(),
+                self.tcp_inspector.inspect_config(config),
+            );
+        }
         #[cfg(feature = "transport_quic")]
         {
             insert_config(

--- a/io/zenoh-links/zenoh-link-tcp/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-tcp/Cargo.toml
@@ -30,6 +30,7 @@ socket2 = { workspace = true }
 tokio = { workspace = true, features = ["net", "io-util", "rt", "time"] }
 tokio-util = { workspace = true, features = ["rt"] }
 tracing = {workspace = true}
+zenoh-config = { workspace = true }
 zenoh-core = { workspace = true }
 zenoh-link-commons = { workspace = true }
 zenoh-protocol = { workspace = true }

--- a/io/zenoh-links/zenoh-link-tcp/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-tcp/Cargo.toml
@@ -35,4 +35,3 @@ zenoh-core = { workspace = true }
 zenoh-link-commons = { workspace = true }
 zenoh-protocol = { workspace = true }
 zenoh-result = { workspace = true }
-zenoh-util = { workspace = true }

--- a/io/zenoh-links/zenoh-link-tcp/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/lib.rs
@@ -31,6 +31,7 @@ use zenoh_result::{zerror, ZResult};
 mod unicast;
 mod utils;
 pub use unicast::*;
+pub use utils::TcpConfigurator;
 
 // Default MTU (TCP PDU) in bytes.
 // NOTE: Since TCP is a byte-stream oriented transport, theoretically it has

--- a/io/zenoh-links/zenoh-link-tcp/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/lib.rs
@@ -29,6 +29,7 @@ use zenoh_protocol::{
 use zenoh_result::{zerror, ZResult};
 
 mod unicast;
+mod utils;
 pub use unicast::*;
 
 // Default MTU (TCP PDU) in bytes.

--- a/io/zenoh-links/zenoh-link-tcp/src/utils.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/utils.rs
@@ -1,0 +1,55 @@
+//
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+use zenoh_link_commons::{
+    tcp::TcpSocketConfig, BIND_INTERFACE, TCP_RX_BUFFER_SIZE, TCP_TX_BUFFER_SIZE,
+};
+use zenoh_protocol::core::Config;
+use zenoh_result::{zerror, ZResult};
+
+pub(crate) struct TcpLinkConfig<'a> {
+    pub(crate) rx_buffer_size: Option<u32>,
+    pub(crate) tx_buffer_size: Option<u32>,
+    pub(crate) bind_iface: Option<&'a str>,
+}
+
+impl<'a> TcpLinkConfig<'a> {
+    pub(crate) fn new(config: &'a Config) -> ZResult<Self> {
+        let mut tcp_config = Self {
+            rx_buffer_size: None,
+            tx_buffer_size: None,
+            bind_iface: config.get(BIND_INTERFACE),
+        };
+
+        if let Some(size) = config.get(TCP_RX_BUFFER_SIZE) {
+            tcp_config.rx_buffer_size = Some(
+                size.parse()
+                    .map_err(|_| zerror!("Unknown TCP read buffer size argument: {}", size))?,
+            );
+        };
+        if let Some(size) = config.get(TCP_TX_BUFFER_SIZE) {
+            tcp_config.tx_buffer_size = Some(
+                size.parse()
+                    .map_err(|_| zerror!("Unknown TCP write buffer size argument: {}", size))?,
+            );
+        };
+
+        Ok(tcp_config)
+    }
+}
+
+impl<'a> From<TcpLinkConfig<'a>> for TcpSocketConfig<'a> {
+    fn from(value: TcpLinkConfig<'a>) -> Self {
+        Self::new(value.tx_buffer_size, value.rx_buffer_size, value.bind_iface)
+    }
+}

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -26,7 +26,7 @@ use x509_parser::prelude::{FromDer, X509Certificate};
 use zenoh_core::zasynclock;
 use zenoh_link_commons::{
     get_ip_interface_names,
-    tcp::TcpSocketUtils,
+    tcp::TcpSocketConfig,
     tls::expiration::{LinkCertExpirationManager, LinkWithCertExpiration},
     LinkAuthId, LinkAuthType, LinkManagerUnicastTrait, LinkUnicast, LinkUnicastTrait,
     ListenersUnicastIP, NewLinkChannelSender,
@@ -324,10 +324,11 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastTls {
         let config = Arc::new(client_config.client_config);
         let connector = TlsConnector::from(config);
 
-        // Initialize the TcpStream
         // TODO: Add interface binding
+        let socket_config = TcpSocketConfig::new(None, None, None);
+        // Initialize the TcpStream
         let (tcp_stream, src_addr, dst_addr) =
-            TcpSocketUtils::connect(&addr, None).await.map_err(|e| {
+            socket_config.new_link(&addr).await.map_err(|e| {
                 zerror!(
                     "Can not create a new TLS link bound to {:?}: {}",
                     server_name,
@@ -390,9 +391,11 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastTls {
             .await
             .map_err(|e| zerror!("Cannot create a new TLS listener on {addr}. {e}"))?;
 
+        // TODO: Add interface binding
+        let socket_config = TcpSocketConfig::new(None, None, None);
         // Initialize the TcpListener
-        // TODO: Add interface bindings
-        let (socket, local_addr) = TcpSocketUtils::listen(&addr, None)
+        let (socket, local_addr) = socket_config
+            .new_listener(&addr)
             .map_err(|e| zerror!("Can not create a new TLS listener on {}: {}", addr, e))?;
 
         let local_port = local_addr.port();

--- a/io/zenoh-links/zenoh-link-tls/src/utils.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/utils.rs
@@ -153,6 +153,19 @@ impl ConfigurationInspector<ZenohConfig> for TlsConfigurator {
             false => ps.push((TLS_CLOSE_LINK_ON_EXPIRATION, "false")),
         }
 
+        let link_c = config.transport().link();
+        let rx_buffer_size;
+        if let Some(size) = link_c.tcp_rx_buffer {
+            rx_buffer_size = size.to_string();
+            ps.push((TCP_RX_BUFFER_SIZE, &rx_buffer_size));
+        }
+
+        let tx_buffer_size;
+        if let Some(size) = link_c.tcp_tx_buffer {
+            tx_buffer_size = size.to_string();
+            ps.push((TCP_TX_BUFFER_SIZE, &tx_buffer_size));
+        }
+
         Ok(parameters::from_iter(ps.drain(..)))
     }
 }

--- a/io/zenoh-links/zenoh-link-tls/src/utils.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/utils.rs
@@ -31,7 +31,10 @@ use rustls_pki_types::ServerName;
 use secrecy::ExposeSecret;
 use webpki::anchor_from_trusted_cert;
 use zenoh_config::Config as ZenohConfig;
-use zenoh_link_commons::{tls::WebPkiVerifierAnyServerName, ConfigurationInspector};
+use zenoh_link_commons::{
+    tcp::TcpSocketConfig, tls::WebPkiVerifierAnyServerName, ConfigurationInspector,
+    TCP_RX_BUFFER_SIZE, TCP_TX_BUFFER_SIZE,
+};
 use zenoh_protocol::core::{
     endpoint::{Address, Config},
     parameters,
@@ -154,14 +157,15 @@ impl ConfigurationInspector<ZenohConfig> for TlsConfigurator {
     }
 }
 
-pub(crate) struct TlsServerConfig {
+pub(crate) struct TlsServerConfig<'a> {
     pub(crate) server_config: ServerConfig,
     pub(crate) tls_handshake_timeout: Duration,
     pub(crate) tls_close_link_on_expiration: bool,
+    pub(crate) tcp_socket_config: TcpSocketConfig<'a>,
 }
 
-impl TlsServerConfig {
-    pub async fn new(config: &Config<'_>) -> ZResult<TlsServerConfig> {
+impl<'a> TlsServerConfig<'a> {
+    pub async fn new(config: &Config<'a>) -> ZResult<Self> {
         let tls_server_client_auth: bool = match config.get(TLS_ENABLE_MTLS) {
             Some(s) => s
                 .parse()
@@ -241,10 +245,27 @@ impl TlsServerConfig {
                 .unwrap_or(config::TLS_HANDSHAKE_TIMEOUT_MS_DEFAULT),
         );
 
+        let mut tcp_rx_buffer_size = None;
+        if let Some(size) = config.get(TCP_RX_BUFFER_SIZE) {
+            tcp_rx_buffer_size = Some(
+                size.parse()
+                    .map_err(|_| zerror!("Unknown TCP read buffer size argument: {}", size))?,
+            );
+        };
+        let mut tcp_tx_buffer_size = None;
+        if let Some(size) = config.get(TCP_TX_BUFFER_SIZE) {
+            tcp_tx_buffer_size = Some(
+                size.parse()
+                    .map_err(|_| zerror!("Unknown TCP write buffer size argument: {}", size))?,
+            );
+        };
+
         Ok(TlsServerConfig {
             server_config: sc,
             tls_handshake_timeout,
             tls_close_link_on_expiration,
+            // TODO: add interface binding
+            tcp_socket_config: TcpSocketConfig::new(tcp_tx_buffer_size, tcp_rx_buffer_size, None),
         })
     }
 
@@ -269,13 +290,14 @@ impl TlsServerConfig {
     }
 }
 
-pub(crate) struct TlsClientConfig {
+pub(crate) struct TlsClientConfig<'a> {
     pub(crate) client_config: ClientConfig,
     pub(crate) tls_close_link_on_expiration: bool,
+    pub(crate) tcp_socket_config: TcpSocketConfig<'a>,
 }
 
-impl TlsClientConfig {
-    pub async fn new(config: &Config<'_>) -> ZResult<TlsClientConfig> {
+impl<'a> TlsClientConfig<'a> {
+    pub async fn new(config: &Config<'a>) -> ZResult<Self> {
         let tls_client_server_auth: bool = match config.get(TLS_ENABLE_MTLS) {
             Some(s) => s
                 .parse()
@@ -386,9 +408,27 @@ impl TlsClientConfig {
                     .with_no_client_auth()
             }
         };
+
+        let mut tcp_rx_buffer_size = None;
+        if let Some(size) = config.get(TCP_RX_BUFFER_SIZE) {
+            tcp_rx_buffer_size = Some(
+                size.parse()
+                    .map_err(|_| zerror!("Unknown TCP read buffer size argument: {}", size))?,
+            );
+        };
+        let mut tcp_tx_buffer_size = None;
+        if let Some(size) = config.get(TCP_TX_BUFFER_SIZE) {
+            tcp_tx_buffer_size = Some(
+                size.parse()
+                    .map_err(|_| zerror!("Unknown TCP write buffer size argument: {}", size))?,
+            );
+        };
+
         Ok(TlsClientConfig {
             client_config: cc,
             tls_close_link_on_expiration,
+            // TODO: add interface binding
+            tcp_socket_config: TcpSocketConfig::new(tcp_tx_buffer_size, tcp_rx_buffer_size, None),
         })
     }
 

--- a/zenoh/tests/tcp_buffers.rs
+++ b/zenoh/tests/tcp_buffers.rs
@@ -62,8 +62,6 @@ fn buffer_size_override() {
     buffer_size_config_override();
 }
 
-#[test]
-#[should_panic(expected = "Can not create a new TCP listener")]
 fn buffer_size_config_override() {
     let mut config = Config::default();
     config

--- a/zenoh/tests/tcp_buffers.rs
+++ b/zenoh/tests/tcp_buffers.rs
@@ -1,0 +1,89 @@
+//
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+use zenoh::{Config, Wait};
+
+#[test]
+fn buffer_size_config() {
+    let mut config = Config::default();
+    config
+        .insert_json5(
+            "transport/link",
+            r#"
+            {
+                tcp_tx_buffer: 65000,
+                tcp_rx_buffer: 65000,
+            }
+            "#,
+        )
+        .unwrap();
+
+    config
+        .insert_json5("listen/endpoints", r#"["tcp/[::]:0"]"#)
+        .unwrap();
+
+    zenoh::open(config).wait().unwrap();
+}
+
+#[test]
+fn buffer_size_endpoint() {
+    let mut config = Config::default();
+    config
+        .insert_json5(
+            "listen/endpoints",
+            r#"["tcp/[::]:0#tcp_tx_buffer=65000;tcp_rx_buffer=65000"]"#,
+        )
+        .unwrap();
+
+    zenoh::open(config).wait().unwrap();
+}
+
+#[test]
+#[should_panic(expected = "Can not create a new TCP listener")]
+fn buffer_size_config_override() {
+    let mut config = Config::default();
+    config
+        .insert_json5(
+            "transport/link",
+            r#"
+            {
+                tcp_tx_buffer: 0,
+                tcp_rx_buffer: 0,
+            }
+            "#,
+        )
+        .unwrap();
+
+    config
+        .insert_json5(
+            "listen/endpoints",
+            r#"["tcp/[::]:0#tcp_tx_buffer=65000;tcp_rx_buffer=65000"]"#,
+        )
+        .unwrap();
+
+    zenoh::open(config).wait().unwrap();
+}
+
+#[test]
+#[should_panic(expected = "Can not create a new TCP listener")]
+fn listen_zero_buffers() {
+    let mut config = Config::default();
+    config
+        .insert_json5(
+            "listen/endpoints",
+            r#"["tcp/[::]:0#tcp_tx_buffer=0;tcp_rx_buffer=0"]"#,
+        )
+        .unwrap();
+    zenoh::open(config).wait().unwrap();
+}

--- a/zenoh/tests/tcp_buffers.rs
+++ b/zenoh/tests/tcp_buffers.rs
@@ -49,6 +49,19 @@ fn buffer_size_endpoint() {
     zenoh::open(config).wait().unwrap();
 }
 
+#[cfg(target_os = "macos")]
+#[test]
+#[should_panic(expected = "Can not create a new TCP listener")]
+fn buffer_size_override() {
+    buffer_size_config_override();
+}
+
+#[cfg(not(target_os = "macos"))]
+#[test]
+fn buffer_size_override() {
+    buffer_size_config_override();
+}
+
 #[test]
 #[should_panic(expected = "Can not create a new TCP listener")]
 fn buffer_size_config_override() {
@@ -75,8 +88,19 @@ fn buffer_size_config_override() {
     zenoh::open(config).wait().unwrap();
 }
 
+#[cfg(target_os = "macos")]
 #[test]
 #[should_panic(expected = "Can not create a new TCP listener")]
+fn buffer_size_zero() {
+    listen_zero_buffers();
+}
+
+#[cfg(not(target_os = "macos"))]
+#[test]
+fn buffer_size_zero() {
+    listen_zero_buffers();
+}
+
 fn listen_zero_buffers() {
     let mut config = Config::default();
     config


### PR DESCRIPTION
Adds the ability to configure TCP read/write buffer sizes via endpoint and config file.
Parameter names are `tcp_tx_buffer` and `tcp_rx_buffer`. Same names in config file, under the `transport/link` key.