### PR TITLE
Add getrandom crate feature=js for KeyExpr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5257,6 +5257,7 @@ version = "1.0.0-dev"
 dependencies = [
  "ahash",
  "criterion",
+ "getrandom 0.2.15",
  "hashbrown",
  "keyed-set",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ form_urlencoded = "1.2.1"
 futures = "0.3.30"
 futures-util = { version = "0.3.30", default-features = false } # Default features are disabled due to some crates' requirements
 git-version = "0.3.9"
+getrandom = { version = "0.2" }
 hashbrown = "0.14"
 hex = { version = "0.4.3", default-features = false } # Default features are disabled due to usage in no_std crates
 hmac = { version = "0.12.1", features = ["std"] }

--- a/commons/zenoh-keyexpr/Cargo.toml
+++ b/commons/zenoh-keyexpr/Cargo.toml
@@ -55,5 +55,6 @@ rand = { workspace = true, features = ["default"] }
 name = "keyexpr_tree"
 harness = false
 
+# NOTE: for the above reason, we need to explicitly ignore getrandom in the CI because it's an indirect dependency which is not used directly by zenoh.
 [package.metadata.cargo-machete]
 ignored = ["getrandom"]

--- a/commons/zenoh-keyexpr/Cargo.toml
+++ b/commons/zenoh-keyexpr/Cargo.toml
@@ -36,6 +36,7 @@ schemars = { workspace = true, optional = true }
 serde = { workspace = true, features = ["alloc"] }
 token-cell = { workspace = true }
 zenoh-result = { workspace = true }
+getrandom = { workspace = true, features = ["js"] }
 
 [target.'cfg(not(features = "std"))'.dependencies]
 hashbrown = { workspace = true }

--- a/commons/zenoh-keyexpr/Cargo.toml
+++ b/commons/zenoh-keyexpr/Cargo.toml
@@ -37,6 +37,8 @@ schemars = { workspace = true, optional = true }
 serde = { workspace = true, features = ["alloc"] }
 token-cell = { workspace = true }
 zenoh-result = { workspace = true }
+# NOTE: getrandom needs to be explicitly added here in order to enable the `js` feature when compiling the rand crate to WASM
+# more information: https://docs.rs/getrandom/latest/getrandom/#webassembly-support 
 getrandom = { workspace = true }
 
 [target.'cfg(not(features = "std"))'.dependencies]

--- a/commons/zenoh-keyexpr/Cargo.toml
+++ b/commons/zenoh-keyexpr/Cargo.toml
@@ -28,6 +28,7 @@ default = ["std"]
 std = ["zenoh-result/std", "dep:schemars"]
 internal = []
 unstable = []
+js = ["getrandom/js"]
 
 [dependencies]
 keyed-set = { workspace = true }
@@ -36,7 +37,7 @@ schemars = { workspace = true, optional = true }
 serde = { workspace = true, features = ["alloc"] }
 token-cell = { workspace = true }
 zenoh-result = { workspace = true }
-getrandom = { workspace = true, features = ["js"] }
+getrandom = { workspace = true }
 
 [target.'cfg(not(features = "std"))'.dependencies]
 hashbrown = { workspace = true }
@@ -51,3 +52,6 @@ rand = { workspace = true, features = ["default"] }
 [[bench]]
 name = "keyexpr_tree"
 harness = false
+
+[package.metadata.cargo-machete]
+ignored = ["getrandom"]


### PR DESCRIPTION
Used to enable compiling key expressions to WASM for zenoh-ts