### PR TITLE
refactor: use a version number for routes computation

### DIFF
--- a/zenoh/src/net/routing/dispatcher/face.rs
+++ b/zenoh/src/net/routing/dispatcher/face.rs
@@ -390,8 +390,7 @@ impl Primitives for Face {
                         &mut |p, m| declares.push((p.clone(), m)),
                     );
 
-                    disable_all_data_routes(&mut wtables);
-                    disable_all_query_routes(&mut wtables);
+                    wtables.disable_all_routes();
 
                     drop(wtables);
                     drop(ctrl_lock);

--- a/zenoh/src/net/routing/dispatcher/pubsub.rs
+++ b/zenoh/src/net/routing/dispatcher/pubsub.rs
@@ -156,19 +156,6 @@ pub(crate) fn undeclare_subscription(
     }
 }
 
-pub(crate) fn disable_all_data_routes(tables: &mut Tables) {
-    pub(crate) fn disable_all_data_routes_rec(res: &mut Arc<Resource>) {
-        let res = get_mut_unchecked(res);
-        if let Some(ctx) = &mut res.context {
-            ctx.disable_data_routes();
-        }
-        for child in res.children.values_mut() {
-            disable_all_data_routes_rec(child);
-        }
-    }
-    disable_all_data_routes_rec(&mut tables.root_res)
-}
-
 pub(crate) fn disable_matches_data_routes(_tables: &mut Tables, res: &mut Arc<Resource>) {
     if res.context.is_some() {
         get_mut_unchecked(res).context_mut().disable_data_routes();
@@ -235,7 +222,13 @@ fn get_data_route(
         .and_then(|res| res.context.as_ref())
         .map(|ctx| &ctx.data_routes)
     {
-        return get_or_set_route(data_routes, face.whatami, local_context, compute_route);
+        return get_or_set_route(
+            data_routes,
+            tables.routes_version,
+            face.whatami,
+            local_context,
+            compute_route,
+        );
     }
     compute_route()
 }

--- a/zenoh/src/net/routing/dispatcher/queries.rs
+++ b/zenoh/src/net/routing/dispatcher/queries.rs
@@ -335,19 +335,6 @@ impl Timed for QueryCleanup {
     }
 }
 
-pub(crate) fn disable_all_query_routes(tables: &mut Tables) {
-    pub(crate) fn disable_all_query_routes_rec(res: &mut Arc<Resource>) {
-        let res = get_mut_unchecked(res);
-        if let Some(ctx) = &mut res.context {
-            ctx.disable_query_routes();
-        }
-        for child in res.children.values_mut() {
-            disable_all_query_routes_rec(child);
-        }
-    }
-    disable_all_query_routes_rec(&mut tables.root_res)
-}
-
 pub(crate) fn disable_matches_query_routes(_tables: &mut Tables, res: &mut Arc<Resource>) {
     if res.context.is_some() {
         get_mut_unchecked(res).context_mut().disable_query_routes();
@@ -378,7 +365,13 @@ fn get_query_route(
         .and_then(|res| res.context.as_ref())
         .map(|ctx| &ctx.query_routes)
     {
-        return get_or_set_route(query_routes, face.whatami, local_context, compute_route);
+        return get_or_set_route(
+            query_routes,
+            tables.routes_version,
+            face.whatami,
+            local_context,
+            compute_route,
+        );
     }
     compute_route()
 }

--- a/zenoh/src/net/routing/dispatcher/tables.rs
+++ b/zenoh/src/net/routing/dispatcher/tables.rs
@@ -78,6 +78,7 @@ pub struct Tables {
     pub(crate) interceptors: Vec<InterceptorFactory>,
     pub(crate) hat: Box<dyn Any + Send + Sync>,
     pub(crate) hat_code: Arc<dyn HatTrait + Send + Sync>, // @TODO make this a Box
+    pub(crate) routes_version: RoutesVersion,
 }
 
 impl Tables {
@@ -112,6 +113,7 @@ impl Tables {
             interceptors: interceptor_factories(config)?,
             hat: hat_code.new_tables(router_peers_failover_brokering),
             hat_code: hat_code.into(),
+            routes_version: 0,
         })
     }
 
@@ -154,6 +156,10 @@ impl Tables {
     #[inline]
     pub(crate) fn get_face(&self, zid: &ZenohIdProto) -> Option<&Arc<FaceState>> {
         self.faces.values().find(|face| face.zid == *zid)
+    }
+
+    pub(crate) fn disable_all_routes(&mut self) {
+        self.routes_version = self.routes_version.saturating_add(1);
     }
 }
 

--- a/zenoh/src/net/routing/hat/client/mod.rs
+++ b/zenoh/src/net/routing/hat/client/mod.rs
@@ -108,6 +108,7 @@ impl HatBaseTrait for HatCode {
         pubsub_new_face(tables, &mut face.state, send_declare);
         queries_new_face(tables, &mut face.state, send_declare);
         token_new_face(tables, &mut face.state, send_declare);
+        tables.disable_all_routes();
         Ok(())
     }
 
@@ -123,6 +124,7 @@ impl HatBaseTrait for HatCode {
         pubsub_new_face(tables, &mut face.state, send_declare);
         queries_new_face(tables, &mut face.state, send_declare);
         token_new_face(tables, &mut face.state, send_declare);
+        tables.disable_all_routes();
         Ok(())
     }
 

--- a/zenoh/src/net/routing/hat/client/pubsub.rs
+++ b/zenoh/src/net/routing/hat/client/pubsub.rs
@@ -37,7 +37,6 @@ use crate::{
             tables::{Route, RoutingExpr, Tables},
         },
         hat::{HatPubSubTrait, SendDeclare, Sources},
-        router::disable_all_data_routes,
         RoutingContext,
     },
 };
