### PR TITLE
Drop queries when session is closed

### DIFF
--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -3194,6 +3194,7 @@ impl Closee for Arc<SessionInner> {
         let _liveliness_subscribers = std::mem::take(&mut state.liveliness_subscribers);
         let _local_resources = std::mem::take(&mut state.local_resources);
         let _remote_resources = std::mem::take(&mut state.remote_resources);
+        let _queries = std::mem::take(&mut state.queries);
         drop(state);
         #[cfg(feature = "unstable")]
         {


### PR DESCRIPTION
`queries` as part of session state is forgotten to be dropped in `close`