### PR TITLE
Switch to another markdown lint CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,12 +190,11 @@ jobs:
   markdown_lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: articulate/actions-markdownlint@v1
+      - uses: actions/checkout@v4
+      - uses: DavidAnson/markdownlint-cli2-action@v18
         with:
-          config: .markdownlint.yaml
-          files: '*.md'
-          ignore: target
-          version: 0.28.1
+          config: '.markdownlint.yaml'
+          globs: '**/README.md'
 
   # NOTE: In GitHub repository settings, the "Require status checks to pass
   # before merging" branch protection rule ensures that commits are only merged
@@ -205,7 +204,7 @@ jobs:
   ci:
     name: CI status checks
     runs-on: ubuntu-latest
-    needs: [check, test, valgrind, typos]
+    needs: [check, test, valgrind, typos, markdown_lint]
     if: always()
     steps:
       - name: Check whether all jobs pass


### PR DESCRIPTION
I just found https://github.com/articulate/actions-markdownlint is not maintained anymore.
The PR is
1. Switch another action https://github.com/DavidAnson/markdownlint-cli2-action
2. Also add markdown_lint to CI `needs`
