### PR TITLE
add CongestionControl::BlockFirst

### DIFF
--- a/commons/zenoh-config/src/qos.rs
+++ b/commons/zenoh-config/src/qos.rs
@@ -53,6 +53,7 @@ pub struct PublisherQoSConfig {
 pub enum CongestionControlConf {
     Drop,
     Block,
+    #[cfg(feature = "unstable")]
     BlockFirst,
 }
 
@@ -61,6 +62,7 @@ impl From<CongestionControlConf> for CongestionControl {
         match value {
             CongestionControlConf::Drop => Self::Drop,
             CongestionControlConf::Block => Self::Block,
+            #[cfg(feature = "unstable")]
             CongestionControlConf::BlockFirst => Self::BlockFirst,
         }
     }
@@ -71,6 +73,7 @@ impl From<CongestionControl> for CongestionControlConf {
         match value {
             CongestionControl::Drop => Self::Drop,
             CongestionControl::Block => Self::Block,
+            #[cfg(feature = "unstable")]
             CongestionControl::BlockFirst => Self::BlockFirst,
         }
     }

--- a/commons/zenoh-config/src/qos.rs
+++ b/commons/zenoh-config/src/qos.rs
@@ -53,6 +53,7 @@ pub struct PublisherQoSConfig {
 pub enum CongestionControlConf {
     Drop,
     Block,
+    BlockFirst,
 }
 
 impl From<CongestionControlConf> for CongestionControl {
@@ -60,6 +61,7 @@ impl From<CongestionControlConf> for CongestionControl {
         match value {
             CongestionControlConf::Drop => Self::Drop,
             CongestionControlConf::Block => Self::Block,
+            CongestionControlConf::BlockFirst => Self::BlockFirst,
         }
     }
 }
@@ -69,6 +71,7 @@ impl From<CongestionControl> for CongestionControlConf {
         match value {
             CongestionControl::Drop => Self::Drop,
             CongestionControl::Block => Self::Block,
+            CongestionControl::BlockFirst => Self::BlockFirst,
         }
     }
 }

--- a/commons/zenoh-protocol/Cargo.toml
+++ b/commons/zenoh-protocol/Cargo.toml
@@ -25,6 +25,7 @@ description = "Internal crate for zenoh."
 
 [features]
 default = ["std"]
+unstable = []
 internal = []
 std = [
     "rand?/std",

--- a/commons/zenoh-protocol/src/core/mod.rs
+++ b/commons/zenoh-protocol/src/core/mod.rs
@@ -570,6 +570,10 @@ pub enum CongestionControl {
     /// When transmitting a message in a node with a full queue, the node will wait for queue to
     /// progress.
     Block = 1,
+    /// When transmitting a message in a node with a full queue, the node will wait for queue to
+    /// progress, but only for the first message sent with this strategy; other messages will be
+    /// dropped.
+    BlockFirst = 2,
 }
 
 impl CongestionControl {

--- a/commons/zenoh-protocol/src/core/mod.rs
+++ b/commons/zenoh-protocol/src/core/mod.rs
@@ -570,6 +570,7 @@ pub enum CongestionControl {
     /// When transmitting a message in a node with a full queue, the node will wait for queue to
     /// progress.
     Block = 1,
+    #[cfg(feature = "unstable")]
     /// When transmitting a message in a node with a full queue, the node will wait for queue to
     /// progress, but only for the first message sent with this strategy; other messages will be
     /// dropped.

--- a/commons/zenoh-protocol/src/network/mod.rs
+++ b/commons/zenoh-protocol/src/network/mod.rs
@@ -413,7 +413,7 @@ pub mod ext {
     /// - prio: Priority class
     /// - D:    Don't drop. Don't drop the message for congestion control.
     /// - E:    Express. Don't batch this message.
-    /// - F:    Block only on the first message for congestion control.
+    /// - F:    Don't drop the first message for congestion control.
     /// - r:  Reserved
     /// ```
     #[repr(transparent)]

--- a/commons/zenoh-protocol/src/network/mod.rs
+++ b/commons/zenoh-protocol/src/network/mod.rs
@@ -455,6 +455,7 @@ pub mod ext {
             let mut inner = priority as u8;
             match congestion_control {
                 CongestionControl::Block => inner |= Self::D_FLAG,
+                #[cfg(feature = "unstable")]
                 CongestionControl::BlockFirst => inner |= Self::F_FLAG,
                 _ => {}
             }
@@ -482,6 +483,7 @@ pub mod ext {
                     self.inner = imsg::unset_flag(self.inner, Self::D_FLAG);
                     self.inner = imsg::unset_flag(self.inner, Self::F_FLAG);
                 }
+                #[cfg(feature = "unstable")]
                 CongestionControl::BlockFirst => {
                     self.inner = imsg::unset_flag(self.inner, Self::D_FLAG);
                     self.inner = imsg::set_flag(self.inner, Self::F_FLAG);
@@ -495,7 +497,10 @@ pub mod ext {
                 imsg::has_flag(self.inner, Self::F_FLAG),
             ) {
                 (false, false) => CongestionControl::Drop,
+                #[cfg(feature = "unstable")]
                 (false, true) => CongestionControl::BlockFirst,
+                #[cfg(not(feature = "unstable"))]
+                (false, true) => CongestionControl::Drop,
                 (true, _) => CongestionControl::Block,
             }
         }

--- a/io/zenoh-transport/src/unicast/universal/transport.rs
+++ b/io/zenoh-transport/src/unicast/universal/transport.rs
@@ -27,6 +27,7 @@ use zenoh_protocol::{
     transport::{close, Close, PrioritySn, TransportMessage, TransportSn},
 };
 use zenoh_result::{bail, zerror, ZResult};
+#[cfg(feature = "unstable")]
 use zenoh_sync::{event, Notifier, Waiter};
 
 #[cfg(feature = "stats")]
@@ -64,9 +65,11 @@ pub(crate) struct TransportUnicastUniversal {
     add_link_lock: Arc<AsyncMutex<()>>,
     // Mutex for notification
     pub(super) alive: Arc<AsyncMutex<bool>>,
+    #[cfg(feature = "unstable")]
     // Notifier for a BlockFirst message to be ready to be sent
     // (after the previous one has been sent)
     pub block_first_notifier: Notifier,
+    #[cfg(feature = "unstable")]
     // Waiter for a BlockFirst message to be ready to be sent
     pub block_first_waiter: Waiter,
     // Transport statistics
@@ -102,8 +105,10 @@ impl TransportUnicastUniversal {
         for c in priority_tx.iter() {
             c.sync(initial_sn)?;
         }
+        #[cfg(feature = "unstable")]
         let (block_first_notifier, block_first_waiter) = event::new();
         // notify to be make the BlockFirst "slot" available
+        #[cfg(feature = "unstable")]
         block_first_notifier.notify().unwrap();
 
         let t = Arc::new(TransportUnicastUniversal {
@@ -117,7 +122,9 @@ impl TransportUnicastUniversal {
             alive: Arc::new(AsyncMutex::new(false)),
             #[cfg(feature = "stats")]
             stats,
+            #[cfg(feature = "unstable")]
             block_first_notifier,
+            #[cfg(feature = "unstable")]
             block_first_waiter,
         });
 

--- a/io/zenoh-transport/src/unicast/universal/tx.rs
+++ b/io/zenoh-transport/src/unicast/universal/tx.rs
@@ -11,8 +11,11 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
+
+#[cfg(feature = "unstable")]
+use zenoh_protocol::core::CongestionControl;
 use zenoh_protocol::{
-    core::{CongestionControl, Priority, PriorityRange, Reliability},
+    core::{Priority, PriorityRange, Reliability},
     network::{NetworkMessageExt, NetworkMessageMut, NetworkMessageRef},
     transport::close,
 };
@@ -156,6 +159,7 @@ impl TransportUnicastUniversal {
             }
         }
 
+        #[cfg(feature = "unstable")]
         if msg.congestion_control() == CongestionControl::BlockFirst {
             if self
                 .block_first_waiter
@@ -176,6 +180,9 @@ impl TransportUnicastUniversal {
         } else {
             self.schedule_on_link(msg.as_ref())
         }
+
+        #[cfg(not(feature = "unstable"))]
+        self.schedule_on_link(msg.as_ref())
     }
 }
 

--- a/io/zenoh-transport/src/unicast/universal/tx.rs
+++ b/io/zenoh-transport/src/unicast/universal/tx.rs
@@ -150,7 +150,9 @@ impl TransportUnicastUniversal {
         {
             if let Err(e) = map_zmsg_to_partner(&mut msg, &self.config.shm) {
                 tracing::trace!("Failed SHM conversion: {}", e);
-                return Ok(false);
+                #[cfg(feature = "stats")]
+                self.stats.inc_tx_n_dropped(1);
+                return Ok(());
             }
         }
 

--- a/io/zenoh-transport/src/unicast/universal/tx.rs
+++ b/io/zenoh-transport/src/unicast/universal/tx.rs
@@ -172,7 +172,7 @@ impl TransportUnicastUniversal {
             };
             let transport = self.clone();
             let msg = msg.to_owned();
-            zenoh_runtime::ZRuntime::Net.spawn(async move {
+            zenoh_runtime::ZRuntime::Net.spawn_blocking(move || {
                 let _ = transport.schedule_on_link(msg.as_ref());
                 let _ = transport.block_first_notifier.notify();
             });

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -72,6 +72,7 @@ unstable = [
   "internal_config",
   "zenoh-keyexpr/unstable",
   "zenoh-config/unstable",
+  "zenoh-protocol/unstable",
 ]
 internal_config = []
 tracing-instrument = [


### PR DESCRIPTION
This congestion controlled is implemented with a special "slot" inside `TransportUnicastUniversal`. When a `BlockFirst` message is sent, the slot is acquired and a task is spawned to send the message, as if it was blocking. If a second `BlockFirst` message arrives, but the slot is not free, then it is dropped (after waiting for the configured time).
The slot is materialized by a event pair (notifier, waiter). Waiting for the event means acquiring the slot, and notifying after having sent the message is means releasing the slot.