### PR TITLE
Add CI for checking markdown format.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,16 @@ jobs:
 
       - name: Check spelling
         uses: crate-ci/typos@master
+  
+  markdown_lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: articulate/actions-markdownlint@v1
+        with:
+          config: .markdownlint.yaml
+          files: '*.md'
+          ignore: target
+          version: 0.28.1
 
   # NOTE: In GitHub repository settings, the "Require status checks to pass
   # before merging" branch protection rule ensures that commits are only merged

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,6 @@
+{
+  "MD013": false, # Line length limitation
+  "MD033": false, # Enable Inline HTML
+  "MD041": false, # Allow first line heading
+  "MD045": false, # Allow Images have no alternate text
+}

--- a/commons/zenoh-buffers/README.md
+++ b/commons/zenoh-buffers/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/commons/zenoh-codec/README.md
+++ b/commons/zenoh-codec/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/commons/zenoh-collections/README.md
+++ b/commons/zenoh-collections/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/commons/zenoh-config/README.md
+++ b/commons/zenoh-config/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/commons/zenoh-core/README.md
+++ b/commons/zenoh-core/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/commons/zenoh-crypto/README.md
+++ b/commons/zenoh-crypto/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/commons/zenoh-keyexpr/README.md
+++ b/commons/zenoh-keyexpr/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/commons/zenoh-macros/README.md
+++ b/commons/zenoh-macros/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/commons/zenoh-protocol/README.md
+++ b/commons/zenoh-protocol/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/commons/zenoh-result/README.md
+++ b/commons/zenoh-result/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/commons/zenoh-runtime/README.md
+++ b/commons/zenoh-runtime/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/commons/zenoh-shm/README.md
+++ b/commons/zenoh-shm/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/commons/zenoh-sync/README.md
+++ b/commons/zenoh-sync/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/commons/zenoh-task/README.md
+++ b/commons/zenoh-task/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/commons/zenoh-util/README.md
+++ b/commons/zenoh-util/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/io/zenoh-link-commons/README.md
+++ b/io/zenoh-link-commons/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/io/zenoh-link/README.md
+++ b/io/zenoh-link/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/io/zenoh-links/README.md
+++ b/io/zenoh-links/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/io/zenoh-links/zenoh-link-quic/README.md
+++ b/io/zenoh-links/zenoh-link-quic/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/io/zenoh-links/zenoh-link-serial/README.md
+++ b/io/zenoh-links/zenoh-link-serial/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/io/zenoh-links/zenoh-link-tcp/README.md
+++ b/io/zenoh-links/zenoh-link-tcp/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/io/zenoh-links/zenoh-link-tls/README.md
+++ b/io/zenoh-links/zenoh-link-tls/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/io/zenoh-links/zenoh-link-udp/README.md
+++ b/io/zenoh-links/zenoh-link-udp/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/io/zenoh-links/zenoh-link-unixpipe/README.md
+++ b/io/zenoh-links/zenoh-link-unixpipe/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/io/zenoh-links/zenoh-link-unixsock_stream/README.md
+++ b/io/zenoh-links/zenoh-link-unixsock_stream/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/io/zenoh-links/zenoh-link-vsock/README.md
+++ b/io/zenoh-links/zenoh-link-vsock/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/io/zenoh-links/zenoh-link-ws/README.md
+++ b/io/zenoh-links/zenoh-link-ws/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/io/zenoh-transport/README.md
+++ b/io/zenoh-transport/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/plugins/zenoh-backend-traits/README.md
+++ b/plugins/zenoh-backend-traits/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/plugins/zenoh-plugin-example/README.md
+++ b/plugins/zenoh-plugin-example/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/plugins/zenoh-plugin-rest/README.md
+++ b/plugins/zenoh-plugin-rest/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/plugins/zenoh-plugin-storage-manager/README.md
+++ b/plugins/zenoh-plugin-storage-manager/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/plugins/zenoh-plugin-trait/README.md
+++ b/plugins/zenoh-plugin-trait/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/zenoh-ext/README.md
+++ b/zenoh-ext/README.md
@@ -4,5 +4,3 @@ This crate is intended for Zenoh's internal use.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)
-
-

--- a/zenoh-ext/examples/examples/README.md
+++ b/zenoh-ext/examples/examples/README.md
@@ -3,6 +3,7 @@
 ## Start instructions
 
    When zenoh is built in release mode:
+
    ```bash
    ./target/release/example/<example_name>
    ```
@@ -22,12 +23,15 @@
    or retransmission.
 
    Typical usage:
+
    ```bash
-      z_advanced_pub
+   z_advanced_pub
    ```
+
    or
+
    ```bash
-      z_advanced_pub --history 10
+   z_advanced_pub --history 10
    ```
 
 ### z_advanced_sub
@@ -38,8 +42,9 @@
    sample loss and ask for retransmission.
 
    Typical usage:
+
    ```bash
-      z_advanced_sub
+   z_advanced_sub
    ```
 
 ### z_member
@@ -47,9 +52,11 @@
    Group Management example: join a group and display the received group events (Join, Leave, LeaseExpired), as well as an updated group view.
 
    Typical usage:
+
    ```bash
-      z_member
+   z_member
    ```
+
    (start/stop several in parallel)
 
 ### z_view_size
@@ -57,8 +64,9 @@
    Group Management example: join a group and wait for the group view to reach a configurable size (default: 3 members).
 
    Typical usage:
-   ```bash
-      z_view_size
-   ```
-   (start/stop several in parallel)
 
+   ```bash
+   z_view_size
+   ```
+
+   (start/stop several in parallel)


### PR DESCRIPTION
The README format is sometimes not well-formatted. Add CI to make sure this can be checked automatically.
For vscode developer, installing `markdownlint` plugin can provide the lint warning.