### PR TITLE
fix: add rust 1.75 CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,30 @@ jobs:
             echo "runner=['ubuntu-latest', 'windows-latest', 'macos-latest']" >> $GITHUB_OUTPUT
           fi
 
+  check_rust:
+    needs: determine-runner
+    name: Check zenoh using Rust 1.75
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
+
+    steps:
+      - name: Clone this repository
+        uses: actions/checkout@v4
+
+      - name: Update Rust 1.75.0 toolchain
+        run: rustup update 1.75.0
+
+      - name: Setup rust-cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
+
+      - name: Check zenoh with rust 1.75.0
+        run: cargo +1.75.0 check --release --bins --lib
+
   check:
     needs: determine-runner
     name: Lints and doc tests on ${{ matrix.os }}


### PR DESCRIPTION
With the toolchain bump proposed in https://github.com/eclipse-zenoh/zenoh/pull/1803, we need to guarantee zenoh can still be built on rust 1.75