### PR TITLE
Reduce TX/RX buffers allocation

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -476,8 +476,8 @@
             time_limit: 1,
           },
           allocation: {
-            /// Mode for memoery allocation of batches in the prioritiey queues. 
-            /// - "init": batches are allocated at initialization time. 
+            /// Mode for memory allocation of batches in the priority queues. 
+            /// - "init": batches are allocated at queue initialization time. 
             /// - "lazy": batches are allocated when needed up to the maximum number of batches configured in the size configuration parameter.
             mode: "init",
           },

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -475,6 +475,12 @@
             /// The maximum time limit (in ms) a message should be retained for batching when back-pressure happens.
             time_limit: 1,
           },
+          allocation: {
+            /// Mode for memoery allocation of batches in the prioritiey queues. 
+            /// - "init": batches are allocated at initialization time. 
+            /// - "lazy": batches are allocated when needed up to the maximum number of batches configured in the size configuration parameter.
+            mode: "init",
+          },
         },
       },
       /// Configure the zenoh RX parameters of a link

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -485,6 +485,13 @@ validated_struct::validator! {
                             /// The maximum time limit (in ms) a message should be retained for batching when back-pressure happens.
                             time_limit: u64,
                         },
+                        /// Perform lazy memory allocation of batches in the prioritiey queues. If set to false all batches are initialized at
+                        /// initialization time. If set to true the batches will be allocated when needed up to the maximum number of batches
+                        /// configured in the size configuration parameter.
+                        pub allocation: #[derive(Default, Copy, PartialEq, Eq)]
+                        QueueAllocConf {
+                            pub mode: QueueAllocMode,
+                        },
                     },
                     // Number of threads used for TX
                     threads: usize,
@@ -617,6 +624,14 @@ validated_struct::validator! {
         /// Please refer to [`PluginsConfig`]'s documentation for further details.
         plugins: PluginsConfig,
     }
