### PR TITLE
Refactor `KeyExpr::try_from<&str>` and add some tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4079,6 +4079,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-case"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "test-case-core",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4487,7 +4520,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 
@@ -5358,6 +5391,7 @@ dependencies = [
  "rand 0.8.5",
  "schemars",
  "serde",
+ "test-case",
  "token-cell",
  "zenoh-result",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,7 @@ shellexpand = "3.1.0"
 socket2 = { version = "0.5.7", features = ["all"] }
 stop-token = "0.7.0"
 syn = "2.0"
-test-case = { version = "3.3.1" }
+test-case = "3.3.1"
 tide = "0.16.0"
 time = "0.3.36"
 token-cell = { version = "1.5.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,6 +168,7 @@ shellexpand = "3.1.0"
 socket2 = { version = "0.5.7", features = ["all"] }
 stop-token = "0.7.0"
 syn = "2.0"
+test-case = { version = "3.3.1" }
 tide = "0.16.0"
 time = "0.3.36"
 token-cell = { version = "1.5.0", default-features = false }

--- a/commons/zenoh-keyexpr/Cargo.toml
+++ b/commons/zenoh-keyexpr/Cargo.toml
@@ -35,7 +35,6 @@ keyed-set = { workspace = true }
 rand = { workspace = true, features = ["alloc", "getrandom"] }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, features = ["alloc"] }
-test-case = { workspace = true }
 token-cell = { workspace = true }
 zenoh-result = { workspace = true }
 # NOTE: getrandom needs to be explicitly added here in order to enable the `js` feature when compiling the rand crate to WASM
@@ -51,6 +50,7 @@ ahash = { workspace = true, default-features = true }
 criterion = { workspace = true }
 lazy_static = { workspace = true }
 rand = { workspace = true, features = ["default"] }
+test-case = { workspace = true }
 
 [[bench]]
 name = "keyexpr_tree"

--- a/commons/zenoh-keyexpr/Cargo.toml
+++ b/commons/zenoh-keyexpr/Cargo.toml
@@ -35,6 +35,7 @@ keyed-set = { workspace = true }
 rand = { workspace = true, features = ["alloc", "getrandom"] }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, features = ["alloc"] }
+test-case = { workspace = true }
 token-cell = { workspace = true }
 zenoh-result = { workspace = true }
 # NOTE: getrandom needs to be explicitly added here in order to enable the `js` feature when compiling the rand crate to WASM

--- a/commons/zenoh-keyexpr/src/key_expr/borrowed.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/borrowed.rs
@@ -25,7 +25,6 @@ use core::{
     ops::{Deref, Div},
 };
 
-use test_case::test_case;
 use zenoh_result::{bail, Error as ZError, ZResult};
 
 use super::{canon::Canonize, OwnedKeyExpr, OwnedNonWildKeyExpr};
@@ -1061,23 +1060,30 @@ fn test_keyexpr_strip_nonwild_prefix() {
     }
 }
 
