### PR TITLE
refactor: use HashSet instead of Vec for network links

### DIFF
--- a/examples/examples/z_pub_thr.rs
+++ b/examples/examples/z_pub_thr.rs
@@ -21,6 +21,7 @@ use zenoh::{
     Wait,
 };
 use zenoh_examples::CommonArgs;
+use zenoh_ext::z_serialize;
 
 fn main() {
     // initiate logging

--- a/examples/examples/z_pub_thr.rs
+++ b/examples/examples/z_pub_thr.rs
@@ -21,7 +21,6 @@ use zenoh::{
     Wait,
 };
 use zenoh_examples::CommonArgs;
-use zenoh_ext::z_serialize;
 
 fn main() {
     // initiate logging

--- a/zenoh/src/net/routing/hat/linkstate_peer/network.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/network.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 //
 // Copyright (c) 2023 ZettaScale Technology
 //
@@ -52,7 +53,7 @@ pub(super) struct Node {
     pub(super) whatami: Option<WhatAmI>,
     pub(super) locators: Option<Vec<Locator>>,
     pub(super) sn: u64,
-    pub(super) links: Vec<ZenohIdProto>,
+    pub(super) links: HashSet<ZenohIdProto>,
 }
 
 impl std::fmt::Debug for Node {
@@ -149,7 +150,7 @@ impl Network {
             whatami: Some(runtime.whatami()),
             locators: None,
             sn: 1,
-            links: vec![],
+            links: HashSet::new(),
         });
         Network {
             name,
@@ -424,7 +425,7 @@ impl Network {
         let link_states = link_states
             .into_iter()
             .map(|(zid, wai, locs, sn, links)| {
-                let links: Vec<ZenohIdProto> = links
+                let links: HashSet<ZenohIdProto> = links
                     .iter()
                     .filter_map(|l| {
                         if let Some(zid) = src_link.get_zid(l) {
@@ -574,7 +575,7 @@ impl Network {
                     }
                 },
             )
-            .collect::<Vec<(Vec<ZenohIdProto>, NodeIndex, bool)>>();
+            .collect::<Vec<(HashSet<ZenohIdProto>, NodeIndex, bool)>>();
 
         // Add/remove edges from graph
         let mut reintroduced_nodes = vec![];
@@ -596,11 +597,11 @@ impl Network {
                         whatami: None,
                         locators: None,
                         sn: 0,
-                        links: vec![],
+                        links: HashSet::new(),
                     };
                     tracing::debug!("{} Add node (reintroduced) {}", self.name, link.clone());
                     let idx = self.add_node(node);
-                    reintroduced_nodes.push((vec![], idx, true));
+                    reintroduced_nodes.push((HashSet::new(), idx, true));
                 }
             }
             let mut edges = vec![];
@@ -626,7 +627,7 @@ impl Network {
         let link_states = link_states
             .into_iter()
             .filter(|ls| !removed.iter().any(|(idx, _)| idx == &ls.1))
-            .collect::<Vec<(Vec<ZenohIdProto>, NodeIndex, bool)>>();
+            .collect::<Vec<(HashSet<ZenohIdProto>, NodeIndex, bool)>>();
 
         if !self.autoconnect.is_empty() {
             // Connect discovered peers
@@ -665,8 +666,8 @@ impl Network {
         #[allow(clippy::type_complexity)] // This is only used here
         if !link_states.is_empty() {
             let (new_idxs, updated_idxs): (
-                Vec<(Vec<ZenohIdProto>, NodeIndex, bool)>,
-                Vec<(Vec<ZenohIdProto>, NodeIndex, bool)>,
+                Vec<(HashSet<ZenohIdProto>, NodeIndex, bool)>,
+                Vec<(HashSet<ZenohIdProto>, NodeIndex, bool)>,
             ) = link_states.into_iter().partition(|(_, _, new)| *new);
             for link in self.links.values() {
                 let new_idxs = new_idxs
@@ -742,7 +743,7 @@ impl Network {
                             whatami: Some(whatami),
                             locators: None,
                             sn: 0,
-                            links: vec![],
+                            links: HashSet::new(),
                         }),
                         true,
                     )
@@ -752,7 +753,7 @@ impl Network {
                 tracing::trace!("Update edge (link) {} {}", self.graph[self.idx].zid, zid);
                 self.update_edge(self.idx, idx);
             }
-            self.graph[self.idx].links.push(zid);
+            self.graph[self.idx].links.insert(zid);
             self.graph[self.idx].sn += 1;
 
             // Send updated self linkstate on all existing links except new one

--- a/zenoh/src/net/routing/hat/p2p_peer/gossip.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/gossip.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 //
 // Copyright (c) 2023 ZettaScale Technology
 //
@@ -47,7 +48,7 @@ pub(super) struct Node {
     pub(super) whatami: Option<WhatAmI>,
     pub(super) locators: Option<Vec<Locator>>,
     pub(super) sn: u64,
-    pub(super) links: Vec<ZenohIdProto>,
+    pub(super) links: HashSet<ZenohIdProto>,
 }
 
 impl std::fmt::Debug for Node {
@@ -125,7 +126,7 @@ impl Network {
             whatami: Some(runtime.whatami()),
             locators: None,
             sn: 1,
-            links: vec![],
+            links: HashSet::new(),
         });
         Network {
             name,
@@ -355,7 +356,7 @@ impl Network {
         let link_states = link_states
             .into_iter()
             .map(|(zid, wai, locs, sn, links)| {
-                let links: Vec<ZenohIdProto> = links
+                let links: HashSet<ZenohIdProto> = links
                     .iter()
                     .filter_map(|l| {
                         if let Some(zid) = src_link.get_zid(l) {
@@ -497,13 +498,13 @@ impl Network {
                             whatami: Some(whatami),
                             locators: None,
                             sn: 0,
-                            links: vec![],
+                            links: HashSet::new(),
                         }),
                         true,
                     )
                 }
             };
-            self.graph[self.idx].links.push(zid);
+            self.graph[self.idx].links.insert(zid);
             self.graph[self.idx].sn += 1;
 
             // Send updated self linkstate on all existing links except new one

--- a/zenoh/src/net/routing/hat/router/pubsub.rs
+++ b/zenoh/src/net/routing/hat/router/pubsub.rs
@@ -843,7 +843,7 @@ pub(super) fn pubsub_tree_change(
 pub(super) fn pubsub_linkstate_change(
     tables: &mut Tables,
     zid: &ZenohIdProto,
-    links: &[ZenohIdProto],
+    links: &HashSet<ZenohIdProto>,
     send_declare: &mut SendDeclare,
 ) {
     if let Some(mut src_face) = tables.get_face(zid).cloned() {

--- a/zenoh/src/net/routing/hat/router/queries.rs
+++ b/zenoh/src/net/routing/hat/router/queries.rs
@@ -13,7 +13,7 @@
 //
 use std::{
     borrow::Cow,
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::{atomic::Ordering, Arc},
 };
 
@@ -947,7 +947,7 @@ pub(super) fn queries_remove_node(
 pub(super) fn queries_linkstate_change(
     tables: &mut Tables,
     zid: &ZenohIdProto,
-    links: &[ZenohIdProto],
+    links: &HashSet<ZenohIdProto>,
     send_declare: &mut SendDeclare,
 ) {
     if let Some(mut src_face) = tables.get_face(zid).cloned() {

--- a/zenoh/src/net/routing/hat/router/token.rs
+++ b/zenoh/src/net/routing/hat/router/token.rs
@@ -12,7 +12,10 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-use std::sync::{atomic::Ordering, Arc};
+use std::{
+    collections::HashSet,
+    sync::{atomic::Ordering, Arc},
+};
 
 use petgraph::graph::NodeIndex;
 use zenoh_protocol::{
@@ -888,7 +891,7 @@ pub(super) fn token_tree_change(
 pub(super) fn token_linkstate_change(
     tables: &mut Tables,
     zid: &ZenohIdProto,
-    links: &[ZenohIdProto],
+    links: &HashSet<ZenohIdProto>,
     send_declare: &mut SendDeclare,
 ) {
     if let Some(mut src_face) = tables.get_face(zid).cloned() {


### PR DESCRIPTION
Links are used a lot for `contains` operation.