### PR TITLE
`ZBytes::chunks`

### DIFF
--- a/commons/zenoh-buffers/src/zslice.rs
+++ b/commons/zenoh-buffers/src/zslice.rs
@@ -206,7 +206,7 @@ impl ZSlice {
         let rem = self.len() % chunk_size;
         let n = if rem > 0 { n + 1 } else { n };
 
-        (0..n).into_iter().map(move |i| ZSlice {
+        (0..n).map(move |i| ZSlice {
             buf: self.buf.clone(),
             start: self.start + i * chunk_size,
             end: usize::min(self.end, self.start + (i + 1) * chunk_size),

--- a/commons/zenoh-buffers/src/zslice.rs
+++ b/commons/zenoh-buffers/src/zslice.rs
@@ -463,7 +463,7 @@ mod tests {
 
     #[test]
     fn test_chunks_inexact_division() {
-        let vec = (0..15).into_iter().collect::<Vec<_>>();
+        let vec = (0..15).collect::<Vec<_>>();
         let zslice = ZSlice::from(vec);
 
         const EXPECTED_CHUNKS: &[&[u8]] =
@@ -478,7 +478,7 @@ mod tests {
 
     #[test]
     fn test_chunks_exact_division() {
-        let vec = (0..8).into_iter().collect::<Vec<_>>();
+        let vec = (0..8).collect::<Vec<_>>();
         let zslice = ZSlice::from(vec);
 
         const EXPECTED_CHUNKS: &[&[u8]] = &[&[0, 1], &[2, 3], &[4, 5], &[6, 7]];

--- a/commons/zenoh-buffers/src/zslice.rs
+++ b/commons/zenoh-buffers/src/zslice.rs
@@ -198,22 +198,6 @@ impl ZSlice {
             None
         }
     }
-
-    pub fn chunks(self, chunk_size: usize) -> impl Iterator<Item = Self> {
-        assert_ne!(chunk_size, 0, "cannot split ZSlice into chunks of size 0");
-
-        let n = self.len() / chunk_size;
-        let rem = self.len() % chunk_size;
-        let n = if rem > 0 { n + 1 } else { n };
-
-        (0..n).map(move |i| ZSlice {
-            buf: self.buf.clone(),
-            start: self.start + i * chunk_size,
-            end: usize::min(self.end, self.start + (i + 1) * chunk_size),
-            #[cfg(feature = "shared-memory")]
-            kind: ZSliceKind::Raw,
-        })
-    }
 }
 
 impl Deref for ZSlice {
@@ -440,60 +424,5 @@ impl ZSlice {
 
         let mut rng = rand::thread_rng();
         (0..len).map(|_| rng.gen()).collect::<Vec<u8>>().into()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn zslice() {
-        let buf = crate::vec::uninit(16);
-        let mut zslice: ZSlice = buf.clone().into();
-        assert_eq!(buf.as_slice(), zslice.as_slice());
-
-        // SAFETY: buffer slize size is not modified
-        let mut_slice = unsafe { zslice.downcast_mut::<Vec<u8>>() }.unwrap();
-
-        mut_slice[..buf.len()].clone_from_slice(&buf[..]);
-
-        assert_eq!(buf.as_slice(), zslice.as_slice());
-    }
-
-    #[test]
-    fn test_chunks_inexact_division() {
-        let vec = (0..15).collect::<Vec<_>>();
-        let zslice = ZSlice::from(vec);
-
-        const EXPECTED_CHUNKS: &[&[u8]] =
-            &[&[0, 1, 2, 3], &[4, 5, 6, 7], &[8, 9, 10, 11], &[12, 13, 14]];
-        const CHUNK_SIZE: usize = 4;
-
-        for (found, expected) in zslice.chunks(CHUNK_SIZE).zip(EXPECTED_CHUNKS) {
-            assert_eq!(found.as_slice(), *expected);
-            assert!(found.len() <= CHUNK_SIZE);
-        }
-    }
-
-    #[test]
-    fn test_chunks_exact_division() {
-        let vec = (0..8).collect::<Vec<_>>();
-        let zslice = ZSlice::from(vec);
-
-        const EXPECTED_CHUNKS: &[&[u8]] = &[&[0, 1], &[2, 3], &[4, 5], &[6, 7]];
-        const CHUNK_SIZE: usize = 2;
-
-        for (found, expected) in zslice.chunks(CHUNK_SIZE).zip(EXPECTED_CHUNKS) {
-            assert_eq!(found.as_slice(), *expected);
-            assert!(found.len() <= CHUNK_SIZE);
-        }
-    }
-
-    #[test]
-    fn test_chunks_empty() {
-        let zslice = ZSlice::empty();
-
-        assert_eq!(zslice.chunks(3).next(), None);
     }
 }

--- a/zenoh/src/api/bytes.rs
+++ b/zenoh/src/api/bytes.rs
@@ -218,6 +218,9 @@ impl ZBytes {
     ///
     /// All chunks have size less then or equal to `chunk_size`.
     ///
+    /// If there are at least two chunks, then every chunk except the last one has size
+    /// `chunk_size`, while the last chunk which has size less than or equal to `chunk_size`.
+    ///
     /// # Panics
     ///
     /// Panics if `chunk_size` is zero.

--- a/zenoh/src/api/bytes.rs
+++ b/zenoh/src/api/bytes.rs
@@ -210,7 +210,26 @@ impl ZBytes {
     pub fn slices(&self) -> ZBytesSliceIterator<'_> {
         ZBytesSliceIterator(self.0.slices())
     }
+
+    /// Return an iterator of chunks in [`ZBytes`].
+    ///
+    /// This method does not entail cloning the underlying buffer unless [`ZBytes`] is not
+    /// contiguous.
+    ///
+    /// All chunks have size less then or equal to `chunk_size`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `chunk_size` is zero.
+    #[zenoh_macros::unstable]
+    pub fn chunks(&self, chunk_size: usize) -> impl Iterator<Item = ZBytes> {
+        self.0
+            .to_zslice()
+            .chunks(chunk_size)
+            .map(|zs| ZBytes::from(ZBuf::from(zs)))
+    }
 }
+
 #[cfg(all(feature = "unstable", feature = "shared-memory"))]
 const _: () = {
     use zenoh_shm::{api::buffer::zshm::zshm, ShmBufInner};

--- a/zenoh/tests/bytes_shm.rs
+++ b/zenoh/tests/bytes_shm.rs
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 ZettaScale Technology
+// Copyright (c) 2025 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -11,6 +11,7 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
+
 #![cfg(all(feature = "shared-memory", feature = "unstable"))]
 use zenoh::{
     bytes::ZBytes,

--- a/zenoh/tests/bytes_unstable.rs
+++ b/zenoh/tests/bytes_unstable.rs
@@ -1,0 +1,121 @@
+//
+// Copyright (c) 2025 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+#![cfg(feature = "unstable")]
+use zenoh::bytes::ZBytes;
+use zenoh_buffers::{ZBuf, ZSlice};
+
+#[test]
+#[should_panic]
+fn test_zbytes_chunks_with_size_zero() {
+    let zbytes = ZBytes::from((0..4).collect::<Vec<_>>());
+    let _chunks = zbytes.chunks(0);
+}
+
+#[test]
+fn test_empty_zbytes_chunks() {
+    let zbytes = ZBytes::new();
+
+    assert_eq!(zbytes.chunks(3).next(), None);
+}
+
+#[test]
+fn test_zbytes_chunks_non_exact_division() {
+    let zbytes = ZBytes::from((0..10).collect::<Vec<_>>());
+
+    const EXPECTED_CHUNKS: &[&[u8]] = &[&[0, 1, 2], &[3, 4, 5], &[6, 7, 8], &[9]];
+    const CHUNK_SIZE: usize = 3;
+
+    assert!(check_zbytes_chunks(zbytes, CHUNK_SIZE, EXPECTED_CHUNKS))
+}
+
+#[test]
+fn test_zbytes_chunks_exact_division() {
+    let zbytes = ZBytes::from((0..12).collect::<Vec<_>>());
+
+    const EXPECTED_CHUNKS: &[&[u8]] = &[&[0, 1, 2], &[3, 4, 5], &[6, 7, 8], &[9, 10, 11]];
+    const CHUNK_SIZE: usize = 3;
+
+    assert!(check_zbytes_chunks(zbytes, CHUNK_SIZE, EXPECTED_CHUNKS))
+}
+
+#[test]
+fn test_zbytes_chunks_with_large_chunk_size() {
+    let zbytes = ZBytes::from((0..5).collect::<Vec<_>>());
+
+    const EXPECTED_CHUNKS: &[&[u8]] = &[&[0, 1, 2, 3, 4]];
+    const CHUNK_SIZE: usize = 10;
+
+    assert!(check_zbytes_chunks(zbytes, CHUNK_SIZE, EXPECTED_CHUNKS))
+}
+
+#[test]
+fn test_zbytes_chunks_with_single_chunk() {
+    let zbytes = ZBytes::from((0..7).collect::<Vec<_>>());
+
+    const EXPECTED_CHUNKS: &[&[u8]] = &[&[0, 1, 2, 3, 4, 5, 6]];
+    const CHUNK_SIZE: usize = 7;
+
+    assert!(check_zbytes_chunks(zbytes, CHUNK_SIZE, EXPECTED_CHUNKS))
+}
+
+#[test]
+fn test_zbytes_chunks_with_size_one() {
+    let zbytes = ZBytes::from((0..4).collect::<Vec<_>>());
+
+    const EXPECTED_CHUNKS: &[&[u8]] = &[&[0], &[1], &[2], &[3]];
+    const CHUNK_SIZE: usize = 1;
+
+    assert!(check_zbytes_chunks(zbytes, CHUNK_SIZE, EXPECTED_CHUNKS))
+}
+
+#[test]
+fn test_non_contiguous_zbytes_chunks() {
+    let data1 = (0..10).collect::<Vec<u8>>();
+    let data2 = (10..20).collect::<Vec<u8>>();
+    let mut zbuf = ZBuf::empty();
+    zbuf.push_zslice(ZSlice::from(data1));
+    zbuf.push_zslice(ZSlice::from(data2));
+    let zbytes = ZBytes::from(zbuf);
+
+    const EXPECTED_CHUNKS: &[&[u8]] = &[
+        &[0, 1, 2, 3],
+        &[4, 5, 6, 7],
+        &[8, 9, 10, 11],
+        &[12, 13, 14, 15],
+        &[16, 17, 18, 19],
+    ];
+    const CHUNK_SIZE: usize = 4;
+
+    assert!(check_zbytes_chunks(zbytes, CHUNK_SIZE, EXPECTED_CHUNKS))
+}
+
+fn check_zbytes_chunks(zbytes: ZBytes, chunk_size: usize, expected_chunks: &[&[u8]]) -> bool {
+    for (idx, (found, expected)) in zbytes.chunks(chunk_size).zip(expected_chunks).enumerate() {
+        if found.to_bytes().as_ref() != *expected {
+            return false;
+        }
+
+        if idx == expected_chunks.len() - 1 {
+            if found.len() > chunk_size {
+                return false;
+            }
+        } else {
+            if found.len() != chunk_size {
+                return false;
+            }
+        }
+    }
+
+    true
+}

--- a/zenoh/tests/bytes_unstable.rs
+++ b/zenoh/tests/bytes_unstable.rs
@@ -110,10 +110,8 @@ fn check_zbytes_chunks(zbytes: ZBytes, chunk_size: usize, expected_chunks: &[&[u
             if found.len() > chunk_size {
                 return false;
             }
-        } else {
-            if found.len() != chunk_size {
-                return false;
-            }
+        } else if found.len() != chunk_size {
+            return false;
         }
     }
 


### PR DESCRIPTION
This function allows for splitting contiguous `ZBytes` into chunks without cloning the underlying buffer.