### PR TITLE
chore: pin indirect dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,9 @@ async-io = "2.3.4"
 async-std = { version = "1.6.5", features = ["tokio1"] }
 async-trait = "0.1.82"
 base64 = "0.22.1"
+base64ct = "=1.6.0"
+zerofrom = "=0.1.5"
+litemap = "=0.7.4"
 bincode = "1.3.3"
 bytes = "1.7.1"
 clap = { version = "4.5.17", features = ["derive"] }


### PR DESCRIPTION
those deps don't work with rust 1.75