### PR TITLE
Add new non periodic last sample miss detection mechanism

### DIFF
--- a/zenoh-ext/src/advanced_publisher.rs
+++ b/zenoh-ext/src/advanced_publisher.rs
@@ -58,6 +58,11 @@ pub(crate) enum Sequencing {
     SequenceNumber,
 }
 
+/// Configuration for sample miss detection
+///
+/// Enabling sample miss detection allows [`AdvancedSubscribers`](crate::AdvancedSubscriber) to detect missed samples
+/// through [`sample_miss_listener`](crate::AdvancedSubscriber::sample_miss_listener)
+/// and to recover missed samples through [`recovery`](crate::AdvancedSubscriberBuilder::recovery).
 #[derive(Default)]
 #[zenoh_macros::unstable]
 pub struct MissDetectionConfig {
@@ -67,12 +72,22 @@ pub struct MissDetectionConfig {
 
 #[zenoh_macros::unstable]
 impl MissDetectionConfig {
+    /// Allow last sample miss detection through periodic heartbeat.
+    ///
+    /// Periodically send the last published Sample's sequence number to allow last sample recovery.
+    /// [`AdvancedSubscribers`](crate::AdvancedSubscriber) can recover last sample with the
+    /// [`heartbeat`](crate::advanced_subscriber::RecoveryConfig::heartbeat) option.
     #[zenoh_macros::unstable]
     pub fn heartbeat(mut self, period: Duration) -> Self {
         self.state_publisher = Some(period);
         self
     }
 
+    /// Allow last sample miss detection through non periodic [`CongestionControl::Block`] heartbeat.
+    ///
+    /// Send the last published Sample's sequence number with [`CongestionControl::Block`] when it changes.
+    /// [`AdvancedSubscribers`](crate::AdvancedSubscriber) can recover last sample with the
+    /// [`heartbeat`](crate::advanced_subscriber::RecoveryConfig::heartbeat) option.
     #[zenoh_macros::unstable]
     pub fn heartbeat_update(mut self, period: Duration) -> Self {
         self.state_update = Some(period);

--- a/zenoh-ext/src/advanced_publisher.rs
+++ b/zenoh-ext/src/advanced_publisher.rs
@@ -89,7 +89,7 @@ impl MissDetectionConfig {
     /// [`AdvancedSubscribers`](crate::AdvancedSubscriber) can recover last sample with the
     /// [`heartbeat`](crate::advanced_subscriber::RecoveryConfig::heartbeat) option.
     #[zenoh_macros::unstable]
-    pub fn heartbeat_update(mut self, period: Duration) -> Self {
+    pub fn heartbeat_change(mut self, period: Duration) -> Self {
         self.state_update = Some(period);
         self
     }

--- a/zenoh-ext/src/advanced_subscriber.rs
+++ b/zenoh-ext/src/advanced_subscriber.rs
@@ -133,10 +133,12 @@ impl RecoveryConfig<Unconfigured> {
 
     /// Subscribe to heartbeats of [`AdvancedPublishers`](crate::AdvancedPublisher).
     ///
-    /// This allows to periodically receive the last published Sample's sequence number and check for misses.
+    /// This allows to receive the last published Sample's sequence number and check for misses.
     /// Heartbeat subscriber must be paired with [`AdvancedPublishers`](crate::AdvancedPublisher)
     /// that enable [`cache`](crate::AdvancedPublisherBuilder::cache) and
-    /// [`sample_miss_detection`](crate::AdvancedPublisherBuilder::sample_miss_detection) with heartbeat.
+    /// [`sample_miss_detection`](crate::AdvancedPublisherBuilder::sample_miss_detection) with
+    /// [`heartbeat`](crate::advanced_publisher::MissDetectionConfig::heartbeat) or
+    /// [`heartbeat_update`](crate::advanced_publisher::MissDetectionConfig::heartbeat_update).
     #[zenoh_macros::unstable]
     #[inline]
     pub fn heartbeat(self) -> RecoveryConfig<Configured> {

--- a/zenoh-ext/src/advanced_subscriber.rs
+++ b/zenoh-ext/src/advanced_subscriber.rs
@@ -138,7 +138,7 @@ impl RecoveryConfig<Unconfigured> {
     /// that enable [`cache`](crate::AdvancedPublisherBuilder::cache) and
     /// [`sample_miss_detection`](crate::AdvancedPublisherBuilder::sample_miss_detection) with
     /// [`heartbeat`](crate::advanced_publisher::MissDetectionConfig::heartbeat) or
-    /// [`heartbeat_update`](crate::advanced_publisher::MissDetectionConfig::heartbeat_update).
+    /// [`heartbeat_change`](crate::advanced_publisher::MissDetectionConfig::heartbeat_change).
     #[zenoh_macros::unstable]
     #[inline]
     pub fn heartbeat(self) -> RecoveryConfig<Configured> {


### PR DESCRIPTION
Introduces a new mechanism to allow last sample miss detection. 
The mechanism reuses AdvPubSub heartbeat message but sent with `CongestionControl::Block` instead of periodically.
