### PR TITLE
fix: pin home to 0.5.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ git-version = "0.3.9"
 hashbrown = "0.14"
 hex = { version = "0.4.3", default-features = false } # Default features are disabled due to usage in no_std crates
 hmac = { version = "0.12.1", features = ["std"] }
-home = "0.5.9"
+home = "=0.5.9"
 http-types = "2.12.0"
 humantime = "2.1.0"
 itertools = "0.13.0"


### PR DESCRIPTION
0.5.11 requires rustc 1.81 so we pin the dependency to the latest one working with the 1.70 series.

Fixes https://github.com/eclipse-zenoh/zenoh/actions/runs/12369352118/job/34522022150