-#[test_case("demo/example/test", true; "Normal key_expr")]
-#[test_case("demo/*/*/test", true; "Single star after single star")]
-#[test_case("demo/*/**/test", true; "Single star after double star")]
-#[test_case("demo/example$*/test", true; "Dollar with star")]
-#[test_case("demo/example$*-$*/test", true; "Multiple dollar with star")]
-#[test_case("/demo/example/test", false; "Leading /")]
-#[test_case("demo/$*/test", false; "Lone $*")]
-#[test_case("demo/**/*/test", false; "Double star after single star")]
-#[test_case("demo/**/**/test", false; "Double star after double star")]
-#[test_case("demo//test", false; "Empty Chunk")]
-#[test_case("demo/exam*ple/test", false; "Stars in chunk")]
-#[test_case("demo/example$*$*/test", false; "Dollar after dollar or star")]
-#[test_case("demo/example#/test", false; "Contain sharp")]
-#[test_case("demo/example?/test", false; "Contain mark")]
-#[test_case("demo/$/test", false; "Contain unbounded dollar")]
-fn test_str_to_keyexpr(key_str: &str, valid: bool) {
-    let key = keyexpr::new(key_str);
-    println!("{:?}", key);
-    assert!(key.is_ok() == valid);
+#[cfg(test)]
+mod tests {
+    use test_case::test_case;
+
+    use crate::keyexpr;
+
+    #[test_case("demo/example/test", true; "Normal key_expr")]
+    #[test_case("demo/*/*/test", true; "Single star after single star")]
+    #[test_case("demo/*/**/test", true; "Single star after double star")]
+    #[test_case("demo/example$*/test", true; "Dollar with star")]
+    #[test_case("demo/example$*-$*/test", true; "Multiple dollar with star")]
+    #[test_case("/demo/example/test", false; "Leading /")]
+    #[test_case("demo/$*/test", false; "Lone $*")]
+    #[test_case("demo/**/*/test", false; "Double star after single star")]
+    #[test_case("demo/**/**/test", false; "Double star after double star")]
+    #[test_case("demo//test", false; "Empty Chunk")]
+    #[test_case("demo/exam*ple/test", false; "Stars in chunk")]
+    #[test_case("demo/example$*$*/test", false; "Dollar after dollar or star")]
+    #[test_case("demo/example#/test", false; "Contain sharp")]
+    #[test_case("demo/example?/test", false; "Contain mark")]
+    #[test_case("demo/$/test", false; "Contain unbounded dollar")]
+    fn test_str_to_keyexpr(key_str: &str, valid: bool) {
+        let key = keyexpr::new(key_str);
+        println!("{:?}", key);
+        assert!(key.is_ok() == valid);
+    }
 }

--- a/commons/zenoh-keyexpr/src/key_expr/borrowed.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/borrowed.rs
@@ -1083,7 +1083,6 @@ mod tests {
     #[test_case("demo/$/test", false; "Contain unbounded dollar")]
     fn test_str_to_keyexpr(key_str: &str, valid: bool) {
         let key = keyexpr::new(key_str);
-        println!("{:?}", key);
         assert!(key.is_ok() == valid);
     }
 }

--- a/commons/zenoh-keyexpr/src/key_expr/borrowed.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/borrowed.rs
@@ -25,9 +25,10 @@ use core::{
     ops::{Deref, Div},
 };
 
+use test_case::test_case;
 use zenoh_result::{bail, Error as ZError, ZResult};
 
-use super::{canon::Canonize, OwnedKeyExpr, OwnedNonWildKeyExpr, FORBIDDEN_CHARS};
+use super::{canon::Canonize, OwnedKeyExpr, OwnedNonWildKeyExpr};
 
 /// A [`str`] newtype that is statically known to be a valid key expression.
 ///
@@ -767,47 +768,55 @@ impl<'a> TryFrom<&'a str> for &'a keyexpr {
             }
             if chunk == "**" {
                 in_big_wild = true;
-            } else {
-                in_big_wild = false;
-                if chunk != "*" {
-                    let mut split = chunk.split('*');
-                    split.next_back();
-                    if split.any(|s| !s.ends_with('$')) {
-                        bail!((KeyExprConstructionError::StarsInChunk)
-                            "Invalid Key Expr `{}`: `*` and `**` may only be preceded an followed by `/`",
+                continue;
+            }
+            in_big_wild = false;
+            if chunk == "*" {
+                continue;
+            }
+
+            // Perform character-level validation for the chunk
+            let chunk_bytes = chunk.as_bytes();
+            let mut i = 0;
+            while i < chunk_bytes.len() {
+                let byte = chunk_bytes[i];
+                match byte {
+                    b'#' | b'?' => {
+                        bail!((KeyExprConstructionError::ContainsSharpOrQMark)
+                            "Invalid Key Expr `{}`: `#` and `?` are forbidden characters",
                             value
-                        )
+                        );
                     }
+                    b'$' => {
+                        if chunk_bytes.get(i + 1) == Some(&b'*') {
+                            if chunk_bytes.get(i + 2) == Some(&b'$') {
+                                bail!((KeyExprConstructionError::DollarAfterDollarOrStar)
+                                    "Invalid Key Expr `{}`: `$` is not allowed after `$*`",
+                                    value
+                                )
+                            }
+                        } else {
+                            bail!((KeyExprConstructionError::ContainsUnboundDollar)
+                                "Invalid Key Expr `{}`: `$` is only allowed in `$*`",
+                                value
+                            );
+                        }
+                        // A valid `$*` was found, skip the next character in the check.
+                        i += 2;
+                    }
+                    b'*' => {
+                        // A bare `*` is not allowed inside a chunk. It must be part of `$*`.
+                        // If we are here, it means it wasn't preceded by a `$`.
+                        bail!((KeyExprConstructionError::StarsInChunk)
+                            "Invalid Key Expr `{}`: `*` may only be preceded by `/` or `$`",
+                            value
+                        );
+                    }
+                    _ => i += 1, // Move to the next character
                 }
             }
         }
 
-        for (index, forbidden) in value.bytes().enumerate().filter_map(|(i, c)| {
-            if FORBIDDEN_CHARS.contains(&c) {
-                Some((i, c))
-            } else {
-                None
-            }
-        }) {
-            let bytes = value.as_bytes();
-            if forbidden == b'$' {
-                if let Some(b'*') = bytes.get(index + 1) {
-                    if let Some(b'$') = bytes.get(index + 2) {
-                        bail!((KeyExprConstructionError::DollarAfterDollarOrStar)
-                            "Invalid Key Expr `{}`: `$` is not allowed after `$*`",
-                            value
-                        )
-                    }
-                } else {
-                    bail!((KeyExprConstructionError::ContainsUnboundDollar)"Invalid Key Expr `{}`: `$` is only allowed in `$*`", value)
-                }
-            } else {
-                bail!((KeyExprConstructionError::ContainsSharpOrQMark)
-                    "Invalid Key Expr `{}`: `#` and `?` are forbidden characters",
-                    value
-                )
-            }
-        }
         Ok(unsafe { keyexpr::from_str_unchecked(value) })
     }
 }
