### PR TITLE
refactor: avoid temporary allocation in `Resource::get_best_key`

### DIFF
--- a/zenoh/src/net/routing/dispatcher/resource.rs
+++ b/zenoh/src/net/routing/dispatcher/resource.rs
@@ -564,19 +564,18 @@ impl Resource {
                 .or_else(|| get_wire_expr(child, || suffix.into(), sid))
         }
         fn get_best_parent_key<'a>(
-            parent: Option<&Resource>,
             prefix: &Resource,
             suffix: &'a str,
             sid: usize,
+            parent: &Resource,
         ) -> Option<WireExpr<'a>> {
-            let parent = parent?;
             let parent_suffix = || [&prefix.expr[parent.expr.len()..], suffix].concat().into();
             get_wire_expr(parent, parent_suffix, sid)
-                .or_else(|| get_best_parent_key(parent.parent.as_deref(), prefix, suffix, sid))
+                .or_else(|| get_best_parent_key(prefix, suffix, sid, parent.parent.as_ref()?))
         }
         get_best_child_key(self, suffix, sid)
             .or_else(|| get_wire_expr(self, || suffix.into(), sid))
-            .or_else(|| get_best_parent_key(self.parent.as_deref(), self, suffix, sid))
+            .or_else(|| get_best_parent_key(self, suffix, sid, self.parent.as_ref()?))
             .unwrap_or_else(|| [&self.expr, suffix].concat().into())
     }
 

--- a/zenoh/src/net/routing/dispatcher/resource.rs
+++ b/zenoh/src/net/routing/dispatcher/resource.rs
@@ -576,7 +576,7 @@ impl Resource {
         get_best_child_key(self, suffix, sid)
             .or_else(|| get_wire_expr(self, || suffix.into(), sid))
             .or_else(|| get_best_parent_key(self, suffix, sid, self.parent.as_ref()?))
-            .unwrap_or_else(|| [&self.expr, suffix].concat().into());
+            .unwrap_or_else(|| [&self.expr, suffix].concat().into())
     }
 
     pub fn get_matches(tables: &Tables, key_expr: &keyexpr) -> Vec<Weak<Resource>> {

--- a/zenoh/src/net/routing/dispatcher/resource.rs
+++ b/zenoh/src/net/routing/dispatcher/resource.rs
@@ -561,7 +561,7 @@ impl Resource {
             let (chunk, rest) = suffix.split_once('/').unwrap_or((suffix, ""));
             let child = prefix.children.get(chunk)?;
             get_best_child_key(child, rest, sid)
-                .or_else(|| get_wire_expr(child, || suffix.into(), sid))
+                .or_else(|| get_wire_expr(child, || rest.into(), sid))
         }
         fn get_best_parent_key<'a>(
             prefix: &Resource,
@@ -573,10 +573,12 @@ impl Resource {
             get_wire_expr(parent, parent_suffix, sid)
                 .or_else(|| get_best_parent_key(prefix, suffix, sid, parent.parent.as_ref()?))
         }
-        get_best_child_key(self, suffix, sid)
+        let res = get_best_child_key(self, suffix, sid)
             .or_else(|| get_wire_expr(self, || suffix.into(), sid))
             .or_else(|| get_best_parent_key(self, suffix, sid, self.parent.as_ref()?))
-            .unwrap_or_else(|| [&self.expr, suffix].concat().into())
+            .unwrap_or_else(|| [&self.expr, suffix].concat().into());
+        dbg!(&self.expr, suffix, sid);
+        dbg!(res)
     }
 
     pub fn get_matches(tables: &Tables, key_expr: &keyexpr) -> Vec<Weak<Resource>> {

--- a/zenoh/src/net/routing/dispatcher/resource.rs
+++ b/zenoh/src/net/routing/dispatcher/resource.rs
@@ -558,10 +558,10 @@ impl Resource {
             if suffix.is_empty() {
                 return None;
             }
-            let (chunk, rest) = suffix.split_once('/').unwrap_or((suffix, ""));
+            let (chunk, remain) = suffix.split_once('/').unwrap_or((suffix, ""));
             let child = prefix.children.get(chunk)?;
-            get_best_child_key(child, rest, sid)
-                .or_else(|| get_wire_expr(child, || rest.into(), sid))
+            get_best_child_key(child, remain, sid)
+                .or_else(|| get_wire_expr(child, || remain.into(), sid))
         }
         fn get_best_parent_key<'a>(
             prefix: &Resource,

--- a/zenoh/src/net/routing/dispatcher/resource.rs
+++ b/zenoh/src/net/routing/dispatcher/resource.rs
@@ -13,6 +13,7 @@
 //
 use std::{
     any::Any,
+    borrow::Cow,
     collections::HashMap,
     convert::TryInto,
     hash::{Hash, Hasher},
@@ -531,43 +532,52 @@ impl Resource {
         }
     }
 
-    #[inline]
-    pub fn get_best_key<'a>(prefix: &Arc<Resource>, suffix: &'a str, sid: usize) -> WireExpr<'a> {
-        fn get_best_key_<'a>(
-            prefix: &Arc<Resource>,
+    pub fn get_best_key<'a>(&self, suffix: &'a str, sid: usize) -> WireExpr<'a> {
+        fn get_wire_expr<'a>(
+            prefix: &Resource,
+            suffix: impl FnOnce() -> Cow<'a, str>,
+            sid: usize,
+        ) -> Option<WireExpr<'a>> {
+            let ctx = prefix.session_ctxs.get(&sid)?;
+            let (scope, mapping) = match (ctx.remote_expr_id, ctx.local_expr_id) {
+                (Some(expr_id), _) => (expr_id, Mapping::Receiver),
+                (_, Some(expr_id)) => (expr_id, Mapping::Sender),
+                _ => return None,
+            };
+            Some(WireExpr {
+                scope,
+                suffix: suffix(),
+                mapping,
+            })
+        }
+        fn get_best_child_key<'a>(
+            prefix: &Resource,
             suffix: &'a str,
             sid: usize,
