### PR TITLE
Add gossip_target configuration option

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -151,6 +151,11 @@
       /// It mostly makes sense when using "linkstate" routing mode where all nodes in the subsystem don't have
       /// direct connectivity with each other.
       multihop: false,
+      /// Which type of Zenoh instances to send gossip messages to.
+      /// Accepts a single value (e.g. target: ["router", "peer"]) which applies whatever the configured "mode" is,
+      /// or different values for router, peer or client mode (e.g. target: { router: ["router", "peer"], peer: ["router"] }).
+      /// Each value is a list of: "peer", "router" and/or "client".
+      target: { router: ["router", "peer"], peer: ["router", "peer"]},
       /// Which type of Zenoh instances to automatically establish sessions with upon discovery on gossip.
       /// Accepts a single value (e.g. autoconnect: ["router", "peer"]) which applies whatever the configured "mode" is,
       /// or different values for router, peer or client mode (e.g. autoconnect: { router: [], peer: ["router", "peer"] }).

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -185,7 +185,8 @@
       /// When set to true a router will forward data between two peers
       /// directly connected to it if it detects that those peers are not
       /// connected to each other.
-      /// The failover brokering only works if gossip discovery is enabled.
+      /// The failover brokering only works if gossip discovery is enabled
+      /// and peers are configured with gossip target "router".
       peers_failover_brokering: true,
     },
     /// The routing strategy to use in peers and it's configuration.

