### PR TITLE
Make replied_id an EntityGlobalId

### DIFF
--- a/zenoh/src/api/query.rs
+++ b/zenoh/src/api/query.rs
@@ -17,11 +17,9 @@ use std::{collections::HashMap, error::Error, fmt::Display};
 #[cfg(feature = "unstable")]
 use serde::Deserialize;
 #[cfg(feature = "unstable")]
-use zenoh_config::ZenohId;
+use zenoh_config::wrappers::EntityGlobalId;
 use zenoh_keyexpr::OwnedKeyExpr;
 use zenoh_protocol::core::Parameters;
-#[cfg(feature = "unstable")]
-use zenoh_protocol::core::ZenohIdProto;
 /// The [`Queryable`](crate::query::Queryable)s that should be target of a [`get`](crate::Session::get).
 pub use zenoh_protocol::network::request::ext::QueryTarget;
 #[doc(inline)]
@@ -129,7 +127,7 @@ impl Error for ReplyError {}
 pub struct Reply {
     pub(crate) result: Result<Sample, ReplyError>,
     #[cfg(feature = "unstable")]
-    pub(crate) replier_id: Option<ZenohIdProto>,
+    pub(crate) replier_id: Option<EntityGlobalId>,
 }
 
 impl Reply {
@@ -149,11 +147,9 @@ impl Reply {
     }
 
     #[zenoh_macros::unstable]
-    // @TODO: maybe return an `Option<EntityGlobalId>`?
-    //
     /// Gets the id of the zenoh instance that answered this Reply.
-    pub fn replier_id(&self) -> Option<ZenohId> {
-        self.replier_id.map(Into::into)
+    pub fn replier_id(&self) -> Option<EntityGlobalId> {
+        self.replier_id
     }
 
     /// Constructs an uninitialized empty Reply.

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -2328,7 +2328,10 @@ impl SessionInner {
                                 query.callback.call(Reply {
                                     result: Err(ReplyError::new("Timeout", Encoding::ZENOH_STRING)),
                                     #[cfg(feature = "unstable")]
-                                    replier_id: Some(session.zid().into()),
+                                    replier_id: Some(zenoh_protocol::core::EntityGlobalIdProto {
+                                        zid: session.zid().into(),
+                                        eid: session.id.into(),
+                                    }.into()),
                                 });
                             }
                         }
@@ -2427,7 +2430,10 @@ impl SessionInner {
                                 query.callback.call(Reply {
                                     result: Err(ReplyError::new("Timeout", Encoding::ZENOH_STRING)),
                                     #[cfg(feature = "unstable")]
-                                    replier_id: Some(session.zid().into()),
+                                    replier_id: Some(zenoh_protocol::core::EntityGlobalIdProto {
+                                        zid: session.zid().into(),
+                                        eid: session.id.into(),
+                                    }.into()),
                                 });
                             }
                         }
@@ -2875,7 +2881,13 @@ impl Primitives for WeakSession {
                                 encoding: mem::take(&mut e.encoding).into(),
                             }),
                             #[cfg(feature = "unstable")]
-                            replier_id: mem::take(&mut msg.ext_respid).map(|rid| rid.zid),
+                            replier_id: mem::take(&mut msg.ext_respid).map(|rid| {
+                                zenoh_protocol::core::EntityGlobalIdProto {
+                                    zid: rid.zid,
+                                    eid: rid.eid,
+                                }
+                                .into()
+                            }),
                         };
                         callback.call(new_reply);
                     }
@@ -2967,7 +2979,13 @@ impl Primitives for WeakSession {
                         let new_reply = Reply {
                             result: Ok(sample),
                             #[cfg(feature = "unstable")]
-                            replier_id: mem::take(&mut msg.ext_respid).map(|rid| rid.zid),
+                            replier_id: mem::take(&mut msg.ext_respid).map(|rid| {
+                                zenoh_protocol::core::EntityGlobalIdProto {
+                                    zid: rid.zid,
+                                    eid: rid.eid,
+                                }
+                                .into()
+                            }),
                         };
                         let callback =
                             match query.reception_mode {

--- a/zenoh/tests/session.rs
+++ b/zenoh/tests/session.rs
@@ -251,7 +251,7 @@ async fn test_session_query_reply_internal<Getter: HasGet>(
             let rs = getter.get("ok_put").await;
             while let Ok(s) = ztimeout!(rs.recv_async()) {
                 #[cfg(feature = "unstable")]
-                assert_eq!(s.replier_id(), Some(qbl.id().zid()));
+                assert_eq!(s.replier_id(), Some(qbl.id()));
                 let s = s.result().unwrap();
                 assert_eq!(s.kind(), SampleKind::Put);
                 assert_eq!(s.payload().len(), size);
@@ -270,7 +270,7 @@ async fn test_session_query_reply_internal<Getter: HasGet>(
             let rs = getter.get("ok_del").await;
             while let Ok(s) = ztimeout!(rs.recv_async()) {
                 #[cfg(feature = "unstable")]
-                assert_eq!(s.replier_id(), Some(qbl.id().zid()));
+                assert_eq!(s.replier_id(), Some(qbl.id()));
                 let s = s.result().unwrap();
                 assert_eq!(s.kind(), SampleKind::Delete);
                 assert_eq!(s.payload().len(), 0);
@@ -289,7 +289,7 @@ async fn test_session_query_reply_internal<Getter: HasGet>(
             let rs = getter.get("err").await;
             while let Ok(s) = ztimeout!(rs.recv_async()) {
                 #[cfg(feature = "unstable")]
-                assert_eq!(s.replier_id(), Some(qbl.id().zid()));
+                assert_eq!(s.replier_id(), Some(qbl.id()));
                 let e = s.result().unwrap_err();
                 assert_eq!(e.payload().len(), size);
                 cnt += 1;


### PR DESCRIPTION
Changes the replied_id on `Reply` messages to an `EntityGlobalId` instead of just a `ZenohId`.
This is a breaking change.

Sister PRs will be made on affected Zenoh bindings.