### PR TITLE
Read the gossip autoconnect config from the GossipConf instead of the ScoutingMulticastConf

### DIFF
--- a/zenoh/src/net/common.rs
+++ b/zenoh/src/net/common.rs
@@ -32,7 +32,7 @@ impl AutoConnect {
             matcher: *unwrap_or_default!(config.scouting().gossip().autoconnect().get(what)),
             strategy: *unwrap_or_default!(config
                 .scouting()
-                .multicast()
+                .gossip()
                 .autoconnect_strategy()
                 .get(what)),
         }


### PR DESCRIPTION
The `scouting.gossip.autoconnect` and `autoconnect_strategy` values were never used to configure the gossip autoconnect mechanism: `scouting.multicast.autoconnect` and `autoconnect_strategy` were used instead. 

⚠️ Breaking change:
Some configurations might break.