### PR TITLE
Pin zenoh internal dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ derive-new = "0.7.0"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 event-listener = "5.3.1"
 flume = "0.11"
-form_urlencoded = "1.2.1"
+form_urlencoded = "=1.2.1"
 futures = "0.3.30"
 futures-util = { version = "0.3.30", default-features = false } # Default features are disabled due to some crates' requirements
 git-version = "0.3.9"
@@ -194,38 +194,38 @@ z-serial = "0.3.1"
 either = "1.13.0"
 prost = "0.13.2"
 tls-listener = { version = "0.11.0", features = ["rustls-ring"] }
-zenoh-ext = { version = "1.2.1", path = "zenoh-ext", default-features = false }
-zenoh-shm = { version = "1.2.1", path = "commons/zenoh-shm" }
-zenoh-result = { version = "1.2.1", path = "commons/zenoh-result", default-features = false }
-zenoh-config = { version = "1.2.1", path = "commons/zenoh-config" }
-zenoh-protocol = { version = "1.2.1", path = "commons/zenoh-protocol", default-features = false }
-zenoh-keyexpr = { version = "1.2.1", path = "commons/zenoh-keyexpr", default-features = false }
-zenoh-core = { version = "1.2.1", path = "commons/zenoh-core" }
-zenoh-buffers = { version = "1.2.1", path = "commons/zenoh-buffers", default-features = false }
-zenoh-util = { version = "1.2.1", path = "commons/zenoh-util" }
-zenoh-crypto = { version = "1.2.1", path = "commons/zenoh-crypto" }
-zenoh-codec = { version = "1.2.1", path = "commons/zenoh-codec" }
-zenoh-sync = { version = "1.2.1", path = "commons/zenoh-sync" }
-zenoh-collections = { version = "1.2.1", path = "commons/zenoh-collections", default-features = false }
-zenoh-macros = { version = "1.2.1", path = "commons/zenoh-macros" }
-zenoh-plugin-trait = { version = "1.2.1", path = "plugins/zenoh-plugin-trait", default-features = false }
-zenoh_backend_traits = { version = "1.2.1", path = "plugins/zenoh-backend-traits", default-features = false }
-zenoh-transport = { version = "1.2.1", path = "io/zenoh-transport", default-features = false }
-zenoh-link-tls = { version = "1.2.1", path = "io/zenoh-links/zenoh-link-tls" }
-zenoh-link-tcp = { version = "1.2.1", path = "io/zenoh-links/zenoh-link-tcp" }
-zenoh-link-unixsock_stream = { version = "1.2.1", path = "io/zenoh-links/zenoh-link-unixsock_stream" }
-zenoh-link-quic = { version = "1.2.1", path = "io/zenoh-links/zenoh-link-quic" }
-zenoh-link-udp = { version = "1.2.1", path = "io/zenoh-links/zenoh-link-udp" }
-zenoh-link-ws = { version = "1.2.1", path = "io/zenoh-links/zenoh-link-ws" }
-zenoh-link-unixpipe = { version = "1.2.1", path = "io/zenoh-links/zenoh-link-unixpipe" }
-zenoh-link-serial = { version = "1.2.1", path = "io/zenoh-links/zenoh-link-serial" }
-zenoh-link-vsock = { version = "1.2.1", path = "io/zenoh-links/zenoh-link-vsock" }
-zenoh-link = { version = "1.2.1", path = "io/zenoh-link" }
-zenoh-link-commons = { version = "1.2.1", path = "io/zenoh-link-commons" }
-zenoh = { version = "1.2.1", path = "zenoh", default-features = false }
-zenoh-runtime = { version = "1.2.1", path = "commons/zenoh-runtime" }
-zenoh-task = { version = "1.2.1", path = "commons/zenoh-task" }
-zenoh-examples = { version = "1.2.1", path = "examples", default-features = false }
+zenoh-ext = { version = "=1.2.1", path = "zenoh-ext", default-features = false }
+zenoh-shm = { version = "=1.2.1", path = "commons/zenoh-shm" }
+zenoh-result = { version = "=1.2.1", path = "commons/zenoh-result", default-features = false }
+zenoh-config = { version = "=1.2.1", path = "commons/zenoh-config" }
+zenoh-protocol = { version = "=1.2.1", path = "commons/zenoh-protocol", default-features = false }
+zenoh-keyexpr = { version = "=1.2.1", path = "commons/zenoh-keyexpr", default-features = false }
+zenoh-core = { version = "=1.2.1", path = "commons/zenoh-core" }
+zenoh-buffers = { version = "=1.2.1", path = "commons/zenoh-buffers", default-features = false }
+zenoh-util = { version = "=1.2.1", path = "commons/zenoh-util" }
+zenoh-crypto = { version = "=1.2.1", path = "commons/zenoh-crypto" }
+zenoh-codec = { version = "=1.2.1", path = "commons/zenoh-codec" }
+zenoh-sync = { version = "=1.2.1", path = "commons/zenoh-sync" }
+zenoh-collections = { version = "=1.2.1", path = "commons/zenoh-collections", default-features = false }
+zenoh-macros = { version = "=1.2.1", path = "commons/zenoh-macros" }
+zenoh-plugin-trait = { version = "=1.2.1", path = "plugins/zenoh-plugin-trait", default-features = false }
+zenoh_backend_traits = { version = "=1.2.1", path = "plugins/zenoh-backend-traits", default-features = false }
+zenoh-transport = { version = "=1.2.1", path = "io/zenoh-transport", default-features = false }
+zenoh-link-tls = { version = "=1.2.1", path = "io/zenoh-links/zenoh-link-tls" }
+zenoh-link-tcp = { version = "=1.2.1", path = "io/zenoh-links/zenoh-link-tcp" }
+zenoh-link-unixsock_stream = { version = "=1.2.1", path = "io/zenoh-links/zenoh-link-unixsock_stream" }
+zenoh-link-quic = { version = "=1.2.1", path = "io/zenoh-links/zenoh-link-quic" }
+zenoh-link-udp = { version = "=1.2.1", path = "io/zenoh-links/zenoh-link-udp" }
+zenoh-link-ws = { version = "=1.2.1", path = "io/zenoh-links/zenoh-link-ws" }
+zenoh-link-unixpipe = { version = "=1.2.1", path = "io/zenoh-links/zenoh-link-unixpipe" }
+zenoh-link-serial = { version = "=1.2.1", path = "io/zenoh-links/zenoh-link-serial" }
+zenoh-link-vsock = { version = "=1.2.1", path = "io/zenoh-links/zenoh-link-vsock" }
+zenoh-link = { version = "=1.2.1", path = "io/zenoh-link" }
+zenoh-link-commons = { version = "=1.2.1", path = "io/zenoh-link-commons" }
+zenoh = { version = "=1.2.1", path = "zenoh", default-features = false }
+zenoh-runtime = { version = "=1.2.1", path = "commons/zenoh-runtime" }
+zenoh-task = { version = "=1.2.1", path = "commons/zenoh-task" }
+zenoh-examples = { version = "=1.2.1", path = "examples", default-features = false }
 
 [profile.dev]
 debug = true

