### PR TITLE
Update README how to avoid an out-of-memory error

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ To build Zenoh, just type the following command after having followed the previo
 cargo build --release --all-targets
 ```
 
+Building all targets may cause an out-of-memory error if memory is limited. Reducing the number of parallel build jobs can help, though it may increase build time. You can fine-tune the job count to balance performance and resource usage.
+
+```bash
+cargo build --release --all-targets --jobs=1
+```
+
 Zenoh's router is built as `target/release/zenohd`. All the examples are built into the `target/release/examples` directory. They can all work in peer-to-peer, or interconnected via the zenoh router.
 
 -------------------------------


### PR DESCRIPTION
Related to https://github.com/eclipse-zenoh/zenoh/issues/1782

This issue is also reported by users on Raspberry Pi, which has insufficient memory.
I think it's worth providing information on the README.
