### PR TITLE
[ZEN-557] Extract udp socket source address via PKTINFO

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5497,6 +5497,7 @@ name = "zenoh-link-udp"
 version = "1.4.0"
 dependencies = [
  "async-trait",
+ "libc",
  "socket2 0.5.7",
  "tokio",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5502,6 +5502,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "windows-sys 0.59.0",
  "zenoh-buffers",
  "zenoh-core",
  "zenoh-link-commons",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,6 +195,7 @@ z-serial = "0.3.1"
 either = "1.13.0"
 prost = "0.13.2"
 tls-listener = { version = "0.11.0", features = ["rustls-ring"] }
+windows-sys = { version = "0.59.0", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_System_IO"] }
 zenoh-ext = { version = "=1.4.0", path = "zenoh-ext", default-features = false }
 zenoh-shm = { version = "=1.4.0", path = "commons/zenoh-shm" }
 zenoh-result = { version = "=1.4.0", path = "commons/zenoh-result", default-features = false }

--- a/io/zenoh-links/zenoh-link-udp/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-udp/Cargo.toml
@@ -37,3 +37,4 @@ zenoh-protocol = { workspace = true }
 zenoh-result = { workspace = true }
 zenoh-sync = { workspace = true }
 zenoh-util = { workspace = true }
+libc = { workspace = true }

--- a/io/zenoh-links/zenoh-link-udp/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-udp/Cargo.toml
@@ -37,4 +37,9 @@ zenoh-protocol = { workspace = true }
 zenoh-result = { workspace = true }
 zenoh-sync = { workspace = true }
 zenoh-util = { workspace = true }
+
+[target.'cfg(target_family = "windows")'.dependencies]
+windows-sys = { version = "0.59.0", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_System_IO"] }
+
+[target.'cfg(target_family = "unix")'.dependencies]
 libc = { workspace = true }

--- a/io/zenoh-links/zenoh-link-udp/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-udp/Cargo.toml
@@ -39,7 +39,7 @@ zenoh-sync = { workspace = true }
 zenoh-util = { workspace = true }
 
 [target.'cfg(target_family = "windows")'.dependencies]
-windows-sys = { version = "0.59.0", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_System_IO"] }
+windows-sys = { workspace = true }
 
 [target.'cfg(target_family = "unix")'.dependencies]
 libc = { workspace = true }

--- a/io/zenoh-links/zenoh-link-udp/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/lib.rs
@@ -18,8 +18,8 @@
 //!
 //! [Click here for Zenoh's documentation](https://docs.rs/zenoh/latest/zenoh)
 mod multicast;
-mod unicast;
 mod pktinfo;
+mod unicast;
 
 use std::{net::SocketAddr, str::FromStr};
 

--- a/io/zenoh-links/zenoh-link-udp/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/lib.rs
@@ -19,6 +19,7 @@
 //! [Click here for Zenoh's documentation](https://docs.rs/zenoh/latest/zenoh)
 mod multicast;
 mod unicast;
+mod pktinfo;
 
 use std::{net::SocketAddr, str::FromStr};
 

--- a/io/zenoh-links/zenoh-link-udp/src/pktinfo/mod.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/pktinfo/mod.rs
@@ -1,0 +1,18 @@
+//
+// Copyright (c) 2025 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+#[cfg(target_family = "unix")]
+mod pktinfo_unix;
+#[cfg(target_family = "unix")]
+pub(crate) use pktinfo_unix::*;

--- a/io/zenoh-links/zenoh-link-udp/src/pktinfo/mod.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/pktinfo/mod.rs
@@ -54,11 +54,12 @@ impl PktInfoUdpSocket {
     ) -> io::Result<(usize, SocketAddr, SocketAddr)> {
         let res = recv_with_dst(&self.socket, &self.pktinfo_retrieval_data, buffer).await?;
 
-        let src_addr = if self.local_address.ip().is_unspecified() && res.2.is_some() {
-            unsafe { res.2.unwrap_unchecked() } // verified just above that it is not None
-        } else {
-            self.local_address
-        };
+        let mut src_addr = self.local_address;
+        if src_addr.ip().is_unspecified() {
+            if let Some(addr) = res.2 {
+                src_addr = addr;
+            }
+        }
         Ok((res.0, res.1, src_addr))
     }
 }

--- a/io/zenoh-links/zenoh-link-udp/src/pktinfo/mod.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/pktinfo/mod.rs
@@ -16,3 +16,13 @@
 mod pktinfo_unix;
 #[cfg(target_family = "unix")]
 pub(crate) use pktinfo_unix::*;
+
+#[cfg(target_family = "windows")]
+mod pktinfo_windows;
+#[cfg(target_family = "windows")]
+pub(crate) use pktinfo_windows::*;
+
+#[cfg(all(not(target_family = "windows"), not(target_family = "unix")))]
+mod pktinfo_generic;
+#[cfg(all(not(target_family = "windows"), not(target_family = "unix")))]
+pub(crate) use pktinfo_generic::*;

--- a/io/zenoh-links/zenoh-link-udp/src/pktinfo/pktinfo_generic.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/pktinfo/pktinfo_generic.rs
@@ -15,9 +15,12 @@ use std::net::SocketAddr;
 
 use tokio::net::UdpSocket;
 
+#[derive(Clone)]
 pub(crate) struct PktInfoRetrievalData;
 pub(crate) fn enable_pktinfo(socket: &UdpSocket) -> io::Result<PktInfoRetrievalData> {
-    tracing::warn!("PKTINFO can be only retrieved on windows and unix");
+    if socket.local_addr()?.ip().is_unspecified() {
+        tracing::warn!("PKTINFO can be only retrieved on windows and unix. Interceptors (e.g. Access Control, Downsampling) are not guaranteed to work on UDP when listening on 0.0.0.0 or [::]. Their usage is discouraged.");
+    }
     Ok(PktInfoRetrievalData)
 }
 

--- a/io/zenoh-links/zenoh-link-udp/src/pktinfo/pktinfo_generic.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/pktinfo/pktinfo_generic.rs
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2025 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+use std::net::SocketAddr;
+
+use tokio::net::UdpSocket;
+
+pub(crate) struct PktInfoRetrievalData;
+pub(crate) fn enable_pktinfo(socket: &UdpSocket) -> io::Result<PktInfoRetrievalData> {
+    tracing::warn!("PKTINFO can be only retrieved on windows and unix");
+    Ok(PktInfoRetrievalData)
+}
+
+pub(crate) async fn recv_with_dst(
+    socket: &UdpSocket,
+    _data: &PktInfoRetrievalData,
+    buffer: &mut [u8],
+) -> io::Result<(usize, SocketAddr, Option<SocketAddr>)> {
+    let res = socket.recv_from(buffer).await?;
+    Ok((res.0, res.1, None))
+}

--- a/io/zenoh-links/zenoh-link-udp/src/pktinfo/pktinfo_unix.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/pktinfo/pktinfo_unix.rs
@@ -49,6 +49,7 @@ where
     }
 }
 
+#[derive(Clone)]
 pub(crate) struct PktInfoRetrievalData {
     port: u16,
 }

--- a/io/zenoh-links/zenoh-link-udp/src/pktinfo/pktinfo_unix.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/pktinfo/pktinfo_unix.rs
@@ -1,0 +1,147 @@
+use std::io::{Error, IoSliceMut};
+use std::mem::MaybeUninit;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::{io, mem, ptr};
+
+use socket2::SockAddr;
+use tokio::io::Interest;
+use tokio::net::UdpSocket;
+
+unsafe fn setsockopt<T>(
+    socket: libc::c_int,
+    level: libc::c_int,
+    name: libc::c_int,
+    value: T,
+) -> io::Result<()>
+where
+    T: Copy,
+{
+    let value = &value as *const T as *const libc::c_void;
+    if libc::setsockopt(
+        socket,
+        level,
+        name,
+        value,
+        mem::size_of::<T>() as libc::socklen_t,
+    ) == 0
+    {
+        Ok(())
+    } else {
+        Err(Error::last_os_error())
+    }
+}
+
+pub(crate) fn enable_pktinfo(socket: &UdpSocket) -> io::Result<()> {
+    let local_src_addr = socket.local_addr()?;
+    match local_src_addr.is_ipv6() {
+        false => unsafe {
+            setsockopt(socket.as_raw_fd(), libc::IPPROTO_IP, libc::IP_PKTINFO, 1)?;
+        },
+        true => unsafe {
+            setsockopt(
+                socket.as_raw_fd(),
+                libc::IPPROTO_IPV6,
+                libc::IPV6_RECVPKTINFO,
+                1,
+            )?;
+        },
+    }
+    Ok(())
+}
+
+fn recv_with_dst_inner(
+    fd: RawFd,
+    buf: &mut [u8],
+    local_port: u16,
+) -> io::Result<(usize, SocketAddr, Option<SocketAddr>)> {
+    let mut addr_src: MaybeUninit<libc::sockaddr_storage> = MaybeUninit::uninit();
+    let mut msg_iov = IoSliceMut::new(buf);
+    let mut cmsg = {
+        let space = unsafe {
+            libc::CMSG_SPACE(mem::size_of::<libc::in_pktinfo>() as libc::c_uint) as usize
+        };
+        Vec::<u8>::with_capacity(space)
+    };
+
+    let mut mhdr = unsafe {
+        let mut mhdr = MaybeUninit::<libc::msghdr>::zeroed();
+        let p = mhdr.as_mut_ptr();
+        (*p).msg_name = addr_src.as_mut_ptr() as *mut libc::c_void;
+        (*p).msg_namelen = mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
+        (*p).msg_iov = &mut msg_iov as *mut IoSliceMut as *mut libc::iovec;
+        (*p).msg_iovlen = 1;
+        (*p).msg_control = cmsg.as_mut_ptr() as *mut libc::c_void;
+        (*p).msg_controllen = cmsg.capacity() as _;
+        (*p).msg_flags = 0;
+        mhdr.assume_init()
+    };
+
+    let bytes_recv = unsafe { libc::recvmsg(fd, &mut mhdr as *mut libc::msghdr, 0) };
+    if bytes_recv <= 0 {
+        return Err(Error::last_os_error());
+    }
+
+    let addr_src = unsafe {
+        SockAddr::new(
+            addr_src.assume_init(),
+            mem::size_of::<libc::sockaddr_storage>() as _,
+        )
+    }
+    .as_socket()
+    .unwrap();
+
+    let mut header = if mhdr.msg_controllen > 0 {
+        debug_assert!(!mhdr.msg_control.is_null());
+        debug_assert!(cmsg.capacity() >= mhdr.msg_controllen as usize);
+
+        Some(unsafe {
+            libc::CMSG_FIRSTHDR(&mhdr as *const libc::msghdr)
+                .as_ref()
+                .unwrap()
+        })
+    } else {
+        None
+    };
+
+    let mut addr_dst = None;
+
+    while addr_dst.is_none() && header.is_some() {
+        let h = header.unwrap();
+        let p = unsafe { libc::CMSG_DATA(h) };
+
+        match (h.cmsg_level, h.cmsg_type) {
+            (libc::IPPROTO_IP, libc::IP_PKTINFO) => {
+                let pktinfo = unsafe { ptr::read_unaligned(p as *const libc::in_pktinfo) };
+                addr_dst = Some(SocketAddr::new(
+                    IpAddr::V4(Ipv4Addr::from(u32::from_be(pktinfo.ipi_addr.s_addr))),
+                    local_port,
+                ));
+            }
+            (libc::IPPROTO_IPV6, libc::IPV6_PKTINFO) => {
+                let pktinfo = unsafe { ptr::read_unaligned(p as *const libc::in6_pktinfo) };
+                addr_dst = Some(SocketAddr::new(
+                    IpAddr::V6(Ipv6Addr::from(pktinfo.ipi6_addr.s6_addr)),
+                    local_port,
+                ));
+            }
+            _ => {
+                header = unsafe {
+                    let p = libc::CMSG_NXTHDR(&mhdr as *const _, h as *const _);
+                    p.as_ref()
+                };
+            }
+        }
+    }
+    Ok((bytes_recv as _, addr_src, addr_dst))
+}
+
+
+pub(crate) async fn recv_with_dst(socket: &UdpSocket, buffer: &mut [u8]) -> io::Result<(usize, SocketAddr, Option<SocketAddr>)> {
+    let fd = socket.as_raw_fd();
+    let local_port = socket.local_addr().unwrap().port();
+    
+    socket.async_io(Interest::READABLE, || {
+        recv_with_dst_inner(fd, buffer, local_port)
+    }).await
+}

--- a/io/zenoh-links/zenoh-link-udp/src/pktinfo/pktinfo_windows.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/pktinfo/pktinfo_windows.rs
@@ -94,6 +94,7 @@ where
     }
 }
 
