### PR TITLE
fix: pin url to 2.5.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,7 +179,7 @@ thread-priority = "1.1.0"
 typenum = "1.17.0"
 uhlc = { version = "0.8.0", default-features = false } # Default features are disabled due to usage in no_std crates
 unzip-n = "0.1.2"
-url = "2.5.2"
+url = "=2.5.2"
 urlencoding = "2.1.3"
 uuid = { version = "1.10.0", default-features = false, features = [
     "v4",


### PR DESCRIPTION
url 2.5.4 pulls in litemap and zerofrom dependencies which are not compatible with rust 1.75