### PR TITLE
Optimize `FaceState::update_interceptors_caches`

### DIFF
--- a/zenoh/src/net/routing/interceptor/mod.rs
+++ b/zenoh/src/net/routing/interceptor/mod.rs
@@ -80,6 +80,10 @@ impl InterceptorsChain {
             interceptors: vec![],
         }
     }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.interceptors.is_empty()
+    }
 }
 
 impl From<Vec<Interceptor>> for InterceptorsChain {


### PR DESCRIPTION
This function performs keyexpr allocation even if `InterceptorsChain` is `None`. Moreover, `InterceptorsChain` can apparently be `Some(..)` even if it's empty.