### PR TITLE
[ZEN-526] Add Bind config option

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -28,8 +28,9 @@
   ///
   /// For TCP and TLS links, it is possible to specify the TCP buffer sizes:
   /// E.g. tcp/192.168.0.1:7447#so_sndbuf=65000;so_rcvbuf=65000
-  /// For TCP, UDP, Quic and TLS links, it is possible to specify a bind address for the local socket:
+  /// For TCP, UDP, Quic and TLS links, it is possible to specify a `bind` address for the local socket:
   /// E.g. tcp/192.168.0.1:7447#bind=192.168.0.1:0
+  //  Note!: Currently it is unsupported to specify both `bind` and `iface`. 
   connect: {
     /// timeout waiting for all endpoints connected (0: no retry, -1: infinite timeout)
     /// Accepts a single value (e.g. timeout_ms: 0)

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -28,6 +28,8 @@
   ///
   /// For TCP and TLS links, it is possible to specify the TCP buffer sizes:
   /// E.g. tcp/192.168.0.1:7447#so_sndbuf=65000;so_rcvbuf=65000
+  /// For TCP, UDP, Quic and TLS links, it is possible to specify a bind address for the local socket:
+  /// E.g. tcp/192.168.0.1:7447#bind=192.168.0.1:0
   connect: {
     /// timeout waiting for all endpoints connected (0: no retry, -1: infinite timeout)
     /// Accepts a single value (e.g. timeout_ms: 0)
@@ -74,8 +76,6 @@
   ///
   /// For TCP and TLS links, it is possible to specify the TCP buffer sizes:
   /// E.g. tcp/192.168.0.1:7447#so_sndbuf=65000;so_rcvbuf=65000
-  /// For TCP, UDP, Quic and TLS it is possible to specify a bind endpoint both in IPV4 and IPV6:
-  /// E.g. tcp/192.168.0.1:7447#bind=192.168.0.1:0
   listen: {
     /// timeout waiting for all listen endpoints (0: no retry, -1: infinite timeout)
     /// Accepts a single value (e.g. timeout_ms: 0)

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -74,6 +74,8 @@
   ///
   /// For TCP and TLS links, it is possible to specify the TCP buffer sizes:
   /// E.g. tcp/192.168.0.1:7447#so_sndbuf=65000;so_rcvbuf=65000
+  /// For TCP, UDP, Quic and TLS it is possible to specify a bind endpoint both in IPV4 and IPV6:
+  /// E.g. tcp/192.168.0.1:7447#bind=192.168.0.1:0
   listen: {
     /// timeout waiting for all listen endpoints (0: no retry, -1: infinite timeout)
     /// Accepts a single value (e.g. timeout_ms: 0)

--- a/commons/zenoh-protocol/src/core/endpoint.rs
+++ b/commons/zenoh-protocol/src/core/endpoint.rs
@@ -880,4 +880,8 @@ fn endpoints() {
     assert_eq!(i.next(), Some("224.0.0.2"));
     assert_eq!(i.next(), Some("224.0.0.3"));
     assert_eq!(i.next(), None);
+
+    let endpoint = EndPoint::from_str("udp/127.0.0.1:7447#bind=224.0.0.1:8080").unwrap();
+    let c = endpoint.config();
+    assert_eq!(c.get("bind"), Some("224.0.0.1:8080"));
 }

--- a/commons/zenoh-protocol/src/core/endpoint.rs
+++ b/commons/zenoh-protocol/src/core/endpoint.rs
@@ -120,7 +120,7 @@ impl fmt::Debug for ProtocolMut<'_> {
 // Address
 #[repr(transparent)]
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
-pub struct Address<'a>(pub &'a str);
+pub struct Address<'a>(pub(super) &'a str);
 
 impl<'a> Address<'a> {
     pub fn as_str(&self) -> &'a str {
@@ -143,6 +143,12 @@ impl fmt::Display for Address<'_> {
 impl fmt::Debug for Address<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self)
+    }
+}
+
+impl<'a> From<&'a str> for Address<'a> {
+    fn from(value: &'a str) -> Self {
+        Address(value)
     }
 }
 
@@ -880,8 +886,4 @@ fn endpoints() {
     assert_eq!(i.next(), Some("224.0.0.2"));
     assert_eq!(i.next(), Some("224.0.0.3"));
     assert_eq!(i.next(), None);
-
-    let endpoint = EndPoint::from_str("udp/127.0.0.1:7447#bind=224.0.0.1:8080").unwrap();
-    let c = endpoint.config();
-    assert_eq!(c.get("bind"), Some("224.0.0.1:8080"));
 }

--- a/commons/zenoh-protocol/src/core/endpoint.rs
+++ b/commons/zenoh-protocol/src/core/endpoint.rs
@@ -120,7 +120,7 @@ impl fmt::Debug for ProtocolMut<'_> {
 // Address
 #[repr(transparent)]
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
-pub struct Address<'a>(pub(super) &'a str);
+pub struct Address<'a>(pub &'a str);
 
 impl<'a> Address<'a> {
     pub fn as_str(&self) -> &'a str {

--- a/io/zenoh-link-commons/src/lib.rs
+++ b/io/zenoh-link-commons/src/lib.rs
@@ -44,6 +44,7 @@ use zenoh_result::ZResult;
 /*            GENERAL                */
 /*************************************/
 
+pub const BIND_SOCKET: &str = "bind";
 pub const BIND_INTERFACE: &str = "iface";
 pub const TCP_SO_SND_BUF: &str = "so_sndbuf";
 pub const TCP_SO_RCV_BUF: &str = "so_rcvbuf";

--- a/io/zenoh-link-commons/src/tcp.rs
+++ b/io/zenoh-link-commons/src/tcp.rs
@@ -100,6 +100,7 @@ impl<'a> TcpSocketConfig<'a> {
             .peer_addr()
             .map_err(|e| zerror!("{}: {}", dst_addr, e))?;
 
+        
         Ok((stream, src_addr, dst_addr))
     }
 

--- a/io/zenoh-link-commons/src/tcp.rs
+++ b/io/zenoh-link-commons/src/tcp.rs
@@ -80,6 +80,7 @@ impl<'a> TcpSocketConfig<'a> {
                 }
                 _ => (), // No issue here
             }
+
             socket
                 .bind(bind_addr)
                 .map_err(|e| zerror!("{}: {}", bind_addr, e))?;

--- a/io/zenoh-link-commons/src/tcp.rs
+++ b/io/zenoh-link-commons/src/tcp.rs
@@ -100,7 +100,6 @@ impl<'a> TcpSocketConfig<'a> {
             .peer_addr()
             .map_err(|e| zerror!("{}: {}", dst_addr, e))?;
 
-        
         Ok((stream, src_addr, dst_addr))
     }
 

--- a/io/zenoh-link-commons/src/tcp.rs
+++ b/io/zenoh-link-commons/src/tcp.rs
@@ -80,7 +80,6 @@ impl<'a> TcpSocketConfig<'a> {
                 }
                 _ => (), // No issue here
             }
-
             socket
                 .bind(bind_addr)
                 .map_err(|e| zerror!("{}: {}", bind_addr, e))?;

--- a/io/zenoh-link-commons/src/tcp.rs
+++ b/io/zenoh-link-commons/src/tcp.rs
@@ -110,10 +110,6 @@ impl<'a> TcpSocketConfig<'a> {
             SocketAddr::V6(_) => TcpSocket::new_v6(),
         }?;
 
-        if let Some(bind_socket) = self.bind_socket {
-            socket.bind(bind_socket)?;
-        };
-
         if let Some(iface) = self.iface {
             zenoh_util::net::set_bind_to_device_tcp_socket(&socket, iface)?;
         }

