### PR TITLE
refactor: lazily compute the push body

### DIFF
--- a/zenoh/src/net/routing/dispatcher/pubsub.rs
+++ b/zenoh/src/net/routing/dispatcher/pubsub.rs
@@ -410,10 +410,8 @@ pub fn route_data(
                             drop(tables);
                             #[cfg(feature = "stats")]
                             if !admin {
-                                inc_stats!(face, rx, user, payload);
                                 inc_stats!(outface, tx, user, payload);
                             } else {
-                                inc_stats!(face, rx, admin, payload);
                                 inc_stats!(outface, tx, admin, payload);
                             }
 

--- a/zenoh/src/net/routing/dispatcher/pubsub.rs
+++ b/zenoh/src/net/routing/dispatcher/pubsub.rs
@@ -353,6 +353,9 @@ macro_rules! inc_stats {
     };
 }
 
+// having all the arguments instead of an intermediate struct seems to enable a better inlining
+// see https://github.com/eclipse-zenoh/zenoh/pull/1713#issuecomment-2590130026
+#[allow(clippy::too_many_arguments)]
 pub fn route_data(
     tables_ref: &Arc<TablesLock>,
     face: &FaceState,


### PR DESCRIPTION
It allows to optimize the local workflow, as it remove all the memmove caused by the body computation if there is no remote route.

Credit to @yellowhatter for the original PR #1599 