--- a/commons/zenoh-config/src/defaults.rs
+++ b/commons/zenoh-config/src/defaults.rs
@@ -95,6 +95,15 @@ pub mod scouting {
     pub mod gossip {
         pub const enabled: bool = true;
         pub const multihop: bool = false;
+        pub mod target {
+            pub const router: &crate::WhatAmIMatcher = // "router|peer"
+                &crate::WhatAmIMatcher::empty().router().peer();
+            pub const peer: &crate::WhatAmIMatcher = // "router|peer"
+                &crate::WhatAmIMatcher::empty().router().peer();
+            pub const client: &crate::WhatAmIMatcher = // ""
+                &crate::WhatAmIMatcher::empty();
+            mode_accessor!(crate::WhatAmIMatcher);
+        }
         pub mod autoconnect {
             pub const router: &crate::WhatAmIMatcher = // ""
                 &crate::WhatAmIMatcher::empty();

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -315,6 +315,8 @@ validated_struct::validator! {
                 /// It mostly makes sense when using "linkstate" routing mode where all nodes in the subsystem don't have
                 /// direct connectivity with each other.
                 multihop: Option<bool>,
+                /// Which type of Zenoh instances to send gossip messages to.
+                target: Option<ModeDependentValue<WhatAmIMatcher>>,
                 /// Which type of Zenoh instances to automatically establish sessions with upon discovery through gossip.
                 autoconnect: Option<ModeDependentValue<WhatAmIMatcher>>,
             },

--- a/zenoh/src/net/routing/hat/client/mod.rs
+++ b/zenoh/src/net/routing/hat/client/mod.rs
@@ -84,7 +84,9 @@ impl HatTables {
 pub(crate) struct HatCode {}
 
 impl HatBaseTrait for HatCode {
-    fn init(&self, _tables: &mut Tables, _runtime: Runtime) {}
+    fn init(&self, _tables: &mut Tables, _runtime: Runtime) -> ZResult<()> {
+        Ok(())
+    }
 
     fn new_tables(&self, _router_peers_failover_brokering: bool) -> Box<dyn Any + Send + Sync> {
         Box::new(HatTables::new())

--- a/zenoh/src/net/routing/hat/linkstate_peer/mod.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/mod.rs
@@ -179,13 +179,16 @@ impl HatTables {
 pub(crate) struct HatCode {}
 
 impl HatBaseTrait for HatCode {
-    fn init(&self, tables: &mut Tables, runtime: Runtime) {
+    fn init(&self, tables: &mut Tables, runtime: Runtime) -> ZResult<()> {
         let config_guard = runtime.config().lock();
         let config = &config_guard.0;
         let whatami = tables.whatami;
         let gossip = unwrap_or_default!(config.scouting().gossip().enabled());
         let gossip_multihop = unwrap_or_default!(config.scouting().gossip().multihop());
         let gossip_target = *unwrap_or_default!(config.scouting().gossip().target().get(whatami));
+        if gossip_target.matches(WhatAmI::Client) {
+            bail!("\"client\" is not allowed as gossip target")
+        }
         let autoconnect = if gossip {
             *unwrap_or_default!(config.scouting().gossip().autoconnect().get(whatami))
         } else {
@@ -209,6 +212,7 @@ impl HatBaseTrait for HatCode {
             gossip_target,
             autoconnect,
         ));
+        Ok(())
     }
 
     fn new_tables(&self, _router_peers_failover_brokering: bool) -> Box<dyn Any + Send + Sync> {

--- a/zenoh/src/net/routing/hat/linkstate_peer/mod.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/mod.rs
@@ -185,6 +185,7 @@ impl HatBaseTrait for HatCode {
         let whatami = tables.whatami;
         let gossip = unwrap_or_default!(config.scouting().gossip().enabled());
         let gossip_multihop = unwrap_or_default!(config.scouting().gossip().multihop());
+        let gossip_target = *unwrap_or_default!(config.scouting().gossip().target().get(whatami));
         let autoconnect = if gossip {
             *unwrap_or_default!(config.scouting().gossip().autoconnect().get(whatami))
         } else {
@@ -205,6 +206,7 @@ impl HatBaseTrait for HatCode {
             router_peers_failover_brokering,
             gossip,
             gossip_multihop,
+            gossip_target,
             autoconnect,
         ));
     }

--- a/zenoh/src/net/routing/hat/mod.rs
+++ b/zenoh/src/net/routing/hat/mod.rs
@@ -78,7 +78,7 @@ pub(crate) trait HatTrait:
 }
 
 pub(crate) trait HatBaseTrait {
-    fn init(&self, tables: &mut Tables, runtime: Runtime);
+    fn init(&self, tables: &mut Tables, runtime: Runtime) -> ZResult<()>;
 
     fn new_tables(&self, router_peers_failover_brokering: bool) -> Box<dyn Any + Send + Sync>;
 

--- a/zenoh/src/net/routing/hat/p2p_peer/gossip.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/gossip.rs
@@ -96,7 +96,7 @@ pub(super) struct Network {
     pub(super) router_peers_failover_brokering: bool,
     pub(super) gossip: bool,
     pub(super) gossip_multihop: bool,
-    pub(super) target: WhatAmIMatcher,
+    pub(super) gossip_target: WhatAmIMatcher,
     pub(super) autoconnect: WhatAmIMatcher,
     pub(super) wait_declares: bool,
     pub(super) idx: NodeIndex,
@@ -114,7 +114,7 @@ impl Network {
         router_peers_failover_brokering: bool,
         gossip: bool,
         gossip_multihop: bool,
-        target: WhatAmIMatcher,
+        gossip_target: WhatAmIMatcher,
         autoconnect: WhatAmIMatcher,
         wait_declares: bool,
     ) -> Self {
@@ -132,7 +132,7 @@ impl Network {
             router_peers_failover_brokering,
             gossip,
             gossip_multihop,
-            target,
+            gossip_target,
             autoconnect,
             wait_declares,
             idx,
@@ -236,7 +236,7 @@ impl Network {
     fn send_on_link(&self, idxs: Vec<(NodeIndex, Details)>, transport: &TransportUnicast) {
         if transport
             .get_whatami()
-            .is_ok_and(|w| self.target.matches(w))
+            .is_ok_and(|w| self.gossip_target.matches(w))
         {
             if let Ok(msg) = self.make_msg(idxs) {
                 tracing::trace!("{} Send to {:?} {:?}", self.name, transport.get_zid(), msg);
@@ -258,7 +258,7 @@ impl Network {
                 if link
                     .transport
                     .get_whatami()
-                    .is_ok_and(|w| self.target.matches(w))
+                    .is_ok_and(|w| self.gossip_target.matches(w))
                     && parameters(link)
                 {
                     tracing::trace!("{} Send to {} {:?}", self.name, link.zid, msg);

--- a/zenoh/src/net/routing/hat/p2p_peer/gossip.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/gossip.rs
@@ -96,6 +96,7 @@ pub(super) struct Network {
     pub(super) router_peers_failover_brokering: bool,
     pub(super) gossip: bool,
     pub(super) gossip_multihop: bool,
+    pub(super) target: WhatAmIMatcher,
     pub(super) autoconnect: WhatAmIMatcher,
     pub(super) wait_declares: bool,
     pub(super) idx: NodeIndex,
@@ -113,6 +114,7 @@ impl Network {
         router_peers_failover_brokering: bool,
         gossip: bool,
         gossip_multihop: bool,
+        target: WhatAmIMatcher,
         autoconnect: WhatAmIMatcher,
         wait_declares: bool,
     ) -> Self {
@@ -130,6 +132,7 @@ impl Network {
             router_peers_failover_brokering,
             gossip,
             gossip_multihop,
+            target,
             autoconnect,
             wait_declares,
             idx,
@@ -231,13 +234,18 @@ impl Network {
     }
 
     fn send_on_link(&self, idxs: Vec<(NodeIndex, Details)>, transport: &TransportUnicast) {
-        if let Ok(msg) = self.make_msg(idxs) {
-            tracing::trace!("{} Send to {:?} {:?}", self.name, transport.get_zid(), msg);
-            if let Err(e) = transport.schedule(msg) {
-                tracing::debug!("{} Error sending LinkStateList: {}", self.name, e);
+        if transport
+            .get_whatami()
+            .is_ok_and(|w| self.target.matches(w))
+        {
+            if let Ok(msg) = self.make_msg(idxs) {
+                tracing::trace!("{} Send to {:?} {:?}", self.name, transport.get_zid(), msg);
+                if let Err(e) = transport.schedule(msg) {
+                    tracing::debug!("{} Error sending LinkStateList: {}", self.name, e);
+                }
+            } else {
+                tracing::error!("Failed to encode Linkstate message");
             }
-        } else {
-            tracing::error!("Failed to encode Linkstate message");
         }
     }
 
@@ -247,7 +255,12 @@ impl Network {
     {
         if let Ok(msg) = self.make_msg(idxs) {
             for link in self.links.values() {
-                if parameters(link) {
+                if link
+                    .transport
+                    .get_whatami()
+                    .is_ok_and(|w| self.target.matches(w))
+                    && parameters(link)
+                {
                     tracing::trace!("{} Send to {} {:?}", self.name, link.zid, msg);
                     if let Err(e) = link.transport.schedule(msg.clone()) {
                         tracing::debug!("{} Error sending LinkStateList: {}", self.name, e);

--- a/zenoh/src/net/routing/hat/p2p_peer/mod.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/mod.rs
@@ -115,6 +115,11 @@ impl HatBaseTrait for HatCode {
         let whatami = tables.whatami;
         let gossip = unwrap_or_default!(config.scouting().gossip().enabled());
         let gossip_multihop = unwrap_or_default!(config.scouting().gossip().multihop());
+        let gossip_target = if gossip {
+            *unwrap_or_default!(config.scouting().gossip().target().get(whatami))
+        } else {
+            WhatAmIMatcher::empty()
+        };
         let autoconnect = if gossip {
             *unwrap_or_default!(config.scouting().gossip().autoconnect().get(whatami))
         } else {
@@ -133,6 +138,7 @@ impl HatBaseTrait for HatCode {
                 router_peers_failover_brokering,
                 gossip,
                 gossip_multihop,
+                gossip_target,
                 autoconnect,
                 wait_declares,
             ));

--- a/zenoh/src/net/routing/hat/p2p_peer/mod.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/mod.rs
@@ -115,11 +115,7 @@ impl HatBaseTrait for HatCode {
         let whatami = tables.whatami;
         let gossip = unwrap_or_default!(config.scouting().gossip().enabled());
         let gossip_multihop = unwrap_or_default!(config.scouting().gossip().multihop());
-        let gossip_target = if gossip {
-            *unwrap_or_default!(config.scouting().gossip().target().get(whatami))
-        } else {
-            WhatAmIMatcher::empty()
-        };
+        let gossip_target = *unwrap_or_default!(config.scouting().gossip().target().get(whatami));
         let autoconnect = if gossip {
             *unwrap_or_default!(config.scouting().gossip().autoconnect().get(whatami))
         } else {

--- a/zenoh/src/net/routing/hat/router/mod.rs
+++ b/zenoh/src/net/routing/hat/router/mod.rs
@@ -306,13 +306,16 @@ impl HatTables {
 pub(crate) struct HatCode {}
 
 impl HatBaseTrait for HatCode {
-    fn init(&self, tables: &mut Tables, runtime: Runtime) {
+    fn init(&self, tables: &mut Tables, runtime: Runtime) -> ZResult<()> {
         let config_guard = runtime.config().lock();
         let config = &config_guard.0;
         let whatami = tables.whatami;
         let gossip = unwrap_or_default!(config.scouting().gossip().enabled());
         let gossip_multihop = unwrap_or_default!(config.scouting().gossip().multihop());
         let gossip_target = *unwrap_or_default!(config.scouting().gossip().target().get(whatami));
+        if gossip_target.matches(WhatAmI::Client) {
+            bail!("\"client\" is not allowed as gossip target")
+        }
         let autoconnect = if gossip {
             *unwrap_or_default!(config.scouting().gossip().autoconnect().get(whatami))
         } else {
@@ -358,6 +361,7 @@ impl HatBaseTrait for HatCode {
                 hat!(tables).linkstatepeers_net.as_ref().unwrap(),
             );
         }
+        Ok(())
     }
 
     fn new_tables(&self, router_peers_failover_brokering: bool) -> Box<dyn Any + Send + Sync> {

--- a/zenoh/src/net/routing/hat/router/mod.rs
+++ b/zenoh/src/net/routing/hat/router/mod.rs
@@ -312,6 +312,7 @@ impl HatBaseTrait for HatCode {
         let whatami = tables.whatami;
         let gossip = unwrap_or_default!(config.scouting().gossip().enabled());
         let gossip_multihop = unwrap_or_default!(config.scouting().gossip().multihop());
+        let gossip_target = *unwrap_or_default!(config.scouting().gossip().target().get(whatami));
         let autoconnect = if gossip {
             *unwrap_or_default!(config.scouting().gossip().autoconnect().get(whatami))
         } else {
@@ -334,6 +335,7 @@ impl HatBaseTrait for HatCode {
                 router_peers_failover_brokering,
                 gossip,
                 gossip_multihop,
+                gossip_target,
                 autoconnect,
             ));
         }
@@ -346,6 +348,7 @@ impl HatBaseTrait for HatCode {
                 router_peers_failover_brokering,
                 gossip,
                 gossip_multihop,
+                gossip_target,
                 autoconnect,
             ));
         }

--- a/zenoh/src/net/routing/hat/router/network.rs
+++ b/zenoh/src/net/routing/hat/router/network.rs
@@ -39,7 +39,7 @@ use crate::net::{
     runtime::Runtime,
 };
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 struct Details {
     zid: bool,
     locators: bool,
@@ -119,6 +119,7 @@ pub(super) struct Network {
     pub(super) router_peers_failover_brokering: bool,
     pub(super) gossip: bool,
     pub(super) gossip_multihop: bool,
+    pub(super) gossip_target: WhatAmIMatcher,
     pub(super) autoconnect: WhatAmIMatcher,
     pub(super) idx: NodeIndex,
     pub(super) links: VecMap<Link>,
@@ -138,6 +139,7 @@ impl Network {
         router_peers_failover_brokering: bool,
         gossip: bool,
         gossip_multihop: bool,
+        gossip_target: WhatAmIMatcher,
         autoconnect: WhatAmIMatcher,
     ) -> Self {
         let mut graph = petgraph::stable_graph::StableGraph::default();
@@ -155,6 +157,7 @@ impl Network {
             router_peers_failover_brokering,
             gossip,
             gossip_multihop,
+            gossip_target,
             autoconnect,
             idx,
             links: VecMap::new(),
@@ -230,7 +233,7 @@ impl Network {
         idx
     }
 
-    fn make_link_state(&self, idx: NodeIndex, details: Details) -> LinkState {
+    fn make_link_state(&self, idx: NodeIndex, details: &Details) -> LinkState {
         let links = if details.links {
             self.graph[idx]
                 .links
@@ -273,10 +276,10 @@ impl Network {
         }
     }
 
-    fn make_msg(&self, idxs: Vec<(NodeIndex, Details)>) -> Result<NetworkMessage, DidntWrite> {
+    fn make_msg(&self, idxs: &Vec<(NodeIndex, Details)>) -> Result<NetworkMessage, DidntWrite> {
         let mut link_states = vec![];
         for (idx, details) in idxs {
-            link_states.push(self.make_link_state(idx, details));
+            link_states.push(self.make_link_state(*idx, details));
         }
         let codec = Zenoh080Routing::new();
         let mut buf = ZBuf::empty();
@@ -290,8 +293,11 @@ impl Network {
         .into())
     }
 
-    fn send_on_link(&self, idxs: Vec<(NodeIndex, Details)>, transport: &TransportUnicast) {
-        if let Ok(msg) = self.make_msg(idxs) {
+    fn send_on_link(&self, mut idxs: Vec<(NodeIndex, Details)>, transport: &TransportUnicast) {
+        for idx in &mut idxs {
+            idx.1.locators = self.propagate_locators(idx.0, transport);
+        }
+        if let Ok(msg) = self.make_msg(&idxs) {
             tracing::trace!("{} Send to {:?} {:?}", self.name, transport.get_zid(), msg);
             if let Err(e) = transport.schedule(msg) {
                 tracing::debug!("{} Error sending LinkStateList: {}", self.name, e);
@@ -301,21 +307,24 @@ impl Network {
         }
     }
 
-    fn send_on_links<P>(&self, idxs: Vec<(NodeIndex, Details)>, mut parameters: P)
+    fn send_on_links<P>(&self, mut idxs: Vec<(NodeIndex, Details)>, mut parameters: P)
     where
         P: FnMut(&Link) -> bool,
     {
-        if let Ok(msg) = self.make_msg(idxs) {
-            for link in self.links.values() {
+        for link in self.links.values() {
+            for idx in &mut idxs {
+                idx.1.locators = self.propagate_locators(idx.0, &link.transport);
+            }
+            if let Ok(msg) = self.make_msg(&idxs) {
                 if parameters(link) {
                     tracing::trace!("{} Send to {} {:?}", self.name, link.zid, msg);
                     if let Err(e) = link.transport.schedule(msg.clone()) {
                         tracing::debug!("{} Error sending LinkStateList: {}", self.name, e);
                     }
                 }
+            } else {
+                tracing::error!("Failed to encode Linkstate message");
             }
-        } else {
-            tracing::error!("Failed to encode Linkstate message");
         }
     }
 
@@ -323,8 +332,10 @@ impl Network {
     // from the given node.
     // Returns true if gossip is enabled and if multihop gossip is enabled or
     // the node is one of self neighbours.
-    fn propagate_locators(&self, idx: NodeIndex) -> bool {
+    fn propagate_locators(&self, idx: NodeIndex, target: &TransportUnicast) -> bool {
+        let target_whatami = target.get_whatami().unwrap_or_default();
         self.gossip
+            && self.gossip_target.matches(target_whatami)
             && (self.gossip_multihop
                 || idx == self.idx
                 || self.links.values().any(|link| {
@@ -495,8 +506,8 @@ impl Network {
                                     idx,
                                     Details {
                                         zid: true,
-                                        locators: true,
                                         links: false,
+                                        ..Default::default()
                                     },
                                 )],
                                 |link| link.zid != zid,
@@ -661,20 +672,20 @@ impl Network {
                 Vec<(Vec<ZenohIdProto>, NodeIndex, bool)>,
                 Vec<(Vec<ZenohIdProto>, NodeIndex, bool)>,
             ) = link_states.into_iter().partition(|(_, _, new)| *new);
-            let new_idxs = new_idxs
-                .into_iter()
-                .map(|(_, idx1, _new_node)| {
-                    (
-                        idx1,
-                        Details {
-                            zid: true,
-                            locators: self.propagate_locators(idx1),
-                            links: true,
-                        },
-                    )
-                })
-                .collect::<Vec<(NodeIndex, Details)>>();
             for link in self.links.values() {
+                let new_idxs = new_idxs
+                    .iter()
+                    .map(|(_, idx1, _new_node)| {
+                        (
+                            *idx1,
+                            Details {
+                                zid: true,
+                                links: true,
+                                ..Default::default()
+                            },
+                        )
+                    })
+                    .collect::<Vec<(NodeIndex, Details)>>();
                 if link.zid != src {
                     let updated_idxs: Vec<(NodeIndex, Details)> = updated_idxs
                         .clone()
@@ -685,8 +696,8 @@ impl Network {
                                     idx1,
                                     Details {
                                         zid: false,
-                                        locators: self.propagate_locators(idx1),
                                         links: true,
+                                        ..Default::default()
                                     },
                                 ))
                             } else {
@@ -765,16 +776,16 @@ impl Network {
                                     idx,
                                     Details {
                                         zid: true,
-                                        locators: false,
                                         links: false,
+                                        ..Default::default()
                                     },
                                 ),
                                 (
                                     self.idx,
                                     Details {
                                         zid: false,
-                                        locators: self.propagate_locators(idx),
                                         links: true,
+                                        ..Default::default()
                                     },
                                 ),
                             ]
@@ -783,8 +794,8 @@ impl Network {
                                 self.idx,
                                 Details {
                                     zid: false,
-                                    locators: self.propagate_locators(idx),
                                     links: true,
+                                    ..Default::default()
                                 },
                             )]
                         },
@@ -810,11 +821,11 @@ impl Network {
                     idx,
                     Details {
                         zid: true,
-                        locators: self.propagate_locators(idx),
                         links: self.full_linkstate
                             || (self.router_peers_failover_brokering
                                 && idx == self.idx
                                 && whatami == WhatAmI::Router),
+                        ..Default::default()
                     },
                 )
             })
@@ -844,8 +855,8 @@ impl Network {
                     self.idx,
                     Details {
                         zid: false,
-                        locators: self.gossip,
                         links: true,
+                        ..Default::default()
                     },
                 )],
                 |_| true,
@@ -862,8 +873,8 @@ impl Network {
                         self.idx,
                         Details {
                             zid: false,
-                            locators: self.gossip,
                             links: true,
+                            ..Default::default()
                         },
                     )],
                     |link| {

--- a/zenoh/src/net/routing/router.rs
+++ b/zenoh/src/net/routing/router.rs
@@ -61,7 +61,7 @@ impl Router {
         })
     }
 
-    pub fn init_link_state(&mut self, runtime: Runtime) {
+    pub fn init_link_state(&mut self, runtime: Runtime) -> ZResult<()> {
         let ctrl_lock = zlock!(self.tables.ctrl_lock);
         let mut tables = zwrite!(self.tables.tables);
         tables.runtime = Some(Runtime::downgrade(&runtime));

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -193,7 +193,7 @@ impl RuntimeBuilder {
             }),
         };
         *handler.runtime.write().unwrap() = Runtime::downgrade(&runtime);
-        get_mut_unchecked(&mut runtime.state.router.clone()).init_link_state(runtime.clone());
+        get_mut_unchecked(&mut runtime.state.router.clone()).init_link_state(runtime.clone())?;
 
         // Admin space
         if start_admin_space {


### PR DESCRIPTION
Add gossip_target configuration option.

This options allows to restrain the type of zenoh instances (router, peer) the configured instance sends gossip messages to.
This may typically be used in rmw_zenoh to make peers do gossip with the router but not between each other saving a lot of traffic and computation.
