### PR TITLE
Close the links after closing the Face

### DIFF
--- a/io/zenoh-transport/src/unicast/universal/transport.rs
+++ b/io/zenoh-transport/src/unicast/universal/transport.rs
@@ -132,7 +132,13 @@ impl TransportUnicastUniversal {
         // Delete the transport on the manager
         let _ = self.manager.del_transport_unicast(&self.config.zid).await;
 
+        // Notify the callback that we have closed the transport
+        if let Some(cb) = callback.as_ref() {
+            cb.closed();
+        }
+
         // Close all the links
+        // Closing links can be slow, so we do it after everything.
         let mut links = {
             let mut l_guard = zwrite!(self.links);
             let links = l_guard.to_vec();
@@ -141,11 +147,6 @@ impl TransportUnicastUniversal {
         };
         for l in links.drain(..) {
             let _ = l.close().await;
-        }
-
-        // Notify the callback that we have closed the transport
-        if let Some(cb) = callback.as_ref() {
-            cb.closed();
         }
 
         Ok(())


### PR DESCRIPTION
This is another attempt to minimize the occurrence of the race condition described in #1886.

When loosing the connection to a peer, if the send buffer happens to fill up before the keep alive timeout, the tx_task can be stuck in the send_batch operation. On my computer, it can be stuck for 15 minutes before returning with EHOSTUNREACH ("No route to host").

Now this is not that bat itself, it's just a dangling task, a TransportLinkUnicastUniversal and a TransportUnicastUniversal. But this make the race condition mentioned in #1886 very likely: if the peer reconnect within those 15 minutes, the re-connection is bogus.

This "fix" make `TransportUnicastUniversal::delete()` notify the RuntimeSession of the transport deletion before closing the link, instead of after closing the link. It doesn't seem to cause any issue. I didn't do the same in TransportUnicastLowlatency because I am not sure it is necessary.

I am not really happy with this hack, because I don't fully understand the consequences of the fix and it just make the race-condition a lot less likely (15min time span vs a few milliseconds). Have a look at #1886 for more information.