### PR TITLE
feat: add hash support for Encoding

### DIFF
--- a/commons/zenoh-buffers/src/zslice.rs
+++ b/commons/zenoh-buffers/src/zslice.rs
@@ -222,6 +222,12 @@ impl<Rhs: AsRef<[u8]> + ?Sized> PartialEq<Rhs> for ZSlice {
 
 impl Eq for ZSlice {}
 
+impl std::hash::Hash for ZSlice {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.as_slice().hash(state);
+    }
+}
+
 impl fmt::Display for ZSlice {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:02x?}", self.as_slice())
@@ -443,5 +449,23 @@ mod tests {
         mut_slice[..buf.len()].clone_from_slice(&buf[..]);
 
         assert_eq!(buf.as_slice(), zslice.as_slice());
+    }
+
+    #[test]
+    fn hash() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        let buf = vec![1, 2, 3, 4, 5];
+        let mut buf_hasher = DefaultHasher::new();
+        buf.hash(&mut buf_hasher);
+        let buf_hash = buf_hasher.finish();
+
+        let zslice: ZSlice = buf.clone().into();
+        let mut zslice_hasher = DefaultHasher::new();
+        zslice.hash(&mut zslice_hasher);
+        let zslice_hash = zslice_hasher.finish();
+
+        assert_eq!(buf_hash, zslice_hash);
     }
 }

--- a/commons/zenoh-protocol/src/core/encoding.rs
+++ b/commons/zenoh-protocol/src/core/encoding.rs
@@ -24,7 +24,7 @@ pub type EncodingId = u16;
 /// impose any encoding mapping and users are free to use any mapping they like.
 /// Nevertheless, it is worth highlighting that Zenoh still provides a default mapping as part
 /// of the API as per user convenience. That mapping has no impact on the Zenoh protocol definition.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Encoding {
     pub id: EncodingId,
     pub schema: Option<ZSlice>,

--- a/zenoh/src/api/encoding.rs
+++ b/zenoh/src/api/encoding.rs
@@ -69,7 +69,7 @@ use zenoh_protocol::core::EncodingId;
 /// assert_eq!("text/plain;utf-8", &encoding2.to_string());
 /// ```
 #[repr(transparent)]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Encoding(zenoh_protocol::core::Encoding);
 
 impl Encoding {
@@ -709,4 +709,32 @@ impl Encoding {
     pub fn new(id: EncodingId, schema: Option<ZSlice>) -> Self {
         Encoding(zenoh_protocol::core::Encoding { id, schema })
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    #[test]
+    fn hash() {
+        let encodings = [
+            Encoding::ZENOH_BYTES,
+            Encoding::ZENOH_STRING,
+            Encoding::ZENOH_STRING.with_schema("utf-8"),
+            Encoding::ZENOH_STRING.with_schema("utf-8"),
+        ];
+        let hashes = encodings.map(|e| {
+            let mut hasher = DefaultHasher::new();
+            e.hash(&mut hasher);
+            hasher.finish()
+        });
+
+        assert_ne!(hashes[0], hashes[1]);
+        assert_ne!(hashes[0], hashes[2]);
+        assert_ne!(hashes[1], hashes[2]);
+        assert_eq!(hashes[2], hashes[3]);
+    }
+
 }


### PR DESCRIPTION
Hash trait was missing for Encoding which prevented them from being used as keys of a HashMap.