### PR TITLE
chore: bump `nonempty-collections`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2304,9 +2304,9 @@ dependencies = [
 
 [[package]]
 name = "nonempty-collections"
-version = "0.3.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f301452dbaf00f14ca0c8204e46cf0c9a96f53543ac72cefa9b4d91c19e0ac"
+checksum = "3761f83543b22e36b7ea1145309acf9c251ef67dd8b186047f85d8cc985272d4"
 dependencies = [
  "serde",
 ]
@@ -4496,7 +4496,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ libloading = "0.8"
 tracing = "0.1"
 lz4_flex = "0.11"
 nix = { version = "0.29.0", features = ["fs"] }
-nonempty-collections = { version = "0.3.0", features = ["serde"] }
+nonempty-collections = { version = "1.0.0", features = ["serde"] }
 num_cpus = "1.16.0"
 num-traits = { version = "0.2.19", default-features = false }
 once_cell = "1.19.0"


### PR DESCRIPTION
This PR bumps `nonempty-collections`, which recently reached `1.0.0`.