### PR TITLE
upgrade some zenoh dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ lazy_static = "1.5.0"
 leb128 = "0.2.5"
 libc = "0.2.172"
 libloading = "0.8.8"
-lz4_flex = "0.11.5"
+lz4_flex = "0.11.3"
 nix = { version = "0.30.1", features = ["fs"] }
 nonempty-collections = { version = "0.3.0", features = ["serde"] }
 num-traits = { version = "0.2.19", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,131 +79,114 @@ version = "1.5.0"
 [workspace.dependencies]
 advisory-lock = "0.3.0"
 aes = "0.8.4"
-ahash = { version = "0.8.11", default-features = false }
-anyhow = { version = "1.0.89", default-features = false } # Default features are disabled due to usage in no_std crates
+ahash = { version = "0.8.12", default-features = false }
+anyhow = { version = "1.0.98", default-features = false } # Default features are disabled due to usage in no_std crates
 arc-swap = "1.7.1"
-async-executor = "1.13.1"
-async-global-executor = "2.4.1"
-async-io = "2.3.4"
-async-std = { version = "1.6.5", features = ["tokio1"] }
-async-trait = "0.1.82"
+async-global-executor = "3.1.0"
+async-std = { version = "1.13.1", features = ["tokio1"] }
+async-trait = "0.1.88"
 base64 = "0.22.1"
 bincode = "1.3.3"
-bytes = "1.7.1"
-clap = { version = "4.5.17", features = ["derive"] }
-console-subscriber = "0.4.0"
-const_format = "0.2.33"
-criterion = "0.5"
+bytes = "1.10.1"
+clap = { version = "4.5.39", features = ["derive"] }
+const_format = "0.2.34"
+criterion = "0.5.1"
 crossbeam-channel = "0.5"
 crossbeam-queue = "0.3.12"
-crossbeam-utils = "0.8.20"
-derive-new = "0.7.0"
+crossbeam-utils = "0.8.21"
 derive_more = { version = "1.0.0", features = ["as_ref"] }
-event-listener = "5.3.1"
-flume = "0.11"
-form_urlencoded = "1.2.1"
+either = "1.15.0"
+event-listener = "5.4.0"
+flume = "0.11.1"
 futures = "0.3.31"
 futures-util = { version = "0.3.31", default-features = false } # Default features are disabled due to some crates' requirements
-getrandom = { version = "0.2" }
+getrandom = { version = "0.2.16" }
 git-version = "0.3.9"
-hashbrown = "0.14"
-hex = { version = "0.4.3", default-features = false } # Default features are disabled due to usage in no_std crates
+hashbrown = { version = "0.15.3", default-features = false } # Default features are disabled because the foldhash use a global variable (incompatible with plugins)
 hmac = { version = "0.12.1", features = ["std"] }
 home = "0.5.9"
 http-types = "2.12.0"
-humantime = "2.1.0"
-itertools = "0.13.0"
+humantime = "2.2.0"
+itertools = "0.14.0"
 json5 = "0.4.1"
-jsonschema = { version = "0.20", default-features = false }
+jsonschema = { version = "0.21", default-features = false }
 keyed-set = "1.0.0"
 lazy_static = "1.5.0"
-leb128 = "0.2"
-libc = "0.2.158"
-libloading = "0.8"
-lz4_flex = "0.11"
-nix = { version = "0.29.0", features = ["fs"] }
+leb128 = "0.2.5"
+libc = "0.2.172"
+libloading = "0.8.8"
+lz4_flex = "0.11.5"
+nix = { version = "0.30.1", features = ["fs"] }
 nonempty-collections = { version = "0.3.0", features = ["serde"] }
 num-traits = { version = "0.2.19", default-features = false }
 num_cpus = "1.16.0"
-once_cell = "1.19.0"
-ordered-float = "4.2.2"
-panic-message = "0.3.0"
+once_cell = "1.21.3"
 paste = "1.0.15"
-petgraph = "0.6.5"
+petgraph = "0.8.1"
 phf = { version = "0.11.2", features = ["macros"] }
-pnet = "0.35.0"
 pnet_datalink = "0.35.0"
-proc-macro2 = "1.0.86"
-quinn = "0.11.5"
-quote = "1.0.37"
+proc-macro2 = "1.0.99"
+prost = "0.13.5"
+quinn = "0.11.8"
+quote = "1.0.40"
 rand = { version = "0.8.5", default-features = false } # Default features are disabled due to usage in no_std crates
 rand_chacha = "0.3.1"
-rcgen = "0.13.1"
-ref-cast = "1.0.23"
-regex = "1.10.6"
-ringbuffer-spsc = "0.1.9"
-ron = "0.8.1"
+ref-cast = "1.0.24"
+ringbuffer-spsc = "0.1.13"
+ron = "0.10.1"
 rsa = "0.9"
 rustc_version = "0.4.1"
-rustls = { version = "0.23.13", default-features = false, features = [
+rustls = { version = "0.23.27", default-features = false, features = [
   "logging",
   "ring",
   "tls12",
 ] }
-rustls-native-certs = "0.8.0"
-rustls-pemfile = "2.1.3"
-rustls-pki-types = "1.8.0"
-rustls-webpki = "0.102.8"
+rustls-pemfile = "2.2.0"
+rustls-pki-types = "1.12.0"
+rustls-webpki = "0.103.4"
 schemars = { version = "0.8.21", features = ["either"] }
 secrecy = { version = "0.8.0", features = ["alloc", "serde"] }
-serde = { version = "1.0.210", default-features = false, features = [
+serde = { version = "1.0.219", default-features = false, features = [
   "derive",
 ] } # Default features are disabled due to usage in no_std crates
-serde_json = "1.0.128"
+serde_json = "1.0.143"
 serde_with = "3.12.0"
 serde_yaml = "0.9.34"
 sha3 = "0.10.8"
-shellexpand = "3.1.0"
-socket2 = { version = "0.5.7", features = ["all"] }
-stabby = "36.1.1"
+shellexpand = "3.1.1"
+socket2 = { version = "0.5.10", features = ["all"] }
+stabby = "72.1.1"
 static_assertions = "1.1.0"
 static_init = "1.0.3"
-stop-token = "0.7.0"
-syn = "2.0"
+syn = "2.0.106"
 test-case = "3.3.1"
+thread-priority = "1.2.0"
 tide = "0.16.0"
-time = "0.3.36"
-token-cell = { version = "1.5.0", default-features = false }
-tokio = { version = "1.40.0", default-features = false } # Default features are disabled due to some crates' requirements
-tokio-rustls = { version = "0.26.0", default-features = false }
-tokio-tungstenite = "0.24.0"
-tokio-util = "0.7.12"
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-# tokio-vsock = see: io/zenoh-links/zenoh-link-vsock/Cargo.toml (workspaces does not support platform dependent dependencies)
-either = "1.13.0"
-prost = "0.13.2"
-thread-priority = "1.1.0"
+time = "0.3.41"
 tls-listener = { version = "0.11.0", features = ["rustls-ring"] }
-typenum = "1.17.0"
-uhlc = { version = "0.8.0", default-features = false } # Default features are disabled due to usage in no_std crates
-unzip-n = "0.1.2"
+token-cell = { version = "1.5.0", default-features = false }
+tokio = { version = "1.47.1", default-features = false } # Default features are disabled due to some crates' requirements
+tokio-rustls = { version = "0.26.2", default-features = false }
+tokio-tungstenite = "0.26.2"
+tokio-util = "0.7.16"
+tracing = "0.1.41 "
+tracing-subscriber = { version = "0.3.19", features = ["env-filter", "json"] }
+uhlc = { version = "0.8.1", default-features = false } # Default features are disabled due to usage in no_std crates
 url = "2.5.2"
-urlencoding = "2.1.3"
-uuid = { version = "1.10.0", default-features = false, features = [
+uuid = { version = "1.17.0", default-features = false, features = [
   "v4",
 ] } # Default features are disabled due to usage in no_std crates
-validated_struct = "2.1.0"
+validated_struct = "2.1.1"
 vec_map = "0.8.2"
-webpki-roots = "0.26.5"
-win-sys = "0.3"
+webpki-roots = "1.0.2"
+win-sys = "0.3.1"
 winapi = { version = "0.3.9", features = ["iphlpapi", "winerror"] }
 windows-sys = { version = "0.59.0", features = [
   "Win32_Foundation",
   "Win32_Networking_WinSock",
   "Win32_System_IO",
 ] }
-x509-parser = "0.16.0"
+x509-parser = "0.17.0"
 z-serial = "0.3.1"
 zenoh = { version = "=1.5.0", path = "zenoh", default-features = false }
 zenoh-buffers = { version = "=1.5.0", path = "commons/zenoh-buffers", default-features = false }

--- a/commons/zenoh-shm/src/shm/unix.rs
+++ b/commons/zenoh-shm/src/shm/unix.rs
@@ -209,11 +209,11 @@ impl<ID: SegmentID> SegmentImpl<ID> {
             let flags = OFlag::O_RDWR;
             let mode = Mode::S_IRUSR | Mode::S_IWUSR;
             // TODO: we cannot use our logger inside of atexit() callstack!
-                //tracing::trace!(
-                //"open(name={:?}, flag={:?}, mode={:?})",
-                //lockpath,
-                //flags,
-                //mode
+            //tracing::trace!(
+            //"open(name={:?}, flag={:?}, mode={:?})",
+            //lockpath,
+            //flags,
+            //mode
             //);
             match open(&lockpath, flags, mode) {
                 Ok(val) => val,

--- a/io/zenoh-links/zenoh-link-ws/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-ws/src/unicast.rs
@@ -30,7 +30,11 @@ use tokio::{
     sync::{Mutex as AsyncMutex, RwLock as AsyncRwLock},
     task::JoinHandle,
 };
-use tokio_tungstenite::{accept_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
+use tokio_tungstenite::{
+    accept_async,
+    tungstenite::{Bytes, Message},
+    MaybeTlsStream, WebSocketStream,
+};
 use tokio_util::sync::CancellationToken;
 use zenoh_core::{zasynclock, zasyncread, zasyncwrite};
 use zenoh_link_commons::{
@@ -57,7 +61,7 @@ pub struct LinkUnicastWs {
     dst_addr: SocketAddr,
     dst_locator: Locator,
     // The leftovers if reading less than what available on the web socket.
-    leftovers: AsyncMutex<Option<(Vec<u8>, usize, usize)>>,
+    leftovers: AsyncMutex<Option<(Bytes, usize, usize)>>,
 }
 
 impl LinkUnicastWs {
@@ -93,7 +97,7 @@ impl LinkUnicastWs {
         }
     }
 
-    async fn recv(&self) -> ZResult<Vec<u8>> {
+    async fn recv(&self) -> ZResult<Bytes> {
         let mut guard = zasynclock!(self.recv);
 
         match guard.next().await {


### PR DESCRIPTION
Here is the exhaustive list of dependencies not upgraded:
- `bincode` 2 --> MSRV 1.85
- `getrandom` 0.3 --> `js` feature replaced by configuration flag
- `home` 0.5.11 --> MSRV 1.81
- `jsonschema` 0.22 --> MSRV 1.82
- `rand` 0.9 + `rand_chacha` 0.9 --> blocked by `rsa` depending on old `rand`/`rand_chacha` version; `rsa` has been updated, but not released yet
- `secrecy` 0.10 --> big API change that may need discussion
- `static_init` 1.0.4 --> MSRV 1.82
- `url` 2.5.4 --> MSRV 1.82