### PR TITLE
Maintain keyexpr type in interceptors

### DIFF
--- a/zenoh/src/net/routing/dispatcher/face.rs
+++ b/zenoh/src/net/routing/dispatcher/face.rs
@@ -22,6 +22,7 @@ use std::{
 
 use arc_swap::ArcSwap;
 use tokio_util::sync::CancellationToken;
+use zenoh_keyexpr::keyexpr;
 use zenoh_protocol::{
     core::{ExprId, Reliability, WhatAmI, WireExpr, ZenohIdProto},
     network::{
@@ -42,16 +43,13 @@ use super::{
     resource::*,
     tables::TablesLock,
 };
-use crate::{
-    api::key_expr::KeyExpr,
-    net::{
-        primitives::{McastMux, Mux, Primitives},
-        routing::{
-            dispatcher::interests::finalize_pending_interests,
-            interceptor::{
-                EgressInterceptor, IngressInterceptor, InterceptorFactory, InterceptorTrait,
-                InterceptorsChain,
-            },
+use crate::net::{
+    primitives::{McastMux, Mux, Primitives},
+    routing::{
+        dispatcher::interests::finalize_pending_interests,
+        interceptor::{
+            EgressInterceptor, IngressInterceptor, InterceptorFactory, InterceptorTrait,
+            InterceptorsChain,
         },
     },
 };
@@ -157,8 +155,8 @@ impl FaceState {
             .map(|itor| itor.load())
             .and_then(|is| is.is_empty().not().then_some(is))
         {
-            if let Ok(expr) = KeyExpr::try_from(res.expr().to_string()) {
-                let cache = interceptor.compute_keyexpr_cache(&expr);
+            if let Ok(expr) = keyexpr::new(res.expr()) {
+                let cache = interceptor.compute_keyexpr_cache(expr);
                 get_mut_unchecked(
                     get_mut_unchecked(res)
                         .session_ctxs
@@ -176,8 +174,8 @@ impl FaceState {
             .map(|mux| mux.interceptor.load())
             .and_then(|is| is.is_empty().not().then_some(is))
         {
-            if let Ok(expr) = KeyExpr::try_from(res.expr().to_string()) {
-                let cache = interceptor.compute_keyexpr_cache(&expr);
+            if let Ok(expr) = keyexpr::new(res.expr()) {
+                let cache = interceptor.compute_keyexpr_cache(expr);
                 get_mut_unchecked(
                     get_mut_unchecked(res)
                         .session_ctxs
@@ -195,8 +193,8 @@ impl FaceState {
             .map(|mux| mux.interceptor.load())
             .and_then(|is| is.is_empty().not().then_some(is))
         {
-            if let Ok(expr) = KeyExpr::try_from(res.expr().to_string()) {
-                let cache = interceptor.compute_keyexpr_cache(&expr);
+            if let Ok(expr) = keyexpr::new(res.expr()) {
+                let cache = interceptor.compute_keyexpr_cache(expr);
                 get_mut_unchecked(
                     get_mut_unchecked(res)
                         .session_ctxs

--- a/zenoh/src/net/routing/dispatcher/face.rs
+++ b/zenoh/src/net/routing/dispatcher/face.rs
@@ -22,7 +22,6 @@ use std::{
 
 use arc_swap::ArcSwap;
 use tokio_util::sync::CancellationToken;
-use zenoh_keyexpr::keyexpr;
 use zenoh_protocol::{
     core::{ExprId, Reliability, WhatAmI, WireExpr, ZenohIdProto},
     network::{

--- a/zenoh/src/net/routing/dispatcher/face.rs
+++ b/zenoh/src/net/routing/dispatcher/face.rs
@@ -155,7 +155,7 @@ impl FaceState {
             .map(|itor| itor.load())
             .and_then(|is| is.is_empty().not().then_some(is))
         {
-            if let Ok(expr) = keyexpr::new(res.expr()) {
+            if let Some(expr) = res.keyexpr() {
                 let cache = interceptor.compute_keyexpr_cache(expr);
                 get_mut_unchecked(
                     get_mut_unchecked(res)
@@ -174,7 +174,7 @@ impl FaceState {
             .map(|mux| mux.interceptor.load())
             .and_then(|is| is.is_empty().not().then_some(is))
         {
-            if let Ok(expr) = keyexpr::new(res.expr()) {
+            if let Some(expr) = res.keyexpr() {
                 let cache = interceptor.compute_keyexpr_cache(expr);
                 get_mut_unchecked(
                     get_mut_unchecked(res)
@@ -193,7 +193,7 @@ impl FaceState {
             .map(|mux| mux.interceptor.load())
             .and_then(|is| is.is_empty().not().then_some(is))
         {
-            if let Ok(expr) = keyexpr::new(res.expr()) {
+            if let Some(expr) = res.keyexpr() {
                 let cache = interceptor.compute_keyexpr_cache(expr);
                 get_mut_unchecked(
                     get_mut_unchecked(res)

--- a/zenoh/src/net/routing/dispatcher/resource.rs
+++ b/zenoh/src/net/routing/dispatcher/resource.rs
@@ -79,10 +79,7 @@ impl InterceptorCache {
     ) -> Option<InterceptorCacheValueType> {
         self.0
             .value(interceptor.version, || {
-                let Some(ke) = resource.keyexpr() else {
-                    return None;
-                };
-                interceptor.compute_keyexpr_cache(ke)
+                interceptor.compute_keyexpr_cache(resource.keyexpr()?)
             })
             .ok()
     }

--- a/zenoh/src/net/routing/dispatcher/resource.rs
+++ b/zenoh/src/net/routing/dispatcher/resource.rs
@@ -81,8 +81,7 @@ impl InterceptorCache {
             .value(interceptor.version, || {
                 // Safety: resource expr is always a valid keyexpr
                 let ke = unsafe { keyexpr::from_str_unchecked(resource.expr()) };
-                let key_expr = ke.into();
-                interceptor.compute_keyexpr_cache(&key_expr)
+                interceptor.compute_keyexpr_cache(ke)
             })
             .ok()
     }

--- a/zenoh/src/net/routing/interceptor/access_control.rs
+++ b/zenoh/src/net/routing/interceptor/access_control.rs
@@ -385,7 +385,7 @@ impl InterceptorTrait for IngressAclEnforcer {
                     cache.map(|c| c.query),
                     AclMessage::Query,
                     "Query (ingress)",
-                    ctx.full_key_expr()?,
+                    ctx.full_keyexpr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -396,7 +396,7 @@ impl InterceptorTrait for IngressAclEnforcer {
                     cache.map(|c| c.reply),
                     AclMessage::Reply,
                     "Reply (ingress)",
-                    ctx.full_key_expr()?,
+                    ctx.full_keyexpr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -410,7 +410,7 @@ impl InterceptorTrait for IngressAclEnforcer {
                     cache.map(|c| c.put),
                     AclMessage::Put,
                     "Put (ingress)",
-                    ctx.full_key_expr()?,
+                    ctx.full_keyexpr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -424,7 +424,7 @@ impl InterceptorTrait for IngressAclEnforcer {
                     cache.map(|c| c.delete),
                     AclMessage::Delete,
                     "Delete (ingress)",
-                    ctx.full_key_expr()?,
+                    ctx.full_keyexpr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -438,7 +438,7 @@ impl InterceptorTrait for IngressAclEnforcer {
                     cache.map(|c| c.declare_subscriber),
                     AclMessage::DeclareSubscriber,
                     "Declare Subscriber (ingress)",
-                    ctx.full_key_expr()?,
+                    ctx.full_keyexpr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -456,7 +456,7 @@ impl InterceptorTrait for IngressAclEnforcer {
                     cache.map(|c| c.declare_subscriber),
                     AclMessage::DeclareSubscriber,
                     "Undeclare Subscriber (ingress)",
-                    ctx.full_key_expr(),
+                    ctx.full_keyexpr(),
                 ) == Permission::Deny
                 {
                     return None;
@@ -470,7 +470,7 @@ impl InterceptorTrait for IngressAclEnforcer {
                     cache.map(|c| c.declare_queryable),
                     AclMessage::DeclareQueryable,
                     "Declare Queryable (ingress)",
-                    ctx.full_key_expr()?,
+                    ctx.full_keyexpr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -488,7 +488,7 @@ impl InterceptorTrait for IngressAclEnforcer {
                     cache.map(|c| c.declare_queryable),
                     AclMessage::DeclareQueryable,
                     "Undeclare Queryable (ingress)",
-                    ctx.full_key_expr(),
+                    ctx.full_keyexpr(),
                 ) == Permission::Deny
                 {
                     return None;
@@ -502,7 +502,7 @@ impl InterceptorTrait for IngressAclEnforcer {
                     cache.map(|c| c.declare_token),
                     AclMessage::LivelinessToken,
                     "Liveliness Token (ingress)",
-                    ctx.full_key_expr()?,
+                    ctx.full_keyexpr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -521,7 +521,7 @@ impl InterceptorTrait for IngressAclEnforcer {
                     cache.map(|c| c.declare_token),
                     AclMessage::LivelinessToken,
                     "Undeclare Liveliness Token (ingress)",
-                    ctx.full_key_expr(),
+                    ctx.full_keyexpr(),
                 ) == Permission::Deny
                 {
                     return None;
@@ -536,7 +536,7 @@ impl InterceptorTrait for IngressAclEnforcer {
                     cache.map(|c| c.query_token),
                     AclMessage::LivelinessQuery,
                     "Liveliness Query (ingress)",
-                    ctx.full_key_expr()?,
+                    ctx.full_keyexpr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -551,7 +551,7 @@ impl InterceptorTrait for IngressAclEnforcer {
                     cache.map(|c| c.declare_liveliness_subscriber),
                     AclMessage::DeclareLivelinessSubscriber,
                     "Declare Liveliness Subscriber (ingress)",
-                    ctx.full_key_expr()?,
+                    ctx.full_keyexpr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -644,7 +644,7 @@ impl InterceptorTrait for EgressAclEnforcer {
                     cache.map(|c| c.query),
                     AclMessage::Query,
                     "Query (egress)",
-                    ctx.full_key_expr()?,
+                    ctx.full_keyexpr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -655,7 +655,7 @@ impl InterceptorTrait for EgressAclEnforcer {
                     cache.map(|c| c.reply),
                     AclMessage::Reply,
                     "Reply (egress)",
-                    ctx.full_key_expr()?,
+                    ctx.full_keyexpr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -669,7 +669,7 @@ impl InterceptorTrait for EgressAclEnforcer {
                     cache.map(|c| c.put),
                     AclMessage::Put,
                     "Put (egress)",
-                    ctx.full_key_expr()?,
+                    ctx.full_keyexpr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -683,7 +683,7 @@ impl InterceptorTrait for EgressAclEnforcer {
                     cache.map(|c| c.put),
                     AclMessage::Delete,
                     "Delete (egress)",
-                    ctx.full_key_expr()?,
+                    ctx.full_keyexpr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -697,7 +697,7 @@ impl InterceptorTrait for EgressAclEnforcer {
                     cache.map(|c| c.declare_subscriber),
                     AclMessage::DeclareSubscriber,
                     "Declare Subscriber (egress)",
-                    ctx.full_key_expr()?,
+                    ctx.full_keyexpr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -713,7 +713,7 @@ impl InterceptorTrait for EgressAclEnforcer {
                     cache.map(|c| c.declare_subscriber),
                     AclMessage::DeclareSubscriber,
                     "Undeclare Subscriber (egress)",
-                    ctx.full_key_expr()?,
+                    ctx.full_keyexpr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -727,7 +727,7 @@ impl InterceptorTrait for EgressAclEnforcer {
                     cache.map(|c| c.declare_queryable),
                     AclMessage::DeclareQueryable,
                     "Declare Queryable (egress)",
-                    ctx.full_key_expr()?,
+                    ctx.full_keyexpr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -743,7 +743,7 @@ impl InterceptorTrait for EgressAclEnforcer {
                     cache.map(|c| c.declare_queryable),
                     AclMessage::DeclareQueryable,
                     "Undeclare Queryable (egress)",
-                    ctx.full_key_expr()?,
+                    ctx.full_keyexpr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -757,7 +757,7 @@ impl InterceptorTrait for EgressAclEnforcer {
                     cache.map(|c| c.declare_token),
                     AclMessage::LivelinessToken,
                     "Liveliness Token (egress)",
-                    ctx.full_key_expr()?,
+                    ctx.full_keyexpr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -773,7 +773,7 @@ impl InterceptorTrait for EgressAclEnforcer {
                     cache.map(|c| c.declare_token),
                     AclMessage::LivelinessToken,
                     "Undeclare Liveliness Token (egress)",
-                    ctx.full_key_expr()?,
+                    ctx.full_keyexpr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -788,7 +788,7 @@ impl InterceptorTrait for EgressAclEnforcer {
                     cache.map(|c| c.query_token),
                     AclMessage::LivelinessQuery,
                     "Liveliness Query (egress)",
-                    ctx.full_key_expr()?,
+                    ctx.full_keyexpr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -803,7 +803,7 @@ impl InterceptorTrait for EgressAclEnforcer {
                     cache.map(|c| c.declare_liveliness_subscriber),
                     AclMessage::DeclareLivelinessSubscriber,
                     "Declare Liveliness Subscriber (egress)",
-                    ctx.full_key_expr()?,
+                    ctx.full_keyexpr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -822,7 +822,7 @@ impl InterceptorTrait for EgressAclEnforcer {
                     cache.map(|c| c.declare_liveliness_subscriber),
                     AclMessage::DeclareLivelinessSubscriber,
                     "Undeclare Liveliness Subscriber (egress)",
-                    ctx.full_key_expr()?,
+                    ctx.full_keyexpr()?,
                 ) == Permission::Deny
                 {
                     return None;

--- a/zenoh/src/net/routing/interceptor/access_control.rs
+++ b/zenoh/src/net/routing/interceptor/access_control.rs
@@ -24,6 +24,7 @@ use itertools::Itertools;
 use zenoh_config::{
     AclConfig, AclMessage, CertCommonName, InterceptorFlow, Interface, Permission, Username,
 };
+use zenoh_keyexpr::keyexpr;
 use zenoh_link::LinkAuthId;
 use zenoh_protocol::{
     core::ZenohIdProto,
@@ -40,10 +41,7 @@ use super::{
     authorization::PolicyEnforcer, EgressInterceptor, IngressInterceptor, InterceptorFactory,
     InterceptorFactoryTrait, InterceptorLinkWrapper, InterceptorTrait,
 };
-use crate::{
-    api::key_expr::KeyExpr,
-    net::routing::{interceptor::authorization::SubjectQuery, RoutingContext},
-};
+use crate::net::routing::{interceptor::authorization::SubjectQuery, RoutingContext};
 pub struct AclEnforcer {
     enforcer: Arc<PolicyEnforcer>,
 }
@@ -59,10 +57,112 @@ struct EgressAclEnforcer {
     zid: ZenohIdProto,
 }
 
+impl EgressAclEnforcer {
+    #[inline]
+    fn cached_result_or_action(
+        &self,
+        cached_permission: Option<Permission>,
+        action: AclMessage,
+        log_msg: &str,
+        key_expr: &keyexpr,
+    ) -> Permission {
+        match cached_permission {
+            Some(p) => {
+                match p {
+                    Permission::Allow => tracing::trace!(
+                        "Using cached result: {} is authorized to {} on {}",
+                        self.zid(),
+                        log_msg,
+                        key_expr
+                    ),
+                    Permission::Deny => tracing::trace!(
+                        "Using cached result: {} is unauthorized to {} on {}",
+                        self.zid(),
+                        log_msg,
+                        key_expr
+                    ),
+                }
+                p
+            }
+            None => self.action(action, log_msg, key_expr),
+        }
+    }
+}
+
 struct IngressAclEnforcer {
     policy_enforcer: Arc<PolicyEnforcer>,
     subject: Vec<AuthSubject>,
     zid: ZenohIdProto,
+}
+
+impl IngressAclEnforcer {
+    #[inline]
+    fn cached_result_or_action(
+        &self,
+        cached_permission: Option<Permission>,
+        action: AclMessage,
+        log_msg: &str,
+        key_expr: &keyexpr,
+    ) -> Permission {
+        match cached_permission {
+            Some(p) => {
+                match p {
+                    Permission::Allow => tracing::trace!(
+                        "Using cached result: {} is authorized to {} on {}",
+                        self.zid(),
+                        log_msg,
+                        key_expr
+                    ),
+                    Permission::Deny => tracing::trace!(
+                        "Using cached result: {} is unauthorized to {} on {}",
+                        self.zid(),
+                        log_msg,
+                        key_expr
+                    ),
+                }
+                p
+            }
+            None => self.action(action, log_msg, key_expr),
+        }
+    }
+
+    #[inline]
+    fn cached_result_or_action_undecl(
+        &self,
+        cached_permission: Option<Permission>,
+        action: AclMessage,
+        log_msg: &str,
+        key_expr: Option<&keyexpr>,
+    ) -> Permission {
+        match cached_permission {
+            Some(p) => {
+                match p {
+                    Permission::Allow => tracing::trace!(
+                        "Using cached result: {} is authorized to {} on {:?}",
+                        self.zid(),
+                        log_msg,
+                        key_expr
+                    ),
+                    Permission::Deny => tracing::trace!(
+                        "Using cached result: {} is unauthorized to {} on {:?}",
+                        self.zid(),
+                        log_msg,
+                        key_expr
+                    ),
+                }
+                p
+            }
+            None => {
+                // Undeclarations in ingress are only filtered if the ext_wire_expr is set.
+                // If it's not set, we let the undeclaration pass, it will be rejected by the routing logic
+                // if its associated declaration was denied.
+                match key_expr {
+                    Some(ke) => self.action(action, log_msg, ke),
+                    None => Permission::Allow,
+                }
+            }
+        }
+    }
 }
 
 pub(crate) fn acl_interceptor_factories(
@@ -215,41 +315,6 @@ impl InterceptorFactoryTrait for AclEnforcer {
     }
 }
 
-macro_rules! cached_result_or_action {
-    ($enforcer:expr, $cached_permission:expr, $action:expr, $log_msg:expr, $key_expr:expr $(,)?) => {
-        match $cached_permission {
-            Some(p) => {
-                match p {
-                    Permission::Allow => tracing::trace!(
-                        "Using cached result: {} is authorized to {} on {}",
-                        $enforcer.zid(),
-                        $log_msg,
-                        $key_expr
-                    ),
-                    Permission::Deny => tracing::trace!(
-                        "Using cached result: {} is unauthorized to {} on {}",
-                        $enforcer.zid(),
-                        $log_msg,
-                        $key_expr
-                    ),
-                }
-                p
-            }
-            None => {
-                let ke = $key_expr;
-                if !ke.is_empty() {
-                    $enforcer.action($action, $log_msg, $key_expr)
-                } else {
-                    // Undeclarations in ingress are only filtered if the ext_wire_expr is set.
-                    // If it's not set, we let the undeclaration pass, it will be rejected by the routing logic
-                    // if its associated declaration was denied.
-                    Permission::Allow
-                }
-            }
-        }
-    }
-}
-
 struct Cache {
     query: Permission,
     reply: Permission,
@@ -263,11 +328,7 @@ struct Cache {
 }
 
 impl InterceptorTrait for IngressAclEnforcer {
-    fn compute_keyexpr_cache(&self, key_expr: &KeyExpr<'_>) -> Option<Box<dyn Any + Send + Sync>> {
-        let key_expr = key_expr.as_str();
-        if key_expr.is_empty() {
-            return None;
-        }
+    fn compute_keyexpr_cache(&self, key_expr: &keyexpr) -> Option<Box<dyn Any + Send + Sync>> {
         tracing::trace!("ACL (ingress): caching permissions for `{}` ...", key_expr);
         Some(Box::new(Cache {
             query: self.action(AclMessage::Query, "Query (ingress)", key_expr),
@@ -320,24 +381,22 @@ impl InterceptorTrait for IngressAclEnforcer {
                 payload: RequestBody::Query(_),
                 ..
             }) => {
-                if cached_result_or_action!(
-                    self,
+                if self.cached_result_or_action(
                     cache.map(|c| c.query),
                     AclMessage::Query,
                     "Query (ingress)",
-                    ctx.full_expr()?,
+                    ctx.full_key_expr()?,
                 ) == Permission::Deny
                 {
                     return None;
                 }
             }
             NetworkBody::Response(Response { .. }) => {
-                if cached_result_or_action!(
-                    self,
+                if self.cached_result_or_action(
                     cache.map(|c| c.reply),
                     AclMessage::Reply,
                     "Reply (ingress)",
-                    ctx.full_expr()?,
+                    ctx.full_key_expr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -347,12 +406,11 @@ impl InterceptorTrait for IngressAclEnforcer {
                 payload: PushBody::Put(_),
                 ..
             }) => {
-                if cached_result_or_action!(
-                    self,
+                if self.cached_result_or_action(
                     cache.map(|c| c.put),
                     AclMessage::Put,
                     "Put (ingress)",
-                    ctx.full_expr()?,
+                    ctx.full_key_expr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -362,12 +420,11 @@ impl InterceptorTrait for IngressAclEnforcer {
                 payload: PushBody::Del(_),
                 ..
             }) => {
-                if cached_result_or_action!(
-                    self,
+                if self.cached_result_or_action(
                     cache.map(|c| c.delete),
                     AclMessage::Delete,
                     "Delete (ingress)",
-                    ctx.full_expr()?,
+                    ctx.full_key_expr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -377,12 +434,11 @@ impl InterceptorTrait for IngressAclEnforcer {
                 body: DeclareBody::DeclareSubscriber(_),
                 ..
             }) => {
-                if cached_result_or_action!(
-                    self,
+                if self.cached_result_or_action(
                     cache.map(|c| c.declare_subscriber),
                     AclMessage::DeclareSubscriber,
                     "Declare Subscriber (ingress)",
-                    ctx.full_expr()?,
+                    ctx.full_key_expr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -396,12 +452,11 @@ impl InterceptorTrait for IngressAclEnforcer {
                 // Undeclarations in ingress are only filtered if the ext_wire_expr is set.
                 // If it's not set, we let the undeclaration pass, it will be rejected by the routing logic
                 // if its associated declaration was denied.
-                if cached_result_or_action!(
-                    self,
+                if self.cached_result_or_action_undecl(
                     cache.map(|c| c.declare_subscriber),
                     AclMessage::DeclareSubscriber,
                     "Undeclare Subscriber (ingress)",
-                    ctx.full_expr().unwrap_or(""),
+                    ctx.full_key_expr(),
                 ) == Permission::Deny
                 {
                     return None;
@@ -411,12 +466,11 @@ impl InterceptorTrait for IngressAclEnforcer {
                 body: DeclareBody::DeclareQueryable(_),
                 ..
             }) => {
-                if cached_result_or_action!(
-                    self,
+                if self.cached_result_or_action(
                     cache.map(|c| c.declare_queryable),
                     AclMessage::DeclareQueryable,
                     "Declare Queryable (ingress)",
-                    ctx.full_expr()?,
+                    ctx.full_key_expr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -430,12 +484,11 @@ impl InterceptorTrait for IngressAclEnforcer {
                 // Undeclarations in ingress are only filtered if the ext_wire_expr is set.
                 // If it's not set, we let the undeclaration pass, it will be rejected by the routing logic
                 // if its associated declaration was denied.
-                if cached_result_or_action!(
-                    self,
+                if self.cached_result_or_action_undecl(
                     cache.map(|c| c.declare_queryable),
                     AclMessage::DeclareQueryable,
                     "Undeclare Queryable (ingress)",
-                    ctx.full_expr().unwrap_or(""),
+                    ctx.full_key_expr(),
                 ) == Permission::Deny
                 {
                     return None;
@@ -445,12 +498,11 @@ impl InterceptorTrait for IngressAclEnforcer {
                 body: DeclareBody::DeclareToken(_),
                 ..
             }) => {
-                if cached_result_or_action!(
-                    self,
+                if self.cached_result_or_action(
                     cache.map(|c| c.declare_token),
                     AclMessage::LivelinessToken,
                     "Liveliness Token (ingress)",
-                    ctx.full_expr()?,
+                    ctx.full_key_expr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -465,12 +517,11 @@ impl InterceptorTrait for IngressAclEnforcer {
                 // Undeclarations in ingress are only filtered if the ext_wire_expr is set.
                 // If it's not set, we let the undeclaration pass, it will be rejected by the routing logic
                 // if its associated declaration was denied.
-                if cached_result_or_action!(
-                    self,
+                if self.cached_result_or_action_undecl(
                     cache.map(|c| c.declare_token),
                     AclMessage::LivelinessToken,
                     "Undeclare Liveliness Token (ingress)",
-                    ctx.full_expr().unwrap_or(""),
+                    ctx.full_key_expr(),
                 ) == Permission::Deny
                 {
                     return None;
@@ -481,12 +532,11 @@ impl InterceptorTrait for IngressAclEnforcer {
                 options,
                 ..
             }) if options.tokens() => {
-                if cached_result_or_action!(
-                    self,
+                if self.cached_result_or_action(
                     cache.map(|c| c.query_token),
                     AclMessage::LivelinessQuery,
                     "Liveliness Query (ingress)",
-                    ctx.full_expr()?,
+                    ctx.full_key_expr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -497,12 +547,11 @@ impl InterceptorTrait for IngressAclEnforcer {
                 options,
                 ..
             }) if options.tokens() => {
-                if cached_result_or_action!(
-                    self,
+                if self.cached_result_or_action(
                     cache.map(|c| c.declare_liveliness_subscriber),
                     AclMessage::DeclareLivelinessSubscriber,
                     "Declare Liveliness Subscriber (ingress)",
-                    ctx.full_expr()?,
+                    ctx.full_key_expr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -537,11 +586,7 @@ impl InterceptorTrait for IngressAclEnforcer {
 }
 
 impl InterceptorTrait for EgressAclEnforcer {
-    fn compute_keyexpr_cache(&self, key_expr: &KeyExpr<'_>) -> Option<Box<dyn Any + Send + Sync>> {
-        let key_expr = key_expr.as_str();
-        if key_expr.is_empty() {
-            return None;
-        }
+    fn compute_keyexpr_cache(&self, key_expr: &keyexpr) -> Option<Box<dyn Any + Send + Sync>> {
         tracing::trace!("ACL (egress): caching permissions for `{}` ...", key_expr);
         Some(Box::new(Cache {
             query: self.action(AclMessage::Query, "Query (egress)", key_expr),
@@ -577,6 +622,7 @@ impl InterceptorTrait for EgressAclEnforcer {
     }
 
     fn intercept(
+        // String, Arc<str>, Box<str>, etc... & -> &str
         &self,
         ctx: RoutingContext<NetworkMessage>,
         cache: Option<&Box<dyn Any + Send + Sync>>,
@@ -594,24 +640,22 @@ impl InterceptorTrait for EgressAclEnforcer {
                 payload: RequestBody::Query(_),
                 ..
             }) => {
-                if cached_result_or_action!(
-                    self,
+                if self.cached_result_or_action(
                     cache.map(|c| c.query),
                     AclMessage::Query,
                     "Query (egress)",
-                    ctx.full_expr()?,
+                    ctx.full_key_expr()?,
                 ) == Permission::Deny
                 {
                     return None;
                 }
             }
             NetworkBody::Response(Response { .. }) => {
-                if cached_result_or_action!(
-                    self,
+                if self.cached_result_or_action(
                     cache.map(|c| c.reply),
                     AclMessage::Reply,
                     "Reply (egress)",
-                    ctx.full_expr()?,
+                    ctx.full_key_expr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -621,12 +665,11 @@ impl InterceptorTrait for EgressAclEnforcer {
                 payload: PushBody::Put(_),
                 ..
             }) => {
-                if cached_result_or_action!(
-                    self,
+                if self.cached_result_or_action(
                     cache.map(|c| c.put),
                     AclMessage::Put,
                     "Put (egress)",
-                    ctx.full_expr()?,
+                    ctx.full_key_expr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -636,12 +679,11 @@ impl InterceptorTrait for EgressAclEnforcer {
                 payload: PushBody::Del(_),
                 ..
             }) => {
-                if cached_result_or_action!(
-                    self,
+                if self.cached_result_or_action(
                     cache.map(|c| c.put),
                     AclMessage::Delete,
                     "Delete (egress)",
-                    ctx.full_expr()?,
+                    ctx.full_key_expr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -651,12 +693,11 @@ impl InterceptorTrait for EgressAclEnforcer {
                 body: DeclareBody::DeclareSubscriber(_),
                 ..
             }) => {
-                if cached_result_or_action!(
-                    self,
+                if self.cached_result_or_action(
                     cache.map(|c| c.declare_subscriber),
                     AclMessage::DeclareSubscriber,
                     "Declare Subscriber (egress)",
-                    ctx.full_expr()?,
+                    ctx.full_key_expr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -668,12 +709,11 @@ impl InterceptorTrait for EgressAclEnforcer {
             }) => {
                 // Undeclaration filtering diverges between ingress and egress:
                 // in egress the keyexpr has to be provided in the RoutingContext
-                if cached_result_or_action!(
-                    self,
+                if self.cached_result_or_action(
                     cache.map(|c| c.declare_subscriber),
                     AclMessage::DeclareSubscriber,
                     "Undeclare Subscriber (egress)",
-                    ctx.full_expr()?,
+                    ctx.full_key_expr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -683,12 +723,11 @@ impl InterceptorTrait for EgressAclEnforcer {
                 body: DeclareBody::DeclareQueryable(_),
                 ..
             }) => {
-                if cached_result_or_action!(
-                    self,
+                if self.cached_result_or_action(
                     cache.map(|c| c.declare_queryable),
                     AclMessage::DeclareQueryable,
                     "Declare Queryable (egress)",
-                    ctx.full_expr()?,
+                    ctx.full_key_expr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -700,12 +739,11 @@ impl InterceptorTrait for EgressAclEnforcer {
             }) => {
                 // Undeclaration filtering diverges between ingress and egress:
                 // in egress the keyexpr has to be provided in the RoutingContext
-                if cached_result_or_action!(
-                    self,
+                if self.cached_result_or_action(
                     cache.map(|c| c.declare_queryable),
                     AclMessage::DeclareQueryable,
                     "Undeclare Queryable (egress)",
-                    ctx.full_expr()?,
+                    ctx.full_key_expr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -715,12 +753,11 @@ impl InterceptorTrait for EgressAclEnforcer {
                 body: DeclareBody::DeclareToken(_),
                 ..
             }) => {
-                if cached_result_or_action!(
-                    self,
+                if self.cached_result_or_action(
                     cache.map(|c| c.declare_token),
                     AclMessage::LivelinessToken,
                     "Liveliness Token (egress)",
-                    ctx.full_expr()?,
+                    ctx.full_key_expr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -732,12 +769,11 @@ impl InterceptorTrait for EgressAclEnforcer {
             }) => {
                 // Undeclaration filtering diverges between ingress and egress:
                 // in egress the keyexpr has to be provided in the RoutingContext
-                if cached_result_or_action!(
-                    self,
+                if self.cached_result_or_action(
                     cache.map(|c| c.declare_token),
                     AclMessage::LivelinessToken,
                     "Undeclare Liveliness Token (egress)",
-                    ctx.full_expr()?,
+                    ctx.full_key_expr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -748,12 +784,11 @@ impl InterceptorTrait for EgressAclEnforcer {
                 options,
                 ..
             }) if options.tokens() => {
-                if cached_result_or_action!(
-                    self,
+                if self.cached_result_or_action(
                     cache.map(|c| c.query_token),
                     AclMessage::LivelinessQuery,
                     "Liveliness Query (egress)",
-                    ctx.full_expr()?,
+                    ctx.full_key_expr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -764,12 +799,11 @@ impl InterceptorTrait for EgressAclEnforcer {
                 options,
                 ..
             }) if options.tokens() => {
-                if cached_result_or_action!(
-                    self,
+                if self.cached_result_or_action(
                     cache.map(|c| c.declare_liveliness_subscriber),
                     AclMessage::DeclareLivelinessSubscriber,
                     "Declare Liveliness Subscriber (egress)",
-                    ctx.full_expr()?,
+                    ctx.full_key_expr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -784,12 +818,11 @@ impl InterceptorTrait for EgressAclEnforcer {
 
                 // InterestMode::Final filtering diverges between ingress and egress:
                 // in egress the keyexpr has to be provided in the RoutingContext
-                if cached_result_or_action!(
-                    self,
+                if self.cached_result_or_action(
                     cache.map(|c| c.declare_liveliness_subscriber),
                     AclMessage::DeclareLivelinessSubscriber,
                     "Undeclare Liveliness Subscriber (egress)",
-                    ctx.full_expr()?,
+                    ctx.full_key_expr()?,
                 ) == Permission::Deny
                 {
                     return None;
@@ -821,7 +854,7 @@ pub trait AclActionMethods {
     fn zid(&self) -> &ZenohIdProto;
     fn flow(&self) -> InterceptorFlow;
     fn authn_ids(&self) -> &Vec<AuthSubject>;
-    fn action(&self, action: AclMessage, log_msg: &str, key_expr: &str) -> Permission {
+    fn action(&self, action: AclMessage, log_msg: &str, key_expr: &keyexpr) -> Permission {
         let policy_enforcer = self.policy_enforcer();
         let authn_ids = self.authn_ids();
         let zid = self.zid();

--- a/zenoh/src/net/routing/interceptor/authorization.rs
+++ b/zenoh/src/net/routing/interceptor/authorization.rs
@@ -571,7 +571,7 @@ impl PolicyEnforcer {
         subject: usize,
         flow: InterceptorFlow,
         message: AclMessage,
-        key_expr: &str,
+        key_expr: &keyexpr,
     ) -> ZResult<Permission> {
         let policy_map = &self.policy_map;
         if policy_map.is_empty() {
@@ -583,7 +583,7 @@ impl PolicyEnforcer {
                     .flow(flow)
                     .action(message)
                     .deny
-                    .nodes_including(keyexpr::new(&key_expr)?)
+                    .nodes_including(key_expr)
                     .any(|n| n.weight().is_some());
                 if deny_result {
                     return Ok(Permission::Deny);
@@ -595,7 +595,7 @@ impl PolicyEnforcer {
                         .flow(flow)
                         .action(message)
                         .allow
-                        .nodes_including(keyexpr::new(&key_expr)?)
+                        .nodes_including(key_expr)
                         .any(|n| n.weight().is_some());
 
                     if allow_result {

--- a/zenoh/src/net/routing/interceptor/downsampling.rs
+++ b/zenoh/src/net/routing/interceptor/downsampling.rs
@@ -197,7 +197,7 @@ impl DownsamplingInterceptor {
 static INFO_FLAG: AtomicBool = AtomicBool::new(false);
 
 impl InterceptorTrait for DownsamplingInterceptor {
-    fn compute_keyexpr_cache(&self, key_expr: &KeyExpr<'_>) -> Option<Box<dyn Any + Send + Sync>> {
+    fn compute_keyexpr_cache(&self, key_expr: &keyexpr) -> Option<Box<dyn Any + Send + Sync>> {
         let ke_id = zlock!(self.ke_id);
         if let Some(node) = ke_id.intersecting_keys(key_expr).next() {
             if let Some(id) = ke_id.weight_at(&node) {

--- a/zenoh/src/net/routing/interceptor/low_pass.rs
+++ b/zenoh/src/net/routing/interceptor/low_pass.rs
@@ -336,7 +336,7 @@ impl LowPassInterceptor {
         }
         let max_allowed_size = match max_allowed_size {
             Some(v) => v,
-            None => match ctx.full_key_expr() {
+            None => match ctx.full_keyexpr() {
                 Some(ke) => self.get_max_allowed_message_size(message_type, ke),
                 None => 0,
             },

--- a/zenoh/src/net/routing/interceptor/low_pass.rs
+++ b/zenoh/src/net/routing/interceptor/low_pass.rs
@@ -18,7 +18,7 @@
 //!
 //! [Click here for Zenoh's documentation](https://docs.rs/zenoh/latest/zenoh)
 
-use std::{collections::HashSet, iter, sync::Arc};
+use std::{any::Any, collections::HashSet, iter, sync::Arc};
 
 use ahash::HashMap;
 use itertools::Itertools;
@@ -336,7 +336,7 @@ impl LowPassInterceptor {
         }
         let max_allowed_size = match max_allowed_size {
             Some(v) => v,
-            None => match ctx.full_expr().and_then(|e| keyexpr::new(e).ok()) {
+            None => match ctx.full_key_expr() {
                 Some(ke) => self.get_max_allowed_message_size(message_type, ke),
                 None => 0,
             },
@@ -350,7 +350,7 @@ impl LowPassInterceptor {
     fn get_max_allowed_message_size(
         &self,
         message: LowPassFilterMessage,
-        key_expr: &zenoh_keyexpr::keyexpr,
+        key_expr: &keyexpr,
     ) -> usize {
         match self
             .subjects
@@ -385,10 +385,7 @@ struct Cache {
 }
 
 impl InterceptorTrait for LowPassInterceptor {
-    fn compute_keyexpr_cache(
-        &self,
-        key_expr: &crate::key_expr::KeyExpr<'_>,
-    ) -> Option<Box<dyn std::any::Any + Send + Sync>> {
+    fn compute_keyexpr_cache(&self, key_expr: &keyexpr) -> Option<Box<dyn Any + Send + Sync>> {
         Some(Box::new(Cache {
             put: self.get_max_allowed_message_size(LowPassFilterMessage::Put, key_expr),
             delete: self.get_max_allowed_message_size(LowPassFilterMessage::Delete, key_expr),

--- a/zenoh/src/net/routing/interceptor/mod.rs
+++ b/zenoh/src/net/routing/interceptor/mod.rs
@@ -211,7 +211,7 @@ impl<T: InterceptorTrait> InterceptorTrait for ComputeOnMiss<T> {
     ) -> Option<RoutingContext<NetworkMessage>> {
         if cache.is_some() {
             self.interceptor.intercept(ctx, cache)
-        } else if let Some(key_expr) = ctx.full_key_expr() {
+        } else if let Some(key_expr) = ctx.full_keyexpr() {
             let cache = self.interceptor.compute_keyexpr_cache(key_expr);
             self.interceptor.intercept(ctx, cache.as_ref())
         } else {

--- a/zenoh/src/net/routing/interceptor/mod.rs
+++ b/zenoh/src/net/routing/interceptor/mod.rs
@@ -29,12 +29,12 @@ use std::any::Any;
 mod low_pass;
 use low_pass::low_pass_interceptor_factories;
 use zenoh_config::{Config, InterceptorFlow, InterceptorLink};
+use zenoh_keyexpr::{keyexpr, OwnedKeyExpr};
 use zenoh_protocol::network::NetworkMessage;
 use zenoh_result::ZResult;
 use zenoh_transport::{multicast::TransportMulticast, unicast::TransportUnicast};
 
 use super::RoutingContext;
-use crate::api::key_expr::KeyExpr;
 
 pub mod downsampling;
 use crate::net::routing::interceptor::downsampling::downsampling_interceptor_factories;
@@ -84,7 +84,7 @@ impl From<&LinkAuthId> for InterceptorLinkWrapper {
 }
 
 pub(crate) trait InterceptorTrait {
-    fn compute_keyexpr_cache(&self, key_expr: &KeyExpr<'_>) -> Option<Box<dyn Any + Send + Sync>>;
+    fn compute_keyexpr_cache(&self, key_expr: &keyexpr) -> Option<Box<dyn Any + Send + Sync>>;
 
     fn intercept(
         &self,
@@ -154,7 +154,7 @@ impl InterceptorsChain {
 }
 
 impl InterceptorTrait for InterceptorsChain {
-    fn compute_keyexpr_cache(&self, key_expr: &KeyExpr<'_>) -> Option<Box<dyn Any + Send + Sync>> {
+    fn compute_keyexpr_cache(&self, key_expr: &keyexpr) -> Option<Box<dyn Any + Send + Sync>> {
         Some(Box::new(
             self.interceptors
                 .iter()
@@ -199,7 +199,7 @@ impl<T: InterceptorTrait> ComputeOnMiss<T> {
 
 impl<T: InterceptorTrait> InterceptorTrait for ComputeOnMiss<T> {
     #[inline]
-    fn compute_keyexpr_cache(&self, key_expr: &KeyExpr<'_>) -> Option<Box<dyn Any + Send + Sync>> {
+    fn compute_keyexpr_cache(&self, key_expr: &keyexpr) -> Option<Box<dyn Any + Send + Sync>> {
         self.interceptor.compute_keyexpr_cache(key_expr)
     }
 
@@ -212,12 +212,8 @@ impl<T: InterceptorTrait> InterceptorTrait for ComputeOnMiss<T> {
         if cache.is_some() {
             self.interceptor.intercept(ctx, cache)
         } else if let Some(key_expr) = ctx.full_key_expr() {
-            self.interceptor.intercept(
-                ctx,
-                self.interceptor
-                    .compute_keyexpr_cache(&key_expr.into())
-                    .as_ref(),
-            )
+            let cache = self.interceptor.compute_keyexpr_cache(key_expr);
+            self.interceptor.intercept(ctx, cache.as_ref())
         } else {
             self.interceptor.intercept(ctx, cache)
         }
@@ -228,8 +224,8 @@ impl<T: InterceptorTrait> InterceptorTrait for ComputeOnMiss<T> {
 pub(crate) struct IngressMsgLogger {}
 
 impl InterceptorTrait for IngressMsgLogger {
-    fn compute_keyexpr_cache(&self, key_expr: &KeyExpr<'_>) -> Option<Box<dyn Any + Send + Sync>> {
-        Some(Box::new(key_expr.to_string()))
+    fn compute_keyexpr_cache(&self, key_expr: &keyexpr) -> Option<Box<dyn Any + Send + Sync>> {
+        Some(Box::new(OwnedKeyExpr::from(key_expr)))
     }
 
     fn intercept(
@@ -257,8 +253,8 @@ impl InterceptorTrait for IngressMsgLogger {
 pub(crate) struct EgressMsgLogger {}
 
 impl InterceptorTrait for EgressMsgLogger {
-    fn compute_keyexpr_cache(&self, key_expr: &KeyExpr<'_>) -> Option<Box<dyn Any + Send + Sync>> {
-        Some(Box::new(key_expr.to_string()))
+    fn compute_keyexpr_cache(&self, key_expr: &keyexpr) -> Option<Box<dyn Any + Send + Sync>> {
+        Some(Box::new(OwnedKeyExpr::from(key_expr)))
     }
 
     fn intercept(

--- a/zenoh/src/net/routing/interceptor/qos_overwrite.rs
+++ b/zenoh/src/net/routing/interceptor/qos_overwrite.rs
@@ -186,7 +186,7 @@ struct Cache {
 }
 
 impl QosInterceptor {
-    fn is_ke_affected(&self, ke: &KeyExpr) -> bool {
+    fn is_ke_affected(&self, ke: &keyexpr) -> bool {
         self.keys.nodes_including(ke).any(|n| n.weight().is_some())
     }
 
@@ -215,14 +215,14 @@ impl QosInterceptor {
         cache.map(|v| v.is_ke_affected).unwrap_or_else(|| {
             ctx.full_key_expr()
                 .as_ref()
-                .map(|ke| self.is_ke_affected(&ke.into()))
+                .map(|ke| self.is_ke_affected(ke))
                 .unwrap_or(false)
         })
     }
 }
 
 impl InterceptorTrait for QosInterceptor {
-    fn compute_keyexpr_cache(&self, key_expr: &KeyExpr<'_>) -> Option<Box<dyn Any + Send + Sync>> {
+    fn compute_keyexpr_cache(&self, key_expr: &keyexpr) -> Option<Box<dyn Any + Send + Sync>> {
         let cache = Cache {
             is_ke_affected: self.is_ke_affected(key_expr),
         };

--- a/zenoh/src/net/routing/interceptor/qos_overwrite.rs
+++ b/zenoh/src/net/routing/interceptor/qos_overwrite.rs
@@ -213,7 +213,7 @@ impl QosInterceptor {
         ctx: &RoutingContext<NetworkMessage>,
     ) -> bool {
         cache.map(|v| v.is_ke_affected).unwrap_or_else(|| {
-            ctx.full_key_expr()
+            ctx.full_keyexpr()
                 .as_ref()
                 .map(|ke| self.is_ke_affected(ke))
                 .unwrap_or(false)

--- a/zenoh/src/net/routing/mod.rs
+++ b/zenoh/src/net/routing/mod.rs
@@ -154,7 +154,6 @@ impl RoutingContext<NetworkMessage> {
     }
 
     #[inline]
-    #[allow(dead_code)]
     pub(crate) fn full_expr(&self) -> Option<&str> {
         if self.full_expr.get().is_some() {
             return Some(self.full_expr.get().as_ref().unwrap());
@@ -169,7 +168,7 @@ impl RoutingContext<NetworkMessage> {
     }
 
     #[inline]
-    pub(crate) fn full_key_expr(&self) -> Option<&keyexpr> {
+    pub(crate) fn full_keyexpr(&self) -> Option<&keyexpr> {
         let full_expr = self.full_expr()?;
         keyexpr::new(full_expr).ok()
     }

--- a/zenoh/src/net/routing/mod.rs
+++ b/zenoh/src/net/routing/mod.rs
@@ -25,10 +25,8 @@ pub mod router;
 
 use std::{cell::OnceCell, sync::Arc};
 
-use zenoh_protocol::{
-    core::{key_expr::OwnedKeyExpr, WireExpr},
-    network::NetworkMessage,
-};
+use zenoh_keyexpr::keyexpr;
+use zenoh_protocol::{core::WireExpr, network::NetworkMessage};
 
 use self::{dispatcher::face::Face, router::Resource};
 use super::runtime;
@@ -171,8 +169,8 @@ impl RoutingContext<NetworkMessage> {
     }
 
     #[inline]
-    pub(crate) fn full_key_expr(&self) -> Option<OwnedKeyExpr> {
+    pub(crate) fn full_key_expr(&self) -> Option<&keyexpr> {
         let full_expr = self.full_expr()?;
-        OwnedKeyExpr::new(full_expr).ok()
+        keyexpr::new(full_expr).ok()
     }
 }

--- a/zenoh/src/tests.rs
+++ b/zenoh/src/tests.rs
@@ -22,10 +22,7 @@ use zenoh_protocol::{
 };
 use zenoh_transport::{multicast::TransportMulticast, unicast::TransportUnicast};
 
-use crate::{
-    key_expr::KeyExpr,
-    net::routing::{interceptor::*, RoutingContext},
-};
+use crate::net::routing::{interceptor::*, RoutingContext};
 
 #[derive(Clone)]
 struct TestInterceptorConf {
@@ -91,7 +88,7 @@ impl TestInterceptor {
 }
 
 impl InterceptorTrait for TestInterceptor {
-    fn compute_keyexpr_cache(&self, _key_expr: keyexpr) -> Option<Box<dyn Any + Send + Sync>> {
+    fn compute_keyexpr_cache(&self, _key_expr: &keyexpr) -> Option<Box<dyn Any + Send + Sync>> {
         Some(Box::new(self.data.clone()))
     }
 

--- a/zenoh/src/tests.rs
+++ b/zenoh/src/tests.rs
@@ -15,6 +15,7 @@
 use std::str::FromStr;
 
 use zenoh_buffers::ZBuf;
+use zenoh_keyexpr::keyexpr;
 use zenoh_protocol::{
     network::{NetworkBody, NetworkMessage, Push},
     zenoh::PushBody,
@@ -90,7 +91,7 @@ impl TestInterceptor {
 }
 
 impl InterceptorTrait for TestInterceptor {
-    fn compute_keyexpr_cache(&self, _key_expr: &KeyExpr<'_>) -> Option<Box<dyn Any + Send + Sync>> {
+    fn compute_keyexpr_cache(&self, _key_expr: keyexpr) -> Option<Box<dyn Any + Send + Sync>> {
         Some(Box::new(self.data.clone()))
     }
 


### PR DESCRIPTION
When profiling subscribers in high throughput scenarios with small messages, I noticed that a significant amount of time is spent checking that cached keyexprs are indeed valid keyexprs.

With this patch, the `keyexpr::new` call disappears from the flamegraph.


![cache-typed-keyexpr](https://github.com/user-attachments/assets/46bd5b3f-03fc-4e14-a7e7-c4e2e2096456)
