### PR TITLE
zenoh_keyexpr should support nostd, std::str:: replaced to core::str::

### DIFF
--- a/commons/zenoh-keyexpr/src/key_expr/borrowed.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/borrowed.rs
@@ -377,7 +377,7 @@ impl keyexpr {
                         }
                         None => unsafe {
                             // "**" can match all remaining non-verbatim chunks
-                            Some(keyexpr::from_str_unchecked(std::str::from_utf8_unchecked(
+                            Some(keyexpr::from_str_unchecked(core::str::from_utf8_unchecked(
                                 &target_bytes[target_idx..],
                             )))
                         },
@@ -394,7 +394,7 @@ impl keyexpr {
                 if prefix_end == prefix_bytes.len() {
                     // Safety: every chunk of keyexpr is also a valid keyexpr
                     return unsafe {
-                        Some(keyexpr::from_str_unchecked(std::str::from_utf8_unchecked(
+                        Some(keyexpr::from_str_unchecked(core::str::from_utf8_unchecked(
                             &target_bytes[(target_end + 1)..],
                         )))
                     };


### PR DESCRIPTION
compilation of zenoh-plugin-trait fails:
```sh
cargo check -p zenoh-plugin-trait
```
![image](https://github.com/user-attachments/assets/4b9d3074-d13b-4301-8639-d1165d00570b)
