### PR TITLE
ci: rustfmt all files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         uses: taiki-e/install-action@cargo-semver-checks
 
       - name: Code format check
-        run: cargo fmt --check -- --config "unstable_features=true,imports_granularity=Crate,group_imports=StdExternalCrate"
+        run: rustfmt --check --config "unstable_features=true,imports_granularity=Crate,group_imports=StdExternalCrate,skip_children=true" $(git ls-files '*.rs')
 
       - name: Clippy zenoh no-default-features
         run: cargo +stable clippy -p zenoh --all-targets --no-default-features -- --deny warnings
@@ -186,7 +186,7 @@ jobs:
 
       - name: Check spelling
         uses: crate-ci/typos@master
-  
+
   markdown_lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -53,7 +53,7 @@ jobs:
         run: rustup component add rustfmt clippy
 
       - name: Code format check
-        run: cargo fmt --check -- --config "unstable_features=true,imports_granularity=Crate,group_imports=StdExternalCrate"
+        run: rustfmt --check --config "unstable_features=true,imports_granularity=Crate,group_imports=StdExternalCrate,skip_children=true" $(git ls-files '*.rs')
         env:
           CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,6 @@ repos:
     hooks:
       - id: fmt
         name: fmt
-        entry: cargo fmt -- --config "unstable_features=true,imports_granularity=Crate,group_imports=StdExternalCrate"
+        entry: rustfmt --config "unstable_features=true,imports_granularity=Crate,group_imports=StdExternalCrate,skip_children=true" $(git ls-files '*.rs')
         language: system
         types: [rust]

--- a/commons/zenoh-buffers/src/slice.rs
+++ b/commons/zenoh-buffers/src/slice.rs
@@ -43,7 +43,10 @@ impl Buffer for &mut [u8] {
 
 // SplitBuffer
 impl<'b> SplitBuffer for &'b [u8] {
-    type Slices<'a> = option::IntoIter<&'a [u8]> where 'b: 'a;
+    type Slices<'a>
+        = option::IntoIter<&'a [u8]>
+    where
+        'b: 'a;
 
     fn slices(&self) -> Self::Slices<'_> {
         Some(*self).into_iter()

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/impls/hashmap_impl.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/impls/hashmap_impl.rs
@@ -87,9 +87,19 @@ impl<T: HasChunk + AsNode<T> + AsNodeMut<T> + 'static, S: core::hash::BuildHashe
     }
 
     #[cfg(feature = "std")]
-    type Entry<'a, 'b> = Entry<'a, OwnedKeyExpr, T> where Self: 'a, 'a: 'b, T: 'b;
+    type Entry<'a, 'b>
+        = Entry<'a, OwnedKeyExpr, T>
+    where
+        Self: 'a,
+        'a: 'b,
+        T: 'b;
     #[cfg(not(feature = "std"))]
-    type Entry<'a, 'b> = Entry<'a, OwnedKeyExpr, T, S> where Self: 'a, 'a: 'b, T: 'b;
+    type Entry<'a, 'b>
+        = Entry<'a, OwnedKeyExpr, T, S>
+    where
+        Self: 'a,
+        'a: 'b,
+        T: 'b;
     fn entry<'a, 'b>(&'a mut self, chunk: &'b keyexpr) -> Self::Entry<'a, 'b>
     where
         Self: 'a,
@@ -99,7 +109,10 @@ impl<T: HasChunk + AsNode<T> + AsNodeMut<T> + 'static, S: core::hash::BuildHashe
         self.entry(chunk.into())
     }
 
-    type Iter<'a> = Values<'a, OwnedKeyExpr, T> where Self: 'a;
+    type Iter<'a>
+        = Values<'a, OwnedKeyExpr, T>
+    where
+        Self: 'a;
     fn children<'a>(&'a self) -> Self::Iter<'a>
     where
         Self: 'a,
@@ -107,9 +120,10 @@ impl<T: HasChunk + AsNode<T> + AsNodeMut<T> + 'static, S: core::hash::BuildHashe
         self.values()
     }
 
-    type IterMut<'a> = ValuesMut<'a, OwnedKeyExpr, T>
-where
-    Self: 'a;
+    type IterMut<'a>
+        = ValuesMut<'a, OwnedKeyExpr, T>
+    where
+        Self: 'a;
 
     fn children_mut<'a>(&'a mut self) -> Self::IterMut<'a>
     where
@@ -122,28 +136,32 @@ where
         self.retain(|_, v| predicate(v));
     }
 
-    type Intersection<'a> = super::FilterMap<Iter<'a, OwnedKeyExpr, T>, super::Intersection<'a>>
+    type Intersection<'a>
+        = super::FilterMap<Iter<'a, OwnedKeyExpr, T>, super::Intersection<'a>>
     where
         Self: 'a,
         Self::Node: 'a;
     fn intersection<'a>(&'a self, key: &'a keyexpr) -> Self::Intersection<'a> {
         super::FilterMap::new(self.iter(), super::Intersection(key))
     }
