### PR TITLE
Migrate zenohd to sync API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5836,13 +5836,11 @@ name = "zenohd"
 version = "1.2.1"
 dependencies = [
  "clap",
- "futures",
  "git-version",
  "json5",
  "lazy_static",
  "rand 0.8.5",
  "rustc_version 0.4.1",
- "tokio",
  "tracing",
  "tracing-subscriber",
  "zenoh",

--- a/zenohd/Cargo.toml
+++ b/zenohd/Cargo.toml
@@ -30,10 +30,8 @@ default = ["zenoh/default"]
 shared-memory = ["zenoh/shared-memory"]
 
 [dependencies]
-tokio = { workspace = true, features = ["rt-multi-thread"] }
 clap = { workspace = true, features = ["derive"] }
 zenoh-util = { workspace = true }
-futures = { workspace = true }
 git-version = { workspace = true }
 json5 = { workspace = true }
 lazy_static = { workspace = true }


### PR DESCRIPTION
This PR migrates zenohd API usage from *async* to *sync*. By doing so, the unnecessary *main* tokio runtime is not spawn. As a result fewer threads are spawn and fewer resources are used by `zenohd`.

On my MacBook Pro M3, an idle `zenohd` now uses `7 MB` of RAM instead of the previous `28 MB`.