@@ -259,9 +258,6 @@ pub(super) fn pubsub_new_face(
             );
         }
     }
-
-    // disable routes
-    disable_all_data_routes(tables);
 }
 
 impl HatPubSubTrait for HatCode {

--- a/zenoh/src/net/routing/hat/client/queries.rs
+++ b/zenoh/src/net/routing/hat/client/queries.rs
@@ -42,7 +42,6 @@ use crate::{
             tables::{QueryTargetQabl, QueryTargetQablSet, RoutingExpr, Tables},
         },
         hat::{HatQueriesTrait, SendDeclare, Sources},
-        router::disable_all_query_routes,
         RoutingContext,
     },
 };
@@ -275,9 +274,6 @@ pub(super) fn queries_new_face(
             propagate_simple_queryable(tables, qabl, Some(&mut face.clone()), send_declare);
         }
     }
-
-    // disable routes
-    disable_all_query_routes(tables);
 }
 
 lazy_static::lazy_static! {

--- a/zenoh/src/net/routing/hat/linkstate_peer/mod.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/mod.rs
@@ -142,6 +142,7 @@ impl TreesComputationWorker {
                     pubsub::pubsub_tree_change(&mut tables, &new_children);
                     queries::queries_tree_change(&mut tables, &new_children);
                     token::token_tree_change(&mut tables, &new_children);
+                    tables.disable_all_routes();
                     drop(tables);
                 }
             }

--- a/zenoh/src/net/routing/hat/linkstate_peer/pubsub.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/pubsub.rs
@@ -45,7 +45,7 @@ use crate::net::routing::{
         tables::{Route, RoutingExpr, Tables},
     },
     hat::{CurrentFutureTrait, HatPubSubTrait, SendDeclare, Sources},
-    router::{disable_all_data_routes, disable_matches_data_routes},
+    router::disable_matches_data_routes,
     RoutingContext,
 };
 
@@ -671,9 +671,6 @@ pub(super) fn pubsub_tree_change(tables: &mut Tables, new_children: &[Vec<NodeIn
             }
         }
     }
-
-    // disable routes
-    disable_all_data_routes(tables);
 }
 
 #[inline]

--- a/zenoh/src/net/routing/hat/linkstate_peer/queries.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/queries.rs
@@ -49,7 +49,7 @@ use crate::net::routing::{
         tables::{QueryTargetQabl, QueryTargetQablSet, RoutingExpr, Tables},
     },
     hat::{CurrentFutureTrait, HatQueriesTrait, SendDeclare, Sources},
-    router::{disable_all_query_routes, disable_matches_query_routes},
+    router::disable_matches_query_routes,
     RoutingContext,
 };
 
@@ -690,9 +690,6 @@ pub(super) fn queries_tree_change(tables: &mut Tables, new_children: &[Vec<NodeI
             }
         }
     }
-
-    // disable routes
-    disable_all_query_routes(tables);
 }
 
 #[inline]

--- a/zenoh/src/net/routing/hat/p2p_peer/mod.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/mod.rs
@@ -167,6 +167,7 @@ impl HatBaseTrait for HatCode {
         pubsub_new_face(tables, &mut face.state, send_declare);
         queries_new_face(tables, &mut face.state, send_declare);
         token_new_face(tables, &mut face.state, send_declare);
+        tables.disable_all_routes();
         Ok(())
     }
 
