### PR TITLE
Fix stats bugs

### DIFF
--- a/io/zenoh-transport/src/common/batch.rs
+++ b/io/zenoh-transport/src/common/batch.rs
@@ -363,7 +363,14 @@ impl Encode<&TransportMessage> for &mut WBatch {
 
     fn encode(self, x: &TransportMessage) -> Self::Output {
         let mut writer = self.buffer.writer();
-        self.codec.write(&mut writer, x)
+        let res = self.codec.write(&mut writer, x);
+        #[cfg(feature = "stats")]
+        {
+            if res.is_ok() {
+                self.stats.t_msgs += 1;
+            }
+        }
+        res
     }
 }
 
@@ -381,7 +388,14 @@ impl Encode<(&NetworkMessage, &FrameHeader)> for &mut WBatch {
 
     fn encode(self, x: (&NetworkMessage, &FrameHeader)) -> Self::Output {
         let mut writer = self.buffer.writer();
-        self.codec.write(&mut writer, x)
+        let res = self.codec.write(&mut writer, x);
+        #[cfg(feature = "stats")]
+        {
+            if res.is_ok() {
+                self.stats.t_msgs += 1;
+            }
+        }
+        res
     }
 }
 
@@ -390,7 +404,14 @@ impl Encode<(&mut ZBufReader<'_>, &mut FragmentHeader)> for &mut WBatch {
 
     fn encode(self, x: (&mut ZBufReader<'_>, &mut FragmentHeader)) -> Self::Output {
         let mut writer = self.buffer.writer();
-        self.codec.write(&mut writer, x)
+        let res = self.codec.write(&mut writer, x);
+        #[cfg(feature = "stats")]
+        {
+            if res.is_ok() {
+                self.stats.t_msgs += 1;
+            }
+        }
+        res
     }
 }
 

--- a/zenoh/src/net/routing/dispatcher/pubsub.rs
+++ b/zenoh/src/net/routing/dispatcher/pubsub.rs
@@ -434,9 +434,9 @@ pub fn route_data(
                             drop(tables);
                             #[cfg(feature = "stats")]
                             if !admin {
-                                inc_stats!(face, tx, user, msg.payload)
+                                inc_stats!(outface, tx, user, msg.payload)
                             } else {
-                                inc_stats!(face, tx, admin, msg.payload)
+                                inc_stats!(outface, tx, admin, msg.payload)
                             }
 
                             outface.primitives.send_push(
@@ -465,9 +465,9 @@ pub fn route_data(
                         for (outface, key_expr, context) in route {
                             #[cfg(feature = "stats")]
                             if !admin {
-                                inc_stats!(face, tx, user, msg.payload)
+                                inc_stats!(outface, tx, user, msg.payload)
                             } else {
-                                inc_stats!(face, tx, admin, msg.payload)
+                                inc_stats!(outface, tx, admin, msg.payload)
                             }
 
                             outface.primitives.send_push(


### PR DESCRIPTION
When routing, the `tx_z_put_pl_bytes` of the source session was increased instead fo the `tx_z_put_pl_bytes` of the destination sessions.