### PR TITLE
Remove unnecessary mutex lock and drop in pipeline serialization

### DIFF
--- a/io/zenoh-transport/src/common/pipeline.rs
+++ b/io/zenoh-transport/src/common/pipeline.rs
@@ -276,7 +276,6 @@ impl StageIn {
                                 break batch;
                             }
                             None => {
-                                drop(c_guard);
                                 // Wait for an available batch until deadline
                                 if !deadline.wait(&self.s_ref)? {
                                     // Still no available batch.
@@ -288,7 +287,6 @@ impl StageIn {
                                     );
                                     return Ok(false);
                                 }
-                                c_guard = self.mutex.current();
                             }
                         },
                     }
@@ -441,11 +439,9 @@ impl StageIn {
                                 break batch;
                             }
                             None => {
-                                drop(c_guard);
                                 if !self.s_ref.wait() {
                                     return false;
                                 }
-                                c_guard = self.mutex.current();
                             }
                         },
                     }


### PR DESCRIPTION
It seems the lock drop and re-lock stayed there from the past where it was a necessity.
It seems now it's an unnecessary thing to do when waiting for new batching in the refill stage.