### PR TITLE
Publish localhost locator if no other locators are avalable or when binding to the localhost interface.

### DIFF
--- a/commons/zenoh-util/src/net/mod.rs
+++ b/commons/zenoh-util/src/net/mod.rs
@@ -11,7 +11,7 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use std::net::{IpAddr, Ipv6Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 #[cfg(unix)]
 use lazy_static::lazy_static;
@@ -376,7 +376,7 @@ pub fn get_interface_names_by_addr(addr: IpAddr) -> ZResult<Vec<String>> {
 }
 
 pub fn get_ipv4_ipaddrs(interface: Option<&str>) -> Vec<IpAddr> {
-    get_local_addresses(interface)
+    let addrs: Vec<_> = get_local_addresses(interface)
         .unwrap_or_else(|_| vec![])
         .drain(..)
         .filter_map(|x| match x {
@@ -385,7 +385,13 @@ pub fn get_ipv4_ipaddrs(interface: Option<&str>) -> Vec<IpAddr> {
         })
         .filter(|x| (!x.is_loopback() || interface.is_some()) && !x.is_multicast())
         .map(IpAddr::V4)
-        .collect()
+        .collect();
+
+    if addrs.is_empty() && interface.is_none() {
+        vec![Ipv4Addr::LOCALHOST.into()]
+    } else {
+        addrs
+    }
 }
 
 pub fn get_ipv6_ipaddrs(interface: Option<&str>) -> Vec<IpAddr> {
@@ -443,11 +449,17 @@ pub fn get_ipv6_ipaddrs(interface: Option<&str>) -> Vec<IpAddr> {
         .map(|x| IpAddr::V4(*x));
 
     // Extend
-    nll_ipv6_addrs
+    let addrs: Vec<_> = nll_ipv6_addrs
         .chain(pub_ipv4_addrs)
         .chain(yll_ipv6_addrs)
         .chain(priv_ipv4_addrs)
-        .collect()
+        .collect();
+
+    if addrs.is_empty() && interface.is_none() {
+        vec![Ipv6Addr::LOCALHOST.into()]
+    } else {
+        addrs
+    }
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]

--- a/commons/zenoh-util/src/net/mod.rs
+++ b/commons/zenoh-util/src/net/mod.rs
@@ -383,7 +383,7 @@ pub fn get_ipv4_ipaddrs(interface: Option<&str>) -> Vec<IpAddr> {
             IpAddr::V4(a) => Some(a),
             IpAddr::V6(_) => None,
         })
-        .filter(|x| !x.is_loopback() && !x.is_multicast())
+        .filter(|x| (!x.is_loopback() || interface.is_some()) && !x.is_multicast())
         .map(IpAddr::V4)
         .collect()
 }
@@ -403,7 +403,10 @@ pub fn get_ipv6_ipaddrs(interface: Option<&str>) -> Vec<IpAddr> {
             IpAddr::V6(_) => None,
         })
         .filter(|x| {
-            !x.is_loopback() && !x.is_link_local() && !x.is_multicast() && !x.is_broadcast()
+            (!x.is_loopback() || interface.is_some())
+                && !x.is_link_local()
+                && !x.is_multicast()
+                && !x.is_broadcast()
         });
 
     // Get next all IPv6 addresses
@@ -415,7 +418,11 @@ pub fn get_ipv6_ipaddrs(interface: Option<&str>) -> Vec<IpAddr> {
     // First match non-linklocal IPv6 addresses
     let nll_ipv6_addrs = ipv6_iter
         .clone()
-        .filter(|x| !x.is_loopback() && !x.is_multicast() && !is_unicast_link_local(x))
+        .filter(|x| {
+            (!x.is_loopback() || interface.is_some())
+                && !x.is_multicast()
+                && !is_unicast_link_local(x)
+        })
         .map(|x| IpAddr::V6(*x));
 
     // Second match public IPv4 addresses

--- a/commons/zenoh-util/src/net/mod.rs
+++ b/commons/zenoh-util/src/net/mod.rs
@@ -375,17 +375,24 @@ pub fn get_interface_names_by_addr(addr: IpAddr) -> ZResult<Vec<String>> {
     }
 }
 
