### PR TITLE
SHM lazy init is now configured in config.json

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -550,14 +550,13 @@
       /// over shared memory (and to not fallback on network mode), shared memory needs to be enabled also on the
       /// subscriber side. By doing so, the probing procedure will succeed and shared memory will operate as expected.
       enabled: true,
-      /// Lazy SHM resources initialization.
-      /// If set to `true`, the SHM subsystem internals will be initialized lazily upon the first SHM buffer
-      /// allocation or reception. (default `true`).
-      /// `true` setting provides better startup time and optimizes resource usage, but produces extra
-      /// latency at the first SHM buffer interaction moment.
-      /// `false` setting sacrifices startup time, but guarantees no latency impact when first SHM buffer is
-      /// processed.
-      lazy_init: true,
+      /// SHM resources initialization mode (default "lazy").
+      /// - "lazy": SHM subsystem internals will be initialized lazily upon the first SHM buffer
+      /// allocation or reception. This setting provides better startup time and optimizes resource usage,
+      /// but produces extra latency at the first SHM buffer interaction.
+      /// - "init" SHM subsystem internals will be initialized upon Session opening. This setting sacrifices
+      /// startup time, but guarantees no latency impact when first SHM buffer is processed.
+      mode: "lazy",
     },
     auth: {
       /// The configuration of authentication.

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -543,10 +543,21 @@
     /// NOTE: shared memory can be used only if zenoh is compiled with "shared-memory" feature, otherwise
     /// settings in this section have no effect.
     shared_memory: {
+      /// Whether shared memory is enabled or not.
+      /// If set to `true`, the SHM buffer optimization support will be announced to other parties. (default `true`).
+      /// This option doesn't make SHM buffer optimization mandatory, the real support depends on other party setting.
       /// A probing procedure for shared memory is performed upon session opening. To enable zenoh to operate
       /// over shared memory (and to not fallback on network mode), shared memory needs to be enabled also on the
       /// subscriber side. By doing so, the probing procedure will succeed and shared memory will operate as expected.
       enabled: true,
+      /// Lazy SHM resources initialization.
+      /// If set to `true`, the SHM subsystem internals will be initialized lazily upon the first SHM buffer
+      /// allocation or reception. (default `true`).
+      /// `true` setting provides better startup time and optimizes resource usage, but produces extra
+      /// latency at the first SHM buffer interaction moment.
+      /// `false` setting sacrifices startup time, but guarantees no latency impact when first SHM buffer is
+      /// processed.
+      lazy_init: true,
     },
     auth: {
       /// The configuration of authentication.

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -554,7 +554,7 @@
       /// - "lazy": SHM subsystem internals will be initialized lazily upon the first SHM buffer
       /// allocation or reception. This setting provides better startup time and optimizes resource usage,
       /// but produces extra latency at the first SHM buffer interaction.
-      /// - "init" SHM subsystem internals will be initialized upon Session opening. This setting sacrifices
+      /// - "init": SHM subsystem internals will be initialized upon Session opening. This setting sacrifices
       /// startup time, but guarantees no latency impact when first SHM buffer is processed.
       mode: "lazy",
     },

--- a/commons/zenoh-config/src/defaults.rs
+++ b/commons/zenoh-config/src/defaults.rs
@@ -309,7 +309,7 @@ impl Default for ShmConf {
     fn default() -> Self {
         Self {
             enabled: true,
-            lazy_init: true,
+            mode: ShmInitMode::default(),
         }
     }
 }

--- a/commons/zenoh-config/src/defaults.rs
+++ b/commons/zenoh-config/src/defaults.rs
@@ -307,7 +307,10 @@ impl Default for LinkRxConf {
 #[allow(clippy::derivable_impls)]
 impl Default for ShmConf {
     fn default() -> Self {
-        Self { enabled: true }
+        Self {
+            enabled: true,
+            lazy_init: true,
+        }
     }
 }
 

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -558,7 +558,7 @@ validated_struct::validator! {
                 /// - "lazy": SHM subsystem internals will be initialized lazily upon the first SHM buffer
                 /// allocation or reception. This setting provides better startup time and optimizes resource usage,
                 /// but produces extra latency at the first SHM buffer interaction.
-                /// - "init" SHM subsystem internals will be initialized upon Session opening. This setting sacrifices
+                /// - "init": SHM subsystem internals will be initialized upon Session opening. This setting sacrifices
                 /// startup time, but guarantees no latency impact when first SHM buffer is processed.
                 mode: ShmInitMode,
             },

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -554,14 +554,13 @@ validated_struct::validator! {
                 /// over shared memory (and to not fallback on network mode), shared memory needs to be enabled also on the
                 /// subscriber side. By doing so, the probing procedure will succeed and shared memory will operate as expected.
                 enabled: bool,
-                /// Lazy SHM resources initialization.
-                /// If set to `true`, the SHM subsystem internals will be initialized lazily upon the first SHM buffer
-                /// allocation or reception. (default `true`).
-                /// `true` setting provides better startup time and optimizes resource usage, but produces extra
-                /// latency at the first SHM buffer interaction moment.
-                /// `false` setting sacrifices startup time, but guarantees no latency impact when first SHM buffer is
-                /// processed.
-                lazy_init: bool,
+                /// SHM resources initialization mode (default "lazy").
+                /// - "lazy": SHM subsystem internals will be initialized lazily upon the first SHM buffer
+                /// allocation or reception. This setting provides better startup time and optimizes resource usage,
+                /// but produces extra latency at the first SHM buffer interaction.
+                /// - "init" SHM subsystem internals will be initialized upon Session opening. This setting sacrifices
+                /// startup time, but guarantees no latency impact when first SHM buffer is processed.
+                mode: ShmInitMode,
             },
             pub auth: #[derive(Default)]
             AuthConf {
@@ -640,6 +639,14 @@ validated_struct::validator! {
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum QueueAllocMode {
+    Init,
+    #[default]
+    Lazy,
+}
+
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ShmInitMode {
     Init,
     #[default]
     Lazy,

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -548,9 +548,20 @@ validated_struct::validator! {
             pub shared_memory:
             ShmConf {
                 /// Whether shared memory is enabled or not.
-                /// If set to `true`, the SHM buffer optimization support will be announced to other parties. (default `false`).
+                /// If set to `true`, the SHM buffer optimization support will be announced to other parties. (default `true`).
                 /// This option doesn't make SHM buffer optimization mandatory, the real support depends on other party setting
+                /// A probing procedure for shared memory is performed upon session opening. To enable zenoh to operate
+                /// over shared memory (and to not fallback on network mode), shared memory needs to be enabled also on the
+                /// subscriber side. By doing so, the probing procedure will succeed and shared memory will operate as expected.
                 enabled: bool,
+                /// Lazy SHM resources initialization.
+                /// If set to `true`, the SHM subsystem internals will be initialized lazily upon the first SHM buffer
+                /// allocation or reception. (default `true`).
+                /// `true` setting provides better startup time and optimizes resource usage, but produces extra
+                /// latency at the first SHM buffer interaction moment.
+                /// `false` setting sacrifices startup time, but guarantees no latency impact when first SHM buffer is
+                /// processed.
+                lazy_init: bool,
             },
             pub auth: #[derive(Default)]
             AuthConf {

--- a/commons/zenoh-shm/src/init.rs
+++ b/commons/zenoh-shm/src/init.rs
@@ -1,0 +1,24 @@
+//
+// Copyright (c) 2024 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+use crate::{api::client_storage::GLOBAL_CLIENT_STORAGE, cleanup::CLEANUP, metadata::{storage::GLOBAL_METADATA_STORAGE, subscription::GLOBAL_METADATA_SUBSCRIPTION}, watchdog::{confirmator::GLOBAL_CONFIRMATOR, validator::GLOBAL_VALIDATOR}};
+
+pub fn init() {
+    let _ = CLEANUP.write();
+    let _ = GLOBAL_CLIENT_STORAGE.write();
+    let _ = GLOBAL_METADATA_STORAGE.write();
+    let _ = GLOBAL_METADATA_SUBSCRIPTION.write();
+    let _ = GLOBAL_CONFIRMATOR.write();
+    let _ = GLOBAL_VALIDATOR.write();
+}

--- a/commons/zenoh-shm/src/init.rs
+++ b/commons/zenoh-shm/src/init.rs
@@ -12,7 +12,12 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-use crate::{api::client_storage::GLOBAL_CLIENT_STORAGE, cleanup::CLEANUP, metadata::{storage::GLOBAL_METADATA_STORAGE, subscription::GLOBAL_METADATA_SUBSCRIPTION}, watchdog::{confirmator::GLOBAL_CONFIRMATOR, validator::GLOBAL_VALIDATOR}};
+use crate::{
+    api::client_storage::GLOBAL_CLIENT_STORAGE,
+    cleanup::CLEANUP,
+    metadata::{storage::GLOBAL_METADATA_STORAGE, subscription::GLOBAL_METADATA_SUBSCRIPTION},
+    watchdog::{confirmator::GLOBAL_CONFIRMATOR, validator::GLOBAL_VALIDATOR},
+};
 
 pub fn init() {
     let _ = CLEANUP.write();

--- a/commons/zenoh-shm/src/init.rs
+++ b/commons/zenoh-shm/src/init.rs
@@ -20,10 +20,10 @@ use crate::{
 };
 
 pub fn init() {
-    let _ = CLEANUP.write();
-    let _ = GLOBAL_CLIENT_STORAGE.write();
-    let _ = GLOBAL_METADATA_STORAGE.write();
-    let _ = GLOBAL_METADATA_SUBSCRIPTION.write();
-    let _ = GLOBAL_CONFIRMATOR.write();
-    let _ = GLOBAL_VALIDATOR.write();
+    CLEANUP.init();
+    GLOBAL_CLIENT_STORAGE.init();
+    GLOBAL_METADATA_STORAGE.init();
+    GLOBAL_METADATA_SUBSCRIPTION.init();
+    GLOBAL_CONFIRMATOR.init();
+    GLOBAL_VALIDATOR.init();
 }

--- a/commons/zenoh-shm/src/lib.rs
+++ b/commons/zenoh-shm/src/lib.rs
@@ -54,6 +54,7 @@ macro_rules! tested_crate_module {
 pub mod api;
 mod cleanup;
 pub mod header;
+pub mod init;
 pub mod metadata;
 pub mod posix_shm;
 pub mod reader;

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -174,7 +174,7 @@ impl RuntimeBuilder {
         let start_admin_space = *config.adminspace.enabled();
         // SHM lazy init flag
         #[cfg(feature = "shared-memory")]
-        let shm_lazy_init = *config.transport.shared_memory.lazy_init();
+        let shm_init_mode = *config.transport.shared_memory.mode();
 
         let config = Notifier::new(crate::config::Config(config));
         let runtime = Runtime {
@@ -235,9 +235,10 @@ impl RuntimeBuilder {
         });
 
         #[cfg(feature = "shared-memory")]
-        if !shm_lazy_init {
-            zenoh_shm::init::init();
-        }
+        match shm_init_mode {
+            zenoh_config::ShmInitMode::Init => zenoh_shm::init::init(),
+            zenoh_config::ShmInitMode::Lazy => {}
+        };
 
         Ok(runtime)
     }

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -172,6 +172,9 @@ impl RuntimeBuilder {
             .unwrap_or_else(|| load_plugins(&config));
         // Admin space creation flag
         let start_admin_space = *config.adminspace.enabled();
+        // SHM lazy init flag
+        #[cfg(feature = "shared-memory")]
+        let shm_lazy_init = *config.transport.shared_memory.lazy_init();
 
         let config = Notifier::new(crate::config::Config(config));
         let runtime = Runtime {
@@ -230,6 +233,11 @@ impl RuntimeBuilder {
                 }
             }
         });
+
+        #[cfg(feature = "shared-memory")]
+        if !shm_lazy_init {
+            zenoh_shm::init::init();
+        }
 
         Ok(runtime)
     }

--- a/zenoh/tests/shm.rs
+++ b/zenoh/tests/shm.rs
@@ -199,7 +199,11 @@ async fn test_session_pubsub(peer01: &Session, peer02: &Session, reliability: Re
 fn zenoh_shm_startup_init() {
     // Open the sessions
     let mut config = zenoh::Config::default();
-    config.transport.shared_memory.set_lazy_init(false).unwrap();
+    config
+        .transport
+        .shared_memory
+        .set_mode(zenoh_config::ShmInitMode::Init)
+        .unwrap();
     tokio::runtime::Runtime::new().unwrap().block_on(async {
         let _session = ztimeout!(zenoh::open(config)).unwrap();
     });

--- a/zenoh/tests/shm.rs
+++ b/zenoh/tests/shm.rs
@@ -196,6 +196,16 @@ async fn test_session_pubsub(peer01: &Session, peer02: &Session, reliability: Re
 }
 
 #[test]
+fn zenoh_shm_startup_init() {
+    // Open the sessions
+    let mut config = zenoh::Config::default();
+    config.transport.shared_memory.set_lazy_init(false).unwrap();
+    tokio::runtime::Runtime::new().unwrap().block_on(async {
+        let _session = ztimeout!(zenoh::open(config)).unwrap();
+    });
+}
+
+#[test]
 fn zenoh_shm_unicast() {
     tokio::runtime::Runtime::new().unwrap().block_on(async {
         // Initiate logging


### PR DESCRIPTION
Adds SHM lazy init behavior control through config

"lazy" was the only behavior of SHM before this PR: initialize SHM internal data and threads on-demand (which means "at first SHM buffer interaction"). This PR adds "init" mode that initializes all SHM stuff at first Session open.

From the config doc:
```
/// - "lazy": SHM subsystem internals will be initialized lazily upon the first SHM buffer
/// allocation or reception. This setting provides better startup time and optimizes resource usage,
/// but produces extra latency at the first SHM buffer interaction.
/// - "init": SHM subsystem internals will be initialized upon Session opening. This setting sacrifices
/// startup time, but guarantees no latency impact when first SHM buffer is processed.
```