### PR TITLE
demonstrate that channel closes on undeclaring subscriber

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4292,6 +4292,7 @@ dependencies = [
  "libc",
  "mio 1.0.2",
  "pin-project-lite 0.2.14",
+ "signal-hook-registry",
  "socket2 0.5.7",
  "tokio-macros",
  "windows-sys 0.52.0",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -36,7 +36,7 @@ clap = { workspace = true, features = ["derive"] }
 futures = { workspace = true }
 prost = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "time", "io-std"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "time", "io-std", "signal"] }
 zenoh = { workspace = true, default-features = false }
 zenoh-ext = { workspace = true, default-features = false, features = ["unstable"] }
 


### PR DESCRIPTION
Undeclare subscriber on Ctrl-C press to demonstrate that the sample reading loop terminates after subscriber closing.

The reason of this update: I found that zenoh-ts doesn't implement this behavior so first I had to check is rust works this way. I think it's good to keep it for future reference