### PR TITLE
Improve error message when opening an empty file

### DIFF
--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -1001,6 +1001,9 @@ impl Config {
                 if let Err(e) = f.read_to_string(&mut content) {
                     bail!(e)
                 }
+                if content.is_empty() {
+                    bail!("Empty config file");
+                }
                 match path
                     .extension()
                     .map(|s| s.to_str().unwrap())

--- a/zenohd/src/main.rs
+++ b/zenohd/src/main.rs
@@ -111,7 +111,7 @@ fn config_from_args(args: &Args) -> Config {
     let mut config = if let Some(cfg) = inline_config {
         Config::from_json5(cfg).expect("Invalid Zenoh config")
     } else if let Some(fname) = args.config.as_ref() {
-        Config::from_file(fname).expect("Failed to open config file")
+        Config::from_file(fname).expect("Failed to load config file")
     } else {
         Config::default()
     };


### PR DESCRIPTION
currently, zenoh gives the following error message:

```
thread 'main' panicked at zenohd/src/main.rs:114:34:                                                                                                                                                  
Failed to open config file:  --> 1:1                                                                                                                                                                  
  |                                                                                                                                                                                                   
1 |                                                                                                                                                                                                   
  | ^---                                                                                                                                                                                              
  |                                                                                                                                                                                                   
  = expected array, boolean, null, number, object, or string at commons/zenoh-config/src/lib.rs:1013. 
```

The PR improves on that:

```
thread 'main' panicked at zenohd/src/main.rs:114:34:
Failed to load config file: Empty config file at commons/zenoh-config/src/lib.rs:1005.
```