### PR TITLE
Add default open timeout for new link establishment

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -336,7 +336,9 @@
   /// Configure internal transport parameters
   transport: {
     unicast: {
-      /// Timeout in milliseconds when opening a link
+      /// Timeout in milliseconds when accepting a link
+      open_timeout: 10000,
+      /// Timeout in milliseconds when accepting a link
       accept_timeout: 10000,
       /// Maximum number of zenoh session in pending state while accepting
       accept_pending: 100,

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -336,7 +336,7 @@
   /// Configure internal transport parameters
   transport: {
     unicast: {
-      /// Timeout in milliseconds when accepting a link
+      /// Timeout in milliseconds when opening a link
       open_timeout: 10000,
       /// Timeout in milliseconds when accepting a link
       accept_timeout: 10000,

--- a/commons/zenoh-config/src/defaults.rs
+++ b/commons/zenoh-config/src/defaults.rs
@@ -171,6 +171,7 @@ impl Default for ConnectConfig {
 impl Default for TransportUnicastConf {
     fn default() -> Self {
         Self {
+            open_timeout: 10_000,
             accept_timeout: 10_000,
             accept_pending: 100,
             max_sessions: 1_000,

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -375,7 +375,7 @@ validated_struct::validator! {
             pub unicast: TransportUnicastConf {
                 /// Timeout in milliseconds when opening a link (default: 10000).
                 open_timeout: u64,
-                /// Timeout in milliseconds when opening a link (default: 10000).
+                /// Timeout in milliseconds when accepting a link (default: 10000).
                 accept_timeout: u64,
                 /// Number of links that may stay pending during accept phase (default: 100).
                 accept_pending: usize,

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -374,6 +374,8 @@ validated_struct::validator! {
         TransportConf {
             pub unicast: TransportUnicastConf {
                 /// Timeout in milliseconds when opening a link (default: 10000).
+                open_timeout: u64,
+                /// Timeout in milliseconds when opening a link (default: 10000).
                 accept_timeout: u64,
                 /// Number of links that may stay pending during accept phase (default: 100).
                 accept_pending: usize,


### PR DESCRIPTION
A default timeout of 10 seconds is already applied for any new link is being accepted.
There is no such timeout for opening a new link. 
Moreover, today the `retry/period_init_ms` timeout is wrongly used leading to a premature connection abortion.

This PR should superseed https://github.com/eclipse-zenoh/zenoh/pull/1661.