### PR TITLE
fix: remove the non-working tracing log in the exit stage

### DIFF
--- a/zenoh/src/api/builders/close.rs
+++ b/zenoh/src/api/builders/close.rs
@@ -91,14 +91,7 @@ impl<TCloseable: Closeable> Wait for CloseBuilder<TCloseable> {
 
                 #[cfg(not(nolocal_thread_not_available))]
                 {
-                    let evaluate = move || {
-                        // NOTE: tracing logger also panics if used inside atexit() handler!!!
-                        tracing::trace!(
-                            "tokio TLS NOT available, closing closeable in separate thread"
-                        );
-                        ZRuntime::Net.block_in_place(future)
-                    };
-                    std::thread::spawn(evaluate)
+                    std::thread::spawn(move || ZRuntime::Net.block_in_place(future))
                         .join()
                         .expect("Error spawning atexit-safe thread")
                 }


### PR DESCRIPTION
As the title suggests, this PR removes logging during the exit stage to prevent potential panics."
