### PR TITLE
Detect change on network interface to update locators and scouting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2241,6 +2241,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "netlink-packet-core"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "483325d4bfef65699214858f097d504eb812c38ce7077d165f301ec406c3066e"
+dependencies = [
+ "anyhow",
+ "bitflags 2.6.0",
+ "byteorder",
+ "libc",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-utils"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "paste",
+ "thiserror 1.0.63",
+]
+
+[[package]]
+name = "netlink-proto"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72452e012c2f8d612410d89eea01e2d9b56205274abb35d53f60200b2ec41d60"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "netlink-packet-core",
+ "netlink-sys",
+ "thiserror 2.0.11",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "416060d346fbaf1f23f9512963e3e878f1a78e707cb699ba9215761754244307"
+dependencies = [
+ "bytes",
+ "futures",
+ "libc",
+ "log",
+ "tokio",
+]
+
+[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3225,6 +3290,24 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rtnetlink"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf09ec6e683fcdd53e34645afadd5d78157b1f6befa751b85d818e9cc2c4f124"
+dependencies = [
+ "futures",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-packet-utils",
+ "netlink-proto",
+ "netlink-sys",
+ "nix 0.29.0",
+ "thiserror 1.0.63",
+ "tokio",
 ]
 
 [[package]]
@@ -4473,7 +4556,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 
@@ -5165,6 +5248,7 @@ dependencies = [
  "phf",
  "rand 0.8.5",
  "ref-cast",
+ "rtnetlink",
  "rustc_version 0.4.1",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,7 @@ regex = "1.10.6"
 ron = "0.8.1"
 ringbuffer-spsc = "0.1.9"
 rsa = "0.9"
+rtnetlink = "0.15"
 rustc_version = "0.4.1"
 rustls = { version = "0.23.13", default-features = false, features = [
     "logging",

--- a/commons/zenoh-util/src/net/mod.rs
+++ b/commons/zenoh-util/src/net/mod.rs
@@ -12,13 +12,13 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use std::net::{IpAddr, Ipv6Addr};
-
+use std::sync::RwLock;
 #[cfg(unix)]
 use lazy_static::lazy_static;
 #[cfg(unix)]
 use pnet_datalink::NetworkInterface;
 use tokio::net::{TcpSocket, UdpSocket};
-use zenoh_core::zconfigurable;
+use zenoh_core::{zconfigurable, zread, zwrite};
 #[cfg(unix)]
 use zenoh_result::zerror;
 use zenoh_result::{bail, ZResult};
@@ -30,7 +30,7 @@ zconfigurable! {
 
 #[cfg(unix)]
 lazy_static! {
-    static ref IFACES: Vec<NetworkInterface> = pnet_datalink::interfaces();
+    static ref IFACES: RwLock<Vec<NetworkInterface>> = RwLock::new(pnet_datalink::interfaces());
 }
 
 #[cfg(windows)]
@@ -68,7 +68,7 @@ unsafe fn get_adapters_addresses(af_spec: i32) -> ZResult<Vec<u8>> {
 pub fn get_interface(name: &str) -> ZResult<Option<IpAddr>> {
     #[cfg(unix)]
     {
-        for iface in IFACES.iter() {
+        for iface in zread!(IFACES).iter() {
             if iface.name == name {
                 for ifaddr in &iface.ips {
                     if ifaddr.is_ipv4() {
@@ -131,7 +131,7 @@ pub fn get_interface(name: &str) -> ZResult<Option<IpAddr>> {
 pub fn get_multicast_interfaces() -> Vec<IpAddr> {
     #[cfg(unix)]
     {
-        IFACES
+        zread!(IFACES)
             .iter()
             .filter_map(|iface| {
                 if iface.is_up() && iface.is_running() && iface.is_multicast() {
@@ -155,7 +155,7 @@ pub fn get_multicast_interfaces() -> Vec<IpAddr> {
 pub fn get_local_addresses(interface: Option<&str>) -> ZResult<Vec<IpAddr>> {
     #[cfg(unix)]
     {
-        Ok(IFACES
+        Ok(zread!(IFACES)
             .iter()
             .filter(|iface| {
                 if let Some(interface) = interface.as_ref() {
@@ -205,7 +205,7 @@ pub fn get_local_addresses(interface: Option<&str>) -> ZResult<Vec<IpAddr>> {
 pub fn get_unicast_addresses_of_multicast_interfaces() -> Vec<IpAddr> {
     #[cfg(unix)]
     {
-        IFACES
+        zread!(IFACES)
             .iter()
             .filter(|iface| iface.is_up() && iface.is_running() && iface.is_multicast())
             .flat_map(|iface| {
@@ -228,7 +228,7 @@ pub fn get_unicast_addresses_of_multicast_interfaces() -> Vec<IpAddr> {
 pub fn get_unicast_addresses_of_interface(name: &str) -> ZResult<Vec<IpAddr>> {
     #[cfg(unix)]
     {
-        match IFACES.iter().find(|iface| iface.name == name) {
+        match zread!(IFACES).iter().find(|iface| iface.name == name) {
             Some(iface) => {
                 if !iface.is_up() {
                     bail!("Interface {name} is not up");
@@ -282,7 +282,7 @@ pub fn get_unicast_addresses_of_interface(name: &str) -> ZResult<Vec<IpAddr>> {
 pub fn get_index_of_interface(addr: IpAddr) -> ZResult<u32> {
     #[cfg(unix)]
     {
-        IFACES
+        zread!(IFACES)
             .iter()
             .find(|iface| iface.ips.iter().any(|ipnet| ipnet.ip() == addr))
             .map(|iface| iface.index)
@@ -319,12 +319,12 @@ pub fn get_interface_names_by_addr(addr: IpAddr) -> ZResult<Vec<String>> {
     #[cfg(unix)]
     {
         if addr.is_unspecified() {
-            Ok(IFACES
+            Ok(zread!(IFACES)
                 .iter()
                 .map(|iface| iface.name.clone())
                 .collect::<Vec<String>>())
         } else {
-            Ok(IFACES
+            Ok(zread!(IFACES)
                 .iter()
                 .filter(|iface| iface.ips.iter().any(|ipnet| ipnet.ip() == addr))
                 .map(|iface| iface.name.clone())
@@ -433,6 +433,12 @@ pub fn get_ipv6_ipaddrs(interface: Option<&str>) -> Vec<IpAddr> {
         .chain(yll_ipv6_addrs)
         .chain(priv_ipv4_addrs)
         .collect()
+}
+
+#[cfg(unix)]
+pub fn update_iface_cache() {
+    let mut interfaces = zwrite!(IFACES);
+    *interfaces = pnet_datalink::interfaces();
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -98,6 +98,7 @@ petgraph = { workspace = true }
 phf = { workspace = true }
 rand = { workspace = true, features = ["default"] }
 ref-cast = { workspace = true }
+rtnetlink = { workspace = true }
 serde = { workspace = true, features = ["default"] }
 serde_json = { workspace = true }
 socket2 = { workspace = true }

--- a/zenoh/src/net/runtime/netlink.rs
+++ b/zenoh/src/net/runtime/netlink.rs
@@ -1,0 +1,66 @@
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use futures::{channel::mpsc::UnboundedReceiver, Stream, StreamExt};
+use rtnetlink::{packet_core::NetlinkMessage, packet_route::RouteNetlinkMessage, sys::SocketAddr};
+use rtnetlink::packet_core::NetlinkPayload;
+use rtnetlink::sys::AsyncSocket;
+
+const RTNLGRP_IPV4_IFADDR: u32 = 5;
+const RTNLGRP_IPV6_IFADDR: u32 = 9;
+
+pub struct NetlinkMonitor {
+    messages: UnboundedReceiver<(NetlinkMessage<RouteNetlinkMessage>, SocketAddr)>,
+}
+
+impl NetlinkMonitor {
+    pub fn new() -> io::Result<Self> {
+        let (mut conn, _handle, messages) = rtnetlink::new_connection()?;
+
+        let groups = nl_mgrp(RTNLGRP_IPV4_IFADDR)
+            | nl_mgrp(RTNLGRP_IPV6_IFADDR);
+
+        let addr = SocketAddr::new(0, groups);
+        conn.socket_mut()
+            .socket_mut()
+            .bind(&addr)?;
+
+        tokio::spawn(conn);
+
+        Ok(Self {
+            messages,
+        })
+    }
+}
+
+impl Stream for NetlinkMonitor {
+    type Item = RouteNetlinkMessage;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match self.messages.poll_next_unpin(cx) {
+            Poll::Ready(Some((msg, _))) => {
+                match msg.payload {
+                    NetlinkPayload::InnerMessage(msg) => Poll::Ready(Some(msg)),
+                    _ => Poll::Pending,
+                }
+            },
+            Poll::Ready(_) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.messages.size_hint()
+    }
+}
+
+const fn nl_mgrp(group: u32) -> u32 {
+    if group > 31 {
+        panic!("use netlink_sys::Socket::add_membership() for this group");
+    }
+    if group == 0 {
+        0
+    } else {
+        1 << (group - 1)
+    }
+}


### PR DESCRIPTION
On Unix systems, use netlink to detect added or delete IPv4 addresses to:
  * Renew the interface list.
  * Update the node locators.
  * Restart the scouting to use the new addresses/discard the old addresses.

This is still quite hacky, with the following shortcomings:
* We do not handle IPv6 addresses, because the IPv6 addresses are "renewed" every few seconds, causing unecessary closing and re-opening of the sockets.
* We perform the locator update and the scouting reset even if the new/old addresses are not used as per the configuration.
* Only works on Linux because of the Netlink dependency.
* The code overall is not the best quality.

This would solve #1823 (with the mentioned caveats).

Feel free to close this, I opened it more for reference and I might not update it.