### PR TITLE
Expose different congestion control defaults as internal

### DIFF
--- a/commons/zenoh-protocol/Cargo.toml
+++ b/commons/zenoh-protocol/Cargo.toml
@@ -25,6 +25,7 @@ description = "Internal crate for zenoh."
 
 [features]
 default = ["std"]
+internal = []
 std = [
     "rand?/std",
     "rand?/std_rng",
@@ -33,9 +34,9 @@ std = [
     "zenoh-keyexpr/std",
     "zenoh-result/std",
 ]
-test = ["rand", "zenoh-buffers/test"]
 shared-memory = ["std", "zenoh-buffers/shared-memory"]
 stats = []
+test = ["rand", "zenoh-buffers/test"]
 
 [dependencies]
 const_format = { workspace = true }

--- a/commons/zenoh-protocol/src/core/mod.rs
+++ b/commons/zenoh-protocol/src/core/mod.rs
@@ -574,6 +574,31 @@ pub enum CongestionControl {
 
 impl CongestionControl {
     pub const DEFAULT: Self = Self::Drop;
+
+    #[cfg(feature = "internal")]
+    pub const DEFAULT_PUSH: Self = Self::Drop;
+    #[cfg(not(feature = "internal"))]
+    pub(crate) const DEFAULT_PUSH: Self = Self::Drop;
+
+    #[cfg(feature = "internal")]
+    pub const DEFAULT_REQUEST: Self = Self::Block;
+    #[cfg(not(feature = "internal"))]
+    pub(crate) const DEFAULT_REQUEST: Self = Self::Block;
+
+    #[cfg(feature = "internal")]
+    pub const DEFAULT_RESPONSE: Self = Self::Block;
+    #[cfg(not(feature = "internal"))]
+    pub(crate) const DEFAULT_RESPONSE: Self = Self::Block;
+
+    #[cfg(feature = "internal")]
+    pub const DEFAULT_DECLARE: Self = Self::Block;
+    #[cfg(not(feature = "internal"))]
+    pub(crate) const DEFAULT_DECLARE: Self = Self::Block;
+
+    #[cfg(feature = "internal")]
+    pub const DEFAULT_OAM: Self = Self::Block;
+    #[cfg(not(feature = "internal"))]
+    pub(crate) const DEFAULT_OAM: Self = Self::Block;
 }
 
 #[cfg(test)]

--- a/commons/zenoh-protocol/src/network/mod.rs
+++ b/commons/zenoh-protocol/src/network/mod.rs
@@ -251,13 +251,22 @@ pub mod ext {
 
         pub const DEFAULT: Self = Self::new(Priority::DEFAULT, CongestionControl::DEFAULT, false);
 
-        pub const DECLARE: Self = Self::new(Priority::Control, CongestionControl::Block, false);
-        pub const PUSH: Self = Self::new(Priority::DEFAULT, CongestionControl::Drop, false);
-        pub const REQUEST: Self = Self::new(Priority::DEFAULT, CongestionControl::Block, false);
-        pub const RESPONSE: Self = Self::new(Priority::DEFAULT, CongestionControl::Block, false);
-        pub const RESPONSE_FINAL: Self =
-            Self::new(Priority::DEFAULT, CongestionControl::Block, false);
-        pub const OAM: Self = Self::new(Priority::Control, CongestionControl::Block, false);
+        pub const DECLARE: Self =
+            Self::new(Priority::Control, CongestionControl::DEFAULT_DECLARE, false);
+        pub const PUSH: Self = Self::new(Priority::DEFAULT, CongestionControl::DEFAULT_PUSH, false);
+        pub const REQUEST: Self =
+            Self::new(Priority::DEFAULT, CongestionControl::DEFAULT_REQUEST, false);
+        pub const RESPONSE: Self = Self::new(
+            Priority::DEFAULT,
+            CongestionControl::DEFAULT_RESPONSE,
+            false,
+        );
+        pub const RESPONSE_FINAL: Self = Self::new(
+            Priority::DEFAULT,
+            CongestionControl::DEFAULT_RESPONSE,
+            false,
+        );
+        pub const OAM: Self = Self::new(Priority::Control, CongestionControl::DEFAULT_OAM, false);
 
         pub const fn new(
             priority: Priority,

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -41,9 +41,13 @@ default = [
   "transport_tls",
   "transport_udp",
   "transport_unixsock-stream",
-  "transport_ws"
+  "transport_ws",
 ]
-internal = ["zenoh-keyexpr/internal", "zenoh-config/internal"]
+internal = [
+  "zenoh-keyexpr/internal",
+  "zenoh-config/internal",
+  "zenoh-protocol/internal",
+]
 plugins = []
 runtime_plugins = ["plugins"]
 shared-memory = [
@@ -64,9 +68,16 @@ transport_udp = ["zenoh-transport/transport_udp"]
 transport_unixsock-stream = ["zenoh-transport/transport_unixsock-stream"]
 transport_ws = ["zenoh-transport/transport_ws"]
 transport_vsock = ["zenoh-transport/transport_vsock"]
-unstable = ["internal_config", "zenoh-keyexpr/unstable", "zenoh-config/unstable"]
+unstable = [
+  "internal_config",
+  "zenoh-keyexpr/unstable",
+  "zenoh-config/unstable",
+]
 internal_config = []
-tracing-instrument = ["zenoh-task/tracing-instrument", "zenoh-runtime/tracing-instrument"]
+tracing-instrument = [
+  "zenoh-task/tracing-instrument",
+  "zenoh-runtime/tracing-instrument",
+]
 
 [dependencies]
 tokio = { workspace = true, features = ["rt", "macros", "time"] }


### PR DESCRIPTION
This is required for properly propagate the `CongestionControl` default values in the various API bindings.