-            checkclildren: bool,
-        ) -> WireExpr<'a> {
-            if checkclildren && !suffix.is_empty() {
-                let (chunk, rest) = suffix.split_at(suffix.find('/').unwrap_or(suffix.len()));
-                if let Some(child) = prefix.children.get(chunk) {
-                    return get_best_key_(child, rest, sid, true);
-                }
+        ) -> Option<WireExpr<'a>> {
+            if suffix.is_empty() {
+                return None;
             }
-            if let Some(ctx) = prefix.session_ctxs.get(&sid) {
-                if let Some(expr_id) = ctx.remote_expr_id {
-                    return WireExpr {
-                        scope: expr_id,
-                        suffix: suffix.into(),
-                        mapping: Mapping::Receiver,
-                    };
-                } else if let Some(expr_id) = ctx.local_expr_id {
-                    return WireExpr {
-                        scope: expr_id,
-                        suffix: suffix.into(),
-                        mapping: Mapping::Sender,
-                    };
-                }
-            }
-            match &prefix.parent {
-                Some(parent) => {
-                    get_best_key_(parent, &[&prefix.suffix, suffix].concat(), sid, false).to_owned()
-                }
-                None => suffix.into(),
-            }
+            let (chunk, rest) = suffix.split_once('/').unwrap_or((suffix, ""));
+            let child = prefix.children.get(chunk)?;
+            get_best_child_key(child, rest, sid)
+                .or_else(|| get_wire_expr(child, || suffix.into(), sid))
         }
-        get_best_key_(prefix, suffix, sid, true)
+        fn get_best_parent_key<'a>(
+            parent: Option<&Resource>,
+            prefix: &Resource,
+            suffix: &'a str,
+            sid: usize,
+        ) -> Option<WireExpr<'a>> {
+            let parent = parent?;
+            let parent_suffix = || [&prefix.expr[parent.expr.len()..], suffix].concat().into();
+            get_wire_expr(parent, parent_suffix, sid)
+                .or_else(|| get_best_parent_key(parent.parent.as_deref(), prefix, suffix, sid))
+        }
+        get_best_child_key(self, suffix, sid)
+            .or_else(|| get_wire_expr(self, || suffix.into(), sid))
+            .or_else(|| get_best_parent_key(self.parent.as_deref(), self, suffix, sid))
+            .unwrap_or_else(|| [&self.expr, suffix].concat().into())
     }
 
     pub fn get_matches(tables: &Tables, key_expr: &keyexpr) -> Vec<Weak<Resource>> {

--- a/zenoh/src/net/routing/dispatcher/resource.rs
+++ b/zenoh/src/net/routing/dispatcher/resource.rs
@@ -573,12 +573,10 @@ impl Resource {
             get_wire_expr(parent, parent_suffix, sid)
                 .or_else(|| get_best_parent_key(prefix, suffix, sid, parent.parent.as_ref()?))
         }
-        let res = get_best_child_key(self, suffix, sid)
+        get_best_child_key(self, suffix, sid)
             .or_else(|| get_wire_expr(self, || suffix.into(), sid))
             .or_else(|| get_best_parent_key(self, suffix, sid, self.parent.as_ref()?))
             .unwrap_or_else(|| [&self.expr, suffix].concat().into());
-        dbg!(&self.expr, suffix, sid);
-        dbg!(res)
     }
 
     pub fn get_matches(tables: &Tables, key_expr: &keyexpr) -> Vec<Weak<Resource>> {


### PR DESCRIPTION
The code has also be refactored to better express the intent.

Supersede #1730 