### PR TITLE
Propagate default zenoh features in subcrates and workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,6 +1264,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4862,12 +4868,12 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "6.0.3"
+version = "7.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+checksum = "2774c861e1f072b3aadc02f8ba886c26ad6321567ecc294c935434cad06f1283"
 dependencies = [
  "either",
- "home",
+ "env_home",
  "rustix 0.38.37",
  "winsafe",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ z-serial = "0.3.1"
 either = "1.13.0"
 prost = "0.13.2"
 tls-listener = { version = "0.10.2", features = ["rustls-ring"] }
-zenoh-ext = { version = "1.2.1", path = "zenoh-ext" }
+zenoh-ext = { version = "1.2.1", path = "zenoh-ext", default-features = false }
 zenoh-shm = { version = "1.2.1", path = "commons/zenoh-shm" }
 zenoh-result = { version = "1.2.1", path = "commons/zenoh-result", default-features = false }
 zenoh-config = { version = "1.2.1", path = "commons/zenoh-config" }
@@ -209,7 +209,7 @@ zenoh-sync = { version = "1.2.1", path = "commons/zenoh-sync" }
 zenoh-collections = { version = "1.2.1", path = "commons/zenoh-collections", default-features = false }
 zenoh-macros = { version = "1.2.1", path = "commons/zenoh-macros" }
 zenoh-plugin-trait = { version = "1.2.1", path = "plugins/zenoh-plugin-trait", default-features = false }
-zenoh_backend_traits = { version = "1.2.1", path = "plugins/zenoh-backend-traits" }
+zenoh_backend_traits = { version = "1.2.1", path = "plugins/zenoh-backend-traits", default-features = false }
 zenoh-transport = { version = "1.2.1", path = "io/zenoh-transport", default-features = false }
 zenoh-link-tls = { version = "1.2.1", path = "io/zenoh-links/zenoh-link-tls" }
 zenoh-link-tcp = { version = "1.2.1", path = "io/zenoh-links/zenoh-link-tcp" }
@@ -225,7 +225,7 @@ zenoh-link-commons = { version = "1.2.1", path = "io/zenoh-link-commons" }
 zenoh = { version = "1.2.1", path = "zenoh", default-features = false }
 zenoh-runtime = { version = "1.2.1", path = "commons/zenoh-runtime" }
 zenoh-task = { version = "1.2.1", path = "commons/zenoh-task" }
-zenoh-examples = { version = "1.2.1", path = "examples" }
+zenoh-examples = { version = "1.2.1", path = "examples", default-features = false }
 
 [profile.dev]
 debug = true

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -27,8 +27,7 @@ readme = "README.md"
 publish = false
 
 [features]
-default = ["zenoh_default"]
-zenoh_default = ["zenoh/default", "zenoh-ext/unstable"]
+default = ["zenoh/default", "zenoh-ext/default"]
 
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
@@ -37,7 +36,7 @@ prost = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "time", "io-std"] }
 zenoh = { workspace = true, default-features = false }
