### PR TITLE
Accept a boolean value for the `complete` field of storage_manager config

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -877,7 +877,7 @@
   //          volume: "memory",
   //          /// A complete storage advertises itself as containing all the known keys matching the configured key expression.
   //          /// If not configured, complete defaults to false.
-  //          complete: "true",
+  //          complete: true,
   //        },
   //        influx_demo: {
   //          key_expr: "demo/influxdb/**",

--- a/plugins/zenoh-backend-traits/src/config.rs
+++ b/plugins/zenoh-backend-traits/src/config.rs
@@ -443,18 +443,24 @@ impl StorageConfig {
                 )
             }
         };
-        let complete = match config.get("complete").and_then(|x| x.as_str()) {
-            Some(s) => match s {
+        let complete = match config.get("complete") {
+            Some(Value::Bool(b)) => *b,
+            Some(Value::String(s)) => match s.as_str() {
                 "true" => true,
                 "false" => false,
                 e => {
                     bail!(
-                        "complete='{}' is not a valid value. Accepted values: ['true', 'false']",
+                        r#"complete='{}' is not a valid value. Only booleans or strings ('true','false') are accepted"#,
                         e
                     )
                 }
             },
             None => false,
+            _ => bail!(
+                "Invalid type for field `complete` of storage `{}`. Only booleans or strings ('true','false') \
+                 are accepted.",
+                storage_name
+            ),
         };
         let strip_prefix: Option<OwnedKeyExpr> = match config.get("strip_prefix") {
             Some(Value::String(s)) => {


### PR DESCRIPTION
Fix https://github.com/eclipse-zenoh/zenoh/issues/1942

I keep the string type for backward compatibility.