-    type IntersectionMut<'a> = super::FilterMap<IterMut<'a, OwnedKeyExpr, T>, super::Intersection<'a>>
+    type IntersectionMut<'a>
+        = super::FilterMap<IterMut<'a, OwnedKeyExpr, T>, super::Intersection<'a>>
     where
         Self: 'a,
         Self::Node: 'a;
     fn intersection_mut<'a>(&'a mut self, key: &'a keyexpr) -> Self::IntersectionMut<'a> {
         super::FilterMap::new(self.iter_mut(), super::Intersection(key))
     }
-    type Inclusion<'a> = super::FilterMap<Iter<'a, OwnedKeyExpr, T>, super::Inclusion<'a>>
+    type Inclusion<'a>
+        = super::FilterMap<Iter<'a, OwnedKeyExpr, T>, super::Inclusion<'a>>
     where
         Self: 'a,
         Self::Node: 'a;
     fn inclusion<'a>(&'a self, key: &'a keyexpr) -> Self::Inclusion<'a> {
         super::FilterMap::new(self.iter(), super::Inclusion(key))
     }
-    type InclusionMut<'a> = super::FilterMap<IterMut<'a, OwnedKeyExpr, T>, super::Inclusion<'a>>
+    type InclusionMut<'a>
+        = super::FilterMap<IterMut<'a, OwnedKeyExpr, T>, super::Inclusion<'a>>
     where
         Self: 'a,
         Self::Node: 'a;

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/impls/keyed_set_impl.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/impls/keyed_set_impl.rs
@@ -65,7 +65,12 @@ impl<T: HasChunk + AsNode<T> + AsNodeMut<T>> IChildren<T> for KeyedSet<T, ChunkE
     fn is_empty(&self) -> bool {
         self.is_empty()
     }
-    type Entry<'a, 'b> = keyed_set::Entry<'a, T, ChunkExtractor, &'b keyexpr> where Self: 'a, 'a: 'b, T: 'b;
+    type Entry<'a, 'b>
+        = keyed_set::Entry<'a, T, ChunkExtractor, &'b keyexpr>
+    where
+        Self: 'a,
+        'a: 'b,
+        T: 'b;
     fn entry<'a, 'b>(&'a mut self, chunk: &'b keyexpr) -> Self::Entry<'a, 'b>
     where
         Self: 'a,
@@ -75,7 +80,10 @@ impl<T: HasChunk + AsNode<T> + AsNodeMut<T>> IChildren<T> for KeyedSet<T, ChunkE
         self.entry(chunk)
     }
 
-    type Iter<'a> = keyed_set::Iter<'a, T> where Self: 'a;
+    type Iter<'a>
+        = keyed_set::Iter<'a, T>
+    where
+        Self: 'a;
     fn children<'a>(&'a self) -> Self::Iter<'a>
     where
         Self: 'a,
@@ -83,9 +91,10 @@ impl<T: HasChunk + AsNode<T> + AsNodeMut<T>> IChildren<T> for KeyedSet<T, ChunkE
         self.iter()
     }
 
-    type IterMut<'a> = keyed_set::IterMut<'a, T>
-where
-    Self: 'a;
+    type IterMut<'a>
+        = keyed_set::IterMut<'a, T>
+    where
+        Self: 'a;
 
     fn children_mut<'a>(&'a mut self) -> Self::IterMut<'a>
     where
@@ -98,28 +107,32 @@ where
         self.drain_where(predicate);
     }
 
-    type Intersection<'a> = super::FilterMap<keyed_set::Iter<'a, T>, super::Intersection<'a>>
+    type Intersection<'a>
+        = super::FilterMap<keyed_set::Iter<'a, T>, super::Intersection<'a>>
     where
         Self: 'a,
         Self::Node: 'a;
     fn intersection<'a>(&'a self, key: &'a keyexpr) -> Self::Intersection<'a> {
         super::FilterMap::new(self.iter(), super::Intersection(key))
     }
-    type IntersectionMut<'a> = super::FilterMap<keyed_set::IterMut<'a, T>, super::Intersection<'a>>
+    type IntersectionMut<'a>
+        = super::FilterMap<keyed_set::IterMut<'a, T>, super::Intersection<'a>>
     where
         Self: 'a,
         Self::Node: 'a;
     fn intersection_mut<'a>(&'a mut self, key: &'a keyexpr) -> Self::IntersectionMut<'a> {
         super::FilterMap::new(self.iter_mut(), super::Intersection(key))
     }
-    type Inclusion<'a> = super::FilterMap<keyed_set::Iter<'a, T>, super::Inclusion<'a>>
+    type Inclusion<'a>
+        = super::FilterMap<keyed_set::Iter<'a, T>, super::Inclusion<'a>>
     where
         Self: 'a,
         Self::Node: 'a;
     fn inclusion<'a>(&'a self, key: &'a keyexpr) -> Self::Inclusion<'a> {
         super::FilterMap::new(self.iter(), super::Inclusion(key))
     }
