### PR TITLE
remove Display implementation for TransportMessage

### DIFF
--- a/commons/zenoh-protocol/src/network/mod.rs
+++ b/commons/zenoh-protocol/src/network/mod.rs
@@ -159,21 +159,6 @@ impl NetworkMessage {
     }
 }
 
-impl fmt::Display for NetworkMessage {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use NetworkBody::*;
-        match &self.body {
-            OAM(_) => write!(f, "OAM"),
-            Push(_) => write!(f, "Push"),
-            Request(_) => write!(f, "Request"),
-            Response(_) => write!(f, "Response"),
-            ResponseFinal(_) => write!(f, "ResponseFinal"),
-            Interest(_) => write!(f, "Interest"),
-            Declare(_) => write!(f, "Declare"),
-        }
-    }
-}
-
 impl From<NetworkBody> for NetworkMessage {
     #[inline]
     fn from(body: NetworkBody) -> Self {

--- a/commons/zenoh-protocol/src/transport/mod.rs
+++ b/commons/zenoh-protocol/src/transport/mod.rs
@@ -20,8 +20,6 @@ pub mod keepalive;
 pub mod oam;
 pub mod open;
 
-use core::fmt;
-
 pub use close::Close;
 pub use fragment::{Fragment, FragmentHeader};
 pub use frame::{Frame, FrameHeader};
@@ -221,34 +219,6 @@ impl From<Fragment> for TransportMessage {
 impl From<Join> for TransportMessage {
     fn from(join: Join) -> Self {
         TransportBody::Join(join).into()
-    }
-}
-
-impl fmt::Display for TransportMessage {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        use TransportBody::*;
-        match &self.body {
-            OAM(_) => write!(f, "OAM"),
-            InitSyn(_) => write!(f, "InitSyn"),
-            InitAck(_) => write!(f, "InitAck"),
-            OpenSyn(_) => write!(f, "OpenSyn"),
-            OpenAck(_) => write!(f, "OpenAck"),
-            Close(_) => write!(f, "Close"),
-            KeepAlive(_) => write!(f, "KeepAlive"),
-            Frame(m) => {
-                write!(f, "Frame[")?;
-                let mut netmsgs = m.payload.iter().peekable();
-                while let Some(m) = netmsgs.next() {
-                    m.fmt(f)?;
-                    if netmsgs.peek().is_some() {
-                        write!(f, ", ")?;
-                    }
-                }
-                write!(f, "]")
-            }
-            Fragment(_) => write!(f, "Fragment"),
-            Join(_) => write!(f, "Join"),
-        }
     }
 }
 


### PR DESCRIPTION
Display implementation was used by dissector, but it has been broken with lazy frame deserialization.
The implementation should be written directly where it's used, e.g. in dissector, where deserialization can be done.