### PR TITLE
Propagate `self: &HatCode` in hat call tree

### DIFF
--- a/zenoh/src/net/routing/hat/client/queries.rs
+++ b/zenoh/src/net/routing/hat/client/queries.rs
@@ -53,176 +53,138 @@ fn merge_qabl_infos(mut this: QueryableInfoType, info: &QueryableInfoType) -> Qu
     this
 }
 
-fn local_qabl_info(
-    _tables: &Tables,
-    res: &Arc<Resource>,
-    face: &Arc<FaceState>,
-) -> QueryableInfoType {
-    res.session_ctxs
-        .values()
-        .fold(None, |accu, ctx| {
-            if ctx.face.id != face.id {
-                if let Some(info) = ctx.qabl.as_ref() {
-                    Some(match accu {
-                        Some(accu) => merge_qabl_infos(accu, info),
-                        None => *info,
-                    })
+impl HatCode {
+    fn local_qabl_info(
+        &self,
+        _tables: &Tables,
+        res: &Arc<Resource>,
+        face: &Arc<FaceState>,
+    ) -> QueryableInfoType {
+        res.session_ctxs
+            .values()
+            .fold(None, |accu, ctx| {
+                if ctx.face.id != face.id {
+                    if let Some(info) = ctx.qabl.as_ref() {
+                        Some(match accu {
+                            Some(accu) => merge_qabl_infos(accu, info),
+                            None => *info,
+                        })
+                    } else {
+                        accu
+                    }
                 } else {
                     accu
                 }
-            } else {
-                accu
-            }
-        })
-        .unwrap_or(QueryableInfoType::DEFAULT)
-}
+            })
+            .unwrap_or(QueryableInfoType::DEFAULT)
+    }
 
-fn propagate_simple_queryable(
-    tables: &mut Tables,
-    res: &Arc<Resource>,
-    src_face: Option<&mut Arc<FaceState>>,
-    send_declare: &mut SendDeclare,
-) {
-    let faces = tables.faces.values().cloned();
-    for mut dst_face in faces {
-        let info = local_qabl_info(tables, res, &dst_face);
-        let current = face_hat!(dst_face).local_qabls.get(res);
-        if src_face
-            .as_ref()
-            .map(|src_face| dst_face.id != src_face.id)
-            .unwrap_or(true)
-            && (current.is_none() || current.unwrap().1 != info)
-            && src_face
+    fn propagate_simple_queryable(
+        &self,
+        tables: &mut Tables,
+        res: &Arc<Resource>,
+        src_face: Option<&mut Arc<FaceState>>,
+        send_declare: &mut SendDeclare,
+    ) {
+        let faces = tables.faces.values().cloned();
+        for mut dst_face in faces {
+            let info = self.local_qabl_info(tables, res, &dst_face);
+            let current = face_hat!(dst_face).local_qabls.get(res);
+            if src_face
                 .as_ref()
-                .map(|src_face| {
-                    src_face.whatami == WhatAmI::Client || dst_face.whatami == WhatAmI::Client
-                })
+                .map(|src_face| dst_face.id != src_face.id)
                 .unwrap_or(true)
-        {
-            let id = current
-                .map(|c| c.0)
-                .unwrap_or(face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst));
-            face_hat_mut!(&mut dst_face)
-                .local_qabls
-                .insert(res.clone(), (id, info));
-            let key_expr = Resource::decl_key(res, &mut dst_face, true);
-            send_declare(
-                &dst_face.primitives,
-                RoutingContext::with_expr(
-                    Declare {
-                        interest_id: None,
-                        ext_qos: ext::QoSType::DECLARE,
-                        ext_tstamp: None,
-                        ext_nodeid: ext::NodeIdType::DEFAULT,
-                        body: DeclareBody::DeclareQueryable(DeclareQueryable {
-                            id,
-                            wire_expr: key_expr,
-                            ext_info: info,
-                        }),
-                    },
-                    res.expr().to_string(),
-                ),
-            );
-        }
-    }
-}
-
-fn register_simple_queryable(
-    _tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    id: QueryableId,
-    res: &mut Arc<Resource>,
-    qabl_info: &QueryableInfoType,
-) {
-    // Register queryable
-    {
-        let res = get_mut_unchecked(res);
-        get_mut_unchecked(
-            res.session_ctxs
-                .entry(face.id)
-                .or_insert_with(|| Arc::new(SessionContext::new(face.clone()))),
-        )
-        .qabl = Some(*qabl_info);
-    }
-    face_hat_mut!(face).remote_qabls.insert(id, res.clone());
-}
-
-fn declare_simple_queryable(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    id: QueryableId,
-    res: &mut Arc<Resource>,
-    qabl_info: &QueryableInfoType,
-    send_declare: &mut SendDeclare,
-) {
-    register_simple_queryable(tables, face, id, res, qabl_info);
-    propagate_simple_queryable(tables, res, Some(face), send_declare);
-}
-
-#[inline]
-fn simple_qabls(res: &Arc<Resource>) -> Vec<Arc<FaceState>> {
-    res.session_ctxs
-        .values()
-        .filter_map(|ctx| {
-            if ctx.qabl.is_some() {
-                Some(ctx.face.clone())
-            } else {
-                None
+                && (current.is_none() || current.unwrap().1 != info)
+                && src_face
+                    .as_ref()
+                    .map(|src_face| {
+                        src_face.whatami == WhatAmI::Client || dst_face.whatami == WhatAmI::Client
+                    })
+                    .unwrap_or(true)
+            {
+                let id = current
+                    .map(|c| c.0)
+                    .unwrap_or(face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst));
+                face_hat_mut!(&mut dst_face)
+                    .local_qabls
+                    .insert(res.clone(), (id, info));
+                let key_expr = Resource::decl_key(res, &mut dst_face, true);
+                send_declare(
+                    &dst_face.primitives,
+                    RoutingContext::with_expr(
+                        Declare {
+                            interest_id: None,
+                            ext_qos: ext::QoSType::DECLARE,
+                            ext_tstamp: None,
+                            ext_nodeid: ext::NodeIdType::DEFAULT,
+                            body: DeclareBody::DeclareQueryable(DeclareQueryable {
+                                id,
+                                wire_expr: key_expr,
+                                ext_info: info,
+                            }),
+                        },
+                        res.expr().to_string(),
+                    ),
+                );
             }
-        })
-        .collect()
-}
-
-fn propagate_forget_simple_queryable(
-    tables: &mut Tables,
-    res: &mut Arc<Resource>,
-    send_declare: &mut SendDeclare,
-) {
-    for face in tables.faces.values_mut() {
-        if let Some((id, _)) = face_hat_mut!(face).local_qabls.remove(res) {
-            send_declare(
-                &face.primitives,
-                RoutingContext::with_expr(
-                    Declare {
-                        interest_id: None,
-                        ext_qos: ext::QoSType::DECLARE,
-                        ext_tstamp: None,
-                        ext_nodeid: ext::NodeIdType::DEFAULT,
-                        body: DeclareBody::UndeclareQueryable(UndeclareQueryable {
-                            id,
-                            ext_wire_expr: WireExprType::null(),
-                        }),
-                    },
-                    res.expr().to_string(),
-                ),
-            );
         }
     }
-}
 
-pub(super) fn undeclare_simple_queryable(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    res: &mut Arc<Resource>,
-    send_declare: &mut SendDeclare,
-) {
-    if !face_hat_mut!(face)
-        .remote_qabls
-        .values()
-        .any(|s| *s == *res)
-    {
-        if let Some(ctx) = get_mut_unchecked(res).session_ctxs.get_mut(&face.id) {
-            get_mut_unchecked(ctx).qabl = None;
+    fn register_simple_queryable(
+        &self,
+        _tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        id: QueryableId,
+        res: &mut Arc<Resource>,
+        qabl_info: &QueryableInfoType,
+    ) {
+        // Register queryable
+        {
+            let res = get_mut_unchecked(res);
+            get_mut_unchecked(
+                res.session_ctxs
+                    .entry(face.id)
+                    .or_insert_with(|| Arc::new(SessionContext::new(face.clone()))),
+            )
+            .qabl = Some(*qabl_info);
         }
+        face_hat_mut!(face).remote_qabls.insert(id, res.clone());
+    }
 
-        let mut simple_qabls = simple_qabls(res);
-        if simple_qabls.is_empty() {
-            propagate_forget_simple_queryable(tables, res, send_declare);
-        } else {
-            propagate_simple_queryable(tables, res, None, send_declare);
-        }
-        if simple_qabls.len() == 1 {
-            let face = &mut simple_qabls[0];
+    fn declare_simple_queryable(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        id: QueryableId,
+        res: &mut Arc<Resource>,
+        qabl_info: &QueryableInfoType,
+        send_declare: &mut SendDeclare,
+    ) {
+        self.register_simple_queryable(tables, face, id, res, qabl_info);
+        self.propagate_simple_queryable(tables, res, Some(face), send_declare);
+    }
+
+    #[inline]
+    fn simple_qabls(&self, res: &Arc<Resource>) -> Vec<Arc<FaceState>> {
+        res.session_ctxs
+            .values()
+            .filter_map(|ctx| {
+                if ctx.qabl.is_some() {
+                    Some(ctx.face.clone())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    fn propagate_forget_simple_queryable(
+        &self,
+        tables: &mut Tables,
+        res: &mut Arc<Resource>,
+        send_declare: &mut SendDeclare,
+    ) {
+        for face in tables.faces.values_mut() {
             if let Some((id, _)) = face_hat_mut!(face).local_qabls.remove(res) {
                 send_declare(
                     &face.primitives,
@@ -243,35 +205,88 @@ pub(super) fn undeclare_simple_queryable(
             }
         }
     }
-}
 
-fn forget_simple_queryable(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    id: QueryableId,
-    send_declare: &mut SendDeclare,
-) -> Option<Arc<Resource>> {
-    if let Some(mut res) = face_hat_mut!(face).remote_qabls.remove(&id) {
-        undeclare_simple_queryable(tables, face, &mut res, send_declare);
-        Some(res)
-    } else {
-        None
+    pub(super) fn undeclare_simple_queryable(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        res: &mut Arc<Resource>,
+        send_declare: &mut SendDeclare,
+    ) {
+        if !face_hat_mut!(face)
+            .remote_qabls
+            .values()
+            .any(|s| *s == *res)
+        {
+            if let Some(ctx) = get_mut_unchecked(res).session_ctxs.get_mut(&face.id) {
+                get_mut_unchecked(ctx).qabl = None;
+            }
+
+            let mut simple_qabls = self.simple_qabls(res);
+            if simple_qabls.is_empty() {
+                self.propagate_forget_simple_queryable(tables, res, send_declare);
+            } else {
+                self.propagate_simple_queryable(tables, res, None, send_declare);
+            }
+            if simple_qabls.len() == 1 {
+                let face = &mut simple_qabls[0];
+                if let Some((id, _)) = face_hat_mut!(face).local_qabls.remove(res) {
+                    send_declare(
+                        &face.primitives,
+                        RoutingContext::with_expr(
+                            Declare {
+                                interest_id: None,
+                                ext_qos: ext::QoSType::DECLARE,
+                                ext_tstamp: None,
+                                ext_nodeid: ext::NodeIdType::DEFAULT,
+                                body: DeclareBody::UndeclareQueryable(UndeclareQueryable {
+                                    id,
+                                    ext_wire_expr: WireExprType::null(),
+                                }),
+                            },
+                            res.expr().to_string(),
+                        ),
+                    );
+                }
+            }
+        }
     }
-}
 
-pub(super) fn queries_new_face(
-    tables: &mut Tables,
-    _face: &mut Arc<FaceState>,
-    send_declare: &mut SendDeclare,
-) {
-    for face in tables
-        .faces
-        .values()
-        .cloned()
-        .collect::<Vec<Arc<FaceState>>>()
-    {
-        for qabl in face_hat!(face).remote_qabls.values() {
-            propagate_simple_queryable(tables, qabl, Some(&mut face.clone()), send_declare);
+    fn forget_simple_queryable(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        id: QueryableId,
+        send_declare: &mut SendDeclare,
+    ) -> Option<Arc<Resource>> {
+        if let Some(mut res) = face_hat_mut!(face).remote_qabls.remove(&id) {
+            self.undeclare_simple_queryable(tables, face, &mut res, send_declare);
+            Some(res)
+        } else {
+            None
+        }
+    }
+
+    pub(super) fn queries_new_face(
+        &self,
+        tables: &mut Tables,
+        _face: &mut Arc<FaceState>,
+        send_declare: &mut SendDeclare,
+    ) {
+        for face in tables
+            .faces
+            .values()
+            .cloned()
+            .collect::<Vec<Arc<FaceState>>>()
+        {
+            for qabl in face_hat!(face).remote_qabls.values() {
+                self.propagate_simple_queryable(
+                    tables,
+                    qabl,
+                    Some(&mut face.clone()),
+                    send_declare,
+                );
+            }
         }
     }
 }
@@ -291,7 +306,7 @@ impl HatQueriesTrait for HatCode {
         _node_id: NodeId,
         send_declare: &mut SendDeclare,
     ) {
-        declare_simple_queryable(tables, face, id, res, qabl_info, send_declare);
+        self.declare_simple_queryable(tables, face, id, res, qabl_info, send_declare);
     }
 
     fn undeclare_queryable(
@@ -303,7 +318,7 @@ impl HatQueriesTrait for HatCode {
         _node_id: NodeId,
         send_declare: &mut SendDeclare,
     ) -> Option<Arc<Resource>> {
-        forget_simple_queryable(tables, face, id, send_declare)
+        self.forget_simple_queryable(tables, face, id, send_declare)
     }
 
     fn get_queryables(&self, tables: &Tables) -> Vec<(Arc<Resource>, Sources)> {

--- a/zenoh/src/net/routing/hat/client/token.rs
+++ b/zenoh/src/net/routing/hat/client/token.rs
@@ -31,325 +31,379 @@ use crate::net::routing::{
     RoutingContext,
 };
 
-#[inline]
-fn propagate_simple_token_to(
-    _tables: &mut Tables,
-    dst_face: &mut Arc<FaceState>,
-    res: &Arc<Resource>,
-    src_face: &mut Arc<FaceState>,
-    send_declare: &mut SendDeclare,
-) {
-    if (src_face.id != dst_face.id || dst_face.whatami == WhatAmI::Client)
-        && !face_hat!(dst_face).local_tokens.contains_key(res)
-        && (src_face.whatami == WhatAmI::Client || dst_face.whatami == WhatAmI::Client)
-    {
-        let id = face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst);
-        face_hat_mut!(dst_face).local_tokens.insert(res.clone(), id);
-        let key_expr = Resource::decl_key(res, dst_face, true);
-        send_declare(
-            &dst_face.primitives,
-            RoutingContext::with_expr(
-                Declare {
-                    interest_id: None,
-                    ext_qos: ext::QoSType::DECLARE,
-                    ext_tstamp: None,
-                    ext_nodeid: ext::NodeIdType::DEFAULT,
-                    body: DeclareBody::DeclareToken(DeclareToken {
-                        id,
-                        wire_expr: key_expr,
-                    }),
-                },
-                res.expr().to_string(),
-            ),
-        );
+impl HatCode {
+    #[inline]
+    fn propagate_simple_token_to(
+        &self,
+        _tables: &mut Tables,
+        dst_face: &mut Arc<FaceState>,
+        res: &Arc<Resource>,
+        src_face: &mut Arc<FaceState>,
+        send_declare: &mut SendDeclare,
+    ) {
+        if (src_face.id != dst_face.id || dst_face.whatami == WhatAmI::Client)
+            && !face_hat!(dst_face).local_tokens.contains_key(res)
+            && (src_face.whatami == WhatAmI::Client || dst_face.whatami == WhatAmI::Client)
+        {
+            let id = face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst);
+            face_hat_mut!(dst_face).local_tokens.insert(res.clone(), id);
+            let key_expr = Resource::decl_key(res, dst_face, true);
+            send_declare(
+                &dst_face.primitives,
+                RoutingContext::with_expr(
+                    Declare {
+                        interest_id: None,
+                        ext_qos: ext::QoSType::DECLARE,
+                        ext_tstamp: None,
+                        ext_nodeid: ext::NodeIdType::DEFAULT,
+                        body: DeclareBody::DeclareToken(DeclareToken {
+                            id,
+                            wire_expr: key_expr,
+                        }),
+                    },
+                    res.expr().to_string(),
+                ),
+            );
+        }
     }
-}
 
-fn propagate_simple_token(
-    tables: &mut Tables,
-    res: &Arc<Resource>,
-    src_face: &mut Arc<FaceState>,
-    send_declare: &mut SendDeclare,
-) {
-    for mut dst_face in tables
-        .faces
-        .values()
-        .cloned()
-        .collect::<Vec<Arc<FaceState>>>()
-    {
-        propagate_simple_token_to(tables, &mut dst_face, res, src_face, send_declare);
+    fn propagate_simple_token(
+        &self,
+        tables: &mut Tables,
+        res: &Arc<Resource>,
+        src_face: &mut Arc<FaceState>,
+        send_declare: &mut SendDeclare,
+    ) {
+        for mut dst_face in tables
+            .faces
+            .values()
+            .cloned()
+            .collect::<Vec<Arc<FaceState>>>()
+        {
+            self.propagate_simple_token_to(tables, &mut dst_face, res, src_face, send_declare);
+        }
     }
-}
 
-fn register_simple_token(
-    _tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    id: TokenId,
-    res: &mut Arc<Resource>,
-) {
-    // Register liveliness
-    {
-        let res = get_mut_unchecked(res);
-        match res.session_ctxs.get_mut(&face.id) {
-            Some(ctx) => {
-                if !ctx.token {
+    fn register_simple_token(
+        &self,
+        _tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        id: TokenId,
+        res: &mut Arc<Resource>,
+    ) {
+        // Register liveliness
+        {
+            let res = get_mut_unchecked(res);
+            match res.session_ctxs.get_mut(&face.id) {
+                Some(ctx) => {
+                    if !ctx.token {
+                        get_mut_unchecked(ctx).token = true;
+                    }
+                }
+                None => {
+                    let ctx = res
+                        .session_ctxs
+                        .entry(face.id)
+                        .or_insert_with(|| Arc::new(SessionContext::new(face.clone())));
                     get_mut_unchecked(ctx).token = true;
                 }
             }
-            None => {
-                let ctx = res
-                    .session_ctxs
-                    .entry(face.id)
-                    .or_insert_with(|| Arc::new(SessionContext::new(face.clone())));
-                get_mut_unchecked(ctx).token = true;
+        }
+        face_hat_mut!(face).remote_tokens.insert(id, res.clone());
+    }
+
+    fn declare_simple_token(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        id: TokenId,
+        res: &mut Arc<Resource>,
+        interest_id: Option<InterestId>,
+        send_declare: &mut SendDeclare,
+    ) {
+        if let Some(interest_id) = interest_id {
+            if let Some(interest) = face
+                .pending_current_interests
+                .get(&interest_id)
+                .map(|p| &p.interest)
+            {
+                if interest.mode == InterestMode::CurrentFuture {
+                    self.register_simple_token(tables, &mut face.clone(), id, res);
+                }
+                let id = self.make_token_id(res, &mut interest.src_face.clone(), interest.mode);
+                let wire_expr = Resource::get_best_key(res, "", interest.src_face.id);
+                send_declare(
+                    &interest.src_face.primitives,
+                    RoutingContext::with_expr(
+                        Declare {
+                            interest_id: Some(interest.src_interest_id),
+                            ext_qos: ext::QoSType::default(),
+                            ext_tstamp: None,
+                            ext_nodeid: ext::NodeIdType::default(),
+                            body: DeclareBody::DeclareToken(DeclareToken { id, wire_expr }),
+                        },
+                        res.expr().to_string(),
+                    ),
+                );
+                return;
+            } else if !face.local_interests.contains_key(&interest_id) {
+                tracing::debug!(
+                    "Received DeclareToken for {} from {} with unknown interest_id {}. Ignore.",
+                    res.expr(),
+                    face,
+                    interest_id,
+                );
+                return;
             }
         }
+        self.register_simple_token(tables, face, id, res);
+        self.propagate_simple_token(tables, res, face, send_declare);
     }
-    face_hat_mut!(face).remote_tokens.insert(id, res.clone());
-}
 
-fn declare_simple_token(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    id: TokenId,
-    res: &mut Arc<Resource>,
-    interest_id: Option<InterestId>,
-    send_declare: &mut SendDeclare,
-) {
-    if let Some(interest_id) = interest_id {
-        if let Some(interest) = face
-            .pending_current_interests
-            .get(&interest_id)
-            .map(|p| &p.interest)
-        {
-            if interest.mode == InterestMode::CurrentFuture {
-                register_simple_token(tables, &mut face.clone(), id, res);
-            }
-            let id = make_token_id(res, &mut interest.src_face.clone(), interest.mode);
-            let wire_expr = Resource::get_best_key(res, "", interest.src_face.id);
-            send_declare(
-                &interest.src_face.primitives,
-                RoutingContext::with_expr(
-                    Declare {
-                        interest_id: Some(interest.src_interest_id),
-                        ext_qos: ext::QoSType::default(),
-                        ext_tstamp: None,
-                        ext_nodeid: ext::NodeIdType::default(),
-                        body: DeclareBody::DeclareToken(DeclareToken { id, wire_expr }),
-                    },
-                    res.expr().to_string(),
-                ),
-            );
-            return;
-        } else if !face.local_interests.contains_key(&interest_id) {
-            tracing::debug!(
-                "Received DeclareToken for {} from {} with unknown interest_id {}. Ignore.",
-                res.expr(),
-                face,
-                interest_id,
-            );
-            return;
-        }
-    }
-    register_simple_token(tables, face, id, res);
-    propagate_simple_token(tables, res, face, send_declare);
-}
-
-#[inline]
-fn simple_tokens(res: &Arc<Resource>) -> Vec<Arc<FaceState>> {
-    res.session_ctxs
-        .values()
-        .filter_map(|ctx| {
-            if ctx.token {
-                Some(ctx.face.clone())
-            } else {
-                None
-            }
-        })
-        .collect()
-}
-
-fn propagate_forget_simple_token(
-    tables: &mut Tables,
-    res: &Arc<Resource>,
-    send_declare: &mut SendDeclare,
-) {
-    for face in tables.faces.values_mut() {
-        if let Some(id) = face_hat_mut!(face).local_tokens.remove(res) {
-            send_declare(
-                &face.primitives,
-                RoutingContext::with_expr(
-                    Declare {
-                        interest_id: None,
-                        ext_qos: ext::QoSType::DECLARE,
-                        ext_tstamp: None,
-                        ext_nodeid: ext::NodeIdType::DEFAULT,
-                        body: DeclareBody::UndeclareToken(UndeclareToken {
-                            id,
-                            ext_wire_expr: WireExprType::null(),
-                        }),
-                    },
-                    res.expr().to_string(),
-                ),
-            );
-        } else if face_hat!(face)
-            .remote_interests
+    #[inline]
+    fn simple_tokens(&self, res: &Arc<Resource>) -> Vec<Arc<FaceState>> {
+        res.session_ctxs
             .values()
-            .any(|i| i.options.tokens() && i.matches(res))
-        {
-            // Token has never been declared on this face.
-            // Send an Undeclare with a one shot generated id and a WireExpr ext.
-            send_declare(
-                &face.primitives,
-                RoutingContext::with_expr(
-                    Declare {
-                        interest_id: None,
-                        ext_qos: ext::QoSType::DECLARE,
-                        ext_tstamp: None,
-                        ext_nodeid: ext::NodeIdType::DEFAULT,
-                        body: DeclareBody::UndeclareToken(UndeclareToken {
-                            id: face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst),
-                            ext_wire_expr: WireExprType {
-                                wire_expr: Resource::get_best_key(res, "", face.id),
-                            },
-                        }),
-                    },
-                    res.expr().to_string(),
-                ),
-            );
+            .filter_map(|ctx| {
+                if ctx.token {
+                    Some(ctx.face.clone())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    fn propagate_forget_simple_token(
+        &self,
+        tables: &mut Tables,
+        res: &Arc<Resource>,
+        send_declare: &mut SendDeclare,
+    ) {
+        for face in tables.faces.values_mut() {
+            if let Some(id) = face_hat_mut!(face).local_tokens.remove(res) {
+                send_declare(
+                    &face.primitives,
+                    RoutingContext::with_expr(
+                        Declare {
+                            interest_id: None,
+                            ext_qos: ext::QoSType::DECLARE,
+                            ext_tstamp: None,
+                            ext_nodeid: ext::NodeIdType::DEFAULT,
+                            body: DeclareBody::UndeclareToken(UndeclareToken {
+                                id,
+                                ext_wire_expr: WireExprType::null(),
+                            }),
+                        },
+                        res.expr().to_string(),
+                    ),
+                );
+            } else if face_hat!(face)
+                .remote_interests
+                .values()
+                .any(|i| i.options.tokens() && i.matches(res))
+            {
+                // Token has never been declared on this face.
+                // Send an Undeclare with a one shot generated id and a WireExpr ext.
+                send_declare(
+                    &face.primitives,
+                    RoutingContext::with_expr(
+                        Declare {
+                            interest_id: None,
+                            ext_qos: ext::QoSType::DECLARE,
+                            ext_tstamp: None,
+                            ext_nodeid: ext::NodeIdType::DEFAULT,
+                            body: DeclareBody::UndeclareToken(UndeclareToken {
+                                id: face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst),
+                                ext_wire_expr: WireExprType {
+                                    wire_expr: Resource::get_best_key(res, "", face.id),
+                                },
+                            }),
+                        },
+                        res.expr().to_string(),
+                    ),
+                );
+            }
         }
     }
-}
 
-pub(super) fn undeclare_simple_token(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    res: &mut Arc<Resource>,
-    send_declare: &mut SendDeclare,
-) {
-    if !face_hat_mut!(face)
-        .remote_tokens
-        .values()
-        .any(|s| *s == *res)
-    {
-        if let Some(ctx) = get_mut_unchecked(res).session_ctxs.get_mut(&face.id) {
-            get_mut_unchecked(ctx).token = false;
-        }
+    pub(super) fn undeclare_simple_token(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        res: &mut Arc<Resource>,
+        send_declare: &mut SendDeclare,
+    ) {
+        if !face_hat_mut!(face)
+            .remote_tokens
+            .values()
+            .any(|s| *s == *res)
+        {
+            if let Some(ctx) = get_mut_unchecked(res).session_ctxs.get_mut(&face.id) {
+                get_mut_unchecked(ctx).token = false;
+            }
 
-        let mut simple_tokens = simple_tokens(res);
-        if simple_tokens.is_empty() {
-            propagate_forget_simple_token(tables, res, send_declare);
-        }
-        if simple_tokens.len() == 1 {
-            let face = &mut simple_tokens[0];
-            if face.whatami != WhatAmI::Client {
-                if let Some(id) = face_hat_mut!(face).local_tokens.remove(res) {
-                    send_declare(
-                        &face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id: None,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::UndeclareToken(UndeclareToken {
-                                    id,
-                                    ext_wire_expr: WireExprType::null(),
-                                }),
-                            },
-                            res.expr().to_string(),
-                        ),
-                    );
+            let mut simple_tokens = self.simple_tokens(res);
+            if simple_tokens.is_empty() {
+                self.propagate_forget_simple_token(tables, res, send_declare);
+            }
+            if simple_tokens.len() == 1 {
+                let face = &mut simple_tokens[0];
+                if face.whatami != WhatAmI::Client {
+                    if let Some(id) = face_hat_mut!(face).local_tokens.remove(res) {
+                        send_declare(
+                            &face.primitives,
+                            RoutingContext::with_expr(
+                                Declare {
+                                    interest_id: None,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType::DEFAULT,
+                                    body: DeclareBody::UndeclareToken(UndeclareToken {
+                                        id,
+                                        ext_wire_expr: WireExprType::null(),
+                                    }),
+                                },
+                                res.expr().to_string(),
+                            ),
+                        );
+                    }
                 }
             }
         }
     }
-}
 
-fn forget_simple_token(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    id: TokenId,
-    res: Option<Arc<Resource>>,
-    send_declare: &mut SendDeclare,
-) -> Option<Arc<Resource>> {
-    if let Some(mut res) = face_hat_mut!(face).remote_tokens.remove(&id) {
-        undeclare_simple_token(tables, face, &mut res, send_declare);
-        Some(res)
-    } else if let Some(mut res) = res {
-        undeclare_simple_token(tables, face, &mut res, send_declare);
-        Some(res)
-    } else {
-        None
-    }
-}
-
-pub(super) fn token_new_face(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    send_declare: &mut SendDeclare,
-) {
-    for src_face in tables
-        .faces
-        .values()
-        .cloned()
-        .collect::<Vec<Arc<FaceState>>>()
-    {
-        for token in face_hat!(src_face).remote_tokens.values() {
-            propagate_simple_token_to(tables, face, token, &mut src_face.clone(), send_declare);
-        }
-    }
-}
-
-#[inline]
-fn make_token_id(res: &Arc<Resource>, face: &mut Arc<FaceState>, mode: InterestMode) -> u32 {
-    if mode.future() {
-        if let Some(id) = face_hat!(face).local_tokens.get(res) {
-            *id
+    fn forget_simple_token(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        id: TokenId,
+        res: Option<Arc<Resource>>,
+        send_declare: &mut SendDeclare,
+    ) -> Option<Arc<Resource>> {
+        if let Some(mut res) = face_hat_mut!(face).remote_tokens.remove(&id) {
+            self.undeclare_simple_token(tables, face, &mut res, send_declare);
+            Some(res)
+        } else if let Some(mut res) = res {
+            self.undeclare_simple_token(tables, face, &mut res, send_declare);
+            Some(res)
         } else {
-            let id = face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst);
-            face_hat_mut!(face).local_tokens.insert(res.clone(), id);
-            id
+            None
         }
-    } else {
-        0
     }
-}
 
-pub(crate) fn declare_token_interest(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    id: InterestId,
-    res: Option<&mut Arc<Resource>>,
-    mode: InterestMode,
-    aggregate: bool,
-    send_declare: &mut SendDeclare,
-) {
-    if mode.current() {
-        let interest_id = (!mode.future()).then_some(id);
-        if let Some(res) = res.as_ref() {
-            if aggregate {
-                if tables.faces.values().any(|src_face| {
-                    face_hat!(src_face)
-                        .remote_tokens
+    pub(super) fn token_new_face(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        send_declare: &mut SendDeclare,
+    ) {
+        for src_face in tables
+            .faces
+            .values()
+            .cloned()
+            .collect::<Vec<Arc<FaceState>>>()
+        {
+            for token in face_hat!(src_face).remote_tokens.values() {
+                self.propagate_simple_token_to(
+                    tables,
+                    face,
+                    token,
+                    &mut src_face.clone(),
+                    send_declare,
+                );
+            }
+        }
+    }
+
+    #[inline]
+    fn make_token_id(
+        &self,
+        res: &Arc<Resource>,
+        face: &mut Arc<FaceState>,
+        mode: InterestMode,
+    ) -> u32 {
+        if mode.future() {
+            if let Some(id) = face_hat!(face).local_tokens.get(res) {
+                *id
+            } else {
+                let id = face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst);
+                face_hat_mut!(face).local_tokens.insert(res.clone(), id);
+                id
+            }
+        } else {
+            0
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn declare_token_interest(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        id: InterestId,
+        res: Option<&mut Arc<Resource>>,
+        mode: InterestMode,
+        aggregate: bool,
+        send_declare: &mut SendDeclare,
+    ) {
+        if mode.current() {
+            let interest_id = (!mode.future()).then_some(id);
+            if let Some(res) = res.as_ref() {
+                if aggregate {
+                    if tables.faces.values().any(|src_face| {
+                        face_hat!(src_face)
+                            .remote_tokens
+                            .values()
+                            .any(|token| token.context.is_some() && token.matches(res))
+                    }) {
+                        let id = self.make_token_id(res, face, mode);
+                        let wire_expr = Resource::decl_key(res, face, true);
+                        send_declare(
+                            &face.primitives,
+                            RoutingContext::with_expr(
+                                Declare {
+                                    interest_id,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType::DEFAULT,
+                                    body: DeclareBody::DeclareToken(DeclareToken { id, wire_expr }),
+                                },
+                                res.expr().to_string(),
+                            ),
+                        );
+                    }
+                } else {
+                    for src_face in tables
+                        .faces
                         .values()
-                        .any(|token| token.context.is_some() && token.matches(res))
-                }) {
-                    let id = make_token_id(res, face, mode);
-                    let wire_expr = Resource::decl_key(res, face, true);
-                    send_declare(
-                        &face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::DeclareToken(DeclareToken { id, wire_expr }),
-                            },
-                            res.expr().to_string(),
-                        ),
-                    );
+                        .filter(|f| f.whatami == WhatAmI::Client)
+                        .cloned()
+                        .collect::<Vec<Arc<FaceState>>>()
+                    {
+                        for token in face_hat!(src_face).remote_tokens.values() {
+                            if token.context.is_some() && token.matches(res) {
+                                let id = self.make_token_id(token, face, mode);
+                                let wire_expr = Resource::decl_key(token, face, true);
+                                send_declare(
+                                    &face.primitives,
+                                    RoutingContext::with_expr(
+                                        Declare {
+                                            interest_id,
+                                            ext_qos: ext::QoSType::default(),
+                                            ext_tstamp: None,
+                                            ext_nodeid: ext::NodeIdType::default(),
+                                            body: DeclareBody::DeclareToken(DeclareToken {
+                                                id,
+                                                wire_expr,
+                                            }),
+                                        },
+                                        res.expr().to_string(),
+                                    ),
+                                )
+                            }
+                        }
+                    }
                 }
             } else {
                 for src_face in tables
@@ -360,53 +414,22 @@ pub(crate) fn declare_token_interest(
                     .collect::<Vec<Arc<FaceState>>>()
                 {
                     for token in face_hat!(src_face).remote_tokens.values() {
-                        if token.context.is_some() && token.matches(res) {
-                            let id = make_token_id(token, face, mode);
-                            let wire_expr = Resource::decl_key(token, face, true);
-                            send_declare(
-                                &face.primitives,
-                                RoutingContext::with_expr(
-                                    Declare {
-                                        interest_id,
-                                        ext_qos: ext::QoSType::default(),
-                                        ext_tstamp: None,
-                                        ext_nodeid: ext::NodeIdType::default(),
-                                        body: DeclareBody::DeclareToken(DeclareToken {
-                                            id,
-                                            wire_expr,
-                                        }),
-                                    },
-                                    res.expr().to_string(),
-                                ),
-                            )
-                        }
+                        let id = self.make_token_id(token, face, mode);
+                        let wire_expr = Resource::decl_key(token, face, true);
+                        send_declare(
+                            &face.primitives,
+                            RoutingContext::with_expr(
+                                Declare {
+                                    interest_id,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType::DEFAULT,
+                                    body: DeclareBody::DeclareToken(DeclareToken { id, wire_expr }),
+                                },
+                                token.expr().to_string(),
+                            ),
+                        );
                     }
-                }
-            }
-        } else {
-            for src_face in tables
-                .faces
-                .values()
-                .filter(|f| f.whatami == WhatAmI::Client)
-                .cloned()
-                .collect::<Vec<Arc<FaceState>>>()
-            {
-                for token in face_hat!(src_face).remote_tokens.values() {
-                    let id = make_token_id(token, face, mode);
-                    let wire_expr = Resource::decl_key(token, face, true);
-                    send_declare(
-                        &face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::DeclareToken(DeclareToken { id, wire_expr }),
-                            },
-                            token.expr().to_string(),
-                        ),
-                    );
                 }
             }
         }
@@ -424,7 +447,7 @@ impl HatTokenTrait for HatCode {
         interest_id: Option<InterestId>,
         send_declare: &mut SendDeclare,
     ) {
-        declare_simple_token(tables, face, id, res, interest_id, send_declare);
+        self.declare_simple_token(tables, face, id, res, interest_id, send_declare);
     }
 
     fn undeclare_token(
@@ -436,6 +459,6 @@ impl HatTokenTrait for HatCode {
         _node_id: NodeId,
         send_declare: &mut SendDeclare,
     ) -> Option<Arc<Resource>> {
-        forget_simple_token(tables, face, id, res, send_declare)
+        self.forget_simple_token(tables, face, id, res, send_declare)
     }
 }

--- a/zenoh/src/net/routing/hat/linkstate_peer/interests.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/interests.rs
@@ -20,10 +20,7 @@ use zenoh_protocol::network::{
 };
 use zenoh_sync::get_mut_unchecked;
 
-use super::{
-    face_hat_mut, pubsub::declare_sub_interest, queries::declare_qabl_interest,
-    token::declare_token_interest, HatCode, HatFace,
-};
+use super::{face_hat_mut, HatCode, HatFace};
 use crate::net::routing::{
     dispatcher::{
         face::FaceState,
@@ -48,7 +45,7 @@ impl HatInterestTrait for HatCode {
         send_declare: &mut SendDeclare,
     ) {
         if options.subscribers() {
-            declare_sub_interest(
+            self.declare_sub_interest(
                 tables,
                 face,
                 id,
@@ -59,7 +56,7 @@ impl HatInterestTrait for HatCode {
             )
         }
         if options.queryables() {
-            declare_qabl_interest(
+            self.declare_qabl_interest(
                 tables,
                 face,
                 id,
@@ -70,7 +67,7 @@ impl HatInterestTrait for HatCode {
             )
         }
         if options.tokens() {
-            declare_token_interest(
+            self.declare_token_interest(
                 tables,
                 face,
                 id,

--- a/zenoh/src/net/routing/hat/linkstate_peer/token.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/token.rs
@@ -40,665 +40,736 @@ use crate::net::{
     },
 };
 
-#[inline]
-fn send_sourced_token_to_net_clildren(
-    tables: &Tables,
-    net: &Network,
-    clildren: &[NodeIndex],
-    res: &Arc<Resource>,
-    src_face: Option<&Arc<FaceState>>,
-    routing_context: NodeId,
-) {
-    for child in clildren {
-        if net.graph.contains_node(*child) {
-            match tables.get_face(&net.graph[*child].zid).cloned() {
-                Some(mut someface) => {
-                    if src_face
-                        .map(|src_face| someface.id != src_face.id)
-                        .unwrap_or(true)
-                    {
-                        let push_declaration = push_declaration_profile(&someface);
-                        let key_expr = Resource::decl_key(res, &mut someface, push_declaration);
+impl HatCode {
+    #[inline]
+    fn send_sourced_token_to_net_clildren(
+        &self,
+        tables: &Tables,
+        net: &Network,
+        clildren: &[NodeIndex],
+        res: &Arc<Resource>,
+        src_face: Option<&Arc<FaceState>>,
+        routing_context: NodeId,
+    ) {
+        for child in clildren {
+            if net.graph.contains_node(*child) {
+                match tables.get_face(&net.graph[*child].zid).cloned() {
+                    Some(mut someface) => {
+                        if src_face
+                            .map(|src_face| someface.id != src_face.id)
+                            .unwrap_or(true)
+                        {
+                            let push_declaration = push_declaration_profile(&someface);
+                            let key_expr = Resource::decl_key(res, &mut someface, push_declaration);
 
-                        someface.primitives.send_declare(RoutingContext::with_expr(
-                            &mut Declare {
-                                interest_id: None,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType {
-                                    node_id: routing_context,
+                            someface.primitives.send_declare(RoutingContext::with_expr(
+                                &mut Declare {
+                                    interest_id: None,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType {
+                                        node_id: routing_context,
+                                    },
+                                    body: DeclareBody::DeclareToken(DeclareToken {
+                                        id: 0, // Sourced tokens do not use ids
+                                        wire_expr: key_expr,
+                                    }),
                                 },
-                                body: DeclareBody::DeclareToken(DeclareToken {
-                                    id: 0, // Sourced tokens do not use ids
-                                    wire_expr: key_expr,
-                                }),
-                            },
-                            res.expr().to_string(),
-                        ));
+                                res.expr().to_string(),
+                            ));
+                        }
+                    }
+                    None => {
+                        tracing::trace!("Unable to find face for zid {}", net.graph[*child].zid)
                     }
                 }
-                None => tracing::trace!("Unable to find face for zid {}", net.graph[*child].zid),
             }
         }
     }
-}
 
-#[inline]
-fn propagate_simple_token_to(
-    tables: &mut Tables,
-    dst_face: &mut Arc<FaceState>,
-    res: &Arc<Resource>,
-    src_face: &mut Arc<FaceState>,
-    send_declare: &mut SendDeclare,
-) {
-    if (src_face.id != dst_face.id || dst_face.zid == tables.zid)
-        && !face_hat!(dst_face).local_tokens.contains_key(res)
-        && dst_face.whatami == WhatAmI::Client
-    {
-        if dst_face.whatami != WhatAmI::Client {
-            let id = face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst);
-            face_hat_mut!(dst_face).local_tokens.insert(res.clone(), id);
-            let key_expr = Resource::decl_key(res, dst_face, push_declaration_profile(dst_face));
-            send_declare(
-                &dst_face.primitives,
-                RoutingContext::with_expr(
-                    Declare {
-                        interest_id: None,
-                        ext_qos: ext::QoSType::DECLARE,
-                        ext_tstamp: None,
-                        ext_nodeid: ext::NodeIdType::DEFAULT,
-                        body: DeclareBody::DeclareToken(DeclareToken {
-                            id,
-                            wire_expr: key_expr,
-                        }),
-                    },
-                    res.expr().to_string(),
-                ),
-            );
-        } else {
-            let matching_interests = face_hat!(dst_face)
-                .remote_interests
-                .values()
-                .filter(|i| i.options.tokens() && i.matches(res))
-                .cloned()
-                .collect::<Vec<_>>();
+    #[inline]
+    fn propagate_simple_token_to(
+        &self,
+        tables: &mut Tables,
+        dst_face: &mut Arc<FaceState>,
+        res: &Arc<Resource>,
+        src_face: &mut Arc<FaceState>,
+        send_declare: &mut SendDeclare,
+    ) {
+        if (src_face.id != dst_face.id || dst_face.zid == tables.zid)
+            && !face_hat!(dst_face).local_tokens.contains_key(res)
+            && dst_face.whatami == WhatAmI::Client
+        {
+            if dst_face.whatami != WhatAmI::Client {
+                let id = face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst);
+                face_hat_mut!(dst_face).local_tokens.insert(res.clone(), id);
+                let key_expr =
+                    Resource::decl_key(res, dst_face, push_declaration_profile(dst_face));
+                send_declare(
+                    &dst_face.primitives,
+                    RoutingContext::with_expr(
+                        Declare {
+                            interest_id: None,
+                            ext_qos: ext::QoSType::DECLARE,
+                            ext_tstamp: None,
+                            ext_nodeid: ext::NodeIdType::DEFAULT,
+                            body: DeclareBody::DeclareToken(DeclareToken {
+                                id,
+                                wire_expr: key_expr,
+                            }),
+                        },
+                        res.expr().to_string(),
+                    ),
+                );
+            } else {
+                let matching_interests = face_hat!(dst_face)
+                    .remote_interests
+                    .values()
+                    .filter(|i| i.options.tokens() && i.matches(res))
+                    .cloned()
+                    .collect::<Vec<_>>();
 
-            for RemoteInterest {
-                res: int_res,
-                options,
-                ..
-            } in matching_interests
-            {
-                let res = if options.aggregate() {
-                    int_res.as_ref().unwrap_or(res)
+                for RemoteInterest {
+                    res: int_res,
+                    options,
+                    ..
+                } in matching_interests
+                {
+                    let res = if options.aggregate() {
+                        int_res.as_ref().unwrap_or(res)
+                    } else {
+                        res
+                    };
+                    if !face_hat!(dst_face).local_tokens.contains_key(res) {
+                        let id = face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst);
+                        face_hat_mut!(dst_face).local_tokens.insert(res.clone(), id);
+                        let key_expr =
+                            Resource::decl_key(res, dst_face, push_declaration_profile(dst_face));
+                        send_declare(
+                            &dst_face.primitives,
+                            RoutingContext::with_expr(
+                                Declare {
+                                    interest_id: None,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType::DEFAULT,
+                                    body: DeclareBody::DeclareToken(DeclareToken {
+                                        id,
+                                        wire_expr: key_expr,
+                                    }),
+                                },
+                                res.expr().to_string(),
+                            ),
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    fn propagate_simple_token(
+        &self,
+        tables: &mut Tables,
+        res: &Arc<Resource>,
+        src_face: &mut Arc<FaceState>,
+        send_declare: &mut SendDeclare,
+    ) {
+        for mut dst_face in tables
+            .faces
+            .values()
+            .cloned()
+            .collect::<Vec<Arc<FaceState>>>()
+        {
+            self.propagate_simple_token_to(tables, &mut dst_face, res, src_face, send_declare);
+        }
+    }
+
+    fn propagate_sourced_token(
+        &self,
+        tables: &Tables,
+        res: &Arc<Resource>,
+        src_face: Option<&Arc<FaceState>>,
+        source: &ZenohIdProto,
+    ) {
+        let net = hat!(tables).linkstatepeers_net.as_ref().unwrap();
+        match net.get_idx(source) {
+            Some(tree_sid) => {
+                if net.trees.len() > tree_sid.index() {
+                    self.send_sourced_token_to_net_clildren(
+                        tables,
+                        net,
+                        &net.trees[tree_sid.index()].children,
+                        res,
+                        src_face,
+                        tree_sid.index() as NodeId,
+                    );
                 } else {
-                    res
-                };
-                if !face_hat!(dst_face).local_tokens.contains_key(res) {
-                    let id = face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst);
-                    face_hat_mut!(dst_face).local_tokens.insert(res.clone(), id);
-                    let key_expr =
-                        Resource::decl_key(res, dst_face, push_declaration_profile(dst_face));
-                    send_declare(
-                        &dst_face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id: None,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::DeclareToken(DeclareToken {
-                                    id,
-                                    wire_expr: key_expr,
-                                }),
-                            },
-                            res.expr().to_string(),
-                        ),
+                    tracing::trace!(
+                        "Propagating token {}: tree for node {} sid:{} not yet ready",
+                        res.expr(),
+                        tree_sid.index(),
+                        source
                     );
                 }
             }
+            None => tracing::error!(
+                "Error propagating token {}: cannot get index of {}!",
+                res.expr(),
+                source
+            ),
         }
     }
-}
 
-fn propagate_simple_token(
-    tables: &mut Tables,
-    res: &Arc<Resource>,
-    src_face: &mut Arc<FaceState>,
-    send_declare: &mut SendDeclare,
-) {
-    for mut dst_face in tables
-        .faces
-        .values()
-        .cloned()
-        .collect::<Vec<Arc<FaceState>>>()
-    {
-        propagate_simple_token_to(tables, &mut dst_face, res, src_face, send_declare);
-    }
-}
-
-fn propagate_sourced_token(
-    tables: &Tables,
-    res: &Arc<Resource>,
-    src_face: Option<&Arc<FaceState>>,
-    source: &ZenohIdProto,
-) {
-    let net = hat!(tables).linkstatepeers_net.as_ref().unwrap();
-    match net.get_idx(source) {
-        Some(tree_sid) => {
-            if net.trees.len() > tree_sid.index() {
-                send_sourced_token_to_net_clildren(
-                    tables,
-                    net,
-                    &net.trees[tree_sid.index()].children,
-                    res,
-                    src_face,
-                    tree_sid.index() as NodeId,
-                );
-            } else {
-                tracing::trace!(
-                    "Propagating token {}: tree for node {} sid:{} not yet ready",
-                    res.expr(),
-                    tree_sid.index(),
-                    source
-                );
+    fn register_linkstatepeer_token(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        res: &mut Arc<Resource>,
+        peer: ZenohIdProto,
+        send_declare: &mut SendDeclare,
+    ) {
+        if !res_hat!(res).linkstatepeer_tokens.contains(&peer) {
+            // Register peer liveliness
+            {
+                res_hat_mut!(res).linkstatepeer_tokens.insert(peer);
+                hat_mut!(tables).linkstatepeer_tokens.insert(res.clone());
             }
-        }
-        None => tracing::error!(
-            "Error propagating token {}: cannot get index of {}!",
-            res.expr(),
-            source
-        ),
-    }
-}
 
-fn register_linkstatepeer_token(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    res: &mut Arc<Resource>,
-    peer: ZenohIdProto,
-    send_declare: &mut SendDeclare,
-) {
-    if !res_hat!(res).linkstatepeer_tokens.contains(&peer) {
-        // Register peer liveliness
+            // Propagate liveliness to peers
+            self.propagate_sourced_token(tables, res, Some(face), &peer);
+        }
+
+        // Propagate liveliness to clients
+        self.propagate_simple_token(tables, res, face, send_declare);
+    }
+
+    fn declare_linkstatepeer_token(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        res: &mut Arc<Resource>,
+        peer: ZenohIdProto,
+        send_declare: &mut SendDeclare,
+    ) {
+        self.register_linkstatepeer_token(tables, face, res, peer, send_declare);
+    }
+
+    fn register_simple_token(
+        &self,
+        _tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        id: TokenId,
+        res: &mut Arc<Resource>,
+    ) {
+        // Register liveliness
         {
-            res_hat_mut!(res).linkstatepeer_tokens.insert(peer);
-            hat_mut!(tables).linkstatepeer_tokens.insert(res.clone());
-        }
-
-        // Propagate liveliness to peers
-        propagate_sourced_token(tables, res, Some(face), &peer);
-    }
-
-    // Propagate liveliness to clients
-    propagate_simple_token(tables, res, face, send_declare);
-}
-
-fn declare_linkstatepeer_token(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    res: &mut Arc<Resource>,
-    peer: ZenohIdProto,
-    send_declare: &mut SendDeclare,
-) {
-    register_linkstatepeer_token(tables, face, res, peer, send_declare);
-}
-
-fn register_simple_token(
-    _tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    id: TokenId,
-    res: &mut Arc<Resource>,
-) {
-    // Register liveliness
-    {
-        let res = get_mut_unchecked(res);
-        match res.session_ctxs.get_mut(&face.id) {
-            Some(ctx) => {
-                if !ctx.token {
+            let res = get_mut_unchecked(res);
+            match res.session_ctxs.get_mut(&face.id) {
+                Some(ctx) => {
+                    if !ctx.token {
+                        get_mut_unchecked(ctx).token = true;
+                    }
+                }
+                None => {
+                    let ctx = res
+                        .session_ctxs
+                        .entry(face.id)
+                        .or_insert_with(|| Arc::new(SessionContext::new(face.clone())));
                     get_mut_unchecked(ctx).token = true;
                 }
             }
-            None => {
-                let ctx = res
-                    .session_ctxs
-                    .entry(face.id)
-                    .or_insert_with(|| Arc::new(SessionContext::new(face.clone())));
-                get_mut_unchecked(ctx).token = true;
-            }
         }
+        face_hat_mut!(face).remote_tokens.insert(id, res.clone());
     }
-    face_hat_mut!(face).remote_tokens.insert(id, res.clone());
-}
 
-fn declare_simple_token(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    id: TokenId,
-    res: &mut Arc<Resource>,
-    send_declare: &mut SendDeclare,
-) {
-    register_simple_token(tables, face, id, res);
-    let zid = tables.zid;
-    register_linkstatepeer_token(tables, face, res, zid, send_declare);
-}
+    fn declare_simple_token(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        id: TokenId,
+        res: &mut Arc<Resource>,
+        send_declare: &mut SendDeclare,
+    ) {
+        self.register_simple_token(tables, face, id, res);
+        let zid = tables.zid;
+        self.register_linkstatepeer_token(tables, face, res, zid, send_declare);
+    }
 
-#[inline]
-fn remote_linkstatepeer_tokens(tables: &Tables, res: &Arc<Resource>) -> bool {
-    res.context.is_some()
-        && res_hat!(res)
-            .linkstatepeer_tokens
-            .iter()
-            .any(|peer| peer != &tables.zid)
-}
+    #[inline]
+    fn remote_linkstatepeer_tokens(&self, tables: &Tables, res: &Arc<Resource>) -> bool {
+        res.context.is_some()
+            && res_hat!(res)
+                .linkstatepeer_tokens
+                .iter()
+                .any(|peer| peer != &tables.zid)
+    }
 
-#[inline]
-fn simple_tokens(res: &Arc<Resource>) -> Vec<Arc<FaceState>> {
-    res.session_ctxs
-        .values()
-        .filter_map(|ctx| {
-            if ctx.token {
-                Some(ctx.face.clone())
-            } else {
-                None
-            }
-        })
-        .collect()
-}
+    #[inline]
+    fn simple_tokens(&self, res: &Arc<Resource>) -> Vec<Arc<FaceState>> {
+        res.session_ctxs
+            .values()
+            .filter_map(|ctx| {
+                if ctx.token {
+                    Some(ctx.face.clone())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
 
-#[inline]
-fn remote_simple_tokens(tables: &Tables, res: &Arc<Resource>, face: &Arc<FaceState>) -> bool {
-    res.session_ctxs
-        .values()
-        .any(|ctx| (ctx.face.id != face.id || face.zid == tables.zid) && ctx.token)
-}
+    #[inline]
+    fn remote_simple_tokens(
+        &self,
+        tables: &Tables,
+        res: &Arc<Resource>,
+        face: &Arc<FaceState>,
+    ) -> bool {
+        res.session_ctxs
+            .values()
+            .any(|ctx| (ctx.face.id != face.id || face.zid == tables.zid) && ctx.token)
+    }
 
-#[inline]
-fn send_forget_sourced_token_to_net_clildren(
-    tables: &Tables,
-    net: &Network,
-    clildren: &[NodeIndex],
-    res: &Arc<Resource>,
-    src_face: Option<&Arc<FaceState>>,
-    routing_context: Option<NodeId>,
-) {
-    for child in clildren {
-        if net.graph.contains_node(*child) {
-            match tables.get_face(&net.graph[*child].zid).cloned() {
-                Some(mut someface) => {
-                    if src_face
-                        .map(|src_face| someface.id != src_face.id)
-                        .unwrap_or(true)
-                    {
-                        let push_declaration = push_declaration_profile(&someface);
-                        let wire_expr = Resource::decl_key(res, &mut someface, push_declaration);
+    #[inline]
+    fn send_forget_sourced_token_to_net_clildren(
+        &self,
+        tables: &Tables,
+        net: &Network,
+        clildren: &[NodeIndex],
+        res: &Arc<Resource>,
+        src_face: Option<&Arc<FaceState>>,
+        routing_context: Option<NodeId>,
+    ) {
+        for child in clildren {
+            if net.graph.contains_node(*child) {
+                match tables.get_face(&net.graph[*child].zid).cloned() {
+                    Some(mut someface) => {
+                        if src_face
+                            .map(|src_face| someface.id != src_face.id)
+                            .unwrap_or(true)
+                        {
+                            let push_declaration = push_declaration_profile(&someface);
+                            let wire_expr =
+                                Resource::decl_key(res, &mut someface, push_declaration);
 
-                        someface.primitives.send_declare(RoutingContext::with_expr(
-                            &mut Declare {
-                                interest_id: None,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType {
-                                    node_id: routing_context.unwrap_or(0),
+                            someface.primitives.send_declare(RoutingContext::with_expr(
+                                &mut Declare {
+                                    interest_id: None,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType {
+                                        node_id: routing_context.unwrap_or(0),
+                                    },
+                                    body: DeclareBody::UndeclareToken(UndeclareToken {
+                                        id: 0, // Sourced tokens do not use ids
+                                        ext_wire_expr: WireExprType { wire_expr },
+                                    }),
                                 },
-                                body: DeclareBody::UndeclareToken(UndeclareToken {
-                                    id: 0, // Sourced tokens do not use ids
-                                    ext_wire_expr: WireExprType { wire_expr },
-                                }),
-                            },
-                            res.expr().to_string(),
-                        ));
+                                res.expr().to_string(),
+                            ));
+                        }
+                    }
+                    None => {
+                        tracing::trace!("Unable to find face for zid {}", net.graph[*child].zid)
                     }
                 }
-                None => tracing::trace!("Unable to find face for zid {}", net.graph[*child].zid),
             }
         }
     }
-}
 
-fn propagate_forget_simple_token(
-    tables: &mut Tables,
-    res: &Arc<Resource>,
-    send_declare: &mut SendDeclare,
-) {
-    for mut face in tables.faces.values().cloned() {
-        if let Some(id) = face_hat_mut!(&mut face).local_tokens.remove(res) {
-            send_declare(
-                &face.primitives,
-                RoutingContext::with_expr(
-                    Declare {
-                        interest_id: None,
-                        ext_qos: ext::QoSType::DECLARE,
-                        ext_tstamp: None,
-                        ext_nodeid: ext::NodeIdType::DEFAULT,
-                        body: DeclareBody::UndeclareToken(UndeclareToken {
-                            id,
-                            ext_wire_expr: WireExprType::null(),
-                        }),
-                    },
-                    res.expr().to_string(),
-                ),
-            );
+    fn propagate_forget_simple_token(
+        &self,
+        tables: &mut Tables,
+        res: &Arc<Resource>,
+        send_declare: &mut SendDeclare,
+    ) {
+        for mut face in tables.faces.values().cloned() {
+            if let Some(id) = face_hat_mut!(&mut face).local_tokens.remove(res) {
+                send_declare(
+                    &face.primitives,
+                    RoutingContext::with_expr(
+                        Declare {
+                            interest_id: None,
+                            ext_qos: ext::QoSType::DECLARE,
+                            ext_tstamp: None,
+                            ext_nodeid: ext::NodeIdType::DEFAULT,
+                            body: DeclareBody::UndeclareToken(UndeclareToken {
+                                id,
+                                ext_wire_expr: WireExprType::null(),
+                            }),
+                        },
+                        res.expr().to_string(),
+                    ),
+                );
+            }
+            for res in face_hat!(face)
+                .local_tokens
+                .keys()
+                .cloned()
+                .collect::<Vec<Arc<Resource>>>()
+            {
+                if !res.context().matches.iter().any(|m| {
+                    m.upgrade().is_some_and(|m| {
+                        m.context.is_some()
+                            && (self.remote_simple_tokens(tables, &m, &face)
+                                || self.remote_linkstatepeer_tokens(tables, &m))
+                    })
+                }) {
+                    if let Some(id) = face_hat_mut!(&mut face).local_tokens.remove(&res) {
+                        send_declare(
+                            &face.primitives,
+                            RoutingContext::with_expr(
+                                Declare {
+                                    interest_id: None,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType::DEFAULT,
+                                    body: DeclareBody::UndeclareToken(UndeclareToken {
+                                        id,
+                                        ext_wire_expr: WireExprType::null(),
+                                    }),
+                                },
+                                res.expr().to_string(),
+                            ),
+                        );
+                    }
+                }
+            }
         }
-        for res in face_hat!(face)
-            .local_tokens
-            .keys()
+    }
+
+    fn propagate_forget_sourced_token(
+        &self,
+        tables: &Tables,
+        res: &Arc<Resource>,
+        src_face: Option<&Arc<FaceState>>,
+        source: &ZenohIdProto,
+    ) {
+        let net = hat!(tables).linkstatepeers_net.as_ref().unwrap();
+        match net.get_idx(source) {
+            Some(tree_sid) => {
+                if net.trees.len() > tree_sid.index() {
+                    self.send_forget_sourced_token_to_net_clildren(
+                        tables,
+                        net,
+                        &net.trees[tree_sid.index()].children,
+                        res,
+                        src_face,
+                        Some(tree_sid.index() as NodeId),
+                    );
+                } else {
+                    tracing::trace!(
+                        "Propagating forget token {}: tree for node {} sid:{} not yet ready",
+                        res.expr().to_string(),
+                        tree_sid.index(),
+                        source
+                    );
+                }
+            }
+            None => tracing::error!(
+                "Error propagating forget token {}: cannot get index of {}!",
+                res.expr().to_string(),
+                source
+            ),
+        }
+    }
+
+    fn unregister_linkstatepeer_token(
+        &self,
+        tables: &mut Tables,
+        res: &mut Arc<Resource>,
+        peer: &ZenohIdProto,
+        send_declare: &mut SendDeclare,
+    ) {
+        res_hat_mut!(res)
+            .linkstatepeer_tokens
+            .retain(|token| token != peer);
+
+        if res_hat!(res).linkstatepeer_tokens.is_empty() {
+            hat_mut!(tables)
+                .linkstatepeer_tokens
+                .retain(|token| !Arc::ptr_eq(token, res));
+
+            self.propagate_forget_simple_token(tables, res, send_declare);
+        }
+    }
+
+    fn undeclare_linkstatepeer_token(
+        &self,
+        tables: &mut Tables,
+        face: Option<&Arc<FaceState>>,
+        res: &mut Arc<Resource>,
+        peer: &ZenohIdProto,
+        send_declare: &mut SendDeclare,
+    ) {
+        if res_hat!(res).linkstatepeer_tokens.contains(peer) {
+            self.unregister_linkstatepeer_token(tables, res, peer, send_declare);
+            self.propagate_forget_sourced_token(tables, res, face, peer);
+        }
+    }
+
+    fn forget_linkstatepeer_token(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        res: &mut Arc<Resource>,
+        peer: &ZenohIdProto,
+        send_declare: &mut SendDeclare,
+    ) {
+        self.undeclare_linkstatepeer_token(tables, Some(face), res, peer, send_declare);
+    }
+
+    pub(super) fn undeclare_simple_token(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        res: &mut Arc<Resource>,
+        send_declare: &mut SendDeclare,
+    ) {
+        if !face_hat_mut!(face)
+            .remote_tokens
+            .values()
+            .any(|s| *s == *res)
+        {
+            if let Some(ctx) = get_mut_unchecked(res).session_ctxs.get_mut(&face.id) {
+                get_mut_unchecked(ctx).token = false;
+            }
+
+            let mut simple_tokens = self.simple_tokens(res);
+            let linkstatepeer_tokens = self.remote_linkstatepeer_tokens(tables, res);
+            if simple_tokens.is_empty() {
+                self.undeclare_linkstatepeer_token(
+                    tables,
+                    None,
+                    res,
+                    &tables.zid.clone(),
+                    send_declare,
+                );
+            }
+
+            if simple_tokens.len() == 1 && !linkstatepeer_tokens {
+                let mut face = &mut simple_tokens[0];
+                if face.whatami != WhatAmI::Client {
+                    if let Some(id) = face_hat_mut!(face).local_tokens.remove(res) {
+                        send_declare(
+                            &face.primitives,
+                            RoutingContext::with_expr(
+                                Declare {
+                                    interest_id: None,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType::DEFAULT,
+                                    body: DeclareBody::UndeclareToken(UndeclareToken {
+                                        id,
+                                        ext_wire_expr: WireExprType::null(),
+                                    }),
+                                },
+                                res.expr().to_string(),
+                            ),
+                        );
+                    }
+                    for res in face_hat!(face)
+                        .local_tokens
+                        .keys()
+                        .cloned()
+                        .collect::<Vec<Arc<Resource>>>()
+                    {
+                        if !res.context().matches.iter().any(|m| {
+                            m.upgrade().is_some_and(|m| {
+                                m.context.is_some()
+                                    && (self.remote_simple_tokens(tables, &m, face)
+                                        || self.remote_linkstatepeer_tokens(tables, &m))
+                            })
+                        }) {
+                            if let Some(id) = face_hat_mut!(&mut face).local_tokens.remove(&res) {
+                                send_declare(
+                                    &face.primitives,
+                                    RoutingContext::with_expr(
+                                        Declare {
+                                            interest_id: None,
+                                            ext_qos: ext::QoSType::DECLARE,
+                                            ext_tstamp: None,
+                                            ext_nodeid: ext::NodeIdType::DEFAULT,
+                                            body: DeclareBody::UndeclareToken(UndeclareToken {
+                                                id,
+                                                ext_wire_expr: WireExprType::null(),
+                                            }),
+                                        },
+                                        res.expr().to_string(),
+                                    ),
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn forget_simple_token(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        id: TokenId,
+        send_declare: &mut SendDeclare,
+    ) -> Option<Arc<Resource>> {
+        if let Some(mut res) = face_hat_mut!(face).remote_tokens.remove(&id) {
+            self.undeclare_simple_token(tables, face, &mut res, send_declare);
+            Some(res)
+        } else {
+            None
+        }
+    }
+
+    pub(super) fn token_remove_node(
+        &self,
+        tables: &mut Tables,
+        node: &ZenohIdProto,
+        send_declare: &mut SendDeclare,
+    ) {
+        for mut res in hat!(tables)
+            .linkstatepeer_tokens
+            .iter()
+            .filter(|res| res_hat!(res).linkstatepeer_tokens.contains(node))
             .cloned()
             .collect::<Vec<Arc<Resource>>>()
         {
-            if !res.context().matches.iter().any(|m| {
-                m.upgrade().is_some_and(|m| {
-                    m.context.is_some()
-                        && (remote_simple_tokens(tables, &m, &face)
-                            || remote_linkstatepeer_tokens(tables, &m))
-                })
-            }) {
-                if let Some(id) = face_hat_mut!(&mut face).local_tokens.remove(&res) {
-                    send_declare(
-                        &face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id: None,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::UndeclareToken(UndeclareToken {
-                                    id,
-                                    ext_wire_expr: WireExprType::null(),
-                                }),
-                            },
-                            res.expr().to_string(),
-                        ),
-                    );
+            self.unregister_linkstatepeer_token(tables, &mut res, node, send_declare);
+            Resource::clean(&mut res)
+        }
+    }
+
+    pub(super) fn token_tree_change(&self, tables: &mut Tables, new_clildren: &[Vec<NodeIndex>]) {
+        let net = match hat!(tables).linkstatepeers_net.as_ref() {
+            Some(net) => net,
+            None => {
+                tracing::error!("Error accessing peers_net in token_tree_change!");
+                return;
+            }
+        };
+        // propagate tokens to new clildren
+        for (tree_sid, tree_clildren) in new_clildren.iter().enumerate() {
+            if !tree_clildren.is_empty() {
+                let tree_idx = NodeIndex::new(tree_sid);
+                if net.graph.contains_node(tree_idx) {
+                    let tree_id = net.graph[tree_idx].zid;
+
+                    let tokens_res = &hat!(tables).linkstatepeer_tokens;
+
+                    for res in tokens_res {
+                        let tokens = &res_hat!(res).linkstatepeer_tokens;
+                        for token in tokens {
+                            if *token == tree_id {
+                                self.send_sourced_token_to_net_clildren(
+                                    tables,
+                                    net,
+                                    tree_clildren,
+                                    res,
+                                    None,
+                                    tree_sid as NodeId,
+                                );
+                            }
+                        }
+                    }
                 }
             }
         }
     }
-}
 
-fn propagate_forget_sourced_token(
-    tables: &Tables,
-    res: &Arc<Resource>,
-    src_face: Option<&Arc<FaceState>>,
-    source: &ZenohIdProto,
-) {
-    let net = hat!(tables).linkstatepeers_net.as_ref().unwrap();
-    match net.get_idx(source) {
-        Some(tree_sid) => {
-            if net.trees.len() > tree_sid.index() {
-                send_forget_sourced_token_to_net_clildren(
-                    tables,
-                    net,
-                    &net.trees[tree_sid.index()].children,
-                    res,
-                    src_face,
-                    Some(tree_sid.index() as NodeId),
-                );
+    #[inline]
+    fn make_token_id(
+        &self,
+        res: &Arc<Resource>,
+        face: &mut Arc<FaceState>,
+        mode: InterestMode,
+    ) -> u32 {
+        if mode.future() {
+            if let Some(id) = face_hat!(face).local_tokens.get(res) {
+                *id
             } else {
-                tracing::trace!(
-                    "Propagating forget token {}: tree for node {} sid:{} not yet ready",
-                    res.expr().to_string(),
-                    tree_sid.index(),
-                    source
-                );
+                let id = face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst);
+                face_hat_mut!(face).local_tokens.insert(res.clone(), id);
+                id
             }
+        } else {
+            0
         }
-        None => tracing::error!(
-            "Error propagating forget token {}: cannot get index of {}!",
-            res.expr().to_string(),
-            source
-        ),
     }
-}
 
-fn unregister_linkstatepeer_token(
-    tables: &mut Tables,
-    res: &mut Arc<Resource>,
-    peer: &ZenohIdProto,
-    send_declare: &mut SendDeclare,
-) {
-    res_hat_mut!(res)
-        .linkstatepeer_tokens
-        .retain(|token| token != peer);
-
-    if res_hat!(res).linkstatepeer_tokens.is_empty() {
-        hat_mut!(tables)
-            .linkstatepeer_tokens
-            .retain(|token| !Arc::ptr_eq(token, res));
-
-        propagate_forget_simple_token(tables, res, send_declare);
-    }
-}
-
-fn undeclare_linkstatepeer_token(
-    tables: &mut Tables,
-    face: Option<&Arc<FaceState>>,
-    res: &mut Arc<Resource>,
-    peer: &ZenohIdProto,
-    send_declare: &mut SendDeclare,
-) {
-    if res_hat!(res).linkstatepeer_tokens.contains(peer) {
-        unregister_linkstatepeer_token(tables, res, peer, send_declare);
-        propagate_forget_sourced_token(tables, res, face, peer);
-    }
-}
-
-fn forget_linkstatepeer_token(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    res: &mut Arc<Resource>,
-    peer: &ZenohIdProto,
-    send_declare: &mut SendDeclare,
-) {
-    undeclare_linkstatepeer_token(tables, Some(face), res, peer, send_declare);
-}
-
-pub(super) fn undeclare_simple_token(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    res: &mut Arc<Resource>,
-    send_declare: &mut SendDeclare,
-) {
-    if !face_hat_mut!(face)
-        .remote_tokens
-        .values()
-        .any(|s| *s == *res)
-    {
-        if let Some(ctx) = get_mut_unchecked(res).session_ctxs.get_mut(&face.id) {
-            get_mut_unchecked(ctx).token = false;
-        }
-
-        let mut simple_tokens = simple_tokens(res);
-        let linkstatepeer_tokens = remote_linkstatepeer_tokens(tables, res);
-        if simple_tokens.is_empty() {
-            undeclare_linkstatepeer_token(tables, None, res, &tables.zid.clone(), send_declare);
-        }
-
-        if simple_tokens.len() == 1 && !linkstatepeer_tokens {
-            let mut face = &mut simple_tokens[0];
-            if face.whatami != WhatAmI::Client {
-                if let Some(id) = face_hat_mut!(face).local_tokens.remove(res) {
-                    send_declare(
-                        &face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id: None,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::UndeclareToken(UndeclareToken {
-                                    id,
-                                    ext_wire_expr: WireExprType::null(),
-                                }),
-                            },
-                            res.expr().to_string(),
-                        ),
-                    );
-                }
-                for res in face_hat!(face)
-                    .local_tokens
-                    .keys()
-                    .cloned()
-                    .collect::<Vec<Arc<Resource>>>()
-                {
-                    if !res.context().matches.iter().any(|m| {
-                        m.upgrade().is_some_and(|m| {
-                            m.context.is_some()
-                                && (remote_simple_tokens(tables, &m, face)
-                                    || remote_linkstatepeer_tokens(tables, &m))
-                        })
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn declare_token_interest(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        id: InterestId,
+        res: Option<&mut Arc<Resource>>,
+        mode: InterestMode,
+        aggregate: bool,
+        send_declare: &mut SendDeclare,
+    ) {
+        if mode.current() && face.whatami == WhatAmI::Client {
+            let interest_id = Some(id);
+            if let Some(res) = res.as_ref() {
+                if aggregate {
+                    if hat!(tables).linkstatepeer_tokens.iter().any(|token| {
+                        token.context.is_some()
+                            && token.matches(res)
+                            && (self.remote_simple_tokens(tables, token, face)
+                                || self.remote_linkstatepeer_tokens(tables, token))
                     }) {
-                        if let Some(id) = face_hat_mut!(&mut face).local_tokens.remove(&res) {
+                        let id = self.make_token_id(res, face, mode);
+                        let wire_expr =
+                            Resource::decl_key(res, face, push_declaration_profile(face));
+                        send_declare(
+                            &face.primitives,
+                            RoutingContext::with_expr(
+                                Declare {
+                                    interest_id,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType::DEFAULT,
+                                    body: DeclareBody::DeclareToken(DeclareToken { id, wire_expr }),
+                                },
+                                res.expr().to_string(),
+                            ),
+                        );
+                    }
+                } else {
+                    for token in &hat!(tables).linkstatepeer_tokens {
+                        if token.context.is_some()
+                            && token.matches(res)
+                            && (self.remote_simple_tokens(tables, token, face)
+                                || self.remote_linkstatepeer_tokens(tables, token))
+                        {
+                            let id = self.make_token_id(token, face, mode);
+                            let wire_expr =
+                                Resource::decl_key(token, face, push_declaration_profile(face));
                             send_declare(
                                 &face.primitives,
                                 RoutingContext::with_expr(
                                     Declare {
-                                        interest_id: None,
+                                        interest_id,
                                         ext_qos: ext::QoSType::DECLARE,
                                         ext_tstamp: None,
                                         ext_nodeid: ext::NodeIdType::DEFAULT,
-                                        body: DeclareBody::UndeclareToken(UndeclareToken {
+                                        body: DeclareBody::DeclareToken(DeclareToken {
                                             id,
-                                            ext_wire_expr: WireExprType::null(),
+                                            wire_expr,
                                         }),
                                     },
-                                    res.expr().to_string(),
+                                    token.expr().to_string(),
                                 ),
                             );
                         }
                     }
                 }
-            }
-        }
-    }
-}
-
-fn forget_simple_token(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    id: TokenId,
-    send_declare: &mut SendDeclare,
-) -> Option<Arc<Resource>> {
-    if let Some(mut res) = face_hat_mut!(face).remote_tokens.remove(&id) {
-        undeclare_simple_token(tables, face, &mut res, send_declare);
-        Some(res)
-    } else {
-        None
-    }
-}
-
-pub(super) fn token_remove_node(
-    tables: &mut Tables,
-    node: &ZenohIdProto,
-    send_declare: &mut SendDeclare,
-) {
-    for mut res in hat!(tables)
-        .linkstatepeer_tokens
-        .iter()
-        .filter(|res| res_hat!(res).linkstatepeer_tokens.contains(node))
-        .cloned()
-        .collect::<Vec<Arc<Resource>>>()
-    {
-        unregister_linkstatepeer_token(tables, &mut res, node, send_declare);
-        Resource::clean(&mut res)
-    }
-}
-
-pub(super) fn token_tree_change(tables: &mut Tables, new_clildren: &[Vec<NodeIndex>]) {
-    let net = match hat!(tables).linkstatepeers_net.as_ref() {
-        Some(net) => net,
-        None => {
-            tracing::error!("Error accessing peers_net in token_tree_change!");
-            return;
-        }
-    };
-    // propagate tokens to new clildren
-    for (tree_sid, tree_clildren) in new_clildren.iter().enumerate() {
-        if !tree_clildren.is_empty() {
-            let tree_idx = NodeIndex::new(tree_sid);
-            if net.graph.contains_node(tree_idx) {
-                let tree_id = net.graph[tree_idx].zid;
-
-                let tokens_res = &hat!(tables).linkstatepeer_tokens;
-
-                for res in tokens_res {
-                    let tokens = &res_hat!(res).linkstatepeer_tokens;
-                    for token in tokens {
-                        if *token == tree_id {
-                            send_sourced_token_to_net_clildren(
-                                tables,
-                                net,
-                                tree_clildren,
-                                res,
-                                None,
-                                tree_sid as NodeId,
-                            );
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-#[inline]
-fn make_token_id(res: &Arc<Resource>, face: &mut Arc<FaceState>, mode: InterestMode) -> u32 {
-    if mode.future() {
-        if let Some(id) = face_hat!(face).local_tokens.get(res) {
-            *id
-        } else {
-            let id = face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst);
-            face_hat_mut!(face).local_tokens.insert(res.clone(), id);
-            id
-        }
-    } else {
-        0
-    }
-}
-
-pub(crate) fn declare_token_interest(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    id: InterestId,
-    res: Option<&mut Arc<Resource>>,
-    mode: InterestMode,
-    aggregate: bool,
-    send_declare: &mut SendDeclare,
-) {
-    if mode.current() && face.whatami == WhatAmI::Client {
-        let interest_id = Some(id);
-        if let Some(res) = res.as_ref() {
-            if aggregate {
-                if hat!(tables).linkstatepeer_tokens.iter().any(|token| {
-                    token.context.is_some()
-                        && token.matches(res)
-                        && (remote_simple_tokens(tables, token, face)
-                            || remote_linkstatepeer_tokens(tables, token))
-                }) {
-                    let id = make_token_id(res, face, mode);
-                    let wire_expr = Resource::decl_key(res, face, push_declaration_profile(face));
-                    send_declare(
-                        &face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::DeclareToken(DeclareToken { id, wire_expr }),
-                            },
-                            res.expr().to_string(),
-                        ),
-                    );
-                }
             } else {
                 for token in &hat!(tables).linkstatepeer_tokens {
                     if token.context.is_some()
-                        && token.matches(res)
-                        && (remote_simple_tokens(tables, token, face)
-                            || remote_linkstatepeer_tokens(tables, token))
+                        && (self.remote_simple_tokens(tables, token, face)
+                            || self.remote_linkstatepeer_tokens(tables, token))
                     {
-                        let id = make_token_id(token, face, mode);
+                        let id = self.make_token_id(token, face, mode);
                         let wire_expr =
                             Resource::decl_key(token, face, push_declaration_profile(face));
                         send_declare(
@@ -715,29 +786,6 @@ pub(crate) fn declare_token_interest(
                             ),
                         );
                     }
-                }
-            }
-        } else {
-            for token in &hat!(tables).linkstatepeer_tokens {
-                if token.context.is_some()
-                    && (remote_simple_tokens(tables, token, face)
-                        || remote_linkstatepeer_tokens(tables, token))
-                {
-                    let id = make_token_id(token, face, mode);
-                    let wire_expr = Resource::decl_key(token, face, push_declaration_profile(face));
-                    send_declare(
-                        &face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::DeclareToken(DeclareToken { id, wire_expr }),
-                            },
-                            token.expr().to_string(),
-                        ),
-                    );
                 }
             }
         }
@@ -757,10 +805,10 @@ impl HatTokenTrait for HatCode {
     ) {
         if face.whatami != WhatAmI::Client {
             if let Some(peer) = get_peer(tables, face, node_id) {
-                declare_linkstatepeer_token(tables, face, res, peer, send_declare)
+                self.declare_linkstatepeer_token(tables, face, res, peer, send_declare)
             }
         } else {
-            declare_simple_token(tables, face, id, res, send_declare)
+            self.declare_simple_token(tables, face, id, res, send_declare)
         }
     }
 
@@ -776,7 +824,7 @@ impl HatTokenTrait for HatCode {
         if face.whatami != WhatAmI::Client {
             if let Some(mut res) = res {
                 if let Some(peer) = get_peer(tables, face, node_id) {
-                    forget_linkstatepeer_token(tables, face, &mut res, &peer, send_declare);
+                    self.forget_linkstatepeer_token(tables, face, &mut res, &peer, send_declare);
                     Some(res)
                 } else {
                     None
@@ -785,7 +833,7 @@ impl HatTokenTrait for HatCode {
                 None
             }
         } else {
-            forget_simple_token(tables, face, id, send_declare)
+            self.forget_simple_token(tables, face, id, send_declare)
         }
     }
 }

--- a/zenoh/src/net/routing/hat/p2p_peer/mod.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/mod.rs
@@ -24,7 +24,6 @@ use std::{
     sync::{atomic::AtomicU32, Arc},
 };
 
-use token::{token_new_face, undeclare_simple_token};
 use zenoh_config::{unwrap_or_default, ModeDependent, WhatAmI};
 use zenoh_protocol::{
     common::ZExtBody,
@@ -43,12 +42,7 @@ use zenoh_result::ZResult;
 use zenoh_sync::get_mut_unchecked;
 use zenoh_transport::unicast::TransportUnicast;
 
-use self::{
-    gossip::Network,
-    interests::interests_new_face,
-    pubsub::{pubsub_new_face, undeclare_simple_subscription},
-    queries::{queries_new_face, undeclare_simple_queryable},
-};
+use self::gossip::Network;
 use super::{
     super::dispatcher::{
         face::FaceState,
@@ -166,10 +160,10 @@ impl HatBaseTrait for HatCode {
         face: &mut Face,
         send_declare: &mut SendDeclare,
     ) -> ZResult<()> {
-        interests_new_face(tables, &mut face.state);
-        pubsub_new_face(tables, &mut face.state, send_declare);
-        queries_new_face(tables, &mut face.state, send_declare);
-        token_new_face(tables, &mut face.state, send_declare);
+        self.interests_new_face(tables, &mut face.state);
+        self.pubsub_new_face(tables, &mut face.state, send_declare);
+        self.queries_new_face(tables, &mut face.state, send_declare);
+        self.token_new_face(tables, &mut face.state, send_declare);
         tables.disable_all_routes();
         Ok(())
     }
@@ -198,10 +192,10 @@ impl HatBaseTrait for HatCode {
             );
         }
 
-        interests_new_face(tables, &mut face.state);
-        pubsub_new_face(tables, &mut face.state, send_declare);
-        queries_new_face(tables, &mut face.state, send_declare);
-        token_new_face(tables, &mut face.state, send_declare);
+        self.interests_new_face(tables, &mut face.state);
+        self.pubsub_new_face(tables, &mut face.state, send_declare);
+        self.queries_new_face(tables, &mut face.state, send_declare);
+        self.token_new_face(tables, &mut face.state, send_declare);
         tables.disable_all_routes();
 
         if face.state.whatami == WhatAmI::Peer {
@@ -256,7 +250,12 @@ impl HatBaseTrait for HatCode {
         let mut subs_matches = vec![];
         for (_id, mut res) in hat_face.remote_subs.drain() {
             get_mut_unchecked(&mut res).session_ctxs.remove(&face.id);
-            undeclare_simple_subscription(&mut wtables, &mut face_clone, &mut res, send_declare);
+            self.undeclare_simple_subscription(
+                &mut wtables,
+                &mut face_clone,
+                &mut res,
+                send_declare,
+            );
 
             if res.context.is_some() {
                 for match_ in &res.context().matches {
@@ -278,7 +277,7 @@ impl HatBaseTrait for HatCode {
         let mut qabls_matches = vec![];
         for (_id, mut res) in hat_face.remote_qabls.drain() {
             get_mut_unchecked(&mut res).session_ctxs.remove(&face.id);
-            undeclare_simple_queryable(&mut wtables, &mut face_clone, &mut res, send_declare);
+            self.undeclare_simple_queryable(&mut wtables, &mut face_clone, &mut res, send_declare);
 
             if res.context.is_some() {
                 for match_ in &res.context().matches {
@@ -299,7 +298,7 @@ impl HatBaseTrait for HatCode {
 
         for (_id, mut res) in hat_face.remote_tokens.drain() {
             get_mut_unchecked(&mut res).session_ctxs.remove(&face.id);
-            undeclare_simple_token(&mut wtables, &mut face_clone, &mut res, send_declare);
+            self.undeclare_simple_token(&mut wtables, &mut face_clone, &mut res, send_declare);
         }
 
         for mut res in subs_matches {

--- a/zenoh/src/net/routing/hat/p2p_peer/token.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/token.rs
@@ -31,512 +31,572 @@ use crate::net::routing::{
     RoutingContext,
 };
 
-fn new_token(
-    tables: &Tables,
-    res: &Arc<Resource>,
-    src_face: &Arc<FaceState>,
-    dst_face: &mut Arc<FaceState>,
-) -> bool {
-    // Is there any face that
-    !res.session_ctxs.values().any(|ctx| {
-        ctx.token // declared the token
+impl HatCode {
+    fn new_token(
+        &self,
+        tables: &Tables,
+        res: &Arc<Resource>,
+        src_face: &Arc<FaceState>,
+        dst_face: &mut Arc<FaceState>,
+    ) -> bool {
+        // Is there any face that
+        !res.session_ctxs.values().any(|ctx| {
+            ctx.token // declared the token
             && (ctx.face.id != src_face.id) // is not the face that just registered it
             && (ctx.face.id != dst_face.id || dst_face.zid == tables.zid) // is not the face we are propagating to (except for local)
             && (ctx.face.whatami == WhatAmI::Client || dst_face.whatami == WhatAmI::Client)
-        // don't forward from/to router/peers
-    })
-}
+            // don't forward from/to router/peers
+        })
+    }
 
-#[inline]
-fn propagate_simple_token_to(
-    tables: &mut Tables,
-    dst_face: &mut Arc<FaceState>,
-    res: &Arc<Resource>,
-    src_face: &mut Arc<FaceState>,
-    src_interest_id: Option<InterestId>,
-    dst_interest_id: Option<InterestId>,
-    send_declare: &mut SendDeclare,
-) {
-    if (src_face.id != dst_face.id || dst_face.zid == tables.zid)
-        && !face_hat!(dst_face).local_tokens.contains_key(res)
-        && (src_face.whatami == WhatAmI::Client || dst_face.whatami == WhatAmI::Client)
-        && new_token(tables, res, src_face, dst_face)
-    {
-        if dst_face.whatami != WhatAmI::Client {
-            let id = face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst);
-            face_hat_mut!(dst_face).local_tokens.insert(res.clone(), id);
-            let key_expr =
-                Resource::decl_key(res, dst_face, super::push_declaration_profile(dst_face));
-            send_declare(
-                &dst_face.primitives,
-                RoutingContext::with_expr(
-                    Declare {
-                        interest_id: dst_interest_id,
-                        ext_qos: ext::QoSType::DECLARE,
-                        ext_tstamp: None,
-                        ext_nodeid: ext::NodeIdType::DEFAULT,
-                        body: DeclareBody::DeclareToken(DeclareToken {
-                            id,
-                            wire_expr: key_expr,
-                        }),
-                    },
-                    res.expr().to_string(),
-                ),
-            );
-        } else {
-            let matching_interests = face_hat!(dst_face)
-                .remote_interests
-                .values()
-                .filter(|i| {
-                    i.options.tokens()
-                        && i.matches(res)
-                        && (i.mode.current() || src_interest_id.is_none())
-                })
-                .cloned()
-                .collect::<Vec<_>>();
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    fn propagate_simple_token_to(
+        &self,
+        tables: &mut Tables,
+        dst_face: &mut Arc<FaceState>,
+        res: &Arc<Resource>,
+        src_face: &mut Arc<FaceState>,
+        src_interest_id: Option<InterestId>,
+        dst_interest_id: Option<InterestId>,
+        send_declare: &mut SendDeclare,
+    ) {
+        if (src_face.id != dst_face.id || dst_face.zid == tables.zid)
+            && !face_hat!(dst_face).local_tokens.contains_key(res)
+            && (src_face.whatami == WhatAmI::Client || dst_face.whatami == WhatAmI::Client)
+            && self.new_token(tables, res, src_face, dst_face)
+        {
+            if dst_face.whatami != WhatAmI::Client {
+                let id = face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst);
+                face_hat_mut!(dst_face).local_tokens.insert(res.clone(), id);
+                let key_expr =
+                    Resource::decl_key(res, dst_face, super::push_declaration_profile(dst_face));
+                send_declare(
+                    &dst_face.primitives,
+                    RoutingContext::with_expr(
+                        Declare {
+                            interest_id: dst_interest_id,
+                            ext_qos: ext::QoSType::DECLARE,
+                            ext_tstamp: None,
+                            ext_nodeid: ext::NodeIdType::DEFAULT,
+                            body: DeclareBody::DeclareToken(DeclareToken {
+                                id,
+                                wire_expr: key_expr,
+                            }),
+                        },
+                        res.expr().to_string(),
+                    ),
+                );
+            } else {
+                let matching_interests = face_hat!(dst_face)
+                    .remote_interests
+                    .values()
+                    .filter(|i| {
+                        i.options.tokens()
+                            && i.matches(res)
+                            && (i.mode.current() || src_interest_id.is_none())
+                    })
+                    .cloned()
+                    .collect::<Vec<_>>();
 
-            for RemoteInterest {
-                res: int_res,
-                options,
-                ..
-            } in matching_interests
-            {
-                let res = if options.aggregate() {
-                    int_res.as_ref().unwrap_or(res)
-                } else {
-                    res
-                };
-                if !face_hat!(dst_face).local_tokens.contains_key(res) {
-                    let id = face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst);
-                    face_hat_mut!(dst_face).local_tokens.insert(res.clone(), id);
-                    let key_expr = Resource::decl_key(
-                        res,
-                        dst_face,
-                        super::push_declaration_profile(dst_face),
-                    );
-                    send_declare(
-                        &dst_face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id: dst_interest_id,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::DeclareToken(DeclareToken {
-                                    id,
-                                    wire_expr: key_expr,
-                                }),
-                            },
-                            res.expr().to_string(),
-                        ),
-                    );
+                for RemoteInterest {
+                    res: int_res,
+                    options,
+                    ..
+                } in matching_interests
+                {
+                    let res = if options.aggregate() {
+                        int_res.as_ref().unwrap_or(res)
+                    } else {
+                        res
+                    };
+                    if !face_hat!(dst_face).local_tokens.contains_key(res) {
+                        let id = face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst);
+                        face_hat_mut!(dst_face).local_tokens.insert(res.clone(), id);
+                        let key_expr = Resource::decl_key(
+                            res,
+                            dst_face,
+                            super::push_declaration_profile(dst_face),
+                        );
+                        send_declare(
+                            &dst_face.primitives,
+                            RoutingContext::with_expr(
+                                Declare {
+                                    interest_id: dst_interest_id,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType::DEFAULT,
+                                    body: DeclareBody::DeclareToken(DeclareToken {
+                                        id,
+                                        wire_expr: key_expr,
+                                    }),
+                                },
+                                res.expr().to_string(),
+                            ),
+                        );
+                    }
                 }
             }
         }
     }
-}
 
-fn propagate_simple_token(
-    tables: &mut Tables,
-    res: &Arc<Resource>,
-    src_face: &mut Arc<FaceState>,
-    interest_id: Option<InterestId>,
-    send_declare: &mut SendDeclare,
-) {
-    for mut dst_face in tables
-        .faces
-        .values()
-        .cloned()
-        .collect::<Vec<Arc<FaceState>>>()
-    {
-        propagate_simple_token_to(
-            tables,
-            &mut dst_face,
-            res,
-            src_face,
-            interest_id,
-            None,
-            send_declare,
-        );
+    fn propagate_simple_token(
+        &self,
+        tables: &mut Tables,
+        res: &Arc<Resource>,
+        src_face: &mut Arc<FaceState>,
+        interest_id: Option<InterestId>,
+        send_declare: &mut SendDeclare,
+    ) {
+        for mut dst_face in tables
+            .faces
+            .values()
+            .cloned()
+            .collect::<Vec<Arc<FaceState>>>()
+        {
+            self.propagate_simple_token_to(
+                tables,
+                &mut dst_face,
+                res,
+                src_face,
+                interest_id,
+                None,
+                send_declare,
+            );
+        }
     }
-}
 
-fn register_simple_token(
-    _tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    id: TokenId,
-    res: &mut Arc<Resource>,
-) {
-    // Register liveliness
-    {
-        let res = get_mut_unchecked(res);
-        match res.session_ctxs.get_mut(&face.id) {
-            Some(ctx) => {
-                if !ctx.token {
+    fn register_simple_token(
+        &self,
+        _tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        id: TokenId,
+        res: &mut Arc<Resource>,
+    ) {
+        // Register liveliness
+        {
+            let res = get_mut_unchecked(res);
+            match res.session_ctxs.get_mut(&face.id) {
+                Some(ctx) => {
+                    if !ctx.token {
+                        get_mut_unchecked(ctx).token = true;
+                    }
+                }
+                None => {
+                    let ctx = res
+                        .session_ctxs
+                        .entry(face.id)
+                        .or_insert_with(|| Arc::new(SessionContext::new(face.clone())));
                     get_mut_unchecked(ctx).token = true;
                 }
             }
-            None => {
-                let ctx = res
-                    .session_ctxs
-                    .entry(face.id)
-                    .or_insert_with(|| Arc::new(SessionContext::new(face.clone())));
-                get_mut_unchecked(ctx).token = true;
-            }
         }
+        face_hat_mut!(face).remote_tokens.insert(id, res.clone());
     }
-    face_hat_mut!(face).remote_tokens.insert(id, res.clone());
-}
 
-fn declare_simple_token(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    id: TokenId,
-    res: &mut Arc<Resource>,
-    interest_id: Option<InterestId>,
-    send_declare: &mut SendDeclare,
-) {
-    if let Some(interest_id) = interest_id {
-        if let Some(interest) = face
-            .pending_current_interests
-            .get(&interest_id)
-            .map(|p| &p.interest)
-        {
-            if interest.mode == InterestMode::CurrentFuture {
-                register_simple_token(tables, &mut face.clone(), id, res);
+    fn declare_simple_token(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        id: TokenId,
+        res: &mut Arc<Resource>,
+        interest_id: Option<InterestId>,
+        send_declare: &mut SendDeclare,
+    ) {
+        if let Some(interest_id) = interest_id {
+            if let Some(interest) = face
+                .pending_current_interests
+                .get(&interest_id)
+                .map(|p| &p.interest)
+            {
+                if interest.mode == InterestMode::CurrentFuture {
+                    self.register_simple_token(tables, &mut face.clone(), id, res);
+                }
+                let id = self.make_token_id(res, &mut interest.src_face.clone(), interest.mode);
+                let wire_expr = Resource::get_best_key(res, "", interest.src_face.id);
+                send_declare(
+                    &interest.src_face.primitives,
+                    RoutingContext::with_expr(
+                        Declare {
+                            interest_id: Some(interest.src_interest_id),
+                            ext_qos: ext::QoSType::default(),
+                            ext_tstamp: None,
+                            ext_nodeid: ext::NodeIdType::default(),
+                            body: DeclareBody::DeclareToken(DeclareToken { id, wire_expr }),
+                        },
+                        res.expr().to_string(),
+                    ),
+                );
+                return;
+            } else if !face.local_interests.contains_key(&interest_id) {
+                println!(
+                    "Received DeclareToken for {} from {} with unknown interest_id {}. Ignore.",
+                    res.expr(),
+                    face,
+                    interest_id,
+                );
+                return;
             }
-            let id = make_token_id(res, &mut interest.src_face.clone(), interest.mode);
-            let wire_expr = Resource::get_best_key(res, "", interest.src_face.id);
-            send_declare(
-                &interest.src_face.primitives,
-                RoutingContext::with_expr(
-                    Declare {
-                        interest_id: Some(interest.src_interest_id),
-                        ext_qos: ext::QoSType::default(),
-                        ext_tstamp: None,
-                        ext_nodeid: ext::NodeIdType::default(),
-                        body: DeclareBody::DeclareToken(DeclareToken { id, wire_expr }),
-                    },
-                    res.expr().to_string(),
-                ),
-            );
-            return;
-        } else if !face.local_interests.contains_key(&interest_id) {
-            println!(
-                "Received DeclareToken for {} from {} with unknown interest_id {}. Ignore.",
-                res.expr(),
-                face,
-                interest_id,
-            );
-            return;
         }
+        self.register_simple_token(tables, face, id, res);
+        self.propagate_simple_token(tables, res, face, interest_id, send_declare);
     }
-    register_simple_token(tables, face, id, res);
-    propagate_simple_token(tables, res, face, interest_id, send_declare);
-}
 
-#[inline]
-fn simple_tokens(res: &Arc<Resource>) -> Vec<Arc<FaceState>> {
-    res.session_ctxs
-        .values()
-        .filter_map(|ctx| {
-            if ctx.token {
-                Some(ctx.face.clone())
-            } else {
-                None
-            }
-        })
-        .collect()
-}
+    #[inline]
+    fn simple_tokens(&self, res: &Arc<Resource>) -> Vec<Arc<FaceState>> {
+        res.session_ctxs
+            .values()
+            .filter_map(|ctx| {
+                if ctx.token {
+                    Some(ctx.face.clone())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
 
-#[inline]
-fn remote_simple_tokens(tables: &Tables, res: &Arc<Resource>, face: &Arc<FaceState>) -> bool {
-    res.session_ctxs
-        .values()
-        .any(|ctx| (ctx.face.id != face.id || face.zid == tables.zid) && ctx.token)
-}
+    #[inline]
+    fn remote_simple_tokens(
+        &self,
+        tables: &Tables,
+        res: &Arc<Resource>,
+        face: &Arc<FaceState>,
+    ) -> bool {
+        res.session_ctxs
+            .values()
+            .any(|ctx| (ctx.face.id != face.id || face.zid == tables.zid) && ctx.token)
+    }
 
-fn propagate_forget_simple_token(
-    tables: &mut Tables,
-    res: &Arc<Resource>,
-    src_face: &Arc<FaceState>,
-    send_declare: &mut SendDeclare,
-) {
-    for mut face in tables.faces.values().cloned() {
-        if let Some(id) = face_hat_mut!(&mut face).local_tokens.remove(res) {
-            send_declare(
-                &face.primitives,
-                RoutingContext::with_expr(
-                    Declare {
-                        interest_id: None,
-                        ext_qos: ext::QoSType::DECLARE,
-                        ext_tstamp: None,
-                        ext_nodeid: ext::NodeIdType::DEFAULT,
-                        body: DeclareBody::UndeclareToken(UndeclareToken {
-                            id,
-                            ext_wire_expr: WireExprType::null(),
-                        }),
-                    },
-                    res.expr().to_string(),
-                ),
-            );
-        } else if src_face.id != face.id
-            && face_hat!(face)
-                .remote_interests
-                .values()
-                .any(|i| i.options.tokens() && i.matches(res) && !i.options.aggregate())
-        {
-            // Token has never been declared on this face.
-            // Send an Undeclare with a one shot generated id and a WireExpr ext.
-            send_declare(
-                &face.primitives,
-                RoutingContext::with_expr(
-                    Declare {
-                        interest_id: None,
-                        ext_qos: ext::QoSType::DECLARE,
-                        ext_tstamp: None,
-                        ext_nodeid: ext::NodeIdType::DEFAULT,
-                        body: DeclareBody::UndeclareToken(UndeclareToken {
-                            id: face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst),
-                            ext_wire_expr: WireExprType {
-                                wire_expr: Resource::get_best_key(res, "", face.id),
-                            },
-                        }),
-                    },
-                    res.expr().to_string(),
-                ),
-            );
-        }
-        for res in face_hat!(face)
-            .local_tokens
-            .keys()
-            .cloned()
-            .collect::<Vec<Arc<Resource>>>()
-        {
-            if !res.context().matches.iter().any(|m| {
-                m.upgrade()
-                    .is_some_and(|m| m.context.is_some() && remote_simple_tokens(tables, &m, &face))
-            }) {
-                if let Some(id) = face_hat_mut!(&mut face).local_tokens.remove(&res) {
-                    send_declare(
-                        &face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id: None,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::UndeclareToken(UndeclareToken {
-                                    id,
-                                    ext_wire_expr: WireExprType::null(),
-                                }),
-                            },
-                            res.expr().to_string(),
-                        ),
-                    );
-                } else if face_hat!(face)
+    fn propagate_forget_simple_token(
+        &self,
+        tables: &mut Tables,
+        res: &Arc<Resource>,
+        src_face: &Arc<FaceState>,
+        send_declare: &mut SendDeclare,
+    ) {
+        for mut face in tables.faces.values().cloned() {
+            if let Some(id) = face_hat_mut!(&mut face).local_tokens.remove(res) {
+                send_declare(
+                    &face.primitives,
+                    RoutingContext::with_expr(
+                        Declare {
+                            interest_id: None,
+                            ext_qos: ext::QoSType::DECLARE,
+                            ext_tstamp: None,
+                            ext_nodeid: ext::NodeIdType::DEFAULT,
+                            body: DeclareBody::UndeclareToken(UndeclareToken {
+                                id,
+                                ext_wire_expr: WireExprType::null(),
+                            }),
+                        },
+                        res.expr().to_string(),
+                    ),
+                );
+            } else if src_face.id != face.id
+                && face_hat!(face)
                     .remote_interests
                     .values()
-                    .any(|i| i.options.tokens() && i.matches(&res) && !i.options.aggregate())
-                {
-                    // Token has never been declared on this face.
-                    // Send an Undeclare with a one shot generated id and a WireExpr ext.
-                    send_declare(
-                        &face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id: None,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::UndeclareToken(UndeclareToken {
-                                    id: face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst),
-                                    ext_wire_expr: WireExprType {
-                                        wire_expr: Resource::get_best_key(&res, "", face.id),
-                                    },
-                                }),
-                            },
-                            res.expr().to_string(),
-                        ),
-                    );
+                    .any(|i| i.options.tokens() && i.matches(res) && !i.options.aggregate())
+            {
+                // Token has never been declared on this face.
+                // Send an Undeclare with a one shot generated id and a WireExpr ext.
+                send_declare(
+                    &face.primitives,
+                    RoutingContext::with_expr(
+                        Declare {
+                            interest_id: None,
+                            ext_qos: ext::QoSType::DECLARE,
+                            ext_tstamp: None,
+                            ext_nodeid: ext::NodeIdType::DEFAULT,
+                            body: DeclareBody::UndeclareToken(UndeclareToken {
+                                id: face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst),
+                                ext_wire_expr: WireExprType {
+                                    wire_expr: Resource::get_best_key(res, "", face.id),
+                                },
+                            }),
+                        },
+                        res.expr().to_string(),
+                    ),
+                );
+            }
+            for res in face_hat!(face)
+                .local_tokens
+                .keys()
+                .cloned()
+                .collect::<Vec<Arc<Resource>>>()
+            {
+                if !res.context().matches.iter().any(|m| {
+                    m.upgrade().is_some_and(|m| {
+                        m.context.is_some() && self.remote_simple_tokens(tables, &m, &face)
+                    })
+                }) {
+                    if let Some(id) = face_hat_mut!(&mut face).local_tokens.remove(&res) {
+                        send_declare(
+                            &face.primitives,
+                            RoutingContext::with_expr(
+                                Declare {
+                                    interest_id: None,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType::DEFAULT,
+                                    body: DeclareBody::UndeclareToken(UndeclareToken {
+                                        id,
+                                        ext_wire_expr: WireExprType::null(),
+                                    }),
+                                },
+                                res.expr().to_string(),
+                            ),
+                        );
+                    } else if face_hat!(face)
+                        .remote_interests
+                        .values()
+                        .any(|i| i.options.tokens() && i.matches(&res) && !i.options.aggregate())
+                    {
+                        // Token has never been declared on this face.
+                        // Send an Undeclare with a one shot generated id and a WireExpr ext.
+                        send_declare(
+                            &face.primitives,
+                            RoutingContext::with_expr(
+                                Declare {
+                                    interest_id: None,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType::DEFAULT,
+                                    body: DeclareBody::UndeclareToken(UndeclareToken {
+                                        id: face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst),
+                                        ext_wire_expr: WireExprType {
+                                            wire_expr: Resource::get_best_key(&res, "", face.id),
+                                        },
+                                    }),
+                                },
+                                res.expr().to_string(),
+                            ),
+                        );
+                    }
                 }
             }
         }
     }
-}
 
-pub(super) fn undeclare_simple_token(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    res: &mut Arc<Resource>,
-    send_declare: &mut SendDeclare,
-) {
-    if !face_hat_mut!(face)
-        .remote_tokens
-        .values()
-        .any(|s| *s == *res)
-    {
-        if let Some(ctx) = get_mut_unchecked(res).session_ctxs.get_mut(&face.id) {
-            get_mut_unchecked(ctx).token = false;
-        }
+    pub(super) fn undeclare_simple_token(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        res: &mut Arc<Resource>,
+        send_declare: &mut SendDeclare,
+    ) {
+        if !face_hat_mut!(face)
+            .remote_tokens
+            .values()
+            .any(|s| *s == *res)
+        {
+            if let Some(ctx) = get_mut_unchecked(res).session_ctxs.get_mut(&face.id) {
+                get_mut_unchecked(ctx).token = false;
+            }
 
-        let mut simple_tokens = simple_tokens(res);
-        if simple_tokens.is_empty() {
-            propagate_forget_simple_token(tables, res, face, send_declare);
-        }
+            let mut simple_tokens = self.simple_tokens(res);
+            if simple_tokens.is_empty() {
+                self.propagate_forget_simple_token(tables, res, face, send_declare);
+            }
 
-        if simple_tokens.len() == 1 {
-            let mut face = &mut simple_tokens[0];
-            if face.whatami != WhatAmI::Client {
-                if let Some(id) = face_hat_mut!(face).local_tokens.remove(res) {
-                    send_declare(
-                        &face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id: None,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::UndeclareToken(UndeclareToken {
-                                    id,
-                                    ext_wire_expr: WireExprType::null(),
-                                }),
-                            },
-                            res.expr().to_string(),
-                        ),
-                    );
-                }
-                for res in face_hat!(face)
-                    .local_tokens
-                    .keys()
-                    .cloned()
-                    .collect::<Vec<Arc<Resource>>>()
-                {
-                    if !res.context().matches.iter().any(|m| {
-                        m.upgrade().is_some_and(|m| {
-                            m.context.is_some() && remote_simple_tokens(tables, &m, face)
-                        })
-                    }) {
-                        if let Some(id) = face_hat_mut!(&mut face).local_tokens.remove(&res) {
-                            send_declare(
-                                &face.primitives,
-                                RoutingContext::with_expr(
-                                    Declare {
-                                        interest_id: None,
-                                        ext_qos: ext::QoSType::DECLARE,
-                                        ext_tstamp: None,
-                                        ext_nodeid: ext::NodeIdType::DEFAULT,
-                                        body: DeclareBody::UndeclareToken(UndeclareToken {
-                                            id,
-                                            ext_wire_expr: WireExprType::null(),
-                                        }),
-                                    },
-                                    res.expr().to_string(),
-                                ),
-                            );
+            if simple_tokens.len() == 1 {
+                let mut face = &mut simple_tokens[0];
+                if face.whatami != WhatAmI::Client {
+                    if let Some(id) = face_hat_mut!(face).local_tokens.remove(res) {
+                        send_declare(
+                            &face.primitives,
+                            RoutingContext::with_expr(
+                                Declare {
+                                    interest_id: None,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType::DEFAULT,
+                                    body: DeclareBody::UndeclareToken(UndeclareToken {
+                                        id,
+                                        ext_wire_expr: WireExprType::null(),
+                                    }),
+                                },
+                                res.expr().to_string(),
+                            ),
+                        );
+                    }
+                    for res in face_hat!(face)
+                        .local_tokens
+                        .keys()
+                        .cloned()
+                        .collect::<Vec<Arc<Resource>>>()
+                    {
+                        if !res.context().matches.iter().any(|m| {
+                            m.upgrade().is_some_and(|m| {
+                                m.context.is_some() && self.remote_simple_tokens(tables, &m, face)
+                            })
+                        }) {
+                            if let Some(id) = face_hat_mut!(&mut face).local_tokens.remove(&res) {
+                                send_declare(
+                                    &face.primitives,
+                                    RoutingContext::with_expr(
+                                        Declare {
+                                            interest_id: None,
+                                            ext_qos: ext::QoSType::DECLARE,
+                                            ext_tstamp: None,
+                                            ext_nodeid: ext::NodeIdType::DEFAULT,
+                                            body: DeclareBody::UndeclareToken(UndeclareToken {
+                                                id,
+                                                ext_wire_expr: WireExprType::null(),
+                                            }),
+                                        },
+                                        res.expr().to_string(),
+                                    ),
+                                );
+                            }
                         }
                     }
                 }
             }
         }
     }
-}
 
-fn forget_simple_token(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    id: TokenId,
-    res: Option<Arc<Resource>>,
-    send_declare: &mut SendDeclare,
-) -> Option<Arc<Resource>> {
-    if let Some(mut res) = face_hat_mut!(face).remote_tokens.remove(&id) {
-        undeclare_simple_token(tables, face, &mut res, send_declare);
-        Some(res)
-    } else if let Some(mut res) = res {
-        undeclare_simple_token(tables, face, &mut res, send_declare);
-        Some(res)
-    } else {
-        None
+    fn forget_simple_token(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        id: TokenId,
+        res: Option<Arc<Resource>>,
+        send_declare: &mut SendDeclare,
+    ) -> Option<Arc<Resource>> {
+        if let Some(mut res) = face_hat_mut!(face).remote_tokens.remove(&id) {
+            self.undeclare_simple_token(tables, face, &mut res, send_declare);
+            Some(res)
+        } else if let Some(mut res) = res {
+            self.undeclare_simple_token(tables, face, &mut res, send_declare);
+            Some(res)
+        } else {
+            None
+        }
     }
-}
 
-pub(super) fn token_new_face(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    send_declare: &mut SendDeclare,
-) {
-    if face.whatami != WhatAmI::Client {
-        for mut src_face in tables
-            .faces
-            .values()
-            .cloned()
-            .collect::<Vec<Arc<FaceState>>>()
-        {
-            for token in face_hat!(src_face.clone()).remote_tokens.values() {
-                propagate_simple_token_to(
-                    tables,
-                    face,
-                    token,
-                    &mut src_face,
-                    None,
-                    Some(INITIAL_INTEREST_ID),
-                    send_declare,
-                );
+    pub(super) fn token_new_face(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        send_declare: &mut SendDeclare,
+    ) {
+        if face.whatami != WhatAmI::Client {
+            for mut src_face in tables
+                .faces
+                .values()
+                .cloned()
+                .collect::<Vec<Arc<FaceState>>>()
+            {
+                for token in face_hat!(src_face.clone()).remote_tokens.values() {
+                    self.propagate_simple_token_to(
+                        tables,
+                        face,
+                        token,
+                        &mut src_face,
+                        None,
+                        Some(INITIAL_INTEREST_ID),
+                        send_declare,
+                    );
+                }
             }
         }
     }
-}
 
-#[inline]
-fn make_token_id(res: &Arc<Resource>, face: &mut Arc<FaceState>, mode: InterestMode) -> u32 {
-    if mode.future() {
-        if let Some(id) = face_hat!(face).local_tokens.get(res) {
-            *id
+    #[inline]
+    fn make_token_id(
+        &self,
+        res: &Arc<Resource>,
+        face: &mut Arc<FaceState>,
+        mode: InterestMode,
+    ) -> u32 {
+        if mode.future() {
+            if let Some(id) = face_hat!(face).local_tokens.get(res) {
+                *id
+            } else {
+                let id = face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst);
+                face_hat_mut!(face).local_tokens.insert(res.clone(), id);
+                id
+            }
         } else {
-            let id = face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst);
-            face_hat_mut!(face).local_tokens.insert(res.clone(), id);
-            id
+            0
         }
-    } else {
-        0
     }
-}
 
-pub(crate) fn declare_token_interest(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    id: InterestId,
-    res: Option<&mut Arc<Resource>>,
-    mode: InterestMode,
-    aggregate: bool,
-    send_declare: &mut SendDeclare,
-) {
-    if mode.current() {
-        let interest_id = Some(id);
-        if let Some(res) = res.as_ref() {
-            if aggregate {
-                if tables.faces.values().any(|src_face| {
-                    face_hat!(src_face)
-                        .remote_tokens
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn declare_token_interest(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        id: InterestId,
+        res: Option<&mut Arc<Resource>>,
+        mode: InterestMode,
+        aggregate: bool,
+        send_declare: &mut SendDeclare,
+    ) {
+        if mode.current() {
+            let interest_id = Some(id);
+            if let Some(res) = res.as_ref() {
+                if aggregate {
+                    if tables.faces.values().any(|src_face| {
+                        face_hat!(src_face)
+                            .remote_tokens
+                            .values()
+                            .any(|token| token.context.is_some() && token.matches(res))
+                    }) {
+                        let id = self.make_token_id(res, face, mode);
+                        let wire_expr =
+                            Resource::decl_key(res, face, super::push_declaration_profile(face));
+                        send_declare(
+                            &face.primitives,
+                            RoutingContext::with_expr(
+                                Declare {
+                                    interest_id,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType::DEFAULT,
+                                    body: DeclareBody::DeclareToken(DeclareToken { id, wire_expr }),
+                                },
+                                res.expr().to_string(),
+                            ),
+                        );
+                    }
+                } else {
+                    for src_face in tables
+                        .faces
                         .values()
-                        .any(|token| token.context.is_some() && token.matches(res))
-                }) {
-                    let id = make_token_id(res, face, mode);
-                    let wire_expr =
-                        Resource::decl_key(res, face, super::push_declaration_profile(face));
-                    send_declare(
-                        &face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::DeclareToken(DeclareToken { id, wire_expr }),
-                            },
-                            res.expr().to_string(),
-                        ),
-                    );
+                        .filter(|f| f.whatami != WhatAmI::Router)
+                        .cloned()
+                        .collect::<Vec<Arc<FaceState>>>()
+                    {
+                        for token in face_hat!(src_face).remote_tokens.values() {
+                            if token.context.is_some() && token.matches(res) {
+                                let id = self.make_token_id(token, face, mode);
+                                let wire_expr = Resource::decl_key(
+                                    token,
+                                    face,
+                                    super::push_declaration_profile(face),
+                                );
+                                send_declare(
+                                    &face.primitives,
+                                    RoutingContext::with_expr(
+                                        Declare {
+                                            interest_id,
+                                            ext_qos: ext::QoSType::DECLARE,
+                                            ext_tstamp: None,
+                                            ext_nodeid: ext::NodeIdType::DEFAULT,
+                                            body: DeclareBody::DeclareToken(DeclareToken {
+                                                id,
+                                                wire_expr,
+                                            }),
+                                        },
+                                        token.expr().to_string(),
+                                    ),
+                                );
+                            }
+                        }
+                    }
                 }
             } else {
                 for src_face in tables
@@ -547,58 +607,23 @@ pub(crate) fn declare_token_interest(
                     .collect::<Vec<Arc<FaceState>>>()
                 {
                     for token in face_hat!(src_face).remote_tokens.values() {
-                        if token.context.is_some() && token.matches(res) {
-                            let id = make_token_id(token, face, mode);
-                            let wire_expr = Resource::decl_key(
-                                token,
-                                face,
-                                super::push_declaration_profile(face),
-                            );
-                            send_declare(
-                                &face.primitives,
-                                RoutingContext::with_expr(
-                                    Declare {
-                                        interest_id,
-                                        ext_qos: ext::QoSType::DECLARE,
-                                        ext_tstamp: None,
-                                        ext_nodeid: ext::NodeIdType::DEFAULT,
-                                        body: DeclareBody::DeclareToken(DeclareToken {
-                                            id,
-                                            wire_expr,
-                                        }),
-                                    },
-                                    token.expr().to_string(),
-                                ),
-                            );
-                        }
+                        let id = self.make_token_id(token, face, mode);
+                        let wire_expr =
+                            Resource::decl_key(token, face, super::push_declaration_profile(face));
+                        send_declare(
+                            &face.primitives,
+                            RoutingContext::with_expr(
+                                Declare {
+                                    interest_id,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType::DEFAULT,
+                                    body: DeclareBody::DeclareToken(DeclareToken { id, wire_expr }),
+                                },
+                                token.expr().to_string(),
+                            ),
+                        );
                     }
-                }
-            }
-        } else {
-            for src_face in tables
-                .faces
-                .values()
-                .filter(|f| f.whatami != WhatAmI::Router)
-                .cloned()
-                .collect::<Vec<Arc<FaceState>>>()
-            {
-                for token in face_hat!(src_face).remote_tokens.values() {
-                    let id = make_token_id(token, face, mode);
-                    let wire_expr =
-                        Resource::decl_key(token, face, super::push_declaration_profile(face));
-                    send_declare(
-                        &face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::DeclareToken(DeclareToken { id, wire_expr }),
-                            },
-                            token.expr().to_string(),
-                        ),
-                    );
                 }
             }
         }
@@ -616,7 +641,7 @@ impl HatTokenTrait for HatCode {
         interest_id: Option<InterestId>,
         send_declare: &mut SendDeclare,
     ) {
-        declare_simple_token(tables, face, id, res, interest_id, send_declare)
+        self.declare_simple_token(tables, face, id, res, interest_id, send_declare)
     }
 
     fn undeclare_token(
@@ -628,6 +653,6 @@ impl HatTokenTrait for HatCode {
         _node_id: NodeId,
         send_declare: &mut SendDeclare,
     ) -> Option<Arc<Resource>> {
-        forget_simple_token(tables, face, id, res, send_declare)
+        self.forget_simple_token(tables, face, id, res, send_declare)
     }
 }

--- a/zenoh/src/net/routing/hat/router/interests.rs
+++ b/zenoh/src/net/routing/hat/router/interests.rs
@@ -23,10 +23,7 @@ use zenoh_protocol::{
 };
 use zenoh_sync::get_mut_unchecked;
 
-use super::{
-    face_hat_mut, pubsub::declare_sub_interest, queries::declare_qabl_interest,
-    token::declare_token_interest, HatCode, HatFace,
-};
+use super::{face_hat_mut, HatCode, HatFace};
 use crate::net::routing::{
     dispatcher::{
         face::FaceState,
@@ -58,7 +55,7 @@ impl HatInterestTrait for HatCode {
             options -= InterestOptions::AGGREGATE;
         }
         if options.subscribers() {
-            declare_sub_interest(
+            self.declare_sub_interest(
                 tables,
                 face,
                 id,
@@ -69,7 +66,7 @@ impl HatInterestTrait for HatCode {
             )
         }
         if options.queryables() {
-            declare_qabl_interest(
+            self.declare_qabl_interest(
                 tables,
                 face,
                 id,
@@ -80,7 +77,7 @@ impl HatInterestTrait for HatCode {
             )
         }
         if options.tokens() {
-            declare_token_interest(
+            self.declare_token_interest(
                 tables,
                 face,
                 id,

--- a/zenoh/src/net/routing/hat/router/pubsub.rs
+++ b/zenoh/src/net/routing/hat/router/pubsub.rs
@@ -52,423 +52,115 @@ use crate::net::{
     },
 };
 
-#[inline]
-fn send_sourced_subscription_to_net_children(
-    tables: &Tables,
-    net: &Network,
-    children: &[NodeIndex],
-    res: &Arc<Resource>,
-    src_face: Option<&Arc<FaceState>>,
-    _sub_info: &SubscriberInfo,
-    routing_context: NodeId,
-) {
-    for child in children {
-        if net.graph.contains_node(*child) {
-            match tables.get_face(&net.graph[*child].zid).cloned() {
-                Some(mut someface) => {
-                    if src_face
-                        .map(|src_face| someface.id != src_face.id)
-                        .unwrap_or(true)
-                    {
-                        let push_declaration = push_declaration_profile(tables, &someface);
-                        let key_expr = Resource::decl_key(res, &mut someface, push_declaration);
+impl HatCode {
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    fn send_sourced_subscription_to_net_children(
+        &self,
+        tables: &Tables,
+        net: &Network,
+        children: &[NodeIndex],
+        res: &Arc<Resource>,
+        src_face: Option<&Arc<FaceState>>,
+        _sub_info: &SubscriberInfo,
+        routing_context: NodeId,
+    ) {
+        for child in children {
+            if net.graph.contains_node(*child) {
+                match tables.get_face(&net.graph[*child].zid).cloned() {
+                    Some(mut someface) => {
+                        if src_face
+                            .map(|src_face| someface.id != src_face.id)
+                            .unwrap_or(true)
+                        {
+                            let push_declaration = push_declaration_profile(tables, &someface);
+                            let key_expr = Resource::decl_key(res, &mut someface, push_declaration);
 
-                        someface.primitives.send_declare(RoutingContext::with_expr(
-                            &mut Declare {
-                                interest_id: None,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType {
-                                    node_id: routing_context,
+                            someface.primitives.send_declare(RoutingContext::with_expr(
+                                &mut Declare {
+                                    interest_id: None,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType {
+                                        node_id: routing_context,
+                                    },
+                                    body: DeclareBody::DeclareSubscriber(DeclareSubscriber {
+                                        id: 0, // Sourced subscriptions do not use ids
+                                        wire_expr: key_expr,
+                                    }),
                                 },
-                                body: DeclareBody::DeclareSubscriber(DeclareSubscriber {
-                                    id: 0, // Sourced subscriptions do not use ids
-                                    wire_expr: key_expr,
-                                }),
-                            },
-                            res.expr().to_string(),
-                        ));
+                                res.expr().to_string(),
+                            ));
+                        }
+                    }
+                    None => {
+                        tracing::trace!("Unable to find face for zid {}", net.graph[*child].zid)
                     }
                 }
-                None => tracing::trace!("Unable to find face for zid {}", net.graph[*child].zid),
             }
         }
     }
-}
 
-#[inline]
-fn propagate_simple_subscription_to(
-    tables: &mut Tables,
-    dst_face: &mut Arc<FaceState>,
-    res: &Arc<Resource>,
-    _sub_info: &SubscriberInfo,
-    src_face: &mut Arc<FaceState>,
-    full_peer_net: bool,
-    send_declare: &mut SendDeclare,
-) {
-    if src_face.id != dst_face.id
-        && !face_hat!(dst_face).local_subs.contains_key(res)
-        && if full_peer_net {
-            dst_face.whatami == WhatAmI::Client
-        } else {
-            dst_face.whatami != WhatAmI::Router
-                && (src_face.whatami != WhatAmI::Peer
-                    || dst_face.whatami != WhatAmI::Peer
-                    || hat!(tables).failover_brokering(src_face.zid, dst_face.zid))
-        }
-    {
-        let matching_interests = face_hat!(dst_face)
-            .remote_interests
-            .values()
-            .filter(|i| i.options.subscribers() && i.matches(res))
-            .cloned()
-            .collect::<Vec<_>>();
-
-        for RemoteInterest {
-            res: int_res,
-            options,
-            ..
-        } in matching_interests
-        {
-            let res = if options.aggregate() {
-                int_res.as_ref().unwrap_or(res)
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    fn propagate_simple_subscription_to(
+        &self,
+        tables: &mut Tables,
+        dst_face: &mut Arc<FaceState>,
+        res: &Arc<Resource>,
+        _sub_info: &SubscriberInfo,
+        src_face: &mut Arc<FaceState>,
+        full_peer_net: bool,
+        send_declare: &mut SendDeclare,
+    ) {
+        if src_face.id != dst_face.id
+            && !face_hat!(dst_face).local_subs.contains_key(res)
+            && if full_peer_net {
+                dst_face.whatami == WhatAmI::Client
             } else {
-                res
-            };
-            if !face_hat!(dst_face).local_subs.contains_key(res) {
-                let id = face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst);
-                face_hat_mut!(dst_face).local_subs.insert(res.clone(), id);
-                let key_expr =
-                    Resource::decl_key(res, dst_face, push_declaration_profile(tables, dst_face));
-                send_declare(
-                    &dst_face.primitives,
-                    RoutingContext::with_expr(
-                        Declare {
-                            interest_id: None,
-                            ext_qos: ext::QoSType::DECLARE,
-                            ext_tstamp: None,
-                            ext_nodeid: ext::NodeIdType::DEFAULT,
-                            body: DeclareBody::DeclareSubscriber(DeclareSubscriber {
-                                id,
-                                wire_expr: key_expr,
-                            }),
-                        },
-                        res.expr().to_string(),
-                    ),
-                );
+                dst_face.whatami != WhatAmI::Router
+                    && (src_face.whatami != WhatAmI::Peer
+                        || dst_face.whatami != WhatAmI::Peer
+                        || hat!(tables).failover_brokering(src_face.zid, dst_face.zid))
             }
-        }
-    }
-}
-
-fn propagate_simple_subscription(
-    tables: &mut Tables,
-    res: &Arc<Resource>,
-    sub_info: &SubscriberInfo,
-    src_face: &mut Arc<FaceState>,
-    send_declare: &mut SendDeclare,
-) {
-    let full_peer_net = hat!(tables).full_net(WhatAmI::Peer);
-    for mut dst_face in tables
-        .faces
-        .values()
-        .cloned()
-        .collect::<Vec<Arc<FaceState>>>()
-    {
-        propagate_simple_subscription_to(
-            tables,
-            &mut dst_face,
-            res,
-            sub_info,
-            src_face,
-            full_peer_net,
-            send_declare,
-        );
-    }
-}
-
-fn propagate_sourced_subscription(
-    tables: &Tables,
-    res: &Arc<Resource>,
-    sub_info: &SubscriberInfo,
-    src_face: Option<&Arc<FaceState>>,
-    source: &ZenohIdProto,
-    net_type: WhatAmI,
-) {
-    let net = hat!(tables).get_net(net_type).unwrap();
-    match net.get_idx(source) {
-        Some(tree_sid) => {
-            if net.trees.len() > tree_sid.index() {
-                send_sourced_subscription_to_net_children(
-                    tables,
-                    net,
-                    &net.trees[tree_sid.index()].children,
-                    res,
-                    src_face,
-                    sub_info,
-                    tree_sid.index() as NodeId,
-                );
-            } else {
-                tracing::trace!(
-                    "Propagating sub {}: tree for node {} sid:{} not yet ready",
-                    res.expr(),
-                    tree_sid.index(),
-                    source
-                );
-            }
-        }
-        None => tracing::error!(
-            "Error propagating sub {}: cannot get index of {}!",
-            res.expr(),
-            source
-        ),
-    }
-}
-
-fn register_router_subscription(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    res: &mut Arc<Resource>,
-    sub_info: &SubscriberInfo,
-    router: ZenohIdProto,
-    send_declare: &mut SendDeclare,
-) {
-    if !res_hat!(res).router_subs.contains(&router) {
-        // Register router subscription
         {
-            res_hat_mut!(res).router_subs.insert(router);
-            hat_mut!(tables).router_subs.insert(res.clone());
-        }
+            let matching_interests = face_hat!(dst_face)
+                .remote_interests
+                .values()
+                .filter(|i| i.options.subscribers() && i.matches(res))
+                .cloned()
+                .collect::<Vec<_>>();
 
-        // Propagate subscription to routers
-        propagate_sourced_subscription(tables, res, sub_info, Some(face), &router, WhatAmI::Router);
-    }
-    // Propagate subscription to peers
-    if hat!(tables).full_net(WhatAmI::Peer) && face.whatami != WhatAmI::Peer {
-        register_linkstatepeer_subscription(tables, face, res, sub_info, tables.zid)
-    }
-
-    // Propagate subscription to clients
-    propagate_simple_subscription(tables, res, sub_info, face, send_declare);
-}
-
-fn declare_router_subscription(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    res: &mut Arc<Resource>,
-    sub_info: &SubscriberInfo,
-    router: ZenohIdProto,
-    send_declare: &mut SendDeclare,
-) {
-    register_router_subscription(tables, face, res, sub_info, router, send_declare);
-}
-
-fn register_linkstatepeer_subscription(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    res: &mut Arc<Resource>,
-    sub_info: &SubscriberInfo,
-    peer: ZenohIdProto,
-) {
-    if !res_hat!(res).linkstatepeer_subs.contains(&peer) {
-        // Register peer subscription
-        {
-            res_hat_mut!(res).linkstatepeer_subs.insert(peer);
-            hat_mut!(tables).linkstatepeer_subs.insert(res.clone());
-        }
-
-        // Propagate subscription to peers
-        propagate_sourced_subscription(tables, res, sub_info, Some(face), &peer, WhatAmI::Peer);
-    }
-}
-
-fn declare_linkstatepeer_subscription(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    res: &mut Arc<Resource>,
-    sub_info: &SubscriberInfo,
-    peer: ZenohIdProto,
-    send_declare: &mut SendDeclare,
-) {
-    register_linkstatepeer_subscription(tables, face, res, sub_info, peer);
-    let propa_sub_info = *sub_info;
-    let zid = tables.zid;
-    register_router_subscription(tables, face, res, &propa_sub_info, zid, send_declare);
-}
-
-fn register_simple_subscription(
-    _tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    id: SubscriberId,
-    res: &mut Arc<Resource>,
-    sub_info: &SubscriberInfo,
-) {
-    // Register subscription
-    {
-        let res = get_mut_unchecked(res);
-        match res.session_ctxs.get_mut(&face.id) {
-            Some(ctx) => {
-                if ctx.subs.is_none() {
-                    get_mut_unchecked(ctx).subs = Some(*sub_info);
-                }
-            }
-            None => {
-                let ctx = res
-                    .session_ctxs
-                    .entry(face.id)
-                    .or_insert_with(|| Arc::new(SessionContext::new(face.clone())));
-                get_mut_unchecked(ctx).subs = Some(*sub_info);
-            }
-        }
-    }
-    face_hat_mut!(face).remote_subs.insert(id, res.clone());
-}
-
-fn declare_simple_subscription(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    id: SubscriberId,
-    res: &mut Arc<Resource>,
-    sub_info: &SubscriberInfo,
-    send_declare: &mut SendDeclare,
-) {
-    register_simple_subscription(tables, face, id, res, sub_info);
-    let zid = tables.zid;
-    register_router_subscription(tables, face, res, sub_info, zid, send_declare);
-}
-
-#[inline]
-fn remote_router_subs(tables: &Tables, res: &Arc<Resource>) -> bool {
-    res.context.is_some()
-        && res_hat!(res)
-            .router_subs
-            .iter()
-            .any(|peer| peer != &tables.zid)
-}
-
-#[inline]
-fn remote_linkstatepeer_subs(tables: &Tables, res: &Arc<Resource>) -> bool {
-    res.context.is_some()
-        && res_hat!(res)
-            .linkstatepeer_subs
-            .iter()
-            .any(|peer| peer != &tables.zid)
-}
-
-#[inline]
-fn simple_subs(res: &Arc<Resource>) -> Vec<Arc<FaceState>> {
-    res.session_ctxs
-        .values()
-        .filter_map(|ctx| {
-            if ctx.subs.is_some() {
-                Some(ctx.face.clone())
-            } else {
-                None
-            }
-        })
-        .collect()
-}
-
-#[inline]
-fn remote_simple_subs(res: &Arc<Resource>, face: &Arc<FaceState>) -> bool {
-    res.session_ctxs
-        .values()
-        .any(|ctx| ctx.face.id != face.id && ctx.subs.is_some())
-}
-
-#[inline]
-fn send_forget_sourced_subscription_to_net_children(
-    tables: &Tables,
-    net: &Network,
-    children: &[NodeIndex],
-    res: &Arc<Resource>,
-    src_face: Option<&Arc<FaceState>>,
-    routing_context: Option<NodeId>,
-) {
-    for child in children {
-        if net.graph.contains_node(*child) {
-            match tables.get_face(&net.graph[*child].zid).cloned() {
-                Some(mut someface) => {
-                    if src_face
-                        .map(|src_face| someface.id != src_face.id)
-                        .unwrap_or(true)
-                    {
-                        let push_declaration = push_declaration_profile(tables, &someface);
-                        let wire_expr = Resource::decl_key(res, &mut someface, push_declaration);
-
-                        someface.primitives.send_declare(RoutingContext::with_expr(
-                            &mut Declare {
-                                interest_id: None,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType {
-                                    node_id: routing_context.unwrap_or(0),
-                                },
-                                body: DeclareBody::UndeclareSubscriber(UndeclareSubscriber {
-                                    id: 0, // Sourced subscriptions do not use ids
-                                    ext_wire_expr: WireExprType { wire_expr },
-                                }),
-                            },
-                            res.expr().to_string(),
-                        ));
-                    }
-                }
-                None => tracing::trace!("Unable to find face for zid {}", net.graph[*child].zid),
-            }
-        }
-    }
-}
-
-fn propagate_forget_simple_subscription(
-    tables: &mut Tables,
-    res: &Arc<Resource>,
-    send_declare: &mut SendDeclare,
-) {
-    for mut face in tables.faces.values().cloned() {
-        if let Some(id) = face_hat_mut!(&mut face).local_subs.remove(res) {
-            send_declare(
-                &face.primitives,
-                RoutingContext::with_expr(
-                    Declare {
-                        interest_id: None,
-                        ext_qos: ext::QoSType::DECLARE,
-                        ext_tstamp: None,
-                        ext_nodeid: ext::NodeIdType::DEFAULT,
-                        body: DeclareBody::UndeclareSubscriber(UndeclareSubscriber {
-                            id,
-                            ext_wire_expr: WireExprType::null(),
-                        }),
-                    },
-                    res.expr().to_string(),
-                ),
-            );
-        }
-        for res in face_hat!(&mut face)
-            .local_subs
-            .keys()
-            .cloned()
-            .collect::<Vec<Arc<Resource>>>()
-        {
-            if !res.context().matches.iter().any(|m| {
-                m.upgrade().is_some_and(|m| {
-                    m.context.is_some()
-                        && (remote_simple_subs(&m, &face)
-                            || remote_linkstatepeer_subs(tables, &m)
-                            || remote_router_subs(tables, &m))
-                })
-            }) {
-                if let Some(id) = face_hat_mut!(&mut face).local_subs.remove(&res) {
+            for RemoteInterest {
+                res: int_res,
+                options,
+                ..
+            } in matching_interests
+            {
+                let res = if options.aggregate() {
+                    int_res.as_ref().unwrap_or(res)
+                } else {
+                    res
+                };
+                if !face_hat!(dst_face).local_subs.contains_key(res) {
+                    let id = face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst);
+                    face_hat_mut!(dst_face).local_subs.insert(res.clone(), id);
+                    let key_expr = Resource::decl_key(
+                        res,
+                        dst_face,
+                        push_declaration_profile(tables, dst_face),
+                    );
                     send_declare(
-                        &face.primitives,
+                        &dst_face.primitives,
                         RoutingContext::with_expr(
                             Declare {
                                 interest_id: None,
                                 ext_qos: ext::QoSType::DECLARE,
                                 ext_tstamp: None,
                                 ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::UndeclareSubscriber(UndeclareSubscriber {
+                                body: DeclareBody::DeclareSubscriber(DeclareSubscriber {
                                     id,
-                                    ext_wire_expr: WireExprType::null(),
+                                    wire_expr: key_expr,
                                 }),
                             },
                             res.expr().to_string(),
@@ -478,200 +170,299 @@ fn propagate_forget_simple_subscription(
             }
         }
     }
-}
 
-fn propagate_forget_simple_subscription_to_peers(
-    tables: &mut Tables,
-    res: &Arc<Resource>,
-    send_declare: &mut SendDeclare,
-) {
-    if !hat!(tables).full_net(WhatAmI::Peer)
-        && res_hat!(res).router_subs.len() == 1
-        && res_hat!(res).router_subs.contains(&tables.zid)
-    {
-        for mut face in tables
+    fn propagate_simple_subscription(
+        &self,
+        tables: &mut Tables,
+        res: &Arc<Resource>,
+        sub_info: &SubscriberInfo,
+        src_face: &mut Arc<FaceState>,
+        send_declare: &mut SendDeclare,
+    ) {
+        let full_peer_net = hat!(tables).full_net(WhatAmI::Peer);
+        for mut dst_face in tables
             .faces
             .values()
             .cloned()
             .collect::<Vec<Arc<FaceState>>>()
         {
-            if face.whatami == WhatAmI::Peer
-                && face_hat!(face).local_subs.contains_key(res)
-                && !res.session_ctxs.values().any(|s| {
-                    face.zid != s.face.zid
-                        && s.subs.is_some()
-                        && (s.face.whatami == WhatAmI::Client
-                            || (s.face.whatami == WhatAmI::Peer
-                                && hat!(tables).failover_brokering(s.face.zid, face.zid)))
-                })
-            {
-                if let Some(id) = face_hat_mut!(&mut face).local_subs.remove(res) {
-                    send_declare(
-                        &face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id: None,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::UndeclareSubscriber(UndeclareSubscriber {
-                                    id,
-                                    ext_wire_expr: WireExprType::null(),
-                                }),
-                            },
-                            res.expr().to_string(),
-                        ),
+            self.propagate_simple_subscription_to(
+                tables,
+                &mut dst_face,
+                res,
+                sub_info,
+                src_face,
+                full_peer_net,
+                send_declare,
+            );
+        }
+    }
+
+    fn propagate_sourced_subscription(
+        &self,
+        tables: &Tables,
+        res: &Arc<Resource>,
+        sub_info: &SubscriberInfo,
+        src_face: Option<&Arc<FaceState>>,
+        source: &ZenohIdProto,
+        net_type: WhatAmI,
+    ) {
+        let net = hat!(tables).get_net(net_type).unwrap();
+        match net.get_idx(source) {
+            Some(tree_sid) => {
+                if net.trees.len() > tree_sid.index() {
+                    self.send_sourced_subscription_to_net_children(
+                        tables,
+                        net,
+                        &net.trees[tree_sid.index()].children,
+                        res,
+                        src_face,
+                        sub_info,
+                        tree_sid.index() as NodeId,
                     );
+                } else {
+                    tracing::trace!(
+                        "Propagating sub {}: tree for node {} sid:{} not yet ready",
+                        res.expr(),
+                        tree_sid.index(),
+                        source
+                    );
+                }
+            }
+            None => tracing::error!(
+                "Error propagating sub {}: cannot get index of {}!",
+                res.expr(),
+                source
+            ),
+        }
+    }
+
+    fn register_router_subscription(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        res: &mut Arc<Resource>,
+        sub_info: &SubscriberInfo,
+        router: ZenohIdProto,
+        send_declare: &mut SendDeclare,
+    ) {
+        if !res_hat!(res).router_subs.contains(&router) {
+            // Register router subscription
+            {
+                res_hat_mut!(res).router_subs.insert(router);
+                hat_mut!(tables).router_subs.insert(res.clone());
+            }
+
+            // Propagate subscription to routers
+            self.propagate_sourced_subscription(
+                tables,
+                res,
+                sub_info,
+                Some(face),
+                &router,
+                WhatAmI::Router,
+            );
+        }
+        // Propagate subscription to peers
+        if hat!(tables).full_net(WhatAmI::Peer) && face.whatami != WhatAmI::Peer {
+            self.register_linkstatepeer_subscription(tables, face, res, sub_info, tables.zid)
+        }
+
+        // Propagate subscription to clients
+        self.propagate_simple_subscription(tables, res, sub_info, face, send_declare);
+    }
+
+    fn declare_router_subscription(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        res: &mut Arc<Resource>,
+        sub_info: &SubscriberInfo,
+        router: ZenohIdProto,
+        send_declare: &mut SendDeclare,
+    ) {
+        self.register_router_subscription(tables, face, res, sub_info, router, send_declare);
+    }
+
+    fn register_linkstatepeer_subscription(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        res: &mut Arc<Resource>,
+        sub_info: &SubscriberInfo,
+        peer: ZenohIdProto,
+    ) {
+        if !res_hat!(res).linkstatepeer_subs.contains(&peer) {
+            // Register peer subscription
+            {
+                res_hat_mut!(res).linkstatepeer_subs.insert(peer);
+                hat_mut!(tables).linkstatepeer_subs.insert(res.clone());
+            }
+
+            // Propagate subscription to peers
+            self.propagate_sourced_subscription(
+                tables,
+                res,
+                sub_info,
+                Some(face),
+                &peer,
+                WhatAmI::Peer,
+            );
+        }
+    }
+
+    fn declare_linkstatepeer_subscription(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        res: &mut Arc<Resource>,
+        sub_info: &SubscriberInfo,
+        peer: ZenohIdProto,
+        send_declare: &mut SendDeclare,
+    ) {
+        self.register_linkstatepeer_subscription(tables, face, res, sub_info, peer);
+        let propa_sub_info = *sub_info;
+        let zid = tables.zid;
+        self.register_router_subscription(tables, face, res, &propa_sub_info, zid, send_declare);
+    }
+
+    fn register_simple_subscription(
+        &self,
+        _tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        id: SubscriberId,
+        res: &mut Arc<Resource>,
+        sub_info: &SubscriberInfo,
+    ) {
+        // Register subscription
+        {
+            let res = get_mut_unchecked(res);
+            match res.session_ctxs.get_mut(&face.id) {
+                Some(ctx) => {
+                    if ctx.subs.is_none() {
+                        get_mut_unchecked(ctx).subs = Some(*sub_info);
+                    }
+                }
+                None => {
+                    let ctx = res
+                        .session_ctxs
+                        .entry(face.id)
+                        .or_insert_with(|| Arc::new(SessionContext::new(face.clone())));
+                    get_mut_unchecked(ctx).subs = Some(*sub_info);
+                }
+            }
+        }
+        face_hat_mut!(face).remote_subs.insert(id, res.clone());
+    }
+
+    fn declare_simple_subscription(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        id: SubscriberId,
+        res: &mut Arc<Resource>,
+        sub_info: &SubscriberInfo,
+        send_declare: &mut SendDeclare,
+    ) {
+        self.register_simple_subscription(tables, face, id, res, sub_info);
+        let zid = tables.zid;
+        self.register_router_subscription(tables, face, res, sub_info, zid, send_declare);
+    }
+
+    #[inline]
+    fn remote_router_subs(&self, tables: &Tables, res: &Arc<Resource>) -> bool {
+        res.context.is_some()
+            && res_hat!(res)
+                .router_subs
+                .iter()
+                .any(|peer| peer != &tables.zid)
+    }
+
+    #[inline]
+    fn remote_linkstatepeer_subs(&self, tables: &Tables, res: &Arc<Resource>) -> bool {
+        res.context.is_some()
+            && res_hat!(res)
+                .linkstatepeer_subs
+                .iter()
+                .any(|peer| peer != &tables.zid)
+    }
+
+    #[inline]
+    fn simple_subs(&self, res: &Arc<Resource>) -> Vec<Arc<FaceState>> {
+        res.session_ctxs
+            .values()
+            .filter_map(|ctx| {
+                if ctx.subs.is_some() {
+                    Some(ctx.face.clone())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    #[inline]
+    fn remote_simple_subs(&self, res: &Arc<Resource>, face: &Arc<FaceState>) -> bool {
+        res.session_ctxs
+            .values()
+            .any(|ctx| ctx.face.id != face.id && ctx.subs.is_some())
+    }
+
+    #[inline]
+    fn send_forget_sourced_subscription_to_net_children(
+        &self,
+        tables: &Tables,
+        net: &Network,
+        children: &[NodeIndex],
+        res: &Arc<Resource>,
+        src_face: Option<&Arc<FaceState>>,
+        routing_context: Option<NodeId>,
+    ) {
+        for child in children {
+            if net.graph.contains_node(*child) {
+                match tables.get_face(&net.graph[*child].zid).cloned() {
+                    Some(mut someface) => {
+                        if src_face
+                            .map(|src_face| someface.id != src_face.id)
+                            .unwrap_or(true)
+                        {
+                            let push_declaration = push_declaration_profile(tables, &someface);
+                            let wire_expr =
+                                Resource::decl_key(res, &mut someface, push_declaration);
+
+                            someface.primitives.send_declare(RoutingContext::with_expr(
+                                &mut Declare {
+                                    interest_id: None,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType {
+                                        node_id: routing_context.unwrap_or(0),
+                                    },
+                                    body: DeclareBody::UndeclareSubscriber(UndeclareSubscriber {
+                                        id: 0, // Sourced subscriptions do not use ids
+                                        ext_wire_expr: WireExprType { wire_expr },
+                                    }),
+                                },
+                                res.expr().to_string(),
+                            ));
+                        }
+                    }
+                    None => {
+                        tracing::trace!("Unable to find face for zid {}", net.graph[*child].zid)
+                    }
                 }
             }
         }
     }
-}
 
-fn propagate_forget_sourced_subscription(
-    tables: &Tables,
-    res: &Arc<Resource>,
-    src_face: Option<&Arc<FaceState>>,
-    source: &ZenohIdProto,
-    net_type: WhatAmI,
-) {
-    let net = hat!(tables).get_net(net_type).unwrap();
-    match net.get_idx(source) {
-        Some(tree_sid) => {
-            if net.trees.len() > tree_sid.index() {
-                send_forget_sourced_subscription_to_net_children(
-                    tables,
-                    net,
-                    &net.trees[tree_sid.index()].children,
-                    res,
-                    src_face,
-                    Some(tree_sid.index() as NodeId),
-                );
-            } else {
-                tracing::trace!(
-                    "Propagating forget sub {}: tree for node {} sid:{} not yet ready",
-                    res.expr(),
-                    tree_sid.index(),
-                    source
-                );
-            }
-        }
-        None => tracing::error!(
-            "Error propagating forget sub {}: cannot get index of {}!",
-            res.expr(),
-            source
-        ),
-    }
-}
-
-fn unregister_router_subscription(
-    tables: &mut Tables,
-    res: &mut Arc<Resource>,
-    router: &ZenohIdProto,
-    send_declare: &mut SendDeclare,
-) {
-    res_hat_mut!(res).router_subs.retain(|sub| sub != router);
-
-    if res_hat!(res).router_subs.is_empty() {
-        hat_mut!(tables)
-            .router_subs
-            .retain(|sub| !Arc::ptr_eq(sub, res));
-
-        if hat_mut!(tables).full_net(WhatAmI::Peer) {
-            undeclare_linkstatepeer_subscription(tables, None, res, &tables.zid.clone());
-        }
-        propagate_forget_simple_subscription(tables, res, send_declare);
-    }
-
-    propagate_forget_simple_subscription_to_peers(tables, res, send_declare);
-}
-
-fn undeclare_router_subscription(
-    tables: &mut Tables,
-    face: Option<&Arc<FaceState>>,
-    res: &mut Arc<Resource>,
-    router: &ZenohIdProto,
-    send_declare: &mut SendDeclare,
-) {
-    if res_hat!(res).router_subs.contains(router) {
-        unregister_router_subscription(tables, res, router, send_declare);
-        propagate_forget_sourced_subscription(tables, res, face, router, WhatAmI::Router);
-    }
-}
-
-fn forget_router_subscription(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    res: &mut Arc<Resource>,
-    router: &ZenohIdProto,
-    send_declare: &mut SendDeclare,
-) {
-    undeclare_router_subscription(tables, Some(face), res, router, send_declare);
-}
-
-fn unregister_peer_subscription(tables: &mut Tables, res: &mut Arc<Resource>, peer: &ZenohIdProto) {
-    res_hat_mut!(res)
-        .linkstatepeer_subs
-        .retain(|sub| sub != peer);
-
-    if res_hat!(res).linkstatepeer_subs.is_empty() {
-        hat_mut!(tables)
-            .linkstatepeer_subs
-            .retain(|sub| !Arc::ptr_eq(sub, res));
-    }
-}
-
-fn undeclare_linkstatepeer_subscription(
-    tables: &mut Tables,
-    face: Option<&Arc<FaceState>>,
-    res: &mut Arc<Resource>,
-    peer: &ZenohIdProto,
-) {
-    if res_hat!(res).linkstatepeer_subs.contains(peer) {
-        unregister_peer_subscription(tables, res, peer);
-        propagate_forget_sourced_subscription(tables, res, face, peer, WhatAmI::Peer);
-    }
-}
-
-fn forget_linkstatepeer_subscription(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    res: &mut Arc<Resource>,
-    peer: &ZenohIdProto,
-    send_declare: &mut SendDeclare,
-) {
-    undeclare_linkstatepeer_subscription(tables, Some(face), res, peer);
-    let simple_subs = res.session_ctxs.values().any(|ctx| ctx.subs.is_some());
-    let linkstatepeer_subs = remote_linkstatepeer_subs(tables, res);
-    let zid = tables.zid;
-    if !simple_subs && !linkstatepeer_subs {
-        undeclare_router_subscription(tables, None, res, &zid, send_declare);
-    }
-}
-
-pub(super) fn undeclare_simple_subscription(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    res: &mut Arc<Resource>,
-    send_declare: &mut SendDeclare,
-) {
-    if !face_hat_mut!(face).remote_subs.values().any(|s| *s == *res) {
-        if let Some(ctx) = get_mut_unchecked(res).session_ctxs.get_mut(&face.id) {
-            get_mut_unchecked(ctx).subs = None;
-        }
-
-        let mut simple_subs = simple_subs(res);
-        let router_subs = remote_router_subs(tables, res);
-        let linkstatepeer_subs = remote_linkstatepeer_subs(tables, res);
-        if simple_subs.is_empty() && !linkstatepeer_subs {
-            undeclare_router_subscription(tables, None, res, &tables.zid.clone(), send_declare);
-        } else {
-            propagate_forget_simple_subscription_to_peers(tables, res, send_declare);
-        }
-
-        if simple_subs.len() == 1 && !router_subs && !linkstatepeer_subs {
-            let mut face = &mut simple_subs[0];
-            if let Some(id) = face_hat_mut!(face).local_subs.remove(res) {
+    fn propagate_forget_simple_subscription(
+        &self,
+        tables: &mut Tables,
+        res: &Arc<Resource>,
+        send_declare: &mut SendDeclare,
+    ) {
+        for mut face in tables.faces.values().cloned() {
+            if let Some(id) = face_hat_mut!(&mut face).local_subs.remove(res) {
                 send_declare(
                     &face.primitives,
                     RoutingContext::with_expr(
@@ -689,7 +480,7 @@ pub(super) fn undeclare_simple_subscription(
                     ),
                 );
             }
-            for res in face_hat!(face)
+            for res in face_hat!(&mut face)
                 .local_subs
                 .keys()
                 .cloned()
@@ -698,9 +489,9 @@ pub(super) fn undeclare_simple_subscription(
                 if !res.context().matches.iter().any(|m| {
                     m.upgrade().is_some_and(|m| {
                         m.context.is_some()
-                            && (remote_simple_subs(&m, face)
-                                || remote_linkstatepeer_subs(tables, &m)
-                                || remote_router_subs(tables, &m))
+                            && (self.remote_simple_subs(&m, &face)
+                                || self.remote_linkstatepeer_subs(tables, &m)
+                                || self.remote_router_subs(tables, &m))
                     })
                 }) {
                     if let Some(id) = face_hat_mut!(&mut face).local_subs.remove(&res) {
@@ -725,193 +516,264 @@ pub(super) fn undeclare_simple_subscription(
             }
         }
     }
-}
 
-fn forget_simple_subscription(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    id: SubscriberId,
-    send_declare: &mut SendDeclare,
-) -> Option<Arc<Resource>> {
-    if let Some(mut res) = face_hat_mut!(face).remote_subs.remove(&id) {
-        undeclare_simple_subscription(tables, face, &mut res, send_declare);
-        Some(res)
-    } else {
-        None
-    }
-}
-
-pub(super) fn pubsub_remove_node(
-    tables: &mut Tables,
-    node: &ZenohIdProto,
-    net_type: WhatAmI,
-    send_declare: &mut SendDeclare,
-) {
-    match net_type {
-        WhatAmI::Router => {
-            for mut res in hat!(tables)
-                .router_subs
-                .iter()
-                .filter(|res| res_hat!(res).router_subs.contains(node))
+    fn propagate_forget_simple_subscription_to_peers(
+        &self,
+        tables: &mut Tables,
+        res: &Arc<Resource>,
+        send_declare: &mut SendDeclare,
+    ) {
+        if !hat!(tables).full_net(WhatAmI::Peer)
+            && res_hat!(res).router_subs.len() == 1
+            && res_hat!(res).router_subs.contains(&tables.zid)
+        {
+            for mut face in tables
+                .faces
+                .values()
                 .cloned()
-                .collect::<Vec<Arc<Resource>>>()
+                .collect::<Vec<Arc<FaceState>>>()
             {
-                unregister_router_subscription(tables, &mut res, node, send_declare);
-
-                disable_matches_data_routes(tables, &mut res);
-                Resource::clean(&mut res)
-            }
-        }
-        WhatAmI::Peer => {
-            for mut res in hat!(tables)
-                .linkstatepeer_subs
-                .iter()
-                .filter(|res| res_hat!(res).linkstatepeer_subs.contains(node))
-                .cloned()
-                .collect::<Vec<Arc<Resource>>>()
-            {
-                unregister_peer_subscription(tables, &mut res, node);
-                let simple_subs = res.session_ctxs.values().any(|ctx| ctx.subs.is_some());
-                let linkstatepeer_subs = remote_linkstatepeer_subs(tables, &res);
-                if !simple_subs && !linkstatepeer_subs {
-                    undeclare_router_subscription(
-                        tables,
-                        None,
-                        &mut res,
-                        &tables.zid.clone(),
-                        send_declare,
-                    );
-                }
-
-                disable_matches_data_routes(tables, &mut res);
-                Resource::clean(&mut res)
-            }
-        }
-        _ => (),
-    }
-}
-
-pub(super) fn pubsub_tree_change(
-    tables: &mut Tables,
-    new_children: &[Vec<NodeIndex>],
-    net_type: WhatAmI,
-) {
-    let net = match hat!(tables).get_net(net_type) {
-        Some(net) => net,
-        None => {
-            tracing::error!("Error accessing net in pubsub_tree_change!");
-            return;
-        }
-    };
-    // propagate subs to new children
-    for (tree_sid, tree_children) in new_children.iter().enumerate() {
-        if !tree_children.is_empty() {
-            let tree_idx = NodeIndex::new(tree_sid);
-            if net.graph.contains_node(tree_idx) {
-                let tree_id = net.graph[tree_idx].zid;
-
-                let subs_res = match net_type {
-                    WhatAmI::Router => &hat!(tables).router_subs,
-                    _ => &hat!(tables).linkstatepeer_subs,
-                };
-
-                for res in subs_res {
-                    let subs = match net_type {
-                        WhatAmI::Router => &res_hat!(res).router_subs,
-                        _ => &res_hat!(res).linkstatepeer_subs,
-                    };
-                    for sub in subs {
-                        if *sub == tree_id {
-                            let sub_info = SubscriberInfo;
-                            send_sourced_subscription_to_net_children(
-                                tables,
-                                net,
-                                tree_children,
-                                res,
-                                None,
-                                &sub_info,
-                                tree_sid as NodeId,
-                            );
-                        }
+                if face.whatami == WhatAmI::Peer
+                    && face_hat!(face).local_subs.contains_key(res)
+                    && !res.session_ctxs.values().any(|s| {
+                        face.zid != s.face.zid
+                            && s.subs.is_some()
+                            && (s.face.whatami == WhatAmI::Client
+                                || (s.face.whatami == WhatAmI::Peer
+                                    && hat!(tables).failover_brokering(s.face.zid, face.zid)))
+                    })
+                {
+                    if let Some(id) = face_hat_mut!(&mut face).local_subs.remove(res) {
+                        send_declare(
+                            &face.primitives,
+                            RoutingContext::with_expr(
+                                Declare {
+                                    interest_id: None,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType::DEFAULT,
+                                    body: DeclareBody::UndeclareSubscriber(UndeclareSubscriber {
+                                        id,
+                                        ext_wire_expr: WireExprType::null(),
+                                    }),
+                                },
+                                res.expr().to_string(),
+                            ),
+                        );
                     }
                 }
             }
         }
     }
-}
 
-pub(super) fn pubsub_linkstate_change(
-    tables: &mut Tables,
-    zid: &ZenohIdProto,
-    links: &HashMap<ZenohIdProto, LinkEdgeWeight>,
-    send_declare: &mut SendDeclare,
-) {
-    if let Some(mut src_face) = tables.get_face(zid).cloned() {
-        if hat!(tables).router_peers_failover_brokering && src_face.whatami == WhatAmI::Peer {
-            let to_forget = face_hat!(src_face)
-                .local_subs
-                .keys()
-                .filter(|res| {
-                    let client_subs = res
-                        .session_ctxs
-                        .values()
-                        .any(|ctx| ctx.face.whatami == WhatAmI::Client && ctx.subs.is_some());
-                    !remote_router_subs(tables, res)
-                        && !client_subs
-                        && !res.session_ctxs.values().any(|ctx| {
-                            ctx.face.whatami == WhatAmI::Peer
-                                && src_face.id != ctx.face.id
-                                && HatTables::failover_brokering_to(links, &ctx.face.zid)
-                        })
-                })
-                .cloned()
-                .collect::<Vec<Arc<Resource>>>();
-            for res in to_forget {
-                if let Some(id) = face_hat_mut!(&mut src_face).local_subs.remove(&res) {
-                    let wire_expr = Resource::get_best_key(&res, "", src_face.id);
+    fn propagate_forget_sourced_subscription(
+        &self,
+        tables: &Tables,
+        res: &Arc<Resource>,
+        src_face: Option<&Arc<FaceState>>,
+        source: &ZenohIdProto,
+        net_type: WhatAmI,
+    ) {
+        let net = hat!(tables).get_net(net_type).unwrap();
+        match net.get_idx(source) {
+            Some(tree_sid) => {
+                if net.trees.len() > tree_sid.index() {
+                    self.send_forget_sourced_subscription_to_net_children(
+                        tables,
+                        net,
+                        &net.trees[tree_sid.index()].children,
+                        res,
+                        src_face,
+                        Some(tree_sid.index() as NodeId),
+                    );
+                } else {
+                    tracing::trace!(
+                        "Propagating forget sub {}: tree for node {} sid:{} not yet ready",
+                        res.expr(),
+                        tree_sid.index(),
+                        source
+                    );
+                }
+            }
+            None => tracing::error!(
+                "Error propagating forget sub {}: cannot get index of {}!",
+                res.expr(),
+                source
+            ),
+        }
+    }
+
+    fn unregister_router_subscription(
+        &self,
+        tables: &mut Tables,
+        res: &mut Arc<Resource>,
+        router: &ZenohIdProto,
+        send_declare: &mut SendDeclare,
+    ) {
+        res_hat_mut!(res).router_subs.retain(|sub| sub != router);
+
+        if res_hat!(res).router_subs.is_empty() {
+            hat_mut!(tables)
+                .router_subs
+                .retain(|sub| !Arc::ptr_eq(sub, res));
+
+            if hat_mut!(tables).full_net(WhatAmI::Peer) {
+                self.undeclare_linkstatepeer_subscription(tables, None, res, &tables.zid.clone());
+            }
+            self.propagate_forget_simple_subscription(tables, res, send_declare);
+        }
+
+        self.propagate_forget_simple_subscription_to_peers(tables, res, send_declare);
+    }
+
+    fn undeclare_router_subscription(
+        &self,
+        tables: &mut Tables,
+        face: Option<&Arc<FaceState>>,
+        res: &mut Arc<Resource>,
+        router: &ZenohIdProto,
+        send_declare: &mut SendDeclare,
+    ) {
+        if res_hat!(res).router_subs.contains(router) {
+            self.unregister_router_subscription(tables, res, router, send_declare);
+            self.propagate_forget_sourced_subscription(tables, res, face, router, WhatAmI::Router);
+        }
+    }
+
+    fn forget_router_subscription(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        res: &mut Arc<Resource>,
+        router: &ZenohIdProto,
+        send_declare: &mut SendDeclare,
+    ) {
+        self.undeclare_router_subscription(tables, Some(face), res, router, send_declare);
+    }
+
+    fn unregister_peer_subscription(
+        &self,
+        tables: &mut Tables,
+        res: &mut Arc<Resource>,
+        peer: &ZenohIdProto,
+    ) {
+        res_hat_mut!(res)
+            .linkstatepeer_subs
+            .retain(|sub| sub != peer);
+
+        if res_hat!(res).linkstatepeer_subs.is_empty() {
+            hat_mut!(tables)
+                .linkstatepeer_subs
+                .retain(|sub| !Arc::ptr_eq(sub, res));
+        }
+    }
+
+    fn undeclare_linkstatepeer_subscription(
+        &self,
+        tables: &mut Tables,
+        face: Option<&Arc<FaceState>>,
+        res: &mut Arc<Resource>,
+        peer: &ZenohIdProto,
+    ) {
+        if res_hat!(res).linkstatepeer_subs.contains(peer) {
+            self.unregister_peer_subscription(tables, res, peer);
+            self.propagate_forget_sourced_subscription(tables, res, face, peer, WhatAmI::Peer);
+        }
+    }
+
+    fn forget_linkstatepeer_subscription(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        res: &mut Arc<Resource>,
+        peer: &ZenohIdProto,
+        send_declare: &mut SendDeclare,
+    ) {
+        self.undeclare_linkstatepeer_subscription(tables, Some(face), res, peer);
+        let simple_subs = res.session_ctxs.values().any(|ctx| ctx.subs.is_some());
+        let linkstatepeer_subs = self.remote_linkstatepeer_subs(tables, res);
+        let zid = tables.zid;
+        if !simple_subs && !linkstatepeer_subs {
+            self.undeclare_router_subscription(tables, None, res, &zid, send_declare);
+        }
+    }
+
+    pub(super) fn undeclare_simple_subscription(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        res: &mut Arc<Resource>,
+        send_declare: &mut SendDeclare,
+    ) {
+        if !face_hat_mut!(face).remote_subs.values().any(|s| *s == *res) {
+            if let Some(ctx) = get_mut_unchecked(res).session_ctxs.get_mut(&face.id) {
+                get_mut_unchecked(ctx).subs = None;
+            }
+
+            let mut simple_subs = self.simple_subs(res);
+            let router_subs = self.remote_router_subs(tables, res);
+            let linkstatepeer_subs = self.remote_linkstatepeer_subs(tables, res);
+            if simple_subs.is_empty() && !linkstatepeer_subs {
+                self.undeclare_router_subscription(
+                    tables,
+                    None,
+                    res,
+                    &tables.zid.clone(),
+                    send_declare,
+                );
+            } else {
+                self.propagate_forget_simple_subscription_to_peers(tables, res, send_declare);
+            }
+
+            if simple_subs.len() == 1 && !router_subs && !linkstatepeer_subs {
+                let mut face = &mut simple_subs[0];
+                if let Some(id) = face_hat_mut!(face).local_subs.remove(res) {
                     send_declare(
-                        &src_face.primitives,
+                        &face.primitives,
                         RoutingContext::with_expr(
                             Declare {
                                 interest_id: None,
                                 ext_qos: ext::QoSType::DECLARE,
                                 ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::default(),
+                                ext_nodeid: ext::NodeIdType::DEFAULT,
                                 body: DeclareBody::UndeclareSubscriber(UndeclareSubscriber {
                                     id,
-                                    ext_wire_expr: WireExprType { wire_expr },
+                                    ext_wire_expr: WireExprType::null(),
                                 }),
                             },
                             res.expr().to_string(),
                         ),
                     );
                 }
-            }
-
-            for mut dst_face in tables.faces.values().cloned() {
-                if src_face.id != dst_face.id
-                    && HatTables::failover_brokering_to(links, &dst_face.zid)
+                for res in face_hat!(face)
+                    .local_subs
+                    .keys()
+                    .cloned()
+                    .collect::<Vec<Arc<Resource>>>()
                 {
-                    for res in face_hat!(src_face).remote_subs.values() {
-                        if !face_hat!(dst_face).local_subs.contains_key(res) {
-                            let id = face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst);
-                            face_hat_mut!(&mut dst_face)
-                                .local_subs
-                                .insert(res.clone(), id);
-                            let push_declaration = push_declaration_profile(tables, &dst_face);
-                            let key_expr = Resource::decl_key(res, &mut dst_face, push_declaration);
+                    if !res.context().matches.iter().any(|m| {
+                        m.upgrade().is_some_and(|m| {
+                            m.context.is_some()
+                                && (self.remote_simple_subs(&m, face)
+                                    || self.remote_linkstatepeer_subs(tables, &m)
+                                    || self.remote_router_subs(tables, &m))
+                        })
+                    }) {
+                        if let Some(id) = face_hat_mut!(&mut face).local_subs.remove(&res) {
                             send_declare(
-                                &dst_face.primitives,
+                                &face.primitives,
                                 RoutingContext::with_expr(
                                     Declare {
                                         interest_id: None,
                                         ext_qos: ext::QoSType::DECLARE,
                                         ext_tstamp: None,
-                                        ext_nodeid: ext::NodeIdType::default(),
-                                        body: DeclareBody::DeclareSubscriber(DeclareSubscriber {
-                                            id,
-                                            wire_expr: key_expr,
-                                        }),
+                                        ext_nodeid: ext::NodeIdType::DEFAULT,
+                                        body: DeclareBody::UndeclareSubscriber(
+                                            UndeclareSubscriber {
+                                                id,
+                                                ext_wire_expr: WireExprType::null(),
+                                            },
+                                        ),
                                     },
                                     res.expr().to_string(),
                                 ),
@@ -922,83 +784,333 @@ pub(super) fn pubsub_linkstate_change(
             }
         }
     }
-}
 
-#[inline]
-fn make_sub_id(res: &Arc<Resource>, face: &mut Arc<FaceState>, mode: InterestMode) -> u32 {
-    if mode.future() {
-        if let Some(id) = face_hat!(face).local_subs.get(res) {
-            *id
+    fn forget_simple_subscription(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        id: SubscriberId,
+        send_declare: &mut SendDeclare,
+    ) -> Option<Arc<Resource>> {
+        if let Some(mut res) = face_hat_mut!(face).remote_subs.remove(&id) {
+            self.undeclare_simple_subscription(tables, face, &mut res, send_declare);
+            Some(res)
         } else {
-            let id = face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst);
-            face_hat_mut!(face).local_subs.insert(res.clone(), id);
-            id
+            None
         }
-    } else {
-        0
     }
-}
 
-pub(crate) fn declare_sub_interest(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    id: InterestId,
-    res: Option<&mut Arc<Resource>>,
-    mode: InterestMode,
-    aggregate: bool,
-    send_declare: &mut SendDeclare,
-) {
-    if mode.current() {
-        let interest_id = Some(id);
-        if let Some(res) = res.as_ref() {
-            if aggregate {
-                if hat!(tables).router_subs.iter().any(|sub| {
-                    sub.context.is_some()
-                        && sub.matches(res)
-                        && (remote_simple_subs(sub, face)
-                            || remote_linkstatepeer_subs(tables, sub)
-                            || remote_router_subs(tables, sub))
-                }) {
-                    let id = make_sub_id(res, face, mode);
-                    let wire_expr =
-                        Resource::decl_key(res, face, push_declaration_profile(tables, face));
-                    send_declare(
-                        &face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::DeclareSubscriber(DeclareSubscriber {
-                                    id,
-                                    wire_expr,
-                                }),
-                            },
-                            res.expr().to_string(),
-                        ),
-                    );
+    pub(super) fn pubsub_remove_node(
+        &self,
+        tables: &mut Tables,
+        node: &ZenohIdProto,
+        net_type: WhatAmI,
+        send_declare: &mut SendDeclare,
+    ) {
+        match net_type {
+            WhatAmI::Router => {
+                for mut res in hat!(tables)
+                    .router_subs
+                    .iter()
+                    .filter(|res| res_hat!(res).router_subs.contains(node))
+                    .cloned()
+                    .collect::<Vec<Arc<Resource>>>()
+                {
+                    self.unregister_router_subscription(tables, &mut res, node, send_declare);
+
+                    disable_matches_data_routes(tables, &mut res);
+                    Resource::clean(&mut res)
+                }
+            }
+            WhatAmI::Peer => {
+                for mut res in hat!(tables)
+                    .linkstatepeer_subs
+                    .iter()
+                    .filter(|res| res_hat!(res).linkstatepeer_subs.contains(node))
+                    .cloned()
+                    .collect::<Vec<Arc<Resource>>>()
+                {
+                    self.unregister_peer_subscription(tables, &mut res, node);
+                    let simple_subs = res.session_ctxs.values().any(|ctx| ctx.subs.is_some());
+                    let linkstatepeer_subs = self.remote_linkstatepeer_subs(tables, &res);
+                    if !simple_subs && !linkstatepeer_subs {
+                        self.undeclare_router_subscription(
+                            tables,
+                            None,
+                            &mut res,
+                            &tables.zid.clone(),
+                            send_declare,
+                        );
+                    }
+
+                    disable_matches_data_routes(tables, &mut res);
+                    Resource::clean(&mut res)
+                }
+            }
+            _ => (),
+        }
+    }
+
+    pub(super) fn pubsub_tree_change(
+        &self,
+        tables: &mut Tables,
+        new_children: &[Vec<NodeIndex>],
+        net_type: WhatAmI,
+    ) {
+        let net = match hat!(tables).get_net(net_type) {
+            Some(net) => net,
+            None => {
+                tracing::error!("Error accessing net in pubsub_tree_change!");
+                return;
+            }
+        };
+        // propagate subs to new children
+        for (tree_sid, tree_children) in new_children.iter().enumerate() {
+            if !tree_children.is_empty() {
+                let tree_idx = NodeIndex::new(tree_sid);
+                if net.graph.contains_node(tree_idx) {
+                    let tree_id = net.graph[tree_idx].zid;
+
+                    let subs_res = match net_type {
+                        WhatAmI::Router => &hat!(tables).router_subs,
+                        _ => &hat!(tables).linkstatepeer_subs,
+                    };
+
+                    for res in subs_res {
+                        let subs = match net_type {
+                            WhatAmI::Router => &res_hat!(res).router_subs,
+                            _ => &res_hat!(res).linkstatepeer_subs,
+                        };
+                        for sub in subs {
+                            if *sub == tree_id {
+                                let sub_info = SubscriberInfo;
+                                self.send_sourced_subscription_to_net_children(
+                                    tables,
+                                    net,
+                                    tree_children,
+                                    res,
+                                    None,
+                                    &sub_info,
+                                    tree_sid as NodeId,
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub(super) fn pubsub_linkstate_change(
+        &self,
+        tables: &mut Tables,
+        zid: &ZenohIdProto,
+        links: &HashMap<ZenohIdProto, LinkEdgeWeight>,
+        send_declare: &mut SendDeclare,
+    ) {
+        if let Some(mut src_face) = tables.get_face(zid).cloned() {
+            if hat!(tables).router_peers_failover_brokering && src_face.whatami == WhatAmI::Peer {
+                let to_forget = face_hat!(src_face)
+                    .local_subs
+                    .keys()
+                    .filter(|res| {
+                        let client_subs = res
+                            .session_ctxs
+                            .values()
+                            .any(|ctx| ctx.face.whatami == WhatAmI::Client && ctx.subs.is_some());
+                        !self.remote_router_subs(tables, res)
+                            && !client_subs
+                            && !res.session_ctxs.values().any(|ctx| {
+                                ctx.face.whatami == WhatAmI::Peer
+                                    && src_face.id != ctx.face.id
+                                    && HatTables::failover_brokering_to(links, &ctx.face.zid)
+                            })
+                    })
+                    .cloned()
+                    .collect::<Vec<Arc<Resource>>>();
+                for res in to_forget {
+                    if let Some(id) = face_hat_mut!(&mut src_face).local_subs.remove(&res) {
+                        let wire_expr = Resource::get_best_key(&res, "", src_face.id);
+                        send_declare(
+                            &src_face.primitives,
+                            RoutingContext::with_expr(
+                                Declare {
+                                    interest_id: None,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType::default(),
+                                    body: DeclareBody::UndeclareSubscriber(UndeclareSubscriber {
+                                        id,
+                                        ext_wire_expr: WireExprType { wire_expr },
+                                    }),
+                                },
+                                res.expr().to_string(),
+                            ),
+                        );
+                    }
+                }
+
+                for mut dst_face in tables.faces.values().cloned() {
+                    if src_face.id != dst_face.id
+                        && HatTables::failover_brokering_to(links, &dst_face.zid)
+                    {
+                        for res in face_hat!(src_face).remote_subs.values() {
+                            if !face_hat!(dst_face).local_subs.contains_key(res) {
+                                let id = face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst);
+                                face_hat_mut!(&mut dst_face)
+                                    .local_subs
+                                    .insert(res.clone(), id);
+                                let push_declaration = push_declaration_profile(tables, &dst_face);
+                                let key_expr =
+                                    Resource::decl_key(res, &mut dst_face, push_declaration);
+                                send_declare(
+                                    &dst_face.primitives,
+                                    RoutingContext::with_expr(
+                                        Declare {
+                                            interest_id: None,
+                                            ext_qos: ext::QoSType::DECLARE,
+                                            ext_tstamp: None,
+                                            ext_nodeid: ext::NodeIdType::default(),
+                                            body: DeclareBody::DeclareSubscriber(
+                                                DeclareSubscriber {
+                                                    id,
+                                                    wire_expr: key_expr,
+                                                },
+                                            ),
+                                        },
+                                        res.expr().to_string(),
+                                    ),
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[inline]
+    fn make_sub_id(
+        &self,
+        res: &Arc<Resource>,
+        face: &mut Arc<FaceState>,
+        mode: InterestMode,
+    ) -> u32 {
+        if mode.future() {
+            if let Some(id) = face_hat!(face).local_subs.get(res) {
+                *id
+            } else {
+                let id = face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst);
+                face_hat_mut!(face).local_subs.insert(res.clone(), id);
+                id
+            }
+        } else {
+            0
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn declare_sub_interest(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        id: InterestId,
+        res: Option<&mut Arc<Resource>>,
+        mode: InterestMode,
+        aggregate: bool,
+        send_declare: &mut SendDeclare,
+    ) {
+        if mode.current() {
+            let interest_id = Some(id);
+            if let Some(res) = res.as_ref() {
+                if aggregate {
+                    if hat!(tables).router_subs.iter().any(|sub| {
+                        sub.context.is_some()
+                            && sub.matches(res)
+                            && (self.remote_simple_subs(sub, face)
+                                || self.remote_linkstatepeer_subs(tables, sub)
+                                || self.remote_router_subs(tables, sub))
+                    }) {
+                        let id = self.make_sub_id(res, face, mode);
+                        let wire_expr =
+                            Resource::decl_key(res, face, push_declaration_profile(tables, face));
+                        send_declare(
+                            &face.primitives,
+                            RoutingContext::with_expr(
+                                Declare {
+                                    interest_id,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType::DEFAULT,
+                                    body: DeclareBody::DeclareSubscriber(DeclareSubscriber {
+                                        id,
+                                        wire_expr,
+                                    }),
+                                },
+                                res.expr().to_string(),
+                            ),
+                        );
+                    }
+                } else {
+                    for sub in &hat!(tables).router_subs {
+                        if sub.context.is_some()
+                            && sub.matches(res)
+                            && (res_hat!(sub).router_subs.iter().any(|r| *r != tables.zid)
+                                || res_hat!(sub)
+                                    .linkstatepeer_subs
+                                    .iter()
+                                    .any(|r| *r != tables.zid)
+                                || sub.session_ctxs.values().any(|s| {
+                                    s.face.id != face.id
+                                        && s.subs.is_some()
+                                        && (s.face.whatami == WhatAmI::Client
+                                            || face.whatami == WhatAmI::Client
+                                            || (s.face.whatami == WhatAmI::Peer
+                                                && hat!(tables)
+                                                    .failover_brokering(s.face.zid, face.zid)))
+                                }))
+                        {
+                            let id = self.make_sub_id(sub, face, mode);
+                            let wire_expr = Resource::decl_key(
+                                sub,
+                                face,
+                                push_declaration_profile(tables, face),
+                            );
+                            send_declare(
+                                &face.primitives,
+                                RoutingContext::with_expr(
+                                    Declare {
+                                        interest_id,
+                                        ext_qos: ext::QoSType::DECLARE,
+                                        ext_tstamp: None,
+                                        ext_nodeid: ext::NodeIdType::DEFAULT,
+                                        body: DeclareBody::DeclareSubscriber(DeclareSubscriber {
+                                            id,
+                                            wire_expr,
+                                        }),
+                                    },
+                                    sub.expr().to_string(),
+                                ),
+                            );
+                        }
+                    }
                 }
             } else {
                 for sub in &hat!(tables).router_subs {
                     if sub.context.is_some()
-                        && sub.matches(res)
                         && (res_hat!(sub).router_subs.iter().any(|r| *r != tables.zid)
                             || res_hat!(sub)
                                 .linkstatepeer_subs
                                 .iter()
                                 .any(|r| *r != tables.zid)
                             || sub.session_ctxs.values().any(|s| {
-                                s.face.id != face.id
-                                    && s.subs.is_some()
-                                    && (s.face.whatami == WhatAmI::Client
-                                        || face.whatami == WhatAmI::Client
-                                        || (s.face.whatami == WhatAmI::Peer
-                                            && hat!(tables)
-                                                .failover_brokering(s.face.zid, face.zid)))
+                                s.subs.is_some()
+                                    && (s.face.whatami != WhatAmI::Peer
+                                        || face.whatami != WhatAmI::Peer
+                                        || hat!(tables).failover_brokering(s.face.zid, face.zid))
                             }))
                     {
-                        let id = make_sub_id(sub, face, mode);
+                        let id = self.make_sub_id(sub, face, mode);
                         let wire_expr =
                             Resource::decl_key(sub, face, push_declaration_profile(tables, face));
                         send_declare(
@@ -1020,42 +1132,6 @@ pub(crate) fn declare_sub_interest(
                     }
                 }
             }
-        } else {
-            for sub in &hat!(tables).router_subs {
-                if sub.context.is_some()
-                    && (res_hat!(sub).router_subs.iter().any(|r| *r != tables.zid)
-                        || res_hat!(sub)
-                            .linkstatepeer_subs
-                            .iter()
-                            .any(|r| *r != tables.zid)
-                        || sub.session_ctxs.values().any(|s| {
-                            s.subs.is_some()
-                                && (s.face.whatami != WhatAmI::Peer
-                                    || face.whatami != WhatAmI::Peer
-                                    || hat!(tables).failover_brokering(s.face.zid, face.zid))
-                        }))
-                {
-                    let id = make_sub_id(sub, face, mode);
-                    let wire_expr =
-                        Resource::decl_key(sub, face, push_declaration_profile(tables, face));
-                    send_declare(
-                        &face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::DeclareSubscriber(DeclareSubscriber {
-                                    id,
-                                    wire_expr,
-                                }),
-                            },
-                            sub.expr().to_string(),
-                        ),
-                    );
-                }
-            }
         }
     }
 }
@@ -1074,13 +1150,20 @@ impl HatPubSubTrait for HatCode {
         match face.whatami {
             WhatAmI::Router => {
                 if let Some(router) = get_router(tables, face, node_id) {
-                    declare_router_subscription(tables, face, res, sub_info, router, send_declare)
+                    self.declare_router_subscription(
+                        tables,
+                        face,
+                        res,
+                        sub_info,
+                        router,
+                        send_declare,
+                    )
                 }
             }
             WhatAmI::Peer => {
                 if hat!(tables).full_net(WhatAmI::Peer) {
                     if let Some(peer) = get_peer(tables, face, node_id) {
-                        declare_linkstatepeer_subscription(
+                        self.declare_linkstatepeer_subscription(
                             tables,
                             face,
                             res,
@@ -1090,10 +1173,10 @@ impl HatPubSubTrait for HatCode {
                         )
                     }
                 } else {
-                    declare_simple_subscription(tables, face, id, res, sub_info, send_declare)
+                    self.declare_simple_subscription(tables, face, id, res, sub_info, send_declare)
                 }
             }
-            _ => declare_simple_subscription(tables, face, id, res, sub_info, send_declare),
+            _ => self.declare_simple_subscription(tables, face, id, res, sub_info, send_declare),
         }
     }
 
@@ -1110,7 +1193,13 @@ impl HatPubSubTrait for HatCode {
             WhatAmI::Router => {
                 if let Some(mut res) = res {
                     if let Some(router) = get_router(tables, face, node_id) {
-                        forget_router_subscription(tables, face, &mut res, &router, send_declare);
+                        self.forget_router_subscription(
+                            tables,
+                            face,
+                            &mut res,
+                            &router,
+                            send_declare,
+                        );
                         Some(res)
                     } else {
                         None
@@ -1123,7 +1212,7 @@ impl HatPubSubTrait for HatCode {
                 if hat!(tables).full_net(WhatAmI::Peer) {
                     if let Some(mut res) = res {
                         if let Some(peer) = get_peer(tables, face, node_id) {
-                            forget_linkstatepeer_subscription(
+                            self.forget_linkstatepeer_subscription(
                                 tables,
                                 face,
                                 &mut res,
@@ -1138,10 +1227,10 @@ impl HatPubSubTrait for HatCode {
                         None
                     }
                 } else {
-                    forget_simple_subscription(tables, face, id, send_declare)
+                    self.forget_simple_subscription(tables, face, id, send_declare)
                 }
             }
-            _ => forget_simple_subscription(tables, face, id, send_declare),
+            _ => self.forget_simple_subscription(tables, face, id, send_declare),
         }
     }
 

--- a/zenoh/src/net/routing/hat/router/queries.rs
+++ b/zenoh/src/net/routing/hat/router/queries.rs
@@ -63,11 +63,46 @@ fn merge_qabl_infos(mut this: QueryableInfoType, info: &QueryableInfoType) -> Qu
     this
 }
 
-fn local_router_qabl_info(tables: &Tables, res: &Arc<Resource>) -> QueryableInfoType {
-    let info = if hat!(tables).full_net(WhatAmI::Peer) {
-        res.context.as_ref().and_then(|_| {
+impl HatCode {
+    fn local_router_qabl_info(&self, tables: &Tables, res: &Arc<Resource>) -> QueryableInfoType {
+        let info = if hat!(tables).full_net(WhatAmI::Peer) {
+            res.context.as_ref().and_then(|_| {
+                res_hat!(res)
+                    .linkstatepeer_qabls
+                    .iter()
+                    .fold(None, |accu, (zid, info)| {
+                        if *zid != tables.zid {
+                            Some(match accu {
+                                Some(accu) => merge_qabl_infos(accu, info),
+                                None => *info,
+                            })
+                        } else {
+                            accu
+                        }
+                    })
+            })
+        } else {
+            None
+        };
+        res.session_ctxs
+            .values()
+            .fold(info, |accu, ctx| {
+                if let Some(info) = ctx.qabl.as_ref() {
+                    Some(match accu {
+                        Some(accu) => merge_qabl_infos(accu, info),
+                        None => *info,
+                    })
+                } else {
+                    accu
+                }
+            })
+            .unwrap_or(QueryableInfoType::DEFAULT)
+    }
+
+    fn local_peer_qabl_info(&self, tables: &Tables, res: &Arc<Resource>) -> QueryableInfoType {
+        let info = if res.context.is_some() {
             res_hat!(res)
-                .linkstatepeer_qabls
+                .router_qabls
                 .iter()
                 .fold(None, |accu, (zid, info)| {
                     if *zid != tables.zid {
@@ -79,102 +114,12 @@ fn local_router_qabl_info(tables: &Tables, res: &Arc<Resource>) -> QueryableInfo
                         accu
                     }
                 })
-        })
-    } else {
-        None
-    };
-    res.session_ctxs
-        .values()
-        .fold(info, |accu, ctx| {
-            if let Some(info) = ctx.qabl.as_ref() {
-                Some(match accu {
-                    Some(accu) => merge_qabl_infos(accu, info),
-                    None => *info,
-                })
-            } else {
-                accu
-            }
-        })
-        .unwrap_or(QueryableInfoType::DEFAULT)
-}
-
-fn local_peer_qabl_info(tables: &Tables, res: &Arc<Resource>) -> QueryableInfoType {
-    let info = if res.context.is_some() {
-        res_hat!(res)
-            .router_qabls
-            .iter()
-            .fold(None, |accu, (zid, info)| {
-                if *zid != tables.zid {
-                    Some(match accu {
-                        Some(accu) => merge_qabl_infos(accu, info),
-                        None => *info,
-                    })
-                } else {
-                    accu
-                }
-            })
-    } else {
-        None
-    };
-    res.session_ctxs
-        .values()
-        .fold(info, |accu, ctx| {
-            if let Some(info) = ctx.qabl.as_ref() {
-                Some(match accu {
-                    Some(accu) => merge_qabl_infos(accu, info),
-                    None => *info,
-                })
-            } else {
-                accu
-            }
-        })
-        .unwrap_or(QueryableInfoType::DEFAULT)
-}
-
-fn local_qabl_info(
-    tables: &Tables,
-    res: &Arc<Resource>,
-    face: &Arc<FaceState>,
-) -> QueryableInfoType {
-    let mut info = if res.context.is_some() {
-        res_hat!(res)
-            .router_qabls
-            .iter()
-            .fold(None, |accu, (zid, info)| {
-                if *zid != tables.zid {
-                    Some(match accu {
-                        Some(accu) => merge_qabl_infos(accu, info),
-                        None => *info,
-                    })
-                } else {
-                    accu
-                }
-            })
-    } else {
-        None
-    };
-    if res.context.is_some() && hat!(tables).full_net(WhatAmI::Peer) {
-        info = res_hat!(res)
-            .linkstatepeer_qabls
-            .iter()
-            .fold(info, |accu, (zid, info)| {
-                if *zid != tables.zid {
-                    Some(match accu {
-                        Some(accu) => merge_qabl_infos(accu, info),
-                        None => *info,
-                    })
-                } else {
-                    accu
-                }
-            })
-    }
-    res.session_ctxs
-        .values()
-        .fold(info, |accu, ctx| {
-            if ctx.face.id != face.id && ctx.face.whatami != WhatAmI::Peer
-                || face.whatami != WhatAmI::Peer
-                || hat!(tables).failover_brokering(ctx.face.zid, face.zid)
-            {
+        } else {
+            None
+        };
+        res.session_ctxs
+            .values()
+            .fold(info, |accu, ctx| {
                 if let Some(info) = ctx.qabl.as_ref() {
                     Some(match accu {
                         Some(accu) => merge_qabl_infos(accu, info),
@@ -183,635 +128,450 @@ fn local_qabl_info(
                 } else {
                     accu
                 }
-            } else {
-                accu
-            }
-        })
-        .unwrap_or(QueryableInfoType::DEFAULT)
-}
-
-#[inline]
-fn send_sourced_queryable_to_net_children(
-    tables: &Tables,
-    net: &Network,
-    children: &[NodeIndex],
-    res: &Arc<Resource>,
-    qabl_info: &QueryableInfoType,
-    src_face: Option<&mut Arc<FaceState>>,
-    routing_context: NodeId,
-) {
-    for child in children {
-        if net.graph.contains_node(*child) {
-            match tables.get_face(&net.graph[*child].zid).cloned() {
-                Some(mut someface) => {
-                    if src_face
-                        .as_ref()
-                        .map(|src_face| someface.id != src_face.id)
-                        .unwrap_or(true)
-                    {
-                        let push_declaration = push_declaration_profile(tables, &someface);
-                        let key_expr = Resource::decl_key(res, &mut someface, push_declaration);
-
-                        someface.primitives.send_declare(RoutingContext::with_expr(
-                            &mut Declare {
-                                interest_id: None,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType {
-                                    node_id: routing_context,
-                                },
-                                body: DeclareBody::DeclareQueryable(DeclareQueryable {
-                                    id: 0, // Sourced queryables do not use ids
-                                    wire_expr: key_expr,
-                                    ext_info: *qabl_info,
-                                }),
-                            },
-                            res.expr().to_string(),
-                        ));
-                    }
-                }
-                None => tracing::trace!("Unable to find face for zid {}", net.graph[*child].zid),
-            }
-        }
+            })
+            .unwrap_or(QueryableInfoType::DEFAULT)
     }
-}
 
-fn propagate_simple_queryable(
-    tables: &mut Tables,
-    res: &Arc<Resource>,
-    src_face: Option<&mut Arc<FaceState>>,
-    send_declare: &mut SendDeclare,
-) {
-    let full_peers_net = hat!(tables).full_net(WhatAmI::Peer);
-    let faces = tables.faces.values().cloned();
-    for mut dst_face in faces {
-        let info = local_qabl_info(tables, res, &dst_face);
-        let current = face_hat!(dst_face).local_qabls.get(res);
-        if src_face
-            .as_ref()
-            .map(|src_face| dst_face.id != src_face.id)
-            .unwrap_or(true)
-            && (current.is_none() || current.unwrap().1 != info)
-            && face_hat!(dst_face)
-                .remote_interests
-                .values()
-                .any(|i| i.options.queryables() && i.matches(res))
-            && if full_peers_net {
-                dst_face.whatami == WhatAmI::Client
-            } else {
-                dst_face.whatami != WhatAmI::Router
-                    && src_face
-                        .as_ref()
-                        .map(|src_face| {
-                            src_face.whatami != WhatAmI::Peer
-                                || dst_face.whatami != WhatAmI::Peer
-                                || hat!(tables).failover_brokering(src_face.zid, dst_face.zid)
+    fn local_qabl_info(
+        &self,
+        tables: &Tables,
+        res: &Arc<Resource>,
+        face: &Arc<FaceState>,
+    ) -> QueryableInfoType {
+        let mut info = if res.context.is_some() {
+            res_hat!(res)
+                .router_qabls
+                .iter()
+                .fold(None, |accu, (zid, info)| {
+                    if *zid != tables.zid {
+                        Some(match accu {
+                            Some(accu) => merge_qabl_infos(accu, info),
+                            None => *info,
                         })
-                        .unwrap_or(true)
-            }
-        {
-            let id = current
-                .map(|c| c.0)
-                .unwrap_or(face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst));
-            face_hat_mut!(&mut dst_face)
-                .local_qabls
-                .insert(res.clone(), (id, info));
-            let push_declaration = push_declaration_profile(tables, &dst_face);
-            let key_expr = Resource::decl_key(res, &mut dst_face, push_declaration);
-            send_declare(
-                &dst_face.primitives,
-                RoutingContext::with_expr(
-                    Declare {
-                        interest_id: None,
-                        ext_qos: ext::QoSType::DECLARE,
-                        ext_tstamp: None,
-                        ext_nodeid: ext::NodeIdType::DEFAULT,
-                        body: DeclareBody::DeclareQueryable(DeclareQueryable {
-                            id,
-                            wire_expr: key_expr,
-                            ext_info: info,
-                        }),
-                    },
-                    res.expr().to_string(),
-                ),
-            );
-        }
-    }
-}
-
-fn propagate_sourced_queryable(
-    tables: &Tables,
-    res: &Arc<Resource>,
-    qabl_info: &QueryableInfoType,
-    src_face: Option<&mut Arc<FaceState>>,
-    source: &ZenohIdProto,
-    net_type: WhatAmI,
-) {
-    let net = hat!(tables).get_net(net_type).unwrap();
-    match net.get_idx(source) {
-        Some(tree_sid) => {
-            if net.trees.len() > tree_sid.index() {
-                send_sourced_queryable_to_net_children(
-                    tables,
-                    net,
-                    &net.trees[tree_sid.index()].children,
-                    res,
-                    qabl_info,
-                    src_face,
-                    tree_sid.index() as NodeId,
-                );
-            } else {
-                tracing::trace!(
-                    "Propagating qabl {}: tree for node {} sid:{} not yet ready",
-                    res.expr(),
-                    tree_sid.index(),
-                    source
-                );
-            }
-        }
-        None => tracing::error!(
-            "Error propagating qabl {}: cannot get index of {}!",
-            res.expr(),
-            source
-        ),
-    }
-}
-
-fn register_router_queryable(
-    tables: &mut Tables,
-    mut face: Option<&mut Arc<FaceState>>,
-    res: &mut Arc<Resource>,
-    qabl_info: &QueryableInfoType,
-    router: ZenohIdProto,
-    send_declare: &mut SendDeclare,
-) {
-    let current_info = res_hat!(res).router_qabls.get(&router);
-    if current_info.is_none() || current_info.unwrap() != qabl_info {
-        // Register router queryable
-        {
-            res_hat_mut!(res).router_qabls.insert(router, *qabl_info);
-            hat_mut!(tables).router_qabls.insert(res.clone());
-        }
-
-        // Propagate queryable to routers
-        propagate_sourced_queryable(
-            tables,
-            res,
-            qabl_info,
-            face.as_deref_mut(),
-            &router,
-            WhatAmI::Router,
-        );
-    }
-
-    if hat!(tables).full_net(WhatAmI::Peer) {
-        // Propagate queryable to peers
-        if face.is_none() || face.as_ref().unwrap().whatami != WhatAmI::Peer {
-            let local_info = local_peer_qabl_info(tables, res);
-            register_linkstatepeer_queryable(
-                tables,
-                face.as_deref_mut(),
-                res,
-                &local_info,
-                tables.zid,
-            )
-        }
-    }
-
-    // Propagate queryable to clients
-    propagate_simple_queryable(tables, res, face, send_declare);
-}
-
-fn declare_router_queryable(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    res: &mut Arc<Resource>,
-    qabl_info: &QueryableInfoType,
-    router: ZenohIdProto,
-    send_declare: &mut SendDeclare,
-) {
-    register_router_queryable(tables, Some(face), res, qabl_info, router, send_declare);
-}
-
-fn register_linkstatepeer_queryable(
-    tables: &mut Tables,
-    face: Option<&mut Arc<FaceState>>,
-    res: &mut Arc<Resource>,
-    qabl_info: &QueryableInfoType,
-    peer: ZenohIdProto,
-) {
-    let current_info = res_hat!(res).linkstatepeer_qabls.get(&peer);
-    if current_info.is_none() || current_info.unwrap() != qabl_info {
-        // Register peer queryable
-        {
-            res_hat_mut!(res)
+                    } else {
+                        accu
+                    }
+                })
+        } else {
+            None
+        };
+        if res.context.is_some() && hat!(tables).full_net(WhatAmI::Peer) {
+            info = res_hat!(res)
                 .linkstatepeer_qabls
-                .insert(peer, *qabl_info);
-            hat_mut!(tables).linkstatepeer_qabls.insert(res.clone());
+                .iter()
+                .fold(info, |accu, (zid, info)| {
+                    if *zid != tables.zid {
+                        Some(match accu {
+                            Some(accu) => merge_qabl_infos(accu, info),
+                            None => *info,
+                        })
+                    } else {
+                        accu
+                    }
+                })
         }
-
-        // Propagate queryable to peers
-        propagate_sourced_queryable(tables, res, qabl_info, face, &peer, WhatAmI::Peer);
+        res.session_ctxs
+            .values()
+            .fold(info, |accu, ctx| {
+                if ctx.face.id != face.id && ctx.face.whatami != WhatAmI::Peer
+                    || face.whatami != WhatAmI::Peer
+                    || hat!(tables).failover_brokering(ctx.face.zid, face.zid)
+                {
+                    if let Some(info) = ctx.qabl.as_ref() {
+                        Some(match accu {
+                            Some(accu) => merge_qabl_infos(accu, info),
+                            None => *info,
+                        })
+                    } else {
+                        accu
+                    }
+                } else {
+                    accu
+                }
+            })
+            .unwrap_or(QueryableInfoType::DEFAULT)
     }
-}
 
-fn declare_linkstatepeer_queryable(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    res: &mut Arc<Resource>,
-    qabl_info: &QueryableInfoType,
-    peer: ZenohIdProto,
-    send_declare: &mut SendDeclare,
-) {
-    let mut face = Some(face);
-    register_linkstatepeer_queryable(tables, face.as_deref_mut(), res, qabl_info, peer);
-    let local_info = local_router_qabl_info(tables, res);
-    let zid = tables.zid;
-    register_router_queryable(tables, face, res, &local_info, zid, send_declare);
-}
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    fn send_sourced_queryable_to_net_children(
+        &self,
+        tables: &Tables,
+        net: &Network,
+        children: &[NodeIndex],
+        res: &Arc<Resource>,
+        qabl_info: &QueryableInfoType,
+        src_face: Option<&mut Arc<FaceState>>,
+        routing_context: NodeId,
+    ) {
+        for child in children {
+            if net.graph.contains_node(*child) {
+                match tables.get_face(&net.graph[*child].zid).cloned() {
+                    Some(mut someface) => {
+                        if src_face
+                            .as_ref()
+                            .map(|src_face| someface.id != src_face.id)
+                            .unwrap_or(true)
+                        {
+                            let push_declaration = push_declaration_profile(tables, &someface);
+                            let key_expr = Resource::decl_key(res, &mut someface, push_declaration);
 
-fn register_simple_queryable(
-    _tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    id: QueryableId,
-    res: &mut Arc<Resource>,
-    qabl_info: &QueryableInfoType,
-) {
-    // Register queryable
-    {
-        let res = get_mut_unchecked(res);
-        get_mut_unchecked(
-            res.session_ctxs
-                .entry(face.id)
-                .or_insert_with(|| Arc::new(SessionContext::new(face.clone()))),
-        )
-        .qabl = Some(*qabl_info);
-    }
-    face_hat_mut!(face).remote_qabls.insert(id, res.clone());
-}
-
-fn declare_simple_queryable(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    id: QueryableId,
-    res: &mut Arc<Resource>,
-    qabl_info: &QueryableInfoType,
-    send_declare: &mut SendDeclare,
-) {
-    register_simple_queryable(tables, face, id, res, qabl_info);
-    let local_details = local_router_qabl_info(tables, res);
-    let zid = tables.zid;
-    register_router_queryable(tables, Some(face), res, &local_details, zid, send_declare);
-}
-
-#[inline]
-fn remote_router_qabls(tables: &Tables, res: &Arc<Resource>) -> bool {
-    res.context.is_some()
-        && res_hat!(res)
-            .router_qabls
-            .keys()
-            .any(|router| router != &tables.zid)
-}
-
-#[inline]
-fn remote_linkstatepeer_qabls(tables: &Tables, res: &Arc<Resource>) -> bool {
-    res.context.is_some()
-        && res_hat!(res)
-            .linkstatepeer_qabls
-            .keys()
-            .any(|peer| peer != &tables.zid)
-}
-
-#[inline]
-fn simple_qabls(res: &Arc<Resource>) -> Vec<Arc<FaceState>> {
-    res.session_ctxs
-        .values()
-        .filter_map(|ctx| {
-            if ctx.qabl.is_some() {
-                Some(ctx.face.clone())
-            } else {
-                None
-            }
-        })
-        .collect()
-}
-
-#[inline]
-fn remote_simple_qabls(res: &Arc<Resource>, face: &Arc<FaceState>) -> bool {
-    res.session_ctxs
-        .values()
-        .any(|ctx| ctx.face.id != face.id && ctx.qabl.is_some())
-}
-
-#[inline]
-fn send_forget_sourced_queryable_to_net_children(
-    tables: &Tables,
-    net: &Network,
-    children: &[NodeIndex],
-    res: &Arc<Resource>,
-    src_face: Option<&Arc<FaceState>>,
-    routing_context: NodeId,
-) {
-    for child in children {
-        if net.graph.contains_node(*child) {
-            match tables.get_face(&net.graph[*child].zid).cloned() {
-                Some(mut someface) => {
-                    if src_face
-                        .map(|src_face| someface.id != src_face.id)
-                        .unwrap_or(true)
-                    {
-                        let push_declaration = push_declaration_profile(tables, &someface);
-                        let wire_expr = Resource::decl_key(res, &mut someface, push_declaration);
-
-                        someface.primitives.send_declare(RoutingContext::with_expr(
-                            &mut Declare {
-                                interest_id: None,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType {
-                                    node_id: routing_context,
+                            someface.primitives.send_declare(RoutingContext::with_expr(
+                                &mut Declare {
+                                    interest_id: None,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType {
+                                        node_id: routing_context,
+                                    },
+                                    body: DeclareBody::DeclareQueryable(DeclareQueryable {
+                                        id: 0, // Sourced queryables do not use ids
+                                        wire_expr: key_expr,
+                                        ext_info: *qabl_info,
+                                    }),
                                 },
-                                body: DeclareBody::UndeclareQueryable(UndeclareQueryable {
-                                    id: 0, // Sourced queryables do not use ids
-                                    ext_wire_expr: WireExprType { wire_expr },
-                                }),
-                            },
-                            res.expr().to_string(),
-                        ));
+                                res.expr().to_string(),
+                            ));
+                        }
+                    }
+                    None => {
+                        tracing::trace!("Unable to find face for zid {}", net.graph[*child].zid)
                     }
                 }
-                None => tracing::trace!("Unable to find face for zid {}", net.graph[*child].zid),
             }
         }
     }
-}
 
-fn propagate_forget_simple_queryable(
-    tables: &mut Tables,
-    res: &mut Arc<Resource>,
-    send_declare: &mut SendDeclare,
-) {
-    for mut face in tables.faces.values().cloned() {
-        if let Some((id, _)) = face_hat_mut!(&mut face).local_qabls.remove(res) {
-            send_declare(
-                &face.primitives,
-                RoutingContext::with_expr(
-                    Declare {
-                        interest_id: None,
-                        ext_qos: ext::QoSType::DECLARE,
-                        ext_tstamp: None,
-                        ext_nodeid: ext::NodeIdType::DEFAULT,
-                        body: DeclareBody::UndeclareQueryable(UndeclareQueryable {
-                            id,
-                            ext_wire_expr: WireExprType::null(),
-                        }),
-                    },
-                    res.expr().to_string(),
-                ),
+    fn propagate_simple_queryable(
+        &self,
+        tables: &mut Tables,
+        res: &Arc<Resource>,
+        src_face: Option<&mut Arc<FaceState>>,
+        send_declare: &mut SendDeclare,
+    ) {
+        let full_peers_net = hat!(tables).full_net(WhatAmI::Peer);
+        let faces = tables.faces.values().cloned();
+        for mut dst_face in faces {
+            let info = self.local_qabl_info(tables, res, &dst_face);
+            let current = face_hat!(dst_face).local_qabls.get(res);
+            if src_face
+                .as_ref()
+                .map(|src_face| dst_face.id != src_face.id)
+                .unwrap_or(true)
+                && (current.is_none() || current.unwrap().1 != info)
+                && face_hat!(dst_face)
+                    .remote_interests
+                    .values()
+                    .any(|i| i.options.queryables() && i.matches(res))
+                && if full_peers_net {
+                    dst_face.whatami == WhatAmI::Client
+                } else {
+                    dst_face.whatami != WhatAmI::Router
+                        && src_face
+                            .as_ref()
+                            .map(|src_face| {
+                                src_face.whatami != WhatAmI::Peer
+                                    || dst_face.whatami != WhatAmI::Peer
+                                    || hat!(tables).failover_brokering(src_face.zid, dst_face.zid)
+                            })
+                            .unwrap_or(true)
+                }
+            {
+                let id = current
+                    .map(|c| c.0)
+                    .unwrap_or(face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst));
+                face_hat_mut!(&mut dst_face)
+                    .local_qabls
+                    .insert(res.clone(), (id, info));
+                let push_declaration = push_declaration_profile(tables, &dst_face);
+                let key_expr = Resource::decl_key(res, &mut dst_face, push_declaration);
+                send_declare(
+                    &dst_face.primitives,
+                    RoutingContext::with_expr(
+                        Declare {
+                            interest_id: None,
+                            ext_qos: ext::QoSType::DECLARE,
+                            ext_tstamp: None,
+                            ext_nodeid: ext::NodeIdType::DEFAULT,
+                            body: DeclareBody::DeclareQueryable(DeclareQueryable {
+                                id,
+                                wire_expr: key_expr,
+                                ext_info: info,
+                            }),
+                        },
+                        res.expr().to_string(),
+                    ),
+                );
+            }
+        }
+    }
+
+    fn propagate_sourced_queryable(
+        &self,
+        tables: &Tables,
+        res: &Arc<Resource>,
+        qabl_info: &QueryableInfoType,
+        src_face: Option<&mut Arc<FaceState>>,
+        source: &ZenohIdProto,
+        net_type: WhatAmI,
+    ) {
+        let net = hat!(tables).get_net(net_type).unwrap();
+        match net.get_idx(source) {
+            Some(tree_sid) => {
+                if net.trees.len() > tree_sid.index() {
+                    self.send_sourced_queryable_to_net_children(
+                        tables,
+                        net,
+                        &net.trees[tree_sid.index()].children,
+                        res,
+                        qabl_info,
+                        src_face,
+                        tree_sid.index() as NodeId,
+                    );
+                } else {
+                    tracing::trace!(
+                        "Propagating qabl {}: tree for node {} sid:{} not yet ready",
+                        res.expr(),
+                        tree_sid.index(),
+                        source
+                    );
+                }
+            }
+            None => tracing::error!(
+                "Error propagating qabl {}: cannot get index of {}!",
+                res.expr(),
+                source
+            ),
+        }
+    }
+
+    fn register_router_queryable(
+        &self,
+        tables: &mut Tables,
+        mut face: Option<&mut Arc<FaceState>>,
+        res: &mut Arc<Resource>,
+        qabl_info: &QueryableInfoType,
+        router: ZenohIdProto,
+        send_declare: &mut SendDeclare,
+    ) {
+        let current_info = res_hat!(res).router_qabls.get(&router);
+        if current_info.is_none() || current_info.unwrap() != qabl_info {
+            // Register router queryable
+            {
+                res_hat_mut!(res).router_qabls.insert(router, *qabl_info);
+                hat_mut!(tables).router_qabls.insert(res.clone());
+            }
+
+            // Propagate queryable to routers
+            self.propagate_sourced_queryable(
+                tables,
+                res,
+                qabl_info,
+                face.as_deref_mut(),
+                &router,
+                WhatAmI::Router,
             );
         }
-        for res in face_hat!(&mut face)
-            .local_qabls
-            .keys()
-            .cloned()
-            .collect::<Vec<Arc<Resource>>>()
-        {
-            if !res.context().matches.iter().any(|m| {
-                m.upgrade().is_some_and(|m| {
-                    m.context.is_some()
-                        && (remote_simple_qabls(&m, &face)
-                            || remote_linkstatepeer_qabls(tables, &m)
-                            || remote_router_qabls(tables, &m))
-                })
-            }) {
-                if let Some((id, _)) = face_hat_mut!(&mut face).local_qabls.remove(&res) {
-                    send_declare(
-                        &face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id: None,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::UndeclareQueryable(UndeclareQueryable {
-                                    id,
-                                    ext_wire_expr: WireExprType::null(),
-                                }),
-                            },
-                            res.expr().to_string(),
-                        ),
-                    );
-                }
-            }
-        }
-    }
-}
-
-fn propagate_forget_simple_queryable_to_peers(
-    tables: &mut Tables,
-    res: &mut Arc<Resource>,
-    send_declare: &mut SendDeclare,
-) {
-    if !hat!(tables).full_net(WhatAmI::Peer)
-        && res_hat!(res).router_qabls.len() == 1
-        && res_hat!(res).router_qabls.contains_key(&tables.zid)
-    {
-        for mut face in tables
-            .faces
-            .values()
-            .cloned()
-            .collect::<Vec<Arc<FaceState>>>()
-        {
-            if face.whatami == WhatAmI::Peer
-                && face_hat!(face).local_qabls.contains_key(res)
-                && !res.session_ctxs.values().any(|s| {
-                    face.zid != s.face.zid
-                        && s.qabl.is_some()
-                        && (s.face.whatami == WhatAmI::Client
-                            || (s.face.whatami == WhatAmI::Peer
-                                && hat!(tables).failover_brokering(s.face.zid, face.zid)))
-                })
-            {
-                if let Some((id, _)) = face_hat_mut!(&mut face).local_qabls.remove(res) {
-                    send_declare(
-                        &face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id: None,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::UndeclareQueryable(UndeclareQueryable {
-                                    id,
-                                    ext_wire_expr: WireExprType::null(),
-                                }),
-                            },
-                            res.expr().to_string(),
-                        ),
-                    );
-                }
-            }
-        }
-    }
-}
-
-fn propagate_forget_sourced_queryable(
-    tables: &mut Tables,
-    res: &mut Arc<Resource>,
-    src_face: Option<&Arc<FaceState>>,
-    source: &ZenohIdProto,
-    net_type: WhatAmI,
-) {
-    let net = hat!(tables).get_net(net_type).unwrap();
-    match net.get_idx(source) {
-        Some(tree_sid) => {
-            if net.trees.len() > tree_sid.index() {
-                send_forget_sourced_queryable_to_net_children(
-                    tables,
-                    net,
-                    &net.trees[tree_sid.index()].children,
-                    res,
-                    src_face,
-                    tree_sid.index() as NodeId,
-                );
-            } else {
-                tracing::trace!(
-                    "Propagating forget qabl {}: tree for node {} sid:{} not yet ready",
-                    res.expr(),
-                    tree_sid.index(),
-                    source
-                );
-            }
-        }
-        None => tracing::error!(
-            "Error propagating forget qabl {}: cannot get index of {}!",
-            res.expr(),
-            source
-        ),
-    }
-}
-
-fn unregister_router_queryable(
-    tables: &mut Tables,
-    res: &mut Arc<Resource>,
-    router: &ZenohIdProto,
-    send_declare: &mut SendDeclare,
-) {
-    res_hat_mut!(res).router_qabls.remove(router);
-
-    if res_hat!(res).router_qabls.is_empty() {
-        hat_mut!(tables)
-            .router_qabls
-            .retain(|qabl| !Arc::ptr_eq(qabl, res));
 
         if hat!(tables).full_net(WhatAmI::Peer) {
-            undeclare_linkstatepeer_queryable(tables, None, res, &tables.zid.clone());
-        }
-        propagate_forget_simple_queryable(tables, res, send_declare);
-    }
-
-    propagate_forget_simple_queryable_to_peers(tables, res, send_declare);
-}
-
-fn undeclare_router_queryable(
-    tables: &mut Tables,
-    face: Option<&Arc<FaceState>>,
-    res: &mut Arc<Resource>,
-    router: &ZenohIdProto,
-    send_declare: &mut SendDeclare,
-) {
-    if res_hat!(res).router_qabls.contains_key(router) {
-        unregister_router_queryable(tables, res, router, send_declare);
-        propagate_forget_sourced_queryable(tables, res, face, router, WhatAmI::Router);
-    }
-}
-
-fn forget_router_queryable(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    res: &mut Arc<Resource>,
-    router: &ZenohIdProto,
-    send_declare: &mut SendDeclare,
-) {
-    undeclare_router_queryable(tables, Some(face), res, router, send_declare);
-}
-
-fn unregister_linkstatepeer_queryable(
-    tables: &mut Tables,
-    res: &mut Arc<Resource>,
-    peer: &ZenohIdProto,
-) {
-    res_hat_mut!(res).linkstatepeer_qabls.remove(peer);
-
-    if res_hat!(res).linkstatepeer_qabls.is_empty() {
-        hat_mut!(tables)
-            .linkstatepeer_qabls
-            .retain(|qabl| !Arc::ptr_eq(qabl, res));
-    }
-}
-
-fn undeclare_linkstatepeer_queryable(
-    tables: &mut Tables,
-    face: Option<&Arc<FaceState>>,
-    res: &mut Arc<Resource>,
-    peer: &ZenohIdProto,
-) {
-    if res_hat!(res).linkstatepeer_qabls.contains_key(peer) {
-        unregister_linkstatepeer_queryable(tables, res, peer);
-        propagate_forget_sourced_queryable(tables, res, face, peer, WhatAmI::Peer);
-    }
-}
-
-fn forget_linkstatepeer_queryable(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    res: &mut Arc<Resource>,
-    peer: &ZenohIdProto,
-    send_declare: &mut SendDeclare,
-) {
-    undeclare_linkstatepeer_queryable(tables, Some(face), res, peer);
-
-    let simple_qabls = res.session_ctxs.values().any(|ctx| ctx.qabl.is_some());
-    let linkstatepeer_qabls = remote_linkstatepeer_qabls(tables, res);
-    let zid = tables.zid;
-    if !simple_qabls && !linkstatepeer_qabls {
-        undeclare_router_queryable(tables, None, res, &zid, send_declare);
-    } else {
-        let local_info = local_router_qabl_info(tables, res);
-        register_router_queryable(tables, None, res, &local_info, zid, send_declare);
-    }
-}
-
-pub(super) fn undeclare_simple_queryable(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    res: &mut Arc<Resource>,
-    send_declare: &mut SendDeclare,
-) {
-    if !face_hat_mut!(face)
-        .remote_qabls
-        .values()
-        .any(|s| *s == *res)
-    {
-        if let Some(ctx) = get_mut_unchecked(res).session_ctxs.get_mut(&face.id) {
-            get_mut_unchecked(ctx).qabl = None;
+            // Propagate queryable to peers
+            if face.is_none() || face.as_ref().unwrap().whatami != WhatAmI::Peer {
+                let local_info = self.local_peer_qabl_info(tables, res);
+                self.register_linkstatepeer_queryable(
+                    tables,
+                    face.as_deref_mut(),
+                    res,
+                    &local_info,
+                    tables.zid,
+                )
+            }
         }
 
-        let mut simple_qabls = simple_qabls(res);
-        let router_qabls = remote_router_qabls(tables, res);
-        let linkstatepeer_qabls = remote_linkstatepeer_qabls(tables, res);
+        // Propagate queryable to clients
+        self.propagate_simple_queryable(tables, res, face, send_declare);
+    }
 
-        if simple_qabls.is_empty() && !linkstatepeer_qabls {
-            undeclare_router_queryable(tables, None, res, &tables.zid.clone(), send_declare);
-        } else {
-            let local_info = local_router_qabl_info(tables, res);
-            register_router_queryable(tables, None, res, &local_info, tables.zid, send_declare);
-            propagate_forget_simple_queryable_to_peers(tables, res, send_declare);
+    fn declare_router_queryable(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        res: &mut Arc<Resource>,
+        qabl_info: &QueryableInfoType,
+        router: ZenohIdProto,
+        send_declare: &mut SendDeclare,
+    ) {
+        self.register_router_queryable(tables, Some(face), res, qabl_info, router, send_declare);
+    }
+
+    fn register_linkstatepeer_queryable(
+        &self,
+        tables: &mut Tables,
+        face: Option<&mut Arc<FaceState>>,
+        res: &mut Arc<Resource>,
+        qabl_info: &QueryableInfoType,
+        peer: ZenohIdProto,
+    ) {
+        let current_info = res_hat!(res).linkstatepeer_qabls.get(&peer);
+        if current_info.is_none() || current_info.unwrap() != qabl_info {
+            // Register peer queryable
+            {
+                res_hat_mut!(res)
+                    .linkstatepeer_qabls
+                    .insert(peer, *qabl_info);
+                hat_mut!(tables).linkstatepeer_qabls.insert(res.clone());
+            }
+
+            // Propagate queryable to peers
+            self.propagate_sourced_queryable(tables, res, qabl_info, face, &peer, WhatAmI::Peer);
         }
+    }
 
-        if simple_qabls.len() == 1 && !router_qabls && !linkstatepeer_qabls {
-            let mut face = &mut simple_qabls[0];
-            if let Some((id, _)) = face_hat_mut!(face).local_qabls.remove(res) {
+    fn declare_linkstatepeer_queryable(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        res: &mut Arc<Resource>,
+        qabl_info: &QueryableInfoType,
+        peer: ZenohIdProto,
+        send_declare: &mut SendDeclare,
+    ) {
+        let mut face = Some(face);
+        self.register_linkstatepeer_queryable(tables, face.as_deref_mut(), res, qabl_info, peer);
+        let local_info = self.local_router_qabl_info(tables, res);
+        let zid = tables.zid;
+        self.register_router_queryable(tables, face, res, &local_info, zid, send_declare);
+    }
+
+    fn register_simple_queryable(
+        &self,
+        _tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        id: QueryableId,
+        res: &mut Arc<Resource>,
+        qabl_info: &QueryableInfoType,
+    ) {
+        // Register queryable
+        {
+            let res = get_mut_unchecked(res);
+            get_mut_unchecked(
+                res.session_ctxs
+                    .entry(face.id)
+                    .or_insert_with(|| Arc::new(SessionContext::new(face.clone()))),
+            )
+            .qabl = Some(*qabl_info);
+        }
+        face_hat_mut!(face).remote_qabls.insert(id, res.clone());
+    }
+
+    fn declare_simple_queryable(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        id: QueryableId,
+        res: &mut Arc<Resource>,
+        qabl_info: &QueryableInfoType,
+        send_declare: &mut SendDeclare,
+    ) {
+        self.register_simple_queryable(tables, face, id, res, qabl_info);
+        let local_details = self.local_router_qabl_info(tables, res);
+        let zid = tables.zid;
+        self.register_router_queryable(tables, Some(face), res, &local_details, zid, send_declare);
+    }
+
+    #[inline]
+    fn remote_router_qabls(&self, tables: &Tables, res: &Arc<Resource>) -> bool {
+        res.context.is_some()
+            && res_hat!(res)
+                .router_qabls
+                .keys()
+                .any(|router| router != &tables.zid)
+    }
+
+    #[inline]
+    fn remote_linkstatepeer_qabls(&self, tables: &Tables, res: &Arc<Resource>) -> bool {
+        res.context.is_some()
+            && res_hat!(res)
+                .linkstatepeer_qabls
+                .keys()
+                .any(|peer| peer != &tables.zid)
+    }
+
+    #[inline]
+    fn simple_qabls(&self, res: &Arc<Resource>) -> Vec<Arc<FaceState>> {
+        res.session_ctxs
+            .values()
+            .filter_map(|ctx| {
+                if ctx.qabl.is_some() {
+                    Some(ctx.face.clone())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    #[inline]
+    fn remote_simple_qabls(&self, res: &Arc<Resource>, face: &Arc<FaceState>) -> bool {
+        res.session_ctxs
+            .values()
+            .any(|ctx| ctx.face.id != face.id && ctx.qabl.is_some())
+    }
+
+    #[inline]
+    fn send_forget_sourced_queryable_to_net_children(
+        &self,
+        tables: &Tables,
+        net: &Network,
+        children: &[NodeIndex],
+        res: &Arc<Resource>,
+        src_face: Option<&Arc<FaceState>>,
+        routing_context: NodeId,
+    ) {
+        for child in children {
+            if net.graph.contains_node(*child) {
+                match tables.get_face(&net.graph[*child].zid).cloned() {
+                    Some(mut someface) => {
+                        if src_face
+                            .map(|src_face| someface.id != src_face.id)
+                            .unwrap_or(true)
+                        {
+                            let push_declaration = push_declaration_profile(tables, &someface);
+                            let wire_expr =
+                                Resource::decl_key(res, &mut someface, push_declaration);
+
+                            someface.primitives.send_declare(RoutingContext::with_expr(
+                                &mut Declare {
+                                    interest_id: None,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType {
+                                        node_id: routing_context,
+                                    },
+                                    body: DeclareBody::UndeclareQueryable(UndeclareQueryable {
+                                        id: 0, // Sourced queryables do not use ids
+                                        ext_wire_expr: WireExprType { wire_expr },
+                                    }),
+                                },
+                                res.expr().to_string(),
+                            ));
+                        }
+                    }
+                    None => {
+                        tracing::trace!("Unable to find face for zid {}", net.graph[*child].zid)
+                    }
+                }
+            }
+        }
+    }
+
+    fn propagate_forget_simple_queryable(
+        &self,
+        tables: &mut Tables,
+        res: &mut Arc<Resource>,
+        send_declare: &mut SendDeclare,
+    ) {
+        for mut face in tables.faces.values().cloned() {
+            if let Some((id, _)) = face_hat_mut!(&mut face).local_qabls.remove(res) {
                 send_declare(
                     &face.primitives,
                     RoutingContext::with_expr(
@@ -829,7 +589,7 @@ pub(super) fn undeclare_simple_queryable(
                     ),
                 );
             }
-            for res in face_hat!(face)
+            for res in face_hat!(&mut face)
                 .local_qabls
                 .keys()
                 .cloned()
@@ -838,9 +598,9 @@ pub(super) fn undeclare_simple_queryable(
                 if !res.context().matches.iter().any(|m| {
                     m.upgrade().is_some_and(|m| {
                         m.context.is_some()
-                            && (remote_simple_qabls(&m, face)
-                                || remote_linkstatepeer_qabls(tables, &m)
-                                || remote_router_qabls(tables, &m))
+                            && (self.remote_simple_qabls(&m, &face)
+                                || self.remote_linkstatepeer_qabls(tables, &m)
+                                || self.remote_router_qabls(tables, &m))
                     })
                 }) {
                     if let Some((id, _)) = face_hat_mut!(&mut face).local_qabls.remove(&res) {
@@ -865,160 +625,277 @@ pub(super) fn undeclare_simple_queryable(
             }
         }
     }
-}
 
-fn forget_simple_queryable(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    id: QueryableId,
-    send_declare: &mut SendDeclare,
-) -> Option<Arc<Resource>> {
-    if let Some(mut res) = face_hat_mut!(face).remote_qabls.remove(&id) {
-        undeclare_simple_queryable(tables, face, &mut res, send_declare);
-        Some(res)
-    } else {
-        None
-    }
-}
-
-pub(super) fn queries_remove_node(
-    tables: &mut Tables,
-    node: &ZenohIdProto,
-    net_type: WhatAmI,
-    send_declare: &mut SendDeclare,
-) {
-    match net_type {
-        WhatAmI::Router => {
-            let mut qabls = vec![];
-            for res in hat!(tables).router_qabls.iter() {
-                for qabl in res_hat!(res).router_qabls.keys() {
-                    if qabl == node {
-                        qabls.push(res.clone());
+    fn propagate_forget_simple_queryable_to_peers(
+        &self,
+        tables: &mut Tables,
+        res: &mut Arc<Resource>,
+        send_declare: &mut SendDeclare,
+    ) {
+        if !hat!(tables).full_net(WhatAmI::Peer)
+            && res_hat!(res).router_qabls.len() == 1
+            && res_hat!(res).router_qabls.contains_key(&tables.zid)
+        {
+            for mut face in tables
+                .faces
+                .values()
+                .cloned()
+                .collect::<Vec<Arc<FaceState>>>()
+            {
+                if face.whatami == WhatAmI::Peer
+                    && face_hat!(face).local_qabls.contains_key(res)
+                    && !res.session_ctxs.values().any(|s| {
+                        face.zid != s.face.zid
+                            && s.qabl.is_some()
+                            && (s.face.whatami == WhatAmI::Client
+                                || (s.face.whatami == WhatAmI::Peer
+                                    && hat!(tables).failover_brokering(s.face.zid, face.zid)))
+                    })
+                {
+                    if let Some((id, _)) = face_hat_mut!(&mut face).local_qabls.remove(res) {
+                        send_declare(
+                            &face.primitives,
+                            RoutingContext::with_expr(
+                                Declare {
+                                    interest_id: None,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType::DEFAULT,
+                                    body: DeclareBody::UndeclareQueryable(UndeclareQueryable {
+                                        id,
+                                        ext_wire_expr: WireExprType::null(),
+                                    }),
+                                },
+                                res.expr().to_string(),
+                            ),
+                        );
                     }
                 }
-            }
-            for mut res in qabls {
-                unregister_router_queryable(tables, &mut res, node, send_declare);
-
-                disable_matches_query_routes(tables, &mut res);
-                Resource::clean(&mut res);
             }
         }
-        WhatAmI::Peer => {
-            let mut qabls = vec![];
-            for res in hat!(tables).router_qabls.iter() {
-                for qabl in res_hat!(res).router_qabls.keys() {
-                    if qabl == node {
-                        qabls.push(res.clone());
-                    }
-                }
-            }
-            for mut res in qabls {
-                unregister_linkstatepeer_queryable(tables, &mut res, node);
+    }
 
-                let simple_qabls = res.session_ctxs.values().any(|ctx| ctx.qabl.is_some());
-                let linkstatepeer_qabls = remote_linkstatepeer_qabls(tables, &res);
-                if !simple_qabls && !linkstatepeer_qabls {
-                    undeclare_router_queryable(
+    fn propagate_forget_sourced_queryable(
+        &self,
+        tables: &mut Tables,
+        res: &mut Arc<Resource>,
+        src_face: Option<&Arc<FaceState>>,
+        source: &ZenohIdProto,
+        net_type: WhatAmI,
+    ) {
+        let net = hat!(tables).get_net(net_type).unwrap();
+        match net.get_idx(source) {
+            Some(tree_sid) => {
+                if net.trees.len() > tree_sid.index() {
+                    self.send_forget_sourced_queryable_to_net_children(
                         tables,
-                        None,
-                        &mut res,
-                        &tables.zid.clone(),
-                        send_declare,
+                        net,
+                        &net.trees[tree_sid.index()].children,
+                        res,
+                        src_face,
+                        tree_sid.index() as NodeId,
                     );
                 } else {
-                    let local_info = local_router_qabl_info(tables, &res);
-                    register_router_queryable(
-                        tables,
-                        None,
-                        &mut res,
-                        &local_info,
-                        tables.zid,
-                        send_declare,
+                    tracing::trace!(
+                        "Propagating forget qabl {}: tree for node {} sid:{} not yet ready",
+                        res.expr(),
+                        tree_sid.index(),
+                        source
                     );
                 }
-
-                disable_matches_query_routes(tables, &mut res);
-                Resource::clean(&mut res)
             }
+            None => tracing::error!(
+                "Error propagating forget qabl {}: cannot get index of {}!",
+                res.expr(),
+                source
+            ),
         }
-        _ => (),
     }
-}
 
-pub(super) fn queries_linkstate_change(
-    tables: &mut Tables,
-    zid: &ZenohIdProto,
-    links: &HashMap<ZenohIdProto, LinkEdgeWeight>,
-    send_declare: &mut SendDeclare,
-) {
-    if let Some(mut src_face) = tables.get_face(zid).cloned() {
-        if hat!(tables).router_peers_failover_brokering && src_face.whatami == WhatAmI::Peer {
-            let to_forget = face_hat!(src_face)
-                .local_qabls
-                .keys()
-                .filter(|res| {
-                    let client_qabls = res
-                        .session_ctxs
-                        .values()
-                        .any(|ctx| ctx.face.whatami == WhatAmI::Client && ctx.qabl.is_some());
-                    !remote_router_qabls(tables, res)
-                        && !client_qabls
-                        && !res.session_ctxs.values().any(|ctx| {
-                            ctx.face.whatami == WhatAmI::Peer
-                                && src_face.id != ctx.face.id
-                                && HatTables::failover_brokering_to(links, &ctx.face.zid)
-                        })
-                })
-                .cloned()
-                .collect::<Vec<Arc<Resource>>>();
-            for res in to_forget {
-                if let Some((id, _)) = face_hat_mut!(&mut src_face).local_qabls.remove(&res) {
-                    let wire_expr = Resource::get_best_key(&res, "", src_face.id);
+    fn unregister_router_queryable(
+        &self,
+        tables: &mut Tables,
+        res: &mut Arc<Resource>,
+        router: &ZenohIdProto,
+        send_declare: &mut SendDeclare,
+    ) {
+        res_hat_mut!(res).router_qabls.remove(router);
+
+        if res_hat!(res).router_qabls.is_empty() {
+            hat_mut!(tables)
+                .router_qabls
+                .retain(|qabl| !Arc::ptr_eq(qabl, res));
+
+            if hat!(tables).full_net(WhatAmI::Peer) {
+                self.undeclare_linkstatepeer_queryable(tables, None, res, &tables.zid.clone());
+            }
+            self.propagate_forget_simple_queryable(tables, res, send_declare);
+        }
+
+        self.propagate_forget_simple_queryable_to_peers(tables, res, send_declare);
+    }
+
+    fn undeclare_router_queryable(
+        &self,
+        tables: &mut Tables,
+        face: Option<&Arc<FaceState>>,
+        res: &mut Arc<Resource>,
+        router: &ZenohIdProto,
+        send_declare: &mut SendDeclare,
+    ) {
+        if res_hat!(res).router_qabls.contains_key(router) {
+            self.unregister_router_queryable(tables, res, router, send_declare);
+            self.propagate_forget_sourced_queryable(tables, res, face, router, WhatAmI::Router);
+        }
+    }
+
+    fn forget_router_queryable(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        res: &mut Arc<Resource>,
+        router: &ZenohIdProto,
+        send_declare: &mut SendDeclare,
+    ) {
+        self.undeclare_router_queryable(tables, Some(face), res, router, send_declare);
+    }
+
+    fn unregister_linkstatepeer_queryable(
+        &self,
+        tables: &mut Tables,
+        res: &mut Arc<Resource>,
+        peer: &ZenohIdProto,
+    ) {
+        res_hat_mut!(res).linkstatepeer_qabls.remove(peer);
+
+        if res_hat!(res).linkstatepeer_qabls.is_empty() {
+            hat_mut!(tables)
+                .linkstatepeer_qabls
+                .retain(|qabl| !Arc::ptr_eq(qabl, res));
+        }
+    }
+
+    fn undeclare_linkstatepeer_queryable(
+        &self,
+        tables: &mut Tables,
+        face: Option<&Arc<FaceState>>,
+        res: &mut Arc<Resource>,
+        peer: &ZenohIdProto,
+    ) {
+        if res_hat!(res).linkstatepeer_qabls.contains_key(peer) {
+            self.unregister_linkstatepeer_queryable(tables, res, peer);
+            self.propagate_forget_sourced_queryable(tables, res, face, peer, WhatAmI::Peer);
+        }
+    }
+
+    fn forget_linkstatepeer_queryable(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        res: &mut Arc<Resource>,
+        peer: &ZenohIdProto,
+        send_declare: &mut SendDeclare,
+    ) {
+        self.undeclare_linkstatepeer_queryable(tables, Some(face), res, peer);
+
+        let simple_qabls = res.session_ctxs.values().any(|ctx| ctx.qabl.is_some());
+        let linkstatepeer_qabls = self.remote_linkstatepeer_qabls(tables, res);
+        let zid = tables.zid;
+        if !simple_qabls && !linkstatepeer_qabls {
+            self.undeclare_router_queryable(tables, None, res, &zid, send_declare);
+        } else {
+            let local_info = self.local_router_qabl_info(tables, res);
+            self.register_router_queryable(tables, None, res, &local_info, zid, send_declare);
+        }
+    }
+
+    pub(super) fn undeclare_simple_queryable(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        res: &mut Arc<Resource>,
+        send_declare: &mut SendDeclare,
+    ) {
+        if !face_hat_mut!(face)
+            .remote_qabls
+            .values()
+            .any(|s| *s == *res)
+        {
+            if let Some(ctx) = get_mut_unchecked(res).session_ctxs.get_mut(&face.id) {
+                get_mut_unchecked(ctx).qabl = None;
+            }
+
+            let mut simple_qabls = self.simple_qabls(res);
+            let router_qabls = self.remote_router_qabls(tables, res);
+            let linkstatepeer_qabls = self.remote_linkstatepeer_qabls(tables, res);
+
+            if simple_qabls.is_empty() && !linkstatepeer_qabls {
+                self.undeclare_router_queryable(
+                    tables,
+                    None,
+                    res,
+                    &tables.zid.clone(),
+                    send_declare,
+                );
+            } else {
+                let local_info = self.local_router_qabl_info(tables, res);
+                self.register_router_queryable(
+                    tables,
+                    None,
+                    res,
+                    &local_info,
+                    tables.zid,
+                    send_declare,
+                );
+                self.propagate_forget_simple_queryable_to_peers(tables, res, send_declare);
+            }
+
+            if simple_qabls.len() == 1 && !router_qabls && !linkstatepeer_qabls {
+                let mut face = &mut simple_qabls[0];
+                if let Some((id, _)) = face_hat_mut!(face).local_qabls.remove(res) {
                     send_declare(
-                        &src_face.primitives,
+                        &face.primitives,
                         RoutingContext::with_expr(
                             Declare {
                                 interest_id: None,
                                 ext_qos: ext::QoSType::DECLARE,
                                 ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::default(),
+                                ext_nodeid: ext::NodeIdType::DEFAULT,
                                 body: DeclareBody::UndeclareQueryable(UndeclareQueryable {
                                     id,
-                                    ext_wire_expr: WireExprType { wire_expr },
+                                    ext_wire_expr: WireExprType::null(),
                                 }),
                             },
                             res.expr().to_string(),
                         ),
                     );
                 }
-            }
-
-            for mut dst_face in tables.faces.values().cloned() {
-                if src_face.id != dst_face.id
-                    && HatTables::failover_brokering_to(links, &dst_face.zid)
+                for res in face_hat!(face)
+                    .local_qabls
+                    .keys()
+                    .cloned()
+                    .collect::<Vec<Arc<Resource>>>()
                 {
-                    for res in face_hat!(src_face).remote_qabls.values() {
-                        if !face_hat!(dst_face).local_qabls.contains_key(res) {
-                            let id = face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst);
-                            let info = local_qabl_info(tables, res, &dst_face);
-                            face_hat_mut!(&mut dst_face)
-                                .local_qabls
-                                .insert(res.clone(), (id, info));
-                            let push_declaration = push_declaration_profile(tables, &dst_face);
-                            let key_expr = Resource::decl_key(res, &mut dst_face, push_declaration);
+                    if !res.context().matches.iter().any(|m| {
+                        m.upgrade().is_some_and(|m| {
+                            m.context.is_some()
+                                && (self.remote_simple_qabls(&m, face)
+                                    || self.remote_linkstatepeer_qabls(tables, &m)
+                                    || self.remote_router_qabls(tables, &m))
+                        })
+                    }) {
+                        if let Some((id, _)) = face_hat_mut!(&mut face).local_qabls.remove(&res) {
                             send_declare(
-                                &dst_face.primitives,
+                                &face.primitives,
                                 RoutingContext::with_expr(
                                     Declare {
                                         interest_id: None,
                                         ext_qos: ext::QoSType::DECLARE,
                                         ext_tstamp: None,
-                                        ext_nodeid: ext::NodeIdType::default(),
-                                        body: DeclareBody::DeclareQueryable(DeclareQueryable {
+                                        ext_nodeid: ext::NodeIdType::DEFAULT,
+                                        body: DeclareBody::UndeclareQueryable(UndeclareQueryable {
                                             id,
-                                            wire_expr: key_expr,
-                                            ext_info: info,
+                                            ext_wire_expr: WireExprType::null(),
                                         }),
                                     },
                                     res.expr().to_string(),
@@ -1030,191 +907,400 @@ pub(super) fn queries_linkstate_change(
             }
         }
     }
-}
 
-pub(super) fn queries_tree_change(
-    tables: &mut Tables,
-    new_children: &[Vec<NodeIndex>],
-    net_type: WhatAmI,
-) {
-    let net = match hat!(tables).get_net(net_type) {
-        Some(net) => net,
-        None => {
-            tracing::error!("Error accessing net in queries_tree_change!");
-            return;
+    fn forget_simple_queryable(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        id: QueryableId,
+        send_declare: &mut SendDeclare,
+    ) -> Option<Arc<Resource>> {
+        if let Some(mut res) = face_hat_mut!(face).remote_qabls.remove(&id) {
+            self.undeclare_simple_queryable(tables, face, &mut res, send_declare);
+            Some(res)
+        } else {
+            None
         }
-    };
-    // propagate qabls to new children
-    for (tree_sid, tree_children) in new_children.iter().enumerate() {
-        if !tree_children.is_empty() {
-            let tree_idx = NodeIndex::new(tree_sid);
-            if net.graph.contains_node(tree_idx) {
-                let tree_id = net.graph[tree_idx].zid;
+    }
 
-                let qabls_res = match net_type {
-                    WhatAmI::Router => &hat!(tables).router_qabls,
-                    _ => &hat!(tables).linkstatepeer_qabls,
-                };
+    pub(super) fn queries_remove_node(
+        &self,
+        tables: &mut Tables,
+        node: &ZenohIdProto,
+        net_type: WhatAmI,
+        send_declare: &mut SendDeclare,
+    ) {
+        match net_type {
+            WhatAmI::Router => {
+                let mut qabls = vec![];
+                for res in hat!(tables).router_qabls.iter() {
+                    for qabl in res_hat!(res).router_qabls.keys() {
+                        if qabl == node {
+                            qabls.push(res.clone());
+                        }
+                    }
+                }
+                for mut res in qabls {
+                    self.unregister_router_queryable(tables, &mut res, node, send_declare);
 
-                for res in qabls_res {
-                    let qabls = match net_type {
-                        WhatAmI::Router => &res_hat!(res).router_qabls,
-                        _ => &res_hat!(res).linkstatepeer_qabls,
-                    };
-                    if let Some(qabl_info) = qabls.get(&tree_id) {
-                        send_sourced_queryable_to_net_children(
+                    disable_matches_query_routes(tables, &mut res);
+                    Resource::clean(&mut res);
+                }
+            }
+            WhatAmI::Peer => {
+                let mut qabls = vec![];
+                for res in hat!(tables).router_qabls.iter() {
+                    for qabl in res_hat!(res).router_qabls.keys() {
+                        if qabl == node {
+                            qabls.push(res.clone());
+                        }
+                    }
+                }
+                for mut res in qabls {
+                    self.unregister_linkstatepeer_queryable(tables, &mut res, node);
+
+                    let simple_qabls = res.session_ctxs.values().any(|ctx| ctx.qabl.is_some());
+                    let linkstatepeer_qabls = self.remote_linkstatepeer_qabls(tables, &res);
+                    if !simple_qabls && !linkstatepeer_qabls {
+                        self.undeclare_router_queryable(
                             tables,
-                            net,
-                            tree_children,
-                            res,
-                            qabl_info,
                             None,
-                            tree_sid as NodeId,
+                            &mut res,
+                            &tables.zid.clone(),
+                            send_declare,
+                        );
+                    } else {
+                        let local_info = self.local_router_qabl_info(tables, &res);
+                        self.register_router_queryable(
+                            tables,
+                            None,
+                            &mut res,
+                            &local_info,
+                            tables.zid,
+                            send_declare,
+                        );
+                    }
+
+                    disable_matches_query_routes(tables, &mut res);
+                    Resource::clean(&mut res)
+                }
+            }
+            _ => (),
+        }
+    }
+
+    pub(super) fn queries_linkstate_change(
+        &self,
+        tables: &mut Tables,
+        zid: &ZenohIdProto,
+        links: &HashMap<ZenohIdProto, LinkEdgeWeight>,
+        send_declare: &mut SendDeclare,
+    ) {
+        if let Some(mut src_face) = tables.get_face(zid).cloned() {
+            if hat!(tables).router_peers_failover_brokering && src_face.whatami == WhatAmI::Peer {
+                let to_forget = face_hat!(src_face)
+                    .local_qabls
+                    .keys()
+                    .filter(|res| {
+                        let client_qabls = res
+                            .session_ctxs
+                            .values()
+                            .any(|ctx| ctx.face.whatami == WhatAmI::Client && ctx.qabl.is_some());
+                        !self.remote_router_qabls(tables, res)
+                            && !client_qabls
+                            && !res.session_ctxs.values().any(|ctx| {
+                                ctx.face.whatami == WhatAmI::Peer
+                                    && src_face.id != ctx.face.id
+                                    && HatTables::failover_brokering_to(links, &ctx.face.zid)
+                            })
+                    })
+                    .cloned()
+                    .collect::<Vec<Arc<Resource>>>();
+                for res in to_forget {
+                    if let Some((id, _)) = face_hat_mut!(&mut src_face).local_qabls.remove(&res) {
+                        let wire_expr = Resource::get_best_key(&res, "", src_face.id);
+                        send_declare(
+                            &src_face.primitives,
+                            RoutingContext::with_expr(
+                                Declare {
+                                    interest_id: None,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType::default(),
+                                    body: DeclareBody::UndeclareQueryable(UndeclareQueryable {
+                                        id,
+                                        ext_wire_expr: WireExprType { wire_expr },
+                                    }),
+                                },
+                                res.expr().to_string(),
+                            ),
                         );
                     }
                 }
-            }
-        }
-    }
-}
 
-#[inline]
-fn insert_target_for_qabls(
-    route: &mut QueryTargetQablSet,
-    expr: &mut RoutingExpr,
-    tables: &Tables,
-    net: &Network,
-    source: NodeId,
-    qabls: &HashMap<ZenohIdProto, QueryableInfoType>,
-    complete: bool,
-) {
-    if net.trees.len() > source as usize {
-        for (qabl, qabl_info) in qabls {
-            if let Some(qabl_idx) = net.get_idx(qabl) {
-                if net.trees[source as usize].directions.len() > qabl_idx.index() {
-                    if let Some(direction) = net.trees[source as usize].directions[qabl_idx.index()]
+                for mut dst_face in tables.faces.values().cloned() {
+                    if src_face.id != dst_face.id
+                        && HatTables::failover_brokering_to(links, &dst_face.zid)
                     {
-                        if net.graph.contains_node(direction) {
-                            if let Some(face) = tables.get_face(&net.graph[direction].zid) {
-                                if net.distances.len() > qabl_idx.index() {
-                                    let key_expr =
-                                        Resource::get_best_key(expr.prefix, expr.suffix, face.id);
-                                    route.push(QueryTargetQabl {
-                                        direction: (face.clone(), key_expr.to_owned(), source),
-                                        info: Some(QueryableInfoType {
-                                            complete: complete && qabl_info.complete,
-                                            distance: net.distances[qabl_idx.index()] as u16,
-                                        }),
-                                    });
-                                }
+                        for res in face_hat!(src_face).remote_qabls.values() {
+                            if !face_hat!(dst_face).local_qabls.contains_key(res) {
+                                let id = face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst);
+                                let info = self.local_qabl_info(tables, res, &dst_face);
+                                face_hat_mut!(&mut dst_face)
+                                    .local_qabls
+                                    .insert(res.clone(), (id, info));
+                                let push_declaration = push_declaration_profile(tables, &dst_face);
+                                let key_expr =
+                                    Resource::decl_key(res, &mut dst_face, push_declaration);
+                                send_declare(
+                                    &dst_face.primitives,
+                                    RoutingContext::with_expr(
+                                        Declare {
+                                            interest_id: None,
+                                            ext_qos: ext::QoSType::DECLARE,
+                                            ext_tstamp: None,
+                                            ext_nodeid: ext::NodeIdType::default(),
+                                            body: DeclareBody::DeclareQueryable(DeclareQueryable {
+                                                id,
+                                                wire_expr: key_expr,
+                                                ext_info: info,
+                                            }),
+                                        },
+                                        res.expr().to_string(),
+                                    ),
+                                );
                             }
                         }
                     }
                 }
             }
         }
-    } else {
-        tracing::trace!("Tree for node sid:{} not yet ready", source);
     }
-}
 
-lazy_static::lazy_static! {
-    static ref EMPTY_ROUTE: Arc<QueryTargetQablSet> = Arc::new(Vec::new());
-}
+    pub(super) fn queries_tree_change(
+        &self,
+        tables: &mut Tables,
+        new_children: &[Vec<NodeIndex>],
+        net_type: WhatAmI,
+    ) {
+        let net = match hat!(tables).get_net(net_type) {
+            Some(net) => net,
+            None => {
+                tracing::error!("Error accessing net in queries_tree_change!");
+                return;
+            }
+        };
+        // propagate qabls to new children
+        for (tree_sid, tree_children) in new_children.iter().enumerate() {
+            if !tree_children.is_empty() {
+                let tree_idx = NodeIndex::new(tree_sid);
+                if net.graph.contains_node(tree_idx) {
+                    let tree_id = net.graph[tree_idx].zid;
 
-#[inline]
-fn make_qabl_id(
-    res: &Arc<Resource>,
-    face: &mut Arc<FaceState>,
-    mode: InterestMode,
-    info: QueryableInfoType,
-) -> u32 {
-    if mode.future() {
-        if let Some((id, _)) = face_hat!(face).local_qabls.get(res) {
-            *id
-        } else {
-            let id = face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst);
-            face_hat_mut!(face)
-                .local_qabls
-                .insert(res.clone(), (id, info));
-            id
+                    let qabls_res = match net_type {
+                        WhatAmI::Router => &hat!(tables).router_qabls,
+                        _ => &hat!(tables).linkstatepeer_qabls,
+                    };
+
+                    for res in qabls_res {
+                        let qabls = match net_type {
+                            WhatAmI::Router => &res_hat!(res).router_qabls,
+                            _ => &res_hat!(res).linkstatepeer_qabls,
+                        };
+                        if let Some(qabl_info) = qabls.get(&tree_id) {
+                            self.send_sourced_queryable_to_net_children(
+                                tables,
+                                net,
+                                tree_children,
+                                res,
+                                qabl_info,
+                                None,
+                                tree_sid as NodeId,
+                            );
+                        }
+                    }
+                }
+            }
         }
-    } else {
-        0
     }
-}
 
-pub(crate) fn declare_qabl_interest(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    id: InterestId,
-    res: Option<&mut Arc<Resource>>,
-    mode: InterestMode,
-    aggregate: bool,
-    send_declare: &mut SendDeclare,
-) {
-    if mode.current() {
-        let interest_id = Some(id);
-        if let Some(res) = res.as_ref() {
-            if aggregate {
-                if hat!(tables).router_qabls.iter().any(|qabl| {
-                    qabl.context.is_some()
-                        && qabl.matches(res)
-                        && (res_hat!(qabl).router_qabls.keys().any(|r| *r != tables.zid)
-                            || res_hat!(qabl)
-                                .linkstatepeer_qabls
-                                .keys()
-                                .any(|r| *r != tables.zid)
-                            || qabl.session_ctxs.values().any(|s| {
-                                s.face.id != face.id
-                                    && s.qabl.is_some()
-                                    && (s.face.whatami == WhatAmI::Client
-                                        || face.whatami == WhatAmI::Client
-                                        || (s.face.whatami == WhatAmI::Peer
-                                            && hat!(tables)
-                                                .failover_brokering(s.face.zid, face.zid)))
-                            }))
-                }) {
-                    let info = local_qabl_info(tables, res, face);
-                    let id = make_qabl_id(res, face, mode, info);
-                    let wire_expr =
-                        Resource::decl_key(res, face, push_declaration_profile(tables, face));
-                    send_declare(
-                        &face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::DeclareQueryable(DeclareQueryable {
-                                    id,
-                                    wire_expr,
-                                    ext_info: info,
-                                }),
-                            },
-                            res.expr().to_string(),
-                        ),
-                    );
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    fn insert_target_for_qabls(
+        &self,
+        route: &mut QueryTargetQablSet,
+        expr: &mut RoutingExpr,
+        tables: &Tables,
+        net: &Network,
+        source: NodeId,
+        qabls: &HashMap<ZenohIdProto, QueryableInfoType>,
+        complete: bool,
+    ) {
+        if net.trees.len() > source as usize {
+            for (qabl, qabl_info) in qabls {
+                if let Some(qabl_idx) = net.get_idx(qabl) {
+                    if net.trees[source as usize].directions.len() > qabl_idx.index() {
+                        if let Some(direction) =
+                            net.trees[source as usize].directions[qabl_idx.index()]
+                        {
+                            if net.graph.contains_node(direction) {
+                                if let Some(face) = tables.get_face(&net.graph[direction].zid) {
+                                    if net.distances.len() > qabl_idx.index() {
+                                        let key_expr = Resource::get_best_key(
+                                            expr.prefix,
+                                            expr.suffix,
+                                            face.id,
+                                        );
+                                        route.push(QueryTargetQabl {
+                                            direction: (face.clone(), key_expr.to_owned(), source),
+                                            info: Some(QueryableInfoType {
+                                                complete: complete && qabl_info.complete,
+                                                distance: net.distances[qabl_idx.index()] as u16,
+                                            }),
+                                        });
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            tracing::trace!("Tree for node sid:{} not yet ready", source);
+        }
+    }
+
+    #[inline]
+    fn make_qabl_id(
+        &self,
+        res: &Arc<Resource>,
+        face: &mut Arc<FaceState>,
+        mode: InterestMode,
+        info: QueryableInfoType,
+    ) -> u32 {
+        if mode.future() {
+            if let Some((id, _)) = face_hat!(face).local_qabls.get(res) {
+                *id
+            } else {
+                let id = face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst);
+                face_hat_mut!(face)
+                    .local_qabls
+                    .insert(res.clone(), (id, info));
+                id
+            }
+        } else {
+            0
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn declare_qabl_interest(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        id: InterestId,
+        res: Option<&mut Arc<Resource>>,
+        mode: InterestMode,
+        aggregate: bool,
+        send_declare: &mut SendDeclare,
+    ) {
+        if mode.current() {
+            let interest_id = Some(id);
+            if let Some(res) = res.as_ref() {
+                if aggregate {
+                    if hat!(tables).router_qabls.iter().any(|qabl| {
+                        qabl.context.is_some()
+                            && qabl.matches(res)
+                            && (res_hat!(qabl).router_qabls.keys().any(|r| *r != tables.zid)
+                                || res_hat!(qabl)
+                                    .linkstatepeer_qabls
+                                    .keys()
+                                    .any(|r| *r != tables.zid)
+                                || qabl.session_ctxs.values().any(|s| {
+                                    s.face.id != face.id
+                                        && s.qabl.is_some()
+                                        && (s.face.whatami == WhatAmI::Client
+                                            || face.whatami == WhatAmI::Client
+                                            || (s.face.whatami == WhatAmI::Peer
+                                                && hat!(tables)
+                                                    .failover_brokering(s.face.zid, face.zid)))
+                                }))
+                    }) {
+                        let info = self.local_qabl_info(tables, res, face);
+                        let id = self.make_qabl_id(res, face, mode, info);
+                        let wire_expr =
+                            Resource::decl_key(res, face, push_declaration_profile(tables, face));
+                        send_declare(
+                            &face.primitives,
+                            RoutingContext::with_expr(
+                                Declare {
+                                    interest_id,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType::DEFAULT,
+                                    body: DeclareBody::DeclareQueryable(DeclareQueryable {
+                                        id,
+                                        wire_expr,
+                                        ext_info: info,
+                                    }),
+                                },
+                                res.expr().to_string(),
+                            ),
+                        );
+                    }
+                } else {
+                    for qabl in hat!(tables).router_qabls.iter() {
+                        if qabl.context.is_some()
+                            && qabl.matches(res)
+                            && (res_hat!(qabl).router_qabls.keys().any(|r| *r != tables.zid)
+                                || res_hat!(qabl)
+                                    .linkstatepeer_qabls
+                                    .keys()
+                                    .any(|r| *r != tables.zid)
+                                || qabl.session_ctxs.values().any(|s| {
+                                    s.qabl.is_some()
+                                        && (s.face.whatami != WhatAmI::Peer
+                                            || face.whatami != WhatAmI::Peer
+                                            || hat!(tables)
+                                                .failover_brokering(s.face.zid, face.zid))
+                                }))
+                        {
+                            let info = self.local_qabl_info(tables, qabl, face);
+                            let id = self.make_qabl_id(qabl, face, mode, info);
+                            let key_expr = Resource::decl_key(
+                                qabl,
+                                face,
+                                push_declaration_profile(tables, face),
+                            );
+                            send_declare(
+                                &face.primitives,
+                                RoutingContext::with_expr(
+                                    Declare {
+                                        interest_id,
+                                        ext_qos: ext::QoSType::DECLARE,
+                                        ext_tstamp: None,
+                                        ext_nodeid: ext::NodeIdType::DEFAULT,
+                                        body: DeclareBody::DeclareQueryable(DeclareQueryable {
+                                            id,
+                                            wire_expr: key_expr,
+                                            ext_info: info,
+                                        }),
+                                    },
+                                    qabl.expr().to_string(),
+                                ),
+                            );
+                        }
+                    }
                 }
             } else {
                 for qabl in hat!(tables).router_qabls.iter() {
                     if qabl.context.is_some()
-                        && qabl.matches(res)
-                        && (res_hat!(qabl).router_qabls.keys().any(|r| *r != tables.zid)
-                            || res_hat!(qabl)
-                                .linkstatepeer_qabls
-                                .keys()
-                                .any(|r| *r != tables.zid)
-                            || qabl.session_ctxs.values().any(|s| {
-                                s.qabl.is_some()
-                                    && (s.face.whatami != WhatAmI::Peer
-                                        || face.whatami != WhatAmI::Peer
-                                        || hat!(tables).failover_brokering(s.face.zid, face.zid))
-                            }))
+                        && (self.remote_simple_qabls(qabl, face)
+                            || self.remote_linkstatepeer_qabls(tables, qabl)
+                            || self.remote_router_qabls(tables, qabl))
                     {
-                        let info = local_qabl_info(tables, qabl, face);
-                        let id = make_qabl_id(qabl, face, mode, info);
+                        let info = self.local_qabl_info(tables, qabl, face);
+                        let id = self.make_qabl_id(qabl, face, mode, info);
                         let key_expr =
                             Resource::decl_key(qabl, face, push_declaration_profile(tables, face));
                         send_declare(
@@ -1237,36 +1323,39 @@ pub(crate) fn declare_qabl_interest(
                     }
                 }
             }
-        } else {
-            for qabl in hat!(tables).router_qabls.iter() {
-                if qabl.context.is_some()
-                    && (remote_simple_qabls(qabl, face)
-                        || remote_linkstatepeer_qabls(tables, qabl)
-                        || remote_router_qabls(tables, qabl))
-                {
-                    let info = local_qabl_info(tables, qabl, face);
-                    let id = make_qabl_id(qabl, face, mode, info);
-                    let key_expr =
-                        Resource::decl_key(qabl, face, push_declaration_profile(tables, face));
-                    send_declare(
-                        &face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::DeclareQueryable(DeclareQueryable {
-                                    id,
-                                    wire_expr: key_expr,
-                                    ext_info: info,
-                                }),
-                            },
-                            qabl.expr().to_string(),
-                        ),
-                    );
+        }
+    }
+
+    #[cfg(feature = "unstable")]
+    #[inline]
+    fn insert_faces_for_qbls(
+        &self,
+        route: &mut HashMap<usize, Arc<FaceState>>,
+        tables: &Tables,
+        net: &Network,
+        qbls: &HashMap<ZenohIdProto, QueryableInfoType>,
+        complete: bool,
+    ) {
+        let source = net.idx.index();
+        if net.trees.len() > source {
+            for qbl in qbls {
+                if complete && !qbl.1.complete {
+                    continue;
+                }
+                if let Some(qbl_idx) = net.get_idx(qbl.0) {
+                    if net.trees[source].directions.len() > qbl_idx.index() {
+                        if let Some(direction) = net.trees[source].directions[qbl_idx.index()] {
+                            if net.graph.contains_node(direction) {
+                                if let Some(face) = tables.get_face(&net.graph[direction].zid) {
+                                    route.entry(face.id).or_insert_with(|| face.clone());
+                                }
+                            }
+                        }
+                    }
                 }
             }
+        } else {
+            tracing::trace!("Tree for node sid:{} not yet ready", source);
         }
     }
 }
@@ -1285,13 +1374,20 @@ impl HatQueriesTrait for HatCode {
         match face.whatami {
             WhatAmI::Router => {
                 if let Some(router) = get_router(tables, face, node_id) {
-                    declare_router_queryable(tables, face, res, qabl_info, router, send_declare)
+                    self.declare_router_queryable(
+                        tables,
+                        face,
+                        res,
+                        qabl_info,
+                        router,
+                        send_declare,
+                    )
                 }
             }
             WhatAmI::Peer => {
                 if hat!(tables).full_net(WhatAmI::Peer) {
                     if let Some(peer) = get_peer(tables, face, node_id) {
-                        declare_linkstatepeer_queryable(
+                        self.declare_linkstatepeer_queryable(
                             tables,
                             face,
                             res,
@@ -1301,10 +1397,10 @@ impl HatQueriesTrait for HatCode {
                         )
                     }
                 } else {
-                    declare_simple_queryable(tables, face, id, res, qabl_info, send_declare)
+                    self.declare_simple_queryable(tables, face, id, res, qabl_info, send_declare)
                 }
             }
-            _ => declare_simple_queryable(tables, face, id, res, qabl_info, send_declare),
+            _ => self.declare_simple_queryable(tables, face, id, res, qabl_info, send_declare),
         }
     }
 
@@ -1321,7 +1417,7 @@ impl HatQueriesTrait for HatCode {
             WhatAmI::Router => {
                 if let Some(mut res) = res {
                     if let Some(router) = get_router(tables, face, node_id) {
-                        forget_router_queryable(tables, face, &mut res, &router, send_declare);
+                        self.forget_router_queryable(tables, face, &mut res, &router, send_declare);
                         Some(res)
                     } else {
                         None
@@ -1334,7 +1430,7 @@ impl HatQueriesTrait for HatCode {
                 if hat!(tables).full_net(WhatAmI::Peer) {
                     if let Some(mut res) = res {
                         if let Some(peer) = get_peer(tables, face, node_id) {
-                            forget_linkstatepeer_queryable(
+                            self.forget_linkstatepeer_queryable(
                                 tables,
                                 face,
                                 &mut res,
@@ -1349,10 +1445,10 @@ impl HatQueriesTrait for HatCode {
                         None
                     }
                 } else {
-                    forget_simple_queryable(tables, face, id, send_declare)
+                    self.forget_simple_queryable(tables, face, id, send_declare)
                 }
             }
-            _ => forget_simple_queryable(tables, face, id, send_declare),
+            _ => self.forget_simple_queryable(tables, face, id, send_declare),
         }
     }
 
@@ -1419,6 +1515,10 @@ impl HatQueriesTrait for HatCode {
         source: NodeId,
         source_type: WhatAmI,
     ) -> Arc<QueryTargetQablSet> {
+        lazy_static::lazy_static! {
+            static ref EMPTY_ROUTE: Arc<QueryTargetQablSet> = Arc::new(Vec::new());
+        }
+
         let mut route = QueryTargetQablSet::new();
         let key_expr = expr.full_expr();
         if key_expr.ends_with('/') {
@@ -1457,7 +1557,7 @@ impl HatQueriesTrait for HatCode {
                     WhatAmI::Router => source,
                     _ => net.idx.index() as NodeId,
                 };
-                insert_target_for_qabls(
+                self.insert_target_for_qabls(
                     &mut route,
                     expr,
                     tables,
@@ -1474,7 +1574,7 @@ impl HatQueriesTrait for HatCode {
                     WhatAmI::Peer => source,
                     _ => net.idx.index() as NodeId,
                 };
-                insert_target_for_qabls(
+                self.insert_target_for_qabls(
                     &mut route,
                     expr,
                     tables,
@@ -1545,7 +1645,7 @@ impl HatQueriesTrait for HatCode {
 
             if master {
                 let net = hat!(tables).routers_net.as_ref().unwrap();
-                insert_faces_for_qbls(
+                self.insert_faces_for_qbls(
                     &mut matching_queryables,
                     tables,
                     net,
@@ -1556,7 +1656,7 @@ impl HatQueriesTrait for HatCode {
 
             if hat!(tables).full_net(WhatAmI::Peer) {
                 let net = hat!(tables).linkstatepeers_net.as_ref().unwrap();
-                insert_faces_for_qbls(
+                self.insert_faces_for_qbls(
                     &mut matching_queryables,
                     tables,
                     net,
@@ -1580,37 +1680,5 @@ impl HatQueriesTrait for HatCode {
             }
         }
         matching_queryables
-    }
-}
-
-#[cfg(feature = "unstable")]
-#[inline]
-fn insert_faces_for_qbls(
-    route: &mut HashMap<usize, Arc<FaceState>>,
-    tables: &Tables,
-    net: &Network,
-    qbls: &HashMap<ZenohIdProto, QueryableInfoType>,
-    complete: bool,
-) {
-    let source = net.idx.index();
-    if net.trees.len() > source {
-        for qbl in qbls {
-            if complete && !qbl.1.complete {
-                continue;
-            }
-            if let Some(qbl_idx) = net.get_idx(qbl.0) {
-                if net.trees[source].directions.len() > qbl_idx.index() {
-                    if let Some(direction) = net.trees[source].directions[qbl_idx.index()] {
-                        if net.graph.contains_node(direction) {
-                            if let Some(face) = tables.get_face(&net.graph[direction].zid) {
-                                route.entry(face.id).or_insert_with(|| face.clone());
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    } else {
-        tracing::trace!("Tree for node sid:{} not yet ready", source);
     }
 }

--- a/zenoh/src/net/routing/hat/router/token.rs
+++ b/zenoh/src/net/routing/hat/router/token.rs
@@ -43,996 +43,1095 @@ use crate::net::{
     },
 };
 
-#[inline]
-fn send_sourced_token_to_net_clildren(
-    tables: &Tables,
-    net: &Network,
-    clildren: &[NodeIndex],
-    res: &Arc<Resource>,
-    src_face: Option<&Arc<FaceState>>,
-    routing_context: NodeId,
-) {
-    for child in clildren {
-        if net.graph.contains_node(*child) {
-            match tables.get_face(&net.graph[*child].zid).cloned() {
-                Some(mut someface) => {
-                    if src_face
-                        .map(|src_face| someface.id != src_face.id)
-                        .unwrap_or(true)
-                    {
-                        let push_declaration = push_declaration_profile(tables, &someface);
-                        let key_expr = Resource::decl_key(res, &mut someface, push_declaration);
+impl HatCode {
+    #[inline]
+    fn send_sourced_token_to_net_clildren(
+        &self,
+        tables: &Tables,
+        net: &Network,
+        clildren: &[NodeIndex],
+        res: &Arc<Resource>,
+        src_face: Option<&Arc<FaceState>>,
+        routing_context: NodeId,
+    ) {
+        for child in clildren {
+            if net.graph.contains_node(*child) {
+                match tables.get_face(&net.graph[*child].zid).cloned() {
+                    Some(mut someface) => {
+                        if src_face
+                            .map(|src_face| someface.id != src_face.id)
+                            .unwrap_or(true)
+                        {
+                            let push_declaration = push_declaration_profile(tables, &someface);
+                            let key_expr = Resource::decl_key(res, &mut someface, push_declaration);
 
-                        someface.primitives.send_declare(RoutingContext::with_expr(
-                            &mut Declare {
+                            someface.primitives.send_declare(RoutingContext::with_expr(
+                                &mut Declare {
+                                    interest_id: None,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType {
+                                        node_id: routing_context,
+                                    },
+                                    body: DeclareBody::DeclareToken(DeclareToken {
+                                        id: 0, // Sourced tokens do not use ids
+                                        wire_expr: key_expr,
+                                    }),
+                                },
+                                res.expr().to_string(),
+                            ));
+                        }
+                    }
+                    None => {
+                        tracing::trace!("Unable to find face for zid {}", net.graph[*child].zid)
+                    }
+                }
+            }
+        }
+    }
+
+    #[inline]
+    fn propagate_simple_token_to(
+        &self,
+        tables: &mut Tables,
+        dst_face: &mut Arc<FaceState>,
+        res: &Arc<Resource>,
+        src_face: &mut Arc<FaceState>,
+        full_peer_net: bool,
+        send_declare: &mut SendDeclare,
+    ) {
+        if (src_face.id != dst_face.id || dst_face.zid == tables.zid)
+            && !face_hat!(dst_face).local_tokens.contains_key(res)
+            && if full_peer_net {
+                dst_face.whatami == WhatAmI::Client
+            } else {
+                dst_face.whatami != WhatAmI::Router
+                    && (src_face.whatami != WhatAmI::Peer
+                        || dst_face.whatami != WhatAmI::Peer
+                        || hat!(tables).failover_brokering(src_face.zid, dst_face.zid))
+            }
+        {
+            let matching_interests = face_hat!(dst_face)
+                .remote_interests
+                .values()
+                .filter(|i| i.options.tokens() && i.matches(res))
+                .cloned()
+                .collect::<Vec<_>>();
+
+            for RemoteInterest {
+                res: int_res,
+                options,
+                ..
+            } in matching_interests
+            {
+                let res = if options.aggregate() {
+                    int_res.as_ref().unwrap_or(res)
+                } else {
+                    res
+                };
+                if !face_hat!(dst_face).local_tokens.contains_key(res) {
+                    let id = face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst);
+                    face_hat_mut!(dst_face).local_tokens.insert(res.clone(), id);
+                    let key_expr = Resource::decl_key(
+                        res,
+                        dst_face,
+                        push_declaration_profile(tables, dst_face),
+                    );
+                    send_declare(
+                        &dst_face.primitives,
+                        RoutingContext::with_expr(
+                            Declare {
                                 interest_id: None,
                                 ext_qos: ext::QoSType::DECLARE,
                                 ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType {
-                                    node_id: routing_context,
-                                },
+                                ext_nodeid: ext::NodeIdType::DEFAULT,
                                 body: DeclareBody::DeclareToken(DeclareToken {
-                                    id: 0, // Sourced tokens do not use ids
+                                    id,
                                     wire_expr: key_expr,
                                 }),
                             },
                             res.expr().to_string(),
-                        ));
-                    }
+                        ),
+                    );
                 }
-                None => tracing::trace!("Unable to find face for zid {}", net.graph[*child].zid),
             }
         }
     }
-}
 
-#[inline]
-fn propagate_simple_token_to(
-    tables: &mut Tables,
-    dst_face: &mut Arc<FaceState>,
-    res: &Arc<Resource>,
-    src_face: &mut Arc<FaceState>,
-    full_peer_net: bool,
-    send_declare: &mut SendDeclare,
-) {
-    if (src_face.id != dst_face.id || dst_face.zid == tables.zid)
-        && !face_hat!(dst_face).local_tokens.contains_key(res)
-        && if full_peer_net {
-            dst_face.whatami == WhatAmI::Client
-        } else {
-            dst_face.whatami != WhatAmI::Router
-                && (src_face.whatami != WhatAmI::Peer
-                    || dst_face.whatami != WhatAmI::Peer
-                    || hat!(tables).failover_brokering(src_face.zid, dst_face.zid))
-        }
-    {
-        let matching_interests = face_hat!(dst_face)
-            .remote_interests
+    fn propagate_simple_token(
+        &self,
+        tables: &mut Tables,
+        res: &Arc<Resource>,
+        src_face: &mut Arc<FaceState>,
+        send_declare: &mut SendDeclare,
+    ) {
+        let full_peer_net = hat!(tables).full_net(WhatAmI::Peer);
+        for mut dst_face in tables
+            .faces
             .values()
-            .filter(|i| i.options.tokens() && i.matches(res))
             .cloned()
-            .collect::<Vec<_>>();
-
-        for RemoteInterest {
-            res: int_res,
-            options,
-            ..
-        } in matching_interests
+            .collect::<Vec<Arc<FaceState>>>()
         {
-            let res = if options.aggregate() {
-                int_res.as_ref().unwrap_or(res)
-            } else {
-                res
-            };
-            if !face_hat!(dst_face).local_tokens.contains_key(res) {
-                let id = face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst);
-                face_hat_mut!(dst_face).local_tokens.insert(res.clone(), id);
-                let key_expr =
-                    Resource::decl_key(res, dst_face, push_declaration_profile(tables, dst_face));
+            self.propagate_simple_token_to(
+                tables,
+                &mut dst_face,
+                res,
+                src_face,
+                full_peer_net,
+                send_declare,
+            );
+        }
+    }
+
+    fn propagate_sourced_token(
+        &self,
+        tables: &Tables,
+        res: &Arc<Resource>,
+        src_face: Option<&Arc<FaceState>>,
+        source: &ZenohIdProto,
+        net_type: WhatAmI,
+    ) {
+        let net = hat!(tables).get_net(net_type).unwrap();
+        match net.get_idx(source) {
+            Some(tree_sid) => {
+                if net.trees.len() > tree_sid.index() {
+                    self.send_sourced_token_to_net_clildren(
+                        tables,
+                        net,
+                        &net.trees[tree_sid.index()].children,
+                        res,
+                        src_face,
+                        tree_sid.index() as NodeId,
+                    );
+                } else {
+                    tracing::trace!(
+                        "Propagating liveliness {}: tree for node {} sid:{} not yet ready",
+                        res.expr(),
+                        tree_sid.index(),
+                        source
+                    );
+                }
+            }
+            None => tracing::error!(
+                "Error propagating token {}: cannot get index of {}!",
+                res.expr(),
+                source
+            ),
+        }
+    }
+
+    fn register_router_token(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        res: &mut Arc<Resource>,
+        router: ZenohIdProto,
+        send_declare: &mut SendDeclare,
+    ) {
+        if !res_hat!(res).router_tokens.contains(&router) {
+            // Register router liveliness
+            {
+                res_hat_mut!(res).router_tokens.insert(router);
+                hat_mut!(tables).router_tokens.insert(res.clone());
+            }
+
+            // Propagate liveliness to routers
+            self.propagate_sourced_token(tables, res, Some(face), &router, WhatAmI::Router);
+        }
+        // Propagate liveliness to peers
+        if hat!(tables).full_net(WhatAmI::Peer) && face.whatami != WhatAmI::Peer {
+            self.register_linkstatepeer_token(tables, face, res, tables.zid)
+        }
+
+        // Propagate liveliness to clients
+        self.propagate_simple_token(tables, res, face, send_declare);
+    }
+
+    fn declare_router_token(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        res: &mut Arc<Resource>,
+        router: ZenohIdProto,
+        send_declare: &mut SendDeclare,
+    ) {
+        self.register_router_token(tables, face, res, router, send_declare);
+    }
+
+    fn register_linkstatepeer_token(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        res: &mut Arc<Resource>,
+        peer: ZenohIdProto,
+    ) {
+        if !res_hat!(res).linkstatepeer_tokens.contains(&peer) {
+            // Register peer liveliness
+            {
+                res_hat_mut!(res).linkstatepeer_tokens.insert(peer);
+                hat_mut!(tables).linkstatepeer_tokens.insert(res.clone());
+            }
+
+            // Propagate liveliness to peers
+            self.propagate_sourced_token(tables, res, Some(face), &peer, WhatAmI::Peer);
+        }
+    }
+
+    fn declare_linkstatepeer_token(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        res: &mut Arc<Resource>,
+        peer: ZenohIdProto,
+        send_declare: &mut SendDeclare,
+    ) {
+        self.register_linkstatepeer_token(tables, face, res, peer);
+        let zid = tables.zid;
+        self.register_router_token(tables, face, res, zid, send_declare);
+    }
+
+    fn register_simple_token(
+        &self,
+        _tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        id: TokenId,
+        res: &mut Arc<Resource>,
+    ) {
+        // Register liveliness
+        {
+            let res = get_mut_unchecked(res);
+            match res.session_ctxs.get_mut(&face.id) {
+                Some(ctx) => {
+                    if !ctx.token {
+                        get_mut_unchecked(ctx).token = true;
+                    }
+                }
+                None => {
+                    let ctx = res
+                        .session_ctxs
+                        .entry(face.id)
+                        .or_insert_with(|| Arc::new(SessionContext::new(face.clone())));
+                    get_mut_unchecked(ctx).token = true;
+                }
+            }
+        }
+        face_hat_mut!(face).remote_tokens.insert(id, res.clone());
+    }
+
+    fn declare_simple_token(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        id: TokenId,
+        res: &mut Arc<Resource>,
+        send_declare: &mut SendDeclare,
+    ) {
+        self.register_simple_token(tables, face, id, res);
+        let zid = tables.zid;
+        self.register_router_token(tables, face, res, zid, send_declare);
+    }
+
+    #[inline]
+    fn remote_router_tokens(&self, tables: &Tables, res: &Arc<Resource>) -> bool {
+        res.context.is_some()
+            && res_hat!(res)
+                .router_tokens
+                .iter()
+                .any(|peer| peer != &tables.zid)
+    }
+
+    #[inline]
+    fn remote_linkstatepeer_tokens(&self, tables: &Tables, res: &Arc<Resource>) -> bool {
+        res.context.is_some()
+            && res_hat!(res)
+                .linkstatepeer_tokens
+                .iter()
+                .any(|peer| peer != &tables.zid)
+    }
+
+    #[inline]
+    fn simple_tokens(&self, res: &Arc<Resource>) -> Vec<Arc<FaceState>> {
+        res.session_ctxs
+            .values()
+            .filter_map(|ctx| {
+                if ctx.token {
+                    Some(ctx.face.clone())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    #[inline]
+    fn remote_simple_tokens(
+        &self,
+        tables: &Tables,
+        res: &Arc<Resource>,
+        face: &Arc<FaceState>,
+    ) -> bool {
+        res.session_ctxs
+            .values()
+            .any(|ctx| (ctx.face.id != face.id || face.zid == tables.zid) && ctx.token)
+    }
+
+    #[inline]
+    fn send_forget_sourced_token_to_net_clildren(
+        &self,
+        tables: &Tables,
+        net: &Network,
+        clildren: &[NodeIndex],
+        res: &Arc<Resource>,
+        src_face: Option<&Arc<FaceState>>,
+        routing_context: Option<NodeId>,
+    ) {
+        for child in clildren {
+            if net.graph.contains_node(*child) {
+                match tables.get_face(&net.graph[*child].zid).cloned() {
+                    Some(mut someface) => {
+                        if src_face
+                            .map(|src_face| someface.id != src_face.id)
+                            .unwrap_or(true)
+                        {
+                            let push_declaration = push_declaration_profile(tables, &someface);
+                            let wire_expr =
+                                Resource::decl_key(res, &mut someface, push_declaration);
+
+                            someface.primitives.send_declare(RoutingContext::with_expr(
+                                &mut Declare {
+                                    interest_id: None,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType {
+                                        node_id: routing_context.unwrap_or(0),
+                                    },
+                                    body: DeclareBody::UndeclareToken(UndeclareToken {
+                                        id: 0, // Sourced tokens do not use ids
+                                        ext_wire_expr: WireExprType { wire_expr },
+                                    }),
+                                },
+                                res.expr().to_string(),
+                            ));
+                        }
+                    }
+                    None => {
+                        tracing::trace!("Unable to find face for zid {}", net.graph[*child].zid)
+                    }
+                }
+            }
+        }
+    }
+
+    fn propagate_forget_simple_token(
+        &self,
+        tables: &mut Tables,
+        res: &Arc<Resource>,
+        src_face: Option<&Arc<FaceState>>,
+        send_declare: &mut SendDeclare,
+    ) {
+        for mut face in tables.faces.values().cloned() {
+            if let Some(id) = face_hat_mut!(&mut face).local_tokens.remove(res) {
                 send_declare(
-                    &dst_face.primitives,
+                    &face.primitives,
                     RoutingContext::with_expr(
                         Declare {
                             interest_id: None,
                             ext_qos: ext::QoSType::DECLARE,
                             ext_tstamp: None,
                             ext_nodeid: ext::NodeIdType::DEFAULT,
-                            body: DeclareBody::DeclareToken(DeclareToken {
+                            body: DeclareBody::UndeclareToken(UndeclareToken {
                                 id,
-                                wire_expr: key_expr,
+                                ext_wire_expr: WireExprType::null(),
+                            }),
+                        },
+                        res.expr().to_string(),
+                    ),
+                );
+            // NOTE(fuzzypixelz): We need to check that `face` is not the source Face of the token
+            // undeclaration, otherwise the undeclaration would be duplicated at the source Face. In
+            // cases where we don't have access to a Face as we didnt't receive an undeclaration and we
+            // default to true.
+            } else if src_face.map_or(true, |src_face| {
+                src_face.id != face.id
+                    && (src_face.whatami != WhatAmI::Peer
+                        || face.whatami != WhatAmI::Peer
+                        || hat!(tables).failover_brokering(src_face.zid, face.zid))
+            }) && face_hat!(face)
+                .remote_interests
+                .values()
+                .any(|i| i.options.tokens() && i.matches(res) && !i.options.aggregate())
+            {
+                // Token has never been declared on this face.
+                // Send an Undeclare with a one shot generated id and a WireExpr ext.
+                send_declare(
+                    &face.primitives,
+                    RoutingContext::with_expr(
+                        Declare {
+                            interest_id: None,
+                            ext_qos: ext::QoSType::DECLARE,
+                            ext_tstamp: None,
+                            ext_nodeid: ext::NodeIdType::DEFAULT,
+                            body: DeclareBody::UndeclareToken(UndeclareToken {
+                                id: face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst),
+                                ext_wire_expr: WireExprType {
+                                    wire_expr: Resource::get_best_key(res, "", face.id),
+                                },
                             }),
                         },
                         res.expr().to_string(),
                     ),
                 );
             }
-        }
-    }
-}
-
-fn propagate_simple_token(
-    tables: &mut Tables,
-    res: &Arc<Resource>,
-    src_face: &mut Arc<FaceState>,
-    send_declare: &mut SendDeclare,
-) {
-    let full_peer_net = hat!(tables).full_net(WhatAmI::Peer);
-    for mut dst_face in tables
-        .faces
-        .values()
-        .cloned()
-        .collect::<Vec<Arc<FaceState>>>()
-    {
-        propagate_simple_token_to(
-            tables,
-            &mut dst_face,
-            res,
-            src_face,
-            full_peer_net,
-            send_declare,
-        );
-    }
-}
-
-fn propagate_sourced_token(
-    tables: &Tables,
-    res: &Arc<Resource>,
-    src_face: Option<&Arc<FaceState>>,
-    source: &ZenohIdProto,
-    net_type: WhatAmI,
-) {
-    let net = hat!(tables).get_net(net_type).unwrap();
-    match net.get_idx(source) {
-        Some(tree_sid) => {
-            if net.trees.len() > tree_sid.index() {
-                send_sourced_token_to_net_clildren(
-                    tables,
-                    net,
-                    &net.trees[tree_sid.index()].children,
-                    res,
-                    src_face,
-                    tree_sid.index() as NodeId,
-                );
-            } else {
-                tracing::trace!(
-                    "Propagating liveliness {}: tree for node {} sid:{} not yet ready",
-                    res.expr(),
-                    tree_sid.index(),
-                    source
-                );
-            }
-        }
-        None => tracing::error!(
-            "Error propagating token {}: cannot get index of {}!",
-            res.expr(),
-            source
-        ),
-    }
-}
-
-fn register_router_token(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    res: &mut Arc<Resource>,
-    router: ZenohIdProto,
-    send_declare: &mut SendDeclare,
-) {
-    if !res_hat!(res).router_tokens.contains(&router) {
-        // Register router liveliness
-        {
-            res_hat_mut!(res).router_tokens.insert(router);
-            hat_mut!(tables).router_tokens.insert(res.clone());
-        }
-
-        // Propagate liveliness to routers
-        propagate_sourced_token(tables, res, Some(face), &router, WhatAmI::Router);
-    }
-    // Propagate liveliness to peers
-    if hat!(tables).full_net(WhatAmI::Peer) && face.whatami != WhatAmI::Peer {
-        register_linkstatepeer_token(tables, face, res, tables.zid)
-    }
-
-    // Propagate liveliness to clients
-    propagate_simple_token(tables, res, face, send_declare);
-}
-
-fn declare_router_token(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    res: &mut Arc<Resource>,
-    router: ZenohIdProto,
-    send_declare: &mut SendDeclare,
-) {
-    register_router_token(tables, face, res, router, send_declare);
-}
-
-fn register_linkstatepeer_token(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    res: &mut Arc<Resource>,
-    peer: ZenohIdProto,
-) {
-    if !res_hat!(res).linkstatepeer_tokens.contains(&peer) {
-        // Register peer liveliness
-        {
-            res_hat_mut!(res).linkstatepeer_tokens.insert(peer);
-            hat_mut!(tables).linkstatepeer_tokens.insert(res.clone());
-        }
-
-        // Propagate liveliness to peers
-        propagate_sourced_token(tables, res, Some(face), &peer, WhatAmI::Peer);
-    }
-}
-
-fn declare_linkstatepeer_token(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    res: &mut Arc<Resource>,
-    peer: ZenohIdProto,
-    send_declare: &mut SendDeclare,
-) {
-    register_linkstatepeer_token(tables, face, res, peer);
-    let zid = tables.zid;
-    register_router_token(tables, face, res, zid, send_declare);
-}
-
-fn register_simple_token(
-    _tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    id: TokenId,
-    res: &mut Arc<Resource>,
-) {
-    // Register liveliness
-    {
-        let res = get_mut_unchecked(res);
-        match res.session_ctxs.get_mut(&face.id) {
-            Some(ctx) => {
-                if !ctx.token {
-                    get_mut_unchecked(ctx).token = true;
-                }
-            }
-            None => {
-                let ctx = res
-                    .session_ctxs
-                    .entry(face.id)
-                    .or_insert_with(|| Arc::new(SessionContext::new(face.clone())));
-                get_mut_unchecked(ctx).token = true;
-            }
-        }
-    }
-    face_hat_mut!(face).remote_tokens.insert(id, res.clone());
-}
-
-fn declare_simple_token(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    id: TokenId,
-    res: &mut Arc<Resource>,
-    send_declare: &mut SendDeclare,
-) {
-    register_simple_token(tables, face, id, res);
-    let zid = tables.zid;
-    register_router_token(tables, face, res, zid, send_declare);
-}
-
-#[inline]
-fn remote_router_tokens(tables: &Tables, res: &Arc<Resource>) -> bool {
-    res.context.is_some()
-        && res_hat!(res)
-            .router_tokens
-            .iter()
-            .any(|peer| peer != &tables.zid)
-}
-
-#[inline]
-fn remote_linkstatepeer_tokens(tables: &Tables, res: &Arc<Resource>) -> bool {
-    res.context.is_some()
-        && res_hat!(res)
-            .linkstatepeer_tokens
-            .iter()
-            .any(|peer| peer != &tables.zid)
-}
-
-#[inline]
-fn simple_tokens(res: &Arc<Resource>) -> Vec<Arc<FaceState>> {
-    res.session_ctxs
-        .values()
-        .filter_map(|ctx| {
-            if ctx.token {
-                Some(ctx.face.clone())
-            } else {
-                None
-            }
-        })
-        .collect()
-}
-
-#[inline]
-fn remote_simple_tokens(tables: &Tables, res: &Arc<Resource>, face: &Arc<FaceState>) -> bool {
-    res.session_ctxs
-        .values()
-        .any(|ctx| (ctx.face.id != face.id || face.zid == tables.zid) && ctx.token)
-}
-
-#[inline]
-fn send_forget_sourced_token_to_net_clildren(
-    tables: &Tables,
-    net: &Network,
-    clildren: &[NodeIndex],
-    res: &Arc<Resource>,
-    src_face: Option<&Arc<FaceState>>,
-    routing_context: Option<NodeId>,
-) {
-    for child in clildren {
-        if net.graph.contains_node(*child) {
-            match tables.get_face(&net.graph[*child].zid).cloned() {
-                Some(mut someface) => {
-                    if src_face
-                        .map(|src_face| someface.id != src_face.id)
-                        .unwrap_or(true)
-                    {
-                        let push_declaration = push_declaration_profile(tables, &someface);
-                        let wire_expr = Resource::decl_key(res, &mut someface, push_declaration);
-
-                        someface.primitives.send_declare(RoutingContext::with_expr(
-                            &mut Declare {
-                                interest_id: None,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType {
-                                    node_id: routing_context.unwrap_or(0),
+            for res in face_hat!(&mut face)
+                .local_tokens
+                .keys()
+                .cloned()
+                .collect::<Vec<Arc<Resource>>>()
+            {
+                if !res.context().matches.iter().any(|m| {
+                    m.upgrade().is_some_and(|m| {
+                        m.context.is_some()
+                            && (self.remote_simple_tokens(tables, &m, &face)
+                                || self.remote_linkstatepeer_tokens(tables, &m)
+                                || self.remote_router_tokens(tables, &m))
+                    })
+                }) {
+                    if let Some(id) = face_hat_mut!(&mut face).local_tokens.remove(&res) {
+                        send_declare(
+                            &face.primitives,
+                            RoutingContext::with_expr(
+                                Declare {
+                                    interest_id: None,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType::DEFAULT,
+                                    body: DeclareBody::UndeclareToken(UndeclareToken {
+                                        id,
+                                        ext_wire_expr: WireExprType::null(),
+                                    }),
                                 },
-                                body: DeclareBody::UndeclareToken(UndeclareToken {
-                                    id: 0, // Sourced tokens do not use ids
-                                    ext_wire_expr: WireExprType { wire_expr },
-                                }),
-                            },
-                            res.expr().to_string(),
-                        ));
+                                res.expr().to_string(),
+                            ),
+                        );
+                    } else if face_hat!(face)
+                        .remote_interests
+                        .values()
+                        .any(|i| i.options.tokens() && i.matches(&res) && !i.options.aggregate())
+                        && src_face.map_or(true, |src_face| {
+                            src_face.whatami != WhatAmI::Peer
+                                || face.whatami != WhatAmI::Peer
+                                || hat!(tables).failover_brokering(src_face.zid, face.zid)
+                        })
+                    {
+                        // Token has never been declared on this face.
+                        // Send an Undeclare with a one shot generated id and a WireExpr ext.
+                        send_declare(
+                            &face.primitives,
+                            RoutingContext::with_expr(
+                                Declare {
+                                    interest_id: None,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType::DEFAULT,
+                                    body: DeclareBody::UndeclareToken(UndeclareToken {
+                                        id: face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst),
+                                        ext_wire_expr: WireExprType {
+                                            wire_expr: Resource::get_best_key(&res, "", face.id),
+                                        },
+                                    }),
+                                },
+                                res.expr().to_string(),
+                            ),
+                        );
                     }
                 }
-                None => tracing::trace!("Unable to find face for zid {}", net.graph[*child].zid),
             }
         }
     }
-}
 
-fn propagate_forget_simple_token(
-    tables: &mut Tables,
-    res: &Arc<Resource>,
-    src_face: Option<&Arc<FaceState>>,
-    send_declare: &mut SendDeclare,
-) {
-    for mut face in tables.faces.values().cloned() {
-        if let Some(id) = face_hat_mut!(&mut face).local_tokens.remove(res) {
-            send_declare(
-                &face.primitives,
-                RoutingContext::with_expr(
-                    Declare {
-                        interest_id: None,
-                        ext_qos: ext::QoSType::DECLARE,
-                        ext_tstamp: None,
-                        ext_nodeid: ext::NodeIdType::DEFAULT,
-                        body: DeclareBody::UndeclareToken(UndeclareToken {
-                            id,
-                            ext_wire_expr: WireExprType::null(),
-                        }),
-                    },
-                    res.expr().to_string(),
-                ),
-            );
-        // NOTE(fuzzypixelz): We need to check that `face` is not the source Face of the token
-        // undeclaration, otherwise the undeclaration would be duplicated at the source Face. In
-        // cases where we don't have access to a Face as we didnt't receive an undeclaration and we
-        // default to true.
-        } else if src_face.map_or(true, |src_face| {
-            src_face.id != face.id
-                && (src_face.whatami != WhatAmI::Peer
-                    || face.whatami != WhatAmI::Peer
-                    || hat!(tables).failover_brokering(src_face.zid, face.zid))
-        }) && face_hat!(face)
-            .remote_interests
-            .values()
-            .any(|i| i.options.tokens() && i.matches(res) && !i.options.aggregate())
+    fn propagate_forget_simple_token_to_peers(
+        &self,
+        tables: &mut Tables,
+        res: &Arc<Resource>,
+        send_declare: &mut SendDeclare,
+    ) {
+        if !hat!(tables).full_net(WhatAmI::Peer)
+            && res_hat!(res).router_tokens.len() == 1
+            && res_hat!(res).router_tokens.contains(&tables.zid)
         {
-            // Token has never been declared on this face.
-            // Send an Undeclare with a one shot generated id and a WireExpr ext.
-            send_declare(
-                &face.primitives,
-                RoutingContext::with_expr(
-                    Declare {
-                        interest_id: None,
-                        ext_qos: ext::QoSType::DECLARE,
-                        ext_tstamp: None,
-                        ext_nodeid: ext::NodeIdType::DEFAULT,
-                        body: DeclareBody::UndeclareToken(UndeclareToken {
-                            id: face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst),
-                            ext_wire_expr: WireExprType {
-                                wire_expr: Resource::get_best_key(res, "", face.id),
-                            },
-                        }),
-                    },
-                    res.expr().to_string(),
-                ),
-            );
-        }
-        for res in face_hat!(&mut face)
-            .local_tokens
-            .keys()
-            .cloned()
-            .collect::<Vec<Arc<Resource>>>()
-        {
-            if !res.context().matches.iter().any(|m| {
-                m.upgrade().is_some_and(|m| {
-                    m.context.is_some()
-                        && (remote_simple_tokens(tables, &m, &face)
-                            || remote_linkstatepeer_tokens(tables, &m)
-                            || remote_router_tokens(tables, &m))
-                })
-            }) {
-                if let Some(id) = face_hat_mut!(&mut face).local_tokens.remove(&res) {
-                    send_declare(
-                        &face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id: None,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::UndeclareToken(UndeclareToken {
-                                    id,
-                                    ext_wire_expr: WireExprType::null(),
-                                }),
-                            },
-                            res.expr().to_string(),
-                        ),
-                    );
-                } else if face_hat!(face)
-                    .remote_interests
-                    .values()
-                    .any(|i| i.options.tokens() && i.matches(&res) && !i.options.aggregate())
-                    && src_face.map_or(true, |src_face| {
-                        src_face.whatami != WhatAmI::Peer
-                            || face.whatami != WhatAmI::Peer
-                            || hat!(tables).failover_brokering(src_face.zid, face.zid)
+            for mut face in tables
+                .faces
+                .values()
+                .cloned()
+                .collect::<Vec<Arc<FaceState>>>()
+            {
+                if face.whatami == WhatAmI::Peer
+                    && face_hat!(face).local_tokens.contains_key(res)
+                    && !res.session_ctxs.values().any(|s| {
+                        face.zid != s.face.zid
+                            && s.token
+                            && (s.face.whatami == WhatAmI::Client
+                                || (s.face.whatami == WhatAmI::Peer
+                                    && hat!(tables).failover_brokering(s.face.zid, face.zid)))
                     })
                 {
-                    // Token has never been declared on this face.
-                    // Send an Undeclare with a one shot generated id and a WireExpr ext.
-                    send_declare(
-                        &face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id: None,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::UndeclareToken(UndeclareToken {
-                                    id: face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst),
-                                    ext_wire_expr: WireExprType {
-                                        wire_expr: Resource::get_best_key(&res, "", face.id),
-                                    },
-                                }),
-                            },
-                            res.expr().to_string(),
-                        ),
-                    );
+                    if let Some(id) = face_hat_mut!(&mut face).local_tokens.remove(res) {
+                        send_declare(
+                            &face.primitives,
+                            RoutingContext::with_expr(
+                                Declare {
+                                    interest_id: None,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType::DEFAULT,
+                                    body: DeclareBody::UndeclareToken(UndeclareToken {
+                                        id,
+                                        ext_wire_expr: WireExprType::null(),
+                                    }),
+                                },
+                                res.expr().to_string(),
+                            ),
+                        );
+                    }
                 }
             }
         }
     }
-}
 
-fn propagate_forget_simple_token_to_peers(
-    tables: &mut Tables,
-    res: &Arc<Resource>,
-    send_declare: &mut SendDeclare,
-) {
-    if !hat!(tables).full_net(WhatAmI::Peer)
-        && res_hat!(res).router_tokens.len() == 1
-        && res_hat!(res).router_tokens.contains(&tables.zid)
-    {
-        for mut face in tables
-            .faces
+    fn propagate_forget_sourced_token(
+        &self,
+        tables: &Tables,
+        res: &Arc<Resource>,
+        src_face: Option<&Arc<FaceState>>,
+        source: &ZenohIdProto,
+        net_type: WhatAmI,
+    ) {
+        let net = hat!(tables).get_net(net_type).unwrap();
+        match net.get_idx(source) {
+            Some(tree_sid) => {
+                if net.trees.len() > tree_sid.index() {
+                    self.send_forget_sourced_token_to_net_clildren(
+                        tables,
+                        net,
+                        &net.trees[tree_sid.index()].children,
+                        res,
+                        src_face,
+                        Some(tree_sid.index() as NodeId),
+                    );
+                } else {
+                    tracing::trace!(
+                        "Propagating forget token {}: tree for node {} sid:{} not yet ready",
+                        res.expr(),
+                        tree_sid.index(),
+                        source
+                    );
+                }
+            }
+            None => tracing::error!(
+                "Error propagating forget token {}: cannot get index of {}!",
+                res.expr(),
+                source
+            ),
+        }
+    }
+
+    fn unregister_router_token(
+        &self,
+        tables: &mut Tables,
+        face: Option<&Arc<FaceState>>,
+        res: &mut Arc<Resource>,
+        router: &ZenohIdProto,
+        send_declare: &mut SendDeclare,
+    ) {
+        res_hat_mut!(res)
+            .router_tokens
+            .retain(|token| token != router);
+
+        if res_hat!(res).router_tokens.is_empty() {
+            hat_mut!(tables)
+                .router_tokens
+                .retain(|token| !Arc::ptr_eq(token, res));
+
+            if hat_mut!(tables).full_net(WhatAmI::Peer) {
+                self.undeclare_linkstatepeer_token(tables, None, res, &tables.zid.clone());
+            }
+            self.propagate_forget_simple_token(tables, res, face, send_declare);
+        }
+
+        self.propagate_forget_simple_token_to_peers(tables, res, send_declare);
+    }
+
+    fn undeclare_router_token(
+        &self,
+        tables: &mut Tables,
+        face: Option<&Arc<FaceState>>,
+        res: &mut Arc<Resource>,
+        router: &ZenohIdProto,
+        send_declare: &mut SendDeclare,
+    ) {
+        if res_hat!(res).router_tokens.contains(router) {
+            self.unregister_router_token(tables, face, res, router, send_declare);
+            self.propagate_forget_sourced_token(tables, res, face, router, WhatAmI::Router);
+        }
+    }
+
+    fn forget_router_token(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        res: &mut Arc<Resource>,
+        router: &ZenohIdProto,
+        send_declare: &mut SendDeclare,
+    ) {
+        self.undeclare_router_token(tables, Some(face), res, router, send_declare);
+    }
+
+    fn unregister_linkstatepeer_token(
+        &self,
+        tables: &mut Tables,
+        res: &mut Arc<Resource>,
+        peer: &ZenohIdProto,
+    ) {
+        res_hat_mut!(res)
+            .linkstatepeer_tokens
+            .retain(|token| token != peer);
+
+        if res_hat!(res).linkstatepeer_tokens.is_empty() {
+            hat_mut!(tables)
+                .linkstatepeer_tokens
+                .retain(|token| !Arc::ptr_eq(token, res));
+        }
+    }
+
+    fn undeclare_linkstatepeer_token(
+        &self,
+        tables: &mut Tables,
+        face: Option<&Arc<FaceState>>,
+        res: &mut Arc<Resource>,
+        peer: &ZenohIdProto,
+    ) {
+        if res_hat!(res).linkstatepeer_tokens.contains(peer) {
+            self.unregister_linkstatepeer_token(tables, res, peer);
+            self.propagate_forget_sourced_token(tables, res, face, peer, WhatAmI::Peer);
+        }
+    }
+
+    fn forget_linkstatepeer_token(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        res: &mut Arc<Resource>,
+        peer: &ZenohIdProto,
+        send_declare: &mut SendDeclare,
+    ) {
+        self.undeclare_linkstatepeer_token(tables, Some(face), res, peer);
+        let simple_tokens = res.session_ctxs.values().any(|ctx| ctx.token);
+        let linkstatepeer_tokens = self.remote_linkstatepeer_tokens(tables, res);
+        let zid = tables.zid;
+        if !simple_tokens && !linkstatepeer_tokens {
+            self.undeclare_router_token(tables, None, res, &zid, send_declare);
+        }
+    }
+
+    pub(super) fn undeclare_simple_token(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        res: &mut Arc<Resource>,
+        send_declare: &mut SendDeclare,
+    ) {
+        if !face_hat_mut!(face)
+            .remote_tokens
             .values()
-            .cloned()
-            .collect::<Vec<Arc<FaceState>>>()
+            .any(|s| *s == *res)
         {
-            if face.whatami == WhatAmI::Peer
-                && face_hat!(face).local_tokens.contains_key(res)
-                && !res.session_ctxs.values().any(|s| {
-                    face.zid != s.face.zid
-                        && s.token
-                        && (s.face.whatami == WhatAmI::Client
-                            || (s.face.whatami == WhatAmI::Peer
-                                && hat!(tables).failover_brokering(s.face.zid, face.zid)))
-                })
-            {
-                if let Some(id) = face_hat_mut!(&mut face).local_tokens.remove(res) {
-                    send_declare(
-                        &face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id: None,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::UndeclareToken(UndeclareToken {
-                                    id,
-                                    ext_wire_expr: WireExprType::null(),
-                                }),
-                            },
-                            res.expr().to_string(),
-                        ),
-                    );
-                }
+            if let Some(ctx) = get_mut_unchecked(res).session_ctxs.get_mut(&face.id) {
+                get_mut_unchecked(ctx).token = false;
             }
-        }
-    }
-}
 
-fn propagate_forget_sourced_token(
-    tables: &Tables,
-    res: &Arc<Resource>,
-    src_face: Option<&Arc<FaceState>>,
-    source: &ZenohIdProto,
-    net_type: WhatAmI,
-) {
-    let net = hat!(tables).get_net(net_type).unwrap();
-    match net.get_idx(source) {
-        Some(tree_sid) => {
-            if net.trees.len() > tree_sid.index() {
-                send_forget_sourced_token_to_net_clildren(
+            let mut simple_tokens = self.simple_tokens(res);
+            let router_tokens = self.remote_router_tokens(tables, res);
+            let linkstatepeer_tokens = self.remote_linkstatepeer_tokens(tables, res);
+            if simple_tokens.is_empty() && !linkstatepeer_tokens {
+                self.undeclare_router_token(
                     tables,
-                    net,
-                    &net.trees[tree_sid.index()].children,
+                    Some(face),
                     res,
-                    src_face,
-                    Some(tree_sid.index() as NodeId),
+                    &tables.zid.clone(),
+                    send_declare,
                 );
             } else {
-                tracing::trace!(
-                    "Propagating forget token {}: tree for node {} sid:{} not yet ready",
-                    res.expr(),
-                    tree_sid.index(),
-                    source
-                );
+                self.propagate_forget_simple_token_to_peers(tables, res, send_declare);
+            }
+
+            if simple_tokens.len() == 1 && !router_tokens && !linkstatepeer_tokens {
+                let mut face = &mut simple_tokens[0];
+                if face.whatami != WhatAmI::Client {
+                    if let Some(id) = face_hat_mut!(face).local_tokens.remove(res) {
+                        send_declare(
+                            &face.primitives,
+                            RoutingContext::with_expr(
+                                Declare {
+                                    interest_id: None,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType::DEFAULT,
+                                    body: DeclareBody::UndeclareToken(UndeclareToken {
+                                        id,
+                                        ext_wire_expr: WireExprType::null(),
+                                    }),
+                                },
+                                res.expr().to_string(),
+                            ),
+                        );
+                    }
+                    for res in face_hat!(face)
+                        .local_tokens
+                        .keys()
+                        .cloned()
+                        .collect::<Vec<Arc<Resource>>>()
+                    {
+                        if !res.context().matches.iter().any(|m| {
+                            m.upgrade().is_some_and(|m| {
+                                m.context.is_some()
+                                    && (self.remote_simple_tokens(tables, &m, face)
+                                        || self.remote_linkstatepeer_tokens(tables, &m)
+                                        || self.remote_router_tokens(tables, &m))
+                            })
+                        }) {
+                            if let Some(id) = face_hat_mut!(&mut face).local_tokens.remove(&res) {
+                                send_declare(
+                                    &face.primitives,
+                                    RoutingContext::with_expr(
+                                        Declare {
+                                            interest_id: None,
+                                            ext_qos: ext::QoSType::DECLARE,
+                                            ext_tstamp: None,
+                                            ext_nodeid: ext::NodeIdType::DEFAULT,
+                                            body: DeclareBody::UndeclareToken(UndeclareToken {
+                                                id,
+                                                ext_wire_expr: WireExprType::null(),
+                                            }),
+                                        },
+                                        res.expr().to_string(),
+                                    ),
+                                );
+                            }
+                        }
+                    }
+                }
             }
         }
-        None => tracing::error!(
-            "Error propagating forget token {}: cannot get index of {}!",
-            res.expr(),
-            source
-        ),
-    }
-}
-
-fn unregister_router_token(
-    tables: &mut Tables,
-    face: Option<&Arc<FaceState>>,
-    res: &mut Arc<Resource>,
-    router: &ZenohIdProto,
-    send_declare: &mut SendDeclare,
-) {
-    res_hat_mut!(res)
-        .router_tokens
-        .retain(|token| token != router);
-
-    if res_hat!(res).router_tokens.is_empty() {
-        hat_mut!(tables)
-            .router_tokens
-            .retain(|token| !Arc::ptr_eq(token, res));
-
-        if hat_mut!(tables).full_net(WhatAmI::Peer) {
-            undeclare_linkstatepeer_token(tables, None, res, &tables.zid.clone());
-        }
-        propagate_forget_simple_token(tables, res, face, send_declare);
     }
 
-    propagate_forget_simple_token_to_peers(tables, res, send_declare);
-}
-
-fn undeclare_router_token(
-    tables: &mut Tables,
-    face: Option<&Arc<FaceState>>,
-    res: &mut Arc<Resource>,
-    router: &ZenohIdProto,
-    send_declare: &mut SendDeclare,
-) {
-    if res_hat!(res).router_tokens.contains(router) {
-        unregister_router_token(tables, face, res, router, send_declare);
-        propagate_forget_sourced_token(tables, res, face, router, WhatAmI::Router);
-    }
-}
-
-fn forget_router_token(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    res: &mut Arc<Resource>,
-    router: &ZenohIdProto,
-    send_declare: &mut SendDeclare,
-) {
-    undeclare_router_token(tables, Some(face), res, router, send_declare);
-}
-
-fn unregister_linkstatepeer_token(
-    tables: &mut Tables,
-    res: &mut Arc<Resource>,
-    peer: &ZenohIdProto,
-) {
-    res_hat_mut!(res)
-        .linkstatepeer_tokens
-        .retain(|token| token != peer);
-
-    if res_hat!(res).linkstatepeer_tokens.is_empty() {
-        hat_mut!(tables)
-            .linkstatepeer_tokens
-            .retain(|token| !Arc::ptr_eq(token, res));
-    }
-}
-
-fn undeclare_linkstatepeer_token(
-    tables: &mut Tables,
-    face: Option<&Arc<FaceState>>,
-    res: &mut Arc<Resource>,
-    peer: &ZenohIdProto,
-) {
-    if res_hat!(res).linkstatepeer_tokens.contains(peer) {
-        unregister_linkstatepeer_token(tables, res, peer);
-        propagate_forget_sourced_token(tables, res, face, peer, WhatAmI::Peer);
-    }
-}
-
-fn forget_linkstatepeer_token(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    res: &mut Arc<Resource>,
-    peer: &ZenohIdProto,
-    send_declare: &mut SendDeclare,
-) {
-    undeclare_linkstatepeer_token(tables, Some(face), res, peer);
-    let simple_tokens = res.session_ctxs.values().any(|ctx| ctx.token);
-    let linkstatepeer_tokens = remote_linkstatepeer_tokens(tables, res);
-    let zid = tables.zid;
-    if !simple_tokens && !linkstatepeer_tokens {
-        undeclare_router_token(tables, None, res, &zid, send_declare);
-    }
-}
-
-pub(super) fn undeclare_simple_token(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    res: &mut Arc<Resource>,
-    send_declare: &mut SendDeclare,
-) {
-    if !face_hat_mut!(face)
-        .remote_tokens
-        .values()
-        .any(|s| *s == *res)
-    {
-        if let Some(ctx) = get_mut_unchecked(res).session_ctxs.get_mut(&face.id) {
-            get_mut_unchecked(ctx).token = false;
-        }
-
-        let mut simple_tokens = simple_tokens(res);
-        let router_tokens = remote_router_tokens(tables, res);
-        let linkstatepeer_tokens = remote_linkstatepeer_tokens(tables, res);
-        if simple_tokens.is_empty() && !linkstatepeer_tokens {
-            undeclare_router_token(tables, Some(face), res, &tables.zid.clone(), send_declare);
+    fn forget_simple_token(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        id: TokenId,
+        send_declare: &mut SendDeclare,
+    ) -> Option<Arc<Resource>> {
+        if let Some(mut res) = face_hat_mut!(face).remote_tokens.remove(&id) {
+            self.undeclare_simple_token(tables, face, &mut res, send_declare);
+            Some(res)
         } else {
-            propagate_forget_simple_token_to_peers(tables, res, send_declare);
+            None
         }
+    }
 
-        if simple_tokens.len() == 1 && !router_tokens && !linkstatepeer_tokens {
-            let mut face = &mut simple_tokens[0];
-            if face.whatami != WhatAmI::Client {
-                if let Some(id) = face_hat_mut!(face).local_tokens.remove(res) {
-                    send_declare(
-                        &face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id: None,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::UndeclareToken(UndeclareToken {
-                                    id,
-                                    ext_wire_expr: WireExprType::null(),
-                                }),
-                            },
-                            res.expr().to_string(),
-                        ),
-                    );
-                }
-                for res in face_hat!(face)
-                    .local_tokens
-                    .keys()
+    pub(super) fn token_remove_node(
+        &self,
+        tables: &mut Tables,
+        node: &ZenohIdProto,
+        net_type: WhatAmI,
+        send_declare: &mut SendDeclare,
+    ) {
+        match net_type {
+            WhatAmI::Router => {
+                for mut res in hat!(tables)
+                    .router_tokens
+                    .iter()
+                    .filter(|res| res_hat!(res).router_tokens.contains(node))
                     .cloned()
                     .collect::<Vec<Arc<Resource>>>()
                 {
-                    if !res.context().matches.iter().any(|m| {
-                        m.upgrade().is_some_and(|m| {
-                            m.context.is_some()
-                                && (remote_simple_tokens(tables, &m, face)
-                                    || remote_linkstatepeer_tokens(tables, &m)
-                                    || remote_router_tokens(tables, &m))
-                        })
+                    self.unregister_router_token(tables, None, &mut res, node, send_declare);
+                    Resource::clean(&mut res)
+                }
+            }
+            WhatAmI::Peer => {
+                for mut res in hat!(tables)
+                    .linkstatepeer_tokens
+                    .iter()
+                    .filter(|res| res_hat!(res).linkstatepeer_tokens.contains(node))
+                    .cloned()
+                    .collect::<Vec<Arc<Resource>>>()
+                {
+                    self.unregister_linkstatepeer_token(tables, &mut res, node);
+                    let simple_tokens = res.session_ctxs.values().any(|ctx| ctx.token);
+                    let linkstatepeer_tokens = self.remote_linkstatepeer_tokens(tables, &res);
+                    if !simple_tokens && !linkstatepeer_tokens {
+                        self.undeclare_router_token(
+                            tables,
+                            None,
+                            &mut res,
+                            &tables.zid.clone(),
+                            send_declare,
+                        );
+                    }
+                    Resource::clean(&mut res)
+                }
+            }
+            _ => (),
+        }
+    }
+
+    pub(super) fn token_tree_change(
+        &self,
+        tables: &mut Tables,
+        new_clildren: &[Vec<NodeIndex>],
+        net_type: WhatAmI,
+    ) {
+        let net = match hat!(tables).get_net(net_type) {
+            Some(net) => net,
+            None => {
+                tracing::error!("Error accessing net in token_tree_change!");
+                return;
+            }
+        };
+        // propagate tokens to new clildren
+        for (tree_sid, tree_clildren) in new_clildren.iter().enumerate() {
+            if !tree_clildren.is_empty() {
+                let tree_idx = NodeIndex::new(tree_sid);
+                if net.graph.contains_node(tree_idx) {
+                    let tree_id = net.graph[tree_idx].zid;
+
+                    let tokens_res = match net_type {
+                        WhatAmI::Router => &hat!(tables).router_tokens,
+                        _ => &hat!(tables).linkstatepeer_tokens,
+                    };
+
+                    for res in tokens_res {
+                        let tokens = match net_type {
+                            WhatAmI::Router => &res_hat!(res).router_tokens,
+                            _ => &res_hat!(res).linkstatepeer_tokens,
+                        };
+                        for token in tokens {
+                            if *token == tree_id {
+                                self.send_sourced_token_to_net_clildren(
+                                    tables,
+                                    net,
+                                    tree_clildren,
+                                    res,
+                                    None,
+                                    tree_sid as NodeId,
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub(super) fn token_linkstate_change(
+        &self,
+        tables: &mut Tables,
+        zid: &ZenohIdProto,
+        links: &HashMap<ZenohIdProto, LinkEdgeWeight>,
+        send_declare: &mut SendDeclare,
+    ) {
+        if let Some(mut src_face) = tables.get_face(zid).cloned() {
+            if hat!(tables).router_peers_failover_brokering && src_face.whatami == WhatAmI::Peer {
+                let to_forget = face_hat!(src_face)
+                    .local_tokens
+                    .keys()
+                    .filter(|res| {
+                        let client_tokens = res
+                            .session_ctxs
+                            .values()
+                            .any(|ctx| ctx.face.whatami == WhatAmI::Client && ctx.token);
+                        !self.remote_router_tokens(tables, res)
+                            && !client_tokens
+                            && !res.session_ctxs.values().any(|ctx| {
+                                ctx.face.whatami == WhatAmI::Peer
+                                    && src_face.id != ctx.face.id
+                                    && HatTables::failover_brokering_to(links, &ctx.face.zid)
+                            })
+                    })
+                    .cloned()
+                    .collect::<Vec<Arc<Resource>>>();
+                for res in to_forget {
+                    if let Some(id) = face_hat_mut!(&mut src_face).local_tokens.remove(&res) {
+                        let wire_expr = Resource::get_best_key(&res, "", src_face.id);
+                        send_declare(
+                            &src_face.primitives,
+                            RoutingContext::with_expr(
+                                Declare {
+                                    interest_id: None,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType::default(),
+                                    body: DeclareBody::UndeclareToken(UndeclareToken {
+                                        id,
+                                        ext_wire_expr: WireExprType { wire_expr },
+                                    }),
+                                },
+                                res.expr().to_string(),
+                            ),
+                        );
+                    }
+                }
+
+                for mut dst_face in tables.faces.values().cloned() {
+                    if src_face.id != dst_face.id
+                        && HatTables::failover_brokering_to(links, &dst_face.zid)
+                    {
+                        for res in face_hat!(src_face).remote_tokens.values() {
+                            if !face_hat!(dst_face).local_tokens.contains_key(res) {
+                                let id = face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst);
+                                face_hat_mut!(&mut dst_face)
+                                    .local_tokens
+                                    .insert(res.clone(), id);
+                                let push_declaration = push_declaration_profile(tables, &dst_face);
+                                let key_expr =
+                                    Resource::decl_key(res, &mut dst_face, push_declaration);
+                                send_declare(
+                                    &dst_face.primitives,
+                                    RoutingContext::with_expr(
+                                        Declare {
+                                            interest_id: None,
+                                            ext_qos: ext::QoSType::DECLARE,
+                                            ext_tstamp: None,
+                                            ext_nodeid: ext::NodeIdType::default(),
+                                            body: DeclareBody::DeclareToken(DeclareToken {
+                                                id,
+                                                wire_expr: key_expr,
+                                            }),
+                                        },
+                                        res.expr().to_string(),
+                                    ),
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[inline]
+    fn make_token_id(
+        &self,
+        res: &Arc<Resource>,
+        face: &mut Arc<FaceState>,
+        mode: InterestMode,
+    ) -> u32 {
+        if mode.future() {
+            if let Some(id) = face_hat!(face).local_tokens.get(res) {
+                *id
+            } else {
+                let id = face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst);
+                face_hat_mut!(face).local_tokens.insert(res.clone(), id);
+                id
+            }
+        } else {
+            0
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn declare_token_interest(
+        &self,
+        tables: &mut Tables,
+        face: &mut Arc<FaceState>,
+        id: InterestId,
+        res: Option<&mut Arc<Resource>>,
+        mode: InterestMode,
+        aggregate: bool,
+        send_declare: &mut SendDeclare,
+    ) {
+        if mode.current()
+            && (face.whatami == WhatAmI::Client
+                || (face.whatami == WhatAmI::Peer && !hat!(tables).full_net(WhatAmI::Peer)))
+        {
+            let interest_id = Some(id);
+            if let Some(res) = res.as_ref() {
+                if aggregate {
+                    if hat!(tables).router_tokens.iter().any(|token| {
+                        token.context.is_some()
+                            && token.matches(res)
+                            && (self.remote_simple_tokens(tables, token, face)
+                                || self.remote_linkstatepeer_tokens(tables, token)
+                                || self.remote_router_tokens(tables, token))
                     }) {
-                        if let Some(id) = face_hat_mut!(&mut face).local_tokens.remove(&res) {
+                        let id = self.make_token_id(res, face, mode);
+                        let wire_expr =
+                            Resource::decl_key(res, face, push_declaration_profile(tables, face));
+                        send_declare(
+                            &face.primitives,
+                            RoutingContext::with_expr(
+                                Declare {
+                                    interest_id,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType::DEFAULT,
+                                    body: DeclareBody::DeclareToken(DeclareToken { id, wire_expr }),
+                                },
+                                res.expr().to_string(),
+                            ),
+                        );
+                    }
+                } else {
+                    for token in &hat!(tables).router_tokens {
+                        if token.context.is_some()
+                            && token.matches(res)
+                            && (res_hat!(token)
+                                .router_tokens
+                                .iter()
+                                .any(|r| *r != tables.zid)
+                                || res_hat!(token)
+                                    .linkstatepeer_tokens
+                                    .iter()
+                                    .any(|r| *r != tables.zid)
+                                || token.session_ctxs.values().any(|s| {
+                                    s.face.id != face.id
+                                        && s.token
+                                        && (s.face.whatami == WhatAmI::Client
+                                            || face.whatami == WhatAmI::Client
+                                            || (s.face.whatami == WhatAmI::Peer
+                                                && hat!(tables)
+                                                    .failover_brokering(s.face.zid, face.zid)))
+                                }))
+                        {
+                            let id = self.make_token_id(token, face, mode);
+                            let wire_expr = Resource::decl_key(
+                                token,
+                                face,
+                                push_declaration_profile(tables, face),
+                            );
                             send_declare(
                                 &face.primitives,
                                 RoutingContext::with_expr(
                                     Declare {
-                                        interest_id: None,
+                                        interest_id,
                                         ext_qos: ext::QoSType::DECLARE,
                                         ext_tstamp: None,
                                         ext_nodeid: ext::NodeIdType::DEFAULT,
-                                        body: DeclareBody::UndeclareToken(UndeclareToken {
-                                            id,
-                                            ext_wire_expr: WireExprType::null(),
-                                        }),
-                                    },
-                                    res.expr().to_string(),
-                                ),
-                            );
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-fn forget_simple_token(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    id: TokenId,
-    send_declare: &mut SendDeclare,
-) -> Option<Arc<Resource>> {
-    if let Some(mut res) = face_hat_mut!(face).remote_tokens.remove(&id) {
-        undeclare_simple_token(tables, face, &mut res, send_declare);
-        Some(res)
-    } else {
-        None
-    }
-}
-
-pub(super) fn token_remove_node(
-    tables: &mut Tables,
-    node: &ZenohIdProto,
-    net_type: WhatAmI,
-    send_declare: &mut SendDeclare,
-) {
-    match net_type {
-        WhatAmI::Router => {
-            for mut res in hat!(tables)
-                .router_tokens
-                .iter()
-                .filter(|res| res_hat!(res).router_tokens.contains(node))
-                .cloned()
-                .collect::<Vec<Arc<Resource>>>()
-            {
-                unregister_router_token(tables, None, &mut res, node, send_declare);
-                Resource::clean(&mut res)
-            }
-        }
-        WhatAmI::Peer => {
-            for mut res in hat!(tables)
-                .linkstatepeer_tokens
-                .iter()
-                .filter(|res| res_hat!(res).linkstatepeer_tokens.contains(node))
-                .cloned()
-                .collect::<Vec<Arc<Resource>>>()
-            {
-                unregister_linkstatepeer_token(tables, &mut res, node);
-                let simple_tokens = res.session_ctxs.values().any(|ctx| ctx.token);
-                let linkstatepeer_tokens = remote_linkstatepeer_tokens(tables, &res);
-                if !simple_tokens && !linkstatepeer_tokens {
-                    undeclare_router_token(
-                        tables,
-                        None,
-                        &mut res,
-                        &tables.zid.clone(),
-                        send_declare,
-                    );
-                }
-                Resource::clean(&mut res)
-            }
-        }
-        _ => (),
-    }
-}
-
-pub(super) fn token_tree_change(
-    tables: &mut Tables,
-    new_clildren: &[Vec<NodeIndex>],
-    net_type: WhatAmI,
-) {
-    let net = match hat!(tables).get_net(net_type) {
-        Some(net) => net,
-        None => {
-            tracing::error!("Error accessing net in token_tree_change!");
-            return;
-        }
-    };
-    // propagate tokens to new clildren
-    for (tree_sid, tree_clildren) in new_clildren.iter().enumerate() {
-        if !tree_clildren.is_empty() {
-            let tree_idx = NodeIndex::new(tree_sid);
-            if net.graph.contains_node(tree_idx) {
-                let tree_id = net.graph[tree_idx].zid;
-
-                let tokens_res = match net_type {
-                    WhatAmI::Router => &hat!(tables).router_tokens,
-                    _ => &hat!(tables).linkstatepeer_tokens,
-                };
-
-                for res in tokens_res {
-                    let tokens = match net_type {
-                        WhatAmI::Router => &res_hat!(res).router_tokens,
-                        _ => &res_hat!(res).linkstatepeer_tokens,
-                    };
-                    for token in tokens {
-                        if *token == tree_id {
-                            send_sourced_token_to_net_clildren(
-                                tables,
-                                net,
-                                tree_clildren,
-                                res,
-                                None,
-                                tree_sid as NodeId,
-                            );
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-pub(super) fn token_linkstate_change(
-    tables: &mut Tables,
-    zid: &ZenohIdProto,
-    links: &HashMap<ZenohIdProto, LinkEdgeWeight>,
-    send_declare: &mut SendDeclare,
-) {
-    if let Some(mut src_face) = tables.get_face(zid).cloned() {
-        if hat!(tables).router_peers_failover_brokering && src_face.whatami == WhatAmI::Peer {
-            let to_forget = face_hat!(src_face)
-                .local_tokens
-                .keys()
-                .filter(|res| {
-                    let client_tokens = res
-                        .session_ctxs
-                        .values()
-                        .any(|ctx| ctx.face.whatami == WhatAmI::Client && ctx.token);
-                    !remote_router_tokens(tables, res)
-                        && !client_tokens
-                        && !res.session_ctxs.values().any(|ctx| {
-                            ctx.face.whatami == WhatAmI::Peer
-                                && src_face.id != ctx.face.id
-                                && HatTables::failover_brokering_to(links, &ctx.face.zid)
-                        })
-                })
-                .cloned()
-                .collect::<Vec<Arc<Resource>>>();
-            for res in to_forget {
-                if let Some(id) = face_hat_mut!(&mut src_face).local_tokens.remove(&res) {
-                    let wire_expr = Resource::get_best_key(&res, "", src_face.id);
-                    send_declare(
-                        &src_face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id: None,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::default(),
-                                body: DeclareBody::UndeclareToken(UndeclareToken {
-                                    id,
-                                    ext_wire_expr: WireExprType { wire_expr },
-                                }),
-                            },
-                            res.expr().to_string(),
-                        ),
-                    );
-                }
-            }
-
-            for mut dst_face in tables.faces.values().cloned() {
-                if src_face.id != dst_face.id
-                    && HatTables::failover_brokering_to(links, &dst_face.zid)
-                {
-                    for res in face_hat!(src_face).remote_tokens.values() {
-                        if !face_hat!(dst_face).local_tokens.contains_key(res) {
-                            let id = face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst);
-                            face_hat_mut!(&mut dst_face)
-                                .local_tokens
-                                .insert(res.clone(), id);
-                            let push_declaration = push_declaration_profile(tables, &dst_face);
-                            let key_expr = Resource::decl_key(res, &mut dst_face, push_declaration);
-                            send_declare(
-                                &dst_face.primitives,
-                                RoutingContext::with_expr(
-                                    Declare {
-                                        interest_id: None,
-                                        ext_qos: ext::QoSType::DECLARE,
-                                        ext_tstamp: None,
-                                        ext_nodeid: ext::NodeIdType::default(),
                                         body: DeclareBody::DeclareToken(DeclareToken {
                                             id,
-                                            wire_expr: key_expr,
+                                            wire_expr,
                                         }),
                                     },
-                                    res.expr().to_string(),
+                                    token.expr().to_string(),
                                 ),
                             );
                         }
                     }
-                }
-            }
-        }
-    }
-}
-
-#[inline]
-fn make_token_id(res: &Arc<Resource>, face: &mut Arc<FaceState>, mode: InterestMode) -> u32 {
-    if mode.future() {
-        if let Some(id) = face_hat!(face).local_tokens.get(res) {
-            *id
-        } else {
-            let id = face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst);
-            face_hat_mut!(face).local_tokens.insert(res.clone(), id);
-            id
-        }
-    } else {
-        0
-    }
-}
-
-pub(crate) fn declare_token_interest(
-    tables: &mut Tables,
-    face: &mut Arc<FaceState>,
-    id: InterestId,
-    res: Option<&mut Arc<Resource>>,
-    mode: InterestMode,
-    aggregate: bool,
-    send_declare: &mut SendDeclare,
-) {
-    if mode.current()
-        && (face.whatami == WhatAmI::Client
-            || (face.whatami == WhatAmI::Peer && !hat!(tables).full_net(WhatAmI::Peer)))
-    {
-        let interest_id = Some(id);
-        if let Some(res) = res.as_ref() {
-            if aggregate {
-                if hat!(tables).router_tokens.iter().any(|token| {
-                    token.context.is_some()
-                        && token.matches(res)
-                        && (remote_simple_tokens(tables, token, face)
-                            || remote_linkstatepeer_tokens(tables, token)
-                            || remote_router_tokens(tables, token))
-                }) {
-                    let id = make_token_id(res, face, mode);
-                    let wire_expr =
-                        Resource::decl_key(res, face, push_declaration_profile(tables, face));
-                    send_declare(
-                        &face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::DeclareToken(DeclareToken { id, wire_expr }),
-                            },
-                            res.expr().to_string(),
-                        ),
-                    );
                 }
             } else {
                 for token in &hat!(tables).router_tokens {
                     if token.context.is_some()
-                        && token.matches(res)
                         && (res_hat!(token)
                             .router_tokens
                             .iter()
@@ -1042,16 +1141,13 @@ pub(crate) fn declare_token_interest(
                                 .iter()
                                 .any(|r| *r != tables.zid)
                             || token.session_ctxs.values().any(|s| {
-                                s.face.id != face.id
-                                    && s.token
-                                    && (s.face.whatami == WhatAmI::Client
-                                        || face.whatami == WhatAmI::Client
-                                        || (s.face.whatami == WhatAmI::Peer
-                                            && hat!(tables)
-                                                .failover_brokering(s.face.zid, face.zid)))
+                                s.token
+                                    && (s.face.whatami != WhatAmI::Peer
+                                        || face.whatami != WhatAmI::Peer
+                                        || hat!(tables).failover_brokering(s.face.zid, face.zid))
                             }))
                     {
-                        let id = make_token_id(token, face, mode);
+                        let id = self.make_token_id(token, face, mode);
                         let wire_expr =
                             Resource::decl_key(token, face, push_declaration_profile(tables, face));
                         send_declare(
@@ -1068,42 +1164,6 @@ pub(crate) fn declare_token_interest(
                             ),
                         );
                     }
-                }
-            }
-        } else {
-            for token in &hat!(tables).router_tokens {
-                if token.context.is_some()
-                    && (res_hat!(token)
-                        .router_tokens
-                        .iter()
-                        .any(|r| *r != tables.zid)
-                        || res_hat!(token)
-                            .linkstatepeer_tokens
-                            .iter()
-                            .any(|r| *r != tables.zid)
-                        || token.session_ctxs.values().any(|s| {
-                            s.token
-                                && (s.face.whatami != WhatAmI::Peer
-                                    || face.whatami != WhatAmI::Peer
-                                    || hat!(tables).failover_brokering(s.face.zid, face.zid))
-                        }))
-                {
-                    let id = make_token_id(token, face, mode);
-                    let wire_expr =
-                        Resource::decl_key(token, face, push_declaration_profile(tables, face));
-                    send_declare(
-                        &face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::DeclareToken(DeclareToken { id, wire_expr }),
-                            },
-                            token.expr().to_string(),
-                        ),
-                    );
                 }
             }
         }
@@ -1124,19 +1184,19 @@ impl HatTokenTrait for HatCode {
         match face.whatami {
             WhatAmI::Router => {
                 if let Some(router) = get_router(tables, face, node_id) {
-                    declare_router_token(tables, face, res, router, send_declare)
+                    self.declare_router_token(tables, face, res, router, send_declare)
                 }
             }
             WhatAmI::Peer => {
                 if hat!(tables).full_net(WhatAmI::Peer) {
                     if let Some(peer) = get_peer(tables, face, node_id) {
-                        declare_linkstatepeer_token(tables, face, res, peer, send_declare)
+                        self.declare_linkstatepeer_token(tables, face, res, peer, send_declare)
                     }
                 } else {
-                    declare_simple_token(tables, face, id, res, send_declare)
+                    self.declare_simple_token(tables, face, id, res, send_declare)
                 }
             }
-            _ => declare_simple_token(tables, face, id, res, send_declare),
+            _ => self.declare_simple_token(tables, face, id, res, send_declare),
         }
     }
 
@@ -1153,7 +1213,7 @@ impl HatTokenTrait for HatCode {
             WhatAmI::Router => {
                 if let Some(mut res) = res {
                     if let Some(router) = get_router(tables, face, node_id) {
-                        forget_router_token(tables, face, &mut res, &router, send_declare);
+                        self.forget_router_token(tables, face, &mut res, &router, send_declare);
                         Some(res)
                     } else {
                         None
@@ -1166,7 +1226,13 @@ impl HatTokenTrait for HatCode {
                 if hat!(tables).full_net(WhatAmI::Peer) {
                     if let Some(mut res) = res {
                         if let Some(peer) = get_peer(tables, face, node_id) {
-                            forget_linkstatepeer_token(tables, face, &mut res, &peer, send_declare);
+                            self.forget_linkstatepeer_token(
+                                tables,
+                                face,
+                                &mut res,
+                                &peer,
+                                send_declare,
+                            );
                             Some(res)
                         } else {
                             None
@@ -1175,10 +1241,10 @@ impl HatTokenTrait for HatCode {
                         None
                     }
                 } else {
-                    forget_simple_token(tables, face, id, send_declare)
+                    self.forget_simple_token(tables, face, id, send_declare)
                 }
             }
-            _ => forget_simple_token(tables, face, id, send_declare),
+            _ => self.forget_simple_token(tables, face, id, send_declare),
         }
     }
 }


### PR DESCRIPTION
`HatCode` strucs are currently empty, which makes it hard to introduce multiple hats within a runtime router, as there is no way to distinguish hats.