### PR TITLE
fix: handle linkstate decoding error

### DIFF
--- a/zenoh/src/net/routing/hat/linkstate_peer/mod.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/mod.rs
@@ -392,7 +392,9 @@ impl HatBaseTrait for HatCode {
                     use zenoh_codec::RCodec;
                     let codec = Zenoh080Routing::new();
                     let mut reader = buf.reader();
-                    let list: LinkStateList = codec.read(&mut reader).unwrap();
+                    let Ok(list): Result<LinkStateList, _> = codec.read(&mut reader) else {
+                        bail!("failed to decode link state");
+                    };
 
                     let whatami = transport.get_whatami()?;
                     if whatami != WhatAmI::Client {

--- a/zenoh/src/net/routing/hat/p2p_peer/mod.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/mod.rs
@@ -337,7 +337,9 @@ impl HatBaseTrait for HatCode {
                             use zenoh_codec::RCodec;
                             let codec = Zenoh080Routing::new();
                             let mut reader = buf.reader();
-                            let list: LinkStateList = codec.read(&mut reader).unwrap();
+                            let Ok(list): Result<LinkStateList, _> = codec.read(&mut reader) else {
+                                bail!("failed to decode link state");
+                            };
 
                             net.link_states(list.link_states, zid, whatami);
                         }

--- a/zenoh/src/net/routing/hat/router/mod.rs
+++ b/zenoh/src/net/routing/hat/router/mod.rs
@@ -625,7 +625,9 @@ impl HatBaseTrait for HatCode {
                     use zenoh_codec::RCodec;
                     let codec = Zenoh080Routing::new();
                     let mut reader = buf.reader();
-                    let list: LinkStateList = codec.read(&mut reader).unwrap();
+                    let Ok(list): Result<LinkStateList, _> = codec.read(&mut reader) else {
+                        bail!("failed to decode link state");
+                    };
 
                     let whatami = transport.get_whatami()?;
                     match whatami {


### PR DESCRIPTION
Panicking here was causing a major security breach concerning every non-encrypted transport, especially UDP ones. An attacker could simply forge a invalid OAM linkstate message to make the transport panic. Regarding UDP multicast network, a single message could make the whole network instantly unresponsive.