+}
+
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QueueAllocMode {
+    #[default]
+    Init,
+    Lazy,
 }
 
 impl Default for PermissionsConf {

--- a/io/zenoh-transport/src/common/pipeline.rs
+++ b/io/zenoh-transport/src/common/pipeline.rs
@@ -73,7 +73,6 @@ impl StageInRefill {
         match self.s_ref_r.pull() {
             Some(b) => Some(b),
             None if self.batch_allocs < self.batch_config.0 => {
-                println!("..............................................");
                 self.batch_allocs += 1;
                 Some(WBatch::new(self.batch_config.1))
             }

--- a/io/zenoh-transport/src/common/pipeline.rs
+++ b/io/zenoh-transport/src/common/pipeline.rs
@@ -70,11 +70,14 @@ impl std::error::Error for TransportClosed {}
 
 impl StageInRefill {
     fn pull(&mut self) -> Option<WBatch> {
-        if self.batch_allocs < self.batch_config.0 {
-            self.batch_allocs += 1;
-            Some(WBatch::new(self.batch_config.1))
-        } else {
-            self.s_ref_r.pull()
+        match self.s_ref_r.pull() {
+            Some(b) => Some(b),
+            None if self.batch_allocs < self.batch_config.0 => {
+                println!("..............................................");
+                self.batch_allocs += 1;
+                Some(WBatch::new(self.batch_config.1))
+            }
+            None => None,
         }
     }
 

--- a/io/zenoh-transport/src/manager.rs
+++ b/io/zenoh-transport/src/manager.rs
@@ -273,6 +273,7 @@ impl TransportManagerBuilder {
         ));
         self = self.wait_before_close(duration_from_i64us(*cc_block.wait_before_close()));
         self = self.queue_size(link.tx().queue().size().clone());
+        self = self.queue_alloc(*link.tx().queue().allocation());
         self = self.tx_threads(*link.tx().threads());
         self = self.protocols(link.protocols().clone());
 

--- a/io/zenoh-transport/src/manager.rs
+++ b/io/zenoh-transport/src/manager.rs
@@ -15,7 +15,7 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use rand::{RngCore, SeedableRng};
 use tokio::sync::Mutex as AsyncMutex;
-use zenoh_config::{Config, LinkRxConf, QueueConf, QueueSizeConf};
+use zenoh_config::{Config, LinkRxConf, QueueAllocConf, QueueConf, QueueSizeConf};
 use zenoh_crypto::{BlockCipher, PseudoRng};
 use zenoh_link::NewLinkChannelSender;
 use zenoh_protocol::{
@@ -112,6 +112,7 @@ pub struct TransportManagerConfig {
     pub wait_before_close: Duration,
     pub queue_size: [usize; Priority::NUM],
     pub queue_backoff: Duration,
+    pub queue_alloc: QueueAllocConf,
     pub defrag_buff_size: usize,
     pub link_rx_buffer_size: usize,
     pub unicast: TransportManagerConfigUnicast,
@@ -143,6 +144,7 @@ pub struct TransportManagerBuilder {
     wait_before_drop: (Duration, Duration),
     wait_before_close: Duration,
     queue_size: QueueSizeConf,
+    queue_alloc: QueueAllocConf,
     defrag_buff_size: usize,
     link_rx_buffer_size: usize,
     unicast: TransportManagerBuilderUnicast,
@@ -188,6 +190,11 @@ impl TransportManagerBuilder {
 
     pub fn batching_time_limit(mut self, batching_time_limit: Duration) -> Self {
         self.batching_time_limit = batching_time_limit;
+        self
+    }
+
+    pub fn queue_alloc(mut self, queue_alloc: QueueAllocConf) -> Self {
+        self.queue_alloc = queue_alloc;
         self
     }
 
@@ -326,6 +333,7 @@ impl TransportManagerBuilder {
             wait_before_close: self.wait_before_close,
             queue_size,
             queue_backoff: self.batching_time_limit,
+            queue_alloc: self.queue_alloc,
             defrag_buff_size: self.defrag_buff_size,
             link_rx_buffer_size: self.link_rx_buffer_size,
             unicast: unicast.config,
@@ -377,6 +385,7 @@ impl Default for TransportManagerBuilder {
             ),
             wait_before_close: duration_from_i64us(*cc_block.wait_before_close()),
             queue_size: queue.size,
+            queue_alloc: queue.allocation,
             batching_time_limit: Duration::from_millis(backoff),
             defrag_buff_size: *link_rx.max_message_size(),
             link_rx_buffer_size: *link_rx.buffer_size(),

--- a/io/zenoh-transport/src/multicast/link.rs
+++ b/io/zenoh-transport/src/multicast/link.rs
@@ -544,8 +544,9 @@ async fn rx_task(
     // The pool of buffers
     let mtu = link.inner.config.batch.mtu as usize;
     let mut n = rx_buffer_size / mtu;
-    if rx_buffer_size % mtu != 0 {
-        n += 1;
+    if n == 0 {
+        tracing::debug!("RX configured buffer of {rx_buffer_size} bytes is too small for {link} that has an MTU of {mtu} bytes. Defaulting to {mtu} bytes for RX buffer.");
+        n = 1;
     }
 
     let pool = RecyclingObjectPool::new(n, || vec![0_u8; mtu].into_boxed_slice());

--- a/io/zenoh-transport/src/multicast/link.rs
+++ b/io/zenoh-transport/src/multicast/link.rs
@@ -314,6 +314,7 @@ impl TransportLinkMulticastUniversal {
                 wait_before_close: self.transport.manager.config.wait_before_close,
                 batching_enabled: self.transport.manager.config.batching,
                 batching_time_limit: self.transport.manager.config.queue_backoff,
+                queue_alloc: self.transport.manager.config.queue_alloc,
             };
             // The pipeline
             let (producer, consumer) = TransmissionPipeline::make(tpc, &priority_tx);

--- a/io/zenoh-transport/src/unicast/lowlatency/link.rs
+++ b/io/zenoh-transport/src/unicast/lowlatency/link.rs
@@ -154,8 +154,9 @@ impl TransportUnicastLowlatency {
             let pool = {
                 let mtu = link_rx.config.batch.mtu as usize;
                 let mut n = rx_buffer_size / mtu;
-                if rx_buffer_size % mtu != 0 {
-                    n += 1;
+                if n == 0 {
+                    tracing::debug!("RX configured buffer of {rx_buffer_size} bytes is too small for {link_rx} that has an MTU of {mtu} bytes. Defaulting to {mtu} bytes for RX buffer.");
+                    n = 1;
                 }
                 zenoh_sync::RecyclingObjectPool::new(n, move || vec![0_u8; mtu].into_boxed_slice())
             };

--- a/io/zenoh-transport/src/unicast/universal/link.rs
+++ b/io/zenoh-transport/src/unicast/universal/link.rs
@@ -66,6 +66,7 @@ impl TransportLinkUnicastUniversal {
             wait_before_close: transport.manager.config.wait_before_close,
             batching_enabled: transport.manager.config.batching,
             batching_time_limit: transport.manager.config.queue_backoff,
+            queue_alloc: transport.manager.config.queue_alloc,
         };
 
         // The pipeline

--- a/io/zenoh-transport/src/unicast/universal/link.rs
+++ b/io/zenoh-transport/src/unicast/universal/link.rs
@@ -262,8 +262,9 @@ async fn rx_task(
     // The pool of buffers
     let mtu = link.config.batch.mtu as usize;
     let mut n = rx_buffer_size / mtu;
-    if rx_buffer_size % mtu != 0 {
-        n += 1;
+    if n == 0 {
+        tracing::debug!("RX configured buffer of {rx_buffer_size} bytes is too small for {link} that has an MTU of {mtu} bytes. Defaulting to {mtu} bytes for RX buffer.");
+        n = 1;
     }
 
     let pool = RecyclingObjectPool::new(n, || vec![0_u8; mtu].into_boxed_slice());


### PR DESCRIPTION
This PR:

1. Lazily allocates the TX batches upon link creation;
2. Adopts a less-aggressive policy for allocating excessive memory for RX buffers.

This allows to reduce the number of allocated batches that are not utilised. 
In general it should improve the overall memory consumption when many links are established.

## Validation

### Target
AMD Ryzen 7 5800X 8-Core Processor
32GB of RAM

### Config
Queue configuration (`queue.conf.json5`)
```json5
{
  transport: {
    link: {
      tx: {
        queue: {
          size: {
            control: 1,
            real_time: 1,
            interactive_high: 1,
            interactive_low: 1,
            data_high: 2,
            data: 4,
            data_low: 4,
            background: 4,
          },
          allocation: {
	    // mode: "init",
            mode: "lazy",
          },
        },
      },
    },
  },
}
```

### Test
Run `zenohd`:

```bash
./target/release/zenohd --no-multicast-scouting -l tcp/localhost:7447 -c queue.conf.json5
```

Run 100 `z_sub`:

```bash
for i in `seq 1 100`; do (./target/release/examples/z_sub --no-multicast-scouting -l tcp/localhost:0 -e tcp/localhost:7447 -c queue.conf.json5 &); done
```

Run 100 `z_pub`:

```bash
for i in `seq 1 100`; do (./target/release/examples/z_pub --no-multicast-scouting -l tcp/localhost:0 -e tcp/localhost:7447 -c queue.conf.json5 &); done
```

### Results
Baseline memory usage: `3.45G`.
Memory mode:
- Init: `14.9G/31.3G` → `11.45G` in total (`56.97M` per process)
- Lazy: `10.2G/31.3G` → `6.75G` in total (`33.58M` per process)

In case of `z_sub` / `z_pub` the gain is `4.7G` less memory.