### PR TITLE
restored internal_config feature as part of "unstable"

### DIFF
--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -64,7 +64,7 @@ transport_udp = ["zenoh-transport/transport_udp"]
 transport_unixsock-stream = ["zenoh-transport/transport_unixsock-stream"]
 transport_ws = ["zenoh-transport/transport_ws"]
 transport_vsock = ["zenoh-transport/transport_vsock"]
-unstable = ["zenoh-keyexpr/unstable", "zenoh-config/unstable"]
+unstable = ["internal_config", "zenoh-keyexpr/unstable", "zenoh-config/unstable"]
 internal_config = []
 
 [dependencies]


### PR DESCRIPTION
It happened that removing "internal_config" feature affects plugin compilation.
Restored it temporary. This is to be fixed later https://github.com/eclipse-zenoh/zenoh/issues/1655