### PR TITLE
fix: change macos runners to use macos-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - name: Clone this repository
@@ -89,7 +89,7 @@ jobs:
         run: cargo +stable clippy --all-targets --features unstable,test -- --deny warnings
 
       - name: Clippy all features
-        if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest' }}
+        if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' }}
         run: cargo +stable clippy --all-targets --all-features -- --deny warnings
 
       - name: Install generic no_std target
@@ -122,7 +122,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - name: Clone this repository
@@ -150,7 +150,7 @@ jobs:
         run: cargo nextest run -F test -F internal_config --exclude zenoh-examples --exclude zenoh-plugin-example --workspace
 
       - name: Run tests with SHM
-        if: ${{ matrix.os == 'macOS-latest' || matrix.os == 'windows-latest' }}
+        if: ${{ matrix.os == 'macos-latest' || matrix.os == 'windows-latest' }}
         run: cargo nextest run -F test -F shared-memory -F unstable -F internal_config -E 'not (test(test_default_features))' --exclude zenoh-examples --exclude zenoh-plugin-example --workspace
 
       - name: Run tests with SHM + unixpipe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,11 +137,10 @@ jobs:
           cache-bin: false
 
       - name: Set rustflags
+        if: ${{ matrix.os == 'windows-latest' }}
         shell: bash
         run: |
-          case ${{ matrix.os }} in
-            *windows*) echo "RUSTFLAGS=-Clink-arg=/DEBUG:NONE" >> $GITHUB_ENV ;;
-          esac
+            echo "RUSTFLAGS=-Clink-arg=/DEBUG:NONE" >> $GITHUB_ENV
 
       - name: Install latest nextest
         uses: taiki-e/install-action@nextest


### PR DESCRIPTION
this makes it easier to target self-hosted runners

This change was introduced in https://github.com/eclipse-zenoh/zenoh/pull/935 and since we don't use macos-12 anymore, it should be fine to revert back to `macos-latest`