### PR TITLE
Improve lock releases in session establishment

### DIFF
--- a/io/zenoh-transport/src/unicast/establishment/accept.rs
+++ b/io/zenoh-transport/src/unicast/establishment/accept.rs
@@ -356,40 +356,44 @@ impl<'a, 'b: 'a> AcceptFsm for &'a mut AcceptLink<'b> {
             .map_err(|e| (e, Some(close::reason::GENERIC)))?;
 
         // Create the cookie
-        let cookie_nonce: u64 = zasynclock!(self.prng).gen();
-        let cookie = Cookie {
-            zid: input.other_zid,
-            whatami: input.other_whatami,
-            resolution: state.transport.resolution,
-            batch_size: state.transport.batch_size,
-            nonce: cookie_nonce,
-            ext_qos: state.transport.ext_qos,
-            #[cfg(feature = "transport_multilink")]
-            ext_mlink: state.transport.ext_mlink,
-            #[cfg(feature = "shared-memory")]
-            ext_shm: state.transport.ext_shm,
-            #[cfg(feature = "transport_auth")]
-            ext_auth: state.link.ext_auth,
-            ext_lowlatency: state.transport.ext_lowlatency,
-            #[cfg(feature = "transport_compression")]
-            ext_compression: state.link.ext_compression,
-            ext_patch: state.transport.ext_patch,
-        };
+        let (cookie, cookie_nonce): (ZSlice, u64) = {
+            let mut prng = zasynclock!(self.prng);
 
-        let mut encrypted = vec![];
-        let mut writer = encrypted.writer();
-        let mut codec = Zenoh080Cookie {
-            prng: &mut *zasynclock!(self.prng),
-            cipher: self.cipher,
-            codec: Zenoh080::new(),
+            let nonce: u64 = prng.gen();
+            let cookie = Cookie {
+                zid: input.other_zid,
+                whatami: input.other_whatami,
+                resolution: state.transport.resolution,
+                batch_size: state.transport.batch_size,
+                nonce,
+                ext_qos: state.transport.ext_qos,
+                #[cfg(feature = "transport_multilink")]
+                ext_mlink: state.transport.ext_mlink,
+                #[cfg(feature = "shared-memory")]
+                ext_shm: state.transport.ext_shm,
+                #[cfg(feature = "transport_auth")]
+                ext_auth: state.link.ext_auth,
+                ext_lowlatency: state.transport.ext_lowlatency,
+                #[cfg(feature = "transport_compression")]
+                ext_compression: state.link.ext_compression,
+                ext_patch: state.transport.ext_patch,
+            };
+
+            let mut encrypted = vec![];
+            let mut writer = encrypted.writer();
+            let mut codec = Zenoh080Cookie {
+                prng: &mut prng,
+                cipher: self.cipher,
+                codec: Zenoh080::new(),
+            };
+            codec.write(&mut writer, &cookie).map_err(|_| {
+                (
+                    zerror!("Encoding cookie failed").into(),
+                    Some(close::reason::INVALID),
+                )
+            })?;
+            (encrypted.into(), nonce)
         };
-        codec.write(&mut writer, &cookie).map_err(|_| {
-            (
-                zerror!("Encoding cookie failed").into(),
-                Some(close::reason::INVALID),
-            )
-        })?;
-        let cookie: ZSlice = encrypted.into();
 
         // Send the message on the link
         let msg: TransportMessage = InitAck {
@@ -477,8 +481,9 @@ impl<'a, 'b: 'a> AcceptFsm for &'a mut AcceptLink<'b> {
 
         // Decrypt the cookie with the cipher
         let cookie: Cookie = {
+            let mut prng = zasynclock!(self.prng);
             let mut codec = Zenoh080Cookie {
-                prng: &mut *zasynclock!(self.prng),
+                prng: &mut prng,
                 cipher: self.cipher,
                 codec: Zenoh080::new(),
             };
@@ -722,6 +727,9 @@ pub(crate) async fn accept_link(link: LinkUnicast, manager: &TransportManager) -
     let batch_size = manager.config.batch_size.min(batch_size::UNICAST).min(mtu);
 
     let iack_out = {
+        #[cfg(feature = "transport_auth")]
+        let mut prng = zasynclock!(manager.prng);
+
         let mut state = State {
             transport: StateTransport {
                 batch_size,
@@ -743,11 +751,7 @@ pub(crate) async fn accept_link(link: LinkUnicast, manager: &TransportManager) -
             #[cfg(any(feature = "transport_auth", feature = "transport_compression"))]
             link: StateLink {
                 #[cfg(feature = "transport_auth")]
-                ext_auth: manager
-                    .state
-                    .unicast
-                    .authenticator
-                    .accept(&mut *zasynclock!(manager.prng)),
+                ext_auth: manager.state.unicast.authenticator.accept(&mut *prng),
                 #[cfg(feature = "transport_compression")]
                 ext_compression: ext::compression::StateAccept::new(
                     manager.config.unicast.is_compression,

--- a/io/zenoh-transport/src/unicast/universal/transport.rs
+++ b/io/zenoh-transport/src/unicast/universal/transport.rs
@@ -195,7 +195,8 @@ impl TransportUnicastUniversal {
         };
 
         // Notify the callback
-        if let Some(callback) = zread!(self.callback).as_ref() {
+        let cb = zread!(self.callback).clone();
+        if let Some(callback) = cb {
             callback.del_link(link);
         }
 


### PR DESCRIPTION
This PR introduces some early release of locks that where held longer than needed.
Keeping these locks longer than needed didn't show any apparent issue, in any case it's safer to drop them as soon as possible.