### PR TITLE
Support QUIC unreliable datagrams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "cipher 0.4.4",
  "cpufeatures",
 ]
@@ -98,7 +98,7 @@ version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "getrandom 0.2.15",
  "once_cell",
  "serde",
@@ -347,7 +347,7 @@ checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
 dependencies = [
  "async-lock 2.8.0",
  "autocfg",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "concurrent-queue",
  "futures-lite 1.13.0",
  "log",
@@ -366,7 +366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "444b0228950ee6501b3568d3c93bf1176a1fdbc3b758dcd9475046d30f4dc7e8"
 dependencies = [
  "async-lock 3.4.0",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "concurrent-queue",
  "futures-io",
  "futures-lite 2.3.0",
@@ -410,7 +410,7 @@ dependencies = [
  "async-signal",
  "async-task",
  "blocking",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "event-listener 5.3.1",
  "futures-lite 2.3.0",
  "rustix 0.38.37",
@@ -447,7 +447,7 @@ dependencies = [
  "async-io 2.3.4",
  "async-lock 3.4.0",
  "atomic-waker",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "futures-core",
  "futures-io",
  "rustix 0.38.37",
@@ -533,7 +533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "libc",
  "miniz_oxide",
  "object",
@@ -738,9 +738,9 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfg_aliases"
@@ -1375,7 +1375,7 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc04871e5ae3aa2952d552dae6b291b3099723bf779a8054281c1366a54613ef"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "js-sys",
  "log",
  "serde",
@@ -1571,7 +1571,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -1582,7 +1582,7 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -1643,7 +1643,7 @@ version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "crunchy",
 ]
 
@@ -1753,7 +1753,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1947510dc91e2bf586ea5ffb412caad7673264e14bb39fb9078da114a94ce1a5"
 dependencies = [
  "async-trait",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "http-types",
  "log",
 ]
@@ -1874,7 +1874,7 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
 ]
 
 [[package]]
@@ -2079,7 +2079,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "windows-targets 0.52.6",
 ]
 
@@ -2256,7 +2256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "libc",
  "memoffset 0.7.1",
  "pin-utils",
@@ -2269,7 +2269,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
  "bitflags 2.6.0",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "libc",
  "memoffset 0.9.1",
 ]
@@ -2281,7 +2281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.6.0",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "cfg_aliases 0.2.1",
  "libc",
 ]
@@ -2527,7 +2527,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "instant",
  "libc",
  "redox_syscall 0.2.16",
@@ -2541,7 +2541,7 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "libc",
  "redox_syscall 0.5.4",
  "smallvec",
@@ -2804,7 +2804,7 @@ checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
 dependencies = [
  "autocfg",
  "bitflags 1.3.2",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "concurrent-queue",
  "libc",
  "log",
@@ -2818,7 +2818,7 @@ version = "3.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc2790cd301dec6cd3b7a025e4815cf825724a51c98dccfe6a3e55f05ffb6511"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "concurrent-queue",
  "hermit-abi 0.4.0",
  "pin-project-lite 0.2.14",
@@ -3189,7 +3189,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "getrandom 0.2.15",
  "libc",
  "untrusted",
@@ -3633,7 +3633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241ebb629ed9bf598b2b392ba42aa429f9ef2a0099001246a36ac4c084ee183f"
 dependencies = [
  "bitflags 2.6.0",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "core-foundation-sys",
  "io-kit-sys",
  "mach2",
@@ -3658,7 +3658,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "cpufeatures",
  "digest 0.10.7",
 ]
@@ -3676,7 +3676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
@@ -3688,7 +3688,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "cpufeatures",
  "digest 0.10.7",
 ]
@@ -4080,7 +4080,7 @@ version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "fastrand 2.1.1",
  "once_cell",
  "rustix 0.38.37",
@@ -4134,7 +4134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d3b04d33c9633b8662b167b847c7ab521f83d1ae20f2321b65b5b925e532e36"
 dependencies = [
  "bitflags 2.6.0",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "libc",
  "log",
  "rustversion",
@@ -4147,7 +4147,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "once_cell",
 ]
 
@@ -4333,7 +4333,7 @@ version = "5.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa6e2e4cf0520a99c5f87d5abb24172b5bd220de57c3181baaaa5440540c64aa"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "futures",
  "log",
  "mio-serial",
@@ -4783,7 +4783,7 @@ version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "once_cell",
  "serde",
  "serde_json",
