### PR TITLE
Add ZID subject property to ACL

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -457,6 +457,11 @@
   //      /// link protocols can also be used to identify transports to filter messages on.
   //      /// If absent, the rules will be applied to all transports. An empty list is invalid.
   //      link_protocols: [ "tcp", "udp", "tls", "quic", "ws", "serial", "unixsock-stream", "unixpipe", "vsock"],
+  //      /// ZIDs can also be used to identify transports to filter messages on.
+  //      /// NOTE: ZID is not backed by an authentication mechanism, it can only be trusted for ACL if it is
+  //      ///       dynamically added/removed by eventual dedicated Zenoh mechanisms when transports are opened/closed.
+  //      ///       If managed manually in ACL config, can be useful for prototyping but should not be used in production!
+  //      zids: ["38a4829bce9166ee"],
   //     },
   //   ],
   //   /// The policies list associates rules to subjects

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -174,6 +174,7 @@ pub struct AclConfigSubjects {
     pub cert_common_names: Option<NEVec<CertCommonName>>,
     pub usernames: Option<NEVec<Username>>,
     pub link_protocols: Option<NEVec<InterceptorLink>>,
+    pub zids: Option<NEVec<ZenohId>>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/io/zenoh-transport/src/unicast/authentication.rs
+++ b/io/zenoh-transport/src/unicast/authentication.rs
@@ -12,17 +12,27 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use zenoh_link::LinkAuthId;
+use zenoh_protocol::core::ZenohIdProto;
 
 #[cfg(feature = "auth_usrpwd")]
 use super::establishment::ext::auth::UsrPwdId;
 
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TransportAuthId {
     username: Option<String>,
+    zid: ZenohIdProto,
     link_auth_ids: Vec<LinkAuthId>,
 }
 
 impl TransportAuthId {
+    pub(crate) fn new(zid: ZenohIdProto) -> Self {
+        Self {
+            username: None,
+            zid,
+            link_auth_ids: vec![],
+        }
+    }
+
     #[cfg(feature = "auth_usrpwd")]
     pub(crate) fn set_username(&mut self, user_pwd_id: &UsrPwdId) {
         self.username = if let Some(username) = &user_pwd_id.0 {
@@ -49,5 +59,9 @@ impl TransportAuthId {
 
     pub fn link_auth_ids(&self) -> &Vec<LinkAuthId> {
         &self.link_auth_ids
+    }
+
+    pub fn zid(&self) -> &ZenohIdProto {
+        &self.zid
     }
 }

--- a/io/zenoh-transport/src/unicast/lowlatency/transport.rs
+++ b/io/zenoh-transport/src/unicast/lowlatency/transport.rs
@@ -183,7 +183,7 @@ impl TransportUnicastTrait for TransportUnicastLowlatency {
 
     fn get_auth_ids(&self) -> TransportAuthId {
         // Convert LinkUnicast auth id to AuthId
-        let mut transport_auth_id = TransportAuthId::default();
+        let mut transport_auth_id = TransportAuthId::new(self.get_zid());
         let handle = tokio::runtime::Handle::current();
         let guard =
             tokio::task::block_in_place(|| handle.block_on(async { zasyncread!(self.link) }));

--- a/io/zenoh-transport/src/unicast/universal/transport.rs
+++ b/io/zenoh-transport/src/unicast/universal/transport.rs
@@ -389,7 +389,7 @@ impl TransportUnicastTrait for TransportUnicastUniversal {
     }
 
     fn get_auth_ids(&self) -> TransportAuthId {
-        let mut transport_auth_id = TransportAuthId::default();
+        let mut transport_auth_id = TransportAuthId::new(self.get_zid());
         // Convert LinkUnicast auth ids to AuthId
         zread!(self.links)
             .iter()


### PR DESCRIPTION
This PR adds ZIDs as subject property in ACL config.
This is useful for prototyping and testing ACL policies, but should not be used in production.