### PR TITLE
Fix TLS endpoint port propagation in gossip

### DIFF
--- a/io/zenoh-links/zenoh-link-quic/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/unicast.rs
@@ -13,7 +13,7 @@
 //
 
 use std::{
-    fmt,
+    fmt::{self, Debug},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     sync::Arc,
     time::Duration,
@@ -540,7 +540,7 @@ async fn accept_task(
                             }
                         }
 
-                        tracing::debug!("Accepted QUIC connection on {:?}: {:?}", src_addr, dst_addr);
+                        tracing::debug!("Accepted QUIC connection on {:?}: {:?}. {:?}.", src_addr, dst_addr, auth_id);
                         // Create the new link object
                         let link = Arc::<LinkUnicastQuic>::new_cyclic(|weak_link| {
                             let mut expiration_manager = None;
@@ -628,9 +628,19 @@ fn get_cert_chain_expiration(conn: &quinn::Connection) -> ZResult<Option<OffsetD
     Ok(link_expiration)
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 struct QuicAuthId {
     auth_value: Option<String>,
+}
+
+impl Debug for QuicAuthId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Common Name: {}",
+            self.auth_value.as_deref().unwrap_or("None")
+        )
+    }
 }
 
 impl From<QuicAuthId> for LinkAuthId {

--- a/io/zenoh-links/zenoh-link-quic/src/utils.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/utils.rs
@@ -506,6 +506,14 @@ pub async fn get_quic_addr(address: &Address<'_>) -> ZResult<SocketAddr> {
     }
 }
 
+pub fn get_quic_host<'a>(address: &'a Address<'a>) -> ZResult<&'a str> {
+    address
+        .as_str()
+        .split(':')
+        .next()
+        .ok_or_else(|| zerror!("Invalid QUIC address").into())
+}
+
 pub fn base64_decode(data: &str) -> ZResult<Vec<u8>> {
     use base64::{engine::general_purpose, Engine};
     Ok(general_purpose::STANDARD

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -426,7 +426,12 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastTls {
             format!("{host}:{local_port}"),
             endpoint.metadata(),
         )?;
-
+        let endpoint = EndPoint::new(
+            locator.protocol(),
+            locator.address(),
+            locator.metadata(),
+            endpoint.config(),
+        )?;
         self.listeners
             .add_listener(endpoint, local_addr, task, token)
             .await?;

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -11,7 +11,14 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use std::{cell::UnsafeCell, convert::TryInto, fmt, net::SocketAddr, sync::Arc, time::Duration};
+use std::{
+    cell::UnsafeCell,
+    convert::TryInto,
+    fmt::{self, Debug},
+    net::SocketAddr,
+    sync::Arc,
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use time::OffsetDateTime;
@@ -503,7 +510,7 @@ async fn accept_task(
                             }
                         }
 
-                        tracing::debug!("Accepted TLS connection on {:?}: {:?}", src_addr, dst_addr);
+                        tracing::debug!("Accepted TLS connection on {:?}: {:?}. {:?}.", src_addr, dst_addr, auth_identifier);
                         // Create the new link object
                         let link = Arc::<LinkUnicastTls>::new_cyclic(|weak_link| {
                             let mut expiration_manager = None;
@@ -607,9 +614,18 @@ fn get_cert_chain_expiration(
     Ok(link_expiration)
 }
 
-#[derive(Debug)]
 struct TlsAuthId {
     auth_value: Option<String>,
+}
+
+impl Debug for TlsAuthId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Common Name: {}",
+            self.auth_value.as_deref().unwrap_or("None")
+        )
+    }
 }
 
 impl From<TlsAuthId> for LinkAuthId {

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -496,7 +496,7 @@ async fn accept_task(
                             match get_cert_chain_expiration(&tls_conn.peer_certificates())? {
                                 exp @ Some(_) => maybe_expiration_time = exp,
                                 None => tracing::warn!(
-                                    "Cannot monitor expiration for TLS link {:?} => {:?} : client does not have certificates",
+                                    "Cannot monitor expiration for TLS link {:?} => {:?}: client does not have certificates",
                                     src_addr,
                                     dst_addr,
                                 ),
@@ -607,6 +607,7 @@ fn get_cert_chain_expiration(
     Ok(link_expiration)
 }
 
+#[derive(Debug)]
 struct TlsAuthId {
     auth_value: Option<String>,
 }


### PR DESCRIPTION
Properly store the TLS listener locator and endpoint as returned by the OS upon socket opening.