### PR TITLE
Update routes pre computation strategy to pre compute less routes

### DIFF
--- a/zenoh/src/net/routing/dispatcher/resource.rs
+++ b/zenoh/src/net/routing/dispatcher/resource.rs
@@ -76,13 +76,6 @@ impl SessionContext {
 }
 
 #[derive(Default)]
-pub(crate) struct RoutesIndexes {
-    pub(crate) routers: Vec<NodeId>,
-    pub(crate) peers: Vec<NodeId>,
-    pub(crate) clients: Vec<NodeId>,
-}
-
-#[derive(Default)]
 pub(crate) struct DataRoutes {
     pub(crate) routers: Vec<Arc<Route>>,
     pub(crate) peers: Vec<Arc<Route>>,

--- a/zenoh/src/net/routing/dispatcher/resource.rs
+++ b/zenoh/src/net/routing/dispatcher/resource.rs
@@ -258,6 +258,14 @@ impl Resource {
         }
     }
 
+    pub(crate) fn has_subs(&self) -> bool {
+        self.session_ctxs.values().any(|sc| sc.subs.is_some())
+    }
+
+    pub(crate) fn has_qabls(&self) -> bool {
+        self.session_ctxs.values().any(|sc| sc.qabl.is_some())
+    }
+
     #[inline]
     pub(crate) fn data_route(&self, whatami: WhatAmI, context: NodeId) -> Option<Arc<Route>> {
         match &self.context {

--- a/zenoh/src/net/routing/hat/client/mod.rs
+++ b/zenoh/src/net/routing/hat/client/mod.rs
@@ -49,7 +49,7 @@ use super::{
 use crate::net::{
     routing::{
         dispatcher::{face::Face, interests::RemoteInterest},
-        router::{compute_data_routes, compute_query_routes, RoutesIndexes},
+        router::{compute_data_routes, compute_query_routes},
     },
     runtime::Runtime,
 };
@@ -330,12 +330,3 @@ impl HatFace {
 }
 
 impl HatTrait for HatCode {}
-
-#[inline]
-fn get_routes_entries() -> RoutesIndexes {
-    RoutesIndexes {
-        routers: vec![0],
-        peers: vec![0],
-        clients: vec![0],
-    }
-}

--- a/zenoh/src/net/routing/hat/client/mod.rs
+++ b/zenoh/src/net/routing/hat/client/mod.rs
@@ -217,11 +217,17 @@ impl HatBaseTrait for HatCode {
         let mut matches_query_routes = vec![];
         let rtables = zread!(tables.tables);
         for _match in subs_matches.drain(..) {
-            let mut expr = RoutingExpr::new(&_match, "");
-            matches_data_routes.push((_match.clone(), compute_data_routes(&rtables, &mut expr)));
+            if !_match.expr().contains('*') && _match.has_subs() {
+                let mut expr = RoutingExpr::new(&_match, "");
+                matches_data_routes
+                    .push((_match.clone(), compute_data_routes(&rtables, &mut expr)));
+            }
         }
         for _match in qabls_matches.drain(..) {
-            matches_query_routes.push((_match.clone(), compute_query_routes(&rtables, &_match)));
+            if !_match.expr().contains('*') && _match.has_qabls() {
+                matches_query_routes
+                    .push((_match.clone(), compute_query_routes(&rtables, &_match)));
+            }
         }
         drop(rtables);
 

--- a/zenoh/src/net/routing/hat/client/pubsub.rs
+++ b/zenoh/src/net/routing/hat/client/pubsub.rs
@@ -26,7 +26,7 @@ use zenoh_protocol::{
 };
 use zenoh_sync::get_mut_unchecked;
 
-use super::{face_hat, face_hat_mut, get_routes_entries, HatCode, HatFace};
+use super::{face_hat, face_hat_mut, HatCode, HatFace};
 use crate::{
     key_expr::KeyExpr,
     net::routing::{
@@ -36,8 +36,8 @@ use crate::{
             resource::{NodeId, Resource, SessionContext},
             tables::{Route, RoutingExpr, Tables},
         },
-        hat::{HatPubSubTrait, SendDeclare, Sources},
-        router::{update_data_routes_from, RoutesIndexes},
+        hat::{DataRoutes, HatPubSubTrait, SendDeclare, Sources},
+        router::update_data_routes_from,
         RoutingContext,
     },
 };
@@ -402,8 +402,17 @@ impl HatPubSubTrait for HatCode {
         Arc::new(route)
     }
 
-    fn get_data_routes_entries(&self, _tables: &Tables) -> RoutesIndexes {
-        get_routes_entries()
+    fn compute_data_routes(
+        &self,
+        tables: &Tables,
+        routes: &mut DataRoutes,
+        expr: &mut RoutingExpr,
+    ) {
+        let route = self.compute_data_route(tables, expr, 0, WhatAmI::Peer);
+        routes.routers.resize_with(1, || route.clone());
+        routes.peers.resize_with(1, || route.clone());
+        let route = self.compute_data_route(tables, expr, 0, WhatAmI::Client);
+        routes.clients.resize_with(1, || route.clone());
     }
 
     #[zenoh_macros::unstable]

--- a/zenoh/src/net/routing/hat/client/queries.rs
+++ b/zenoh/src/net/routing/hat/client/queries.rs
@@ -32,7 +32,7 @@ use zenoh_protocol::{
 };
 use zenoh_sync::get_mut_unchecked;
 
-use super::{face_hat, face_hat_mut, get_routes_entries, HatCode, HatFace};
+use super::{face_hat, face_hat_mut, HatCode, HatFace};
 use crate::{
     key_expr::KeyExpr,
     net::routing::{
@@ -41,8 +41,8 @@ use crate::{
             resource::{NodeId, Resource, SessionContext},
             tables::{QueryTargetQabl, QueryTargetQablSet, RoutingExpr, Tables},
         },
-        hat::{HatQueriesTrait, SendDeclare, Sources},
-        router::{update_query_routes_from, RoutesIndexes},
+        hat::{HatQueriesTrait, QueryRoutes, SendDeclare, Sources},
+        router::update_query_routes_from,
         RoutingContext,
     },
 };
@@ -427,8 +427,17 @@ impl HatQueriesTrait for HatCode {
         Arc::new(route)
     }
 
-    fn get_query_routes_entries(&self, _tables: &Tables) -> RoutesIndexes {
-        get_routes_entries()
+    fn compute_query_routes(
+        &self,
+        tables: &Tables,
+        routes: &mut QueryRoutes,
+        expr: &mut RoutingExpr,
+    ) {
+        let route = self.compute_query_route(tables, expr, 0, WhatAmI::Peer);
+        routes.routers.resize_with(1, || route.clone());
+        routes.peers.resize_with(1, || route.clone());
+        let route = self.compute_query_route(tables, expr, 0, WhatAmI::Client);
+        routes.clients.resize_with(1, || route.clone());
     }
 
     #[cfg(feature = "unstable")]

--- a/zenoh/src/net/routing/hat/linkstate_peer/mod.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/mod.rs
@@ -352,11 +352,17 @@ impl HatBaseTrait for HatCode {
         let mut matches_query_routes = vec![];
         let rtables = zread!(tables.tables);
         for _match in subs_matches.drain(..) {
-            let mut expr = RoutingExpr::new(&_match, "");
-            matches_data_routes.push((_match.clone(), compute_data_routes(&rtables, &mut expr)));
+            if !_match.expr().contains('*') && _match.has_subs() {
+                let mut expr = RoutingExpr::new(&_match, "");
+                matches_data_routes
+                    .push((_match.clone(), compute_data_routes(&rtables, &mut expr)));
+            }
         }
         for _match in qabls_matches.drain(..) {
-            matches_query_routes.push((_match.clone(), compute_query_routes(&rtables, &_match)));
+            if !_match.expr().contains('*') && _match.has_qabls() {
+                matches_query_routes
+                    .push((_match.clone(), compute_query_routes(&rtables, &_match)));
+            }
         }
         drop(rtables);
 

--- a/zenoh/src/net/routing/hat/linkstate_peer/mod.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/mod.rs
@@ -352,31 +352,34 @@ impl HatBaseTrait for HatCode {
         let mut matches_query_routes = vec![];
         let rtables = zread!(tables.tables);
         for _match in subs_matches.drain(..) {
-            if !_match.expr().contains('*') && _match.has_subs() {
+            let route = (!_match.expr().contains('*') && _match.has_subs()).then(|| {
                 let mut expr = RoutingExpr::new(&_match, "");
-                matches_data_routes
-                    .push((_match.clone(), compute_data_routes(&rtables, &mut expr)));
-            }
+                compute_data_routes(&rtables, &mut expr)
+            });
+            matches_data_routes.push((_match.clone(), route));
         }
         for _match in qabls_matches.drain(..) {
-            if !_match.expr().contains('*') && _match.has_qabls() {
-                matches_query_routes
-                    .push((_match.clone(), compute_query_routes(&rtables, &_match)));
-            }
+            let route = (!_match.expr().contains('*') && _match.has_qabls())
+                .then(|| compute_query_routes(&rtables, &_match));
+            matches_query_routes.push((_match.clone(), route));
         }
         drop(rtables);
 
         let mut wtables = zwrite!(tables.tables);
         for (mut res, data_routes) in matches_data_routes {
-            get_mut_unchecked(&mut res)
-                .context_mut()
-                .update_data_routes(data_routes);
+            if let Some(data_routes) = data_routes {
+                get_mut_unchecked(&mut res)
+                    .context_mut()
+                    .update_data_routes(data_routes);
+            }
             Resource::clean(&mut res);
         }
         for (mut res, query_routes) in matches_query_routes {
-            get_mut_unchecked(&mut res)
-                .context_mut()
-                .update_query_routes(query_routes);
+            if let Some(query_routes) = query_routes {
+                get_mut_unchecked(&mut res)
+                    .context_mut()
+                    .update_query_routes(query_routes);
+            }
             Resource::clean(&mut res);
         }
         wtables.faces.remove(&face.id);

--- a/zenoh/src/net/routing/hat/linkstate_peer/mod.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/mod.rs
@@ -58,7 +58,7 @@ use crate::net::{
     routing::{
         dispatcher::{face::Face, interests::RemoteInterest},
         hat::TREES_COMPUTATION_DELAY_MS,
-        router::{compute_data_routes, compute_query_routes, RoutesIndexes},
+        router::{compute_data_routes, compute_query_routes},
     },
     runtime::Runtime,
 };
@@ -554,20 +554,3 @@ fn get_peer(tables: &Tables, face: &Arc<FaceState>, nodeid: NodeId) -> Option<Ze
 }
 
 impl HatTrait for HatCode {}
-
-#[inline]
-fn get_routes_entries(tables: &Tables) -> RoutesIndexes {
-    let indexes = hat!(tables)
-        .linkstatepeers_net
-        .as_ref()
-        .unwrap()
-        .graph
-        .node_indices()
-        .map(|i| i.index() as NodeId)
-        .collect::<Vec<NodeId>>();
-    RoutesIndexes {
-        routers: indexes.clone(),
-        peers: indexes,
-        clients: vec![0],
-    }
-}

--- a/zenoh/src/net/routing/hat/mod.rs
+++ b/zenoh/src/net/routing/hat/mod.rs
@@ -39,7 +39,7 @@ use super::{
         pubsub::SubscriberInfo,
         tables::{NodeId, QueryTargetQablSet, Resource, Route, RoutingExpr, Tables, TablesLock},
     },
-    router::RoutesIndexes,
+    router::{DataRoutes, QueryRoutes},
     RoutingContext,
 };
 use crate::net::runtime::Runtime;
@@ -191,7 +191,7 @@ pub(crate) trait HatPubSubTrait {
         source_type: WhatAmI,
     ) -> Arc<Route>;
 
-    fn get_data_routes_entries(&self, tables: &Tables) -> RoutesIndexes;
+    fn compute_data_routes(&self, tables: &Tables, routes: &mut DataRoutes, expr: &mut RoutingExpr);
 
     #[zenoh_macros::unstable]
     fn get_matching_subscriptions(
@@ -235,7 +235,12 @@ pub(crate) trait HatQueriesTrait {
         source_type: WhatAmI,
     ) -> Arc<QueryTargetQablSet>;
 
-    fn get_query_routes_entries(&self, tables: &Tables) -> RoutesIndexes;
+    fn compute_query_routes(
+        &self,
+        tables: &Tables,
+        routes: &mut QueryRoutes,
+        expr: &mut RoutingExpr,
+    );
 
     #[zenoh_macros::unstable]
     fn get_matching_queryables(

--- a/zenoh/src/net/routing/hat/p2p_peer/mod.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/mod.rs
@@ -303,11 +303,17 @@ impl HatBaseTrait for HatCode {
         let mut matches_query_routes = vec![];
         let rtables = zread!(tables.tables);
         for _match in subs_matches.drain(..) {
-            let mut expr = RoutingExpr::new(&_match, "");
-            matches_data_routes.push((_match.clone(), compute_data_routes(&rtables, &mut expr)));
+            if !_match.expr().contains('*') && _match.has_subs() {
+                let mut expr = RoutingExpr::new(&_match, "");
+                matches_data_routes
+                    .push((_match.clone(), compute_data_routes(&rtables, &mut expr)));
+            }
         }
         for _match in qabls_matches.drain(..) {
-            matches_query_routes.push((_match.clone(), compute_query_routes(&rtables, &_match)));
+            if !_match.expr().contains('*') && _match.has_qabls() {
+                matches_query_routes
+                    .push((_match.clone(), compute_query_routes(&rtables, &_match)));
+            }
         }
         drop(rtables);
 

--- a/zenoh/src/net/routing/hat/p2p_peer/mod.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/mod.rs
@@ -303,31 +303,34 @@ impl HatBaseTrait for HatCode {
         let mut matches_query_routes = vec![];
         let rtables = zread!(tables.tables);
         for _match in subs_matches.drain(..) {
-            if !_match.expr().contains('*') && _match.has_subs() {
+            let route = (!_match.expr().contains('*') && _match.has_subs()).then(|| {
                 let mut expr = RoutingExpr::new(&_match, "");
-                matches_data_routes
-                    .push((_match.clone(), compute_data_routes(&rtables, &mut expr)));
-            }
+                compute_data_routes(&rtables, &mut expr)
+            });
+            matches_data_routes.push((_match.clone(), route));
         }
         for _match in qabls_matches.drain(..) {
-            if !_match.expr().contains('*') && _match.has_qabls() {
-                matches_query_routes
-                    .push((_match.clone(), compute_query_routes(&rtables, &_match)));
-            }
+            let route = (!_match.expr().contains('*') && _match.has_qabls())
+                .then(|| compute_query_routes(&rtables, &_match));
+            matches_query_routes.push((_match.clone(), route));
         }
         drop(rtables);
 
         let mut wtables = zwrite!(tables.tables);
         for (mut res, data_routes) in matches_data_routes {
-            get_mut_unchecked(&mut res)
-                .context_mut()
-                .update_data_routes(data_routes);
+            if let Some(data_routes) = data_routes {
+                get_mut_unchecked(&mut res)
+                    .context_mut()
+                    .update_data_routes(data_routes);
+            }
             Resource::clean(&mut res);
         }
         for (mut res, query_routes) in matches_query_routes {
-            get_mut_unchecked(&mut res)
-                .context_mut()
-                .update_query_routes(query_routes);
+            if let Some(query_routes) = query_routes {
+                get_mut_unchecked(&mut res)
+                    .context_mut()
+                    .update_query_routes(query_routes);
+            }
             Resource::clean(&mut res);
         }
         wtables.faces.remove(&face.id);

--- a/zenoh/src/net/routing/hat/p2p_peer/mod.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/mod.rs
@@ -63,7 +63,7 @@ use crate::net::{
             face::{Face, InterestState},
             interests::RemoteInterest,
         },
-        router::{compute_data_routes, compute_query_routes, RoutesIndexes},
+        router::{compute_data_routes, compute_query_routes},
         RoutingContext,
     },
     runtime::Runtime,
@@ -441,15 +441,6 @@ impl HatFace {
 }
 
 impl HatTrait for HatCode {}
-
-#[inline]
-fn get_routes_entries() -> RoutesIndexes {
-    RoutesIndexes {
-        routers: vec![0],
-        peers: vec![0],
-        clients: vec![0],
-    }
-}
 
 // In p2p, at connection, while no interest is sent on the network,
 // peers act as if they received an interest CurrentFuture with id 0

--- a/zenoh/src/net/routing/hat/p2p_peer/pubsub.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/pubsub.rs
@@ -29,7 +29,7 @@ use zenoh_protocol::{
 };
 use zenoh_sync::get_mut_unchecked;
 
-use super::{face_hat, face_hat_mut, get_routes_entries, HatCode, HatFace};
+use super::{face_hat, face_hat_mut, HatCode, HatFace};
 use crate::{
     key_expr::KeyExpr,
     net::routing::{
@@ -41,9 +41,10 @@ use crate::{
             tables::{Route, RoutingExpr, Tables},
         },
         hat::{
-            p2p_peer::initial_interest, CurrentFutureTrait, HatPubSubTrait, SendDeclare, Sources,
+            p2p_peer::initial_interest, CurrentFutureTrait, DataRoutes, HatPubSubTrait,
+            SendDeclare, Sources,
         },
-        router::{update_data_routes_from, RoutesIndexes},
+        router::update_data_routes_from,
         RoutingContext,
     },
 };
@@ -692,8 +693,18 @@ impl HatPubSubTrait for HatCode {
         Arc::new(route)
     }
 
-    fn get_data_routes_entries(&self, _tables: &Tables) -> RoutesIndexes {
-        get_routes_entries()
+    fn compute_data_routes(
+        &self,
+        tables: &Tables,
+        routes: &mut DataRoutes,
+        expr: &mut RoutingExpr,
+    ) {
+        let route = self.compute_data_route(tables, expr, 0, WhatAmI::Peer);
+        routes.routers.resize_with(1, || route.clone());
+        routes.peers.resize_with(1, || route.clone());
+        routes.clients.resize_with(1, || {
+            self.compute_data_route(tables, expr, 0, WhatAmI::Client)
+        });
     }
 
     #[zenoh_macros::unstable]

--- a/zenoh/src/net/routing/hat/p2p_peer/queries.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/queries.rs
@@ -35,7 +35,7 @@ use zenoh_protocol::{
 };
 use zenoh_sync::get_mut_unchecked;
 
-use super::{face_hat, face_hat_mut, get_routes_entries, HatCode, HatFace};
+use super::{face_hat, face_hat_mut, HatCode, HatFace};
 use crate::{
     key_expr::KeyExpr,
     net::routing::{
@@ -45,9 +45,10 @@ use crate::{
             tables::{QueryTargetQabl, QueryTargetQablSet, RoutingExpr, Tables},
         },
         hat::{
-            p2p_peer::initial_interest, CurrentFutureTrait, HatQueriesTrait, SendDeclare, Sources,
+            p2p_peer::initial_interest, CurrentFutureTrait, HatQueriesTrait, QueryRoutes,
+            SendDeclare, Sources,
         },
-        router::{update_query_routes_from, RoutesIndexes},
+        router::update_query_routes_from,
         RoutingContext,
     },
 };
@@ -685,8 +686,17 @@ impl HatQueriesTrait for HatCode {
         Arc::new(route)
     }
 
-    fn get_query_routes_entries(&self, _tables: &Tables) -> RoutesIndexes {
-        get_routes_entries()
+    fn compute_query_routes(
+        &self,
+        tables: &Tables,
+        routes: &mut QueryRoutes,
+        expr: &mut RoutingExpr,
+    ) {
+        let route = self.compute_query_route(tables, expr, 0, WhatAmI::Peer);
+        routes.routers.resize_with(1, || route.clone());
+        routes.peers.resize_with(1, || route.clone());
+        let route = self.compute_query_route(tables, expr, 0, WhatAmI::Client);
+        routes.clients.resize_with(1, || route.clone());
     }
 
     #[cfg(feature = "unstable")]

--- a/zenoh/src/net/routing/hat/router/mod.rs
+++ b/zenoh/src/net/routing/hat/router/mod.rs
@@ -59,7 +59,7 @@ use crate::net::{
     routing::{
         dispatcher::{face::Face, interests::RemoteInterest},
         hat::TREES_COMPUTATION_DELAY_MS,
-        router::{compute_data_routes, compute_query_routes, RoutesIndexes},
+        router::{compute_data_routes, compute_query_routes},
     },
     runtime::Runtime,
 };
@@ -947,32 +947,3 @@ fn get_peer(tables: &Tables, face: &Arc<FaceState>, nodeid: NodeId) -> Option<Ze
 }
 
 impl HatTrait for HatCode {}
-
-#[inline]
-fn get_routes_entries(tables: &Tables) -> RoutesIndexes {
-    let routers_indexes = hat!(tables)
-        .routers_net
-        .as_ref()
-        .unwrap()
-        .graph
-        .node_indices()
-        .map(|i| i.index() as NodeId)
-        .collect::<Vec<NodeId>>();
-    let peers_indexes = if hat!(tables).full_net(WhatAmI::Peer) {
-        hat!(tables)
-            .linkstatepeers_net
-            .as_ref()
-            .unwrap()
-            .graph
-            .node_indices()
-            .map(|i| i.index() as NodeId)
-            .collect::<Vec<NodeId>>()
-    } else {
-        vec![0]
-    };
-    RoutesIndexes {
-        routers: routers_indexes,
-        peers: peers_indexes,
-        clients: vec![0],
-    }
-}

--- a/zenoh/src/net/routing/hat/router/mod.rs
+++ b/zenoh/src/net/routing/hat/router/mod.rs
@@ -522,11 +522,17 @@ impl HatBaseTrait for HatCode {
         let mut matches_query_routes = vec![];
         let rtables = zread!(tables.tables);
         for _match in subs_matches.drain(..) {
-            let mut expr = RoutingExpr::new(&_match, "");
-            matches_data_routes.push((_match.clone(), compute_data_routes(&rtables, &mut expr)));
+            if !_match.expr().contains('*') && _match.has_subs() {
+                let mut expr = RoutingExpr::new(&_match, "");
+                matches_data_routes
+                    .push((_match.clone(), compute_data_routes(&rtables, &mut expr)));
+            }
         }
         for _match in qabls_matches.drain(..) {
-            matches_query_routes.push((_match.clone(), compute_query_routes(&rtables, &_match)));
+            if !_match.expr().contains('*') && _match.has_qabls() {
+                matches_query_routes
+                    .push((_match.clone(), compute_query_routes(&rtables, &_match)));
+            }
         }
         drop(rtables);
 

--- a/zenoh/src/net/routing/hat/router/mod.rs
+++ b/zenoh/src/net/routing/hat/router/mod.rs
@@ -522,31 +522,34 @@ impl HatBaseTrait for HatCode {
         let mut matches_query_routes = vec![];
         let rtables = zread!(tables.tables);
         for _match in subs_matches.drain(..) {
-            if !_match.expr().contains('*') && _match.has_subs() {
+            let route = (!_match.expr().contains('*') && _match.has_subs()).then(|| {
                 let mut expr = RoutingExpr::new(&_match, "");
-                matches_data_routes
-                    .push((_match.clone(), compute_data_routes(&rtables, &mut expr)));
-            }
+                compute_data_routes(&rtables, &mut expr)
+            });
+            matches_data_routes.push((_match.clone(), route));
         }
         for _match in qabls_matches.drain(..) {
-            if !_match.expr().contains('*') && _match.has_qabls() {
-                matches_query_routes
-                    .push((_match.clone(), compute_query_routes(&rtables, &_match)));
-            }
+            let route = (!_match.expr().contains('*') && _match.has_qabls())
+                .then(|| compute_query_routes(&rtables, &_match));
+            matches_query_routes.push((_match.clone(), route));
         }
         drop(rtables);
 
         let mut wtables = zwrite!(tables.tables);
         for (mut res, data_routes) in matches_data_routes {
-            get_mut_unchecked(&mut res)
-                .context_mut()
-                .update_data_routes(data_routes);
+            if let Some(data_routes) = data_routes {
+                get_mut_unchecked(&mut res)
+                    .context_mut()
+                    .update_data_routes(data_routes);
+            }
             Resource::clean(&mut res);
         }
         for (mut res, query_routes) in matches_query_routes {
-            get_mut_unchecked(&mut res)
-                .context_mut()
-                .update_query_routes(query_routes);
+            if let Some(query_routes) = query_routes {
+                get_mut_unchecked(&mut res)
+                    .context_mut()
+                    .update_query_routes(query_routes);
+            }
             Resource::clean(&mut res);
         }
         wtables.faces.remove(&face.id);

--- a/zenoh/src/net/routing/hat/router/pubsub.rs
+++ b/zenoh/src/net/routing/hat/router/pubsub.rs
@@ -31,7 +31,7 @@ use zenoh_protocol::{
 use zenoh_sync::get_mut_unchecked;
 
 use super::{
-    face_hat, face_hat_mut, get_peer, get_router, get_routes_entries, hat, hat_mut,
+    face_hat, face_hat_mut, get_peer, get_router, hat, hat_mut,
     interests::push_declaration_profile, network::Network, res_hat, res_hat_mut, HatCode,
     HatContext, HatFace, HatTables,
 };
@@ -45,8 +45,7 @@ use crate::net::routing::{
         resource::{NodeId, Resource, SessionContext},
         tables::{Route, RoutingExpr, Tables},
     },
-    hat::{CurrentFutureTrait, HatPubSubTrait, SendDeclare, Sources},
-    router::RoutesIndexes,
+    hat::{CurrentFutureTrait, DataRoutes, HatPubSubTrait, SendDeclare, Sources},
     RoutingContext,
 };
 
@@ -1334,8 +1333,55 @@ impl HatPubSubTrait for HatCode {
         Arc::new(route)
     }
 
-    fn get_data_routes_entries(&self, tables: &Tables) -> RoutesIndexes {
-        get_routes_entries(tables)
+    fn compute_data_routes(
+        &self,
+        tables: &Tables,
+        routes: &mut DataRoutes,
+        expr: &mut RoutingExpr,
+    ) {
+        let routers_indexes = hat!(tables)
+            .routers_net
+            .as_ref()
+            .unwrap()
+            .graph
+            .node_indices()
+            .map(|i| i.index() as NodeId)
+            .collect::<Vec<NodeId>>();
+        let max_idx = routers_indexes.iter().max().unwrap();
+        routes
+            .routers
+            .resize_with((*max_idx as usize) + 1, || Arc::new(HashMap::new()));
+
+        for idx in routers_indexes {
+            routes.routers[idx as usize] =
+                self.compute_data_route(tables, expr, idx, WhatAmI::Router);
+        }
+
+        if hat!(tables).full_net(WhatAmI::Peer) {
+            let peers_indexes = hat!(tables)
+                .linkstatepeers_net
+                .as_ref()
+                .unwrap()
+                .graph
+                .node_indices()
+                .map(|i| i.index() as NodeId)
+                .collect::<Vec<NodeId>>();
+            let max_idx = peers_indexes.iter().max().unwrap();
+            routes
+                .peers
+                .resize_with((*max_idx as usize) + 1, || Arc::new(HashMap::new()));
+            for idx in peers_indexes {
+                routes.peers[idx as usize] =
+                    self.compute_data_route(tables, expr, idx, WhatAmI::Peer);
+            }
+        } else {
+            routes.peers.resize_with(1, || {
+                self.compute_data_route(tables, expr, 0, WhatAmI::Peer)
+            });
+        };
+        routes.clients.resize_with(1, || {
+            self.compute_data_route(tables, expr, 0, WhatAmI::Client)
+        });
     }
 
     #[zenoh_macros::unstable]

--- a/zenoh/src/net/routing/hat/router/queries.rs
+++ b/zenoh/src/net/routing/hat/router/queries.rs
@@ -37,7 +37,7 @@ use zenoh_protocol::{
 use zenoh_sync::get_mut_unchecked;
 
 use super::{
-    face_hat, face_hat_mut, get_peer, get_router, get_routes_entries, hat, hat_mut,
+    face_hat, face_hat_mut, get_peer, get_router, hat, hat_mut,
     interests::push_declaration_profile, network::Network, res_hat, res_hat_mut, HatCode,
     HatContext, HatFace, HatTables,
 };
@@ -50,8 +50,7 @@ use crate::net::routing::{
         resource::{NodeId, Resource, SessionContext},
         tables::{QueryTargetQabl, QueryTargetQablSet, RoutingExpr, Tables},
     },
-    hat::{CurrentFutureTrait, HatQueriesTrait, SendDeclare, Sources},
-    router::RoutesIndexes,
+    hat::{CurrentFutureTrait, HatQueriesTrait, QueryRoutes, SendDeclare, Sources},
     RoutingContext,
 };
 
@@ -1512,8 +1511,57 @@ impl HatQueriesTrait for HatCode {
         Arc::new(route)
     }
 
-    fn get_query_routes_entries(&self, tables: &Tables) -> RoutesIndexes {
-        get_routes_entries(tables)
+    fn compute_query_routes(
+        &self,
+        tables: &Tables,
+        routes: &mut QueryRoutes,
+        expr: &mut RoutingExpr,
+    ) {
+        let routers_indexes = hat!(tables)
+            .routers_net
+            .as_ref()
+            .unwrap()
+            .graph
+            .node_indices()
+            .map(|i| i.index() as NodeId)
+            .collect::<Vec<NodeId>>();
+        let max_idx = routers_indexes.iter().max().unwrap();
+        routes.routers.resize_with((*max_idx as usize) + 1, || {
+            Arc::new(QueryTargetQablSet::new())
+        });
+
+        for idx in routers_indexes {
+            routes.routers[idx as usize] =
+                self.compute_query_route(tables, expr, idx, WhatAmI::Router);
+        }
+
+        if hat!(tables).full_net(WhatAmI::Peer) {
+            let peers_indexes = hat!(tables)
+                .linkstatepeers_net
+                .as_ref()
+                .unwrap()
+                .graph
+                .node_indices()
+                .map(|i| i.index() as NodeId)
+                .collect::<Vec<NodeId>>();
+            let max_idx = peers_indexes.iter().max().unwrap();
+            routes.peers.resize_with((*max_idx as usize) + 1, || {
+                Arc::new(QueryTargetQablSet::new())
+            });
+            for idx in peers_indexes {
+                routes.peers[idx as usize] =
+                    self.compute_query_route(tables, expr, idx, WhatAmI::Peer);
+            }
+        } else {
+            routes.peers.resize_with(1, || {
+                self.compute_query_route(tables, expr, 0, WhatAmI::Peer)
+            });
+        };
+        routes.clients.resize_with(1, || {
+            tables
+                .hat_code
+                .compute_query_route(tables, expr, 0, WhatAmI::Client)
+        });
     }
 
     #[cfg(feature = "unstable")]


### PR DESCRIPTION
Routes pre computation strategy was a bit brutal and was computing too many unnecessary routes leading to high CPU consumption during system setup.
The routes pre computation strategy was updated to only compute 
- data routes for known keys that have no wildcard and have subscribers
- query routes for known keys that have no wildcard and have queriables

In a 30 talkers/30 listeners zenoh_rmw test the stabilisation time was reduced from 35 seconds to 7 seconds.

The p2p throughput and latency tests have been run on a MacBook Air M2. No observed regressions.