-zenoh-ext = { workspace = true, default-features = false }
+zenoh-ext = { workspace = true, default-features = false, features = ["unstable"] }
 
 [dev-dependencies]
 rand = { workspace = true, features = ["default"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -28,6 +28,8 @@ publish = false
 
 [features]
 default = ["zenoh/default", "zenoh-ext/default"]
+shared-memory = ["zenoh/shared-memory"]
+unstable = ["zenoh/unstable"]
 
 [dependencies]
 clap = { workspace = true, features = ["derive"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -27,9 +27,8 @@ readme = "README.md"
 publish = false
 
 [features]
-shared-memory = ["zenoh/shared-memory"]
-unstable = ["zenoh/unstable"]
-transport_unixpipe = ["zenoh/transport_unixpipe"]
+default = ["zenoh_default"]
+zenoh_default = ["zenoh/default", "zenoh-ext/unstable"]
 
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
@@ -37,15 +36,15 @@ futures = { workspace = true }
 prost = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "time", "io-std"] }
-zenoh = { workspace = true, default-features = true }
-zenoh-ext = { workspace = true, features = ["unstable"] }
+zenoh = { workspace = true, default-features = false }
+zenoh-ext = { workspace = true, default-features = false }
 
 [dev-dependencies]
 rand = { workspace = true, features = ["default"] }
 
 [build-dependencies]
 prost-build = "0.13"
-which = "6"
+which = "7.0.2"
 
 [[example]]
 name = "z_scout"

--- a/plugins/zenoh-backend-example/Cargo.toml
+++ b/plugins/zenoh-backend-example/Cargo.toml
@@ -20,8 +20,9 @@ edition = { workspace = true }
 publish = false
 
 [features]
-default = ["dynamic_plugin"]
+default = ["dynamic_plugin", "zenoh_default"]
 dynamic_plugin = []
+zenoh_default = ["zenoh/default"]
 
 [lib]
 name = "zenoh_backend_example"
@@ -29,13 +30,13 @@ name = "zenoh_backend_example"
 crate-type = ["cdylib"]
 
 [dependencies]
-git-version = { workspace = true }
-tokio = { workspace = true }
-serde_json = { workspace = true }
-zenoh = { workspace = true, features = ["default"] }
-zenoh-plugin-trait = { workspace = true }
 async-trait = { workspace = true }
-zenoh_backend_traits = { workspace = true }
+git-version = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+zenoh = { workspace = true, default-features = false }
+zenoh-plugin-trait = { workspace = true, default-features = false }
+zenoh_backend_traits = { workspace = true, default-features = false }
 
 [package.metadata.cargo-machete]
 ignored = ["git-version"]

--- a/plugins/zenoh-backend-example/Cargo.toml
+++ b/plugins/zenoh-backend-example/Cargo.toml
@@ -20,9 +20,8 @@ edition = { workspace = true }
 publish = false
 
 [features]
-default = ["dynamic_plugin", "zenoh_default"]
+default = ["dynamic_plugin", "zenoh/default"]
 dynamic_plugin = []
-zenoh_default = ["zenoh/default"]
 
 [lib]
 name = "zenoh_backend_example"

--- a/plugins/zenoh-backend-traits/Cargo.toml
+++ b/plugins/zenoh-backend-traits/Cargo.toml
@@ -26,17 +26,18 @@ description = "Zenoh: traits to be implemented by backends libraries"
 [badges]
 maintenance = { status = "actively-developed" }
 
+[features]
+default = ["zenoh_default"]
+zenoh_default = ["zenoh/unstable", "zenoh/internal"]
+
 [dependencies]
 async-trait = { workspace = true }
 derive_more = { workspace = true }
 serde_json = { workspace = true }
-zenoh = { workspace = true, features = ["unstable", "internal"] }
+zenoh = { workspace = true, default-features = false }
 zenoh-result = { workspace = true }
 zenoh-util = { workspace = true }
 schemars = { workspace = true }
 zenoh-plugin-trait = { workspace = true }
 const_format = { workspace = true }
 either = { workspace = true }
-
-[features]
-default = []

--- a/plugins/zenoh-backend-traits/Cargo.toml
+++ b/plugins/zenoh-backend-traits/Cargo.toml
@@ -27,14 +27,13 @@ description = "Zenoh: traits to be implemented by backends libraries"
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["zenoh_default"]
-zenoh_default = ["zenoh/unstable", "zenoh/internal"]
+default = ["zenoh/default"]
 
 [dependencies]
 async-trait = { workspace = true }
 derive_more = { workspace = true }
 serde_json = { workspace = true }
-zenoh = { workspace = true, default-features = false }
+zenoh = { workspace = true, default-features = false, features = ["unstable", "internal"] }
 zenoh-result = { workspace = true }
 zenoh-util = { workspace = true }
 schemars = { workspace = true }

--- a/plugins/zenoh-plugin-example/Cargo.toml
+++ b/plugins/zenoh-plugin-example/Cargo.toml
@@ -20,8 +20,9 @@ edition = { workspace = true }
 publish = false
 
 [features]
-default = ["dynamic_plugin"]
+default = ["dynamic_plugin", "zenoh_default"]
 dynamic_plugin = []
+zenoh_default = ["zenoh/default", "zenoh/plugins", "zenoh/internal", "zenoh/unstable"]
 
 [lib]
 # When auto-detecting the "example" plugin, `zenohd` will look for a dynamic library named "zenoh_plugin_example"
@@ -41,12 +42,7 @@ git-version = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
 serde_json = { workspace = true }
-zenoh = { workspace = true, features = [
-    "default",
-    "plugins",
-    "internal",
-    "unstable",
-] }
+zenoh = { workspace = true, default-features = false }
 zenoh-plugin-trait = { workspace = true }
 
 [package.metadata.cargo-machete]

--- a/plugins/zenoh-plugin-example/Cargo.toml
+++ b/plugins/zenoh-plugin-example/Cargo.toml
@@ -20,9 +20,8 @@ edition = { workspace = true }
 publish = false
 
 [features]
-default = ["dynamic_plugin", "zenoh_default"]
+default = ["dynamic_plugin"]
 dynamic_plugin = []
-zenoh_default = ["zenoh/default", "zenoh/plugins", "zenoh/internal", "zenoh/unstable"]
 
 [lib]
 # When auto-detecting the "example" plugin, `zenohd` will look for a dynamic library named "zenoh_plugin_example"
@@ -42,7 +41,12 @@ git-version = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
 serde_json = { workspace = true }
-zenoh = { workspace = true, default-features = false }
+zenoh = { workspace = true, features = [
+    "default",
+    "plugins",
+    "internal",
+    "unstable",
+] }
 zenoh-plugin-trait = { workspace = true }
 
 [package.metadata.cargo-machete]

--- a/plugins/zenoh-plugin-rest/Cargo.toml
+++ b/plugins/zenoh-plugin-rest/Cargo.toml
@@ -24,10 +24,9 @@ categories = ["network-programming", "web-programming::http-server"]
 description = "The zenoh REST plugin"
 
 [features]
-default = ["dynamic_plugin", "zenoh_default"]
+default = ["dynamic_plugin", "zenoh/default"]
 dynamic_plugin = []
 static_plugin = ['async-std']
-zenoh_default = ["zenoh/default", "zenoh/plugins", "zenoh/internal", "zenoh/unstable"]
 
 [lib]
 name = "zenoh_plugin_rest"
@@ -48,7 +47,11 @@ serde = { workspace = true, features = ["default"] }
 serde_json = { workspace = true }
 tide = { workspace = true }
 tokio = { workspace = true }
-zenoh = { workspace = true, default-features = false }
+zenoh = { workspace = true, default-features = false, features = [
+    "plugins",
+    "internal",
+    "unstable",
+] }
 zenoh-plugin-trait = { workspace = true }
 
 [build-dependencies]

--- a/plugins/zenoh-plugin-rest/Cargo.toml
+++ b/plugins/zenoh-plugin-rest/Cargo.toml
@@ -24,9 +24,10 @@ categories = ["network-programming", "web-programming::http-server"]
 description = "The zenoh REST plugin"
 
 [features]
-default = ["dynamic_plugin"]
+default = ["dynamic_plugin", "zenoh_default"]
 dynamic_plugin = []
 static_plugin = ['async-std']
+zenoh_default = ["zenoh/default", "zenoh/plugins", "zenoh/internal", "zenoh/unstable"]
 
 [lib]
 name = "zenoh_plugin_rest"
@@ -47,12 +48,7 @@ serde = { workspace = true, features = ["default"] }
 serde_json = { workspace = true }
 tide = { workspace = true }
 tokio = { workspace = true }
-zenoh = { workspace = true, features = [
-    "plugins",
-    "default",
-    "internal",
-    "unstable",
-] }
+zenoh = { workspace = true, default-features = false }
 zenoh-plugin-trait = { workspace = true }
 
 [build-dependencies]

--- a/plugins/zenoh-plugin-storage-manager/Cargo.toml
+++ b/plugins/zenoh-plugin-storage-manager/Cargo.toml
@@ -24,8 +24,9 @@ categories = { workspace = true }
 description = "The zenoh storages plugin."
 
 [features]
-default = ["dynamic_plugin"]
+default = ["dynamic_plugin", "zenoh_default"]
 dynamic_plugin = []
+zenoh_default = ["zenoh/default", "zenoh/plugins", "zenoh/internal", "zenoh/unstable"]
 
 [lib]
 name = "zenoh_plugin_storage_manager"
@@ -45,12 +46,7 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
-zenoh = { workspace = true, features = [
-    "default",
-    "plugins",
-    "internal",
-    "unstable",
-] }
+zenoh = { workspace = true, default-features = false }
 zenoh-plugin-trait = { workspace = true }
 zenoh_backend_traits = { workspace = true }
 

--- a/plugins/zenoh-plugin-storage-manager/Cargo.toml
+++ b/plugins/zenoh-plugin-storage-manager/Cargo.toml
@@ -24,9 +24,8 @@ categories = { workspace = true }
 description = "The zenoh storages plugin."
 
 [features]
-default = ["dynamic_plugin", "zenoh_default"]
+default = ["dynamic_plugin", "zenoh/default"]
 dynamic_plugin = []
-zenoh_default = ["zenoh/default", "zenoh/plugins", "zenoh/internal", "zenoh/unstable"]
 
 [lib]
 name = "zenoh_plugin_storage_manager"
@@ -46,7 +45,11 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
-zenoh = { workspace = true, default-features = false }
+zenoh = { workspace = true, default-features = false, features = [
+    "plugins",
+    "internal",
+    "unstable",
+] }
 zenoh-plugin-trait = { workspace = true }
 zenoh_backend_traits = { workspace = true }
 

--- a/zenoh-ext/Cargo.toml
+++ b/zenoh-ext/Cargo.toml
@@ -27,10 +27,9 @@ description = "Zenoh: extensions to the client API."
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["zenoh_default"]
+default = ["zenoh/default"]
 internal = []
 unstable = ["zenoh/unstable", "zenoh/internal"]
-zenoh_default = ["zenoh/default"]
 
 [dependencies]
 tokio = { workspace = true, features = [

--- a/zenoh-ext/Cargo.toml
+++ b/zenoh-ext/Cargo.toml
@@ -27,8 +27,10 @@ description = "Zenoh: extensions to the client API."
 maintenance = { status = "actively-developed" }
 
 [features]
+default = ["zenoh_default"]
 internal = []
 unstable = ["zenoh/unstable", "zenoh/internal"]
+zenoh_default = ["zenoh/default"]
 
 [dependencies]
 tokio = { workspace = true, features = [

--- a/zenoh-ext/examples/Cargo.toml
+++ b/zenoh-ext/examples/Cargo.toml
@@ -28,16 +28,8 @@ publish = false
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["zenoh_default"]
+default = ["zenoh/default", "zenoh-ext/default"]
 unstable = []
-zenoh_default = [
-    "zenoh/default",
-    "zenoh/unstable",
-    "zenoh/internal_config",
-    "zenoh-examples/default",
-    "zenoh-ext/default",
-    "zenoh-ext/unstable",
-]
 
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
@@ -50,7 +42,7 @@ tokio = { workspace = true, features = [
     "io-std",
 ] }
 zenoh = { workspace = true, default-features = false }
-zenoh-ext = { workspace = true, default-features = false }
+zenoh-ext = { workspace = true, default-features = false, features = ["unstable"]}
 zenoh-examples = { workspace = true, default-features = false }
 
 [dev-dependencies]

--- a/zenoh-ext/examples/Cargo.toml
+++ b/zenoh-ext/examples/Cargo.toml
@@ -28,16 +28,30 @@ publish = false
 maintenance = { status = "actively-developed" }
 
 [features]
+default = ["zenoh_default"]
 unstable = []
-default = []
+zenoh_default = [
+    "zenoh/default",
+    "zenoh/unstable",
+    "zenoh/internal_config",
+    "zenoh-examples/default",
+    "zenoh-ext/default",
+    "zenoh-ext/unstable",
+]
 
 [dependencies]
-tokio = { workspace = true, features = ["rt", "sync", "time", "macros", "io-std"] }
-futures = { workspace = true }
-zenoh = { workspace = true, features = ["unstable", "internal_config"], default-features = false }
 clap = { workspace = true, features = ["derive"] }
-zenoh-ext = { workspace = true, features = ["unstable"] }
-zenoh-examples = { workspace = true }
+futures = { workspace = true }
+tokio = { workspace = true, features = [
+    "rt",
+    "sync",
+    "time",
+    "macros",
+    "io-std",
+] }
+zenoh = { workspace = true, default-features = false }
+zenoh-ext = { workspace = true, default-features = false }
+zenoh-examples = { workspace = true, default-features = false }
 
 [dev-dependencies]
 zenoh-config = { workspace = true }

--- a/zenoh-ext/examples/Cargo.toml
+++ b/zenoh-ext/examples/Cargo.toml
@@ -28,7 +28,7 @@ publish = false
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["zenoh/default", "zenoh-ext/default"]
+default = ["zenoh/default", "zenoh-ext/default", "zenoh-examples/default"]
 unstable = []
 
 [dependencies]

--- a/zenohd/Cargo.toml
+++ b/zenohd/Cargo.toml
@@ -26,15 +26,8 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["zenoh_default"]
-zenoh_default = [
-  "zenoh/default",
-  "zenoh/unstable",
-  "zenoh/internal",
-  "zenoh/plugins",
-  "zenoh/runtime_plugins",
-  "zenoh/internal_config"
-]
+default = ["zenoh/default"]
+shared-memory = ["zenoh/shared-memory"]
 
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
@@ -44,7 +37,13 @@ json5 = { workspace = true }
 lazy_static = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-zenoh = { workspace = true, default-features = false }
+zenoh = { workspace = true, default-features = false, features = [
+  "unstable",
+  "internal",
+  "plugins",
+  "runtime_plugins",
+  "internal_config",
+] }
 zenoh-config = { workspace = true }
 
 [dev-dependencies]

--- a/zenohd/Cargo.toml
+++ b/zenohd/Cargo.toml
@@ -26,8 +26,15 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["zenoh/default"]
-shared-memory = ["zenoh/shared-memory"]
+default = ["zenoh_default"]
+zenoh_default = [
+  "zenoh/default",
+  "zenoh/unstable",
+  "zenoh/internal",
+  "zenoh/plugins",
+  "zenoh/runtime_plugins",
+  "zenoh/internal_config"
+]
 
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
@@ -37,13 +44,7 @@ json5 = { workspace = true }
 lazy_static = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-zenoh = { workspace = true, features = [
-  "unstable",
-  "internal",
-  "plugins",
-  "runtime_plugins",
-  "internal_config",
-] }
+zenoh = { workspace = true, default-features = false }
 zenoh-config = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Zenoh default features where wrongly propagated to the all crates in the workspace.

This PR is an attempt to fix that and allow examples/zenohd to be compiled only with the desired features.
E.g.:
```sh
cargo build -p zenoh-examples --no-default-features --features="zenoh/transport_udp" --example z_sub --example z_pub
```
compiles `z_sub` and `z_pub` examples with only `UDP` enabled.

**WARNING:** The impact of this PR on bindings and external dependencies should be assessed before approving and eventually merging this PR.
