### PR TITLE
[ Tracing] Add instrumentation support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5609,6 +5609,7 @@ dependencies = [
  "ron",
  "serde",
  "tokio",
+ "tracing",
  "zenoh-macros",
  "zenoh-result",
 ]

--- a/commons/zenoh-core/Cargo.toml
+++ b/commons/zenoh-core/Cargo.toml
@@ -30,6 +30,7 @@ description = "Internal crate for zenoh."
 [features]
 std = []
 default = ["std"]
+tracing-instrument = ["zenoh-runtime/tracing-instrument"]
 
 [dependencies]
 tokio = { workspace = true, features = ["rt"] }

--- a/commons/zenoh-runtime/Cargo.toml
+++ b/commons/zenoh-runtime/Cargo.toml
@@ -13,6 +13,7 @@ description = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+tracing = { workspace = true }
 ron = { workspace = true }
 serde = { workspace = true }
 lazy_static = { workspace = true }

--- a/commons/zenoh-runtime/Cargo.toml
+++ b/commons/zenoh-runtime/Cargo.toml
@@ -12,6 +12,9 @@ description = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+tracing-instrument = []
+
 [dependencies]
 tracing = { workspace = true }
 ron = { workspace = true }

--- a/commons/zenoh-runtime/src/lib.rs
+++ b/commons/zenoh-runtime/src/lib.rs
@@ -33,8 +33,10 @@ use std::{
 
 use lazy_static::lazy_static;
 use serde::Deserialize;
-use tokio::runtime::{Handle, Runtime, RuntimeFlavor};
-use tokio::task::JoinHandle;
+use tokio::{
+    runtime::{Handle, Runtime, RuntimeFlavor},
+    task::JoinHandle,
+};
 use zenoh_macros::{GenericRuntimeParam, RegisterParam};
 use zenoh_result::ZResult as Result;
 
@@ -127,7 +129,7 @@ pub enum ZRuntime {
 
 impl ZRuntime {
     pub fn handle(&self) -> &Handle {
-        ZRUNTIME_POOL.get(&self)
+        ZRUNTIME_POOL.get(self)
     }
 
     pub fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>

--- a/commons/zenoh-task/Cargo.toml
+++ b/commons/zenoh-task/Cargo.toml
@@ -24,6 +24,9 @@ categories = { workspace = true }
 description = "Internal crate for zenoh."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+tracing-instrument = ["zenoh-runtime/tracing-instrument"]
+
 [dependencies]
 tokio = { workspace = true, features = ["default", "sync"] }
 futures = { workspace = true }

--- a/commons/zenoh-task/src/lib.rs
+++ b/commons/zenoh-task/src/lib.rs
@@ -49,6 +49,7 @@ impl TaskController {
         F: Future<Output = T> + Send + 'static,
         T: Send + 'static,
     {
+        #[cfg(feature = "tracing-instrument")]
         let future = tracing::Instrument::instrument(future, tracing::Span::current());
 
         let token = self.token.child_token();
@@ -69,6 +70,7 @@ impl TaskController {
         F: Future<Output = T> + Send + 'static,
         T: Send + 'static,
     {
+        #[cfg(feature = "tracing-instrument")]
         let future = tracing::Instrument::instrument(future, tracing::Span::current());
 
         let token = self.token.child_token();
@@ -78,7 +80,7 @@ impl TaskController {
                 _ = future => {}
             }
         };
-        self.tracker.spawn_on(task, rt.handle())
+        self.tracker.spawn_on(task, &rt)
     }
 
     pub fn get_cancellation_token(&self) -> CancellationToken {
@@ -93,6 +95,7 @@ impl TaskController {
         F: Future<Output = T> + Send + 'static,
         T: Send + 'static,
     {
+        #[cfg(feature = "tracing-instrument")]
         let future = tracing::Instrument::instrument(future, tracing::Span::current());
 
         self.tracker.spawn(future.map(|_f| ()))
@@ -106,9 +109,10 @@ impl TaskController {
         F: Future<Output = T> + Send + 'static,
         T: Send + 'static,
     {
+        #[cfg(feature = "tracing-instrument")]
         let future = tracing::Instrument::instrument(future, tracing::Span::current());
 
-        self.tracker.spawn_on(future.map(|_f| ()), rt.handle())
+        self.tracker.spawn_on(future.map(|_f| ()), &rt)
     }
 
     /// Attempts tp terminate all previously spawned tasks

--- a/commons/zenoh-task/src/lib.rs
+++ b/commons/zenoh-task/src/lib.rs
@@ -49,6 +49,8 @@ impl TaskController {
         F: Future<Output = T> + Send + 'static,
         T: Send + 'static,
     {
+        let future = tracing::Instrument::instrument(future, tracing::Span::current());
+
         let token = self.token.child_token();
         let task = async move {
             tokio::select! {
@@ -56,6 +58,7 @@ impl TaskController {
                 _ = future => {}
             }
         };
+
         self.tracker.spawn(task)
     }
 
@@ -66,6 +69,8 @@ impl TaskController {
         F: Future<Output = T> + Send + 'static,
         T: Send + 'static,
     {
+        let future = tracing::Instrument::instrument(future, tracing::Span::current());
+
         let token = self.token.child_token();
         let task = async move {
             tokio::select! {
@@ -73,7 +78,7 @@ impl TaskController {
                 _ = future => {}
             }
         };
-        self.tracker.spawn_on(task, &rt)
+        self.tracker.spawn_on(task, rt.handle())
     }
 
     pub fn get_cancellation_token(&self) -> CancellationToken {
@@ -88,6 +93,8 @@ impl TaskController {
         F: Future<Output = T> + Send + 'static,
         T: Send + 'static,
     {
+        let future = tracing::Instrument::instrument(future, tracing::Span::current());
+
         self.tracker.spawn(future.map(|_f| ()))
     }
 
@@ -99,7 +106,9 @@ impl TaskController {
         F: Future<Output = T> + Send + 'static,
         T: Send + 'static,
     {
-        self.tracker.spawn_on(future.map(|_f| ()), &rt)
+        let future = tracing::Instrument::instrument(future, tracing::Span::current());
+
+        self.tracker.spawn_on(future.map(|_f| ()), rt.handle())
     }
 
     /// Attempts tp terminate all previously spawned tasks

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -66,6 +66,7 @@ transport_ws = ["zenoh-transport/transport_ws"]
 transport_vsock = ["zenoh-transport/transport_vsock"]
 unstable = ["internal_config", "zenoh-keyexpr/unstable", "zenoh-config/unstable"]
 internal_config = []
+tracing-instrument = ["zenoh-task/tracing-instrument", "zenoh-runtime/tracing-instrument"]
 
 [dependencies]
 tokio = { workspace = true, features = ["rt", "macros", "time"] }


### PR DESCRIPTION
When spawning futures, we lose the original span information.  
This should fix that.  
I tried to capture the obvious spots, but I probably didn't get them all.  