### PR TITLE
Block drop/undeclare for subscribers/queryables/listeners until callbacks return

### DIFF
--- a/zenoh/src/api/handlers/callback.rs
+++ b/zenoh/src/api/handlers/callback.rs
@@ -127,7 +127,13 @@ where
     }
 }
 
-#[doc(hidden)]
+#[cfg(not(feature = "internal"))]
+pub(crate) struct WeakCallback<T> {
+    use_guard: Arc<()>,
+    cb: Callback<T>,
+}
+
+#[zenoh_macros::internal]
 pub struct WeakCallback<T> {
     use_guard: Arc<()>,
     cb: Callback<T>,
@@ -149,7 +155,12 @@ impl<T> WeakCallback<T> {
     }
 }
 
-#[doc(hidden)]
+#[cfg(not(feature = "internal"))]
+pub(crate) struct StrongCallback<T> {
+    cb: WeakCallback<T>,
+}
+
+#[zenoh_macros::internal]
 // A Callback that blocks on Drop operation until all of its weak clones are dropped
 pub struct StrongCallback<T> {
     cb: WeakCallback<T>,

--- a/zenoh/src/api/matching.rs
+++ b/zenoh/src/api/matching.rs
@@ -24,7 +24,7 @@ use zenoh_core::{Resolvable, Wait};
 use zenoh_result::ZResult;
 
 use super::{
-    handlers::Callback,
+    handlers::StrongCallback,
     key_expr::KeyExpr,
     sample::Locality,
     session::{UndeclarableSealed, WeakSession},
@@ -85,7 +85,7 @@ pub(crate) struct MatchingListenerState {
     pub(crate) key_expr: KeyExpr<'static>,
     pub(crate) destination: Locality,
     pub(crate) match_type: MatchingStatusType,
-    pub(crate) callback: Callback<MatchingStatus>,
+    pub(crate) callback: StrongCallback<MatchingStatus>,
 }
 
 #[cfg(feature = "unstable")]

--- a/zenoh/src/api/query.rs
+++ b/zenoh/src/api/query.rs
@@ -27,9 +27,9 @@ pub use zenoh_protocol::network::request::ext::QueryTarget;
 #[doc(inline)]
 pub use zenoh_protocol::zenoh::query::ConsolidationMode;
 
+use super::handlers::StrongCallback;
 use crate::api::{
-    bytes::ZBytes, encoding::Encoding, handlers::Callback, key_expr::KeyExpr, sample::Sample,
-    selector::Selector,
+    bytes::ZBytes, encoding::Encoding, key_expr::KeyExpr, sample::Sample, selector::Selector,
 };
 
 /// The replies consolidation strategy to apply on replies to a [`get`](crate::Session::get).
@@ -174,7 +174,7 @@ impl From<Reply> for Result<Sample, ReplyError> {
 }
 
 pub(crate) struct LivelinessQueryState {
-    pub(crate) callback: Callback<Reply>,
+    pub(crate) callback: StrongCallback<Reply>,
 }
 
 pub(crate) struct QueryState {
@@ -183,7 +183,7 @@ pub(crate) struct QueryState {
     pub(crate) parameters: Parameters<'static>,
     pub(crate) reception_mode: ConsolidationMode,
     pub(crate) replies: Option<HashMap<OwnedKeyExpr, Reply>>,
-    pub(crate) callback: Callback<Reply>,
+    pub(crate) callback: StrongCallback<Reply>,
 }
 
 impl QueryState {

--- a/zenoh/src/api/queryable.rs
+++ b/zenoh/src/api/queryable.rs
@@ -32,6 +32,7 @@ use {
     zenoh_protocol::core::EntityGlobalIdProto,
 };
 
+use super::handlers::StrongCallback;
 #[zenoh_macros::unstable]
 use crate::api::selector::ZenohParameters;
 #[zenoh_macros::internal]
@@ -47,7 +48,6 @@ use crate::{
         session::{UndeclarableSealed, WeakSession},
         Id,
     },
-    handlers::Callback,
     net::primitives::Primitives,
 };
 
@@ -333,7 +333,7 @@ pub(crate) struct QueryableState {
     pub(crate) key_expr: WireExpr<'static>,
     pub(crate) complete: bool,
     pub(crate) origin: Locality,
-    pub(crate) callback: Callback<Query>,
+    pub(crate) callback: StrongCallback<Query>,
 }
 
 impl fmt::Debug for QueryableState {

--- a/zenoh/src/api/subscriber.rs
+++ b/zenoh/src/api/subscriber.rs
@@ -23,8 +23,8 @@ use zenoh_result::ZResult;
 #[cfg(feature = "unstable")]
 use {zenoh_config::wrappers::EntityGlobalId, zenoh_protocol::core::EntityGlobalIdProto};
 
+use super::handlers::StrongCallback;
 use crate::api::{
-    handlers::Callback,
     key_expr::KeyExpr,
     sample::{Locality, Sample},
     session::{UndeclarableSealed, WeakSession},
@@ -36,7 +36,7 @@ pub(crate) struct SubscriberState {
     pub(crate) remote_id: Id,
     pub(crate) key_expr: KeyExpr<'static>,
     pub(crate) origin: Locality,
-    pub(crate) callback: Callback<Sample>,
+    pub(crate) callback: StrongCallback<Sample>,
 }
 
 impl fmt::Debug for SubscriberState {

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -352,7 +352,7 @@ pub mod handlers {
     pub use crate::api::handlers::locked;
     pub use crate::api::handlers::{
         Callback, CallbackDrop, DefaultHandler, FifoChannel, FifoChannelHandler, IntoHandler,
-        RingChannel, RingChannelHandler,
+        RingChannel, RingChannelHandler, StrongCallback, WeakCallback,
     };
     pub mod fifo {
         pub use crate::api::handlers::{

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -349,10 +349,10 @@ pub mod matching {
 /// Zenoh object.
 pub mod handlers {
     #[zenoh_macros::internal]
-    pub use crate::api::handlers::locked;
+    pub use crate::api::handlers::{locked, StrongCallback, WeakCallback};
     pub use crate::api::handlers::{
         Callback, CallbackDrop, DefaultHandler, FifoChannel, FifoChannelHandler, IntoHandler,
-        RingChannel, RingChannelHandler, StrongCallback, WeakCallback,
+        RingChannel, RingChannelHandler,
     };
     pub mod fifo {
         pub use crate::api::handlers::{

--- a/zenoh/tests/session.rs
+++ b/zenoh/tests/session.rs
@@ -442,3 +442,57 @@ async fn test_undeclare_subscribers_same_keyexpr() {
     ztimeout!(sub1.undeclare()).unwrap();
     ztimeout!(sub2.undeclare()).unwrap();
 }
+
+#[cfg(feature = "unstable")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_subscriber_undeclare_blocks_until_callback_returns() {
+    use std::sync::atomic::AtomicBool;
+
+    let finished = Arc::new(AtomicBool::new(false));
+    let finished_sub = finished.clone();
+
+    let session1 = zenoh::open(zenoh::Config::default()).await.unwrap();
+    let ke = KeyExpr::new("test/subscriber_undeclare_blocks_until_callback_returns").unwrap();
+    let sub = session1
+        .declare_subscriber(ke.clone())
+        .callback(move |_s| {
+            std::thread::sleep(Duration::from_secs(5));
+            finished_sub.store(true, Ordering::Relaxed);
+        })
+        .await
+        .unwrap();
+
+    let session2 = zenoh::open(zenoh::Config::default()).await.unwrap();
+    tokio::time::sleep(SLEEP).await;
+    session2.put(ke, "payload").await.unwrap();
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(sub.undeclare()).unwrap();
+    assert!(finished.load(Ordering::Relaxed))
+}
+
+#[cfg(feature = "unstable")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_queryable_undeclare_blocks_until_callback_returns() {
+    use std::sync::atomic::AtomicBool;
+
+    let finished = Arc::new(AtomicBool::new(false));
+    let finished_sub = finished.clone();
+
+    let session1 = zenoh::open(zenoh::Config::default()).await.unwrap();
+    let ke = KeyExpr::new("test/queryable_undeclare_blocks_until_callback_returns").unwrap();
+    let qbl = session1
+        .declare_queryable(ke.clone())
+        .callback(move |_q| {
+            std::thread::sleep(Duration::from_secs(5));
+            finished_sub.store(true, Ordering::Relaxed);
+        })
+        .await
+        .unwrap();
+
+    let session2 = zenoh::open(zenoh::Config::default()).await.unwrap();
+    tokio::time::sleep(SLEEP).await;
+    session2.get(ke).await.unwrap();
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(qbl.undeclare()).unwrap();
+    assert!(finished.load(Ordering::Relaxed))
+}


### PR DESCRIPTION
Block drop/undeclare for subscribers/queryables/listeners until callbacks return.
Resolves #1818 