### PR TITLE
chore: unpin home dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ getrandom = { version = "0.2" }
 hashbrown = "0.14"
 hex = { version = "0.4.3", default-features = false } # Default features are disabled due to usage in no_std crates
 hmac = { version = "0.12.1", features = ["std"] }
-home = "=0.5.9"
+home = "0.5.9"
 http-types = "2.12.0"
 humantime = "2.1.0"
 itertools = "0.13.0"


### PR DESCRIPTION
The rust toolchain version has be upgraded to 1.8.5 in (#1803).
we don't need to pin the home to 0.5.9 (#1673)