### PR TITLE
Use client multicast autoconnect config

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -137,7 +137,7 @@
       /// Accepts a single value (e.g. autoconnect: ["router", "peer"]) which applies whatever the configured "mode" is,
       /// or different values for router, peer or client mode (e.g. autoconnect: { router: [], peer: ["router", "peer"] }).
       /// Each value is a list of: "peer", "router" and/or "client".
-      autoconnect: { router: [], peer: ["router", "peer"], client: ["router", "peer"] },
+      autoconnect: { router: [], peer: ["router", "peer"], client: ["router"] },
       /// Whether or not to listen for scout messages on UDP multicast and reply to them.
       listen: true,
     },

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -141,7 +141,7 @@
       /// Whether or not to listen for scout messages on UDP multicast and reply to them.
       listen: true,
     },
-    /// The gossip scouting configuration.
+    /// The gossip scouting configuration. Note that instances in "client" mode do not participate in gossip.
     gossip: {
       /// Whether gossip scouting is enabled or not
       enabled: true,
@@ -153,14 +153,14 @@
       multihop: false,
       /// Which type of Zenoh instances to send gossip messages to.
       /// Accepts a single value (e.g. target: ["router", "peer"]) which applies whatever the configured "mode" is,
-      /// or different values for router, peer or client mode (e.g. target: { router: ["router", "peer"], peer: ["router"] }).
-      /// Each value is a list of: "peer", "router" and/or "client".
+      /// or different values for router or peer mode (e.g. target: { router: ["router", "peer"], peer: ["router"] }).
+      /// Each value is a list of "peer" and/or "router".
       target: { router: ["router", "peer"], peer: ["router", "peer"]},
       /// Which type of Zenoh instances to automatically establish sessions with upon discovery on gossip.
       /// Accepts a single value (e.g. autoconnect: ["router", "peer"]) which applies whatever the configured "mode" is,
-      /// or different values for router, peer or client mode (e.g. autoconnect: { router: [], peer: ["router", "peer"] }).
-      /// Each value is a list of: "peer", "router" and/or "client".
-      autoconnect: { router: [], peer: ["router", "peer"], client: ["router", "peer"] },
+      /// or different values for router or peer mode (e.g. autoconnect: { router: [], peer: ["router", "peer"] }).
+      /// Each value is a list of: "peer" and/or "router".
+      autoconnect: { router: [], peer: ["router", "peer"] },
     },
   },
 

--- a/commons/zenoh-config/src/defaults.rs
+++ b/commons/zenoh-config/src/defaults.rs
@@ -81,8 +81,8 @@ pub mod scouting {
                 &crate::WhatAmIMatcher::empty();
             pub const peer: &crate::WhatAmIMatcher = // "router|peer"
                 &crate::WhatAmIMatcher::empty().router().peer();
-            pub const client: &crate::WhatAmIMatcher = // "router|peer"
-                &crate::WhatAmIMatcher::empty().router().peer();
+            pub const client: &crate::WhatAmIMatcher = // "router"
+                &crate::WhatAmIMatcher::empty().router();
             mode_accessor!(crate::WhatAmIMatcher);
         }
         pub mod listen {

--- a/commons/zenoh-config/src/defaults.rs
+++ b/commons/zenoh-config/src/defaults.rs
@@ -109,8 +109,8 @@ pub mod scouting {
                 &crate::WhatAmIMatcher::empty();
             pub const peer: &crate::WhatAmIMatcher = // "router|peer"
                 &crate::WhatAmIMatcher::empty().router().peer();
-            pub const client: &crate::WhatAmIMatcher = // "router|peer"
-                &crate::WhatAmIMatcher::empty().router().peer();
+            pub const client: &crate::WhatAmIMatcher = // ""
+                &crate::WhatAmIMatcher::empty();
             mode_accessor!(crate::WhatAmIMatcher);
         }
     }


### PR DESCRIPTION
Clients were hardcoded to autoconnect to routers through multicast scouting. This PR makes clients use the autoconnect config, and updates default config to autoconnect to routers to maintain the current client behavior.

While on the subject, this PR removes all mention of clients in gossip config (since they do not participate to gossip).