### PR TITLE
Scan network interfaces once at startup

### DIFF
--- a/commons/zenoh-util/src/net/mod.rs
+++ b/commons/zenoh-util/src/net/mod.rs
@@ -13,6 +13,8 @@
 //
 use std::net::{IpAddr, Ipv6Addr};
 
+use lazy_static::lazy_static;
+use pnet_datalink::NetworkInterface;
 use tokio::net::{TcpSocket, UdpSocket};
 use zenoh_core::zconfigurable;
 #[cfg(unix)]
@@ -22,6 +24,10 @@ use zenoh_result::{bail, ZResult};
 zconfigurable! {
     static ref WINDOWS_GET_ADAPTERS_ADDRESSES_BUF_SIZE: u32 = 8192;
     static ref WINDOWS_GET_ADAPTERS_ADDRESSES_MAX_RETRIES: u32 = 3;
+}
+
+lazy_static! {
+    static ref IFACES: Vec<NetworkInterface> = pnet_datalink::interfaces();
 }
 
 #[cfg(windows)]
@@ -59,7 +65,7 @@ unsafe fn get_adapters_addresses(af_spec: i32) -> ZResult<Vec<u8>> {
 pub fn get_interface(name: &str) -> ZResult<Option<IpAddr>> {
     #[cfg(unix)]
     {
-        for iface in pnet_datalink::interfaces() {
+        for iface in IFACES.iter() {
             if iface.name == name {
                 for ifaddr in &iface.ips {
                     if ifaddr.is_ipv4() {
@@ -122,7 +128,7 @@ pub fn get_interface(name: &str) -> ZResult<Option<IpAddr>> {
 pub fn get_multicast_interfaces() -> Vec<IpAddr> {
     #[cfg(unix)]
     {
-        pnet_datalink::interfaces()
+        IFACES
             .iter()
             .filter_map(|iface| {
                 if iface.is_up() && iface.is_running() && iface.is_multicast() {
@@ -146,8 +152,8 @@ pub fn get_multicast_interfaces() -> Vec<IpAddr> {
 pub fn get_local_addresses(interface: Option<&str>) -> ZResult<Vec<IpAddr>> {
     #[cfg(unix)]
     {
-        Ok(pnet_datalink::interfaces()
-            .into_iter()
+        Ok(IFACES
+            .iter()
             .filter(|iface| {
                 if let Some(interface) = interface.as_ref() {
                     if iface.name != *interface {
@@ -156,7 +162,7 @@ pub fn get_local_addresses(interface: Option<&str>) -> ZResult<Vec<IpAddr>> {
                 }
                 iface.is_up() && iface.is_running()
             })
-            .flat_map(|iface| iface.ips)
+            .flat_map(|iface| iface.ips.clone())
             .map(|ipnet| ipnet.ip())
             .collect())
     }
@@ -196,7 +202,7 @@ pub fn get_local_addresses(interface: Option<&str>) -> ZResult<Vec<IpAddr>> {
 pub fn get_unicast_addresses_of_multicast_interfaces() -> Vec<IpAddr> {
     #[cfg(unix)]
     {
-        pnet_datalink::interfaces()
+        IFACES
             .iter()
             .filter(|iface| iface.is_up() && iface.is_running() && iface.is_multicast())
             .flat_map(|iface| {
@@ -219,10 +225,7 @@ pub fn get_unicast_addresses_of_multicast_interfaces() -> Vec<IpAddr> {
 pub fn get_unicast_addresses_of_interface(name: &str) -> ZResult<Vec<IpAddr>> {
     #[cfg(unix)]
     {
-        match pnet_datalink::interfaces()
-            .into_iter()
-            .find(|iface| iface.name == name)
-        {
+        match IFACES.iter().find(|iface| iface.name == name) {
             Some(iface) => {
                 if !iface.is_up() {
                     bail!("Interface {name} is not up");
@@ -276,7 +279,7 @@ pub fn get_unicast_addresses_of_interface(name: &str) -> ZResult<Vec<IpAddr>> {
 pub fn get_index_of_interface(addr: IpAddr) -> ZResult<u32> {
     #[cfg(unix)]
     {
-        pnet_datalink::interfaces()
+        IFACES
             .iter()
             .find(|iface| iface.ips.iter().any(|ipnet| ipnet.ip() == addr))
             .map(|iface| iface.index)
@@ -313,12 +316,12 @@ pub fn get_interface_names_by_addr(addr: IpAddr) -> ZResult<Vec<String>> {
     #[cfg(unix)]
     {
         if addr.is_unspecified() {
-            Ok(pnet_datalink::interfaces()
+            Ok(IFACES
                 .iter()
                 .map(|iface| iface.name.clone())
                 .collect::<Vec<String>>())
         } else {
-            Ok(pnet_datalink::interfaces()
+            Ok(IFACES
                 .iter()
                 .filter(|iface| iface.ips.iter().any(|ipnet| ipnet.ip() == addr))
                 .map(|iface| iface.name.clone())

--- a/commons/zenoh-util/src/net/mod.rs
+++ b/commons/zenoh-util/src/net/mod.rs
@@ -13,7 +13,9 @@
 //
 use std::net::{IpAddr, Ipv6Addr};
 
+#[cfg(unix)]
 use lazy_static::lazy_static;
+#[cfg(unix)]
 use pnet_datalink::NetworkInterface;
 use tokio::net::{TcpSocket, UdpSocket};
 use zenoh_core::zconfigurable;
@@ -26,6 +28,7 @@ zconfigurable! {
     static ref WINDOWS_GET_ADAPTERS_ADDRESSES_MAX_RETRIES: u32 = 3;
 }
 
+#[cfg(unix)]
 lazy_static! {
     static ref IFACES: Vec<NetworkInterface> = pnet_datalink::interfaces();
 }


### PR DESCRIPTION
Network interfaces scanning is a costly operation.
It was previously done at each link creation which leaded to significant CPU consumption at startup when lot of links were established.
Network interfaces scanning is now performed once at startup. The result of this initial scan is then used for the whole life of the process.