+/// Return all IPv4 unicast addresses to listen on the specified interface, or all addresses except loopback if `interface` is `None`.
+/// If no addresses are found and the interface is `None`, return the loopback address.
 pub fn get_ipv4_ipaddrs(interface: Option<&str>) -> Vec<IpAddr> {
-    let addrs: Vec<_> = get_local_addresses(interface)
-        .unwrap_or_else(|_| vec![])
-        .drain(..)
+    let addrs = get_local_addresses(interface).unwrap_or_else(|_| vec![]);
+
+    filter_ipv4_addrs_for_interface(interface, addrs)
+}
+
+fn filter_ipv4_addrs_for_interface(interface: Option<&str>, all_addrs: Vec<IpAddr>) -> Vec<IpAddr> {
+    let addrs = all_addrs
+        .into_iter()
         .filter_map(|x| match x {
             IpAddr::V4(a) => Some(a),
             IpAddr::V6(_) => None,
         })
         .filter(|x| (!x.is_loopback() || interface.is_some()) && !x.is_multicast())
         .map(IpAddr::V4)
-        .collect();
+        .collect::<Vec<_>>();
 
     if addrs.is_empty() && interface.is_none() {
         vec![Ipv4Addr::LOCALHOST.into()]
@@ -394,15 +401,27 @@ pub fn get_ipv4_ipaddrs(interface: Option<&str>) -> Vec<IpAddr> {
     }
 }
 
+/// Return unicast addresses to listen on the specified interface, or all addresses except loopback if `interface` is `None`.
+/// The addresses are sorted by the following order:
+/// 1. Non-linklocal IPv6 addresses
+/// 2. Public IPv4 addresses
+/// 3. Linklocal IPv6 addresses
+/// 4. Private IPv4 addresses
+///
+/// If no addresses are found and the interface is `None`, return the loopback address.
 pub fn get_ipv6_ipaddrs(interface: Option<&str>) -> Vec<IpAddr> {
+    let ipaddrs = get_local_addresses(interface).unwrap_or_else(|_| vec![]);
+
+    filter_ipv6_addrs_for_interface(interface, ipaddrs)
+}
+
+fn filter_ipv6_addrs_for_interface(interface: Option<&str>, all_addrs: Vec<IpAddr>) -> Vec<IpAddr> {
     const fn is_unicast_link_local(addr: &Ipv6Addr) -> bool {
         (addr.segments()[0] & 0xffc0) == 0xfe80
     }
 
-    let ipaddrs = get_local_addresses(interface).unwrap_or_else(|_| vec![]);
-
     // Get first all IPv4 addresses
-    let ipv4_iter = ipaddrs
+    let ipv4_iter = all_addrs
         .iter()
         .filter_map(|x| match x {
             IpAddr::V4(a) => Some(a),
@@ -416,7 +435,7 @@ pub fn get_ipv6_ipaddrs(interface: Option<&str>) -> Vec<IpAddr> {
         });
 
     // Get next all IPv6 addresses
-    let ipv6_iter = ipaddrs.iter().filter_map(|x| match x {
+    let ipv6_iter = all_addrs.iter().filter_map(|x| match x {
         IpAddr::V4(_) => None,
         IpAddr::V6(a) => Some(a),
     });
@@ -484,4 +503,126 @@ pub fn set_bind_to_device_tcp_socket(socket: &TcpSocket, iface: &str) -> ZResult
 pub fn set_bind_to_device_udp_socket(socket: &UdpSocket, iface: &str) -> ZResult<()> {
     tracing::warn!("Binding the socket {socket:?} to the interface {iface} is not supported on macOS, iOS, and Windows");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_filter_ipv4_addrs_for_interface() {
+        let addrs = vec![
+            IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            IpAddr::V4(Ipv4Addr::new(224, 0, 0, 1)),
+            IpAddr::V6(Ipv6Addr::LOCALHOST),
+        ];
+        let filtered_addrs = filter_ipv4_addrs_for_interface(None, addrs);
+
+        assert_eq!(
+            filtered_addrs,
+            vec![IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1))]
+        );
+    }
+
+    #[test]
+    fn test_filter_ipv4_addrs_for_loopback() {
+        let addrs = vec![
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            IpAddr::V6(Ipv6Addr::LOCALHOST),
+        ];
+        let filtered_addrs = filter_ipv4_addrs_for_interface(Some("lo"), addrs);
+
+        assert_eq!(filtered_addrs, vec![IpAddr::V4(Ipv4Addr::LOCALHOST)]);
+    }
+
+    #[test]
+    fn test_filter_ipv4_addrs_return_loopback_when_no_other_choice() {
+        let addrs = vec![
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            IpAddr::V6(Ipv6Addr::LOCALHOST),
+        ];
+        let filtered_addrs = filter_ipv4_addrs_for_interface(None, addrs);
+
+        assert_eq!(filtered_addrs, vec![IpAddr::V4(Ipv4Addr::LOCALHOST)]);
+    }
+
+    #[test]
+    fn test_filter_ipv4_addrs_return_nothing_if_interface_doesn_t_have_any_addr() {
+        let addrs = vec![IpAddr::V4(Ipv4Addr::new(224, 0, 0, 1))];
+        let filtered_addrs = filter_ipv4_addrs_for_interface(Some("eno1"), addrs);
+
+        assert_eq!(filtered_addrs.len(), 0);
+    }
+
+    #[test]
+    fn test_filter_ipv4_addrs_fall_back_on_loopback() {
+        let filtered_addrs = filter_ipv4_addrs_for_interface(None, vec![]);
+
+        assert_eq!(filtered_addrs, vec![IpAddr::V4(Ipv4Addr::LOCALHOST)]);
+    }
+
+    #[test]
+    fn test_filter_ipv6_addrs_for_interface() {
+        let addrs = vec![
+            IpAddr::V6(Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0, 1)),
+            IpAddr::V6(Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0, 2)),
+            IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
+        ];
+        let filtered_addrs = filter_ipv6_addrs_for_interface(Some("abc"), addrs);
+
+        assert_eq!(
+            filtered_addrs,
+            vec![
+                IpAddr::V6(Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0, 1)),
+                IpAddr::V6(Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0, 2)),
+                IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_filter_ipv6_addrs_for_lo() {
+        let addrs = vec![
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            IpAddr::V6(Ipv6Addr::LOCALHOST),
+        ];
+        let filtered_addrs = filter_ipv6_addrs_for_interface(Some("lo"), addrs);
+
+        assert_eq!(
+            filtered_addrs,
+            vec![
+                IpAddr::V6(Ipv6Addr::LOCALHOST),
+                IpAddr::V4(Ipv4Addr::LOCALHOST),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_filter_ipv6_addrs_no_interface() {
+        let addrs = vec![
+            IpAddr::V6(Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0, 1)),
+            IpAddr::V6(Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0, 2)),
+            IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            IpAddr::V6(Ipv6Addr::LOCALHOST),
+        ];
+        let filtered_addrs = filter_ipv6_addrs_for_interface(None, addrs);
+
+        assert_eq!(
+            filtered_addrs,
+            vec![
+                IpAddr::V6(Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0, 1)),
+                IpAddr::V6(Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0, 2)),
+                IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1))
+            ]
+        );
+    }
+
+    #[test]
+    fn test_filter_ipv6_addrs_fallback_on_loopback() {
+        let filtered_addrs = filter_ipv6_addrs_for_interface(None, vec![]);
+
+        assert_eq!(filtered_addrs, vec![IpAddr::V6(Ipv6Addr::LOCALHOST)]);
+    }
 }


### PR DESCRIPTION
This PR does two things:

When listening on an unspecified IP address (i.e. 0.0.0.0 and [::]):

1. If a binding interface is specified, do not filter out localhost addresses. Rational: we'll only get localhost addresses if the bound interface is the loopback interface (at least on Unix systems, someone correct me on Windows?)
2. If the list of IP locator is empty and we didn't specify any interface, manually add a localhost locator.

Note that is has the side effect of adding the localhost locator to the list even if there is already another non-ip locator (e.g. Unix socket, ...). I think that's all-right.

Closes #1989

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [x] **Reproduction test added** - Test that fails on main branch without the fix
- [x] **Test passes with fix** - The reproduction test passes with your changes
- [x] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->