### PR TITLE
docs(storage-manager): improve documentation of Replication

### DIFF
--- a/plugins/zenoh-plugin-storage-manager/src/replication/classification.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replication/classification.rs
@@ -156,6 +156,8 @@ impl Interval {
 
     /// Returns an [HashMap] of the index and [Fingerprint] of all the [SubInterval]s contained in
     /// this [Interval].
+    //
+    // This is a convenience method used to compute the Digest and an AlignmentReply.
     pub(crate) fn sub_intervals_fingerprints(&self) -> HashMap<SubIntervalIdx, Fingerprint> {
         self.sub_intervals
             .iter()
@@ -174,7 +176,7 @@ impl Interval {
     /// As its name indicates, this method DOES NOT CHECK if there is another [Event] associated to
     /// the same key expression (regardless of its [Timestamp]).
     ///
-    /// This uniqueness property (i.e. there should only be a single [Event] in the replication Log
+    /// This uniqueness property (i.e. there should only be a single [Event] in the Replication Log
     /// for a given key expression) cannot be enforced at the [Interval] level. Hence, this method
     /// assumes the check has already been performed and thus does not do redundant work.
     pub(crate) fn insert_unchecked(&mut self, sub_interval_idx: SubIntervalIdx, event: Event) {
@@ -220,6 +222,9 @@ impl Interval {
         result
     }
 
+    /// Removes and returns, if found, the [Event] having the provided [EventMetadata].
+    ///
+    /// The fingerprint of the Interval will be updated accordingly.
     pub(crate) fn remove_event(
         &mut self,
         sub_interval_idx: &SubIntervalIdx,
@@ -422,6 +427,9 @@ impl SubInterval {
         }
     }
 
+    /// Removes and returns, if found, the [Event] having the same [EventMetadata].
+    ///
+    /// The Fingerprint of the SubInterval is updated accordingly.
     fn remove_event(&mut self, event_to_remove: &EventMetadata) -> Option<Event> {
         let removed_event = self.events.remove(&event_to_remove.log_key());
         if let Some(event) = &removed_event {
@@ -438,6 +446,8 @@ impl SubInterval {
     /// is where the Wildcard Update should be recorded.
     /// It is only in that specific scenario that we are not sure that all [Event]s have a lower
     /// timestamp.
+    ///
+    /// The Fingerprint of the [SubInterval] is updated accordingly.
     fn remove_events_overridden_by_wildcard_update(
         &mut self,
         prefix: Option<&OwnedKeyExpr>,

--- a/plugins/zenoh-plugin-storage-manager/src/replication/configuration.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replication/configuration.rs
@@ -79,6 +79,11 @@ impl Configuration {
         }
     }
 
+    /// Returns the `prefix`, if one is set, that is stripped before keys are stored in the Storage.
+    ///
+    /// This corresponds to the `strip_prefix` configuration parameter of the Storage.
+    ///
+    /// TODO Rename this field and method to `strip_prefix` for consistency.
     pub fn prefix(&self) -> Option<&OwnedKeyExpr> {
         self.prefix.as_ref()
     }
@@ -120,8 +125,8 @@ impl Configuration {
         Ok(IntervalIdx(last_elapsed_interval as u64))
     }
 
-    /// Returns the index of the lowest interval contained in the *hot* era, assuming that the
-    /// highest interval contained in the *hot* era is the one provided.
+    /// Returns the index of the lowest interval contained in the *Hot* Era, assuming that the
+    /// highest interval contained in the *Hot* Era is the one provided.
     ///
     /// # Example
     ///
@@ -139,8 +144,8 @@ impl Configuration {
         (*hot_era_upper_bound - self.hot + 1).into()
     }
 
-    /// Returns the index of the lowest interval contained in the *warm* era, assuming that the
-    /// highest interval contained in the *hot* era is the one provided.
+    /// Returns the index of the lowest interval contained in the *Warm* Era, assuming that the
+    /// highest interval contained in the *Hot* Era is the one provided.
     ///
     /// ⚠️ Note that, even though this method computes the lower bound of the WARM era, the index
     /// provided is the upper bound of the HOT era.
@@ -162,7 +167,7 @@ impl Configuration {
         (*hot_era_upper_bound - self.hot - self.warm + 1).into()
     }
 
-    /// Returns the time classification — [Interval] and [SubInterval] — of the provided
+    /// Returns the time classification — i.e. [Interval] and [SubInterval] — of the provided
     /// [Timestamp].
     ///
     /// # Errors

--- a/plugins/zenoh-plugin-storage-manager/src/storages_mgt/mod.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/storages_mgt/mod.rs
@@ -113,10 +113,6 @@ pub(crate) async fn create_and_start_storage(
     //
     //      Doing so also allows us to return early from the creation of the Storage, creation which
     //      blocks populating the routing tables.
-    //
-    // TODO Do we really want to perform such an initial alignment? Because this query will
-    //      target any Storage that matches the same key expression, regardless of if they have
-    //      been configured to be replicated.
     tokio::task::spawn(async move {
         let storage_service = Arc::new(
             StorageService::new(


### PR DESCRIPTION
Some comments were outdated and some methods, functions had none. This commit fixes these oversights.