### PR TITLE
fix: pin base64ct to 1.6.0 for valgrind-check

### DIFF
--- a/ci/valgrind-check/Cargo.toml
+++ b/ci/valgrind-check/Cargo.toml
@@ -22,6 +22,7 @@ categories = ["network-programming"]
 description = "Internal crate for zenoh."
 
 [dependencies]
+base64ct = "~1.6.0"
 tokio = { version = "1.35.1", features = ["rt-multi-thread", "time", "io-std"] }
 zenoh = { path = "../../zenoh/" }
 zenoh-runtime = { path = "../../commons/zenoh-runtime/" }


### PR DESCRIPTION
Today's release of base64ct 1.7.0 made the check fail to compile due to MSRV 1.85