### PR TITLE
fix: update changelog to exclude internal

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -21,15 +21,27 @@ changelog:
       labels:
         - enhancement
         - new feature
+      exclude:
+        labels:
+          - internal
     - title: Bug fixes 🐞
       labels:
         - bug
+      exclude:
+        labels:
+          - internal
     - title: Documentation 📝
       labels:
         - documentation
+      exclude:
+        labels:
+          - internal
     - title: Dependencies 👷
       labels:
         - dependencies
+      exclude:
+        labels:
+          - internal
     - title: Other changes
       labels:
         - "*"


### PR DESCRIPTION
Exclude internal labeled PRs from any categories. This way when a PR is an internal enhancement or bug, it doesn't show up in the automatically generated changelog