### PR TITLE
Allow to make get request without payload in the example

### DIFF
--- a/examples/examples/z_get.rs
+++ b/examples/examples/z_get.rs
@@ -31,18 +31,19 @@ async fn main() {
     let session = zenoh::open(config).await.unwrap();
 
     println!("Sending Query '{selector}'...");
-    let replies = session
+    let mut builder = session
         .get(&selector)
         // // By default get receives replies from a FIFO.
         // // Uncomment this line to use a ring channel instead.
         // // More information on the ring channel are available in the z_pull example.
         // .with(zenoh::handlers::RingChannel::default())
         // Refer to z_bytes.rs to see how to serialize different types of message
-        .payload(payload.unwrap_or_default())
         .target(target)
-        .timeout(timeout)
-        .await
-        .unwrap();
+        .timeout(timeout);
+    if let Some(payload) = payload {
+        builder = builder.payload(payload);
+    }
+    let replies = builder.await.unwrap();
     while let Ok(reply) = replies.recv_async().await {
         match reply.result() {
             Ok(sample) => {


### PR DESCRIPTION
When "z_get" example is executed without `--payload` parameter it should make request without payload instead of empty payload. There cases are distinguished on the z_queryable side:

E.g. for these z_get's

```sh
cargo run --example z_queryable
cargo run --example z_get
cargo run --example z_get --p ""
...

the output of z_queryable after the PR is different:

```sh
>> [Queryable ] Received Query 'demo/example/**'
...
>> [Queryable ] Received Query 'demo/example/**' with payload ''
```