--- a/io/zenoh-link-commons/src/tcp.rs
+++ b/io/zenoh-link-commons/src/tcp.rs
@@ -67,14 +67,16 @@ impl<'a> TcpSocketConfig<'a> {
         if let Some(bind_addr) = self.bind_socket {
             match (bind_addr, dst_addr) {
                 (SocketAddr::V6(local), SocketAddr::V4(dest)) => {
-                    return zerror!(
-                    "Protocols must match: Cannot bind to IPv6 {local} and connect to IPv4 {dest}"
-                )
+                    return Err(Box::from(format!(
+                        "Protocols must match: Cannot bind to IPv6 {} and connect to IPv4 {}",
+                        local, dest
+                    )));
                 }
                 (SocketAddr::V4(local), SocketAddr::V6(dest)) => {
-                    return zerror!(
-                    "Protocols must match: Cannot bind to IPv4 {local} and connect to IPv6 {dest}"
-                )
+                    return Err(Box::from(format!(
+                        "Protocols must match: Cannot bind to IPv4 {} and connect to IPv6 {}",
+                        local, dest
+                    )));
                 }
                 _ => (), // No issue here
             }

--- a/io/zenoh-links/zenoh-link-quic/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/unicast.rs
@@ -36,7 +36,7 @@ use zenoh_link_commons::{
     ListenersUnicastIP, NewLinkChannelSender, BIND_INTERFACE, BIND_SOCKET,
 };
 use zenoh_protocol::{
-    core::{EndPoint, Locator},
+    core::{Address, EndPoint, Locator},
     transport::BatchSize,
 };
 use zenoh_result::{bail, zerror, ZResult};
@@ -273,8 +273,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastQuic {
             ALPN_QUIC_HTTP.iter().map(|&x| x.into()).collect();
 
         let src_addr = if let Some(bind_socket_str) = epconf.get(BIND_SOCKET) {
-            let bind_endpoint = EndPoint::new("", bind_socket_str, "", "")?;
-            get_quic_addr(&bind_endpoint.address()).await?
+            get_quic_addr(&Address(bind_socket_str)).await?
         } else if dst_addr.is_ipv4() {
             SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 0)
         } else {

--- a/io/zenoh-links/zenoh-link-quic/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/unicast.rs
@@ -314,7 +314,6 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastQuic {
             .local_addr()
             .map_err(|e| zerror!("Can not create a new QUIC link bound to {}: {}", host, e))?;
 
-        println!("dst_addr, host {:?} {:?}",dst_addr, host);
         let quic_conn = quic_endpoint
             .connect(dst_addr, host)
             .map_err(|e| zerror!("Can not create a new QUIC link bound to {}: {}", host, e))?

--- a/io/zenoh-links/zenoh-link-quic/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/unicast.rs
@@ -273,7 +273,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastQuic {
             ALPN_QUIC_HTTP.iter().map(|&x| x.into()).collect();
 
         let src_addr = if let Some(bind_socket_str) = epconf.get(BIND_SOCKET) {
-            get_quic_addr(&Address(bind_socket_str)).await?
+            get_quic_addr(&Address::from(bind_socket_str)).await?
         } else if dst_addr.is_ipv4() {
             SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 0)
         } else {

--- a/io/zenoh-links/zenoh-link-quic/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/unicast.rs
@@ -315,7 +315,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastQuic {
             .connect(dst_addr, host)
             .map_err(|e| {
                 zerror!(
-                    "Can not get connect quick endpoing : {} : {} : {}",
+                    "Can not get connect quick endpoint : {} : {} : {}",
                     dst_addr,
                     host,
                     e

--- a/io/zenoh-links/zenoh-link-quic/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/unicast.rs
@@ -15,7 +15,6 @@
 use std::{
     fmt::{self, Debug},
     net::{Ipv4Addr, Ipv6Addr, SocketAddr},
-    str::FromStr,
     sync::Arc,
     time::Duration,
 };
@@ -266,7 +265,8 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastQuic {
             ALPN_QUIC_HTTP.iter().map(|&x| x.into()).collect();
 
         let src_addr = if let Some(bind_socket_str) = epconf.get(BIND_SOCKET) {
-            SocketAddr::from_str(bind_socket_str)?
+            let bind_endpoint = EndPoint::new("", bind_socket_str, "", "")?;
+            get_quic_addr(&bind_endpoint.address()).await?
         } else if dst_addr.is_ipv4() {
             SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 0)
         } else {

--- a/io/zenoh-links/zenoh-link-quic/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/unicast.rs
@@ -314,6 +314,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastQuic {
             .local_addr()
             .map_err(|e| zerror!("Can not create a new QUIC link bound to {}: {}", host, e))?;
 
+        println!("dst_addr, host {:?} {:?}",dst_addr, host);
         let quic_conn = quic_endpoint
             .connect(dst_addr, host)
             .map_err(|e| zerror!("Can not create a new QUIC link bound to {}: {}", host, e))?

--- a/io/zenoh-links/zenoh-link-tcp/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/lib.rs
@@ -85,6 +85,7 @@ zconfigurable! {
 }
 
 pub async fn get_tcp_addrs(address: Address<'_>) -> ZResult<impl Iterator<Item = SocketAddr>> {
+    println!("get_tcp_addrs {:?}", address);
     let iter = tokio::net::lookup_host(address.as_str().to_string())
         .await
         .map_err(|e| zerror!("{}", e))?

--- a/io/zenoh-links/zenoh-link-tcp/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/lib.rs
@@ -85,7 +85,6 @@ zconfigurable! {
 }
 
 pub async fn get_tcp_addrs(address: Address<'_>) -> ZResult<impl Iterator<Item = SocketAddr>> {
-    println!("get_tcp_addrs {:?}", address);
     let iter = tokio::net::lookup_host(address.as_str().to_string())
         .await
         .map_err(|e| zerror!("{}", e))?

--- a/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
@@ -248,7 +248,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastTcp {
 
         let config = endpoint.config();
 
-        let link_config = TcpLinkConfig::new(&config)?;
+        let link_config = TcpLinkConfig::new(&config).await?;
         let socket_config = TcpSocketConfig::new(
             link_config.tx_buffer_size,
             link_config.rx_buffer_size,
@@ -285,7 +285,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastTcp {
 
         let config = endpoint.config();
 
-        let link_config = TcpLinkConfig::new(&config)?;
+        let link_config = TcpLinkConfig::new(&config).await?;
         let socket_config: TcpSocketConfig<'_> = link_config.into();
 
         let mut errs: Vec<ZError> = vec![];

--- a/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
@@ -245,6 +245,7 @@ impl LinkManagerUnicastTcp {
 impl LinkManagerUnicastTrait for LinkManagerUnicastTcp {
     async fn new_link(&self, endpoint: EndPoint) -> ZResult<LinkUnicast> {
         let dst_addrs = get_tcp_addrs(endpoint.address()).await?;
+
         let config = endpoint.config();
 
         let link_config = TcpLinkConfig::new(&config)?;
@@ -252,6 +253,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastTcp {
             link_config.tx_buffer_size,
             link_config.rx_buffer_size,
             link_config.bind_iface,
+            link_config.bind_socket,
         );
 
         let mut errs: Vec<ZError> = vec![];
@@ -280,6 +282,7 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastTcp {
 
     async fn new_listener(&self, mut endpoint: EndPoint) -> ZResult<Locator> {
         let addrs = get_tcp_addrs(endpoint.address()).await?;
+
         let config = endpoint.config();
 
         let link_config = TcpLinkConfig::new(&config)?;

--- a/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
@@ -21,7 +21,7 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 use zenoh_link_commons::{
     get_ip_interface_names, tcp::TcpSocketConfig, LinkAuthId, LinkManagerUnicastTrait, LinkUnicast,
-    LinkUnicastTrait, ListenersUnicastIP, NewLinkChannelSender,
+    LinkUnicastTrait, ListenersUnicastIP, NewLinkChannelSender, BIND_INTERFACE, BIND_SOCKET,
 };
 use zenoh_protocol::{
     core::{EndPoint, Locator},
@@ -247,6 +247,15 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastTcp {
         let dst_addrs = get_tcp_addrs(endpoint.address()).await?;
 
         let config = endpoint.config();
+
+        // if both `iface`, and `bind` are present, return error
+        if let (Some(_), Some(_)) = (config.get(BIND_INTERFACE), config.get(BIND_SOCKET)) {
+            bail!(
+                "Using Config options `iface` and `bind` in conjunction is unsupported at this time {} {:?}",
+                BIND_INTERFACE,
+                BIND_SOCKET
+            )
+        }
 
         let link_config = TcpLinkConfig::new(&config).await?;
         let socket_config = TcpSocketConfig::new(

--- a/io/zenoh-links/zenoh-link-tcp/src/utils.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/utils.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use std::net::SocketAddr;
+
 use zenoh_config::{Config as ZenohConfig, EndPoint};
 use zenoh_link_commons::{
     tcp::TcpSocketConfig, ConfigurationInspector, BIND_INTERFACE, BIND_SOCKET, TCP_SO_RCV_BUF,

--- a/io/zenoh-links/zenoh-link-tcp/src/utils.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/utils.rs
@@ -13,12 +13,12 @@
 //
 use std::net::SocketAddr;
 
-use zenoh_config::{Config as ZenohConfig, EndPoint};
+use zenoh_config::Config as ZenohConfig;
 use zenoh_link_commons::{
     tcp::TcpSocketConfig, ConfigurationInspector, BIND_INTERFACE, BIND_SOCKET, TCP_SO_RCV_BUF,
     TCP_SO_SND_BUF,
 };
-use zenoh_protocol::core::{parameters, Config};
+use zenoh_protocol::core::{parameters, Address, Config};
 use zenoh_result::{zerror, ZResult};
 
 use crate::get_tcp_addrs;
@@ -57,8 +57,7 @@ impl<'a> TcpLinkConfig<'a> {
     pub(crate) async fn new(config: &'a Config<'a>) -> ZResult<Self> {
         let mut bind_socket = None;
         if let Some(bind_socket_str) = config.get(BIND_SOCKET) {
-            let bind_endpoint = EndPoint::new("", bind_socket_str, "", "")?;
-            bind_socket = get_tcp_addrs(bind_endpoint.address()).await?.next();
+            bind_socket = get_tcp_addrs(Address(bind_socket_str)).await?.next();
         };
 
         let mut tcp_config = Self {

--- a/io/zenoh-links/zenoh-link-tcp/src/utils.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/utils.rs
@@ -57,7 +57,7 @@ impl<'a> TcpLinkConfig<'a> {
     pub(crate) async fn new(config: &'a Config<'a>) -> ZResult<Self> {
         let mut bind_socket = None;
         if let Some(bind_socket_str) = config.get(BIND_SOCKET) {
-            bind_socket = get_tcp_addrs(Address(bind_socket_str)).await?.next();
+            bind_socket = get_tcp_addrs(Address::from(bind_socket_str)).await?.next();
         };
 
         let mut tcp_config = Self {

--- a/io/zenoh-links/zenoh-link-tcp/src/utils.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/utils.rs
@@ -1,3 +1,5 @@
+use std::{net::SocketAddr, str::FromStr};
+
 //
 // Copyright (c) 2024 ZettaScale Technology
 //
@@ -13,7 +15,8 @@
 //
 use zenoh_config::Config as ZenohConfig;
 use zenoh_link_commons::{
-    tcp::TcpSocketConfig, ConfigurationInspector, BIND_INTERFACE, TCP_SO_RCV_BUF, TCP_SO_SND_BUF,
+    tcp::TcpSocketConfig, ConfigurationInspector, BIND_INTERFACE, BIND_SOCKET, TCP_SO_RCV_BUF,
+    TCP_SO_SND_BUF,
 };
 use zenoh_protocol::core::{parameters, Config};
 use zenoh_result::{zerror, ZResult};
@@ -45,14 +48,21 @@ pub(crate) struct TcpLinkConfig<'a> {
     pub(crate) rx_buffer_size: Option<u32>,
     pub(crate) tx_buffer_size: Option<u32>,
     pub(crate) bind_iface: Option<&'a str>,
+    pub(crate) bind_socket: Option<SocketAddr>,
 }
 
 impl<'a> TcpLinkConfig<'a> {
     pub(crate) fn new(config: &'a Config) -> ZResult<Self> {
+        let mut bind_socket = None;
+        if let Some(bind_socket_str) = config.get(BIND_SOCKET) {
+            bind_socket = Some(SocketAddr::from_str(bind_socket_str)?)
+        };
+
         let mut tcp_config = Self {
             rx_buffer_size: None,
             tx_buffer_size: None,
             bind_iface: config.get(BIND_INTERFACE),
+            bind_socket,
         };
 
         if let Some(size) = config.get(TCP_SO_RCV_BUF) {
@@ -74,6 +84,11 @@ impl<'a> TcpLinkConfig<'a> {
 
 impl<'a> From<TcpLinkConfig<'a>> for TcpSocketConfig<'a> {
     fn from(value: TcpLinkConfig<'a>) -> Self {
-        Self::new(value.tx_buffer_size, value.rx_buffer_size, value.bind_iface)
+        Self::new(
+            value.tx_buffer_size,
+            value.rx_buffer_size,
+            value.bind_iface,
+            value.bind_socket,
+        )
     }
 }

--- a/io/zenoh-links/zenoh-link-tcp/src/utils.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/utils.rs
@@ -1,5 +1,3 @@
-use std::{net::SocketAddr, str::FromStr};
-
 //
 // Copyright (c) 2024 ZettaScale Technology
 //
@@ -13,6 +11,7 @@ use std::{net::SocketAddr, str::FromStr};
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
+use std::{net::SocketAddr, str::FromStr};
 use zenoh_config::Config as ZenohConfig;
 use zenoh_link_commons::{
     tcp::TcpSocketConfig, ConfigurationInspector, BIND_INTERFACE, BIND_SOCKET, TCP_SO_RCV_BUF,

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -385,8 +385,8 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastTls {
             }
             LinkUnicastTls::new(
                 tls_stream,
-                dst_addr,
                 src_addr,
+                dst_addr,
                 auth_identifier.into(),
                 expiration_manager,
             )
@@ -535,8 +535,8 @@ async fn accept_task(
                             }
                             LinkUnicastTls::new(
                                 tokio_rustls::TlsStream::Server(tls_stream),
-                                dst_addr,
                                 src_addr,
+                                dst_addr,
                                 auth_identifier.into(),
                                 expiration_manager,
                             )

--- a/io/zenoh-links/zenoh-link-tls/src/utils.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/utils.rs
@@ -30,7 +30,7 @@ use rustls::{
 use rustls_pki_types::ServerName;
 use secrecy::ExposeSecret;
 use webpki::anchor_from_trusted_cert;
-use zenoh_config::Config as ZenohConfig;
+use zenoh_config::{Config as ZenohConfig, EndPoint};
 use zenoh_link_commons::{
     tcp::TcpSocketConfig, tls::WebPkiVerifierAnyServerName, ConfigurationInspector, BIND_INTERFACE,
     BIND_SOCKET, TCP_SO_RCV_BUF, TCP_SO_SND_BUF,
@@ -273,7 +273,8 @@ impl<'a> TlsServerConfig<'a> {
         };
         let mut bind_socket = None;
         if let Some(bind_socket_str) = config.get(BIND_SOCKET) {
-            bind_socket = Some(SocketAddr::from_str(bind_socket_str)?);
+            let bind_endpoint = EndPoint::new("", bind_socket_str, "", "")?;
+            bind_socket = Some(get_tls_addr(&bind_endpoint.address()).await?);
         };
 
         Ok(TlsServerConfig {
@@ -444,10 +445,10 @@ impl<'a> TlsClientConfig<'a> {
             );
         };
 
-        // TODO: Do we want this option for a TLS Client ?
         let mut bind_socket = None;
         if let Some(bind_socket_str) = config.get(BIND_SOCKET) {
-            bind_socket = Some(SocketAddr::from_str(bind_socket_str)?);
+            let bind_endpoint = EndPoint::new("", bind_socket_str, "", "")?;
+            bind_socket = Some(get_tls_addr(&bind_endpoint.address()).await?);
         };
 
         Ok(TlsClientConfig {

--- a/io/zenoh-links/zenoh-link-tls/src/utils.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/utils.rs
@@ -273,7 +273,7 @@ impl<'a> TlsServerConfig<'a> {
         };
         let mut bind_socket = None;
         if let Some(bind_socket_str) = config.get(BIND_SOCKET) {
-            bind_socket = Some(get_tls_addr(&Address(bind_socket_str)).await?);
+            bind_socket = Some(get_tls_addr(&Address::from(bind_socket_str)).await?);
         };
 
         Ok(TlsServerConfig {
@@ -446,7 +446,7 @@ impl<'a> TlsClientConfig<'a> {
 
         let mut bind_socket = None;
         if let Some(bind_socket_str) = config.get(BIND_SOCKET) {
-            bind_socket = Some(get_tls_addr(&Address(bind_socket_str)).await?);
+            bind_socket = Some(get_tls_addr(&Address::from(bind_socket_str)).await?);
         };
 
         Ok(TlsClientConfig {

--- a/io/zenoh-links/zenoh-link-tls/src/utils.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/utils.rs
@@ -30,7 +30,7 @@ use rustls::{
 use rustls_pki_types::ServerName;
 use secrecy::ExposeSecret;
 use webpki::anchor_from_trusted_cert;
-use zenoh_config::{Config as ZenohConfig, EndPoint};
+use zenoh_config::Config as ZenohConfig;
 use zenoh_link_commons::{
     tcp::TcpSocketConfig, tls::WebPkiVerifierAnyServerName, ConfigurationInspector, BIND_INTERFACE,
     BIND_SOCKET, TCP_SO_RCV_BUF, TCP_SO_SND_BUF,
@@ -273,8 +273,7 @@ impl<'a> TlsServerConfig<'a> {
         };
         let mut bind_socket = None;
         if let Some(bind_socket_str) = config.get(BIND_SOCKET) {
-            let bind_endpoint = EndPoint::new("", bind_socket_str, "", "")?;
-            bind_socket = Some(get_tls_addr(&bind_endpoint.address()).await?);
+            bind_socket = Some(get_tls_addr(&Address(bind_socket_str)).await?);
         };
 
         Ok(TlsServerConfig {
@@ -447,8 +446,7 @@ impl<'a> TlsClientConfig<'a> {
 
         let mut bind_socket = None;
         if let Some(bind_socket_str) = config.get(BIND_SOCKET) {
-            let bind_endpoint = EndPoint::new("", bind_socket_str, "", "")?;
-            bind_socket = Some(get_tls_addr(&bind_endpoint.address()).await?);
+            bind_socket = Some(get_tls_addr(&Address(bind_socket_str)).await?);
         };
 
         Ok(TlsClientConfig {

--- a/io/zenoh-links/zenoh-link-tls/src/utils.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/utils.rs
@@ -33,7 +33,7 @@ use webpki::anchor_from_trusted_cert;
 use zenoh_config::Config as ZenohConfig;
 use zenoh_link_commons::{
     tcp::TcpSocketConfig, tls::WebPkiVerifierAnyServerName, ConfigurationInspector, BIND_INTERFACE,
-    TCP_SO_RCV_BUF, TCP_SO_SND_BUF,
+    BIND_SOCKET, TCP_SO_RCV_BUF, TCP_SO_SND_BUF,
 };
 use zenoh_protocol::core::{
     endpoint::{Address, Config},
@@ -271,6 +271,10 @@ impl<'a> TlsServerConfig<'a> {
                     .map_err(|_| zerror!("Unknown TCP write buffer size argument: {}", size))?,
             );
         };
+        let mut bind_socket = None;
+        if let Some(bind_socket_str) = config.get(BIND_SOCKET) {
+            bind_socket = Some(SocketAddr::from_str(bind_socket_str)?);
+        };
 
         Ok(TlsServerConfig {
             server_config: sc,
@@ -280,6 +284,7 @@ impl<'a> TlsServerConfig<'a> {
                 tcp_tx_buffer_size,
                 tcp_rx_buffer_size,
                 config.get(BIND_INTERFACE),
+                bind_socket,
             ),
         })
     }
@@ -439,6 +444,12 @@ impl<'a> TlsClientConfig<'a> {
             );
         };
 
+        // TODO: Do we want this option for a TLS Client ?
+        let mut bind_socket = None;
+        if let Some(bind_socket_str) = config.get(BIND_SOCKET) {
+            bind_socket = Some(SocketAddr::from_str(bind_socket_str)?);
+        };
+
         Ok(TlsClientConfig {
             client_config: cc,
             tls_close_link_on_expiration,
@@ -446,6 +457,7 @@ impl<'a> TlsClientConfig<'a> {
                 tcp_tx_buffer_size,
                 tcp_rx_buffer_size,
                 config.get(BIND_INTERFACE),
+                bind_socket,
             ),
         })
     }

--- a/io/zenoh-links/zenoh-link-udp/src/multicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/multicast.rs
@@ -15,13 +15,16 @@ use std::{
     borrow::Cow,
     fmt,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    str::FromStr,
     sync::Arc,
 };
 
 use async_trait::async_trait;
 use socket2::{Domain, Protocol, Socket, Type};
 use tokio::net::UdpSocket;
-use zenoh_link_commons::{LinkManagerMulticastTrait, LinkMulticast, LinkMulticastTrait};
+use zenoh_link_commons::{
+    LinkManagerMulticastTrait, LinkMulticast, LinkMulticastTrait, BIND_SOCKET,
+};
 use zenoh_protocol::{
     core::{Config, EndPoint, Locator},
     transport::BatchSize,
@@ -181,35 +184,60 @@ impl LinkManagerMulticastUdp {
         &self,
         mcast_addr: &SocketAddr,
         config: Config<'_>,
+        bind_socket: Option<&str>,
     ) -> ZResult<(UdpSocket, UdpSocket, SocketAddr)> {
         let domain = match mcast_addr.ip() {
             IpAddr::V4(_) => Domain::IPV4,
             IpAddr::V6(_) => Domain::IPV6,
         };
 
-        // Get default iface address to bind the socket on if provided
-        let mut iface_addr: Option<IpAddr> = None;
-        if let Some(iface) = config.get(UDP_MULTICAST_IFACE) {
-            iface_addr = match iface.parse() {
-                Ok(addr) => Some(addr),
-                Err(_) => zenoh_util::net::get_unicast_addresses_of_interface(iface)?
-                    .into_iter()
-                    .filter(|x| match mcast_addr.ip() {
-                        IpAddr::V4(_) => x.is_ipv4(),
-                        IpAddr::V6(_) => x.is_ipv6(),
-                    })
-                    .take(1)
-                    .collect::<Vec<IpAddr>>()
-                    .first()
-                    .copied(),
-            };
-        }
-
         // Get local unicast address to bind the socket on
-        let local_addr = match iface_addr {
-            Some(iface_addr) => iface_addr,
-            None => {
-                let iface = zenoh_util::net::get_unicast_addresses_of_multicast_interfaces()
+        let mut local_addr = if let Some(bind_socket) = bind_socket {
+            let bind_addr = SocketAddr::from_str(bind_socket)?;
+            match (bind_addr, mcast_addr) {
+                (SocketAddr::V6(local), SocketAddr::V4(dest)) => {
+                    return Err(Box::from(format!(
+                        "Protocols must match: Cannot bind to IPv6 {} and join IPv4 {}",
+                        local, dest
+                    )));
+                }
+                (SocketAddr::V4(local), SocketAddr::V6(dest)) => {
+                    return Err(Box::from(format!(
+                        "Protocols must match: Cannot bind to IPv4 {} and join IPv6 {}",
+                        local, dest
+                    )));
+                }
+                _ => bind_addr, // No issue here
+            }
+        } else if mcast_addr.is_ipv4() {
+            SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 0)
+        } else {
+            SocketAddr::new(Ipv6Addr::UNSPECIFIED.into(), 0)
+        };
+        if local_addr.ip() == IpAddr::V4(Ipv4Addr::UNSPECIFIED)
+            || local_addr.ip() == IpAddr::V6(Ipv6Addr::UNSPECIFIED)
+        {
+            // Get default iface address to bind the socket on if provided
+            let mut iface_addr: Option<IpAddr> = None;
+            if let Some(iface) = config.get(UDP_MULTICAST_IFACE) {
+                iface_addr = match iface.parse() {
+                    Ok(addr) => Some(addr),
+                    Err(_) => zenoh_util::net::get_unicast_addresses_of_interface(iface)?
+                        .into_iter()
+                        .filter(|x| match mcast_addr.ip() {
+                            IpAddr::V4(_) => x.is_ipv4(),
+                            IpAddr::V6(_) => x.is_ipv6(),
+                        })
+                        .take(1)
+                        .collect::<Vec<IpAddr>>()
+                        .first()
+                        .copied(),
+                };
+            }
+            if let Some(iface_addr) = iface_addr {
+                local_addr.set_ip(iface_addr);
+            } else if let Some(iface_addr) =
+                zenoh_util::net::get_unicast_addresses_of_multicast_interfaces()
                     .into_iter()
                     .filter(|x| {
                         !x.is_loopback()
@@ -221,28 +249,22 @@ impl LinkManagerMulticastUdp {
                     .take(1)
                     .collect::<Vec<IpAddr>>()
                     .first()
-                    .copied();
-
-                match iface {
-                    Some(iface) => iface,
-                    None => match mcast_addr.ip() {
-                        IpAddr::V4(_) => IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-                        IpAddr::V6(_) => IpAddr::V6(Ipv6Addr::UNSPECIFIED),
-                    },
-                }
+                    .copied()
+            {
+                local_addr.set_ip(iface_addr);
             }
-        };
+        }
 
         // Establish a unicast UDP socket
         let ucast_sock = Socket::new(domain, Type::DGRAM, Some(Protocol::UDP))
             .map_err(|e| zerror!("{}: {}", mcast_addr, e))?;
-        match &local_addr {
+        match &local_addr.ip() {
             IpAddr::V4(addr) => {
                 ucast_sock
                     .set_multicast_if_v4(addr)
                     .map_err(|e| zerror!("{}: {}", mcast_addr, e))?;
             }
-            IpAddr::V6(_) => match zenoh_util::net::get_index_of_interface(local_addr) {
+            IpAddr::V6(_) => match zenoh_util::net::get_index_of_interface(local_addr.ip()) {
                 Ok(idx) => ucast_sock
                     .set_multicast_if_v6(idx)
                     .map_err(|e| zerror!("{}: {}", mcast_addr, e))?,
@@ -251,7 +273,7 @@ impl LinkManagerMulticastUdp {
         }
 
         ucast_sock
-            .bind(&SocketAddr::new(local_addr, 0).into())
+            .bind(&local_addr.into())
             .map_err(|e| zerror!("{}: {}", mcast_addr, e))?;
 
         // Must set to nonblocking according to the doc of tokio
@@ -285,7 +307,7 @@ impl LinkManagerMulticastUdp {
         // Join the multicast group
         let join = config.values(UDP_MULTICAST_JOIN);
         match mcast_addr.ip() {
-            IpAddr::V4(dst_ip4) => match local_addr {
+            IpAddr::V4(dst_ip4) => match local_addr.ip() {
                 IpAddr::V4(src_ip4) => {
                     // Join default multicast group
                     mcast_sock
@@ -327,7 +349,7 @@ impl LinkManagerMulticastUdp {
         let ucast_addr = ucast_sock
             .local_addr()
             .map_err(|e| zerror!("{}: {}", mcast_addr, e))?;
-        assert_eq!(ucast_addr.ip(), local_addr);
+        assert_eq!(ucast_addr.ip(), local_addr.ip());
 
         Ok((mcast_sock, ucast_sock, ucast_addr))
     }
@@ -340,10 +362,15 @@ impl LinkManagerMulticastTrait for LinkManagerMulticastUdp {
             .await?
             .filter(|a| a.ip().is_multicast())
             .collect::<Vec<SocketAddr>>();
+        let config = endpoint.config();
+        let bind_socket = config.get(BIND_SOCKET);
 
         let mut errs: Vec<ZError> = vec![];
         for maddr in mcast_addrs {
-            match self.new_link_inner(&maddr, endpoint.config()).await {
+            match self
+                .new_link_inner(&maddr, endpoint.config(), bind_socket)
+                .await
+            {
                 Ok((mcast_sock, ucast_sock, ucast_addr)) => {
                     let link = Arc::new(LinkMulticastUdp::new(
                         ucast_addr, ucast_sock, maddr, mcast_sock,

--- a/io/zenoh-links/zenoh-link-udp/src/multicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/multicast.rs
@@ -272,7 +272,7 @@ impl LinkManagerMulticastUdp {
                 .map_err(|e| zerror!("{}: {}", mcast_addr, e))?;
         }
 
-        // Bind the socket: let's bing to the unspecified address so we can join and read
+        // Bind the socket: let's bind to the unspecified address so we can join and read
         // from multiple multicast groups.
         let bind_mcast_addr = match mcast_addr.ip() {
             IpAddr::V4(_) => IpAddr::V4(Ipv4Addr::UNSPECIFIED),

--- a/io/zenoh-links/zenoh-link-udp/src/multicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/multicast.rs
@@ -345,7 +345,7 @@ impl LinkManagerMulticastUdp {
 
         // If TTL is specified, add set the socket's TTL
         if let Some(ttl_str) = config.get(UDP_MULTICAST_TTL) {
-            match &local_addr {
+            match &local_addr.ip() {
                 IpAddr::V4(_) => {
                     let ttl = match ttl_str.parse::<u32>() {
                         Ok(ttl) => ttl,

--- a/io/zenoh-links/zenoh-link-udp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/unicast.rs
@@ -285,7 +285,11 @@ impl LinkManagerUnicastUdp {
 
         // Establish a UDP socket
         let socket = UdpSocket::bind(src_socket_addr).await.map_err(|e| {
-            let e = zerror!("Can not create a new UDP link bound to {}: {}", dst_addr, e);
+            let e = zerror!(
+                "Can not create a new UDP link bound to {}: {}",
+                src_socket_addr,
+                e
+            );
             tracing::warn!("{}", e);
             e
         })?;
@@ -296,20 +300,30 @@ impl LinkManagerUnicastUdp {
 
         // Connect the socket to the remote address
         socket.connect(dst_addr).await.map_err(|e| {
-            let e = zerror!("Can not create a new UDP link bound to {}: {}", dst_addr, e);
+            let e = zerror!("Can not connect a new UDP link to {}: {}", dst_addr, e);
             tracing::warn!("{}", e);
             e
         })?;
 
         // Get source and destination UDP addresses
         let src_addr = socket.local_addr().map_err(|e| {
-            let e = zerror!("Can not create a new UDP link bound to {}: {}", dst_addr, e);
+            let e = zerror!(
+                "Can not get local_addr for UDP link bound src {}: to :{} : {}",
+                src_socket_addr,
+                dst_addr,
+                e
+            );
             tracing::warn!("{}", e);
             e
         })?;
 
         let dst_addr = socket.peer_addr().map_err(|e| {
-            let e = zerror!("Can not create a new UDP link bound to {}: {}", dst_addr, e);
+            let e = zerror!(
+                "Can not get peer_addr for UDP link bound src {}: to :{} : {}",
+                src_socket_addr,
+                dst_addr,
+                e
+            );
             tracing::warn!("{}", e);
             e
         })?;

--- a/io/zenoh-links/zenoh-link-udp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/unicast.rs
@@ -276,9 +276,10 @@ impl LinkManagerUnicastUdp {
     ) -> ZResult<(UdpSocket, SocketAddr, SocketAddr)> {
         let src_socket_addr = if let Some(bind_socket) = bind_socket {
             let address = Address::from(bind_socket);
-            get_udp_addrs(address).await?.next().ok_or_else(|| {
-                zerror!("No UDP socket addr found bound to {}", address)
-            })?
+            get_udp_addrs(address)
+                .await?
+                .next()
+                .ok_or_else(|| zerror!("No UDP socket addr found bound to {}", address))?
         } else if dst_addr.is_ipv4() {
             SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 0)
         } else {

--- a/io/zenoh-links/zenoh-link-udp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/unicast.rs
@@ -15,6 +15,7 @@ use std::{
     collections::HashMap,
     fmt,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr},
+    str::FromStr,
     sync::{Arc, Mutex, Weak},
     time::Duration,
 };
@@ -26,6 +27,7 @@ use zenoh_core::{zasynclock, zlock};
 use zenoh_link_commons::{
     get_ip_interface_names, ConstructibleLinkManagerUnicast, LinkAuthId, LinkManagerUnicastTrait,
     LinkUnicast, LinkUnicastTrait, ListenersUnicastIP, NewLinkChannelSender, BIND_INTERFACE,
+    BIND_SOCKET,
 };
 use zenoh_protocol::{
     core::{EndPoint, Locator},
@@ -271,18 +273,18 @@ impl LinkManagerUnicastUdp {
         &self,
         dst_addr: &SocketAddr,
         iface: Option<&str>,
+        bind_socket: Option<&str>,
     ) -> ZResult<(UdpSocket, SocketAddr, SocketAddr)> {
+        let src_socket_addr = if let Some(bind_socket) = bind_socket {
+            SocketAddr::from_str(bind_socket)?
+        } else if dst_addr.is_ipv4() {
+            SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 0)
+        } else {
+            SocketAddr::new(Ipv6Addr::UNSPECIFIED.into(), 0)
+        };
+
         // Establish a UDP socket
-        let socket = UdpSocket::bind(SocketAddr::new(
-            if dst_addr.is_ipv4() {
-                Ipv4Addr::UNSPECIFIED.into()
-            } else {
-                Ipv6Addr::UNSPECIFIED.into()
-            }, // UDP addr
-            0, // UDP port
-        ))
-        .await
-        .map_err(|e| {
+        let socket = UdpSocket::bind(src_socket_addr).await.map_err(|e| {
             let e = zerror!("Can not create a new UDP link bound to {}: {}", dst_addr, e);
             tracing::warn!("{}", e);
             e
@@ -349,10 +351,11 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastUdp {
             .filter(|a| !a.ip().is_multicast());
         let config = endpoint.config();
         let iface = config.get(BIND_INTERFACE);
+        let bind_socket = config.get(BIND_SOCKET);
 
         let mut errs: Vec<ZError> = vec![];
         for da in dst_addrs {
-            match self.new_link_inner(&da, iface).await {
+            match self.new_link_inner(&da, iface, bind_socket).await {
                 Ok((socket, src_addr, dst_addr)) => {
                     // Create UDP link
                     let link = Arc::new(LinkUnicastUdp::new(

--- a/io/zenoh-links/zenoh-link-udp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/unicast.rs
@@ -29,7 +29,7 @@ use zenoh_link_commons::{
     BIND_SOCKET,
 };
 use zenoh_protocol::{
-    core::{EndPoint, Locator},
+    core::{Address, EndPoint, Locator},
     transport::BatchSize,
 };
 use zenoh_result::{bail, zerror, Error as ZError, ZResult};
@@ -275,13 +275,10 @@ impl LinkManagerUnicastUdp {
         bind_socket: Option<&str>,
     ) -> ZResult<(UdpSocket, SocketAddr, SocketAddr)> {
         let src_socket_addr = if let Some(bind_socket) = bind_socket {
-            let endpoint = EndPoint::new("", bind_socket, "", "")?;
-            get_udp_addrs(endpoint.address())
-                .await?
-                .next()
-                .ok_or_else(|| {
-                    zerror!("No UDP socket addr found bound to {}", endpoint.address())
-                })?
+            let address = Address::from(bind_socket);
+            get_udp_addrs(address).await?.next().ok_or_else(|| {
+                zerror!("No UDP socket addr found bound to {}", address)
+            })?
         } else if dst_addr.is_ipv4() {
             SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 0)
         } else {

--- a/io/zenoh-links/zenoh-link-udp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/unicast.rs
@@ -280,10 +280,7 @@ impl LinkManagerUnicastUdp {
                 .await?
                 .next()
                 .ok_or_else(|| {
-                    zerror!(
-                        "No UDP socket addr found bound to {}",
-                        endpoint.address()
-                    )
+                    zerror!("No UDP socket addr found bound to {}", endpoint.address())
                 })?
         } else if dst_addr.is_ipv4() {
             SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 0)
@@ -373,6 +370,15 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastUdp {
             .filter(|a| !a.ip().is_multicast());
         let config = endpoint.config();
         let iface = config.get(BIND_INTERFACE);
+
+        if let (Some(_), Some(_)) = (config.get(BIND_INTERFACE), config.get(BIND_SOCKET)) {
+            bail!(
+                "Using Config options `iface` and `bind` in conjunction is unsupported at this time {} {:?}",
+                BIND_INTERFACE,
+                BIND_SOCKET
+            )
+        }
+
         let bind_socket = config.get(BIND_SOCKET);
 
         let mut errs: Vec<ZError> = vec![];

--- a/io/zenoh-transport/tests/unicast_bind.rs
+++ b/io/zenoh-transport/tests/unicast_bind.rs
@@ -436,7 +436,7 @@ async fn openclose_tls_only_connect_with_bind_restriction() {
     openclose_transport(&listen_endpoint, &connect_endpoint, false).await;
 }
 
-#[cfg(all(any(feature = "transport_tls", feature = "transport_quic"),))]
+#[cfg(any(feature = "transport_tls", feature = "transport_quic"))]
 const CLIENT_KEY: &str = "-----BEGIN RSA PRIVATE KEY-----
 MIIEpAIBAAKCAQEAsfqAuhElN4HnyeqLovSd4Qe+nNv5AwCjSO+HFiF30x3vQ1Hi
 qRA0UmyFlSqBnFH3TUHm4Jcad40QfrX8f11NKGZdpvKHsMYqYjZnYkRFGS2s4fQy
@@ -465,7 +465,7 @@ tYsqC2FtWzY51VOEKNpnfH7zH5n+bjoI9nAEAW63TK9ZKkr2hRGsDhJdGzmLfQ7v
 F6/CuIw9EsAq6qIB8O88FXQqald+BZOx6AzB8Oedsz/WtMmIEmr/+Q==
 -----END RSA PRIVATE KEY-----";
 
-#[cfg(all(any(feature = "transport_tls", feature = "transport_quic"),))]
+#[cfg(any(feature = "transport_tls", feature = "transport_quic"))]
 const CLIENT_CERT: &str = "-----BEGIN CERTIFICATE-----
 MIIDLjCCAhagAwIBAgIIeUtmIdFQznMwDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
 AxMVbWluaWNhIHJvb3QgY2EgMDc4ZGE3MCAXDTIzMDMwNjE2MDMxOFoYDzIxMjMw
@@ -487,7 +487,7 @@ p5e60QweRuJsb60aUaCG8HoICevXYK2fFqCQdlb5sIqQqXyN2K6HuKAFywsjsGyJ
 abY=
 -----END CERTIFICATE-----";
 
-#[cfg(all(any(feature = "transport_tls", feature = "transport_quic"),))]
+#[cfg(any(feature = "transport_tls", feature = "transport_quic"))]
 const CLIENT_CA: &str = "-----BEGIN CERTIFICATE-----
 MIIDSzCCAjOgAwIBAgIIB42n1ZIkOakwDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
 AxMVbWluaWNhIHJvb3QgY2EgMDc4ZGE3MCAXDTIzMDMwNjE2MDMwN1oYDzIxMjMw

--- a/io/zenoh-transport/tests/unicast_bind.rs
+++ b/io/zenoh-transport/tests/unicast_bind.rs
@@ -131,9 +131,9 @@ async fn openclose_transport<'a>(
     /* [1] */
     println!("\nTransport Open Close [1a1]");
     // Add the locator on the router
-    let res = ztimeout!(router_manager.add_listener(listen_endpoint.clone()));
-    println!("Transport Open Close [1a1]: {res:?}");
-    assert!(res.is_ok());
+    let router_res = ztimeout!(router_manager.add_listener(listen_endpoint.clone()));
+    println!("Transport Open Close [1a1]: {router_res:?}");
+    assert!(router_res.is_ok());
     println!("Transport Open Close [1a2]");
     let locators = ztimeout!(router_manager.get_listeners());
     println!("Transport Open Close [1a2]: {locators:?}");
@@ -179,7 +179,9 @@ async fn openclose_transport<'a>(
         }
     });
 
-    // Check link on each side
+    // Check link on each side of connection
+    // Expect Client to be bound to bind_addr
+    // Expect Router to connect to bind_addr as foreign link
     println!("Transport Open Close [1f2]");
     ztimeout!(async {
         let router_transports = ztimeout!(router_manager.get_transports_unicast());
@@ -197,11 +199,12 @@ async fn openclose_transport<'a>(
                 let router_links = r_to_c_tx.get_links().unwrap();
                 let client_links = c_to_r_tx.get_links().unwrap();
 
-                println!("Transport Open Close [1f2]: {res:?}");
+                println!("Transport Open Close [1f2]: {router_res:?}");
+                println!("Router src {:?}", router_links[0].src);
                 println!("Router dst {:?}", router_links[0].dst);
                 println!("Client src {:?}", client_links[0].src);
+                println!("Client dst {:?}", client_links[0].dst);
                 println!("Bind Addr {:?}", bind_addr);
-
                 assert!(router_links[0].dst == client_links[0].src);
                 assert!(router_links[0].dst.address() == *bind_addr);
                 assert!(client_links[0].src.address() == *bind_addr);
@@ -436,7 +439,7 @@ async fn openclose_tls_only_connect_with_bind_restriction() {
     use zenoh_link::tls::config::*;
 
     zenoh_util::init_log_from_env_or("error");
-    let bind_addr_str = format!("127.0.0.1:{}", 13012);
+    let bind_addr_str = format!("127.0.0.1:{}", 13014);
     let bind_addr = Address::from(bind_addr_str.as_str());
 
     let client_auth = "true";

--- a/io/zenoh-transport/tests/unicast_bind.rs
+++ b/io/zenoh-transport/tests/unicast_bind.rs
@@ -280,6 +280,31 @@ async fn openclose_tcp_only_connect_with_bind_restriction_mismatch_protocols() {
     openclose_transport(&listen_endpoint, &connect_endpoint, false).await;
 }
 
+
+#[cfg(feature = "transport_udp")]
+#[should_panic(expected = "assertion failed: open_res.is_ok()")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn openclose_udp_only_connect_with_bind_restriction_mismatch_protocols() {
+    use zenoh_util::net::get_ipv6_ipaddrs;
+
+    let addrs = get_ipv4_ipaddrs(None);
+    let addrs_v6 = get_ipv6_ipaddrs(None);
+
+    zenoh_util::init_log_from_env_or("error");
+
+    let listen_endpoint: EndPoint = format!("udp/{}:{}", addrs[0], 13005).parse().unwrap();
+
+    // Bind to different port on same IP address
+    let connect_endpoint: EndPoint =
+        format!("udp/{}:{}#bind={}:{}", addrs[0], 13005, addrs_v6[0], 13006)
+            .parse()
+            .unwrap();
+
+    // should not connect to local interface and external address
+    openclose_transport(&listen_endpoint, &connect_endpoint, false).await;
+}
+
+
 #[cfg(feature = "transport_udp")]
 #[should_panic(expected = "assertion failed: open_res.is_ok()")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/io/zenoh-transport/tests/unicast_bind.rs
+++ b/io/zenoh-transport/tests/unicast_bind.rs
@@ -280,7 +280,6 @@ async fn openclose_tcp_only_connect_with_bind_restriction_mismatch_protocols() {
     openclose_transport(&listen_endpoint, &connect_endpoint, false).await;
 }
 
-
 #[cfg(feature = "transport_udp")]
 #[should_panic(expected = "assertion failed: open_res.is_ok()")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -303,7 +302,6 @@ async fn openclose_udp_only_connect_with_bind_restriction_mismatch_protocols() {
     // should not connect to local interface and external address
     openclose_transport(&listen_endpoint, &connect_endpoint, false).await;
 }
-
 
 #[cfg(feature = "transport_udp")]
 #[should_panic(expected = "assertion failed: open_res.is_ok()")]

--- a/io/zenoh-transport/tests/unicast_bind.rs
+++ b/io/zenoh-transport/tests/unicast_bind.rs
@@ -327,7 +327,7 @@ async fn openclose_udp_only_connect_with_bind_restriction() {
 
 #[cfg(feature = "transport_quic")]
 #[cfg(target_os = "linux")]
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+// #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn openclose_quic_only_connect_with_bind_restriction() {
     use zenoh_link::quic::config::*;
 
@@ -335,7 +335,7 @@ async fn openclose_quic_only_connect_with_bind_restriction() {
     let addrs = get_ipv4_ipaddrs(None);
     let (ca, cert, key) = get_tls_certs();
 
-    let mut listen_endpoint: EndPoint = format!("quic/{}:{}", addrs[0], 130011).parse().unwrap();
+    let mut listen_endpoint: EndPoint = format!("quic/{}:{}", addrs[0], 13011).parse().unwrap();
     listen_endpoint
         .config_mut()
         .extend_from_iter(
@@ -350,7 +350,7 @@ async fn openclose_quic_only_connect_with_bind_restriction() {
         .unwrap();
 
     let connect_endpoint: EndPoint =
-        format!("quic/{}:{}#bind={}:{}", addrs[0], 130011, addrs[0], 130012)
+        format!("quic/{}:{}#bind={}:{}", addrs[0], 13011, addrs[0], 13012)
             .parse()
             .unwrap();
 
@@ -361,7 +361,7 @@ async fn openclose_quic_only_connect_with_bind_restriction() {
 #[cfg(feature = "transport_tls")]
 #[cfg(target_os = "linux")]
 #[should_panic(expected = "Elapsed")]
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+// #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn openclose_tls_only_connect_with_bind_restriction() {
     use zenoh_link::tls::config::*;
 

--- a/io/zenoh-transport/tests/unicast_bind.rs
+++ b/io/zenoh-transport/tests/unicast_bind.rs
@@ -317,7 +317,7 @@ async fn openclose_udp_only_connect_with_bind_restriction() {
     let listen_endpoint: EndPoint = format!("udp/{}:{}", addrs[0], 13009).parse().unwrap();
 
     let connect_endpoint: EndPoint =
-        format!("udp/{}:{}bind={}:{}", addrs[0], 13009, addrs[0], 13010)
+        format!("udp/{}:{}#bind={}:{}", addrs[0], 13009, addrs[0], 13010)
             .parse()
             .unwrap();
 

--- a/io/zenoh-transport/tests/unicast_bind.rs
+++ b/io/zenoh-transport/tests/unicast_bind.rs
@@ -1,0 +1,356 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+use std::{convert::TryFrom, sync::Arc, time::Duration};
+
+use zenoh_core::ztimeout;
+use zenoh_link::EndPoint;
+use zenoh_protocol::core::{WhatAmI, ZenohIdProto};
+use zenoh_result::ZResult;
+use zenoh_transport::{
+    multicast::TransportMulticast,
+    unicast::{test_helpers::make_transport_manager_builder, TransportUnicast},
+    DummyTransportPeerEventHandler, TransportEventHandler, TransportManager,
+    TransportMulticastEventHandler, TransportPeer, TransportPeerEventHandler,
+};
+#[cfg(target_os = "linux")]
+#[cfg(any(feature = "transport_tcp", feature = "transport_udp"))]
+use zenoh_util::net::get_ipv4_ipaddrs;
+
+const TIMEOUT: Duration = Duration::from_secs(60);
+const TIMEOUT_EXPECTED: Duration = Duration::from_secs(5);
+const SLEEP: Duration = Duration::from_millis(100);
+
+macro_rules! ztimeout_expected {
+    ($f:expr) => {
+        tokio::time::timeout(TIMEOUT_EXPECTED, $f).await.unwrap()
+    };
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct SHRouterOpenClose;
+
+impl TransportEventHandler for SHRouterOpenClose {
+    fn new_unicast(
+        &self,
+        _peer: TransportPeer,
+        _transport: TransportUnicast,
+    ) -> ZResult<Arc<dyn TransportPeerEventHandler>> {
+        Ok(Arc::new(DummyTransportPeerEventHandler))
+    }
+
+    fn new_multicast(
+        &self,
+        _transport: TransportMulticast,
+    ) -> ZResult<Arc<dyn TransportMulticastEventHandler>> {
+        panic!();
+    }
+}
+
+// Transport Handler for the client
+struct SHClientOpenClose {}
+
+impl SHClientOpenClose {
+    fn new() -> Self {
+        Self {}
+    }
+}
+
+impl TransportEventHandler for SHClientOpenClose {
+    fn new_unicast(
+        &self,
+        _peer: TransportPeer,
+        _transport: TransportUnicast,
+    ) -> ZResult<Arc<dyn TransportPeerEventHandler>> {
+        Ok(Arc::new(DummyTransportPeerEventHandler))
+    }
+
+    fn new_multicast(
+        &self,
+        _transport: TransportMulticast,
+    ) -> ZResult<Arc<dyn TransportMulticastEventHandler>> {
+        panic!();
+    }
+}
+
+async fn openclose_transport(
+    listen_endpoint: &EndPoint,
+    connect_endpoint: &EndPoint,
+    lowlatency_transport: bool,
+) {
+    /* [ROUTER] */
+    let router_id = ZenohIdProto::try_from([1]).unwrap();
+
+    let router_handler = Arc::new(SHRouterOpenClose);
+    // Create the router transport manager
+    let unicast = make_transport_manager_builder(
+        #[cfg(feature = "transport_multilink")]
+        2,
+        #[cfg(feature = "shared-memory")]
+        false,
+        lowlatency_transport,
+    )
+    .max_sessions(1);
+    let router_manager = TransportManager::builder()
+        .whatami(WhatAmI::Router)
+        .zid(router_id)
+        .unicast(unicast)
+        .build(router_handler.clone())
+        .unwrap();
+
+    /* [CLIENT] */
+    let client01_id = ZenohIdProto::try_from([2]).unwrap();
+    let client02_id = ZenohIdProto::try_from([3]).unwrap();
+
+    // Create the transport transport manager for the first client
+    let unicast = make_transport_manager_builder(
+        #[cfg(feature = "transport_multilink")]
+        2,
+        #[cfg(feature = "shared-memory")]
+        false,
+        lowlatency_transport,
+    )
+    .max_sessions(1);
+    let client01_manager = TransportManager::builder()
+        .whatami(WhatAmI::Client)
+        .zid(client01_id)
+        .unicast(unicast)
+        .build(Arc::new(SHClientOpenClose::new()))
+        .unwrap();
+
+    // Create the transport transport manager for the second client
+    let unicast = make_transport_manager_builder(
+        #[cfg(feature = "transport_multilink")]
+        1,
+        #[cfg(feature = "shared-memory")]
+        false,
+        lowlatency_transport,
+    )
+    .max_sessions(1);
+    let client02_manager = TransportManager::builder()
+        .whatami(WhatAmI::Client)
+        .zid(client02_id)
+        .unicast(unicast)
+        .build(Arc::new(SHClientOpenClose::new()))
+        .unwrap();
+
+    /* [1] */
+    println!("\nTransport Open Close [1a1]");
+    // Add the locator on the router
+    let res = ztimeout!(router_manager.add_listener(listen_endpoint.clone()));
+    println!("Transport Open Close [1a1]: {res:?}");
+    assert!(res.is_ok());
+    println!("Transport Open Close [1a2]");
+    let locators = ztimeout!(router_manager.get_listeners());
+    println!("Transport Open Close [1a2]: {locators:?}");
+    assert_eq!(locators.len(), 1);
+
+    // Open a first transport from the client to the router
+    // -> This should be accepted
+    let links_num = 1;
+
+    println!("Transport Open Close [1c1]");
+    let open_res =
+        ztimeout_expected!(client01_manager.open_transport_unicast(connect_endpoint.clone()));
+    println!("Transport Open Close [1c2]: {open_res:?}");
+    assert!(open_res.is_ok());
+    let c_ses1 = open_res.unwrap();
+    println!("Transport Open Close [1d1]");
+    let transports = ztimeout!(client01_manager.get_transports_unicast());
+    println!("Transport Open Close [1d2]: {transports:?}");
+    assert_eq!(transports.len(), 1);
+    assert_eq!(c_ses1.get_zid().unwrap(), router_id);
+    println!("Transport Open Close [1e1]");
+    let links = c_ses1.get_links().unwrap();
+    println!("Transport Open Close [1e2]: {links:?}");
+    assert_eq!(links.len(), links_num);
+
+    // Verify that the transport has been open on the router
+    println!("Transport Open Close [1f1]");
+    ztimeout!(async {
+        loop {
+            let transports = ztimeout!(router_manager.get_transports_unicast());
+            let s = transports
+                .iter()
+                .find(|s| s.get_zid().unwrap() == client01_id);
+
+            match s {
+                Some(s) => {
+                    let links = s.get_links().unwrap();
+                    assert_eq!(links.len(), links_num);
+                    break;
+                }
+                None => tokio::time::sleep(SLEEP).await,
+            }
+        }
+    });
+
+    /* [2] */
+    // Close the open transport on the client
+    println!("\nTransport Open Close [2a1]");
+    let res = ztimeout!(c_ses1.close());
+    println!("Transport Open Close [2a2]: {res:?}");
+    assert!(res.is_ok());
+    println!("Transport Open Close [2b1]");
+    let transports = ztimeout!(client01_manager.get_transports_unicast());
+    println!("Transport Open Close [2b2]: {transports:?}");
+    assert_eq!(transports.len(), 0);
+
+    // Verify that the transport has been closed also on the router
+    println!("Transport Open Close [2c1]");
+    ztimeout!(async {
+        loop {
+            let transports = ztimeout!(router_manager.get_transports_unicast());
+            let index = transports
+                .iter()
+                .find(|s| s.get_zid().unwrap() == client01_id);
+            if index.is_none() {
+                break;
+            }
+            tokio::time::sleep(SLEEP).await;
+        }
+    });
+
+    // Wait a little bit
+    tokio::time::sleep(SLEEP).await;
+
+    ztimeout!(router_manager.close());
+    ztimeout!(client01_manager.close());
+    ztimeout!(client02_manager.close());
+
+    // Wait a little bit
+    tokio::time::sleep(SLEEP).await;
+}
+
+#[cfg(feature = "transport_tcp")]
+#[cfg(target_os = "linux")]
+#[should_panic(expected = "assertion failed: open_res.is_ok()")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn openclose_tcp_only_connect_with_bind_and_interface() {
+    let addrs = get_ipv4_ipaddrs(None);
+
+    zenoh_util::init_log_from_env_or("error");
+
+    let listen_endpoint: EndPoint = format!("tcp/{}:{}", addrs[0], 13001).parse().unwrap();
+
+    // declaring `bind` and `iface` simultaneously should be unsupported, and there for fail
+    let connect_endpoint: EndPoint = format!(
+        "tcp/{}:{}#iface=lo;bind={}:{}",
+        addrs[0], 13001, addrs[0], 13002
+    )
+    .parse()
+    .unwrap();
+
+    // should not connect to local interface and external address
+    openclose_transport(&listen_endpoint, &connect_endpoint, false).await;
+}
+
+#[cfg(feature = "transport_tcp")]
+#[cfg(target_os = "linux")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn openclose_tcp_only_connect_with_bind_restriction() {
+    let addrs = get_ipv4_ipaddrs(None);
+
+    zenoh_util::init_log_from_env_or("error");
+
+    let listen_endpoint: EndPoint = format!("tcp/{}:{}", addrs[0], 13003).parse().unwrap();
+
+    // Bind to different port on same IP address
+    let connect_endpoint: EndPoint =
+        format!("tcp/{}:{}#bind={}:{}", addrs[0], 13003, addrs[0], 13009)
+            .parse()
+            .unwrap();
+
+    // should not connect to local interface and external address
+    openclose_transport(&listen_endpoint, &connect_endpoint, false).await;
+}
+
+fn get_tls_certs() -> (&'static str, &'static str, &'static str) {
+    // NOTE: this an auto-generated pair of certificate and key.
+    //       The target domain is localhost, so it has no real
+    //       mapping to any existing domain. The certificate and key
+    //       have been generated using: https://github.com/jsha/minica
+    let key = "-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAsfqAuhElN4HnyeqLovSd4Qe+nNv5AwCjSO+HFiF30x3vQ1Hi
+qRA0UmyFlSqBnFH3TUHm4Jcad40QfrX8f11NKGZdpvKHsMYqYjZnYkRFGS2s4fQy
+aDbV5M06s3UDX8ETPgY41Y8fCKTSVdi9iHkwcVrXMxUu4IBBx0C1r2GSo3gkIBnU
+cELdFdaUOSbdCipJhbnkwixEr2h7PXxwba7SIZgZtRaQWak1VE9b716qe3iMuMha
+Efo/UoFmeZCPu5spfwaOZsnCsxRPk2IjbzlsHTJ09lM9wmbEFHBMVAXejLTk++Sr
+Xt8jASZhNen/2GzyLQNAquGn98lCMQ6SsE9vLQIDAQABAoIBAGQkKggHm6Q20L+4
+2+bNsoOqguLplpvM4RMpyx11qWE9h6GeUmWD+5yg+SysJQ9aw0ZSHWEjRD4ePji9
+lxvm2IIxzuIftp+NcM2gBN2ywhpfq9XbO/2NVR6PJ0dQQJzBG12bzKDFDdYkP0EU
+WdiPL+WoEkvo0F57bAd77n6G7SZSgxYekBF+5S6rjbu5I1cEKW+r2vLehD4uFCVX
+Q0Tu7TyIOE1KJ2anRb7ZXVUaguNj0/Er7EDT1+wN8KJKvQ1tYGIq/UUBtkP9nkOI
+9XJd25k6m5AQPDddzd4W6/5+M7kjyVPi3CsQcpBPss6ueyecZOMaKqdWAHeEyaak
+r67TofUCgYEA6GBa+YkRvp0Ept8cd5mh4gCRM8wUuhtzTQnhubCPivy/QqMWScdn
+qD0OiARLAsqeoIfkAVgyqebVnxwTrKTvWe0JwpGylEVWQtpGz3oHgjST47yZxIiY
+CSAaimi2CYnJZ+QB2oBkFVwNCuXdPEGX6LgnOGva19UKrm6ONsy6V9MCgYEAxBJu
+fu4dGXZreARKEHa/7SQjI9ayAFuACFlON/EgSlICzQyG/pumv1FsMEiFrv6w7PRj
+4AGqzyzGKXWVDRMrUNVeGPSKJSmlPGNqXfPaXRpVEeB7UQhAs5wyMrWDl8jEW7Ih
+XcWhMLn1f/NOAKyrSDSEaEM+Nuu+xTifoAghvP8CgYEAlta9Fw+nihDIjT10cBo0
+38w4dOP7bFcXQCGy+WMnujOYPzw34opiue1wOlB3FIfL8i5jjY/fyzPA5PhHuSCT
+Ec9xL3B9+AsOFHU108XFi/pvKTwqoE1+SyYgtEmGKKjdKOfzYA9JaCgJe1J8inmV
+jwXCx7gTJVjwBwxSmjXIm+sCgYBQF8NhQD1M0G3YCdCDZy7BXRippCL0OGxVfL2R
+5oKtOVEBl9NxH/3+evE5y/Yn5Mw7Dx3ZPHUcygpslyZ6v9Da5T3Z7dKcmaVwxJ+H
+n3wcugv0EIHvOPLNK8npovINR6rGVj6BAqD0uZHKYYYEioQxK5rGyGkaoDQ+dgHm
+qku12wKBgQDem5FvNp5iW7mufkPZMqf3sEGtu612QeqejIPFM1z7VkUgetsgPBXD
+tYsqC2FtWzY51VOEKNpnfH7zH5n+bjoI9nAEAW63TK9ZKkr2hRGsDhJdGzmLfQ7v
+F6/CuIw9EsAq6qIB8O88FXQqald+BZOx6AzB8Oedsz/WtMmIEmr/+Q==
+-----END RSA PRIVATE KEY-----";
+
+    let cert = "-----BEGIN CERTIFICATE-----
+MIIDLjCCAhagAwIBAgIIeUtmIdFQznMwDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
+AxMVbWluaWNhIHJvb3QgY2EgMDc4ZGE3MCAXDTIzMDMwNjE2MDMxOFoYDzIxMjMw
+MzA2MTYwMzE4WjAUMRIwEAYDVQQDEwlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQCx+oC6ESU3gefJ6oui9J3hB76c2/kDAKNI74cWIXfT
+He9DUeKpEDRSbIWVKoGcUfdNQebglxp3jRB+tfx/XU0oZl2m8oewxipiNmdiREUZ
+Lazh9DJoNtXkzTqzdQNfwRM+BjjVjx8IpNJV2L2IeTBxWtczFS7ggEHHQLWvYZKj
+eCQgGdRwQt0V1pQ5Jt0KKkmFueTCLESvaHs9fHBtrtIhmBm1FpBZqTVUT1vvXqp7
+eIy4yFoR+j9SgWZ5kI+7myl/Bo5mycKzFE+TYiNvOWwdMnT2Uz3CZsQUcExUBd6M
+tOT75Kte3yMBJmE16f/YbPItA0Cq4af3yUIxDpKwT28tAgMBAAGjdjB0MA4GA1Ud
+DwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDAYDVR0T
+AQH/BAIwADAfBgNVHSMEGDAWgBTWfAmQ/BUIQm/9/llJJs2jUMWzGzAUBgNVHREE
+DTALgglsb2NhbGhvc3QwDQYJKoZIhvcNAQELBQADggEBAG/POnBob0S7iYwsbtI2
+3LTTbRnmseIErtJuJmI9yYzgVIm6sUSKhlIUfAIm4rfRuzE94KFeWR2w9RabxOJD
+wjYLLKvQ6rFY5g2AV/J0TwDjYuq0absdaDPZ8MKJ+/lpGYK3Te+CTOfq5FJRFt1q
+GOkXAxnNpGg0obeRWRKFiAMHbcw6a8LIMfRjCooo3+uSQGsbVzGxSB4CYo720KcC
+9vB1K9XALwzoqCewP4aiQsMY1GWpAmzXJftY3w+lka0e9dBYcdEdOqxSoZb5OBBZ
+p5e60QweRuJsb60aUaCG8HoICevXYK2fFqCQdlb5sIqQqXyN2K6HuKAFywsjsGyJ
+abY=
+-----END CERTIFICATE-----";
+
+    // Configure the client
+    let ca = "-----BEGIN CERTIFICATE-----
+MIIDSzCCAjOgAwIBAgIIB42n1ZIkOakwDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
+AxMVbWluaWNhIHJvb3QgY2EgMDc4ZGE3MCAXDTIzMDMwNjE2MDMwN1oYDzIxMjMw
+MzA2MTYwMzA3WjAgMR4wHAYDVQQDExVtaW5pY2Egcm9vdCBjYSAwNzhkYTcwggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIuCq24O4P4Aep5vAVlrIQ7P8+
+uWWgcHIFYa02TmhBUB/hjo0JANCQvAtpVNuQ8NyKPlqnnq1cttePbSYVeA0rrnOs
+DcfySAiyGBEY9zMjFfHJtH1wtrPcJEU8XIEY3xUlrAJE2CEuV9dVYgfEEydnvgLc
+8Ug0WXSiARjqbnMW3l8jh6bYCp/UpL/gSM4mxdKrgpfyPoweGhlOWXc3RTS7cqM9
+T25acURGOSI6/g8GF0sNE4VZmUvHggSTmsbLeXMJzxDWO+xVehRmbQx3IkG7u++b
+QdRwGIJcDNn7zHlDMHtQ0Z1DBV94fZNBwCULhCBB5g20XTGw//S7Fj2FPwyhAgMB
+AAGjgYYwgYMwDgYDVR0PAQH/BAQDAgKEMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggr
+BgEFBQcDAjASBgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBTWfAmQ/BUIQm/9
+/llJJs2jUMWzGzAfBgNVHSMEGDAWgBTWfAmQ/BUIQm/9/llJJs2jUMWzGzANBgkq
+hkiG9w0BAQsFAAOCAQEAvtcZFAELKiTuOiAeYts6zeKxc+nnHCzayDeD/BDCbxGJ
+e1n+xdHjLtWGd+/Anc+fvftSYBPTFQqCi84lPiUIln5z/rUxE+ke81hNPIfw2obc
+yIg87xCabQpVyEh8s+MV+7YPQ1+fH4FuSi2Fck1FejxkVqN2uOZPvOYUmSTsaVr1
+8SfRnwJNZ9UMRPM2bD4Jkvj0VcL42JM3QkOClOzYW4j/vll2cSs4kx7er27cIoo1
+Ck0v2xSPAiVjg6w65rUQeW6uB5m0T2wyj+wm0At8vzhZPlgS1fKhcmT2dzOq3+oN
+R+IdLiXcyIkg0m9N8I17p0ljCSkbrgGMD3bbePRTfg==
+-----END CERTIFICATE-----";
+
+    (ca, cert, key)
+}

--- a/io/zenoh-transport/tests/unicast_bind.rs
+++ b/io/zenoh-transport/tests/unicast_bind.rs
@@ -83,10 +83,10 @@ impl TransportEventHandler for SHClientOpenClose {
     }
 }
 
-async fn openclose_transport<'a>(
+async fn openclose_transport(
     listen_endpoint: &EndPoint,
     connect_endpoint: &EndPoint,
-    bind_addr: &Address<'a>,
+    bind_addr: &Address<'_>,
     lowlatency_transport: bool,
 ) {
     /* [ROUTER] */

--- a/io/zenoh-transport/tests/unicast_bind.rs
+++ b/io/zenoh-transport/tests/unicast_bind.rs
@@ -23,7 +23,6 @@ use zenoh_transport::{
     DummyTransportPeerEventHandler, TransportEventHandler, TransportManager,
     TransportMulticastEventHandler, TransportPeer, TransportPeerEventHandler,
 };
-#[cfg(target_os = "linux")]
 #[cfg(any(feature = "transport_tcp", feature = "transport_udp"))]
 use zenoh_util::net::get_ipv4_ipaddrs;
 
@@ -216,7 +215,6 @@ async fn openclose_transport(
 }
 
 #[cfg(feature = "transport_tcp")]
-#[cfg(target_os = "linux")]
 #[should_panic(expected = "assertion failed: open_res.is_ok()")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn openclose_tcp_only_connect_with_bind_and_interface() {
@@ -239,7 +237,6 @@ async fn openclose_tcp_only_connect_with_bind_and_interface() {
 }
 
 #[cfg(feature = "transport_tcp")]
-#[cfg(target_os = "linux")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn openclose_tcp_only_connect_with_bind_restriction() {
     let addrs = get_ipv4_ipaddrs(None);
@@ -261,7 +258,6 @@ async fn openclose_tcp_only_connect_with_bind_restriction() {
 }
 
 #[cfg(feature = "transport_tcp")]
-#[cfg(target_os = "linux")]
 #[should_panic(expected = "assertion failed: open_res.is_ok()")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn openclose_tcp_only_connect_with_bind_restriction_mismatch_protocols() {
@@ -285,7 +281,6 @@ async fn openclose_tcp_only_connect_with_bind_restriction_mismatch_protocols() {
 }
 
 #[cfg(feature = "transport_udp")]
-#[cfg(target_os = "linux")]
 #[should_panic(expected = "assertion failed: open_res.is_ok()")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn openclose_udp_only_connect_with_bind_and_interface() {
@@ -307,7 +302,6 @@ async fn openclose_udp_only_connect_with_bind_and_interface() {
 }
 
 #[cfg(feature = "transport_udp")]
-#[cfg(target_os = "linux")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn openclose_udp_only_connect_with_bind_restriction() {
     let addrs = get_ipv4_ipaddrs(None);
@@ -326,7 +320,6 @@ async fn openclose_udp_only_connect_with_bind_restriction() {
 }
 
 #[cfg(feature = "transport_quic")]
-#[cfg(target_os = "linux")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn openclose_quic_only_connect_with_bind_restriction() {
     use zenoh_link::quic::config::*;
@@ -374,7 +367,6 @@ async fn openclose_quic_only_connect_with_bind_restriction() {
 }
 
 #[cfg(feature = "transport_tls")]
-#[cfg(target_os = "linux")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn openclose_tls_only_connect_with_bind_restriction() {
     use zenoh_link::tls::config::*;

--- a/io/zenoh-transport/tests/unicast_bind.rs
+++ b/io/zenoh-transport/tests/unicast_bind.rs
@@ -436,10 +436,7 @@ async fn openclose_tls_only_connect_with_bind_restriction() {
     openclose_transport(&listen_endpoint, &connect_endpoint, false).await;
 }
 
-#[cfg(all(
-    any(feature = "transport_tls", feature = "transport_quic"),
-    target_family = "unix"
-))]
+#[cfg(all(any(feature = "transport_tls", feature = "transport_quic"),))]
 const CLIENT_KEY: &str = "-----BEGIN RSA PRIVATE KEY-----
 MIIEpAIBAAKCAQEAsfqAuhElN4HnyeqLovSd4Qe+nNv5AwCjSO+HFiF30x3vQ1Hi
 qRA0UmyFlSqBnFH3TUHm4Jcad40QfrX8f11NKGZdpvKHsMYqYjZnYkRFGS2s4fQy
@@ -468,10 +465,7 @@ tYsqC2FtWzY51VOEKNpnfH7zH5n+bjoI9nAEAW63TK9ZKkr2hRGsDhJdGzmLfQ7v
 F6/CuIw9EsAq6qIB8O88FXQqald+BZOx6AzB8Oedsz/WtMmIEmr/+Q==
 -----END RSA PRIVATE KEY-----";
 
-#[cfg(all(
-    any(feature = "transport_tls", feature = "transport_quic"),
-    target_family = "unix"
-))]
+#[cfg(all(any(feature = "transport_tls", feature = "transport_quic"),))]
 const CLIENT_CERT: &str = "-----BEGIN CERTIFICATE-----
 MIIDLjCCAhagAwIBAgIIeUtmIdFQznMwDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
 AxMVbWluaWNhIHJvb3QgY2EgMDc4ZGE3MCAXDTIzMDMwNjE2MDMxOFoYDzIxMjMw
@@ -493,10 +487,7 @@ p5e60QweRuJsb60aUaCG8HoICevXYK2fFqCQdlb5sIqQqXyN2K6HuKAFywsjsGyJ
 abY=
 -----END CERTIFICATE-----";
 
-#[cfg(all(
-    any(feature = "transport_tls", feature = "transport_quic"),
-    target_family = "unix"
-))]
+#[cfg(all(any(feature = "transport_tls", feature = "transport_quic"),))]
 const CLIENT_CA: &str = "-----BEGIN CERTIFICATE-----
 MIIDSzCCAjOgAwIBAgIIB42n1ZIkOakwDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
 AxMVbWluaWNhIHJvb3QgY2EgMDc4ZGE3MCAXDTIzMDMwNjE2MDMwN1oYDzIxMjMw

--- a/io/zenoh-transport/tests/unicast_openclose.rs
+++ b/io/zenoh-transport/tests/unicast_openclose.rs
@@ -645,23 +645,6 @@ async fn openclose_tcp_only_listen_with_interface_restriction() {
     openclose_transport(&listen_endpoint, &connect_endpoint, false).await;
 }
 
-#[cfg(feature = "transport_tcp")]
-#[cfg(target_os = "linux")]
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn openclose_tcp_only_listen_with_bind_restriction() {
-    let addrs = get_ipv4_ipaddrs(None);
-    zenoh_util::init_log_from_env_or("error");
-
-    let listen_endpoint: EndPoint =
-        format!("tcp/{}:{}#bind={}:{}", addrs[0], 13003, addrs[0], 13003)
-            .parse()
-            .unwrap();
-
-    let connect_endpoint: EndPoint = format!("tcp/{}:{}", addrs[0], 13003).parse().unwrap();
-
-    openclose_transport(&listen_endpoint, &connect_endpoint, false).await;
-}
-
 #[cfg(feature = "transport_udp")]
 #[cfg(target_os = "linux")]
 #[should_panic(expected = "Elapsed")]

--- a/io/zenoh-transport/tests/unicast_openclose.rs
+++ b/io/zenoh-transport/tests/unicast_openclose.rs
@@ -645,6 +645,23 @@ async fn openclose_tcp_only_listen_with_interface_restriction() {
     openclose_transport(&listen_endpoint, &connect_endpoint, false).await;
 }
 
+#[cfg(feature = "transport_tcp")]
+#[cfg(target_os = "linux")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn openclose_tcp_only_listen_with_bind_restriction() {
+    let addrs = get_ipv4_ipaddrs(None);
+    zenoh_util::init_log_from_env_or("error");
+
+    let listen_endpoint: EndPoint =
+        format!("tcp/{}:{}#bind={}:{}", addrs[0], 13003, addrs[0], 13003)
+            .parse()
+            .unwrap();
+
+    let connect_endpoint: EndPoint = format!("tcp/{}:{}", addrs[0], 13003).parse().unwrap();
+
+    openclose_transport(&listen_endpoint, &connect_endpoint, false).await;
+}
+
 #[cfg(feature = "transport_udp")]
 #[cfg(target_os = "linux")]
 #[should_panic(expected = "Elapsed")]
@@ -654,9 +671,9 @@ async fn openclose_udp_only_connect_with_interface_restriction() {
 
     zenoh_util::init_log_from_env_or("error");
 
-    let listen_endpoint: EndPoint = format!("udp/{}:{}", addrs[0], 13003).parse().unwrap();
+    let listen_endpoint: EndPoint = format!("udp/{}:{}", addrs[0], 13004).parse().unwrap();
 
-    let connect_endpoint: EndPoint = format!("udp/{}:{}#iface=lo", addrs[0], 13003)
+    let connect_endpoint: EndPoint = format!("udp/{}:{}#iface=lo", addrs[0], 13004)
         .parse()
         .unwrap();
 
@@ -672,11 +689,11 @@ async fn openclose_udp_only_listen_with_interface_restriction() {
     let addrs = get_ipv4_ipaddrs(None);
 
     zenoh_util::init_log_from_env_or("error");
-    let listen_endpoint: EndPoint = format!("udp/{}:{}#iface=lo", addrs[0], 13004)
+    let listen_endpoint: EndPoint = format!("udp/{}:{}#iface=lo", addrs[0], 13005)
         .parse()
         .unwrap();
 
-    let connect_endpoint: EndPoint = format!("udp/{}:{}", addrs[0], 13004).parse().unwrap();
+    let connect_endpoint: EndPoint = format!("udp/{}:{}", addrs[0], 13005).parse().unwrap();
 
     // should not connect to local interface and external address
     openclose_transport(&listen_endpoint, &connect_endpoint, false).await;
@@ -701,7 +718,7 @@ async fn openclose_quic_only_connect_with_interface_restriction() {
     let addrs = get_ipv4_ipaddrs(None);
     let (ca, cert, key) = get_tls_certs();
 
-    let mut listen_endpoint: EndPoint = format!("quic/{}:{}", addrs[0], 13005).parse().unwrap();
+    let mut listen_endpoint: EndPoint = format!("quic/{}:{}", addrs[0], 13006).parse().unwrap();
     listen_endpoint
         .config_mut()
         .extend_from_iter(
@@ -715,7 +732,7 @@ async fn openclose_quic_only_connect_with_interface_restriction() {
         )
         .unwrap();
 
-    let connect_endpoint: EndPoint = format!("quic/{}:{}#iface=lo", addrs[0], 13005)
+    let connect_endpoint: EndPoint = format!("quic/{}:{}#iface=lo", addrs[0], 13006)
         .parse()
         .unwrap();
 
@@ -734,7 +751,7 @@ async fn openclose_quic_only_listen_with_interface_restriction() {
     let addrs = get_ipv4_ipaddrs(None);
     let (ca, cert, key) = get_tls_certs();
 
-    let mut listen_endpoint: EndPoint = format!("quic/{}:{}#iface=lo", addrs[0], 13006)
+    let mut listen_endpoint: EndPoint = format!("quic/{}:{}#iface=lo", addrs[0], 13007)
         .parse()
         .unwrap();
     listen_endpoint
@@ -750,7 +767,7 @@ async fn openclose_quic_only_listen_with_interface_restriction() {
         )
         .unwrap();
 
-    let connect_endpoint: EndPoint = format!("quic/{}:{}", addrs[0], 13006).parse().unwrap();
+    let connect_endpoint: EndPoint = format!("quic/{}:{}", addrs[0], 13007).parse().unwrap();
 
     // should not connect to local interface and external address
     openclose_transport(&listen_endpoint, &connect_endpoint, false).await;
@@ -767,7 +784,7 @@ async fn openclose_tls_only_connect_with_interface_restriction() {
     let addrs = get_ipv4_ipaddrs(None);
     let (ca, cert, key) = get_tls_certs();
 
-    let mut listen_endpoint: EndPoint = format!("tls/{}:{}", addrs[0], 13007).parse().unwrap();
+    let mut listen_endpoint: EndPoint = format!("tls/{}:{}", addrs[0], 13008).parse().unwrap();
     listen_endpoint
         .config_mut()
         .extend_from_iter(
@@ -781,7 +798,7 @@ async fn openclose_tls_only_connect_with_interface_restriction() {
         )
         .unwrap();
 
-    let connect_endpoint: EndPoint = format!("tls/{}:{}#iface=lo", addrs[0], 13007)
+    let connect_endpoint: EndPoint = format!("tls/{}:{}#iface=lo", addrs[0], 13008)
         .parse()
         .unwrap();
 
@@ -800,7 +817,7 @@ async fn openclose_tls_only_listen_with_interface_restriction() {
     let addrs = get_ipv4_ipaddrs(None);
     let (ca, cert, key) = get_tls_certs();
 
-    let mut listen_endpoint: EndPoint = format!("tls/{}:{}#iface=lo", addrs[0], 13008)
+    let mut listen_endpoint: EndPoint = format!("tls/{}:{}#iface=lo", addrs[0], 13009)
         .parse()
         .unwrap();
     listen_endpoint
@@ -816,7 +833,7 @@ async fn openclose_tls_only_listen_with_interface_restriction() {
         )
         .unwrap();
 
-    let connect_endpoint: EndPoint = format!("tls/{}:{}", addrs[0], 13008).parse().unwrap();
+    let connect_endpoint: EndPoint = format!("tls/{}:{}", addrs[0], 13009).parse().unwrap();
 
     // should not connect to local interface and external address
     openclose_transport(&listen_endpoint, &connect_endpoint, false).await;


### PR DESCRIPTION
This is a relive of https://github.com/eclipse-zenoh/zenoh/pull/1822

This PR aims to address issue https://github.com/eclipse-zenoh/zenoh/issues/1810 

Add a bind Endpoint config option. For example:
`tcp/192.168.0.10:7447#bind=192.168.0.5:0`
- [x] TCP 
- [x] TLS, 
- [x] UDP
- [x] Quic