### PR TITLE
Add link protocols subject to interceptors

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -279,8 +279,11 @@
   //      /// Optional Id, has to be unique
   //      "id": "wlan0egress",
   //      /// Optional list of network interfaces messages will be processed on, the rest will be passed as is.
-  //      /// If absent, the rules will be applied to all interfaces, in case of an empty list it means that they will not be applied to any.
+  //      /// If absent, the rules will be applied to all interfaces. An empty list is invalid.
   //      interfaces: [ "wlan0" ],
+  //      /// Optional list of link protocols. Transports with at least one of these links will have their messages filtered.
+  //      /// If absent, the rules will be applied to all transports. An empty list is invalid.
+  //      link_protocols: [ "tcp", "udp", "tls", "quic", "ws", "serial", "unixsock-stream", "unixpipe", "vsock"],
   //      /// Optional list of data flows messages will be processed on ("egress" and/or "ingress").
   //      /// If absent, the rules will be applied to both flows.
   //      flow: ["ingress", "egress"],
@@ -379,6 +382,12 @@
   //       "id": "subject3",
   //       /// An empty subject combination is a wildcard
   //     },
+  //     {
+  //       "id": "subject4",
+  //      /// link protocols can also be used to identify transports to filter messages on.
+  //      /// If absent, the rules will be applied to all transports. An empty list is invalid.
+  //      link_protocols: [ "tcp", "udp", "tls", "quic", "ws", "serial", "unixsock-stream", "unixpipe", "vsock"],
+  //     },
   //   ],
   //   /// The policies list associates rules to subjects
   //   "policies":
@@ -393,7 +402,7 @@
   //      },
   //      {
   //         "rules": ["rule2"],
-  //         "subjects": ["subject3"],
+  //         "subjects": ["subject3", "subject4"],
   //      },
   //   ]
   //},

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -135,6 +135,7 @@ pub struct AclConfigSubjects {
     pub interfaces: Option<Vec<Interface>>,
     pub cert_common_names: Option<Vec<CertCommonName>>,
     pub usernames: Option<Vec<Username>>,
+    pub link_protocols: Option<Vec<InterceptorLink>>,
 }
 
 #[derive(Serialize, Debug, Deserialize, Clone, PartialEq, Eq, Hash)]

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -165,6 +165,26 @@ impl std::fmt::Display for Username {
 }
 
 #[derive(Serialize, Debug, Deserialize, Clone, PartialEq, Eq, Hash)]