-    type InclusionMut<'a> = super::FilterMap<keyed_set::IterMut<'a, T>, super::Inclusion<'a>>
+    type InclusionMut<'a>
+        = super::FilterMap<keyed_set::IterMut<'a, T>, super::Inclusion<'a>>
     where
         Self: 'a,
         Self::Node: 'a;

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/impls/vec_set_impl.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/impls/vec_set_impl.rs
@@ -61,7 +61,12 @@ impl<T: HasChunk + AsNode<T> + AsNodeMut<T> + 'static> IChildren<T> for Vec<T> {
     fn is_empty(&self) -> bool {
         self.is_empty()
     }
-    type Entry<'a, 'b> = Entry<'a, 'b, T> where Self: 'a , 'a: 'b, T: 'b;
+    type Entry<'a, 'b>
+        = Entry<'a, 'b, T>
+    where
+        Self: 'a,
+        'a: 'b,
+        T: 'b;
     fn entry<'a, 'b>(&'a mut self, chunk: &'b keyexpr) -> Self::Entry<'a, 'b>
     where
         Self: 'a,
@@ -75,7 +80,10 @@ impl<T: HasChunk + AsNode<T> + AsNodeMut<T> + 'static> IChildren<T> for Vec<T> {
         }
     }
 
-    type Iter<'a> = core::slice::Iter<'a, T> where Self: 'a;
+    type Iter<'a>
+        = core::slice::Iter<'a, T>
+    where
+        Self: 'a;
     fn children<'a>(&'a self) -> Self::Iter<'a>
     where
         Self: 'a,
@@ -83,9 +91,10 @@ impl<T: HasChunk + AsNode<T> + AsNodeMut<T> + 'static> IChildren<T> for Vec<T> {
         self.iter()
     }
 
-    type IterMut<'a> = core::slice::IterMut<'a, T>
-where
-    Self: 'a;
+    type IterMut<'a>
+        = core::slice::IterMut<'a, T>
+    where
+        Self: 'a;
 
     fn children_mut<'a>(&'a mut self) -> Self::IterMut<'a>
     where
@@ -102,28 +111,32 @@ where
         }
     }
 
-    type Intersection<'a> = super::FilterMap<core::slice::Iter<'a, T>, super::Intersection<'a>>
+    type Intersection<'a>
+        = super::FilterMap<core::slice::Iter<'a, T>, super::Intersection<'a>>
     where
         Self: 'a,
         Self::Node: 'a;
     fn intersection<'a>(&'a self, key: &'a keyexpr) -> Self::Intersection<'a> {
         super::FilterMap::new(self.iter(), super::Intersection(key))
     }
-    type IntersectionMut<'a> = super::FilterMap<core::slice::IterMut<'a, T>, super::Intersection<'a>>
+    type IntersectionMut<'a>
+        = super::FilterMap<core::slice::IterMut<'a, T>, super::Intersection<'a>>
     where
         Self: 'a,
         Self::Node: 'a;
     fn intersection_mut<'a>(&'a mut self, key: &'a keyexpr) -> Self::IntersectionMut<'a> {
         super::FilterMap::new(self.iter_mut(), super::Intersection(key))
     }
-    type Inclusion<'a> = super::FilterMap<core::slice::Iter<'a, T>, super::Inclusion<'a>>
+    type Inclusion<'a>
+        = super::FilterMap<core::slice::Iter<'a, T>, super::Inclusion<'a>>
     where
         Self: 'a,
         Self::Node: 'a;
     fn inclusion<'a>(&'a self, key: &'a keyexpr) -> Self::Inclusion<'a> {
         super::FilterMap::new(self.iter(), super::Inclusion(key))
     }
-    type InclusionMut<'a> = super::FilterMap<core::slice::IterMut<'a, T>, super::Inclusion<'a>>
+    type InclusionMut<'a>
+        = super::FilterMap<core::slice::IterMut<'a, T>, super::Inclusion<'a>>
     where
         Self: 'a,
         Self::Node: 'a;

--- a/commons/zenoh-shm/src/posix_shm/segment.rs
+++ b/commons/zenoh-shm/src/posix_shm/segment.rs
@@ -18,10 +18,9 @@ use rand::Rng;
 use shared_memory::{Shmem, ShmemConf, ShmemError};
 use zenoh_result::{bail, zerror, ZResult};
 
-use crate::cleanup::CLEANUP;
-
 #[cfg(target_os = "linux")]
 use super::segment_lock::unix::{ExclusiveShmLock, ShmLock};
+use crate::cleanup::CLEANUP;
 
 const SEGMENT_DEDICATE_TRIES: usize = 100;
 const ECMA: crc::Crc<u64> = crc::Crc::<u64>::new(&crc::CRC_64_ECMA_182);


### PR DESCRIPTION
`cargo fmt` doesn't respect the macro expansion, so some rust files behind the macros aren't formatted, especially the recent #1714. The feature of including all files has been discussed and decided not in the roadmap. https://github.com/rust-lang/rustfmt/issues/4977.

This PR resolves the above issue as suggested in [tokio](https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md#cargo-commands). This also includes a style fix with the latest stable rustfmt v1.8.0.