### PR TITLE
Lowlatency async finalize

### DIFF
--- a/io/zenoh-transport/src/unicast/lowlatency/link.rs
+++ b/io/zenoh-transport/src/unicast/lowlatency/link.rs
@@ -136,8 +136,7 @@ impl TransportUnicastLowlatency {
                 // Spawn a task to avoid a deadlock waiting for this same task
                 // to finish in the close() joining its handle
                 // WARN: Must be spawned on RX
-                let _ =
-                    zenoh_runtime::ZRuntime::RX.spawn(async move { c_transport.finalize(0).await });
+                zenoh_runtime::ZRuntime::RX.spawn(async move { c_transport.finalize(0).await });
             }
         };
         self.tracker.spawn_on(task, &ZRuntime::TX);
@@ -211,8 +210,7 @@ impl TransportUnicastLowlatency {
                     // Spawn a task to avoid a deadlock waiting for this same task
                     // to finish in the close() joining its handle
                     // WARN: Must be spawned on RX
-                    let _ = zenoh_runtime::ZRuntime::RX
-                        .spawn(async move { c_transport.finalize(0).await });
+                    zenoh_runtime::ZRuntime::RX.spawn(async move { c_transport.finalize(0).await });
                 }
             },
             &ZRuntime::RX,

--- a/io/zenoh-transport/src/unicast/lowlatency/link.rs
+++ b/io/zenoh-transport/src/unicast/lowlatency/link.rs
@@ -132,7 +132,12 @@ impl TransportUnicastLowlatency {
                     c_transport.manager.config.zid,
                     c_transport.config.zid
                 );
-                let _ = c_transport.finalize(0).await;
+
+                // Spawn a task to avoid a deadlock waiting for this same task
+                // to finish in the close() joining its handle
+                // WARN: Must be spawned on RX
+                let _ =
+                    zenoh_runtime::ZRuntime::RX.spawn(async move { c_transport.finalize(0).await });
             }
         };
         self.tracker.spawn_on(task, &ZRuntime::TX);
@@ -202,7 +207,12 @@ impl TransportUnicastLowlatency {
                         c_transport.manager.config.zid,
                         c_transport.config.zid
                     );
-                    let _ = c_transport.finalize(0).await;
+
+                    // Spawn a task to avoid a deadlock waiting for this same task
+                    // to finish in the close() joining its handle
+                    // WARN: Must be spawned on RX
+                    let _ = zenoh_runtime::ZRuntime::RX
+                        .spawn(async move { c_transport.finalize(0).await });
                 }
             },
             &ZRuntime::RX,


### PR DESCRIPTION
Async finalize lowlatency transport when triggered from link to avoid deadlock (the same approach as it is done in unicast transport)