### PR TITLE
feat: Add TTL connection param to multicast

### DIFF
--- a/io/zenoh-links/zenoh-link-udp/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/lib.rs
@@ -107,6 +107,7 @@ impl LocatorInspector for UdpLocatorInspector {
 pub mod config {
     pub const UDP_MULTICAST_IFACE: &str = "iface";
     pub const UDP_MULTICAST_JOIN: &str = "join";
+    pub const UDP_MULTICAST_TTL: &str = "ttl";
 }
 
 pub async fn get_udp_addrs(address: Address<'_>) -> ZResult<impl Iterator<Item = SocketAddr>> {

--- a/io/zenoh-links/zenoh-link-udp/src/multicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/multicast.rs
@@ -326,7 +326,7 @@ impl LinkManagerMulticastUdp {
             match &local_addr {
                 IpAddr::V4(_) => {
                     let ttl = match ttl_str.parse::<u32>() {
-                        Ok(ttl)  => ttl,
+                        Ok(ttl) => ttl,
                         Err(e) => bail!("Can not parse TTL '{}' to a u32: {}", ttl_str, e),
                     };
 

--- a/io/zenoh-links/zenoh-link-udp/src/multicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/multicast.rs
@@ -324,8 +324,8 @@ impl LinkManagerMulticastUdp {
         // If TTL is specified, add set the socket's TTL
         if let Some(ttl_str) = config.get(UDP_MULTICAST_TTL) {
             let ttl = match ttl_str.parse::<u32>() {
-                Ok(ttl)  => ttl,
-                Err(e) => bail!("Can not parse TTL '{}' to a u32: {}", ttl_str, e)
+                Ok(ttl) => ttl,
+                Err(e) => bail!("Can not parse TTL '{}' to a u32: {}", ttl_str, e),
             };
 
             match &local_addr {
@@ -336,11 +336,14 @@ impl LinkManagerMulticastUdp {
                 }
                 IpAddr::V6(_) => match zenoh_util::net::get_index_of_interface(local_addr) {
                     Ok(_) => {
-                        tracing::warn!("set_multicast_ttl_v4 on v6 socket (may have no effect): {}", mcast_addr);
+                        tracing::warn!(
+                            "set_multicast_ttl_v4 on v6 socket (may have no effect): {}",
+                            mcast_addr
+                        );
                         ucast_sock
                             .set_multicast_ttl_v4(ttl)
                             .map_err(|e| zerror!("{}: {}", mcast_addr, e))?
-                    },
+                    }
                     Err(e) => bail!("{}: {}", mcast_addr, e),
                 },
             }


### PR DESCRIPTION
Hi, I am using Zenoh for a project and I use a multicast listen endpoint in peer mode.

Using a multicast endpoint for multicast communication works fine on flat networks, but once a router is involved, the multicast traffic is lost, [due to the default TTL of 1 in multicast connections in the Tokio library](https://docs.rs/tokio/latest/tokio/net/struct.UdpSocket.html#method.set_multicast_ttl_v4).

See also: https://docs.rs/tokio/latest/tokio/net/struct.UdpSocket.html#method.set_multicast_ttl_v4

Note I have minimal rust programming experience, and used online resources and the code surrounding this addition to help me craft this PR, so feel free to make changes if I did something suboptimally or wrong.

I was able to build zenoh and run the zenoh pub client like so:

```
./target/release/examples/z_pub -m peer -l 'udp/239.1.3.37:9001#iface=myinterface;ttl=32' -k 'testkey' -p 'Hello from beyond the router' --no-multicast-scouting
```

I confirmed that the outgoing multicast TTL is set to what I specify it to, and that the traffic is no longer dropped on the other end of the network.

This is a critical feature when handling multicast traffic that is routed.

P.S., very nice library :)