@@ -198,6 +199,7 @@ impl HatBaseTrait for HatCode {
         pubsub_new_face(tables, &mut face.state, send_declare);
         queries_new_face(tables, &mut face.state, send_declare);
         token_new_face(tables, &mut face.state, send_declare);
+        tables.disable_all_routes();
 
         if face.state.whatami == WhatAmI::Peer {
             send_declare(

--- a/zenoh/src/net/routing/hat/p2p_peer/pubsub.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/pubsub.rs
@@ -43,7 +43,6 @@ use crate::{
         hat::{
             p2p_peer::initial_interest, CurrentFutureTrait, HatPubSubTrait, SendDeclare, Sources,
         },
-        router::disable_all_data_routes,
         RoutingContext,
     },
 };
@@ -403,8 +402,6 @@ pub(super) fn pubsub_new_face(
             }
         }
     }
-    // disable routes
-    disable_all_data_routes(tables);
 }
 
 #[inline]

--- a/zenoh/src/net/routing/hat/p2p_peer/queries.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/queries.rs
@@ -47,7 +47,6 @@ use crate::{
         hat::{
             p2p_peer::initial_interest, CurrentFutureTrait, HatQueriesTrait, SendDeclare, Sources,
         },
-        router::disable_all_query_routes,
         RoutingContext,
     },
 };
@@ -375,8 +374,6 @@ pub(super) fn queries_new_face(
             }
         }
     }
-    // disable routes
-    disable_all_query_routes(tables);
 }
 
 lazy_static::lazy_static! {

--- a/zenoh/src/net/routing/hat/router/mod.rs
+++ b/zenoh/src/net/routing/hat/router/mod.rs
@@ -150,6 +150,7 @@ impl TreesComputationWorker {
                     pubsub::pubsub_tree_change(&mut tables, &new_children, net_type);
                     queries::queries_tree_change(&mut tables, &new_children, net_type);
                     token::token_tree_change(&mut tables, &new_children, net_type);
+                    tables.disable_all_routes();
                     drop(tables);
                 }
             }

--- a/zenoh/src/net/routing/hat/router/pubsub.rs
+++ b/zenoh/src/net/routing/hat/router/pubsub.rs
@@ -46,7 +46,7 @@ use crate::net::routing::{
         tables::{Route, RoutingExpr, Tables},
     },
     hat::{CurrentFutureTrait, HatPubSubTrait, SendDeclare, Sources},
-    router::{disable_all_data_routes, disable_matches_data_routes},
+    router::disable_matches_data_routes,
     RoutingContext,
 };
 
@@ -836,9 +836,6 @@ pub(super) fn pubsub_tree_change(
             }
         }
     }
-
-    // disable routes
-    disable_all_data_routes(tables);
 }
 
 pub(super) fn pubsub_linkstate_change(

--- a/zenoh/src/net/routing/hat/router/queries.rs
+++ b/zenoh/src/net/routing/hat/router/queries.rs
@@ -50,7 +50,7 @@ use crate::net::routing::{
         tables::{QueryTargetQabl, QueryTargetQablSet, RoutingExpr, Tables},
     },
     hat::{CurrentFutureTrait, HatQueriesTrait, SendDeclare, Sources},
-    router::{disable_all_query_routes, disable_matches_query_routes},
+    router::disable_matches_query_routes,
     RoutingContext,
 };
 
@@ -1074,9 +1074,6 @@ pub(super) fn queries_tree_change(
             }
         }
     }
-
-    // disable routes
-    disable_all_query_routes(tables);
 }
 
 #[inline]

--- a/zenoh/src/net/routing/router.rs
+++ b/zenoh/src/net/routing/router.rs
@@ -210,7 +210,7 @@ impl Router {
         });
         tables.mcast_groups.push(face);
 
-        disable_all_data_routes(&mut tables);
+        tables.disable_all_routes();
         Ok(())
     }
 
@@ -243,7 +243,7 @@ impl Router {
         );
         tables.mcast_faces.push(face_state.clone());
 
-        disable_all_data_routes(&mut tables);
+        tables.disable_all_routes();
         Ok(Arc::new(DeMux::new(
             Face {
                 tables: self.tables.clone(),


### PR DESCRIPTION
Using a version number allows resetting all computed routes just by incrementing it.
Each time a route is computed, it associated with the current version number. When the already computed route is accessed, its associated version number is compared, and no route is returned if it doesn't match.