### PR TITLE
move nested part of advanced pub-sub key expressions to the beginning to allow advanced pub-sub work with namespace prefixes

### DIFF
--- a/zenoh-ext/src/advanced_cache.rs
+++ b/zenoh-ext/src/advanced_cache.rs
@@ -28,13 +28,13 @@ use zenoh::{
     qos::{CongestionControl, Priority},
     query::{Queryable, ZenohParameters},
     sample::{Locality, Sample, SampleBuilder},
-    Resolvable, Result as ZResult, Session, Wait, KE_ADV_PREFIX, KE_AT, KE_STARSTAR,
+    Resolvable, Result as ZResult, Session, Wait, KE_ADV_PREFIX, KE_STARSTAR,
 };
 
 pub(crate) static KE_UHLC: &keyexpr = ke!("uhlc");
 #[zenoh_macros::unstable]
 kedefine!(
-    pub(crate) ke_liveliness: "@adv/${entity:*}/${zid:*}/${eid:*}/${meta:**}/@/${remaining:**}",
+    pub(crate) ke_liveliness: "${remaining:**}/@adv/${entity:*}/${zid:*}/${eid:*}/${meta:**}",
 );
 
 #[zenoh_macros::unstable]
@@ -122,7 +122,7 @@ impl CacheConfig {
 pub struct AdvancedCacheBuilder<'a, 'b, 'c> {
     session: &'a Session,
     pub_key_expr: ZResult<KeyExpr<'b>>,
-    queryable_prefix: Option<ZResult<KeyExpr<'c>>>,
+    queryable_suffix: Option<ZResult<KeyExpr<'c>>>,
     queryable_origin: Locality,
     history: CacheConfig,
     liveliness: bool,
@@ -138,21 +138,21 @@ impl<'a, 'b, 'c> AdvancedCacheBuilder<'a, 'b, 'c> {
         AdvancedCacheBuilder {
             session,
             pub_key_expr,
-            queryable_prefix: Some(Ok((KE_ADV_PREFIX / KE_STARSTAR / KE_AT).into())),
+            queryable_suffix: Some(Ok((KE_ADV_PREFIX / KE_STARSTAR).into())),
             queryable_origin: Locality::default(),
             history: CacheConfig::default(),
             liveliness: false,
         }
     }
 
-    /// Change the prefix used for queryable.
+    /// Change the suffix used for queryable.
     #[zenoh_macros::unstable]
-    pub fn queryable_prefix<TryIntoKeyExpr>(mut self, queryable_prefix: TryIntoKeyExpr) -> Self
+    pub fn queryable_suffix<TryIntoKeyExpr>(mut self, queryable_suffix: TryIntoKeyExpr) -> Self
     where
         TryIntoKeyExpr: TryInto<KeyExpr<'c>>,
         <TryIntoKeyExpr as TryInto<KeyExpr<'c>>>::Error: Into<zenoh::Error>,
     {
-        self.queryable_prefix = Some(queryable_prefix.try_into().map_err(Into::into));
+        self.queryable_suffix = Some(queryable_suffix.try_into().map_err(Into::into));
         self
     }
 
@@ -220,11 +220,11 @@ impl AdvancedCache {
     #[zenoh_macros::unstable]
     fn new(conf: AdvancedCacheBuilder<'_, '_, '_>) -> ZResult<AdvancedCache> {
         let key_expr = conf.pub_key_expr?.into_owned();
-        // the queryable_prefix (optional), and the key_expr for AdvancedCache's queryable ("[<queryable_prefix>]/<pub_key_expr>")
-        let queryable_key_expr = match conf.queryable_prefix {
+        // the queryable_suffix (optional), and the key_expr for AdvancedCache's queryable ("<pub_key_expr>/[<queryable_suffix>]")
+        let queryable_key_expr = match conf.queryable_suffix {
             None => key_expr.clone(),
-            Some(Ok(ke)) => (&ke) / &key_expr,
-            Some(Err(e)) => bail!("Invalid key expression for queryable_prefix: {}", e),
+            Some(Ok(ke)) => &key_expr / &ke,
+            Some(Err(e)) => bail!("Invalid key expression for queryable_suffix: {}", e),
         };
         tracing::debug!(
             "Create AdvancedCache on {} with max_samples={:?}",

--- a/zenoh-ext/src/advanced_publisher.rs
+++ b/zenoh-ext/src/advanced_publisher.rs
@@ -39,7 +39,7 @@ use zenoh::{
     qos::{CongestionControl, Priority, Reliability},
     sample::{Locality, SourceInfo},
     session::EntityGlobalId,
-    Resolvable, Resolve, Result as ZResult, Session, Wait, KE_ADV_PREFIX, KE_AT, KE_EMPTY,
+    Resolvable, Resolve, Result as ZResult, Session, Wait, KE_ADV_PREFIX, KE_EMPTY,
 };
 use zenoh_macros::ke;
 
@@ -284,17 +284,17 @@ impl<'a> AdvancedPublisher<'a> {
             .express(conf.is_express)
             .wait()?;
         let id = publisher.id();
-        let prefix = KE_ADV_PREFIX / KE_PUB / &id.zid().into_keyexpr();
-        let prefix = match conf.sequencing {
+        let suffix = KE_ADV_PREFIX / KE_PUB / &id.zid().into_keyexpr();
+        let suffix = match conf.sequencing {
             Sequencing::SequenceNumber => {
-                prefix / &KeyExpr::try_from(id.eid().to_string()).unwrap()
+                suffix / &KeyExpr::try_from(id.eid().to_string()).unwrap()
             }
-            _ => prefix / KE_UHLC,
+            _ => suffix / KE_UHLC,
         };
-        let prefix = match meta {
-            Some(meta) => prefix / &meta / KE_AT,
+        let suffix = match meta {
+            Some(meta) => suffix / &meta,
             // We need this empty chunk because af a routing matching bug
-            _ => prefix / KE_EMPTY / KE_AT,
+            _ => suffix / KE_EMPTY,
         };
 
         let seqnum = match conf.sequencing {
@@ -316,7 +316,7 @@ impl<'a> AdvancedPublisher<'a> {
             Some(
                 AdvancedCacheBuilder::new(conf.session, Ok(key_expr.clone()))
                     .history(conf.history)
-                    .queryable_prefix(&prefix)
+                    .queryable_suffix(&suffix)
                     .wait()?,
             )
         } else {
@@ -327,7 +327,7 @@ impl<'a> AdvancedPublisher<'a> {
             Some(
                 conf.session
                     .liveliness()
-                    .declare_token(&prefix / &key_expr)
+                    .declare_token(&key_expr / &suffix)
                     .wait()?,
             )
         } else {
@@ -339,7 +339,7 @@ impl<'a> AdvancedPublisher<'a> {
             if let Some(seqnum) = seqnum.as_ref() {
                 let seqnum = seqnum.clone();
 
-                let publisher = conf.session.declare_publisher(prefix / &key_expr).wait()?;
+                let publisher = conf.session.declare_publisher(&key_expr / &suffix).wait()?;
                 Some(TerminatableTask::spawn_abortable(
                     ZRuntime::Net,
                     async move {

--- a/zenoh-ext/src/advanced_subscriber.rs
+++ b/zenoh-ext/src/advanced_subscriber.rs
@@ -24,8 +24,8 @@ use zenoh::{
     },
     sample::{Locality, Sample, SampleKind, SourceSn},
     session::{EntityGlobalId, EntityId},
-    Resolvable, Resolve, Session, Wait, KE_ADV_PREFIX, KE_AT, KE_EMPTY, KE_PUB, KE_STAR,
-    KE_STARSTAR, KE_SUB,
+    Resolvable, Resolve, Session, Wait, KE_ADV_PREFIX, KE_EMPTY, KE_PUB, KE_STAR, KE_STARSTAR,
+    KE_SUB,
 };
 use zenoh_util::{Timed, TimedEvent, Timer};
 #[zenoh_macros::unstable]
@@ -608,13 +608,12 @@ impl Timed for PeriodicQuery {
         let states = &mut *lock;
         if let Some(state) = states.sequenced_states.get_mut(&self.source_id) {
             state.pending_queries += 1;
-            let query_expr = KE_ADV_PREFIX
+            let query_expr = &states.key_expr
+                / KE_ADV_PREFIX
                 / KE_STAR
                 / &self.source_id.zid().into_keyexpr()
                 / &KeyExpr::try_from(self.source_id.eid().to_string()).unwrap()
-                / KE_STARSTAR
-                / KE_AT
-                / &states.key_expr;
+                / KE_STARSTAR;
             let seq_num_range = seq_num_range(state.last_delivered.map(|s| s + 1), None);
 
             let session = states.session.clone();
@@ -712,13 +711,12 @@ impl<Handler> AdvancedSubscriber<Handler> {
                             && !state.pending_samples.is_empty()
                         {
                             state.pending_queries += 1;
-                            let query_expr = KE_ADV_PREFIX
+                            let query_expr = &key_expr
+                                / KE_ADV_PREFIX
                                 / KE_STAR
                                 / &source_id.zid().into_keyexpr()
                                 / &KeyExpr::try_from(source_id.eid().to_string()).unwrap()
-                                / KE_STARSTAR
-                                / KE_AT
-                                / &key_expr;
+                                / KE_STARSTAR;
                             let seq_num_range =
                                 seq_num_range(state.last_delivered.map(|s| s + 1), None);
                             drop(lock);
@@ -774,7 +772,7 @@ impl<Handler> AdvancedSubscriber<Handler> {
             let _ = conf
                 .session
                 .get(Selector::from((
-                    KE_ADV_PREFIX / KE_STARSTAR / KE_AT / &key_expr,
+                    &key_expr / KE_ADV_PREFIX / KE_STARSTAR,
                     params,
                 )))
                 .callback({
@@ -968,14 +966,13 @@ impl<Handler> AdvancedSubscriber<Handler> {
                 };
 
                 Some(
-                    conf
-                .session
-                .liveliness()
-                .declare_subscriber(KE_ADV_PREFIX / KE_PUB / KE_STARSTAR / KE_AT / &key_expr)
-                // .declare_subscriber(keformat!(ke_liveliness_all::formatter(), zid = 0, eid = 0, remaining = key_expr).unwrap())
-                .history(true)
-                .callback(live_callback)
-                .wait()?,
+                    conf.session
+                        .liveliness()
+                        .declare_subscriber(&key_expr / KE_ADV_PREFIX / KE_PUB / KE_STARSTAR)
+                        // .declare_subscriber(keformat!(ke_liveliness_all::formatter(), zid = 0, eid = 0, remaining = key_expr).unwrap())
+                        .history(true)
+                        .callback(live_callback)
+                        .wait()?,
                 )
             } else {
                 None
@@ -985,7 +982,7 @@ impl<Handler> AdvancedSubscriber<Handler> {
         };
 
         let heartbeat_subscriber = if retransmission.is_some_and(|r| r.heartbeat.is_some()) {
-            let ke_heartbeat_sub = KE_ADV_PREFIX / KE_PUB / KE_STARSTAR / KE_AT / &key_expr;
+            let ke_heartbeat_sub = &key_expr / KE_ADV_PREFIX / KE_PUB / KE_STARSTAR;
             let statesref = statesref.clone();
             let heartbeat_sub = conf
                 .session
@@ -1083,19 +1080,19 @@ impl<Handler> AdvancedSubscriber<Handler> {
         };
 
         if conf.liveliness {
-            let prefix = KE_ADV_PREFIX
+            let suffix = KE_ADV_PREFIX
                 / KE_SUB
                 / &subscriber.id().zid().into_keyexpr()
                 / &KeyExpr::try_from(subscriber.id().eid().to_string()).unwrap();
-            let prefix = match meta {
-                Some(meta) => prefix / &meta / KE_AT,
+            let suffix = match meta {
+                Some(meta) => suffix / &meta,
                 // We need this empty chunk because af a routing matching bug
-                _ => prefix / KE_EMPTY / KE_AT,
+                _ => suffix / KE_EMPTY,
             };
             let token = conf
                 .session
                 .liveliness()
-                .declare_token(prefix / &key_expr)
+                .declare_token(&key_expr / &suffix)
                 .wait()?;
             zlock!(statesref).token = Some(token)
         }
@@ -1157,9 +1154,10 @@ impl<Handler> AdvancedSubscriber<Handler> {
     /// [`publisher_detection`](crate::AdvancedPublisherBuilder::publisher_detection) can be detected.
     #[zenoh_macros::unstable]
     pub fn detect_publishers(&self) -> LivelinessSubscriberBuilder<'_, '_, DefaultHandler> {
-        self.subscriber.session().liveliness().declare_subscriber(
-            KE_ADV_PREFIX / KE_PUB / KE_STARSTAR / KE_AT / self.subscriber.key_expr(),
-        )
+        self.subscriber
+            .session()
+            .liveliness()
+            .declare_subscriber(self.subscriber.key_expr() / KE_ADV_PREFIX / KE_PUB / KE_STARSTAR)
     }
 
     /// Undeclares this AdvancedSubscriber


### PR DESCRIPTION
move nested part of advanced pub-sub key expressions to the beginning