### PR TITLE
optimize hashmap for integer keys

### DIFF
--- a/commons/zenoh-collections/src/lib.rs
+++ b/commons/zenoh-collections/src/lib.rs
@@ -37,3 +37,8 @@ pub use ring_buffer::*;
 pub mod stack_buffer;
 #[cfg(feature = "std")]
 pub use stack_buffer::*;
+
+#[cfg(feature = "std")]
+pub mod small_hash_map;
+#[cfg(feature = "std")]
+pub use small_hash_map::*;

--- a/commons/zenoh-collections/src/small_hash_map.rs
+++ b/commons/zenoh-collections/src/small_hash_map.rs
@@ -1,0 +1,313 @@
+use std::{collections::hash_map, hash::Hash, mem, slice};
+
+#[derive(Debug)]
+pub enum SmallHashMap<K: Copy + Into<usize> + TryFrom<usize>, V, const SMALL_SIZE: usize> {
+    Vec {
+        vec: Vec<(K, Option<V>)>,
+        // use usize for len/first increase the size of SmallHashMap, while u16 is fine here
+        len: u16,
+        first: Option<u16>,
+    },
+    Map(ahash::HashMap<K, V>),
+}
+
+impl<K: Copy + Into<usize> + TryFrom<usize>, V, const SMALL_SIZE: usize>
+    SmallHashMap<K, V, SMALL_SIZE>
+{
+    #[inline]
+    pub fn new() -> Self {
+        Self::Vec {
+            vec: Vec::new(),
+            len: 0,
+            first: None,
+        }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Vec { len, .. } => *len as _,
+            Self::Map(m) => m.len(),
+        }
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    #[inline]
+    pub fn iter(&self) -> Iter<K, V> {
+        match self {
+            Self::Vec {
+                vec,
+                first: Some(first),
+                ..
+            } => Iter::Vec(unsafe { vec.get_unchecked(*first as usize..) }.iter()),
+            Self::Vec { .. } => Iter::Vec([].iter()),
+            Self::Map(map) => Iter::Map(map.iter()),
+        }
+    }
+
+    #[inline]
+    pub fn values(&self) -> Values<K, V> {
+        match self {
+            Self::Vec {
+                vec,
+                first: Some(first),
+                ..
+            } => Values::Vec(unsafe { vec.get_unchecked(*first as usize..) }.iter()),
+            Self::Vec { .. } => Values::Vec([].iter()),
+            Self::Map(map) => Values::Map(map.values()),
+        }
+    }
+
+    #[inline]
+    pub fn values_mut(&mut self) -> ValuesMut<K, V> {
+        match self {
+            Self::Vec {
+                vec,
+                first: Some(first),
+                ..
+            } => ValuesMut::Vec(unsafe { vec.get_unchecked_mut(*first as usize..) }.iter_mut()),
+            Self::Vec { .. } => ValuesMut::Vec([].iter_mut()),
+            Self::Map(map) => ValuesMut::Map(map.values_mut()),
+        }
+    }
+}
+
+impl<K: Copy + Into<usize> + TryFrom<usize> + Eq + Hash, V, const SMALL_SIZE: usize>
+    SmallHashMap<K, V, SMALL_SIZE>
+{
+    #[inline]
+    pub fn get(&self, k: &K) -> Option<&V> {
+        match self {
+            Self::Vec { vec, .. } => vec.get((*k).into())?.1.as_ref(),
+            Self::Map(map) => map.get(k),
+        }
+    }
+
+    #[inline]
+    pub fn get_mut(&mut self, k: &K) -> Option<&mut V> {
+        match self {
+            Self::Vec { vec, .. } => vec.get_mut((*k).into())?.1.as_mut(),
+            Self::Map(map) => map.get_mut(k),
+        }
+    }
+
+    #[inline]
+    pub fn contains_key(&self, k: &K) -> bool {
+        match self {
+            Self::Vec { vec, .. } => vec.get((*k).into()).is_some(),
+            Self::Map(map) => map.contains_key(&k),
+        }
+    }
+
+    fn resize(&mut self, k: K) {
+        let idx = k.into();
+        match self {
+            Self::Vec { vec, .. } if idx < SMALL_SIZE && vec.len() < idx => {
+                for i in vec.len()..=idx {
+                    vec.push((i.try_into().unwrap_or_else(|_| unreachable!()), None));
+                }
+            }
+            Self::Vec { vec, .. } => {
+                let map = mem::take(vec)
+                    .into_iter()
+                    .filter_map(|(k, v)| Some((k, v?)))
+                    .collect();
+                *self = Self::Map(map);
+            }
+            _ => {}
+        }
+    }
+
+    #[inline]
+    pub fn insert(&mut self, k: K, value: V) {
+        self.resize(k);
+        match self {
+            Self::Vec { vec, len, first } => {
+                if vec[k.into()].1.replace(value).is_none() {
+                    if first.is_none() || matches!(first, Some(f) if *f< k.into() as u16) {
+                        *first = Some(k.into() as u16)
+                    }
+                    *len += 1;
+                }
+            }
+            Self::Map(map) => {
+                map.insert(k, value);
+            }
+        }
+    }
+
+    #[inline]
+    pub fn remove(&mut self, k: &K) -> Option<V> {
+        match self {
+            Self::Vec { vec, len, first } => {
+                let prev = vec.get_mut((*k).into())?.1.take();
+                if prev.is_some() {
+                    *len -= 1;
+                    if *len == 0 {
+                        *first = None;
+                    } else if first.unwrap() == (*k).into() as u16 {
+                        *first = vec.iter().position(|(_, v)| v.is_some()).map(|f| f as u16);
+                    }
+                }
+                prev
+            }
+            Self::Map(map) => map.remove(&k),
+        }
+    }
+
+    #[inline]
+    pub fn clear(&mut self) {
+        match self {
+            Self::Vec { vec, len, first } => {
+                vec.clear();
+                *len = 0;
+                *first = None;
+            }
+            Self::Map(map) => {
+                map.clear();
+                *self = Self::new();
+            }
+        }
+    }
+
+    pub fn entry(&mut self, k: K) -> Entry<K, V> {
+        self.resize(k);
+        match self {
+            Self::Vec { vec, len, first } => Entry::Vec {
+                idx: k.into(),
+                value: &mut vec[k.into()].1,
+                len,
+                first,
+            },
+            Self::Map(map) => Entry::Map(map.entry(k)),
+        }
+    }
+}
+
+impl<K: Copy + Into<usize> + TryFrom<usize>, V, const SMALL_SIZE: usize> Default
+    for SmallHashMap<K, V, SMALL_SIZE>
+{
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub enum Entry<'a, K, V> {
+    Vec {
+        idx: usize,
+        value: &'a mut Option<V>,
+        len: &'a mut u16,
+        first: &'a mut Option<u16>,
+    },
+    Map(hash_map::Entry<'a, K, V>),
+}
+
+impl<'a, K, V> Entry<'a, K, V> {
+    pub fn or_insert_with<F: FnOnce() -> V>(self, default: F) -> &'a mut V {
+        match self {
+            Entry::Vec {
+                idx,
+                value,
+                len,
+                first,
+            } => {
+                if value.is_none() {
+                    *len += 1;
+                    if first.is_none() || matches!(first, Some(f) if *f< idx as u16) {
+                        *first = Some(idx as u16)
+                    }
+                }
+                value.get_or_insert_with(default)
+            }
+            Entry::Map(entry) => entry.or_insert_with(default),
+        }
+    }
+}
+
+pub enum Iter<'a, K, V> {
+    Vec(slice::Iter<'a, (K, Option<V>)>),
+    Map(hash_map::Iter<'a, K, V>),
+}
+impl<'a, K: Copy + TryFrom<usize>, V> Iterator for Iter<'a, K, V> {
+    type Item = (&'a K, &'a V);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Vec(iter) => iter.next().and_then(|(k, v)| Some((k, v.as_ref()?))),
+            Self::Map(iter) => iter.next().map(|(k, v)| (k, v)),
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            Self::Vec(iter) => (0, Some(iter.len())),
+            Self::Map(iter) => iter.size_hint(),
+        }
+    }
+}
+
+pub enum Values<'a, K, V> {
+    Vec(slice::Iter<'a, (K, Option<V>)>),
+    Map(hash_map::Values<'a, K, V>),
+}
+impl<'a, K, V> Iterator for Values<'a, K, V> {
+    type Item = &'a V;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Vec(iter) => iter.next()?.1.as_ref(),
+            Self::Map(iter) => iter.next(),
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            Self::Vec(iter) => (0, Some(iter.len())),
+            Self::Map(iter) => iter.size_hint(),
+        }
+    }
+}
+
+pub enum ValuesMut<'a, K, V> {
+    Vec(slice::IterMut<'a, (K, Option<V>)>),
+    Map(hash_map::ValuesMut<'a, K, V>),
+}
+impl<'a, K, V> Iterator for ValuesMut<'a, K, V> {
+    type Item = &'a mut V;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Vec(iter) => iter.next()?.1.as_mut(),
+            Self::Map(iter) => iter.next(),
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            Self::Vec(iter) => (0, Some(iter.len())),
+            Self::Map(iter) => iter.size_hint(),
+        }
+    }
+}
+
+impl<'a, K: Copy + Into<usize> + TryFrom<usize>, V, const SMALL_SIZE: usize> IntoIterator
+    for &'a SmallHashMap<K, V, SMALL_SIZE>
+{
+    type Item = (&'a K, &'a V);
+    type IntoIter = Iter<'a, K, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -23,7 +23,6 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use ahash::HashMapExt;
 use async_trait::async_trait;
 #[cfg(feature = "unstable")]
 use once_cell::sync::OnceCell;
@@ -35,7 +34,7 @@ use uhlc::Timestamp;
 #[cfg(feature = "internal")]
 use uhlc::HLC;
 use zenoh_buffers::ZBuf;
-use zenoh_collections::SingleOrVec;
+use zenoh_collections::{SingleOrVec, SmallHashMap};
 use zenoh_config::{qos::PublisherQoSConfig, unwrap_or_default, wrappers::ZenohId};
 use zenoh_core::{zconfigurable, zread, Resolve, ResolveClosure, ResolveFuture, Wait};
 use zenoh_keyexpr::{keyexpr_tree::KeBoxTree, OwnedNonWildKeyExpr};
@@ -135,8 +134,8 @@ pub(crate) struct SessionState {
     pub(crate) expr_id_counter: AtomicExprId,           // @TODO: manage rollover and uniqueness
     pub(crate) qid_counter: AtomicRequestId,
     pub(crate) liveliness_qid_counter: AtomicRequestId,
-    pub(crate) local_resources: ahash::HashMap<ExprId, Resource>,
-    pub(crate) remote_resources: ahash::HashMap<ExprId, Resource>,
+    pub(crate) local_resources: SmallHashMap<ExprId, Resource, 64>,
+    pub(crate) remote_resources: SmallHashMap<ExprId, Resource, 64>,
     #[cfg(feature = "unstable")]
     pub(crate) remote_subscribers: HashMap<SubscriberId, KeyExpr<'static>>,
     pub(crate) publishers: HashMap<Id, PublisherState>,
@@ -169,8 +168,8 @@ impl SessionState {
             expr_id_counter: AtomicExprId::new(1), // Note: start at 1 because 0 is reserved for NO_RESOURCE
             qid_counter: AtomicRequestId::new(0),
             liveliness_qid_counter: AtomicRequestId::new(0),
-            local_resources: ahash::HashMap::new(),
-            remote_resources: ahash::HashMap::new(),
+            local_resources: SmallHashMap::new(),
+            remote_resources: SmallHashMap::new(),
             #[cfg(feature = "unstable")]
             remote_subscribers: HashMap::new(),
             publishers: HashMap::new(),

--- a/zenoh/src/net/routing/dispatcher/face.rs
+++ b/zenoh/src/net/routing/dispatcher/face.rs
@@ -20,9 +20,9 @@ use std::{
     time::Duration,
 };
 
-use ahash::HashMapExt;
 use arc_swap::ArcSwap;
 use tokio_util::sync::CancellationToken;
+use zenoh_collections::SmallHashMap;
 use zenoh_protocol::{
     core::{ExprId, Reliability, WhatAmI, ZenohIdProto},
     network::{
@@ -70,8 +70,8 @@ pub struct FaceState {
     pub(crate) local_interests: HashMap<InterestId, InterestState>,
     pub(crate) remote_key_interests: HashMap<InterestId, Option<Arc<Resource>>>,
     pub(crate) pending_current_interests: HashMap<InterestId, PendingCurrentInterest>,
-    pub(crate) local_mappings: ahash::HashMap<ExprId, Arc<Resource>>,
-    pub(crate) remote_mappings: ahash::HashMap<ExprId, Arc<Resource>>,
+    pub(crate) local_mappings: SmallHashMap<ExprId, Arc<Resource>, 64>,
+    pub(crate) remote_mappings: SmallHashMap<ExprId, Arc<Resource>, 64>,
     pub(crate) next_qid: RequestId,
     pub(crate) pending_queries: HashMap<RequestId, (Arc<Query>, CancellationToken)>,
     pub(crate) mcast_group: Option<TransportMulticast>,
@@ -104,8 +104,8 @@ impl FaceState {
             local_interests: HashMap::new(),
             remote_key_interests: HashMap::new(),
             pending_current_interests: HashMap::new(),
-            local_mappings: ahash::HashMap::new(),
-            remote_mappings: ahash::HashMap::new(),
+            local_mappings: SmallHashMap::new(),
+            remote_mappings: SmallHashMap::new(),
             next_qid: 0,
             pending_queries: HashMap::new(),
             mcast_group,

--- a/zenoh/src/net/routing/dispatcher/resource.rs
+++ b/zenoh/src/net/routing/dispatcher/resource.rs
@@ -21,8 +21,7 @@ use std::{
     sync::{Arc, RwLock, Weak},
 };
 
-use ahash::HashMapExt;
-use zenoh_collections::SingleOrBoxHashSet;
+use zenoh_collections::{SingleOrBoxHashSet, SmallHashMap};
 use zenoh_config::WhatAmI;
 use zenoh_protocol::{
     core::{key_expr::keyexpr, ExprId, WireExpr},
@@ -237,7 +236,7 @@ pub struct Resource {
     pub(crate) nonwild_prefix: Option<Arc<Resource>>,
     pub(crate) children: SingleOrBoxHashSet<Child>,
     pub(crate) context: Option<Box<ResourceContext>>,
-    pub(crate) session_ctxs: ahash::HashMap<usize, Arc<SessionContext>>,
+    pub(crate) session_ctxs: SmallHashMap<usize, Arc<SessionContext>, 64>,
 }
 
 impl PartialEq for Resource {
@@ -314,7 +313,7 @@ impl Resource {
             nonwild_prefix,
             children: SingleOrBoxHashSet::new(),
             context: context.map(Box::new),
-            session_ctxs: ahash::HashMap::new(),
+            session_ctxs: SmallHashMap::new(),
         }
     }
 
@@ -379,7 +378,7 @@ impl Resource {
             nonwild_prefix: None,
             children: SingleOrBoxHashSet::new(),
             context: None,
-            session_ctxs: ahash::HashMap::new(),
+            session_ctxs: SmallHashMap::new(),
         })
     }
 


### PR DESCRIPTION
In the case of a small number of integer keys starting from zero, hashmap can be replaced by a vector to eliminate hash cost. It must of course fallback to a regular hashmap if keys overflow a given small constant.