@@ -4811,7 +4811,7 @@ version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -5206,6 +5206,7 @@ dependencies = [
  "zenoh-core",
  "zenoh-keyexpr",
  "zenoh-link",
+ "zenoh-link-commons",
  "zenoh-macros",
  "zenoh-plugin-trait",
  "zenoh-protocol",
@@ -5378,6 +5379,7 @@ dependencies = [
  "zenoh-config",
  "zenoh-link-commons",
  "zenoh-link-quic",
+ "zenoh-link-quic_datagram",
  "zenoh-link-serial",
  "zenoh-link-tcp",
  "zenoh-link-tls",
@@ -5395,18 +5397,26 @@ name = "zenoh-link-commons"
 version = "1.4.0"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "flume",
  "futures",
+ "quinn",
  "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
  "rustls-webpki",
+ "secrecy",
  "serde",
  "socket2 0.5.7",
  "time 0.3.36",
  "tokio",
  "tokio-util",
  "tracing",
+ "webpki-roots",
+ "x509-parser",
  "zenoh-buffers",
  "zenoh-codec",
+ "zenoh-config",
  "zenoh-core",
  "zenoh-protocol",
  "zenoh-result",
@@ -5423,7 +5433,6 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pemfile",
- "rustls-pki-types",
  "rustls-webpki",
  "secrecy",
  "time 0.3.36",
@@ -5431,8 +5440,26 @@ dependencies = [
  "tokio-util",
  "tracing",
  "webpki-roots",
- "x509-parser",
  "zenoh-config",
+ "zenoh-core",
+ "zenoh-link-commons",
+ "zenoh-protocol",
+ "zenoh-result",
+ "zenoh-util",
+]
+
+[[package]]
+name = "zenoh-link-quic_datagram"
+version = "1.4.0"
+dependencies = [
+ "async-trait",
+ "quinn",
+ "rustls",
+ "rustls-webpki",
+ "time 0.3.36",
+ "tokio",
+ "tokio-util",
+ "tracing",
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,44 +14,45 @@
 [workspace]
 resolver = "2"
 members = [
-  "commons/zenoh-buffers",
-  "commons/zenoh-codec",
-  "commons/zenoh-collections",
-  "commons/zenoh-config",
-  "commons/zenoh-core",
-  "commons/zenoh-crypto",
-  "commons/zenoh-keyexpr",
-  "commons/zenoh-macros",
-  "commons/zenoh-protocol",
-  "commons/zenoh-result",
-  "commons/zenoh-shm",
-  "commons/zenoh-sync",
-  "commons/zenoh-task",
-  "commons/zenoh-util",
-  "commons/zenoh-runtime",
-  "examples",
-  "io/zenoh-link",
-  "io/zenoh-link-commons",
-  "io/zenoh-links/zenoh-link-quic/",
-  "io/zenoh-links/zenoh-link-serial",
-  "io/zenoh-links/zenoh-link-tcp/",
-  "io/zenoh-links/zenoh-link-tls/",
-  "io/zenoh-links/zenoh-link-udp/",
-  "io/zenoh-links/zenoh-link-unixsock_stream/",
-  "io/zenoh-links/zenoh-link-ws/",
-  "io/zenoh-links/zenoh-link-unixpipe/",
-  "io/zenoh-links/zenoh-link-vsock/",
-  "io/zenoh-transport",
-  "plugins/zenoh-backend-example",
-  "plugins/zenoh-plugin-example",
-  "plugins/zenoh-backend-traits",
-  "plugins/zenoh-plugin-rest",
-  "plugins/zenoh-plugin-storage-manager",
-  "plugins/zenoh-plugin-trait",
-  "zenoh",
-  "zenoh-ext",
-  "zenoh-ext/examples",
-  "zenohd",
+    "commons/zenoh-buffers",
+    "commons/zenoh-codec",
+    "commons/zenoh-collections",
+    "commons/zenoh-config",
+    "commons/zenoh-core",
+    "commons/zenoh-crypto",
+    "commons/zenoh-keyexpr",
+    "commons/zenoh-macros",
+    "commons/zenoh-protocol",
+    "commons/zenoh-result",
+    "commons/zenoh-shm",
+    "commons/zenoh-sync",
+    "commons/zenoh-task",
+    "commons/zenoh-util",
+    "commons/zenoh-runtime",
+    "examples",
+    "io/zenoh-link",
+    "io/zenoh-link-commons",
+    "io/zenoh-links/zenoh-link-quic/",
+    "io/zenoh-links/zenoh-link-quic_datagram/",
+    "io/zenoh-links/zenoh-link-serial",
+    "io/zenoh-links/zenoh-link-tcp/",
+    "io/zenoh-links/zenoh-link-tls/",
+    "io/zenoh-links/zenoh-link-udp/",
+    "io/zenoh-links/zenoh-link-unixsock_stream/",
+    "io/zenoh-links/zenoh-link-ws/",
+    "io/zenoh-links/zenoh-link-unixpipe/",
+    "io/zenoh-links/zenoh-link-vsock/",
+    "io/zenoh-transport",
+    "plugins/zenoh-backend-example",
+    "plugins/zenoh-plugin-example",
+    "plugins/zenoh-backend-traits",
+    "plugins/zenoh-plugin-rest",
+    "plugins/zenoh-plugin-storage-manager",
+    "plugins/zenoh-plugin-trait",
+    "zenoh",
+    "zenoh-ext",
+    "zenoh-ext/examples",
+    "zenohd",
 ]
 exclude = ["ci/nostd-check", "ci/valgrind-check"]
 
@@ -61,11 +62,11 @@ version = "1.4.0"
 repository = "https://github.com/eclipse-zenoh/zenoh"
 homepage = "http://zenoh.io"
 authors = [
-  "kydos <angelo@icorsaro.net>",
-  "Julien Enoch <julien@enoch.fr>",
-  "Olivier Hécart <olivier.hecart@zettascale.tech>",
-  "Luca Cominardi <luca.cominardi@zettascale.tech>",
-  "Pierre Avital <pierre.avital@zettascale.tech>",
+    "kydos <angelo@icorsaro.net>",
+    "Julien Enoch <julien@enoch.fr>",
+    "Olivier Hécart <olivier.hecart@zettascale.tech>",
+    "Luca Cominardi <luca.cominardi@zettascale.tech>",
+    "Pierre Avital <pierre.avital@zettascale.tech>",
 ]
 edition = "2021"
 license = "EPL-2.0 OR Apache-2.0"
@@ -147,9 +148,9 @@ ringbuffer-spsc = "0.1.9"
 rsa = "0.9"
 rustc_version = "0.4.1"
 rustls = { version = "0.23.13", default-features = false, features = [
-  "logging",
-  "tls12",
-  "ring",
+    "logging",
+    "tls12",
+    "ring",
 ] }
 rustls-native-certs = "0.8.0"
 rustls-pemfile = "2.1.3"
@@ -158,7 +159,7 @@ rustls-pki-types = "1.8.0"
 schemars = { version = "0.8.21", features = ["either"] }
 secrecy = { version = "0.8.0", features = ["serde", "alloc"] }
 serde = { version = "1.0.210", default-features = false, features = [
-  "derive",
+    "derive",
 ] } # Default features are disabled due to usage in no_std crates
 serde_json = "1.0.128"
 serde_with = "3.12.0"
@@ -185,7 +186,7 @@ unzip-n = "0.1.2"
 url = "2.5.2"
 urlencoding = "2.1.3"
 uuid = { version = "1.10.0", default-features = false, features = [
-  "v4",
+    "v4",
 ] } # Default features are disabled due to usage in no_std crates
 validated_struct = "2.1.0"
 vec_map = "0.8.2"
@@ -197,7 +198,11 @@ z-serial = "0.3.1"
 either = "1.13.0"
 prost = "0.13.2"
 tls-listener = { version = "0.11.0", features = ["rustls-ring"] }
-windows-sys = { version = "0.59.0", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_System_IO"] }
+windows-sys = { version = "0.59.0", features = [
+    "Win32_Foundation",
+    "Win32_Networking_WinSock",
+    "Win32_System_IO",
+] }
 zenoh-ext = { version = "=1.4.0", path = "zenoh-ext", default-features = false }
 zenoh-shm = { version = "=1.4.0", path = "commons/zenoh-shm" }
 zenoh-result = { version = "=1.4.0", path = "commons/zenoh-result", default-features = false }
@@ -219,6 +224,7 @@ zenoh-link-tls = { version = "=1.4.0", path = "io/zenoh-links/zenoh-link-tls" }
 zenoh-link-tcp = { version = "=1.4.0", path = "io/zenoh-links/zenoh-link-tcp" }
 zenoh-link-unixsock_stream = { version = "=1.4.0", path = "io/zenoh-links/zenoh-link-unixsock_stream" }
 zenoh-link-quic = { version = "=1.4.0", path = "io/zenoh-links/zenoh-link-quic" }
+zenoh-link-quic_datagram = { version = "=1.4.0", path = "io/zenoh-links/zenoh-link-quic_datagram" }
 zenoh-link-udp = { version = "=1.4.0", path = "io/zenoh-links/zenoh-link-udp" }
 zenoh-link-ws = { version = "=1.4.0", path = "io/zenoh-links/zenoh-link-ws" }
 zenoh-link-unixpipe = { version = "=1.4.0", path = "io/zenoh-links/zenoh-link-unixpipe" }

--- a/commons/zenoh-protocol/src/core/parameters.rs
+++ b/commons/zenoh-protocol/src/core/parameters.rs
@@ -306,7 +306,7 @@ impl<'s> Parameters<'s> {
         item
     }
 
-    /// Removes a key from the map, returning the value at the key if the key was previously in the parameters.    
+    /// Removes a key from the map, returning the value at the key if the key was previously in the parameters.
     pub fn remove<K>(&mut self, k: K) -> Option<String>
     where
         K: Borrow<str>,

--- a/io/zenoh-link-commons/Cargo.toml
+++ b/io/zenoh-link-commons/Cargo.toml
@@ -27,27 +27,46 @@ version = { workspace = true }
 [features]
 compression = []
 tls = ["dep:rustls", "dep:rustls-webpki"]
+quic = [
+    "tls",
+    "dep:secrecy",
+    "dep:zenoh-config",
+    "dep:rustls-pemfile",
+    "dep:webpki-roots",
+    "dep:base64",
+    "dep:quinn",
+    "dep:rustls-pki-types",
+    "dep:x509-parser",
+]
 
 [dependencies]
 async-trait = { workspace = true }
+base64 = { workspace = true, optional = true }
 flume = { workspace = true }
 futures = { workspace = true }
+quinn = { workspace = true, optional = true }
 rustls = { workspace = true, optional = true }
+rustls-pemfile = { workspace = true, optional = true }
 rustls-webpki = { workspace = true, optional = true }
+rustls-pki-types = { workspace = true, optional = true }
 serde = { workspace = true, features = ["default"] }
+secrecy = { workspace = true, optional = true }
 socket2 = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true, features = [
-  "fs",
-  "io-util",
-  "net",
-  "sync",
-  "time",
+    "fs",
+    "io-util",
+    "net",
+    "sync",
+    "time",
 ] }
 tokio-util = { workspace = true, features = ["rt"] }
 tracing = { workspace = true }
+webpki-roots = { workspace = true, optional = true }
+x509-parser = { workspace = true, optional = true }
 zenoh-buffers = { workspace = true }
 zenoh-codec = { workspace = true }
+zenoh-config = { workspace = true, optional = true }
 zenoh-core = { workspace = true }
 zenoh-protocol = { workspace = true }
 zenoh-result = { workspace = true }

--- a/io/zenoh-link-commons/src/lib.rs
+++ b/io/zenoh-link-commons/src/lib.rs
@@ -22,6 +22,8 @@ extern crate alloc;
 mod dscp;
 mod listener;
 mod multicast;
+#[cfg(feature = "quic")]
+pub mod quic;
 pub mod tcp;
 #[cfg(feature = "tls")]
 pub mod tls;

--- a/io/zenoh-link-commons/src/tls.rs
+++ b/io/zenoh-link-commons/src/tls.rs
@@ -12,6 +12,41 @@ use rustls::{
 };
 use webpki::ALL_VERIFICATION_ALGS;
 
+pub mod config {
+    pub const TLS_ROOT_CA_CERTIFICATE_FILE: &str = "root_ca_certificate_file";
+    pub const TLS_ROOT_CA_CERTIFICATE_RAW: &str = "root_ca_certificate_raw";
+    pub const TLS_ROOT_CA_CERTIFICATE_BASE64: &str = "root_ca_certificate_base64";
+
+    pub const TLS_LISTEN_PRIVATE_KEY_FILE: &str = "listen_private_key_file";
+    pub const TLS_LISTEN_PRIVATE_KEY_RAW: &str = "listen_private_key_raw";
+    pub const TLS_LISTEN_PRIVATE_KEY_BASE64: &str = "listen_private_key_base64";
+
+    pub const TLS_LISTEN_CERTIFICATE_FILE: &str = "listen_certificate_file";
+    pub const TLS_LISTEN_CERTIFICATE_RAW: &str = "listen_certificate_raw";
+    pub const TLS_LISTEN_CERTIFICATE_BASE64: &str = "listen_certificate_base64";
+
+    pub const TLS_CONNECT_PRIVATE_KEY_FILE: &str = "connect_private_key_file";
+    pub const TLS_CONNECT_PRIVATE_KEY_RAW: &str = "connect_private_key_raw";
+    pub const TLS_CONNECT_PRIVATE_KEY_BASE64: &str = "connect_private_key_base64";
+
+    pub const TLS_CONNECT_CERTIFICATE_FILE: &str = "connect_certificate_file";
+    pub const TLS_CONNECT_CERTIFICATE_RAW: &str = "connect_certificate_raw";
+    pub const TLS_CONNECT_CERTIFICATE_BASE64: &str = "connect_certificate_base64";
+
+    pub const TLS_ENABLE_MTLS: &str = "enable_mtls";
+    pub const TLS_ENABLE_MTLS_DEFAULT: bool = false;
+
+    pub const TLS_VERIFY_NAME_ON_CONNECT: &str = "verify_name_on_connect";
+    pub const TLS_VERIFY_NAME_ON_CONNECT_DEFAULT: bool = true;
+
+    pub const TLS_CLOSE_LINK_ON_EXPIRATION: &str = "close_link_on_expiration";
+    pub const TLS_CLOSE_LINK_ON_EXPIRATION_DEFAULT: bool = false;
+
+    /// The time duration in milliseconds to wait for the TLS handshake to complete.
+    pub const TLS_HANDSHAKE_TIMEOUT_MS: &str = "tls_handshake_timeout_ms";
+    pub const TLS_HANDSHAKE_TIMEOUT_MS_DEFAULT: u64 = 10_000;
+}
+
 impl ServerCertVerifier for WebPkiVerifierAnyServerName {
     /// Will verify the certificate is valid in the following ways:
     /// - Signed by a  trusted `RootCertStore` CA

--- a/io/zenoh-link/Cargo.toml
+++ b/io/zenoh-link/Cargo.toml
@@ -26,19 +26,24 @@ description = "Internal crate for zenoh."
 
 [features]
 transport_quic = ["zenoh-link-quic"]
+transport_quic_datagram = ["zenoh-link-quic_datagram"]
 transport_tcp = ["zenoh-link-tcp", "zenoh-config/transport_tcp"]
 transport_tls = ["zenoh-link-tls"]
 transport_udp = ["zenoh-link-udp"]
 transport_unixsock-stream = ["zenoh-link-unixsock_stream"]
 transport_ws = ["zenoh-link-ws"]
 transport_serial = ["zenoh-link-serial"]
-transport_unixpipe = ["zenoh-link-unixpipe", "zenoh-link-unixpipe/transport_unixpipe"]
+transport_unixpipe = [
+    "zenoh-link-unixpipe",
+    "zenoh-link-unixpipe/transport_unixpipe",
+]
 transport_vsock = ["zenoh-link-vsock"]
 
 [dependencies]
 zenoh-config = { workspace = true }
 zenoh-link-commons = { workspace = true }
 zenoh-link-quic = { workspace = true, optional = true }
+zenoh-link-quic_datagram = { workspace = true, optional = true }
 zenoh-link-serial = { workspace = true, optional = true }
 zenoh-link-tcp = { workspace = true, optional = true }
 zenoh-link-tls = { workspace = true, optional = true }

--- a/io/zenoh-links/zenoh-link-quic/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/lib.rs
@@ -29,12 +29,8 @@ use zenoh_protocol::{
 use zenoh_result::ZResult;
 
 mod unicast;
-mod utils;
 pub use unicast::*;
-pub use utils::TlsConfigurator as QuicConfigurator;
-
-// Default ALPN protocol
-pub const ALPN_QUIC_HTTP: &[&[u8]] = &[b"hq-29"];
+pub use zenoh_link_commons::quic::TlsConfigurator as QuicConfigurator;
 
 // Default MTU (QUIC PDU) in bytes.
 // NOTE: Since QUIC is a byte-stream oriented transport, theoretically it has
@@ -85,35 +81,4 @@ zconfigurable! {
     // Amount of time in microseconds to throttle the accept loop upon an error.
     // Default set to 100 ms.
     static ref QUIC_ACCEPT_THROTTLE_TIME: u64 = 100_000;
-}
-
-pub mod config {
-    pub const TLS_ROOT_CA_CERTIFICATE_FILE: &str = "root_ca_certificate_file";
-    pub const TLS_ROOT_CA_CERTIFICATE_RAW: &str = "root_ca_certificate_raw";
-    pub const TLS_ROOT_CA_CERTIFICATE_BASE64: &str = "root_ca_certificate_base64";
-
-    pub const TLS_LISTEN_PRIVATE_KEY_FILE: &str = "listen_private_key_file";
-    pub const TLS_LISTEN_PRIVATE_KEY_RAW: &str = "listen_private_key_raw";
-    pub const TLS_LISTEN_PRIVATE_KEY_BASE64: &str = "listen_private_key_base64";
-
-    pub const TLS_LISTEN_CERTIFICATE_FILE: &str = "listen_certificate_file";
-    pub const TLS_LISTEN_CERTIFICATE_RAW: &str = "listen_certificate_raw";
-    pub const TLS_LISTEN_CERTIFICATE_BASE64: &str = "listen_certificate_base64";
-
-    pub const TLS_CONNECT_PRIVATE_KEY_FILE: &str = "connect_private_key_file";
-    pub const TLS_CONNECT_PRIVATE_KEY_RAW: &str = "connect_private_key_raw";
-    pub const TLS_CONNECT_PRIVATE_KEY_BASE64: &str = "connect_private_key_base64";
-
-    pub const TLS_CONNECT_CERTIFICATE_FILE: &str = "connect_certificate_file";
-    pub const TLS_CONNECT_CERTIFICATE_RAW: &str = "connect_certificate_raw";
-    pub const TLS_CONNECT_CERTIFICATE_BASE64: &str = "connect_certificate_base64";
-
-    pub const TLS_ENABLE_MTLS: &str = "enable_mtls";
-    pub const TLS_ENABLE_MTLS_DEFAULT: bool = false;
-
-    pub const TLS_VERIFY_NAME_ON_CONNECT: &str = "verify_name_on_connect";
-    pub const TLS_VERIFY_NAME_ON_CONNECT_DEFAULT: bool = true;
-
-    pub const TLS_CLOSE_LINK_ON_EXPIRATION: &str = "close_link_on_expiration";
-    pub const TLS_CLOSE_LINK_ON_EXPIRATION_DEFAULT: bool = false;
 }

--- a/io/zenoh-links/zenoh-link-quic_datagram/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-quic_datagram/Cargo.toml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 ZettaScale Technology
+# Copyright (c) 2025 ZettaScale Technology
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -18,7 +18,7 @@ description = "Internal crate for zenoh."
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
-name = "zenoh-link-quic"
+name = "zenoh-link-quic_datagram"
 repository = { workspace = true }
 rust-version = { workspace = true }
 version = { workspace = true }
@@ -26,12 +26,9 @@ version = { workspace = true }
 
 [dependencies]
 async-trait = { workspace = true }
-base64 = { workspace = true }
 quinn = { workspace = true }
 rustls = { workspace = true }
-rustls-pemfile = { workspace = true }
 rustls-webpki = { workspace = true }
-secrecy = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true, features = [
     "fs",
@@ -43,8 +40,6 @@ tokio = { workspace = true, features = [
 # tokio-rustls = { workspace = true }
 tokio-util = { workspace = true, features = ["rt"] }
 tracing = { workspace = true }
-webpki-roots = { workspace = true }
-zenoh-config = { workspace = true }
 zenoh-core = { workspace = true }
 zenoh-link-commons = { workspace = true, features = ["quic"] }
 zenoh-protocol = { workspace = true }

--- a/io/zenoh-links/zenoh-link-quic_datagram/README.md
+++ b/io/zenoh-links/zenoh-link-quic_datagram/README.md
@@ -1,0 +1,6 @@
+# ⚠️ WARNING ⚠️
+
+This crate is intended for Zenoh's internal use.
+
+- [Click here for Zenoh's main repository](https://github.com/eclipse-zenoh/zenoh)
+- [Click here for Zenoh's documentation](https://zenoh.io)

--- a/io/zenoh-links/zenoh-link-quic_datagram/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-quic_datagram/src/lib.rs
@@ -1,0 +1,119 @@
+//
+// Copyright (c) 2025 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+//! ⚠️ WARNING ⚠️
+//!
+//! This crate is intended for Zenoh's internal use.
+//!
+//! [Click here for Zenoh's documentation](https://docs.rs/zenoh/latest/zenoh)
+use std::{str::FromStr, sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use zenoh_core::{zconfigurable, zerror};
+use zenoh_link_commons::LocatorInspector;
+use zenoh_protocol::{
+    core::{Config, Locator, Metadata, Reliability},
+    transport::BatchSize,
+};
+use zenoh_result::ZResult;
+
+mod unicast;
+pub use unicast::*;
+pub use zenoh_link_commons::quic::TlsConfigurator as QuicDatagramConfigurator;
+
+pub const QUIC_DATAGRAM_LOCATOR_PREFIX: &str = "quic";
+
+// NOTE: this was copied from `zenoh-link-udp`
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+const QUIC_DATAGRAM_MAX_MTU: BatchSize = u16::MAX - 8 - 40;
+#[cfg(target_os = "macos")]
+const QUIC_DATAGRAM_MAX_MTU: BatchSize = 9_216;
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+const QUIC_DATAGRAM_MAX_MTU: BatchSize = 8_192;
+
+const IS_RELIABLE: bool = false;
+
+#[derive(Default, Clone, Copy, Debug)]
+pub struct QuicDatagramLocatorInspector;
+
+#[async_trait]
+impl LocatorInspector for QuicDatagramLocatorInspector {
+    fn protocol(&self) -> &str {
+        QUIC_DATAGRAM_LOCATOR_PREFIX
+    }
+
+    async fn is_multicast(&self, _locator: &Locator) -> ZResult<bool> {
+        Ok(false)
+    }
+
+    fn is_reliable(&self, locator: &Locator) -> ZResult<bool> {
+        if let Some(reliability) = locator
+            .metadata()
+            .get(Metadata::RELIABILITY)
+            .map(Reliability::from_str)
+            .transpose()?
+        {
+            Ok(reliability == Reliability::Reliable)
+        } else {
+            Ok(IS_RELIABLE)
+        }
+    }
+}
+
+zconfigurable! {
+    // Default MTU (QUIC PDU) in bytes.
+    static ref QUIC_DATAGRAM_DEFAULT_MTU: BatchSize = QUIC_DATAGRAM_MAX_MTU;
+    // The LINGER option causes the shutdown() call to block until (1) all application data is delivered
+    // to the remote end or (2) a timeout expires. The timeout is expressed in seconds.
+    // More info on the LINGER option and its dynamics can be found at:
+    // https://blog.netherlabs.nl/articles/2009/01/18/the-ultimate-so_linger-page-or-why-is-my-tcp-not-reliable
+    static ref QUIC_DATAGRAM_LINGER_TIMEOUT: i32 = 10;
+    // Amount of time in microseconds to throttle the accept loop upon an error.
+    // Default set to 100 ms.
+    static ref QUIC_DATAGRAM_ACCEPT_THROTTLE_TIME: u64 = 100_000;
+}
+
+pub(crate) fn set_mtu_config(
+    config: Config,
+    server_config: &mut quinn::ServerConfig,
+) -> ZResult<()> {
+    if let Some(initial_mtu) = config.get("initial_mtu") {
+        let initial_mtu = initial_mtu.parse::<u16>().map_err(|err| {
+            zerror!(
+                "could not parse QUIC Datagram endpoint's initial_mtu value `{initial_mtu}`: {err}"
+            )
+        })?;
+        Arc::get_mut(&mut server_config.transport)
+            .unwrap()
+            .initial_mtu(initial_mtu);
+    }
+
+    if let Some(mtu_discovery_interval_secs) = config.get("mtu_discovery_interval_secs") {
+        let mtu_discovery_interval = mtu_discovery_interval_secs
+            .parse::<u64>()
+            .map_err(|err| {
+                zerror!(
+                    "could not parse QUIC Datagram endpoint's mtu_discovery_interval_secs value `{mtu_discovery_interval_secs}`: {err}"
+                )
+            })
+            .map(Duration::from_secs)?;
+        let mut mtu_discovery_config = quinn::MtuDiscoveryConfig::default();
+        mtu_discovery_config.interval(mtu_discovery_interval);
+        Arc::get_mut(&mut server_config.transport)
+            .unwrap()
+            .mtu_discovery_config(Some(mtu_discovery_config));
+    }
+
+    Ok(())
+}

--- a/io/zenoh-links/zenoh-link-tls/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/lib.rs
@@ -82,38 +82,3 @@ zconfigurable! {
     // Default set to 100 ms.
     static ref TLS_ACCEPT_THROTTLE_TIME: u64 = 100_000;
 }
-
-pub mod config {
-    pub const TLS_ROOT_CA_CERTIFICATE_FILE: &str = "root_ca_certificate_file";
-    pub const TLS_ROOT_CA_CERTIFICATE_RAW: &str = "root_ca_certificate_raw";
-    pub const TLS_ROOT_CA_CERTIFICATE_BASE64: &str = "root_ca_certificate_base64";
-
-    pub const TLS_LISTEN_PRIVATE_KEY_FILE: &str = "listen_private_key_file";
-    pub const TLS_LISTEN_PRIVATE_KEY_RAW: &str = "listen_private_key_raw";
-    pub const TLS_LISTEN_PRIVATE_KEY_BASE_64: &str = "listen_private_key_base64";
-
-    pub const TLS_LISTEN_CERTIFICATE_FILE: &str = "listen_certificate_file";
-    pub const TLS_LISTEN_CERTIFICATE_RAW: &str = "listen_certificate_raw";
-    pub const TLS_LISTEN_CERTIFICATE_BASE64: &str = "listen_certificate_base64";
-
-    pub const TLS_CONNECT_PRIVATE_KEY_FILE: &str = "connect_private_key_file";
-    pub const TLS_CONNECT_PRIVATE_KEY_RAW: &str = "connect_private_key_raw";
-    pub const TLS_CONNECT_PRIVATE_KEY_BASE64: &str = "connect_private_key_base64";
-
-    pub const TLS_CONNECT_CERTIFICATE_FILE: &str = "connect_certificate_file";
-    pub const TLS_CONNECT_CERTIFICATE_RAW: &str = "connect_certificate_raw";
-    pub const TLS_CONNECT_CERTIFICATE_BASE64: &str = "connect_certificate_base64";
-
-    pub const TLS_ENABLE_MTLS: &str = "enable_mtls";
-    pub const TLS_ENABLE_MTLS_DEFAULT: bool = false;
-
-    pub const TLS_VERIFY_NAME_ON_CONNECT: &str = "verify_name_on_connect";
-    pub const TLS_VERIFY_NAME_ON_CONNECT_DEFAULT: bool = true;
-
-    pub const TLS_CLOSE_LINK_ON_EXPIRATION: &str = "close_link_on_expiration";
-    pub const TLS_CLOSE_LINK_ON_EXPIRATION_DEFAULT: bool = false;
-
-    /// The time duration in milliseconds to wait for the TLS handshake to complete.
-    pub const TLS_HANDSHAKE_TIMEOUT_MS: &str = "tls_handshake_timeout_ms";
-    pub const TLS_HANDSHAKE_TIMEOUT_MS_DEFAULT: u64 = 10_000;
-}

--- a/io/zenoh-transport/Cargo.toml
+++ b/io/zenoh-transport/Cargo.toml
@@ -36,6 +36,7 @@ auth_usrpwd = ["transport_auth"]
 transport_auth = []
 transport_multilink = ["auth_pubkey"]
 transport_quic = ["zenoh-link/transport_quic"]
+transport_quic_datagram = ["zenoh-link/transport_quic_datagram"]
 transport_tcp = ["zenoh-link/transport_tcp", "zenoh-config/transport_tcp"]
 transport_tls = ["zenoh-link/transport_tls"]
 transport_udp = ["zenoh-link/transport_udp"]
@@ -86,12 +87,10 @@ zenoh-sync = { workspace = true }
 zenoh-util = { workspace = true }
 zenoh-runtime = { workspace = true }
 zenoh-task = { workspace = true }
-
-
+zenoh-link-commons = { workspace = true }
 
 [dev-dependencies]
 futures-util = { workspace = true }
 zenoh-util = { workspace = true }
 zenoh-protocol = { workspace = true, features = ["test"] }
 futures = { workspace = true }
-zenoh-link-commons = { workspace = true }

--- a/io/zenoh-transport/src/manager.rs
+++ b/io/zenoh-transport/src/manager.rs
@@ -17,7 +17,7 @@ use rand::{RngCore, SeedableRng};
 use tokio::sync::Mutex as AsyncMutex;
 use zenoh_config::{Config, LinkRxConf, QueueAllocConf, QueueConf, QueueSizeConf};
 use zenoh_crypto::{BlockCipher, PseudoRng};
-use zenoh_link::NewLinkChannelSender;
+use zenoh_link::{LinkKind, NewLinkChannelSender};
 use zenoh_protocol::{
     core::{EndPoint, Field, Locator, Priority, Resolution, WhatAmI, ZenohIdProto},
     transport::BatchSize,
@@ -117,10 +117,10 @@ pub struct TransportManagerConfig {
     pub link_rx_buffer_size: usize,
     pub unicast: TransportManagerConfigUnicast,
     pub multicast: TransportManagerConfigMulticast,
-    pub endpoints: HashMap<String, String>, // (protocol, config)
+    pub link_configs: HashMap<LinkKind, String>, // (protocol, config)
     pub handler: Arc<dyn TransportEventHandler>,
     pub tx_threads: usize,
-    pub protocols: Vec<String>,
+    pub supported_links: Vec<LinkKind>,
 }
 
 pub struct TransportManagerState {
@@ -149,9 +149,9 @@ pub struct TransportManagerBuilder {
     link_rx_buffer_size: usize,
     unicast: TransportManagerBuilderUnicast,
     multicast: TransportManagerBuilderMulticast,
-    endpoints: HashMap<String, String>, // (protocol, config)
+    link_configs: HashMap<LinkKind, String>, // (protocol, config)
     tx_threads: usize,
-    protocols: Option<Vec<String>>,
+    supported_links: Option<Vec<LinkKind>>,
     #[cfg(feature = "shared-memory")]
     shm_reader: Option<ShmReader>,
 }
@@ -223,8 +223,8 @@ impl TransportManagerBuilder {
         self
     }
 
-    pub fn endpoints(mut self, endpoints: HashMap<String, String>) -> Self {
-        self.endpoints = endpoints;
+    pub fn link_configs(mut self, link_configs: HashMap<LinkKind, String>) -> Self {
+        self.link_configs = link_configs;
         self
     }
 
@@ -244,7 +244,8 @@ impl TransportManagerBuilder {
     }
 
     pub fn protocols(mut self, protocols: Option<Vec<String>>) -> Self {
-        self.protocols = protocols;
+        self.supported_links =
+            protocols.map(|ps| LinkKind::new_supported_links(ps.iter().map(|s| s.as_str())));
         self
     }
 
@@ -284,11 +285,11 @@ impl TransportManagerBuilder {
             use std::fmt::Write;
             let mut formatter = String::from("Some protocols reported configuration errors:\r\n");
             for (proto, err) in errors {
-                write!(&mut formatter, "\t{proto}: {err}\r\n")?;
+                write!(&mut formatter, "\t{proto:?}: {err}\r\n")?;
             }
             bail!("{}", formatter);
         }
-        self = self.endpoints(c);
+        self = self.link_configs(c);
         self = self.unicast(
             TransportManagerBuilderUnicast::default()
                 .from_config(config)
@@ -341,15 +342,12 @@ impl TransportManagerBuilder {
             link_rx_buffer_size: self.link_rx_buffer_size,
             unicast: unicast.config,
             multicast: multicast.config,
-            endpoints: self.endpoints,
+            link_configs: self.link_configs,
             handler,
             tx_threads: self.tx_threads,
-            protocols: self.protocols.unwrap_or_else(|| {
-                zenoh_link::PROTOCOLS
-                    .iter()
-                    .map(|x| x.to_string())
-                    .collect()
-            }),
+            supported_links: self
+                .supported_links
+                .unwrap_or_else(|| zenoh_link::ALL_SUPPORTED_LINKS.to_vec()),
         };
 
         let state = TransportManagerState {
@@ -392,11 +390,11 @@ impl Default for TransportManagerBuilder {
             batching_time_limit: Duration::from_millis(backoff),
             defrag_buff_size: *link_rx.max_message_size(),
             link_rx_buffer_size: *link_rx.buffer_size(),
-            endpoints: HashMap::new(),
+            link_configs: HashMap::new(),
             unicast: TransportManagerBuilderUnicast::default(),
             multicast: TransportManagerBuilderMulticast::default(),
             tx_threads: 1,
-            protocols: None,
+            supported_links: None,
             #[cfg(feature = "shared-memory")]
             shm_reader: None,
         }

--- a/io/zenoh-transport/tests/endpoints.rs
+++ b/io/zenoh-transport/tests/endpoints.rs
@@ -255,7 +255,7 @@ async fn endpoint_udp_unix() {
 #[cfg(feature = "transport_tls")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn endpoint_tls() {
-    use zenoh_link::tls::config::*;
+    use zenoh_link_commons::tls::config::*;
 
     zenoh_util::init_log_from_env_or("error");
 
@@ -334,7 +334,7 @@ AXVFFIgCSluyrolaD6CWD9MqOex4YOfJR2bNxI7lFvuK4AwjyUJzT1U1HXib17mM
 #[cfg(feature = "transport_quic")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn endpoint_quic() {
-    use zenoh_link::quic::config::*;
+    use zenoh_link_commons::tls::config::*;
 
     zenoh_util::init_log_from_env_or("error");
 

--- a/io/zenoh-transport/tests/unicast_authenticator.rs
+++ b/io/zenoh-transport/tests/unicast_authenticator.rs
@@ -710,7 +710,7 @@ async fn authenticator_unix() {
 #[cfg(feature = "transport_tls")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn authenticator_tls() {
-    use zenoh_link::tls::config::*;
+    use zenoh_link_commons::tls::config::*;
 
     zenoh_util::init_log_from_env_or("error");
 
@@ -810,7 +810,7 @@ R+IdLiXcyIkg0m9N8I17p0ljCSkbrgGMD3bbePRTfg==
 #[cfg(feature = "transport_quic")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn authenticator_quic() {
-    use zenoh_link::quic::config::*;
+    use zenoh_link_commons::tls::config::*;
 
     zenoh_util::init_log_from_env_or("error");
 

--- a/io/zenoh-transport/tests/unicast_bind.rs
+++ b/io/zenoh-transport/tests/unicast_bind.rs
@@ -412,7 +412,7 @@ async fn openclose_udp_only_connect_with_bind_restriction() {
 #[cfg(feature = "transport_quic")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn openclose_quic_only_connect_with_bind_restriction() {
-    use zenoh_link::quic::config::*;
+    use zenoh_link_commons::tls::config::*;
 
     zenoh_util::init_log_from_env_or("error");
     let bind_addr_str = format!("localhost:{}", 13012);
@@ -461,7 +461,7 @@ async fn openclose_quic_only_connect_with_bind_restriction() {
 #[cfg(feature = "transport_tls")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn openclose_tls_only_connect_with_bind_restriction() {
-    use zenoh_link::tls::config::*;
+    use zenoh_link_commons::tls::config::*;
 
     zenoh_util::init_log_from_env_or("error");
     let bind_addr_str = format!("localhost:{}", 13014);

--- a/io/zenoh-transport/tests/unicast_multilink.rs
+++ b/io/zenoh-transport/tests/unicast_multilink.rs
@@ -530,7 +530,7 @@ mod tests {
     #[cfg(feature = "transport_tls")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn multilink_tls_only() {
-        use zenoh_link::tls::config::*;
+        use zenoh_link_commons::tls::config::*;
 
         zenoh_util::init_log_from_env_or("error");
 
@@ -629,7 +629,7 @@ R+IdLiXcyIkg0m9N8I17p0ljCSkbrgGMD3bbePRTfg==
     #[cfg(feature = "transport_quic")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn multilink_quic_only() {
-        use zenoh_link::quic::config::*;
+        use zenoh_link_commons::tls::config::*;
 
         // NOTE: this an auto-generated pair of certificate and key.
         //       The target domain is localhost, so it has no real

--- a/io/zenoh-transport/tests/unicast_openclose.rs
+++ b/io/zenoh-transport/tests/unicast_openclose.rs
@@ -559,7 +559,7 @@ async fn openclose_unix_only() {
 #[cfg(feature = "transport_tls")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn openclose_tls_only() {
-    use zenoh_link::tls::config::*;
+    use zenoh_link_commons::tls::config::*;
 
     zenoh_util::init_log_from_env_or("error");
 
@@ -585,7 +585,7 @@ async fn openclose_tls_only() {
 #[cfg(feature = "transport_quic")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn openclose_quic_only() {
-    use zenoh_link::quic::config::*;
+    use zenoh_link_commons::tls::config::*;
 
     let (ca, cert, key) = get_tls_certs();
 
@@ -695,7 +695,7 @@ async fn openclose_vsock() {
 #[should_panic(expected = "Elapsed")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn openclose_quic_only_connect_with_interface_restriction() {
-    use zenoh_link::quic::config::*;
+    use zenoh_link_commons::tls::config::*;
 
     zenoh_util::init_log_from_env_or("error");
     let addrs = get_ipv4_ipaddrs(None);
@@ -728,7 +728,7 @@ async fn openclose_quic_only_connect_with_interface_restriction() {
 #[should_panic(expected = "Elapsed")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn openclose_quic_only_listen_with_interface_restriction() {
-    use zenoh_link::quic::config::*;
+    use zenoh_link_commons::tls::config::*;
 
     zenoh_util::init_log_from_env_or("error");
     let addrs = get_ipv4_ipaddrs(None);
@@ -761,7 +761,7 @@ async fn openclose_quic_only_listen_with_interface_restriction() {
 #[should_panic(expected = "Elapsed")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn openclose_tls_only_connect_with_interface_restriction() {
-    use zenoh_link::tls::config::*;
+    use zenoh_link_commons::tls::config::*;
 
     zenoh_util::init_log_from_env_or("error");
     let addrs = get_ipv4_ipaddrs(None);
@@ -794,7 +794,7 @@ async fn openclose_tls_only_connect_with_interface_restriction() {
 #[should_panic(expected = "assertion failed: open_res.is_ok()")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn openclose_tls_only_listen_with_interface_restriction() {
-    use zenoh_link::tls::config::*;
+    use zenoh_link_commons::tls::config::*;
 
     zenoh_util::init_log_from_env_or("error");
     let addrs = get_ipv4_ipaddrs(None);

--- a/io/zenoh-transport/tests/unicast_time.rs
+++ b/io/zenoh-transport/tests/unicast_time.rs
@@ -318,7 +318,7 @@ async fn time_unix_only() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[ignore]
 async fn time_tls_only() {
-    use zenoh_link::tls::config::*;
+    use zenoh_link_commons::tls::config::*;
     zenoh_util::init_log_from_env_or("error");
     // NOTE: this an auto-generated pair of certificate and key.
     //       The target domain is localhost, so it has no real
@@ -416,7 +416,7 @@ R+IdLiXcyIkg0m9N8I17p0ljCSkbrgGMD3bbePRTfg==
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[ignore]
 async fn time_quic_only() {
-    use zenoh_link::quic::config::*;
+    use zenoh_link_commons::tls::config::*;
 
     // NOTE: this an auto-generated pair of certificate and key.
     //       The target domain is localhost, so it has no real

--- a/io/zenoh-transport/tests/unicast_transport.rs
+++ b/io/zenoh-transport/tests/unicast_transport.rs
@@ -72,7 +72,11 @@ use zenoh_transport::{
 // will validate the key and certificate brought in by the server in front of the client.
 //
 #[cfg(all(
-    any(feature = "transport_tls", feature = "transport_quic"),
+    any(
+        feature = "transport_tls",
+        feature = "transport_quic",
+        feature = "transport_quic_datagram"
+    ),
     target_family = "unix"
 ))]
 const CLIENT_KEY: &str = "-----BEGIN RSA PRIVATE KEY-----
@@ -104,7 +108,11 @@ F6/CuIw9EsAq6qIB8O88FXQqald+BZOx6AzB8Oedsz/WtMmIEmr/+Q==
 -----END RSA PRIVATE KEY-----";
 
 #[cfg(all(
-    any(feature = "transport_tls", feature = "transport_quic"),
+    any(
+        feature = "transport_tls",
+        feature = "transport_quic",
+        feature = "transport_quic_datagram"
+    ),
     target_family = "unix"
 ))]
 const CLIENT_CERT: &str = "-----BEGIN CERTIFICATE-----
@@ -129,7 +137,11 @@ abY=
 -----END CERTIFICATE-----";
 
 #[cfg(all(
-    any(feature = "transport_tls", feature = "transport_quic"),
+    any(
+        feature = "transport_tls",
+        feature = "transport_quic",
+        feature = "transport_quic_datagram"
+    ),
     target_family = "unix"
 ))]
 const CLIENT_CA: &str = "-----BEGIN CERTIFICATE-----
@@ -153,7 +165,11 @@ Ck0v2xSPAiVjg6w65rUQeW6uB5m0T2wyj+wm0At8vzhZPlgS1fKhcmT2dzOq3+oN
 R+IdLiXcyIkg0m9N8I17p0ljCSkbrgGMD3bbePRTfg==
 -----END CERTIFICATE-----";
 
-#[cfg(any(feature = "transport_tls", feature = "transport_quic"))]
+#[cfg(any(
+    feature = "transport_tls",
+    feature = "transport_quic",
+    feature = "transport_quic_datagram"
+))]
 const SERVER_KEY: &str = "-----BEGIN RSA PRIVATE KEY-----
 MIIEpAIBAAKCAQEAmDCySqKHPmEZShDH3ldPaV/Zsh9+HlHFLk9H10vJZj5WfzVu
 5puZQ8GvBFIOtVrl0L9qLkA6bZiHHXm/8OEVvd135ZMp4NV23fdTsEASXfvGVQY8
@@ -182,7 +198,11 @@ H7HZKUCly2lCIizZdDVBkz4AWvaJlRc/3lE2Hd3Es6E52kTvROVKhdz06xuS8t5j
 ESElGO6qXEA821RpQp+2+uhL90+iC294cPqlS5LDmvTMypVDHzrxPQ==
 -----END RSA PRIVATE KEY-----";
 
-#[cfg(any(feature = "transport_tls", feature = "transport_quic"))]
+#[cfg(any(
+    feature = "transport_tls",
+    feature = "transport_quic",
+    feature = "transport_quic_datagram"
+))]
 const SERVER_CERT: &str = "-----BEGIN CERTIFICATE-----
 MIIDLjCCAhagAwIBAgIIW1mAtJWJAJYwDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
 AxMVbWluaWNhIHJvb3QgY2EgNGRjYzJmMCAXDTIzMDMwNjE2NDEwNloYDzIxMjMw
@@ -204,7 +224,11 @@ C1LSpiiQUaRSglOvYf/Zx6r+4BOS4OaaArwHkecZQqBSCcBLEAyb/FaaXdBowI0U
 PQ4=
 -----END CERTIFICATE-----";
 
-#[cfg(any(feature = "transport_tls", feature = "transport_quic"))]
+#[cfg(any(
+    feature = "transport_tls",
+    feature = "transport_quic",
+    feature = "transport_quic_datagram"
+))]
 const SERVER_CA: &str = "-----BEGIN CERTIFICATE-----
 MIIDSzCCAjOgAwIBAgIITcwv1N10nqEwDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
 AxMVbWluaWNhIHJvb3QgY2EgNGRjYzJmMCAXDTIzMDMwNjE2NDEwNloYDzIxMjMw
@@ -235,6 +259,7 @@ const MSG_SIZE_ALL: [usize; 3] = [1_024, 131_072, 100 * 1024 * 1024];
 #[cfg(any(
     feature = "transport_tcp",
     feature = "transport_udp",
+    feature = "transport_quic_datagram",
     feature = "transport_unixsock-stream",
 ))]
 const MSG_SIZE_NOFRAG: [usize; 1] = [1_024];
@@ -1005,7 +1030,7 @@ async fn transport_unicast_tcp_udp_unix() {
 #[cfg(all(feature = "transport_tls", target_family = "unix"))]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn transport_unicast_tls_only_server() {
-    use zenoh_link::tls::config::*;
+    use zenoh_link_commons::tls::config::*;
 
     zenoh_util::init_log_from_env_or("error");
 
@@ -1051,7 +1076,7 @@ async fn transport_unicast_tls_only_server() {
 #[cfg(feature = "transport_quic")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn transport_unicast_quic_only_server() {
-    use zenoh_link::quic::config::*;
+    use zenoh_link_commons::tls::config::*;
 
     zenoh_util::init_log_from_env_or("error");
     // Define the locator
@@ -1096,7 +1121,7 @@ async fn transport_unicast_quic_only_server() {
 #[cfg(all(feature = "transport_tls", target_family = "unix"))]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn transport_unicast_tls_only_mutual_success() {
-    use zenoh_link::tls::config::*;
+    use zenoh_link_commons::tls::config::*;
 
     zenoh_util::init_log_from_env_or("error");
 
@@ -1169,7 +1194,7 @@ async fn transport_unicast_tls_only_mutual_success() {
 async fn transport_unicast_tls_only_mutual_no_client_certs_failure() {
     use std::vec;
 
-    use zenoh_link::tls::config::*;
+    use zenoh_link_commons::tls::config::*;
 
     zenoh_util::init_log_from_env_or("error");
 
@@ -1233,7 +1258,7 @@ async fn transport_unicast_tls_only_mutual_no_client_certs_failure() {
 #[cfg(all(feature = "transport_tls", target_family = "unix"))]
 #[test]
 fn transport_unicast_tls_only_mutual_wrong_client_certs_failure() {
-    use zenoh_link::tls::config::*;
+    use zenoh_link_commons::tls::config::*;
 
     zenoh_util::init_log_from_env_or("error");
 
@@ -1312,7 +1337,7 @@ fn transport_unicast_tls_only_mutual_wrong_client_certs_failure() {
 #[cfg(all(feature = "transport_quic", target_family = "unix"))]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn transport_unicast_quic_only_mutual_success() {
-    use zenoh_link::quic::config::*;
+    use zenoh_link_commons::tls::config::*;
 
     zenoh_util::init_log_from_env_or("error");
 
@@ -1385,7 +1410,7 @@ async fn transport_unicast_quic_only_mutual_success() {
 async fn transport_unicast_quic_only_mutual_no_client_certs_failure() {
     use std::vec;
 
-    use zenoh_link::quic::config::*;
+    use zenoh_link_commons::tls::config::*;
 
     zenoh_util::init_log_from_env_or("error");
 
@@ -1449,7 +1474,7 @@ async fn transport_unicast_quic_only_mutual_no_client_certs_failure() {
 #[cfg(all(feature = "transport_quic", target_family = "unix"))]
 #[test]
 fn transport_unicast_quic_only_mutual_wrong_client_certs_failure() {
-    use zenoh_link::quic::config::*;
+    use zenoh_link_commons::tls::config::*;
 
     zenoh_util::init_log_from_env_or("error");
 
@@ -1576,4 +1601,241 @@ fn transport_unicast_qos_and_lowlatency_failure() {
         )
         .build(peer_shm02_handler.clone());
     assert!(good_manager2.is_ok());
+}
+
+#[cfg(all(feature = "transport_quic_datagram", target_family = "unix"))]
+#[test]
+fn transport_unicast_quic_datagram_only_mutual_wrong_client_certs_failure() {
+    use zenoh_link_commons::tls::config::*;
+
+    zenoh_util::init_log_from_env_or("error");
+
+    let client_auth = "true";
+
+    // Define the locator
+    let mut client_endpoint: EndPoint = "quic/localhost:10464?rel=0".parse().unwrap();
+    client_endpoint
+        .config_mut()
+        .extend_from_iter(
+            [
+                (TLS_ROOT_CA_CERTIFICATE_RAW, SERVER_CA),
+                // Using the SERVER_CERT and SERVER_KEY in the client to simulate the case the client has
+                // wrong certificates and keys. The SERVER_CA (cetificate authority) will not recognize
+                // these certificates as it is expecting to receive CLIENT_CERT and CLIENT_KEY from the
+                // client.
+                (TLS_CONNECT_CERTIFICATE_RAW, SERVER_CERT),
+                (TLS_CONNECT_PRIVATE_KEY_RAW, SERVER_KEY),
+                (TLS_ENABLE_MTLS, client_auth),
+            ]
+            .iter()
+            .copied(),
+        )
+        .unwrap();
+
+    // Define the locator
+    let mut server_endpoint: EndPoint = "quic/localhost:10464?rel=0".parse().unwrap();
+    server_endpoint
+        .config_mut()
+        .extend_from_iter(
+            [
+                (TLS_ROOT_CA_CERTIFICATE_RAW, CLIENT_CA),
+                (TLS_LISTEN_CERTIFICATE_RAW, SERVER_CERT),
+                (TLS_LISTEN_PRIVATE_KEY_RAW, SERVER_KEY),
+                (TLS_ENABLE_MTLS, client_auth),
+            ]
+            .iter()
+            .copied(),
+        )
+        .unwrap();
+    // Define the reliability and congestion control
+    let channel = [
+        Channel {
+            priority: Priority::default(),
+            reliability: Reliability::BestEffort,
+        },
+        Channel {
+            priority: Priority::RealTime,
+            reliability: Reliability::BestEffort,
+        },
+    ];
+    // Run
+    let client_endpoints = vec![client_endpoint];
+    let server_endpoints = vec![server_endpoint];
+    let result = std::panic::catch_unwind(|| {
+        tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(run_with_universal_transport(
+                &client_endpoints,
+                &server_endpoints,
+                &channel,
+                &MSG_SIZE_NOFRAG,
+            ))
+    });
+    assert!(result.is_err());
+}
+
+#[cfg(all(feature = "transport_quic_datagram", target_family = "unix"))]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn transport_unicast_quic_datagram_only_mutual_no_client_certs_failure() {
+    use std::vec;
+
+    use zenoh_link_commons::tls::config::*;
+
+    zenoh_util::init_log_from_env_or("error");
+
+    // Define the locator
+    let mut client_endpoint: EndPoint = "quic/localhost:10465?rel=0".parse().unwrap();
+    client_endpoint
+        .config_mut()
+        .extend_from_iter([(TLS_ROOT_CA_CERTIFICATE_RAW, SERVER_CA)].iter().copied())
+        .unwrap();
+
+    // Define the locator
+    let mut server_endpoint: EndPoint = "quic/localhost:10465?rel=0".parse().unwrap();
+    server_endpoint
+        .config_mut()
+        .extend_from_iter(
+            [
+                (TLS_ROOT_CA_CERTIFICATE_RAW, CLIENT_CA),
+                (TLS_LISTEN_CERTIFICATE_RAW, SERVER_CERT),
+                (TLS_LISTEN_PRIVATE_KEY_RAW, SERVER_KEY),
+                (TLS_ENABLE_MTLS, "true"),
+            ]
+            .iter()
+            .copied(),
+        )
+        .unwrap();
+    // Define the reliability and congestion control
+    let channel = [
+        Channel {
+            priority: Priority::default(),
+            reliability: Reliability::Reliable,
+        },
+        Channel {
+            priority: Priority::default(),
+            reliability: Reliability::BestEffort,
+        },
+        Channel {
+            priority: Priority::RealTime,
+            reliability: Reliability::Reliable,
+        },
+        Channel {
+            priority: Priority::RealTime,
+            reliability: Reliability::BestEffort,
+        },
+    ];
+    // Run
+    let client_endpoints = vec![client_endpoint];
+    let server_endpoints = vec![server_endpoint];
+    let result = std::panic::catch_unwind(|| {
+        tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(run_with_universal_transport(
+                &client_endpoints,
+                &server_endpoints,
+                &channel,
+                &MSG_SIZE_ALL,
+            ))
+    });
+    assert!(result.is_err());
+}
+
+#[cfg(all(feature = "transport_quic_datagram", target_family = "unix"))]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn transport_unicast_quic_datagram_only_mutual_success() {
+    use zenoh_link_commons::tls::config::*;
+
+    zenoh_util::init_log_from_env_or("error");
+
+    let client_auth = "true";
+
+    // Define the locator
+    let mut client_endpoint: EndPoint = "quic/localhost:10466?rel=0".parse().unwrap();
+    client_endpoint
+        .config_mut()
+        .extend_from_iter(
+            [
+                (TLS_ROOT_CA_CERTIFICATE_RAW, SERVER_CA),
+                (TLS_CONNECT_CERTIFICATE_RAW, CLIENT_CERT),
+                (TLS_CONNECT_PRIVATE_KEY_RAW, CLIENT_KEY),
+                (TLS_ENABLE_MTLS, client_auth),
+            ]
+            .iter()
+            .copied(),
+        )
+        .unwrap();
+
+    // Define the locator
+    let mut server_endpoint: EndPoint = "quic/localhost:10466?rel=0".parse().unwrap();
+    server_endpoint
+        .config_mut()
+        .extend_from_iter(
+            [
+                (TLS_ROOT_CA_CERTIFICATE_RAW, CLIENT_CA),
+                (TLS_LISTEN_CERTIFICATE_RAW, SERVER_CERT),
+                (TLS_LISTEN_PRIVATE_KEY_RAW, SERVER_KEY),
+                (TLS_ENABLE_MTLS, client_auth),
+            ]
+            .iter()
+            .copied(),
+        )
+        .unwrap();
+    // Define the reliability and congestion control
+    let channel = [
+        Channel {
+            priority: Priority::default(),
+            reliability: Reliability::BestEffort,
+        },
+        Channel {
+            priority: Priority::RealTime,
+            reliability: Reliability::BestEffort,
+        },
+    ];
+    // Run
+    let client_endpoints = vec![client_endpoint];
+    let server_endpoints = vec![server_endpoint];
+    run_with_universal_transport(
+        &client_endpoints,
+        &server_endpoints,
+        &channel,
+        &MSG_SIZE_NOFRAG,
+    )
+    .await;
+}
+
+#[cfg(feature = "transport_quic_datagram")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn transport_unicast_quic_datagram_only_server() {
+    use zenoh_link_commons::tls::config::*;
+
+    zenoh_util::init_log_from_env_or("error");
+    // Define the locator
+    let mut endpoint: EndPoint = "quic/localhost:10467?rel=0".parse().unwrap();
+    endpoint
+        .config_mut()
+        .extend_from_iter(
+            [
+                (TLS_ROOT_CA_CERTIFICATE_RAW, SERVER_CA),
+                (TLS_LISTEN_CERTIFICATE_RAW, SERVER_CERT),
+                (TLS_LISTEN_PRIVATE_KEY_RAW, SERVER_KEY),
+            ]
+            .iter()
+            .copied(),
+        )
+        .unwrap();
+
+    // Define the reliability and congestion control
+    let channel = [
+        Channel {
+            priority: Priority::DEFAULT,
+            reliability: Reliability::BestEffort,
+        },
+        Channel {
+            priority: Priority::RealTime,
+            reliability: Reliability::BestEffort,
+        },
+    ];
+    // Run
+    let endpoints = vec![endpoint];
+    run_with_universal_transport(&endpoints, &endpoints, &channel, &MSG_SIZE_NOFRAG).await;
 }

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -32,34 +32,36 @@ maintenance = { status = "actively-developed" }
 auth_pubkey = ["zenoh-transport/auth_pubkey"]
 auth_usrpwd = ["zenoh-transport/auth_usrpwd"]
 default = [
-  "auth_pubkey",
-  "auth_usrpwd",
-  "transport_multilink",
-  "transport_compression",
-  "transport_quic",
-  "transport_tcp",
-  "transport_tls",
-  "transport_udp",
-  "transport_unixsock-stream",
-  "transport_ws",
+    "auth_pubkey",
+    "auth_usrpwd",
+    "transport_multilink",
+    "transport_compression",
+    "transport_quic",
+    "transport_quic_datagram",
+    "transport_tcp",
+    "transport_tls",
+    "transport_udp",
+    "transport_unixsock-stream",
+    "transport_ws",
 ]
 internal = [
-  "zenoh-keyexpr/internal",
-  "zenoh-config/internal",
-  "zenoh-protocol/internal",
+    "zenoh-keyexpr/internal",
+    "zenoh-config/internal",
+    "zenoh-protocol/internal",
 ]
 plugins = []
 runtime_plugins = ["plugins"]
 shared-memory = [
-  "zenoh-shm",
-  "zenoh-protocol/shared-memory",
-  "zenoh-transport/shared-memory",
-  "zenoh-buffers/shared-memory",
+    "zenoh-shm",
+    "zenoh-protocol/shared-memory",
+    "zenoh-transport/shared-memory",
+    "zenoh-buffers/shared-memory",
 ]
 stats = ["zenoh-transport/stats"]
 transport_multilink = ["zenoh-transport/transport_multilink"]
 transport_compression = ["zenoh-transport/transport_compression"]
 transport_quic = ["zenoh-transport/transport_quic"]
+transport_quic_datagram = ["zenoh-transport/transport_quic_datagram"]
 transport_serial = ["zenoh-transport/transport_serial"]
 transport_unixpipe = ["zenoh-transport/transport_unixpipe"]
 transport_tcp = ["zenoh-transport/transport_tcp", "zenoh-config/transport_tcp"]
@@ -69,15 +71,15 @@ transport_unixsock-stream = ["zenoh-transport/transport_unixsock-stream"]
 transport_ws = ["zenoh-transport/transport_ws"]
 transport_vsock = ["zenoh-transport/transport_vsock"]
 unstable = [
-  "internal_config",
-  "zenoh-keyexpr/unstable",
-  "zenoh-config/unstable",
-  "zenoh-protocol/unstable",
+    "internal_config",
+    "zenoh-keyexpr/unstable",
+    "zenoh-config/unstable",
+    "zenoh-protocol/unstable",
 ]
 internal_config = []
 tracing-instrument = [
-  "zenoh-task/tracing-instrument",
-  "zenoh-runtime/tracing-instrument",
+    "zenoh-task/tracing-instrument",
+    "zenoh-runtime/tracing-instrument",
 ]
 
 [dependencies]
@@ -112,6 +114,7 @@ zenoh-config = { workspace = true }
 zenoh-core = { workspace = true }
 zenoh-keyexpr = { workspace = true, features = ["internal"] }
 zenoh-link = { workspace = true }
+zenoh-link-commons = { workspace = true }
 zenoh-macros = { workspace = true }
 zenoh-plugin-trait = { workspace = true }
 zenoh-protocol = { workspace = true, features = ["std"] }

--- a/zenoh/tests/open_time.rs
+++ b/zenoh/tests/open_time.rs
@@ -227,7 +227,7 @@ async fn time_unix_only_open() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[ignore]
 async fn time_tls_only_open() {
-    use zenoh_link::tls::config::*;
+    use zenoh_link_commons::tls::config::*;
 
     zenoh::init_log_from_env_or("error");
     // NOTE: this an auto-generated pair of certificate and key.
@@ -326,7 +326,7 @@ R+IdLiXcyIkg0m9N8I17p0ljCSkbrgGMD3bbePRTfg==
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[ignore]
 async fn time_quic_only_open() {
-    use zenoh_link::quic::config::*;
+    use zenoh_link_commons::tls::config::*;
 
     // NOTE: this an auto-generated pair of certificate and key.
     //       The target domain is localhost, so it has no real


### PR DESCRIPTION
This commit makes it possible to use unreliable datagrams in QUIC by setting `rel=0` in QUIC endpoints. The initial MTU value and the MTU discovery interval are both configurable via endpoint configuration.

This is the first link to reuse an exiting protocol name, so the transport manager has to be updated to support it. Now links are identified by both their protocol name and reliability.

The transport_quic and transport_quic_datagram can be independently enabled/disabled.

I took the opportunity refactor TLS configuration options into zenoh-link-commons; QUIC and TLS use the exact same values except for the handshake timeout duration (not used by QUIC links).