### PR TITLE
Improve batching wait on multifragment messages

### DIFF
--- a/io/zenoh-transport/src/common/pipeline.rs
+++ b/io/zenoh-transport/src/common/pipeline.rs
@@ -167,14 +167,26 @@ impl WaitTime {
     }
 
     fn advance(&mut self, instant: &mut Instant) {
+        // grow wait_time exponentially
+        self.wait_time = self.wait_time.saturating_mul(2);
+
+        // check for waiting limits
         match &mut self.max_wait_time {
-            Some(max_wait_time) => {
-                if let Some(new_max_wait_time) = max_wait_time.checked_sub(self.wait_time) {
-                    *instant += self.wait_time;
-                    *max_wait_time = new_max_wait_time;
-                    self.wait_time *= 2;
-                }
+            // if we have reached the waiting limit, we do not increase wait instant
+            Some(max_wait_time) if *max_wait_time == Duration::ZERO => {
+                tracing::trace!("Backoff increase limit reached")
             }
+            // if the leftover of waiting time is less than next iteration, we select leftover
+            Some(max_wait_time) if *max_wait_time <= self.wait_time => {
+                *instant += *max_wait_time;
+                *max_wait_time = Duration::ZERO;
+            }
+            // if the leftover of waiting time is bigger than next iteration, select next iteration
+            Some(max_wait_time) => {
+                *instant += self.wait_time;
+                *max_wait_time -= self.wait_time;
+            }
+            // just select next iteration without checking the upper limit
             None => {
                 *instant += self.wait_time;
             }


### PR DESCRIPTION
Refactor for batching wait:
- start exponential growth from the first advance (vs second previously)
- improve some edge cases behavior