### PR TITLE
removed unnecessary feature from zenoh-plugin-trait to avoid false compatibility errors

### DIFF
--- a/plugins/zenoh-plugin-trait/Cargo.toml
+++ b/plugins/zenoh-plugin-trait/Cargo.toml
@@ -23,9 +23,6 @@ license = { workspace = true }
 categories = { workspace = true }
 description = { workspace = true }
 
-[features]
-default = []
-
 [lib]
 name = "zenoh_plugin_trait"
 

--- a/plugins/zenoh-plugin-trait/src/lib.rs
+++ b/plugins/zenoh-plugin-trait/src/lib.rs
@@ -47,10 +47,6 @@ pub use plugin::{
     PluginStartArgs, PluginState, PluginStatus, PluginStatusRec,
 };
 pub use vtable::{PluginLoaderVersion, PluginVTable, PLUGIN_LOADER_VERSION};
-use zenoh_util::concat_enabled_features;
-
-pub const FEATURES: &str =
-    concat_enabled_features!(prefix = "zenoh-plugin-trait", features = ["default"]);
 
 #[doc(hidden)]
 pub mod export {

--- a/plugins/zenoh-plugin-trait/src/vtable.rs
+++ b/plugins/zenoh-plugin-trait/src/vtable.rs
@@ -13,7 +13,7 @@
 //
 use zenoh_result::ZResult;
 
-use crate::{Plugin, StructVersion, FEATURES};
+use crate::{Plugin, StructVersion};
 
 pub type PluginLoaderVersion = u64;
 pub const PLUGIN_LOADER_VERSION: PluginLoaderVersion = 1;
@@ -31,7 +31,7 @@ impl<StartArgs, Instance> StructVersion for PluginVTable<StartArgs, Instance> {
         1
     }
     fn struct_features() -> &'static str {
-        FEATURES
+        ""
     }
 }
 


### PR DESCRIPTION
The "default" feature in the crate is dummy, but it causes plugin incompatibility diagnostic if plugin is built without "default-features = false" for this crate. Better to remove it to avoid such failures

This problem causes plugin incompatibility for zehoh-ts. It can be fixed on zenoh-ts level, but better to fix the root cause