--- a/commons/zenoh-buffers/README.md
+++ b/commons/zenoh-buffers/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/commons/zenoh-codec/README.md
+++ b/commons/zenoh-codec/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/commons/zenoh-collections/README.md
+++ b/commons/zenoh-collections/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/commons/zenoh-config/README.md
+++ b/commons/zenoh-config/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/commons/zenoh-core/README.md
+++ b/commons/zenoh-core/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/commons/zenoh-crypto/README.md
+++ b/commons/zenoh-crypto/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/commons/zenoh-keyexpr/README.md
+++ b/commons/zenoh-keyexpr/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/commons/zenoh-macros/README.md
+++ b/commons/zenoh-macros/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/commons/zenoh-protocol/README.md
+++ b/commons/zenoh-protocol/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/commons/zenoh-result/README.md
+++ b/commons/zenoh-result/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/commons/zenoh-runtime/README.md
+++ b/commons/zenoh-runtime/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/commons/zenoh-shm/README.md
+++ b/commons/zenoh-shm/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/commons/zenoh-sync/README.md
+++ b/commons/zenoh-sync/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/commons/zenoh-task/README.md
+++ b/commons/zenoh-task/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/commons/zenoh-util/README.md
+++ b/commons/zenoh-util/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/io/zenoh-link-commons/README.md
+++ b/io/zenoh-link-commons/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/io/zenoh-link/README.md
+++ b/io/zenoh-link/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/io/zenoh-links/README.md
+++ b/io/zenoh-links/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/io/zenoh-links/zenoh-link-quic/README.md
+++ b/io/zenoh-links/zenoh-link-quic/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/io/zenoh-links/zenoh-link-serial/README.md
+++ b/io/zenoh-links/zenoh-link-serial/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/io/zenoh-links/zenoh-link-tcp/README.md
+++ b/io/zenoh-links/zenoh-link-tcp/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/io/zenoh-links/zenoh-link-tls/README.md
+++ b/io/zenoh-links/zenoh-link-tls/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/io/zenoh-links/zenoh-link-udp/README.md
+++ b/io/zenoh-links/zenoh-link-udp/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/io/zenoh-links/zenoh-link-unixpipe/README.md
+++ b/io/zenoh-links/zenoh-link-unixpipe/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/io/zenoh-links/zenoh-link-unixsock_stream/README.md
+++ b/io/zenoh-links/zenoh-link-unixsock_stream/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/io/zenoh-links/zenoh-link-vsock/README.md
+++ b/io/zenoh-links/zenoh-link-vsock/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/io/zenoh-links/zenoh-link-ws/README.md
+++ b/io/zenoh-links/zenoh-link-ws/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/io/zenoh-transport/README.md
+++ b/io/zenoh-transport/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/plugins/zenoh-backend-traits/README.md
+++ b/plugins/zenoh-backend-traits/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/plugins/zenoh-plugin-example/README.md
+++ b/plugins/zenoh-plugin-example/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/plugins/zenoh-plugin-rest/README.md
+++ b/plugins/zenoh-plugin-rest/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/plugins/zenoh-plugin-storage-manager/README.md
+++ b/plugins/zenoh-plugin-storage-manager/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/plugins/zenoh-plugin-trait/README.md
+++ b/plugins/zenoh-plugin-trait/README.md
@@ -1,6 +1,8 @@
 # ⚠️ WARNING ⚠️
 
 This crate is intended for Zenoh's internal use.
