### PR TITLE
feat: add code coverage report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,7 @@ jobs:
             uses: taiki-e/install-action@cargo-llvm-cov
 
           - name: Generate code coverage
-            run: cargo +${{ matrix.rust }} llvm-cov test --features unstable --features test --features shared-memory ${{ matrix.rust == 'nightly' && '--doctests' || '' }} --lcov --output-path lcov.info --no-cfg-coverage --no-cfg-coverage-nightly -- --skip test_default_features
+            run: cargo +${{ matrix.rust }} llvm-cov test --features unstable --features test --features shared-memory ${{ matrix.rust == 'nightly' && '--doctests' || '' }} --lcov --output-path lcov.info --no-cfg-coverage --no-cfg-coverage-nightly --ignore-run-fail -- --skip test_default_features
 
           - name: Upload coverage to Codecov
             uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,41 @@ jobs:
           config: '.markdownlint.yaml'
           globs: '**/README.md'
 
+  coverage:
+        name: Coverage
+        strategy:
+          fail-fast: false
+          matrix:
+            os: [ubuntu-latest]
+            rust: [nightly, stable]
+        runs-on: ${{ matrix.os }}
+        steps:
+          - name: Checkout sources
+            uses: actions/checkout@v4
+
+          - name: Install ${{ matrix.rust }} Rust toolchain
+            run: |
+              rustup override set ${{ matrix.rust }}
+              rustup update ${{ matrix.rust }}
+              rustup component add llvm-tools-preview
+
+          - uses: Swatinem/rust-cache@v2
+            with:
+              cache-bin: false
+
+          - name: Install cargo-llvm-cov
+            uses: taiki-e/install-action@cargo-llvm-cov
+
+          - name: Generate code coverage
+            run: cargo +${{ matrix.rust }} llvm-cov test --features unstable --features test --features shared-memory ${{ matrix.rust == 'nightly' && '--doctests' || '' }} --lcov --output-path lcov.info --no-cfg-coverage --no-cfg-coverage-nightly -- --skip test_default_features
+
+          - name: Upload coverage to Codecov
+            uses: codecov/codecov-action@v4
+            with:
+              #token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+              files: lcov.info
+              fail_ci_if_error: true
+
   # NOTE: In GitHub repository settings, the "Require status checks to pass
   # before merging" branch protection rule ensures that commits are only merged
   # from branches where specific status checks have passed. These checks are
@@ -228,7 +263,7 @@ jobs:
   ci:
     name: CI status checks
     runs-on: ubuntu-latest
-    needs: [check, test, valgrind, typos, markdown_lint]
+    needs: [check, test, valgrind, typos, markdown_lint, coverage]
     if: always()
     steps:
       - name: Check whether all jobs pass

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,7 @@ jobs:
             uses: taiki-e/install-action@cargo-llvm-cov
 
           - name: Generate code coverage
-            run: cargo +${{ matrix.rust }} llvm-cov test --features unstable --features test --features shared-memory ${{ matrix.rust == 'nightly' && '--doctests' || '' }} --lcov --output-path lcov.info --no-cfg-coverage --no-cfg-coverage-nightly --ignore-run-fail -- --skip test_default_features
+            run: cargo +${{ matrix.rust }} llvm-cov test --features unstable --features test --features shared-memory ${{ matrix.rust == 'nightly' && '--doctests' || '' }} --lcov --output-path lcov.info --no-cfg-coverage --no-cfg-coverage-nightly --ignore-run-fail -- --skip test_default_features --skip router_linkstate --skip three_node_combination  --skip three_node_combination_multicast
 
           - name: Upload coverage to Codecov
             uses: codecov/codecov-action@v4

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 cargo-timing*.html
 
 ci/valgrind-check/*.log
+
+# Code coverage reports
+*.profraw


### PR DESCRIPTION
A few caveats
- I had to `--skip` a few tests that were hanging during CI runs under `llvm-cov` (e.g. `router_linkstate`, `three_node_combination`, `three_node_combination_multicast`). Those tests pass during normal unit tests runs, not sure why they hang when executed under llvm-cov
- the new workflow adds a matrix job for both nightly and stable. Enabling nightly allows us to run the llvm-cov with the `--doctests` option
- added `--ignore-run-fail` so we upload the code coverage report even if the tests fail. We still have flaky tests that causes failures, which end up cancelling the report upload step.
- I still need to configure the code cov token for zenoh but that will require a separate PR to `eclipse-zenho/.eclipsefdn`. The token is used for reports on protected branches, like zenoh main.
