### PR TITLE
Implement `From<&ZBytes> for ZBytes` to simplify usage

### DIFF
--- a/examples/examples/z_ping.rs
+++ b/examples/examples/z_ping.rs
@@ -49,16 +49,14 @@ fn main() {
     println!("Warming up for {warmup:?}...");
     let now = Instant::now();
     while now.elapsed() < warmup {
-        let data = data.clone();
-        publisher.put(data).wait().unwrap();
+        publisher.put(&data).wait().unwrap();
 
         let _ = sub.recv();
     }
 
     for _ in 0..n {
-        let data = data.clone();
         let write_time = Instant::now();
-        publisher.put(data).wait().unwrap();
+        publisher.put(&data).wait().unwrap();
 
         let _ = sub.recv();
         let ts = write_time.elapsed().as_micros();

--- a/examples/examples/z_ping_shm.rs
+++ b/examples/examples/z_ping_shm.rs
@@ -71,14 +71,13 @@ fn main() {
     println!("Warming up for {warmup:?}...");
     let now = Instant::now();
     while now.elapsed() < warmup {
-        publisher.put(buf.clone()).wait().unwrap();
+        publisher.put(&buf).wait().unwrap();
         let _ = sub.recv().unwrap();
     }
 
     for _ in 0..n {
-        let buf = buf.clone();
         let write_time = Instant::now();
-        publisher.put(buf).wait().unwrap();
+        publisher.put(&buf).wait().unwrap();
 
         let _ = sub.recv();
         let ts = write_time.elapsed().as_micros();

--- a/examples/examples/z_pong.rs
+++ b/examples/examples/z_pong.rs
@@ -38,7 +38,7 @@ fn main() {
 
     session
         .declare_subscriber(key_expr_ping)
-        .callback(move |sample| publisher.put(sample.payload().clone()).wait().unwrap())
+        .callback(move |sample| publisher.put(sample.payload()).wait().unwrap())
         .background()
         .wait()
         .unwrap();

--- a/examples/examples/z_pub_shm_thr.rs
+++ b/examples/examples/z_pub_shm_thr.rs
@@ -62,7 +62,7 @@ async fn main() {
 
     println!("Press CTRL-C to quit...");
     loop {
-        publisher.put(buf.clone()).await.unwrap();
+        publisher.put(&buf).await.unwrap();
     }
 }
 

--- a/examples/examples/z_pub_thr.rs
+++ b/examples/examples/z_pub_thr.rs
@@ -53,7 +53,7 @@ fn main() {
     let mut count: usize = 0;
     let mut start = std::time::Instant::now();
     loop {
-        publisher.put(data.clone()).wait().unwrap();
+        publisher.put(&data).wait().unwrap();
 
         if args.print {
             if count < args.number {

--- a/examples/examples/z_queryable.rs
+++ b/examples/examples/z_queryable.rs
@@ -59,7 +59,7 @@ async fn main() {
         );
         // Refer to z_bytes.rs to see how to serialize different types of message
         query
-            .reply(key_expr.clone(), payload.clone())
+            .reply(key_expr.clone(), &payload)
             .await
             .unwrap_or_else(|e| println!(">> [Queryable ] Error sending reply: {e}"));
     }

--- a/examples/examples/z_storage.rs
+++ b/examples/examples/z_storage.rs
@@ -64,7 +64,7 @@ async fn main() {
                 println!(">> [Queryable ] Received Query '{}'", query.selector());
                 for (stored_name, sample) in stored.iter() {
                     if query.key_expr().intersects(unsafe {keyexpr::from_str_unchecked(stored_name)}) {
-                        query.reply(sample.key_expr().clone(), sample.payload().clone()).await.unwrap();
+                        query.reply(sample.key_expr().clone(), sample.payload()).await.unwrap();
                     }
                 }
             }

--- a/zenoh/src/api/bytes.rs
+++ b/zenoh/src/api/bytes.rs
@@ -363,6 +363,12 @@ impl<'a> Iterator for ZBytesSliceIterator<'a> {
     }
 }
 
+impl From<&ZBytes> for ZBytes {
+    fn from(value: &ZBytes) -> Self {
+        value.clone()
+    }
+}
+
 impl From<ZBuf> for ZBytes {
     fn from(value: ZBuf) -> Self {
         Self(value)


### PR DESCRIPTION
Now we need to use `publisher.put(sample.payload().clone()).wait().unwrap()` because ZBytes can't be transformed into &ZBytes.
Initially, we considered implementing the Copy trait, but Copy can't be implemented in Vec, which is used in `SingleOrVec`.
If we implement `From<&ZBytes> for ZBytes`, then `sample.payload()` (&ZBytes) can be transformed into ZBytes implicitly, and it simplifies the usage.
The downside might be that users aren't aware of the implicit clone, but it should be okay when the clone here is cheap.