+It is not guaranteed that the API will remain unchanged in any version, including patch updates.
+It is highly recommended to depend solely on the zenoh and zenoh-ext crates and to utilize their public APIs.
 
 - [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
 - [Click here for Zenoh's documentation](https://zenoh.io)

--- a/zenoh-ext/README.md
+++ b/zenoh-ext/README.md
@@ -1,6 +1,14 @@
-# ⚠️ WARNING ⚠️
+<img src="https://raw.githubusercontent.com/eclipse-zenoh/zenoh/master/zenoh-dragon.png" height="150">
 
-This crate is intended for Zenoh's internal use.
+[![CI](https://github.com/eclipse-zenoh/zenoh/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/eclipse-zenoh/zenoh/actions?query=workflow%3ACI+branch%3Amain++)
+[![Discussion](https://img.shields.io/badge/discussion-on%20github-blue)](https://github.com/eclipse-zenoh/roadmap/discussions)
+[![Discord](https://img.shields.io/badge/chat-on%20discord-blue)](https://discord.gg/2GJ958VuHs)
+[![License](https://img.shields.io/badge/License-EPL%202.0-blue)](https://choosealicense.com/licenses/epl-2.0/)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-- [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
-- [Click here for Zenoh's documentation](https://zenoh.io)
+# Eclipse Zenoh Extensions
+
+This crate provides some useful extensions on top of [`zenoh`](https://crates.io/crates/zenoh) crate.
+
+For more information, see its documentation: https://docs.rs/zenoh-ext
+and some examples of usage in https://github.com/eclipse-zenoh/zenoh/tree/main/zenoh-ext/examples/examples


### PR DESCRIPTION
In its workspace [`Cargo.toml`](https://github.com/eclipse-zenoh/zenoh/blob/16ba77c83d292e3108ad65bc2f39c5c74778d434/Cargo.toml#L197C1-L229C1), Zenoh depends on a non-pinned version of its "internal" crates.

Those "internal" crates have been made to accelerate the build time. They are released on crates.io but should not be used as direct dependency by any other project that zenoh, as we don't guarantee that their API will remain unchanged in any version, including patch updates.

A problem that could occur is if a project depends on a pinned version of `zenoh`, and we release a patch version of Zenoh with some changes in the APIs of those internal crates. Cargo will automatically bump the internal crates, leading to compile errors with the pinned `zenoh` crate.
Thus we have to pin the internal dependencies of Zenoh.