+#[derive(Clone)]
 pub(crate) struct PktInfoRetrievalData {
     port: u16,
     is_ipv6: bool,

--- a/io/zenoh-links/zenoh-link-udp/src/pktinfo/pktinfo_windows.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/pktinfo/pktinfo_windows.rs
@@ -70,18 +70,14 @@ fn locate_wsarecvmsg(socket: RawSocket) -> io::Result<WSARecvMsgExtension> {
     }
 
     if mem::size_of::<LPFN_WSARECVMSG>() != byte_len as usize {
-        return Err(io::Error::new(
-            io::ErrorKind::Other,
+        return Err(io::Error::other(
             "Locating fn pointer to WSARecvMsg returned different expected bytes",
         ));
     }
     let cast_to_fn: LPFN_WSARECVMSG = unsafe { mem::transmute(fn_pointer) };
 
     match cast_to_fn {
-        None => Err(io::Error::new(
-            io::ErrorKind::Other,
-            "WSARecvMsg extension not found",
-        )),
+        None => Err(io::Error::other("WSARecvMsg extension not found")),
         Some(extension) => Ok(extension),
     }
 }

--- a/io/zenoh-links/zenoh-link-udp/src/pktinfo/pktinfo_windows.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/pktinfo/pktinfo_windows.rs
@@ -1,0 +1,221 @@
+//
+// Copyright (c) 2025 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+/// mostly taken from https://github.com/pixsper/socket-pktinfo/blob/main/src/win.rs
+use std::io::Error;
+use std::{
+    io, mem,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    os::windows::io::{AsRawSocket, RawSocket},
+    ptr,
+};
+
+use socket2::SockAddr;
+use tokio::{io::Interest, net::UdpSocket};
+use windows_sys::{
+    core::{PCSTR, PSTR},
+    Win32::{
+        Networking::WinSock::{
+            self, CMSGHDR, IN6_PKTINFO, IN_PKTINFO, IPPROTO_IP, IPPROTO_IPV6, IPV6_PKTINFO,
+            IP_PKTINFO, LPFN_WSARECVMSG, LPWSAOVERLAPPED_COMPLETION_ROUTINE,
+            SIO_GET_EXTENSION_FUNCTION_POINTER, SOCKET, WSABUF, WSAID_WSARECVMSG, WSAMSG,
+        },
+        System::IO::OVERLAPPED,
+    },
+};
+const CMSG_HEADER_SIZE: usize = mem::size_of::<CMSGHDR>();
+const PKTINFOV4_DATA_SIZE: usize = mem::size_of::<IN_PKTINFO>();
+const PKTINFOV6_DATA_SIZE: usize = mem::size_of::<IN6_PKTINFO>();
+const CONTROL_PKTINFOV4_BUFFER_SIZE: usize = CMSG_HEADER_SIZE + PKTINFOV4_DATA_SIZE;
+const CONTROL_PKTINFOV6_BUFFER_SIZE: usize = CMSG_HEADER_SIZE + PKTINFOV6_DATA_SIZE + 8;
+
+type WSARecvMsgExtension = unsafe extern "system" fn(
+    s: SOCKET,
+    lpMsg: *mut WSAMSG,
+    lpdwNumberOfBytesRecvd: *mut u32,
+    lpOverlapped: *mut OVERLAPPED,
+    lpCompletionRoutine: LPWSAOVERLAPPED_COMPLETION_ROUTINE,
+) -> i32;
+
+fn locate_wsarecvmsg(socket: RawSocket) -> io::Result<WSARecvMsgExtension> {
+    let mut fn_pointer: usize = 0;
+    let mut byte_len: u32 = 0;
+
+    let r = unsafe {
+        WinSock::WSAIoctl(
+            socket as _,
+            SIO_GET_EXTENSION_FUNCTION_POINTER,
+            &WSAID_WSARECVMSG as *const _ as *mut _,
+            mem::size_of_val(&WSAID_WSARECVMSG) as u32,
+            &mut fn_pointer as *const _ as *mut _,
+            mem::size_of_val(&fn_pointer) as u32,
+            &mut byte_len,
+            ptr::null_mut(),
+            None,
+        )
+    };
+    if r != 0 {
+        return Err(Error::last_os_error());
+    }
+
+    if mem::size_of::<LPFN_WSARECVMSG>() != byte_len as usize {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            "Locating fn pointer to WSARecvMsg returned different expected bytes",
+        ));
+    }
+    let cast_to_fn: LPFN_WSARECVMSG = unsafe { mem::transmute(fn_pointer) };
+
+    match cast_to_fn {
+        None => Err(io::Error::new(
+            io::ErrorKind::Other,
+            "WSARecvMsg extension not found",
+        )),
+        Some(extension) => Ok(extension),
+    }
+}
+
+unsafe fn setsockopt<T>(socket: RawSocket, opt: i32, val: i32, payload: T) -> io::Result<()>
+where
+    T: Copy,
+{
+    let payload = &payload as *const T as PCSTR;
+    if WinSock::setsockopt(socket as _, opt, val, payload, mem::size_of::<T>() as i32) == 0 {
+        Ok(())
+    } else {
+        Err(Error::from_raw_os_error(WinSock::WSAGetLastError()))
+    }
+}
+
+pub(crate) struct PktInfoRetrievalData {
+    port: u16,
+    is_ipv6: bool,
+    wsarecvmsg: WSARecvMsgExtension,
+}
+
+pub(crate) fn enable_pktinfo(socket: &UdpSocket) -> io::Result<PktInfoRetrievalData> {
+    let local_src_addr = socket.local_addr()?;
+    match local_src_addr.is_ipv6() {
+        false => unsafe {
+            setsockopt(socket.as_raw_socket(), IPPROTO_IP, IP_PKTINFO, 1)?;
+        },
+        true => unsafe {
+            setsockopt(socket.as_raw_socket(), IPPROTO_IPV6, IPV6_PKTINFO, 1)?;
+        },
+    }
+    Ok(PktInfoRetrievalData {
+        port: local_src_addr.port(),
+        is_ipv6: local_src_addr.is_ipv6(),
+        wsarecvmsg: locate_wsarecvmsg(socket.as_raw_socket())?,
+    })
+}
+
+pub fn recv_with_dst_inner(
+    socket: RawSocket,
+    local_port: u16,
+    is_ipv6: bool,
+    wsarecvmsg: WSARecvMsgExtension,
+    buf: &mut [u8],
+) -> io::Result<(usize, SocketAddr, Option<SocketAddr>)> {
+    let mut data = WSABUF {
+        buf: buf.as_mut_ptr() as PSTR,
+        len: buf.len() as u32,
+    };
+
+    let mut control_buffer = [0; CONTROL_PKTINFOV6_BUFFER_SIZE]; // Allocate the largest possible buffer
+    let control = WSABUF {
+        buf: control_buffer.as_mut_ptr(),
+        len: match is_ipv6 {
+            false => CONTROL_PKTINFOV4_BUFFER_SIZE as u32,
+            true => CONTROL_PKTINFOV6_BUFFER_SIZE as u32,
+        },
+    };
+
+    let mut addr = unsafe { mem::zeroed() };
+    let mut wsa_msg = WSAMSG {
+        name: &mut addr as *mut _ as *mut _,
+        namelen: mem::size_of_val(&addr) as i32,
+        lpBuffers: &mut data,
+        Control: control,
+        dwBufferCount: 1,
+        dwFlags: 0,
+    };
+
+    let mut read_bytes = 0;
+    let error_code = {
+        unsafe {
+            (wsarecvmsg)(
+                socket as _,
+                &mut wsa_msg,
+                &mut read_bytes,
+                ptr::null_mut(),
+                None,
+            )
+        }
+    };
+
+    if error_code != 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let addr_src = unsafe { SockAddr::new(addr, mem::size_of_val(&addr) as i32) }
+        .as_socket()
+        .unwrap();
+
+    let mut addr_dst = None;
+
+    if control.len as usize == CONTROL_PKTINFOV4_BUFFER_SIZE {
+        let cmsg_header: CMSGHDR = unsafe { ptr::read_unaligned(control.buf as *const _) };
+        if cmsg_header.cmsg_level == IPPROTO_IP && cmsg_header.cmsg_type == IP_PKTINFO {
+            let interface_info: IN_PKTINFO =
+                unsafe { ptr::read_unaligned(control.buf.add(CMSG_HEADER_SIZE) as *const _) };
+
+            addr_dst = Some(SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::from(unsafe {
+                    u32::from_be(interface_info.ipi_addr.S_un.S_addr)
+                })),
+                local_port,
+            ));
+        }
+    } else if control.len as usize == CONTROL_PKTINFOV6_BUFFER_SIZE {
+        let cmsg_header: CMSGHDR = unsafe { ptr::read_unaligned(control.buf as *const _) };
+        if cmsg_header.cmsg_level == IPPROTO_IPV6 && cmsg_header.cmsg_type == IPV6_PKTINFO {
+            let interface_info: IN6_PKTINFO =
+                unsafe { ptr::read_unaligned(control.buf.add(CMSG_HEADER_SIZE) as *const _) };
+
+            addr_dst = Some(SocketAddr::new(
+                IpAddr::V6(Ipv6Addr::from(unsafe { interface_info.ipi6_addr.u.Byte })),
+                local_port,
+            ));
+        }
+    }
+    Ok((read_bytes as usize, addr_src, addr_dst))
+}
+
+pub(crate) async fn recv_with_dst(
+    socket: &UdpSocket,
+    data: &PktInfoRetrievalData,
+    buffer: &mut [u8],
+) -> io::Result<(usize, SocketAddr, Option<SocketAddr>)> {
+    let fd = socket.as_raw_socket();
+    let local_port = data.port;
+    let wsarecvmsg = data.wsarecvmsg;
+    let is_ipv6 = data.is_ipv6;
+
+    socket
+        .async_io(Interest::READABLE, || {
+            recv_with_dst_inner(fd, local_port, is_ipv6, wsarecvmsg, buffer)
+        })
+        .await
+}


### PR DESCRIPTION
Extract udp socket source address via PKTINFO (in particular to find source address when 0.0.0.0 ip is used)
Resolves #1126 