### PR TITLE
make interceptor-rejected queries and liveliness queries return an empty reply instead of timeout

### DIFF
--- a/zenoh/src/net/primitives/demux.rs
+++ b/zenoh/src/net/primitives/demux.rs
@@ -14,7 +14,9 @@
 use std::{any::Any, sync::Arc};
 
 use zenoh_link::Link;
-use zenoh_protocol::network::{NetworkBody, NetworkMessage};
+use zenoh_protocol::network::{
+    ext, response, Declare, DeclareBody, DeclareFinal, NetworkBody, NetworkMessage, ResponseFinal,
+};
 use zenoh_result::ZResult;
 use zenoh_transport::{unicast::TransportUnicast, TransportPeerEventHandler};
 
@@ -58,10 +60,55 @@ impl TransportPeerEventHandler for DeMux {
             let cache = prefix
                 .as_ref()
                 .and_then(|p| p.get_ingress_cache(&self.face));
-            let ctx = match self.interceptor.intercept(ctx, cache) {
-                Some(ctx) => ctx,
-                None => return Ok(()),
+
+            let ctx = match &ctx.msg.body {
+                NetworkBody::Request(request) => {
+                    let request_id = request.id;
+                    match self.interceptor.intercept(ctx, cache) {
+                        Some(ctx) => ctx,
+                        None => {
+                            // request was blocked by an interceptor, we need to send response final to avoid timeout error
+                            self.face
+                                .state
+                                .primitives
+                                .send_response_final(ResponseFinal {
+                                    rid: request_id,
+                                    ext_qos: response::ext::QoSType::RESPONSE_FINAL,
+                                    ext_tstamp: None,
+                                });
+                            return Ok(());
+                        }
+                    }
+                }
+                NetworkBody::Interest(interest) => {
+                    let interest_id = interest.id;
+                    match self.interceptor.intercept(ctx, cache) {
+                        Some(ctx) => ctx,
+                        None => {
+                            // request was blocked by an interceptor, we need to send declare final to avoid timeout error
+                            self.face
+                                .state
+                                .primitives
+                                .send_declare(RoutingContext::new_in(
+                                    Declare {
+                                        interest_id: Some(interest_id),
+                                        ext_qos: ext::QoSType::DECLARE,
+                                        ext_tstamp: None,
+                                        ext_nodeid: ext::NodeIdType::DEFAULT,
+                                        body: DeclareBody::DeclareFinal(DeclareFinal),
+                                    },
+                                    self.face.clone(),
+                                ));
+                            return Ok(());
+                        }
+                    }
+                }
+                _ => match self.interceptor.intercept(ctx, cache) {
+                    Some(ctx) => ctx,
+                    None => return Ok(()),
+                },
             };
+
             msg = ctx.msg;
         }
 

--- a/zenoh/src/net/primitives/mux.rs
+++ b/zenoh/src/net/primitives/mux.rs
@@ -16,13 +16,13 @@ use std::sync::OnceLock;
 use zenoh_protocol::{
     core::Reliability,
     network::{
-        interest::Interest, Declare, NetworkBody, NetworkMessage, Push, Request, Response,
-        ResponseFinal,
+        interest::Interest, response, Declare, NetworkBody, NetworkMessage, Push, Request,
+        Response, ResponseFinal,
     },
 };
 use zenoh_transport::{multicast::TransportMulticast, unicast::TransportUnicast};
 
-use super::EPrimitives;
+use super::{EPrimitives, Primitives};
 use crate::net::routing::{
     dispatcher::face::{Face, WeakFace},
     interceptor::{InterceptorTrait, InterceptorsChain},
@@ -47,6 +47,7 @@ impl Mux {
 
 impl EPrimitives for Mux {
     fn send_interest(&self, ctx: RoutingContext<Interest>) {
+        let interest_id = ctx.msg.id;
         let ctx = RoutingContext {
             msg: NetworkMessage {
                 body: NetworkBody::Interest(ctx.msg),
@@ -67,9 +68,18 @@ impl EPrimitives for Mux {
         let cache = prefix
             .as_ref()
             .and_then(|p| p.get_egress_cache(ctx.outface.get().unwrap()));
-        if let Some(ctx) = self.interceptor.intercept(ctx, cache) {
-            let _ = self.handler.schedule(ctx.msg);
-        }
+
+        match self.interceptor.intercept(ctx, cache) {
+            Some(ctx) => {
+                let _ = self.handler.schedule(ctx.msg);
+            }
+            None => {
+                // send declare final to avoid timeout on blocked interest
+                if let Some(face) = self.face.get().and_then(|f| f.upgrade()) {
+                    face.reject_interest(interest_id);
+                }
+            }
+        };
     }
 
     fn send_declare(&self, ctx: RoutingContext<Declare>) {
@@ -124,6 +134,7 @@ impl EPrimitives for Mux {
     }
 
     fn send_request(&self, msg: Request) {
+        let request_id = msg.id;
         let msg = NetworkMessage {
             body: NetworkBody::Request(msg),
             reliability: Reliability::Reliable,
@@ -140,8 +151,19 @@ impl EPrimitives for Mux {
                 .flatten()
                 .cloned();
             let cache = prefix.as_ref().and_then(|p| p.get_egress_cache(&face));
-            if let Some(ctx) = self.interceptor.intercept(ctx, cache) {
-                let _ = self.handler.schedule(ctx.msg);
+
+            match self.interceptor.intercept(ctx, cache) {
+                Some(ctx) => {
+                    let _ = self.handler.schedule(ctx.msg);
+                }
+                None => {
+                    // request was blocked by an interceptor, we need to send response final to avoid timeout error
+                    face.send_response_final(ResponseFinal {
+                        rid: request_id,
+                        ext_qos: response::ext::QoSType::RESPONSE_FINAL,
+                        ext_tstamp: None,
+                    })
+                }
             }
         } else {
             tracing::error!("Uninitialized multiplexer!");

--- a/zenoh/src/net/routing/dispatcher/face.rs
+++ b/zenoh/src/net/routing/dispatcher/face.rs
@@ -37,7 +37,10 @@ use zenoh_transport::stats::TransportStats;
 
 use super::{
     super::router::*,
-    interests::{declare_final, declare_interest, undeclare_interest, CurrentInterest},
+    interests::{
+        declare_final, declare_interest, undeclare_interest,
+        PendingCurrentInterest,
+    },
     resource::*,
     tables::TablesLock,
 };
@@ -67,8 +70,7 @@ pub struct FaceState {
     pub(crate) primitives: Arc<dyn crate::net::primitives::EPrimitives + Send + Sync>,
     pub(crate) local_interests: HashMap<InterestId, InterestState>,
     pub(crate) remote_key_interests: HashMap<InterestId, Option<Arc<Resource>>>,
-    pub(crate) pending_current_interests:
-        HashMap<InterestId, (Arc<CurrentInterest>, CancellationToken)>,
+    pub(crate) pending_current_interests: HashMap<InterestId, PendingCurrentInterest>,
     pub(crate) local_mappings: HashMap<ExprId, Arc<Resource>>,
     pub(crate) remote_mappings: HashMap<ExprId, Arc<Resource>>,
     pub(crate) next_qid: RequestId,
@@ -255,6 +257,13 @@ impl Face {
         WeakFace {
             tables: Arc::downgrade(&self.tables),
             state: Arc::downgrade(&self.state),
+        }
+    }
+
+
+    pub(crate) fn reject_interest(&self, interest_id: u32) {
+        if let Some(interest) = self.state.pending_current_interests.get(&interest_id) {
+            interest.rejection_token.cancel();
         }
     }
 }

--- a/zenoh/src/net/routing/dispatcher/face.rs
+++ b/zenoh/src/net/routing/dispatcher/face.rs
@@ -37,10 +37,7 @@ use zenoh_transport::stats::TransportStats;
 
 use super::{
     super::router::*,
-    interests::{
-        declare_final, declare_interest, undeclare_interest,
-        PendingCurrentInterest,
-    },
+    interests::{declare_final, declare_interest, undeclare_interest, PendingCurrentInterest},
     resource::*,
     tables::TablesLock,
 };
@@ -259,7 +256,6 @@ impl Face {
             state: Arc::downgrade(&self.state),
         }
     }
-
 
     pub(crate) fn reject_interest(&self, interest_id: u32) {
         if let Some(interest) = self.state.pending_current_interests.get(&interest_id) {

--- a/zenoh/src/net/routing/hat/client/token.rs
+++ b/zenoh/src/net/routing/hat/client/token.rs
@@ -117,7 +117,11 @@ fn declare_simple_token(
     send_declare: &mut SendDeclare,
 ) {
     if let Some(interest_id) = interest_id {
-        if let Some((interest, _)) = face.pending_current_interests.get(&interest_id) {
+        if let Some(interest) = face
+            .pending_current_interests
+            .get(&interest_id)
+            .map(|p| &p.interest)
+        {
             if interest.mode == InterestMode::CurrentFuture {
                 register_simple_token(tables, &mut face.clone(), id, res);
             }

--- a/zenoh/src/net/routing/hat/p2p_peer/token.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/token.rs
@@ -197,7 +197,11 @@ fn declare_simple_token(
     send_declare: &mut SendDeclare,
 ) {
     if let Some(interest_id) = interest_id {
-        if let Some((interest, _)) = face.pending_current_interests.get(&interest_id) {
+        if let Some(interest) = face
+            .pending_current_interests
+            .get(&interest_id)
+            .map(|p| &p.interest)
+        {
             if interest.mode == InterestMode::CurrentFuture {
                 register_simple_token(tables, &mut face.clone(), id, res);
             }

--- a/zenoh/tests/acl.rs
+++ b/zenoh/tests/acl.rs
@@ -1753,7 +1753,7 @@ async fn test_acl_query_ingress_deny() {
                 {
                     "id": "deny query ingress",
                     "permission": "deny",
-                    "messages": ["query", "liveliness_query"],
+                    "messages": ["query"],
                     "flows": ["ingress"],
                     "key_exprs": ["**"],
                 }
@@ -1797,7 +1797,7 @@ async fn test_acl_query_egress_deny() {
                 {
                     "id": "deny query egress",
                     "permission": "deny",
-                    "messages": ["query", "liveliness_query"],
+                    "messages": ["query"],
                     "flows": ["egress"],
                     "key_exprs": ["**"],
                 }
@@ -1840,7 +1840,7 @@ async fn test_acl_liveliness_query_ingress_deny() {
                 {
                     "id": "deny query ingress",
                     "permission": "deny",
-                    "messages": ["query", "liveliness_token", "liveliness_query"],
+                    "messages": ["liveliness_query"],
                     "flows": ["ingress"],
                     "key_exprs": ["**"],
                 }
@@ -1896,7 +1896,7 @@ async fn test_acl_liveliness_query_egress_deny() {
                 {
                     "id": "deny query egress",
                     "permission": "deny",
-                    "messages": ["query", "liveliness_token", "liveliness_query"],
+                    "messages": ["liveliness_query"],
                     "flows": ["egress"],
                     "key_exprs": ["**"],
                 }

--- a/zenoh/tests/acl.rs
+++ b/zenoh/tests/acl.rs
@@ -21,7 +21,6 @@ use std::{
 
 use tokio::runtime::Handle;
 use zenoh::{config::WhatAmI, sample::SampleKind, Config, Session};
-use zenoh_config::{EndPoint, ModeDependentValue};
 use zenoh_core::{zlock, ztimeout};
 
 const TIMEOUT: Duration = Duration::from_secs(60);

--- a/zenoh/tests/acl.rs
+++ b/zenoh/tests/acl.rs
@@ -85,6 +85,18 @@ async fn get_basic_router_config(port: u16) -> Config {
     config
 }
 
+async fn get_basic_client_config(port: u16) -> Config {
+    let mut config = Config::default();
+    config.set_mode(Some(WhatAmI::Client)).unwrap();
+    config
+        .connect
+        .endpoints
+        .set(vec![format!("tcp/127.0.0.1:{port}").parse().unwrap()])
+        .unwrap();
+    config.scouting.multicast.set_enabled(Some(false)).unwrap();
+    config
+}
+
 async fn close_router_session(s: Session) {
     println!("Closing router session");
     ztimeout!(s.close()).unwrap();
@@ -92,30 +104,9 @@ async fn close_router_session(s: Session) {
 
 async fn get_client_sessions(port: u16) -> (Session, Session) {
     println!("Opening client sessions");
-    let mut config = zenoh::Config::default();
-    config.set_mode(Some(WhatAmI::Client)).unwrap();
-    config
-        .connect
-        .set_endpoints(ModeDependentValue::Unique(vec![format!(
-            "tcp/127.0.0.1:{port}"
-        )
-        .parse::<EndPoint>()
-        .unwrap()]))
-        .unwrap();
 
-    let s01 = ztimeout!(zenoh::open(config)).unwrap();
-
-    let mut config = zenoh::Config::default();
-    config.set_mode(Some(WhatAmI::Client)).unwrap();
-    config
-        .connect
-        .set_endpoints(ModeDependentValue::Unique(vec![format!(
-            "tcp/127.0.0.1:{port}"
-        )
-        .parse::<EndPoint>()
-        .unwrap()]))
-        .unwrap();
-    let s02 = ztimeout!(zenoh::open(config)).unwrap();
+    let s01 = ztimeout!(zenoh::open(get_basic_client_config(port).await)).unwrap();
+    let s02 = ztimeout!(zenoh::open(get_basic_client_config(port).await)).unwrap();
     (s01, s02)
 }
 
@@ -1747,4 +1738,201 @@ async fn test_liveliness_deny_allow_query(port: u16) {
     ztimeout!(subscriber.undeclare()).unwrap();
     close_sessions(reader_session, writer_session).await;
     close_router_session(session).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_acl_query_ingress_deny() {
+    zenoh::init_log_from_env_or("error");
+    let mut config_router = get_basic_router_config(27501).await;
+    config_router
+        .insert_json5(
+            "access_control",
+            r#"{
+            "enabled": true,
+            "default_permission": "allow",
+            "rules": [
+                {
+                    "id": "deny query ingress",
+                    "permission": "deny",
+                    "messages": ["query", "liveliness_query"],
+                    "flows": ["ingress"],
+                    "key_exprs": ["**"],
+                }
+            ],
+            "subjects": [
+                { "id": "all" }
+            ],
+            "policies": [
+                {
+                    "rules": ["deny query ingress"],
+                    "subjects": ["all"],
+                }
+            ],
+          }"#,
+        )
+        .unwrap();
+
+    let _router = ztimeout!(zenoh::open(config_router)).unwrap();
+    let (session1, session2) = get_client_sessions(27501).await;
+    tokio::time::sleep(SLEEP).await;
+
+    let _qbl = session1.declare_queryable("test/ingress").await.unwrap();
+    tokio::time::sleep(SLEEP).await;
+
+    let replies = session2.get("test/ingress").await.unwrap();
+
+    assert!(replies.recv_async().await.is_err());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_acl_query_egress_deny() {
+    zenoh::init_log_from_env_or("error");
+    let mut config_router = get_basic_router_config(27502).await;
+    config_router
+        .insert_json5(
+            "access_control",
+            r#"{
+            "enabled": true,
+            "default_permission": "allow",
+            "rules": [
+                {
+                    "id": "deny query egress",
+                    "permission": "deny",
+                    "messages": ["query", "liveliness_query"],
+                    "flows": ["egress"],
+                    "key_exprs": ["**"],
+                }
+            ],
+            "subjects": [
+                { "id": "all" }
+            ],
+            "policies": [
+                {
+                    "rules": ["deny query egress"],
+                    "subjects": ["all"],
+                }
+            ],
+          }"#,
+        )
+        .unwrap();
+
+    let _router = ztimeout!(zenoh::open(config_router)).unwrap();
+    let (session1, session2) = get_client_sessions(27502).await;
+    tokio::time::sleep(SLEEP).await;
+
+    let _qbl = session1.declare_queryable("test/egress").await.unwrap();
+    tokio::time::sleep(SLEEP).await;
+    let replies = session2.get("test/egress").await.unwrap();
+
+    assert!(replies.recv_async().await.is_err());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_acl_liveliness_query_ingress_deny() {
+    zenoh::init_log_from_env_or("error");
+    let mut config_router = get_basic_router_config(27503).await;
+    config_router
+        .insert_json5(
+            "access_control",
+            r#"{
+            "enabled": true,
+            "default_permission": "allow",
+            "rules": [
+                {
+                    "id": "deny query ingress",
+                    "permission": "deny",
+                    "messages": ["query", "liveliness_token", "liveliness_query"],
+                    "flows": ["ingress"],
+                    "key_exprs": ["**"],
+                }
+            ],
+            "subjects": [
+                { "id": "all" }
+            ],
+            "policies": [
+                {
+                    "rules": ["deny query ingress"],
+                    "subjects": ["all"],
+                }
+            ],
+          }"#,
+        )
+        .unwrap();
+
+    let _router = ztimeout!(zenoh::open(config_router)).unwrap();
+    tokio::time::sleep(SLEEP).await;
+    let (session1, session2) = get_client_sessions(27503).await;
+    tokio::time::sleep(SLEEP).await;
+
+    let _token = session1
+        .liveliness()
+        .declare_token("test/token/ingress")
+        .await
+        .unwrap();
+    tokio::time::sleep(SLEEP).await;
+
+    let replies = session2
+        .liveliness()
+        .get("test/token/ingress")
+        .timeout(Duration::from_secs(10))
+        .await
+        .unwrap();
+
+    assert!(replies.recv_timeout(Duration::from_secs(1)).is_err());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_acl_liveliness_query_egress_deny() {
+    zenoh::init_log_from_env_or("error");
+    let config_router = get_basic_router_config(27504).await;
+    let mut config_client1 = get_basic_client_config(27504).await;
+    let config_client2 = get_basic_client_config(27504).await;
+    config_client1
+        .insert_json5(
+            "access_control",
+            r#"{
+            "enabled": true,
+            "default_permission": "allow",
+            "rules": [
+                {
+                    "id": "deny query egress",
+                    "permission": "deny",
+                    "messages": ["query", "liveliness_token", "liveliness_query"],
+                    "flows": ["egress"],
+                    "key_exprs": ["**"],
+                }
+            ],
+            "subjects": [
+                { "id": "all" }
+            ],
+            "policies": [
+                {
+                    "rules": ["deny query egress"],
+                    "subjects": ["all"],
+                }
+            ],
+          }"#,
+        )
+        .unwrap();
+
+    let _router = ztimeout!(zenoh::open(config_router)).unwrap();
+    tokio::time::sleep(SLEEP).await;
+    let session1 = ztimeout!(zenoh::open(config_client1)).unwrap();
+    let session2 = ztimeout!(zenoh::open(config_client2)).unwrap();
+    tokio::time::sleep(SLEEP).await;
+
+    let _token = session2
+        .liveliness()
+        .declare_token("test/token/egress")
+        .await
+        .unwrap();
+    tokio::time::sleep(SLEEP).await;
+    let replies = session1
+        .liveliness()
+        .get("test/token/egress")
+        .timeout(Duration::from_secs(10))
+        .await
+        .unwrap();
+
+    assert!(replies.recv_timeout(Duration::from_secs(1)).is_err());
 }


### PR DESCRIPTION
make interceptor-rejected queries and liveliness queries return an empty reply instead of timeout
Resolves #1779 