@@ -1050,4 +1059,25 @@ fn test_keyexpr_strip_nonwild_prefix() {
         dbg!(ke, prefix);
         assert_eq!(ke.strip_nonwild_prefix(prefix), expected)
     }
+}
+
+#[test_case("demo/example/test", true; "Normal key_expr")]
+#[test_case("demo/*/*/test", true; "Single star after single star")]
+#[test_case("demo/*/**/test", true; "Single star after double star")]
+#[test_case("demo/example$*/test", true; "Dollar with star")]
+#[test_case("demo/example$*-$*/test", true; "Multiple dollar with star")]
+#[test_case("/demo/example/test", false; "Leading /")]
+#[test_case("demo/$*/test", false; "Lone $*")]
+#[test_case("demo/**/*/test", false; "Double star after single star")]
+#[test_case("demo/**/**/test", false; "Double star after double star")]
+#[test_case("demo//test", false; "Empty Chunk")]
+#[test_case("demo/exam*ple/test", false; "Stars in chunk")]
+#[test_case("demo/example$*$*/test", false; "Dollar after dollar or star")]
+#[test_case("demo/example#/test", false; "Contain sharp")]
+#[test_case("demo/example?/test", false; "Contain mark")]
+#[test_case("demo/$/test", false; "Contain unbounded dollar")]
+fn test_str_to_keyexpr(key_str: &str, valid: bool) {
+    let key = keyexpr::new(key_str);
+    println!("{:?}", key);
+    assert!(key.is_ok() == valid);
 }

--- a/commons/zenoh-keyexpr/src/key_expr/mod.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/mod.rs
@@ -18,7 +18,6 @@ pub(crate) const DELIMITER: u8 = b'/';
 pub(crate) const SINGLE_WILD: u8 = b'*';
 pub(crate) const DOUBLE_WILD: &[u8] = b"**";
 pub(crate) const STAR_DSL: &[u8] = b"$*";
-pub(crate) const FORBIDDEN_CHARS: [u8; 3] = [b'#', b'?', b'$'];
 
 pub(crate) mod owned;
 pub use owned::{OwnedKeyExpr, OwnedNonWildKeyExpr};


### PR DESCRIPTION
In the current `KeyExpr::try_from<&str>`, it requires two passes to check the validity of keyexpr.
Since it's called frequently, we can optimize it.
Before:
![image](https://github.com/user-attachments/assets/13b872e0-c0b5-4e5b-a875-ad5efdfe418a)
After:
![image](https://github.com/user-attachments/assets/0d18c884-fa23-4832-afe9-6aeea62b898a)