+#[serde(rename_all = "kebab-case")]
+pub enum InterceptorLink {
+    Tcp,
+    Udp,
+    Tls,
+    Quic,
+    Serial,
+    Unixpipe,
+    UnixsockStream,
+    Vsock,
+    Ws,
+}
+
+impl std::fmt::Display for InterceptorLink {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Transport({:?})", self)
+    }
+}
+
+#[derive(Serialize, Debug, Deserialize, Clone, PartialEq, Eq, Hash)]
 pub struct AclConfigPolicyEntry {
     pub id: Option<String>,
     pub rules: Vec<String>,

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -112,6 +112,9 @@ pub struct DownsamplingItemConf {
     /// A list of interfaces to which the downsampling will be applied
     /// Downsampling will be applied for all interfaces if the parameter is None
     pub interfaces: Option<Vec<String>>,
+    /// A list of link types, transports having one of those link types will have the downsampling applied
+    /// Downsampling will be applied for all link types if the parameter is None
+    pub link_protocols: Option<Vec<InterceptorLink>>,
     // list of message types on which the downsampling will be applied
     pub messages: Vec<DownsamplingMessage>,
     /// A list of interfaces to which the downsampling will be applied.

--- a/io/zenoh-link-commons/src/lib.rs
+++ b/io/zenoh-link-commons/src/lib.rs
@@ -105,7 +105,7 @@ impl Link {
             mtu: link.get_mtu(),
             is_streamed: false,
             interfaces: vec![],
-            auth_identifier: LinkAuthId::default(),
+            auth_identifier: link.get_auth_id().clone(),
             priorities: None,
             reliability: None,
         }

--- a/io/zenoh-link-commons/src/multicast.rs
+++ b/io/zenoh-link-commons/src/multicast.rs
@@ -27,6 +27,8 @@ use zenoh_protocol::{
 };
 use zenoh_result::{zerror, ZResult};
 
+use crate::LinkAuthId;
+
 /*************************************/
 /*             MANAGER               */
 /*************************************/
@@ -48,6 +50,7 @@ pub trait LinkMulticastTrait: Send + Sync {
     fn get_mtu(&self) -> BatchSize;
     fn get_src(&self) -> &Locator;
     fn get_dst(&self) -> &Locator;
+    fn get_auth_id(&self) -> &LinkAuthId;
     fn is_reliable(&self) -> bool;
     async fn write(&self, buffer: &[u8]) -> ZResult<usize>;
     async fn write_all(&self, buffer: &[u8]) -> ZResult<()>;

--- a/io/zenoh-link-commons/src/unicast.rs
+++ b/io/zenoh-link-commons/src/unicast.rs
@@ -123,74 +123,21 @@ pub fn get_ip_interface_names(addr: &SocketAddr) -> Vec<String> {
 }
 
 #[derive(Clone, Debug, Serialize, Hash, PartialEq, Eq)]
-pub enum LinkAuthType {
-    Tls,
-    Quic,
+pub enum LinkAuthId {
+    Tls(Option<String>),
+    Quic(Option<String>),
+    Tcp,
+    Udp,
+    Serial,
+    UnixPipe,
+    UnixSockStream,
+    VSock,
+    WebSocket,
     None,
-}
-
-#[derive(Clone, Debug, Serialize, Hash, PartialEq, Eq)]
-pub struct LinkAuthId {
-    auth_type: LinkAuthType,
-    auth_value: Option<String>,
-}
-
-impl LinkAuthId {
-    pub const NONE: Self = Self {
-        auth_type: LinkAuthType::None,
-        auth_value: None,
-    };
-    pub fn get_type(&self) -> &LinkAuthType {
-        &self.auth_type
-    }
-    pub fn get_value(&self) -> &Option<String> {
-        &self.auth_value
-    }
-    pub fn builder() -> LinkAuthIdBuilder {
-        LinkAuthIdBuilder::new()
-    }
 }
 
 impl Default for LinkAuthId {
     fn default() -> Self {
-        LinkAuthId::NONE.clone()
-    }
-}
-
-#[derive(Debug)]
-pub struct LinkAuthIdBuilder {
-    pub auth_type: LinkAuthType,    // HAS to be provided when building
-    pub auth_value: Option<String>, // actual value added to the above type; is None for None type
-}
-
-impl Default for LinkAuthIdBuilder {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl LinkAuthIdBuilder {
-    pub fn new() -> LinkAuthIdBuilder {
-        LinkAuthIdBuilder {
-            auth_type: LinkAuthType::None,
-            auth_value: None,
-        }
-    }
-
-    pub fn auth_type(mut self, auth_type: LinkAuthType) -> Self {
-        self.auth_type = auth_type;
-        self
-    }
-
-    pub fn auth_value(mut self, auth_value: Option<String>) -> Self {
-        self.auth_value = auth_value;
-        self
-    }
-
-    pub fn build(self) -> LinkAuthId {
-        LinkAuthId {
-            auth_type: self.auth_type.clone(),
-            auth_value: self.auth_value.clone(),
-        }
+        LinkAuthId::None
     }
 }

--- a/io/zenoh-link-commons/src/unicast.rs
+++ b/io/zenoh-link-commons/src/unicast.rs
@@ -133,11 +133,4 @@ pub enum LinkAuthId {
     UnixsockStream,
     Vsock,
     Ws,
-    None,
-}
-
-impl Default for LinkAuthId {
-    fn default() -> Self {
-        LinkAuthId::None
-    }
 }

--- a/io/zenoh-link-commons/src/unicast.rs
+++ b/io/zenoh-link-commons/src/unicast.rs
@@ -129,10 +129,10 @@ pub enum LinkAuthId {
     Tcp,
     Udp,
     Serial,
-    UnixPipe,
-    UnixSockStream,
-    VSock,
-    WebSocket,
+    Unixpipe,
+    UnixsockStream,
+    Vsock,
+    Ws,
     None,
 }
 

--- a/io/zenoh-links/zenoh-link-quic/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/unicast.rs
@@ -32,8 +32,8 @@ use zenoh_core::zasynclock;
 use zenoh_link_commons::{
     get_ip_interface_names,
     tls::expiration::{LinkCertExpirationManager, LinkWithCertExpiration},
-    LinkAuthId, LinkAuthType, LinkManagerUnicastTrait, LinkUnicast, LinkUnicastTrait,
-    ListenersUnicastIP, NewLinkChannelSender,
+    LinkAuthId, LinkManagerUnicastTrait, LinkUnicast, LinkUnicastTrait, ListenersUnicastIP,
+    NewLinkChannelSender,
 };
 use zenoh_protocol::{
     core::{EndPoint, Locator},
@@ -645,9 +645,6 @@ impl Debug for QuicAuthId {
 
 impl From<QuicAuthId> for LinkAuthId {
     fn from(value: QuicAuthId) -> Self {
-        LinkAuthId::builder()
-            .auth_type(LinkAuthType::Quic)
-            .auth_value(value.auth_value.clone())
-            .build()
+        LinkAuthId::Quic(value.auth_value.clone())
     }
 }

--- a/io/zenoh-links/zenoh-link-serial/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-serial/src/unicast.rs
@@ -221,7 +221,7 @@ impl LinkUnicastTrait for LinkUnicastSerial {
 
     #[inline(always)]
     fn get_auth_id(&self) -> &LinkAuthId {
-        &LinkAuthId::NONE
+        &LinkAuthId::Serial
     }
 }
 

--- a/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
@@ -194,7 +194,7 @@ impl LinkUnicastTrait for LinkUnicastTcp {
 
     #[inline(always)]
     fn get_auth_id(&self) -> &LinkAuthId {
-        &LinkAuthId::NONE
+        &LinkAuthId::Tcp
     }
 }
 

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -34,8 +34,8 @@ use zenoh_core::zasynclock;
 use zenoh_link_commons::{
     get_ip_interface_names,
     tls::expiration::{LinkCertExpirationManager, LinkWithCertExpiration},
-    LinkAuthId, LinkAuthType, LinkManagerUnicastTrait, LinkUnicast, LinkUnicastTrait,
-    ListenersUnicastIP, NewLinkChannelSender,
+    LinkAuthId, LinkManagerUnicastTrait, LinkUnicast, LinkUnicastTrait, ListenersUnicastIP,
+    NewLinkChannelSender,
 };
 use zenoh_protocol::{
     core::{EndPoint, Locator},
@@ -630,9 +630,6 @@ impl Debug for TlsAuthId {
 
 impl From<TlsAuthId> for LinkAuthId {
     fn from(value: TlsAuthId) -> Self {
-        LinkAuthId::builder()
-            .auth_type(LinkAuthType::Tls)
-            .auth_value(value.auth_value.clone())
-            .build()
+        LinkAuthId::Tls(value.auth_value.clone())
     }
 }

--- a/io/zenoh-links/zenoh-link-udp/src/multicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/multicast.rs
@@ -21,7 +21,9 @@ use std::{
 use async_trait::async_trait;
 use socket2::{Domain, Protocol, Socket, Type};
 use tokio::net::UdpSocket;
-use zenoh_link_commons::{LinkManagerMulticastTrait, LinkMulticast, LinkMulticastTrait};
+use zenoh_link_commons::{
+    LinkAuthId, LinkManagerMulticastTrait, LinkMulticast, LinkMulticastTrait,
+};
 use zenoh_protocol::{
     core::{Config, EndPoint, Locator},
     transport::BatchSize,
@@ -131,6 +133,10 @@ impl LinkMulticastTrait for LinkMulticastUdp {
                 break Ok((n, Cow::Owned(locator)));
             }
         }
+    }
+
+    fn get_auth_id(&self) -> &LinkAuthId {
+        &LinkAuthId::Udp
     }
 
     #[inline(always)]

--- a/io/zenoh-links/zenoh-link-udp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/unicast.rs
@@ -227,7 +227,7 @@ impl LinkUnicastTrait for LinkUnicastUdp {
 
     #[inline(always)]
     fn get_auth_id(&self) -> &LinkAuthId {
-        &LinkAuthId::NONE
+        &LinkAuthId::Udp
     }
 }
 

--- a/io/zenoh-links/zenoh-link-unixpipe/src/unix/unicast.rs
+++ b/io/zenoh-links/zenoh-link-unixpipe/src/unix/unicast.rs
@@ -528,7 +528,7 @@ impl LinkUnicastTrait for UnicastPipe {
 
     #[inline(always)]
     fn get_auth_id(&self) -> &LinkAuthId {
-        &LinkAuthId::UnixPipe
+        &LinkAuthId::Unixpipe
     }
 }
 

--- a/io/zenoh-links/zenoh-link-unixpipe/src/unix/unicast.rs
+++ b/io/zenoh-links/zenoh-link-unixpipe/src/unix/unicast.rs
@@ -528,7 +528,7 @@ impl LinkUnicastTrait for UnicastPipe {
 
     #[inline(always)]
     fn get_auth_id(&self) -> &LinkAuthId {
-        &LinkAuthId::NONE
+        &LinkAuthId::UnixPipe
     }
 }
 

--- a/io/zenoh-links/zenoh-link-unixsock_stream/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-unixsock_stream/src/unicast.rs
@@ -146,7 +146,7 @@ impl LinkUnicastTrait for LinkUnicastUnixSocketStream {
 
     #[inline(always)]
     fn get_auth_id(&self) -> &LinkAuthId {
-        &LinkAuthId::NONE
+        &LinkAuthId::UnixSockStream
     }
 }
 

--- a/io/zenoh-links/zenoh-link-unixsock_stream/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-unixsock_stream/src/unicast.rs
@@ -146,7 +146,7 @@ impl LinkUnicastTrait for LinkUnicastUnixSocketStream {
 
     #[inline(always)]
     fn get_auth_id(&self) -> &LinkAuthId {
-        &LinkAuthId::UnixSockStream
+        &LinkAuthId::UnixsockStream
     }
 }
 

--- a/io/zenoh-links/zenoh-link-vsock/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-vsock/src/unicast.rs
@@ -192,7 +192,7 @@ impl LinkUnicastTrait for LinkUnicastVsock {
 
     #[inline(always)]
     fn get_auth_id(&self) -> &LinkAuthId {
-        &LinkAuthId::NONE
+        &LinkAuthId::VSock
     }
 }
 

--- a/io/zenoh-links/zenoh-link-ws/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-ws/src/unicast.rs
@@ -229,7 +229,7 @@ impl LinkUnicastTrait for LinkUnicastWs {
 
     #[inline(always)]
     fn get_auth_id(&self) -> &LinkAuthId {
-        &LinkAuthId::WebSocket
+        &LinkAuthId::Ws
     }
 }
 

--- a/io/zenoh-links/zenoh-link-ws/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-ws/src/unicast.rs
@@ -229,7 +229,7 @@ impl LinkUnicastTrait for LinkUnicastWs {
 
     #[inline(always)]
     fn get_auth_id(&self) -> &LinkAuthId {
-        &LinkAuthId::NONE
+        &LinkAuthId::WebSocket
     }
 }
 

--- a/io/zenoh-transport/src/unicast/mod.rs
+++ b/io/zenoh-transport/src/unicast/mod.rs
@@ -42,7 +42,7 @@ use self::transport_unicast_inner::TransportUnicastTrait;
 use super::{TransportPeer, TransportPeerEventHandler};
 #[cfg(feature = "shared-memory")]
 use crate::shm::TransportShmConfig;
-use crate::unicast::authentication::AuthId;
+use crate::unicast::authentication::TransportAuthId;
 #[cfg(feature = "auth_usrpwd")]
 use crate::unicast::establishment::ext::auth::UsrPwdId;
 
@@ -123,7 +123,7 @@ impl TransportUnicast {
         Ok(transport.get_links())
     }
 
-    pub fn get_auth_ids(&self) -> ZResult<Vec<AuthId>> {
+    pub fn get_auth_ids(&self) -> ZResult<TransportAuthId> {
         let transport = self.get_inner()?;
         Ok(transport.get_auth_ids())
     }

--- a/io/zenoh-transport/src/unicast/transport_unicast_inner.rs
+++ b/io/zenoh-transport/src/unicast/transport_unicast_inner.rs
@@ -63,7 +63,7 @@ pub(crate) trait TransportUnicastTrait: Send + Sync {
     fn get_whatami(&self) -> WhatAmI;
     fn get_callback(&self) -> Option<Arc<dyn TransportPeerEventHandler>>;
     fn get_links(&self) -> Vec<Link>;
-    fn get_auth_ids(&self) -> Vec<super::authentication::AuthId>;
+    fn get_auth_ids(&self) -> super::authentication::TransportAuthId;
     #[cfg(feature = "shared-memory")]
     fn is_shm(&self) -> bool;
     fn is_qos(&self) -> bool;

--- a/zenoh/src/net/routing/interceptor/access_control.rs
+++ b/zenoh/src/net/routing/interceptor/access_control.rs
@@ -22,7 +22,8 @@ use std::{any::Any, collections::HashSet, iter, sync::Arc};
 
 use itertools::Itertools;
 use zenoh_config::{
-    AclConfig, AclMessage, CertCommonName, InterceptorFlow, Interface, Permission, Username,
+    AclConfig, AclMessage, CertCommonName, InterceptorFlow, InterceptorLink, Interface, Permission,
+    Username,
 };
 use zenoh_link::LinkAuthId;
 use zenoh_protocol::{
@@ -102,23 +103,28 @@ impl InterceptorFactoryTrait for AclEnforcer {
         };
 
         let mut cert_common_names = Vec::new();
+        let mut link_types = Vec::new();
         let username = auth_ids.username().cloned().map(|v| Username(v));
 
         for auth_id in auth_ids.link_auth_ids() {
             match auth_id {
                 LinkAuthId::Tls(value) => {
+                    link_types.push(Some(InterceptorLink::Tls));
                     cert_common_names.push(value.as_ref().map(|v| CertCommonName(v.clone())));
                 }
                 LinkAuthId::Quic(value) => {
+                    link_types.push(Some(InterceptorLink::Quic));
                     cert_common_names.push(value.as_ref().map(|v| CertCommonName(v.clone())));
                 }
-                LinkAuthId::Tcp => {}
-                LinkAuthId::Udp => {}
-                LinkAuthId::Serial => {}
-                LinkAuthId::UnixPipe => {}
-                LinkAuthId::UnixSockStream => {}
-                LinkAuthId::VSock => {}
-                LinkAuthId::WebSocket => {}
+                LinkAuthId::Tcp => link_types.push(Some(InterceptorLink::Tcp)),
+                LinkAuthId::Udp => link_types.push(Some(InterceptorLink::Udp)),
+                LinkAuthId::Serial => link_types.push(Some(InterceptorLink::Serial)),
+                LinkAuthId::Unixpipe => link_types.push(Some(InterceptorLink::Unixpipe)),
+                LinkAuthId::UnixsockStream => {
+                    link_types.push(Some(InterceptorLink::UnixsockStream))
+                }
+                LinkAuthId::Vsock => link_types.push(Some(InterceptorLink::Vsock)),
+                LinkAuthId::Ws => link_types.push(Some(InterceptorLink::Ws)),
                 LinkAuthId::None => {}
             }
         }

--- a/zenoh/src/net/routing/interceptor/access_control.rs
+++ b/zenoh/src/net/routing/interceptor/access_control.rs
@@ -113,14 +113,9 @@ impl InterceptorFactoryTrait for AclEnforcer {
                 LinkAuthId::Quic(value) => {
                     cert_common_names.push(value.as_ref().map(|v| CertCommonName(v.clone())));
                 }
-                LinkAuthId::None => continue,
                 _ => {}
             }
-            link_protocols.push(Some(
-                InterceptorLinkWrapper::try_from(auth_id)
-                    .expect("auth_id should not be None")
-                    .0,
-            ));
+            link_protocols.push(Some(InterceptorLinkWrapper::from(auth_id).0));
         }
         if cert_common_names.is_empty() {
             cert_common_names.push(None);

--- a/zenoh/src/net/routing/interceptor/mod.rs
+++ b/zenoh/src/net/routing/interceptor/mod.rs
@@ -27,7 +27,7 @@ use std::any::Any;
 
 use zenoh_config::{Config, InterceptorFlow, InterceptorLink};
 use zenoh_protocol::network::NetworkMessage;
-use zenoh_result::{ZError, ZResult};
+use zenoh_result::ZResult;
 use zenoh_transport::{multicast::TransportMulticast, unicast::TransportUnicast};
 
 use super::RoutingContext;
@@ -58,25 +58,22 @@ impl From<&[InterceptorFlow]> for InterfaceEnabled {
     }
 }
 
-/// Wrapper for InterceptorLink in order to implement From/TryFrom traits.
+/// Wrapper for InterceptorLink in order to implement From trait.
 pub(crate) struct InterceptorLinkWrapper(pub(crate) InterceptorLink);
 
-impl TryFrom<&LinkAuthId> for InterceptorLinkWrapper {
-    type Error = ZError;
-
+impl From<&LinkAuthId> for InterceptorLinkWrapper {
     /// fails only for LinkAuthId::None which does not map to an InterceptorLink
-    fn try_from(value: &LinkAuthId) -> Result<Self, Self::Error> {
+    fn from(value: &LinkAuthId) -> Self {
         match value {
-            LinkAuthId::Tls(_) => Ok(Self(InterceptorLink::Tls)),
-            LinkAuthId::Quic(_) => Ok(Self(InterceptorLink::Quic)),
-            LinkAuthId::Tcp => Ok(Self(InterceptorLink::Tcp)),
-            LinkAuthId::Udp => Ok(Self(InterceptorLink::Udp)),
-            LinkAuthId::Serial => Ok(Self(InterceptorLink::Serial)),
-            LinkAuthId::Unixpipe => Ok(Self(InterceptorLink::Unixpipe)),
-            LinkAuthId::UnixsockStream => Ok(Self(InterceptorLink::UnixsockStream)),
-            LinkAuthId::Vsock => Ok(Self(InterceptorLink::Vsock)),
-            LinkAuthId::Ws => Ok(Self(InterceptorLink::Ws)),
-            LinkAuthId::None => bail!("variant 'None' cannot be converted"),
+            LinkAuthId::Tls(_) => Self(InterceptorLink::Tls),
+            LinkAuthId::Quic(_) => Self(InterceptorLink::Quic),
+            LinkAuthId::Tcp => Self(InterceptorLink::Tcp),
+            LinkAuthId::Udp => Self(InterceptorLink::Udp),
+            LinkAuthId::Serial => Self(InterceptorLink::Serial),
+            LinkAuthId::Unixpipe => Self(InterceptorLink::Unixpipe),
+            LinkAuthId::UnixsockStream => Self(InterceptorLink::UnixsockStream),
+            LinkAuthId::Vsock => Self(InterceptorLink::Vsock),
+            LinkAuthId::Ws => Self(InterceptorLink::Ws),
         }
     }
 }

--- a/zenoh/tests/acl.rs
+++ b/zenoh/tests/acl.rs
@@ -29,9 +29,14 @@ const KEY_EXPR: &str = "test/demo";
 const VALUE: &str = "zenoh";
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_acl_config() {
+    zenoh::init_log_from_env_or("error");
+    test_acl_config_format(27446).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_acl_pub_sub() {
     zenoh::init_log_from_env_or("error");
-    test_acl_config_format(27447).await;
     test_pub_sub_deny(27447).await;
     test_pub_sub_allow(27447).await;
     test_pub_sub_deny_then_allow(27447).await;
@@ -331,6 +336,41 @@ async fn test_acl_config_format(port: u16) {
         .unwrap();
     assert!(ztimeout!(zenoh::open(config_router.clone()))
         .is_err_and(|e| e.to_string().contains("does not exist in subjects list")));
+
+    // empty link_protocols list
+    config_router
+        .insert_json5(
+            "access_control",
+            r#"{
+                "enabled": true,
+                "default_permission": "deny",
+                "rules": [
+                    {
+                        "id": "r1",
+                        "permission": "allow",
+                        "flows": ["egress", "ingress"],
+                        "messages": ["put"],
+                        "key_exprs": ["foo"],
+                    },
+                ],
+                "subjects": [
+                    {
+                        id: "s1",
+                        link_protocols: [],
+                    },
+                ],
+                "policies": [
+                    {
+                        id: "p1",
+                        rules: ["r1"],
+                        subjects: ["s1"],
+                    },
+                ],
+            }"#,
+        )
+        .unwrap();
+    assert!(ztimeout!(zenoh::open(config_router.clone()))
+        .is_err_and(|e| e.to_string().contains("`link_protocols` cannot be empty")));
 }
 
 async fn test_pub_sub_deny(port: u16) {

--- a/zenoh/tests/authentication.rs
+++ b/zenoh/tests/authentication.rs
@@ -25,7 +25,7 @@ mod test {
     use once_cell::sync::Lazy;
     use tokio::runtime::Handle;
     use zenoh::{config::WhatAmI, Config, Session};
-    use zenoh_config::{EndPoint, ModeDependentValue};
+    use zenoh_config::{EndPoint, ModeDependentValue, ZenohId};
     use zenoh_core::{zlock, ztimeout};
 
     const TIMEOUT: Duration = Duration::from_secs(60);
@@ -89,6 +89,11 @@ mod test {
             .unwrap();
         test_deny_allow_combination(29457).await;
         test_allow_deny_combination(29458).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_authentication_link_protocols() {
+        test_pub_sub_auth_link_protocol(1234).await
     }
 
     #[allow(clippy::all)]
@@ -1975,5 +1980,112 @@ client2name:client2passwd";
             ztimeout!(subscriber.undeclare()).unwrap();
         }
         close_router_session(session).await;
+    }
+
+    async fn test_pub_sub_auth_link_protocol(port: u16) {
+        let key_expr = "acl_auth_test/pubsub/by_protocols";
+
+        let mut config_listener = zenoh::Config::default();
+        config_listener
+            .listen
+            .set_endpoints(ModeDependentValue::Unique(vec![
+                format!("tcp/127.0.0.1:{port}").parse().unwrap(),
+                format!("udp/127.0.0.1:{port}").parse().unwrap(),
+            ]))
+            .unwrap();
+        config_listener
+            .scouting
+            .gossip
+            .set_enabled(Some(false))
+            .unwrap();
+        config_listener
+            .scouting
+            .multicast
+            .set_enabled(Some(false))
+            .unwrap();
+
+        config_listener
+            .insert_json5(
+                "access_control",
+                r#"{
+                    "enabled": true,
+                    "default_permission": "allow",
+                    "rules": [
+                        {
+                            "id": "r1",
+                            "permission": "deny",
+                            "flows": ["ingress"],
+                            "messages": [
+                                "put",
+                            ],
+                            "key_exprs": [
+                                "**"
+                            ],
+                        },
+                    ],
+                    "subjects": [
+                        {
+                            "id": "s1",
+                            "link_protocols": [ "tcp" ],
+                        }
+                    ],
+                    "policies": [
+                        {
+                            "rules": ["r1"],
+                            "subjects": ["s1"],
+                        }
+                    ]
+                }"#,
+            )
+            .unwrap();
+
+        let listener_session = zenoh::open(config_listener).await.unwrap();
+        tokio::time::sleep(SLEEP).await;
+
+        let mut config_connect = zenoh::Config::default();
+        config_connect.set_mode(Some(WhatAmI::Client)).unwrap();
+        config_connect
+            .scouting
+            .multicast
+            .set_enabled(Some(false))
+            .unwrap();
+        config_connect
+            .scouting
+            .gossip
+            .set_enabled(Some(false))
+            .unwrap();
+        config_connect
+            .connect
+            .endpoints
+            .set(vec![format!("tcp/127.0.0.1:{port}").parse().unwrap()])
+            .unwrap();
+        let session_denied = zenoh::open(config_connect.clone()).await.unwrap();
+
+        config_connect
+            .connect
+            .endpoints
+            .set(vec![format!("udp/127.0.0.1:{port}").parse().unwrap()])
+            .unwrap();
+        config_connect.set_id(ZenohId::default()).unwrap();
+        let session_allowed = zenoh::open(config_connect).await.unwrap();
+
+        let sub = listener_session.declare_subscriber(key_expr).await.unwrap();
+
+        session_denied.put(key_expr, "DENIED").await.unwrap();
+        tokio::time::sleep(SLEEP).await;
+        assert!(sub.try_recv().unwrap().is_none());
+
+        session_allowed.put(key_expr, "ALLOWED").await.unwrap();
+        tokio::time::sleep(SLEEP).await;
+        let value = sub.recv_async().await;
+        assert!(value.is_ok());
+        let sample = value.unwrap();
+        let payload = sample.payload().try_to_string().unwrap();
+        assert!(payload.eq("ALLOWED"));
+
+        sub.undeclare().await.unwrap();
+        session_allowed.close().await.unwrap();
+        session_denied.close().await.unwrap();
+        listener_session.close().await.unwrap();
     }
 }


### PR DESCRIPTION
Link protocols can be used to identify transports that should have interceptor rules applied to them.
For example: 
- Downsampling can be configured to limit throughput to 10Hz on all transports that have a TCP connection.
- Access Control can be configured to deny confidential messages from passing on transports with clear-text communication (i.e not TLS and QUIC).

The configuration field is named `link_protocols`. Possible values are all of Zenoh's currently supported link protocols: `tcp`, `udp`, `tls`, `quic`, `ws`, `serial`, `unixsock-stream`, `unixpipe`, `vsock`.