### PR TITLE
Stop plugins on runtime close.

### DIFF
--- a/zenoh/src/api/loader.rs
+++ b/zenoh/src/api/loader.rs
@@ -96,7 +96,7 @@ pub(crate) fn start_plugins(runtime: &Runtime) {
                     };
                 if required {
                     panic!(
-                        "Plugin \"{}\" failed to start: {}",
+                        "Required plugin \"{}\" failed to start: {}",
                         plugin.id(),
                         if report.is_empty() {
                             "no details provided"
@@ -106,7 +106,7 @@ pub(crate) fn start_plugins(runtime: &Runtime) {
                     );
                 } else {
                     tracing::error!(
-                        "Required plugin \"{}\" failed to start: {}",
+                        "Plugin \"{}\" failed to start: {}",
                         plugin.id(),
                         if report.is_empty() {
                             "no details provided"


### PR DESCRIPTION
Plugins don't receive a kill signal so cleanup is difficult, if not straight-up impossible.

This just stops the plugins when the runtime is closed.

(Also fixed a small error message)