### PR TITLE
Improve interceptors performances

### DIFF
--- a/zenoh/src/net/primitives/demux.rs
+++ b/zenoh/src/net/primitives/demux.rs
@@ -11,13 +11,13 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use std::{any::Any, sync::Arc};
+use std::{any::Any, cell::OnceCell, sync::Arc};
 
 use arc_swap::ArcSwap;
 use zenoh_link::Link;
 use zenoh_protocol::network::{
-    ext, response, Declare, DeclareBody, DeclareFinal, NetworkBodyMut, NetworkMessageMut,
-    ResponseFinal,
+    ext, response, Declare, DeclareBody, DeclareFinal, NetworkBodyMut, NetworkMessageExt as _,
+    NetworkMessageMut, ResponseFinal,
 };
 use zenoh_result::ZResult;
 use zenoh_transport::{unicast::TransportUnicast, TransportPeerEventHandler};
@@ -25,7 +25,8 @@ use zenoh_transport::{unicast::TransportUnicast, TransportPeerEventHandler};
 use super::Primitives;
 use crate::net::routing::{
     dispatcher::face::Face,
-    interceptor::{InterceptorTrait, InterceptorsChain},
+    interceptor::{InterceptorContext, InterceptorTrait, InterceptorsChain},
+    router::{InterceptorCacheValueType, Resource},
     RoutingContext,
 };
 
@@ -49,26 +50,73 @@ impl DeMux {
     }
 }
 
+struct DeMuxContext<'a> {
+    demux: &'a DeMux,
+    cache: OnceCell<InterceptorCacheValueType>,
+    expr: OnceCell<String>,
+}
+
+impl DeMuxContext<'_> {
+    fn prefix(&self, msg: &NetworkMessageMut) -> Option<Arc<Resource>> {
+        if let Some(wire_expr) = msg.wire_expr() {
+            let wire_expr = wire_expr.to_owned();
+            if let Some(prefix) = zread!(self.demux.face.tables.tables)
+                .get_mapping(&self.demux.face.state, &wire_expr.scope, wire_expr.mapping)
+                .cloned()
+            {
+                return Some(prefix);
+            }
+        }
+        None
+    }
+}
+
+impl InterceptorContext for DeMuxContext<'_> {
+    fn face(&self) -> Option<Face> {
+        Some(self.demux.face.clone())
+    }
+
+    fn full_expr(&self, msg: &NetworkMessageMut) -> Option<&str> {
+        if self.expr.get().is_none() {
+            if let Some(wire_expr) = msg.wire_expr() {
+                if let Some(prefix) = self.prefix(msg) {
+                    self.expr
+                        .set(prefix.expr().to_string() + wire_expr.suffix.as_ref())
+                        .ok();
+                }
+            }
+        }
+        self.expr.get().map(|x| x.as_str())
+    }
+    fn get_cache(&self, msg: &NetworkMessageMut) -> Option<&Box<dyn Any + Send + Sync>> {
+        if self.cache.get().is_none() {
+            if let Some(prefix) = self.prefix(msg) {
+                if let Some(cache) =
+                    prefix.get_ingress_cache(&self.demux.face, &self.demux.interceptor.load())
+                {
+                    self.cache.set(cache).ok();
+                }
+            }
+        }
+        self.cache.get().and_then(|c| c.get_ref().as_ref())
+    }
+}
+
 impl TransportPeerEventHandler for DeMux {
     #[inline]
     fn handle_message(&self, mut msg: NetworkMessageMut) -> ZResult<()> {
         let interceptor = self.interceptor.load();
         if !interceptor.interceptors.is_empty() {
-            let mut ctx = RoutingContext::new_in(msg.as_mut(), self.face.clone());
-            let prefix = ctx
-                .wire_expr()
-                .and_then(|we| (!we.has_suffix()).then(|| ctx.prefix()))
-                .flatten()
-                .cloned();
-            let cache_guard = prefix
-                .as_ref()
-                .and_then(|p| p.get_ingress_cache(&self.face, &interceptor));
-            let cache = cache_guard.as_ref().and_then(|c| c.get_ref().as_ref());
+            let mut ctx = DeMuxContext {
+                demux: self,
+                cache: OnceCell::new(),
+                expr: OnceCell::new(),
+            };
 
-            match &ctx.msg.body {
+            match &msg.body {
                 NetworkBodyMut::Request(request) => {
                     let request_id = request.id;
-                    if !interceptor.intercept(&mut ctx, cache) {
+                    if !interceptor.intercept(&mut msg, &mut ctx as &mut dyn InterceptorContext) {
                         // request was blocked by an interceptor, we need to send response final to avoid timeout error
                         self.face
                             .state
@@ -83,26 +131,22 @@ impl TransportPeerEventHandler for DeMux {
                 }
                 NetworkBodyMut::Interest(interest) => {
                     let interest_id = interest.id;
-                    if !interceptor.intercept(&mut ctx, cache) {
+                    if !interceptor.intercept(&mut msg, &mut ctx as &mut dyn InterceptorContext) {
                         // request was blocked by an interceptor, we need to send declare final to avoid timeout error
-                        self.face
-                            .state
-                            .primitives
-                            .send_declare(RoutingContext::new_in(
-                                &mut Declare {
-                                    interest_id: Some(interest_id),
-                                    ext_qos: ext::QoSType::DECLARE,
-                                    ext_tstamp: None,
-                                    ext_nodeid: ext::NodeIdType::DEFAULT,
-                                    body: DeclareBody::DeclareFinal(DeclareFinal),
-                                },
-                                self.face.clone(),
-                            ));
+                        self.face.state.primitives.send_declare(RoutingContext::new(
+                            &mut Declare {
+                                interest_id: Some(interest_id),
+                                ext_qos: ext::QoSType::DECLARE,
+                                ext_tstamp: None,
+                                ext_nodeid: ext::NodeIdType::DEFAULT,
+                                body: DeclareBody::DeclareFinal(DeclareFinal),
+                            },
+                        ));
                         return Ok(());
                     }
                 }
                 _ => {
-                    if !interceptor.intercept(&mut ctx, cache) {
+                    if !interceptor.intercept(&mut msg, &mut ctx as &mut dyn InterceptorContext) {
                         return Ok(());
                     }
                 }

--- a/zenoh/src/net/primitives/demux.rs
+++ b/zenoh/src/net/primitives/demux.rs
@@ -89,7 +89,7 @@ impl InterceptorContext for DeMuxContext<'_> {
         self.expr.get().map(|x| x.as_str())
     }
     fn get_cache(&self, msg: &NetworkMessageMut) -> Option<&Box<dyn Any + Send + Sync>> {
-        if self.cache.get().is_none() {
+        if self.cache.get().is_none() && msg.wire_expr().is_some_and(|we| !we.has_suffix()) {
             if let Some(prefix) = self.prefix(msg) {
                 if let Some(cache) =
                     prefix.get_ingress_cache(&self.demux.face, &self.demux.interceptor.load())

--- a/zenoh/src/net/primitives/mux.rs
+++ b/zenoh/src/net/primitives/mux.rs
@@ -115,29 +115,10 @@ impl EPrimitives for Mux {
             body: NetworkBodyMut::Interest(ctx.msg),
             reliability: Reliability::Reliable,
         };
-        let mut ctx = MuxContext {
-            mux: self,
-            cache: OnceCell::new(),
-            expr: ctx.full_expr,
+        let mut ctx = RoutingContext {
+            msg: (),
+            full_expr: ctx.full_expr,
         };
-        // let mut ctx = RoutingContext {
-        //     msg: &mut msg,
-        //     inface: ctx.inface,
-        //     outface: ctx.outface,
-        //     // prefix: ctx.prefix,
-        //     full_expr: ctx.full_expr,
-        // };
-        // let prefix = ctx
-        //     .wire_expr()
-        //     .and_then(|we| (!we.has_suffix()).then(|| ctx.prefix()))
-        //     .flatten()
-        //     .cloned();
-        // let interceptor = self.interceptor.load();
-        // let cache_guard = prefix
-        //     .as_ref()
-        //     .and_then(|p| p.get_egress_cache(ctx.outface.get().unwrap(), &interceptor));
-
-        // let cache = cache_guard.as_ref().and_then(|c| c.get_ref().as_ref());
 
         if self
             .interceptor
@@ -154,44 +135,14 @@ impl EPrimitives for Mux {
     }
 
     fn send_declare(&self, ctx: RoutingContext<&mut Declare>) {
-        // let mut ctx = RoutingContext {
-        //     msg: NetworkMessageMut {
-        //         body: NetworkBodyMut::Declare(ctx.msg),
-        //         reliability: Reliability::Reliable,
-        //     },
-        //     inface: ctx.inface,
-        //     outface: ctx.outface,
-        //     prefix: ctx.prefix,
-        //     full_expr: ctx.full_expr,
-        // };
-        // let prefix = ctx
-        //     .wire_expr()
-        //     .and_then(|we| (!we.has_suffix()).then(|| ctx.prefix()))
-        //     .flatten()
-        //     .cloned();
-        // let interceptor = self.interceptor.load();
-        // let cache_guard = prefix
-        //     .as_ref()
-        //     .and_then(|p| p.get_egress_cache(ctx.outface.get().unwrap(), &interceptor));
-        // let cache = cache_guard.as_ref().and_then(|c| c.get_ref().as_ref());
-
         let mut msg = NetworkMessageMut {
             body: NetworkBodyMut::Declare(ctx.msg),
             reliability: Reliability::Reliable,
         };
-
-        let mut ctx = MuxContext {
-            mux: self,
-            cache: OnceCell::new(),
-            expr: ctx.full_expr,
+        let mut ctx = RoutingContext {
+            msg: (),
+            full_expr: ctx.full_expr,
         };
-        // let mut ctx = RoutingContext {
-        //     msg: &mut msg,
-        //     inface: ctx.inface,
-        //     outface: ctx.outface,
-        //     // prefix: ctx.prefix,
-        //     full_expr: ctx.full_expr,
-        // };
 
         if self
             .interceptor
@@ -370,10 +321,9 @@ impl EPrimitives for McastMux {
             body: NetworkBodyMut::Interest(ctx.msg),
             reliability: Reliability::Reliable,
         };
-        let mut ctx = McastMuxContext {
-            mux: self,
-            cache: OnceCell::new(),
-            expr: ctx.full_expr,
+        let mut ctx = RoutingContext {
+            msg: (),
+            full_expr: ctx.full_expr,
         };
 
         if self
@@ -395,10 +345,9 @@ impl EPrimitives for McastMux {
             body: NetworkBodyMut::Declare(ctx.msg),
             reliability: Reliability::Reliable,
         };
-        let mut ctx = McastMuxContext {
-            mux: self,
-            cache: OnceCell::new(),
-            expr: ctx.full_expr,
+        let mut ctx = RoutingContext {
+            msg: (),
+            full_expr: ctx.full_expr,
         };
 
         if self

--- a/zenoh/src/net/primitives/mux.rs
+++ b/zenoh/src/net/primitives/mux.rs
@@ -11,14 +11,18 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use std::sync::OnceLock;
+use std::{
+    any::Any,
+    cell::OnceCell,
+    sync::{Arc, OnceLock},
+};
 
 use arc_swap::ArcSwap;
 use zenoh_protocol::{
     core::Reliability,
     network::{
-        interest::Interest, response, Declare, NetworkBodyMut, NetworkMessageMut, Push, Request,
-        Response, ResponseFinal,
+        interest::Interest, response, Declare, NetworkBodyMut, NetworkMessageExt as _,
+        NetworkMessageMut, Push, Request, Response, ResponseFinal,
     },
 };
 use zenoh_transport::{multicast::TransportMulticast, unicast::TransportUnicast};
@@ -26,7 +30,8 @@ use zenoh_transport::{multicast::TransportMulticast, unicast::TransportUnicast};
 use super::{EPrimitives, Primitives};
 use crate::net::routing::{
     dispatcher::face::{Face, WeakFace},
-    interceptor::{InterceptorTrait, InterceptorsChain},
+    interceptor::{InterceptorContext, InterceptorTrait, InterceptorsChain},
+    router::{InterceptorCacheValueType, Resource},
     RoutingContext,
 };
 
@@ -46,33 +51,100 @@ impl Mux {
     }
 }
 
+struct MuxContext<'a> {
+    mux: &'a Mux,
+    cache: OnceCell<InterceptorCacheValueType>,
+    expr: OnceCell<String>,
+}
+
+impl MuxContext<'_> {
+    fn prefix(&self, msg: &NetworkMessageMut) -> Option<Arc<Resource>> {
+        if let Some(wire_expr) = msg.wire_expr() {
+            let wire_expr = wire_expr.to_owned();
+            if let Some(face) = self.mux.face.get().and_then(|f| f.upgrade()) {
+                if let Some(prefix) = zread!(face.tables.tables)
+                    .get_sent_mapping(&face.state, &wire_expr.scope, wire_expr.mapping)
+                    .cloned()
+                {
+                    return Some(prefix);
+                }
+            }
+        }
+        None
+    }
+}
+
+impl InterceptorContext for MuxContext<'_> {
+    fn face(&self) -> Option<Face> {
+        self.mux.face.get().and_then(|f| f.upgrade())
+    }
+
+    fn full_expr(&self, msg: &NetworkMessageMut) -> Option<&str> {
+        if self.expr.get().is_none() {
+            if let Some(wire_expr) = msg.wire_expr() {
+                if let Some(prefix) = self.prefix(msg) {
+                    self.expr
+                        .set(prefix.expr().to_string() + wire_expr.suffix.as_ref())
+                        .ok();
+                }
+            }
+        }
+        self.expr.get().map(|x| x.as_str())
+    }
+    fn get_cache(&self, msg: &NetworkMessageMut) -> Option<&Box<dyn Any + Send + Sync>> {
+        if self.cache.get().is_none() {
+            if let Some(prefix) = self.prefix(msg) {
+                if let Some(face) = self.mux.face.get().and_then(|f| f.upgrade()) {
+                    if let Some(cache) =
+                        prefix.get_egress_cache(&face, &self.mux.interceptor.load())
+                    {
+                        self.cache.set(cache).ok();
+                    }
+                }
+            }
+        }
+        self.cache.get().and_then(|c| c.get_ref().as_ref())
+    }
+}
+
 impl EPrimitives for Mux {
     fn send_interest(&self, ctx: RoutingContext<&mut Interest>) {
         let interest_id = ctx.msg.id;
-        let mut ctx = RoutingContext {
-            msg: NetworkMessageMut {
-                body: NetworkBodyMut::Interest(ctx.msg),
-                reliability: Reliability::Reliable,
-            },
-            inface: ctx.inface,
-            outface: ctx.outface,
-            prefix: ctx.prefix,
-            full_expr: ctx.full_expr,
+
+        let mut msg = NetworkMessageMut {
+            body: NetworkBodyMut::Interest(ctx.msg),
+            reliability: Reliability::Reliable,
         };
-        let prefix = ctx
-            .wire_expr()
-            .and_then(|we| (!we.has_suffix()).then(|| ctx.prefix()))
-            .flatten()
-            .cloned();
-        let interceptor = self.interceptor.load();
-        let cache_guard = prefix
-            .as_ref()
-            .and_then(|p| p.get_egress_cache(ctx.outface.get().unwrap(), &interceptor));
+        let mut ctx = MuxContext {
+            mux: self,
+            cache: OnceCell::new(),
+            expr: ctx.full_expr,
+        };
+        // let mut ctx = RoutingContext {
+        //     msg: &mut msg,
+        //     inface: ctx.inface,
+        //     outface: ctx.outface,
+        //     // prefix: ctx.prefix,
+        //     full_expr: ctx.full_expr,
+        // };
+        // let prefix = ctx
+        //     .wire_expr()
+        //     .and_then(|we| (!we.has_suffix()).then(|| ctx.prefix()))
+        //     .flatten()
+        //     .cloned();
+        // let interceptor = self.interceptor.load();
+        // let cache_guard = prefix
+        //     .as_ref()
+        //     .and_then(|p| p.get_egress_cache(ctx.outface.get().unwrap(), &interceptor));
 
-        let cache = cache_guard.as_ref().and_then(|c| c.get_ref().as_ref());
+        // let cache = cache_guard.as_ref().and_then(|c| c.get_ref().as_ref());
 
-        if self.interceptor.load().intercept(&mut ctx, cache) {
-            let _ = self.handler.schedule(ctx.msg);
+        if self
+            .interceptor
+            .load()
+            .intercept(&mut msg, &mut ctx as &mut dyn InterceptorContext)
+        {
+            let _ = self.handler.schedule(msg);
         } else {
             // send declare final to avoid timeout on blocked interest
             if let Some(face) = self.face.get().and_then(|f| f.upgrade()) {
@@ -82,83 +154,89 @@ impl EPrimitives for Mux {
     }
 
     fn send_declare(&self, ctx: RoutingContext<&mut Declare>) {
-        let mut ctx = RoutingContext {
-            msg: NetworkMessageMut {
-                body: NetworkBodyMut::Declare(ctx.msg),
-                reliability: Reliability::Reliable,
-            },
-            inface: ctx.inface,
-            outface: ctx.outface,
-            prefix: ctx.prefix,
-            full_expr: ctx.full_expr,
-        };
-        let prefix = ctx
-            .wire_expr()
-            .and_then(|we| (!we.has_suffix()).then(|| ctx.prefix()))
-            .flatten()
-            .cloned();
-        let interceptor = self.interceptor.load();
-        let cache_guard = prefix
-            .as_ref()
-            .and_then(|p| p.get_egress_cache(ctx.outface.get().unwrap(), &interceptor));
-        let cache = cache_guard.as_ref().and_then(|c| c.get_ref().as_ref());
+        // let mut ctx = RoutingContext {
+        //     msg: NetworkMessageMut {
+        //         body: NetworkBodyMut::Declare(ctx.msg),
+        //         reliability: Reliability::Reliable,
+        //     },
+        //     inface: ctx.inface,
+        //     outface: ctx.outface,
+        //     prefix: ctx.prefix,
+        //     full_expr: ctx.full_expr,
+        // };
+        // let prefix = ctx
+        //     .wire_expr()
+        //     .and_then(|we| (!we.has_suffix()).then(|| ctx.prefix()))
+        //     .flatten()
+        //     .cloned();
+        // let interceptor = self.interceptor.load();
+        // let cache_guard = prefix
+        //     .as_ref()
+        //     .and_then(|p| p.get_egress_cache(ctx.outface.get().unwrap(), &interceptor));
+        // let cache = cache_guard.as_ref().and_then(|c| c.get_ref().as_ref());
 
-        if self.interceptor.load().intercept(&mut ctx, cache) {
-            let _ = self.handler.schedule(ctx.msg);
+        let mut msg = NetworkMessageMut {
+            body: NetworkBodyMut::Declare(ctx.msg),
+            reliability: Reliability::Reliable,
+        };
+
+        let mut ctx = MuxContext {
+            mux: self,
+            cache: OnceCell::new(),
+            expr: ctx.full_expr,
+        };
+        // let mut ctx = RoutingContext {
+        //     msg: &mut msg,
+        //     inface: ctx.inface,
+        //     outface: ctx.outface,
+        //     // prefix: ctx.prefix,
+        //     full_expr: ctx.full_expr,
+        // };
+
+        if self
+            .interceptor
+            .load()
+            .intercept(&mut msg, &mut ctx as &mut dyn InterceptorContext)
+        {
+            let _ = self.handler.schedule(msg);
         }
     }
 
     fn send_push(&self, msg: &mut Push, reliability: Reliability) {
-        let msg = NetworkMessageMut {
+        let mut msg = NetworkMessageMut {
             body: NetworkBodyMut::Push(msg),
             reliability,
         };
+        let mut ctx = MuxContext {
+            mux: self,
+            cache: OnceCell::new(),
+            expr: OnceCell::new(),
+        };
         let interceptor = self.interceptor.load();
-        if interceptor.interceptors.is_empty() {
+        if interceptor.interceptors.is_empty()
+            || interceptor.intercept(&mut msg, &mut ctx as &mut dyn InterceptorContext)
+        {
             let _ = self.handler.schedule(msg);
-        } else if let Some(face) = self.face.get().and_then(|f| f.upgrade()) {
-            let mut ctx = RoutingContext::new_out(msg, face.clone());
-            let prefix = ctx
-                .wire_expr()
-                .and_then(|we| (!we.has_suffix()).then(|| ctx.prefix()))
-                .flatten()
-                .cloned();
-            let cache_guard = prefix
-                .as_ref()
-                .and_then(|p| p.get_egress_cache(&face, &interceptor));
-            let cache = cache_guard.as_ref().and_then(|c| c.get_ref().as_ref());
-
-            if interceptor.intercept(&mut ctx, cache) {
-                let _ = self.handler.schedule(ctx.msg);
-            }
-        } else {
-            tracing::error!("Uninitialized multiplexer!");
         }
     }
 
     fn send_request(&self, msg: &mut Request) {
         let request_id = msg.id;
-        let msg = NetworkMessageMut {
+        let mut msg = NetworkMessageMut {
             body: NetworkBodyMut::Request(msg),
             reliability: Reliability::Reliable,
+        };
+        let mut ctx = MuxContext {
+            mux: self,
+            cache: OnceCell::new(),
+            expr: OnceCell::new(),
         };
         let interceptor = self.interceptor.load();
         if interceptor.interceptors.is_empty() {
             let _ = self.handler.schedule(msg);
         } else if let Some(face) = self.face.get().and_then(|f| f.upgrade()) {
-            let mut ctx = RoutingContext::new_out(msg, face.clone());
-            let prefix = ctx
-                .wire_expr()
-                .and_then(|we| (!we.has_suffix()).then(|| ctx.prefix()))
-                .flatten()
-                .cloned();
-            let cache_guard = prefix
-                .as_ref()
-                .and_then(|p| p.get_egress_cache(&face, &interceptor));
-            let cache = cache_guard.as_ref().and_then(|c| c.get_ref().as_ref());
-
-            if interceptor.intercept(&mut ctx, cache) {
-                let _ = self.handler.schedule(ctx.msg);
+            if interceptor.intercept(&mut msg, &mut ctx as &mut dyn InterceptorContext) {
+                let _ = self.handler.schedule(msg);
             } else {
                 // request was blocked by an interceptor, we need to send response final to avoid timeout error
                 face.send_response_final(&mut ResponseFinal {
@@ -173,57 +251,38 @@ impl EPrimitives for Mux {
     }
 
     fn send_response(&self, msg: &mut Response) {
-        let msg = NetworkMessageMut {
+        let mut msg = NetworkMessageMut {
             body: NetworkBodyMut::Response(msg),
             reliability: Reliability::Reliable,
         };
+        let mut ctx = MuxContext {
+            mux: self,
+            cache: OnceCell::new(),
+            expr: OnceCell::new(),
+        };
         let interceptor = self.interceptor.load();
-        if interceptor.interceptors.is_empty() {
+        if interceptor.interceptors.is_empty()
+            || interceptor.intercept(&mut msg, &mut ctx as &mut dyn InterceptorContext)
+        {
             let _ = self.handler.schedule(msg);
-        } else if let Some(face) = self.face.get().and_then(|f| f.upgrade()) {
-            let mut ctx = RoutingContext::new_out(msg, face.clone());
-            let prefix = ctx
-                .wire_expr()
-                .and_then(|we| (!we.has_suffix()).then(|| ctx.prefix()))
-                .flatten()
-                .cloned();
-            let cache_guard = prefix
-                .as_ref()
-                .and_then(|p| p.get_egress_cache(&face, &interceptor));
-            let cache = cache_guard.as_ref().and_then(|c| c.get_ref().as_ref());
-
-            if interceptor.intercept(&mut ctx, cache) {
-                let _ = self.handler.schedule(ctx.msg);
-            }
-        } else {
-            tracing::error!("Uninitialized multiplexer!");
         }
     }
 
     fn send_response_final(&self, msg: &mut ResponseFinal) {
-        let msg = NetworkMessageMut {
+        let mut msg = NetworkMessageMut {
             body: NetworkBodyMut::ResponseFinal(msg),
             reliability: Reliability::Reliable,
         };
+        let mut ctx = MuxContext {
+            mux: self,
+            cache: OnceCell::new(),
+            expr: OnceCell::new(),
+        };
         let interceptor = self.interceptor.load();
-        if interceptor.interceptors.is_empty() {
+        if interceptor.interceptors.is_empty()
+            || interceptor.intercept(&mut msg, &mut ctx as &mut dyn InterceptorContext)
+        {
             let _ = self.handler.schedule(msg);
-        } else if let Some(face) = self.face.get().and_then(|f| f.upgrade()) {
-            let mut ctx = RoutingContext::new_out(msg, face.clone());
-            let prefix = ctx
-                .wire_expr()
-                .and_then(|we| (!we.has_suffix()).then(|| ctx.prefix()))
-                .flatten()
-                .cloned();
-            let cache_guard = prefix
-                .as_ref()
-                .and_then(|p| p.get_egress_cache(&face, &interceptor));
-            let cache = cache_guard.as_ref().and_then(|c| c.get_ref().as_ref());
-            if interceptor.intercept(&mut ctx, cache) {
-                let _ = self.handler.schedule(ctx.msg);
-            }
-        } else {
-            tracing::error!("Uninitialized multiplexer!");
         }
     }
 
@@ -248,107 +307,151 @@ impl McastMux {
     }
 }
 
+struct McastMuxContext<'a> {
+    mux: &'a McastMux,
+    cache: OnceCell<InterceptorCacheValueType>,
+    expr: OnceCell<String>,
+}
+
+impl McastMuxContext<'_> {
+    fn prefix(&self, msg: &NetworkMessageMut) -> Option<Arc<Resource>> {
+        if let Some(wire_expr) = msg.wire_expr() {
+            let wire_expr = wire_expr.to_owned();
+            if let Some(face) = self.mux.face.get() {
+                if let Some(prefix) = zread!(face.tables.tables)
+                    .get_sent_mapping(&face.state, &wire_expr.scope, wire_expr.mapping)
+                    .cloned()
+                {
+                    return Some(prefix);
+                }
+            }
+        }
+        None
+    }
+}
+
+impl InterceptorContext for McastMuxContext<'_> {
+    fn face(&self) -> Option<Face> {
+        self.mux.face.get().cloned()
+    }
+
+    fn full_expr(&self, msg: &NetworkMessageMut) -> Option<&str> {
+        if self.expr.get().is_none() {
+            if let Some(wire_expr) = msg.wire_expr() {
+                if let Some(prefix) = self.prefix(msg) {
+                    self.expr
+                        .set(prefix.expr().to_string() + wire_expr.suffix.as_ref())
+                        .ok();
+                }
+            }
+        }
+        self.expr.get().map(|x| x.as_str())
+    }
+    fn get_cache(&self, msg: &NetworkMessageMut) -> Option<&Box<dyn Any + Send + Sync>> {
+        if self.cache.get().is_none() {
+            if let Some(prefix) = self.prefix(msg) {
+                if let Some(face) = self.mux.face.get() {
+                    if let Some(cache) = prefix.get_egress_cache(face, &self.mux.interceptor.load())
+                    {
+                        self.cache.set(cache).ok();
+                    }
+                }
+            }
+        }
+        self.cache.get().and_then(|c| c.get_ref().as_ref())
+    }
+}
+
 impl EPrimitives for McastMux {
     fn send_interest(&self, ctx: RoutingContext<&mut Interest>) {
-        let mut ctx = RoutingContext {
-            msg: NetworkMessageMut {
-                body: NetworkBodyMut::Interest(ctx.msg),
-                reliability: Reliability::Reliable,
-            },
-            inface: ctx.inface,
-            outface: ctx.outface,
-            prefix: ctx.prefix,
-            full_expr: ctx.full_expr,
+        let interest_id = ctx.msg.id;
+
+        let mut msg = NetworkMessageMut {
+            body: NetworkBodyMut::Interest(ctx.msg),
+            reliability: Reliability::Reliable,
         };
-        let prefix = ctx
-            .wire_expr()
-            .and_then(|we| (!we.has_suffix()).then(|| ctx.prefix()))
-            .flatten()
-            .cloned();
-        let interceptor = self.interceptor.load();
-        let cache_guard = prefix
-            .as_ref()
-            .and_then(|p| p.get_egress_cache(ctx.outface.get().unwrap(), &interceptor));
-        let cache = cache_guard.as_ref().and_then(|c| c.get_ref().as_ref());
-        if self.interceptor.load().intercept(&mut ctx, cache) {
-            let _ = self.handler.schedule(ctx.msg);
+        let mut ctx = McastMuxContext {
+            mux: self,
+            cache: OnceCell::new(),
+            expr: ctx.full_expr,
+        };
+
+        if self
+            .interceptor
+            .load()
+            .intercept(&mut msg, &mut ctx as &mut dyn InterceptorContext)
+        {
+            let _ = self.handler.schedule(msg);
+        } else {
+            // send declare final to avoid timeout on blocked interest
+            if let Some(face) = self.face.get() {
+                face.reject_interest(interest_id);
+            }
         }
     }
 
     fn send_declare(&self, ctx: RoutingContext<&mut Declare>) {
-        let mut ctx = RoutingContext {
-            msg: NetworkMessageMut {
-                body: NetworkBodyMut::Declare(ctx.msg),
-                reliability: Reliability::Reliable,
-            },
-            inface: ctx.inface,
-            outface: ctx.outface,
-            prefix: ctx.prefix,
-            full_expr: ctx.full_expr,
+        let mut msg = NetworkMessageMut {
+            body: NetworkBodyMut::Declare(ctx.msg),
+            reliability: Reliability::Reliable,
         };
-        let prefix = ctx
-            .wire_expr()
-            .and_then(|we| (!we.has_suffix()).then(|| ctx.prefix()))
-            .flatten()
-            .cloned();
-        let interceptor = self.interceptor.load();
-        let cache_guard = prefix
-            .as_ref()
-            .and_then(|p| p.get_egress_cache(ctx.outface.get().unwrap(), &interceptor));
-        let cache = cache_guard.as_ref().and_then(|c| c.get_ref().as_ref());
-        if self.interceptor.load().intercept(&mut ctx, cache) {
-            let _ = self.handler.schedule(ctx.msg);
+        let mut ctx = McastMuxContext {
+            mux: self,
+            cache: OnceCell::new(),
+            expr: ctx.full_expr,
+        };
+
+        if self
+            .interceptor
+            .load()
+            .intercept(&mut msg, &mut ctx as &mut dyn InterceptorContext)
+        {
+            let _ = self.handler.schedule(msg);
         }
     }
 
     fn send_push(&self, msg: &mut Push, reliability: Reliability) {
-        let msg = NetworkMessageMut {
+        let mut msg = NetworkMessageMut {
             body: NetworkBodyMut::Push(msg),
             reliability,
         };
+        let mut ctx = McastMuxContext {
+            mux: self,
+            cache: OnceCell::new(),
+            expr: OnceCell::new(),
+        };
         let interceptor = self.interceptor.load();
-        if interceptor.interceptors.is_empty() {
+        if interceptor.interceptors.is_empty()
+            || interceptor.intercept(&mut msg, &mut ctx as &mut dyn InterceptorContext)
+        {
             let _ = self.handler.schedule(msg);
-        } else if let Some(face) = self.face.get() {
-            let mut ctx = RoutingContext::new_out(msg, face.clone());
-            let prefix = ctx
-                .wire_expr()
-                .and_then(|we| (!we.has_suffix()).then(|| ctx.prefix()))
-                .flatten()
-                .cloned();
-            let cache_guard = prefix
-                .as_ref()
-                .and_then(|p| p.get_egress_cache(face, &interceptor));
-            let cache = cache_guard.as_ref().and_then(|c| c.get_ref().as_ref());
-            if interceptor.intercept(&mut ctx, cache) {
-                let _ = self.handler.schedule(ctx.msg);
-            }
-        } else {
-            tracing::error!("Uninitialized multiplexer!");
         }
     }
 
     fn send_request(&self, msg: &mut Request) {
-        let msg = NetworkMessageMut {
+        let request_id = msg.id;
+        let mut msg = NetworkMessageMut {
             body: NetworkBodyMut::Request(msg),
             reliability: Reliability::Reliable,
+        };
+        let mut ctx = McastMuxContext {
+            mux: self,
+            cache: OnceCell::new(),
+            expr: OnceCell::new(),
         };
         let interceptor = self.interceptor.load();
         if interceptor.interceptors.is_empty() {
             let _ = self.handler.schedule(msg);
         } else if let Some(face) = self.face.get() {
-            let mut ctx = RoutingContext::new_out(msg, face.clone());
-            let prefix = ctx
-                .wire_expr()
-                .and_then(|we| (!we.has_suffix()).then(|| ctx.prefix()))
-                .flatten()
-                .cloned();
-            let cache_guard = prefix
-                .as_ref()
-                .and_then(|p| p.get_egress_cache(face, &interceptor));
-            let cache = cache_guard.as_ref().and_then(|c| c.get_ref().as_ref());
-            if interceptor.intercept(&mut ctx, cache) {
-                let _ = self.handler.schedule(ctx.msg);
+            if interceptor.intercept(&mut msg, &mut ctx as &mut dyn InterceptorContext) {
+                let _ = self.handler.schedule(msg);
+            } else {
+                // request was blocked by an interceptor, we need to send response final to avoid timeout error
+                face.send_response_final(&mut ResponseFinal {
+                    rid: request_id,
+                    ext_qos: response::ext::QoSType::RESPONSE_FINAL,
+                    ext_tstamp: None,
+                })
             }
         } else {
             tracing::error!("Uninitialized multiplexer!");
@@ -356,56 +459,38 @@ impl EPrimitives for McastMux {
     }
 
     fn send_response(&self, msg: &mut Response) {
-        let msg = NetworkMessageMut {
+        let mut msg = NetworkMessageMut {
             body: NetworkBodyMut::Response(msg),
             reliability: Reliability::Reliable,
         };
+        let mut ctx = McastMuxContext {
+            mux: self,
+            cache: OnceCell::new(),
+            expr: OnceCell::new(),
+        };
         let interceptor = self.interceptor.load();
-        if interceptor.interceptors.is_empty() {
+        if interceptor.interceptors.is_empty()
+            || interceptor.intercept(&mut msg, &mut ctx as &mut dyn InterceptorContext)
+        {
             let _ = self.handler.schedule(msg);
-        } else if let Some(face) = self.face.get() {
-            let mut ctx = RoutingContext::new_out(msg, face.clone());
-            let prefix = ctx
-                .wire_expr()
-                .and_then(|we| (!we.has_suffix()).then(|| ctx.prefix()))
-                .flatten()
-                .cloned();
-            let cache_guard = prefix
-                .as_ref()
-                .and_then(|p| p.get_egress_cache(face, &interceptor));
-            let cache = cache_guard.as_ref().and_then(|c| c.get_ref().as_ref());
-            if interceptor.intercept(&mut ctx, cache) {
-                let _ = self.handler.schedule(ctx.msg);
-            }
-        } else {
-            tracing::error!("Uninitialized multiplexer!");
         }
     }
 
     fn send_response_final(&self, msg: &mut ResponseFinal) {
-        let msg = NetworkMessageMut {
+        let mut msg = NetworkMessageMut {
             body: NetworkBodyMut::ResponseFinal(msg),
             reliability: Reliability::Reliable,
         };
+        let mut ctx = McastMuxContext {
+            mux: self,
+            cache: OnceCell::new(),
+            expr: OnceCell::new(),
+        };
         let interceptor = self.interceptor.load();
-        if interceptor.interceptors.is_empty() {
+        if interceptor.interceptors.is_empty()
+            || interceptor.intercept(&mut msg, &mut ctx as &mut dyn InterceptorContext)
+        {
             let _ = self.handler.schedule(msg);
-        } else if let Some(face) = self.face.get() {
-            let mut ctx = RoutingContext::new_out(msg, face.clone());
-            let prefix = ctx
-                .wire_expr()
-                .and_then(|we| (!we.has_suffix()).then(|| ctx.prefix()))
-                .flatten()
-                .cloned();
-            let cache_guard = prefix
-                .as_ref()
-                .and_then(|p| p.get_egress_cache(face, &interceptor));
-            let cache = cache_guard.as_ref().and_then(|c| c.get_ref().as_ref());
-            if interceptor.intercept(&mut ctx, cache) {
-                let _ = self.handler.schedule(ctx.msg);
-            }
-        } else {
-            tracing::error!("Uninitialized multiplexer!");
         }
     }
 

--- a/zenoh/src/net/primitives/mux.rs
+++ b/zenoh/src/net/primitives/mux.rs
@@ -92,7 +92,7 @@ impl InterceptorContext for MuxContext<'_> {
         self.expr.get().map(|x| x.as_str())
     }
     fn get_cache(&self, msg: &NetworkMessageMut) -> Option<&Box<dyn Any + Send + Sync>> {
-        if self.cache.get().is_none() {
+        if self.cache.get().is_none() && msg.wire_expr().is_some_and(|we| !we.has_suffix()) {
             if let Some(prefix) = self.prefix(msg) {
                 if let Some(face) = self.mux.face.get().and_then(|f| f.upgrade()) {
                     if let Some(cache) =
@@ -348,7 +348,7 @@ impl InterceptorContext for McastMuxContext<'_> {
         self.expr.get().map(|x| x.as_str())
     }
     fn get_cache(&self, msg: &NetworkMessageMut) -> Option<&Box<dyn Any + Send + Sync>> {
-        if self.cache.get().is_none() {
+        if self.cache.get().is_none() && msg.wire_expr().is_some_and(|we| !we.has_suffix()) {
             if let Some(prefix) = self.prefix(msg) {
                 if let Some(face) = self.mux.face.get() {
                     if let Some(cache) = prefix.get_egress_cache(face, &self.mux.interceptor.load())

--- a/zenoh/src/net/routing/interceptor/mod.rs
+++ b/zenoh/src/net/routing/interceptor/mod.rs
@@ -34,10 +34,13 @@ use zenoh_protocol::network::NetworkMessageMut;
 use zenoh_result::ZResult;
 use zenoh_transport::{multicast::TransportMulticast, unicast::TransportUnicast};
 
-use super::RoutingContext;
-
 pub mod downsampling;
-use crate::net::routing::interceptor::downsampling::downsampling_interceptor_factories;
+use crate::{
+    key_expr::KeyExpr,
+    net::routing::{
+        dispatcher::face::Face, interceptor::downsampling::downsampling_interceptor_factories,
+    },
+};
 
 pub mod qos_overwrite;
 use crate::net::routing::interceptor::qos_overwrite::qos_overwrite_interceptor_factories;
@@ -83,14 +86,22 @@ impl From<&LinkAuthId> for InterceptorLinkWrapper {
     }
 }
 
+pub(crate) trait InterceptorContext {
+    #[allow(dead_code)]
+    fn face(&self) -> Option<Face>;
+    fn full_expr(&self, msg: &NetworkMessageMut) -> Option<&str>;
+    #[inline]
+    fn full_keyexpr(&self, msg: &NetworkMessageMut) -> Option<KeyExpr> {
+        let full_expr = self.full_expr(msg)?;
+        KeyExpr::new(full_expr).ok()
+    }
+    fn get_cache(&self, msg: &NetworkMessageMut) -> Option<&Box<dyn Any + Send + Sync>>;
+}
+
 pub(crate) trait InterceptorTrait {
     fn compute_keyexpr_cache(&self, key_expr: &keyexpr) -> Option<Box<dyn Any + Send + Sync>>;
 
-    fn intercept(
-        &self,
-        ctx: &mut RoutingContext<NetworkMessageMut>,
-        cache: Option<&Box<dyn Any + Send + Sync>>,
-    ) -> bool;
+    fn intercept(&self, msg: &mut NetworkMessageMut, ctx: &mut dyn InterceptorContext) -> bool;
 }
 
 pub(crate) type Interceptor = Box<dyn InterceptorTrait + Send + Sync>;
@@ -162,18 +173,10 @@ impl InterceptorTrait for InterceptorsChain {
         ))
     }
 
-    fn intercept<'a>(
-        &self,
-        ctx: &mut RoutingContext<NetworkMessageMut>,
-        caches: Option<&Box<dyn Any + Send + Sync>>,
-    ) -> bool {
-        let caches =
-            caches.and_then(|i| i.downcast_ref::<Vec<Option<Box<dyn Any + Send + Sync>>>>());
-        for (idx, interceptor) in self.interceptors.iter().enumerate() {
-            let cache = caches
-                .and_then(|caches| caches.get(idx).map(|k| k.as_ref()))
-                .flatten();
-            if !interceptor.intercept(ctx, cache) {
+    fn intercept<'a>(&self, msg: &mut NetworkMessageMut, ctx: &mut dyn InterceptorContext) -> bool {
+        let mut ctx = ChainContext { ctx, index: 0 };
+        for interceptor in &self.interceptors {
+            if !interceptor.intercept(msg, &mut ctx as &mut dyn InterceptorContext) {
                 tracing::trace!("Msg intercepted!");
                 return false;
             }
@@ -182,36 +185,59 @@ impl InterceptorTrait for InterceptorsChain {
     }
 }
 
-pub(crate) struct ComputeOnMiss<T: InterceptorTrait> {
-    interceptor: T,
+struct ChainContext<'a> {
+    ctx: &'a mut dyn InterceptorContext,
+    index: usize,
 }
 
-impl<T: InterceptorTrait> ComputeOnMiss<T> {
-    #[allow(dead_code)]
-    pub(crate) fn new(interceptor: T) -> Self {
-        Self { interceptor }
+impl InterceptorContext for ChainContext<'_> {
+    fn face(&self) -> Option<Face> {
+        self.ctx.face()
+    }
+
+    fn full_expr(&self, msg: &NetworkMessageMut) -> Option<&str> {
+        self.ctx.full_expr(msg)
+    }
+
+    fn full_keyexpr(&self, msg: &NetworkMessageMut) -> Option<KeyExpr> {
+        self.ctx.full_keyexpr(msg)
+    }
+
+    fn get_cache(&self, msg: &NetworkMessageMut) -> Option<&Box<dyn Any + Send + Sync>> {
+        let caches = self.ctx.get_cache(msg)?;
+        let caches = caches.downcast_ref::<Vec<Option<Box<dyn Any + Send + Sync>>>>()?;
+        caches[self.index].as_ref()
     }
 }
 
-impl<T: InterceptorTrait> InterceptorTrait for ComputeOnMiss<T> {
-    #[inline]
-    fn compute_keyexpr_cache(&self, key_expr: &keyexpr) -> Option<Box<dyn Any + Send + Sync>> {
-        self.interceptor.compute_keyexpr_cache(key_expr)
-    }
+pub(crate) enum ComputedOnMiss<'a> {
+    Hit(Option<&'a Box<dyn Any + Send + Sync>>),
+    Computed(Option<Box<dyn Any + Send + Sync>>),
+}
 
-    #[inline]
-    fn intercept<'a>(
-        &self,
-        ctx: &mut RoutingContext<NetworkMessageMut>,
-        cache: Option<&Box<dyn Any + Send + Sync>>,
-    ) -> bool {
-        if cache.is_some() {
-            self.interceptor.intercept(ctx, cache)
-        } else if let Some(key_expr) = ctx.full_keyexpr() {
-            let cache = self.interceptor.compute_keyexpr_cache(key_expr);
-            self.interceptor.intercept(ctx, cache.as_ref())
-        } else {
-            self.interceptor.intercept(ctx, cache)
+impl ComputedOnMiss<'_> {
+    fn as_ref(&self) -> Option<&Box<dyn Any + Send + Sync>> {
+        match self {
+            ComputedOnMiss::Hit(cache) => *cache,
+            ComputedOnMiss::Computed(cache) => cache.as_ref(),
+        }
+    }
+}
+
+impl<'a> ComputedOnMiss<'a> {
+    pub(crate) fn new(
+        interceptor: &dyn InterceptorTrait,
+        msg: &mut NetworkMessageMut,
+        ctx: &'a mut dyn InterceptorContext,
+    ) -> Self {
+        match ctx.get_cache(msg) {
+            Some(cache) => ComputedOnMiss::Hit(Some(cache)),
+            None => {
+                let cache = ctx
+                    .full_keyexpr(msg)
+                    .and_then(|key_expr| interceptor.compute_keyexpr_cache(&key_expr));
+                ComputedOnMiss::Computed(cache)
+            }
         }
     }
 }
@@ -224,21 +250,18 @@ impl InterceptorTrait for IngressMsgLogger {
         Some(Box::new(OwnedKeyExpr::from(key_expr)))
     }
 
-    fn intercept(
-        &self,
-        ctx: &mut RoutingContext<NetworkMessageMut>,
-        cache: Option<&Box<dyn Any + Send + Sync>>,
-    ) -> bool {
-        let expr = cache
+    fn intercept(&self, msg: &mut NetworkMessageMut, ctx: &mut dyn InterceptorContext) -> bool {
+        let expr = ctx
+            .get_cache(msg)
             .and_then(|i| i.downcast_ref::<String>().map(|e| e.as_str()))
-            .or_else(|| ctx.full_expr());
+            .or_else(|| ctx.full_expr(msg));
 
         tracing::debug!(
             "{} Recv {} Expr:{:?}",
-            ctx.inface()
+            ctx.face()
                 .map(|f| f.to_string())
                 .unwrap_or("None".to_string()),
-            ctx.msg,
+            msg,
             expr,
         );
         true
@@ -253,20 +276,17 @@ impl InterceptorTrait for EgressMsgLogger {
         Some(Box::new(OwnedKeyExpr::from(key_expr)))
     }
 
-    fn intercept(
-        &self,
-        ctx: &mut RoutingContext<NetworkMessageMut>,
-        cache: Option<&Box<dyn Any + Send + Sync>>,
-    ) -> bool {
-        let expr = cache
+    fn intercept(&self, msg: &mut NetworkMessageMut, ctx: &mut dyn InterceptorContext) -> bool {
+        let expr = ctx
+            .get_cache(msg)
             .and_then(|i| i.downcast_ref::<String>().map(|e| e.as_str()))
-            .or_else(|| ctx.full_expr());
+            .or_else(|| ctx.full_expr(msg));
         tracing::debug!(
             "{} Send {} Expr:{:?}",
-            ctx.outface()
+            ctx.face()
                 .map(|f| f.to_string())
                 .unwrap_or("None".to_string()),
-            ctx.msg,
+            msg,
             expr
         );
         true

--- a/zenoh/src/net/routing/interceptor/mod.rs
+++ b/zenoh/src/net/routing/interceptor/mod.rs
@@ -180,6 +180,7 @@ impl InterceptorTrait for InterceptorsChain {
                 tracing::trace!("Msg intercepted!");
                 return false;
             }
+            ctx.index += 1;
         }
         true
     }

--- a/zenoh/src/net/routing/mod.rs
+++ b/zenoh/src/net/routing/mod.rs
@@ -25,19 +25,11 @@ pub mod router;
 
 use std::{cell::OnceCell, sync::Arc};
 
-use zenoh_keyexpr::keyexpr;
-use zenoh_protocol::{
-    core::WireExpr,
-    network::{NetworkMessageExt, NetworkMessageMut},
-};
-
-use self::{dispatcher::face::Face, router::Resource};
+use self::router::Resource;
 use super::runtime;
 
 pub(crate) struct RoutingContext<Msg> {
     pub(crate) msg: Msg,
-    pub(crate) inface: OnceCell<Face>,
-    pub(crate) outface: OnceCell<Face>,
     pub(crate) prefix: OnceCell<Arc<Resource>>,
     pub(crate) full_expr: OnceCell<String>,
 }
@@ -47,30 +39,6 @@ impl<Msg> RoutingContext<Msg> {
     pub(crate) fn new(msg: Msg) -> Self {
         Self {
             msg,
-            inface: OnceCell::new(),
-            outface: OnceCell::new(),
-            prefix: OnceCell::new(),
-            full_expr: OnceCell::new(),
-        }
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn new_in(msg: Msg, inface: Face) -> Self {
-        Self {
-            msg,
-            inface: OnceCell::from(inface),
-            outface: OnceCell::new(),
-            prefix: OnceCell::new(),
-            full_expr: OnceCell::new(),
-        }
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn new_out(msg: Msg, outface: Face) -> Self {
-        Self {
-            msg,
-            inface: OnceCell::new(),
-            outface: OnceCell::from(outface),
             prefix: OnceCell::new(),
             full_expr: OnceCell::new(),
         }
@@ -80,90 +48,16 @@ impl<Msg> RoutingContext<Msg> {
     pub(crate) fn with_expr(msg: Msg, expr: String) -> Self {
         Self {
             msg,
-            inface: OnceCell::new(),
-            outface: OnceCell::new(),
             prefix: OnceCell::new(),
             full_expr: OnceCell::from(expr),
         }
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn inface(&self) -> Option<&Face> {
-        self.inface.get()
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn outface(&self) -> Option<&Face> {
-        self.outface.get()
-    }
-
     pub(crate) fn with_mut<R>(mut self, f: impl FnOnce(RoutingContext<&mut Msg>) -> R) -> R {
         f(RoutingContext {
             msg: &mut self.msg,
-            inface: self.inface,
-            outface: self.outface,
             prefix: self.prefix,
             full_expr: self.full_expr,
         })
-    }
-}
-
-impl RoutingContext<NetworkMessageMut<'_>> {
-    #[inline]
-    pub(crate) fn wire_expr(&self) -> Option<&WireExpr> {
-        self.msg.wire_expr()
-    }
-
-    #[inline]
-    pub(crate) fn prefix(&self) -> Option<&Arc<Resource>> {
-        if let Some(face) = self.outface.get() {
-            if let Some(wire_expr) = self.wire_expr() {
-                let wire_expr = wire_expr.to_owned();
-                if self.prefix.get().is_none() {
-                    if let Some(prefix) = zread!(face.tables.tables)
-                        .get_sent_mapping(&face.state, &wire_expr.scope, wire_expr.mapping)
-                        .cloned()
-                    {
-                        let _ = self.prefix.set(prefix);
-                    }
-                }
-                return self.prefix.get();
-            }
-        }
-        if let Some(face) = self.inface.get() {
-            if let Some(wire_expr) = self.wire_expr() {
-                let wire_expr = wire_expr.to_owned();
-                if self.prefix.get().is_none() {
-                    if let Some(prefix) = zread!(face.tables.tables)
-                        .get_mapping(&face.state, &wire_expr.scope, wire_expr.mapping)
-                        .cloned()
-                    {
-                        let _ = self.prefix.set(prefix);
-                    }
-                }
-                return self.prefix.get();
-            }
-        }
-        None
-    }
-
-    #[inline]
-    pub(crate) fn full_expr(&self) -> Option<&str> {
-        if self.full_expr.get().is_some() {
-            return Some(self.full_expr.get().as_ref().unwrap());
-        }
-        if let Some(prefix) = self.prefix() {
-            let _ = self
-                .full_expr
-                .set(prefix.expr().to_string() + self.wire_expr().unwrap().suffix.as_ref());
-            return Some(self.full_expr.get().as_ref().unwrap());
-        }
-        None
-    }
-
-    #[inline]
-    pub(crate) fn full_keyexpr(&self) -> Option<&keyexpr> {
-        let full_expr = self.full_expr()?;
-        keyexpr::new(full_expr).ok()
     }
 }

--- a/zenoh/src/tests/interceptor_cache.rs
+++ b/zenoh/src/tests/interceptor_cache.rs
@@ -1,414 +1,411 @@
-// //
-// // Copyright (c) 2025 ZettaScale Technology
-// //
-// // This program and the accompanying materials are made available under the
-// // terms of the Eclipse Public License 2.0 which is available at
-// // http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
-// // which is available at https://www.apache.org/licenses/LICENSE-2.0.
-// //
-// // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
-// //
-// // Contributors:
-// //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-// //
-// #![cfg(feature = "internal_config")]
-// use std::str::FromStr;
+//
+// Copyright (c) 2025 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+#![cfg(feature = "internal_config")]
+use std::str::FromStr;
 
-// use zenoh_buffers::ZBuf;
-// use zenoh_keyexpr::keyexpr;
-// use zenoh_protocol::{
-//     network::{NetworkBodyMut, NetworkMessageMut, Push},
-//     zenoh::PushBody,
-// };
-// use zenoh_transport::{multicast::TransportMulticast, unicast::TransportUnicast};
+use zenoh_buffers::ZBuf;
+use zenoh_keyexpr::keyexpr;
+use zenoh_protocol::{
+    network::{NetworkBodyMut, NetworkMessageMut, Push},
+    zenoh::PushBody,
+};
+use zenoh_transport::{multicast::TransportMulticast, unicast::TransportUnicast};
 
-// use crate::net::routing::{interceptor::*, RoutingContext};
+use crate::net::routing::interceptor::*;
 
-// #[derive(Clone)]
-// struct TestInterceptorConf {
-//     flow: InterceptorFlow,
-//     data: String,
-// }
+#[derive(Clone)]
+struct TestInterceptorConf {
+    flow: InterceptorFlow,
+    data: String,
+}
 
-// fn test_interceptor_factories(config: &Vec<TestInterceptorConf>) -> Vec<InterceptorFactory> {
-//     let mut res: Vec<InterceptorFactory> = vec![];
-//     for c in config {
-//         res.push(Box::new(TestInterceptorFactory::new(c.clone())));
-//     }
-//     res
-// }
+fn test_interceptor_factories(config: &Vec<TestInterceptorConf>) -> Vec<InterceptorFactory> {
+    let mut res: Vec<InterceptorFactory> = vec![];
+    for c in config {
+        res.push(Box::new(TestInterceptorFactory::new(c.clone())));
+    }
+    res
+}
 
-// struct TestInterceptorFactory {
-//     conf: TestInterceptorConf,
-// }
+struct TestInterceptorFactory {
+    conf: TestInterceptorConf,
+}
 
-// impl TestInterceptorFactory {
-//     pub fn new(conf: TestInterceptorConf) -> Self {
-//         Self { conf }
-//     }
-// }
+impl TestInterceptorFactory {
+    pub fn new(conf: TestInterceptorConf) -> Self {
+        Self { conf }
+    }
+}
 
-// impl InterceptorFactoryTrait for TestInterceptorFactory {
-//     fn new_transport_unicast(
-//         &self,
-//         _transport: &TransportUnicast,
-//     ) -> (Option<IngressInterceptor>, Option<EgressInterceptor>) {
-//         match self.conf.flow {
-//             InterceptorFlow::Egress => {
-//                 (None, Some(Box::new(TestInterceptor::new(&self.conf.data))))
-//             }
-//             InterceptorFlow::Ingress => {
-//                 (Some(Box::new(TestInterceptor::new(&self.conf.data))), None)
-//             }
-//         }
-//     }
+impl InterceptorFactoryTrait for TestInterceptorFactory {
+    fn new_transport_unicast(
+        &self,
+        _transport: &TransportUnicast,
+    ) -> (Option<IngressInterceptor>, Option<EgressInterceptor>) {
+        match self.conf.flow {
+            InterceptorFlow::Egress => {
+                (None, Some(Box::new(TestInterceptor::new(&self.conf.data))))
+            }
+            InterceptorFlow::Ingress => {
+                (Some(Box::new(TestInterceptor::new(&self.conf.data))), None)
+            }
+        }
+    }
 
-//     fn new_transport_multicast(
-//         &self,
-//         _transport: &TransportMulticast,
-//     ) -> Option<EgressInterceptor> {
-//         None
-//     }
+    fn new_transport_multicast(
+        &self,
+        _transport: &TransportMulticast,
+    ) -> Option<EgressInterceptor> {
+        None
+    }
 
-//     fn new_peer_multicast(&self, _transport: &TransportMulticast) -> Option<IngressInterceptor> {
-//         None
-//     }
-// }
+    fn new_peer_multicast(&self, _transport: &TransportMulticast) -> Option<IngressInterceptor> {
+        None
+    }
+}
 
-// struct TestInterceptor {
-//     data: String,
-// }
+struct TestInterceptor {
+    data: String,
+}
 
-// impl TestInterceptor {
-//     fn new(data: &str) -> Self {
-//         TestInterceptor {
-//             data: data.to_owned(),
-//         }
-//     }
-// }
+impl TestInterceptor {
+    fn new(data: &str) -> Self {
+        TestInterceptor {
+            data: data.to_owned(),
+        }
+    }
+}
 
-// impl InterceptorTrait for TestInterceptor {
-//     fn compute_keyexpr_cache(&self, _key_expr: &keyexpr) -> Option<Box<dyn Any + Send + Sync>> {
-//         Some(Box::new(self.data.clone()))
-//     }
+impl InterceptorTrait for TestInterceptor {
+    fn compute_keyexpr_cache(&self, _key_expr: &keyexpr) -> Option<Box<dyn Any + Send + Sync>> {
+        Some(Box::new(self.data.clone()))
+    }
 
-//     fn intercept(
-//         &self,
-//         ctx: &mut RoutingContext<NetworkMessageMut<'_>>,
-//         cache: Option<&Box<dyn Any + Send + Sync>>,
-//     ) -> bool {
-//         if let NetworkBodyMut::Push(&mut Push {
-//             payload: PushBody::Put(ref mut p),
-//             ..
-//         }) = &mut ctx.msg.body
-//         {
-//             let out = format!("Cache hit: {}, data: {}", cache.is_some(), &self.data);
-//             p.payload = ZBuf::from(out.as_bytes().to_owned());
-//         }
-//         true
-//     }
-// }
+    fn intercept(&self, msg: &mut NetworkMessageMut, ctx: &mut dyn InterceptorContext) -> bool {
+        let cache_hit = ctx.get_cache(msg).is_some();
+        if let NetworkBodyMut::Push(&mut Push {
+            payload: PushBody::Put(ref mut p),
+            ..
+        }) = &mut msg.body
+        {
+            let out = format!("Cache hit: {cache_hit}, data: {}", &self.data);
+            p.payload = ZBuf::from(out.as_bytes().to_owned());
+        }
+        true
+    }
+}
 
-// use std::{any::Any, time::Duration};
+use std::{any::Any, time::Duration};
 
-// use zenoh_config::{InterceptorFlow, ZenohId};
-// use zenoh_core::ztimeout;
+use zenoh_config::{InterceptorFlow, ZenohId};
+use zenoh_core::ztimeout;
 
-// use crate::{config::WhatAmI, init_log_from_env_or, open, Config};
+use crate::{config::WhatAmI, init_log_from_env_or, open, Config};
 
-// const TIMEOUT: Duration = Duration::from_secs(60);
-// const SLEEP: Duration = Duration::from_secs(1);
+const TIMEOUT: Duration = Duration::from_secs(60);
+const SLEEP: Duration = Duration::from_secs(1);
 
-// async fn get_basic_router_config(port: u16) -> Config {
-//     let mut config = Config::default();
-//     config.set_mode(Some(WhatAmI::Router)).unwrap();
-//     config
-//         .listen
-//         .endpoints
-//         .set(vec![format!("tcp/127.0.0.1:{port}").parse().unwrap()])
-//         .unwrap();
-//     config.scouting.multicast.set_enabled(Some(false)).unwrap();
-//     config
-// }
+async fn get_basic_router_config(port: u16) -> Config {
+    let mut config = Config::default();
+    config.set_mode(Some(WhatAmI::Router)).unwrap();
+    config
+        .listen
+        .endpoints
+        .set(vec![format!("tcp/127.0.0.1:{port}").parse().unwrap()])
+        .unwrap();
+    config.scouting.multicast.set_enabled(Some(false)).unwrap();
+    config
+}
 
-// async fn get_basic_client_config(port: u16) -> Config {
-//     let mut config = Config::default();
-//     config.set_mode(Some(WhatAmI::Client)).unwrap();
-//     config
-//         .connect
-//         .endpoints
-//         .set(vec![format!("tcp/127.0.0.1:{port}").parse().unwrap()])
-//         .unwrap();
-//     config.scouting.multicast.set_enabled(Some(false)).unwrap();
-//     config
-// }
+async fn get_basic_client_config(port: u16) -> Config {
+    let mut config = Config::default();
+    config.set_mode(Some(WhatAmI::Client)).unwrap();
+    config
+        .connect
+        .endpoints
+        .set(vec![format!("tcp/127.0.0.1:{port}").parse().unwrap()])
+        .unwrap();
+    config.scouting.multicast.set_enabled(Some(false)).unwrap();
+    config
+}
 
-// #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-// async fn test_interceptors_cache_update_ingress() {
-//     let router_id = ZenohId::from_str("a1").unwrap();
-//     let c = TestInterceptorConf {
-//         flow: InterceptorFlow::Ingress,
-//         data: "1".to_string(),
-//     };
-//     let f = move || test_interceptor_factories(&vec![c.clone()]);
-//     let _ = crate::net::routing::interceptor::tests::ID_TO_INTERCEPTOR_FACTORIES
-//         .lock()
-//         .unwrap()
-//         .insert(router_id, Box::new(f));
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_interceptors_cache_update_ingress() {
+    let router_id = ZenohId::from_str("a1").unwrap();
+    let c = TestInterceptorConf {
+        flow: InterceptorFlow::Ingress,
+        data: "1".to_string(),
+    };
+    let f = move || test_interceptor_factories(&vec![c.clone()]);
+    let _ = crate::net::routing::interceptor::tests::ID_TO_INTERCEPTOR_FACTORIES
+        .lock()
+        .unwrap()
+        .insert(router_id, Box::new(f));
 
-//     init_log_from_env_or("error");
-//     let mut config_router = get_basic_router_config(27701).await;
-//     config_router.set_id(Some(router_id)).unwrap();
+    init_log_from_env_or("error");
+    let mut config_router = get_basic_router_config(27701).await;
+    config_router.set_id(Some(router_id)).unwrap();
 
-//     let config_client1 = get_basic_client_config(27701).await;
-//     let config_client2 = get_basic_client_config(27701).await;
+    let config_client1 = get_basic_client_config(27701).await;
+    let config_client2 = get_basic_client_config(27701).await;
 
-//     let router = ztimeout!(open(config_router.clone())).unwrap();
-//     tokio::time::sleep(SLEEP).await;
-//     let session1 = ztimeout!(open(config_client1)).unwrap();
-//     let session2 = ztimeout!(open(config_client2)).unwrap();
-//     tokio::time::sleep(SLEEP).await;
-//     let sub = ztimeout!(session2.declare_subscriber("test/cache")).unwrap();
-//     let pub1 = ztimeout!(session1.declare_publisher("test/cache")).unwrap();
-//     let pub2 = ztimeout!(session1.declare_publisher("test/*")).unwrap();
-//     tokio::time::sleep(SLEEP).await;
-//     ztimeout!(pub1.put("some_data_1")).unwrap();
-//     tokio::time::sleep(SLEEP).await;
-//     ztimeout!(pub2.put("some_data_2")).unwrap();
+    let router = ztimeout!(open(config_router.clone())).unwrap();
+    tokio::time::sleep(SLEEP).await;
+    let session1 = ztimeout!(open(config_client1)).unwrap();
+    let session2 = ztimeout!(open(config_client2)).unwrap();
+    tokio::time::sleep(SLEEP).await;
+    let sub = ztimeout!(session2.declare_subscriber("test/cache")).unwrap();
+    let pub1 = ztimeout!(session1.declare_publisher("test/cache")).unwrap();
+    let pub2 = ztimeout!(session1.declare_publisher("test/*")).unwrap();
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(pub1.put("some_data_1")).unwrap();
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(pub2.put("some_data_2")).unwrap();
 
-//     let msg1 = ztimeout!(sub.recv_async()).unwrap();
-//     let msg2 = ztimeout!(sub.recv_async()).unwrap();
+    let msg1 = ztimeout!(sub.recv_async()).unwrap();
+    let msg2 = ztimeout!(sub.recv_async()).unwrap();
 
-//     assert_eq!(
-//         msg1.payload().try_to_string().unwrap().as_ref(),
-//         "Cache hit: true, data: 1"
-//     );
-//     assert_eq!(
-//         msg2.payload().try_to_string().unwrap().as_ref(),
-//         "Cache hit: false, data: 1"
-//     );
+    assert_eq!(
+        msg1.payload().try_to_string().unwrap().as_ref(),
+        "Cache hit: true, data: 1"
+    );
+    assert_eq!(
+        msg2.payload().try_to_string().unwrap().as_ref(),
+        "Cache hit: false, data: 1"
+    );
 
-//     let c = TestInterceptorConf {
-//         flow: InterceptorFlow::Ingress,
-//         data: "2".to_string(),
-//     };
-//     let f = move || test_interceptor_factories(&vec![c.clone()]);
-//     let _ = crate::net::routing::interceptor::tests::ID_TO_INTERCEPTOR_FACTORIES
-//         .lock()
-//         .unwrap()
-//         .insert(router_id, Box::new(f));
+    let c = TestInterceptorConf {
+        flow: InterceptorFlow::Ingress,
+        data: "2".to_string(),
+    };
+    let f = move || test_interceptor_factories(&vec![c.clone()]);
+    let _ = crate::net::routing::interceptor::tests::ID_TO_INTERCEPTOR_FACTORIES
+        .lock()
+        .unwrap()
+        .insert(router_id, Box::new(f));
 
-//     router
-//         .0
-//         .runtime
-//         .router()
-//         .tables
-//         .regen_interceptors(&config_router)
-//         .unwrap();
-//     tokio::time::sleep(SLEEP).await;
+    router
+        .0
+        .runtime
+        .router()
+        .tables
+        .regen_interceptors(&config_router)
+        .unwrap();
+    tokio::time::sleep(SLEEP).await;
 
-//     ztimeout!(pub1.put("some_data_1")).unwrap();
-//     tokio::time::sleep(SLEEP).await;
-//     ztimeout!(pub2.put("some_data_2")).unwrap();
-//     let sub2 = ztimeout!(session2.declare_subscriber("test2/cache")).unwrap();
-//     let pub3 = ztimeout!(session1.declare_publisher("test2/cache")).unwrap();
-//     tokio::time::sleep(SLEEP).await;
-//     ztimeout!(pub3.put("some_data_3")).unwrap();
+    ztimeout!(pub1.put("some_data_1")).unwrap();
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(pub2.put("some_data_2")).unwrap();
+    let sub2 = ztimeout!(session2.declare_subscriber("test2/cache")).unwrap();
+    let pub3 = ztimeout!(session1.declare_publisher("test2/cache")).unwrap();
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(pub3.put("some_data_3")).unwrap();
 
-//     let msg1 = ztimeout!(sub.recv_async()).unwrap();
-//     let msg2 = ztimeout!(sub.recv_async()).unwrap();
-//     let msg3 = ztimeout!(sub2.recv_async()).unwrap();
+    let msg1 = ztimeout!(sub.recv_async()).unwrap();
+    let msg2 = ztimeout!(sub.recv_async()).unwrap();
+    let msg3 = ztimeout!(sub2.recv_async()).unwrap();
 
-//     assert_eq!(
-//         msg1.payload().try_to_string().unwrap().as_ref(),
-//         "Cache hit: true, data: 2"
-//     );
-//     assert_eq!(
-//         msg2.payload().try_to_string().unwrap().as_ref(),
-//         "Cache hit: false, data: 2"
-//     );
-//     assert_eq!(
-//         msg3.payload().try_to_string().unwrap().as_ref(),
-//         "Cache hit: true, data: 2"
-//     );
-// }
+    assert_eq!(
+        msg1.payload().try_to_string().unwrap().as_ref(),
+        "Cache hit: true, data: 2"
+    );
+    assert_eq!(
+        msg2.payload().try_to_string().unwrap().as_ref(),
+        "Cache hit: false, data: 2"
+    );
+    assert_eq!(
+        msg3.payload().try_to_string().unwrap().as_ref(),
+        "Cache hit: true, data: 2"
+    );
+}
 
-// #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-// async fn test_interceptors_cache_update_egress() {
-//     let router_id = ZenohId::from_str("a1").unwrap();
-//     let c = TestInterceptorConf {
-//         flow: InterceptorFlow::Egress,
-//         data: "1".to_string(),
-//     };
-//     let f = move || test_interceptor_factories(&vec![c.clone()]);
-//     let _ = crate::net::routing::interceptor::tests::ID_TO_INTERCEPTOR_FACTORIES
-//         .lock()
-//         .unwrap()
-//         .insert(router_id, Box::new(f));
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_interceptors_cache_update_egress() {
+    let router_id = ZenohId::from_str("a1").unwrap();
+    let c = TestInterceptorConf {
+        flow: InterceptorFlow::Egress,
+        data: "1".to_string(),
+    };
+    let f = move || test_interceptor_factories(&vec![c.clone()]);
+    let _ = crate::net::routing::interceptor::tests::ID_TO_INTERCEPTOR_FACTORIES
+        .lock()
+        .unwrap()
+        .insert(router_id, Box::new(f));
 
-//     init_log_from_env_or("error");
-//     let mut config_router = get_basic_router_config(27702).await;
-//     config_router.set_id(Some(router_id)).unwrap();
+    init_log_from_env_or("error");
+    let mut config_router = get_basic_router_config(27702).await;
+    config_router.set_id(Some(router_id)).unwrap();
 
-//     let config_client1 = get_basic_client_config(27702).await;
-//     let config_client2 = get_basic_client_config(27702).await;
+    let config_client1 = get_basic_client_config(27702).await;
+    let config_client2 = get_basic_client_config(27702).await;
 
-//     let router = ztimeout!(open(config_router.clone())).unwrap();
-//     tokio::time::sleep(SLEEP).await;
-//     let session1 = ztimeout!(open(config_client1)).unwrap();
-//     let session2 = ztimeout!(open(config_client2)).unwrap();
-//     tokio::time::sleep(SLEEP).await;
-//     let sub = ztimeout!(session2.declare_subscriber("test/cache")).unwrap();
-//     let pub1 = ztimeout!(session1.declare_publisher("test/cache")).unwrap();
-//     let pub2 = ztimeout!(session1.declare_publisher("test/*")).unwrap();
-//     tokio::time::sleep(SLEEP).await;
-//     ztimeout!(pub1.put("some_data_1")).unwrap();
-//     tokio::time::sleep(SLEEP).await;
-//     ztimeout!(pub2.put("some_data_2")).unwrap();
+    let router = ztimeout!(open(config_router.clone())).unwrap();
+    tokio::time::sleep(SLEEP).await;
+    let session1 = ztimeout!(open(config_client1)).unwrap();
+    let session2 = ztimeout!(open(config_client2)).unwrap();
+    tokio::time::sleep(SLEEP).await;
+    let sub = ztimeout!(session2.declare_subscriber("test/cache")).unwrap();
+    let pub1 = ztimeout!(session1.declare_publisher("test/cache")).unwrap();
+    let pub2 = ztimeout!(session1.declare_publisher("test/*")).unwrap();
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(pub1.put("some_data_1")).unwrap();
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(pub2.put("some_data_2")).unwrap();
 
-//     let msg1 = ztimeout!(sub.recv_async()).unwrap();
-//     let msg2 = ztimeout!(sub.recv_async()).unwrap();
+    let msg1 = ztimeout!(sub.recv_async()).unwrap();
+    let msg2 = ztimeout!(sub.recv_async()).unwrap();
 
-//     assert_eq!(
-//         msg1.payload().try_to_string().unwrap().as_ref(),
-//         "Cache hit: true, data: 1"
-//     );
-//     assert_eq!(
-//         msg2.payload().try_to_string().unwrap().as_ref(),
-//         "Cache hit: false, data: 1"
-//     );
+    assert_eq!(
+        msg1.payload().try_to_string().unwrap().as_ref(),
+        "Cache hit: true, data: 1"
+    );
+    assert_eq!(
+        msg2.payload().try_to_string().unwrap().as_ref(),
+        "Cache hit: false, data: 1"
+    );
 
-//     let c = TestInterceptorConf {
-//         flow: InterceptorFlow::Egress,
-//         data: "2".to_string(),
-//     };
-//     let f = move || test_interceptor_factories(&vec![c.clone()]);
-//     let _ = crate::net::routing::interceptor::tests::ID_TO_INTERCEPTOR_FACTORIES
-//         .lock()
-//         .unwrap()
-//         .insert(router_id, Box::new(f));
+    let c = TestInterceptorConf {
+        flow: InterceptorFlow::Egress,
+        data: "2".to_string(),
+    };
+    let f = move || test_interceptor_factories(&vec![c.clone()]);
+    let _ = crate::net::routing::interceptor::tests::ID_TO_INTERCEPTOR_FACTORIES
+        .lock()
+        .unwrap()
+        .insert(router_id, Box::new(f));
 
-//     router
-//         .0
-//         .runtime
-//         .router()
-//         .tables
-//         .regen_interceptors(&config_router)
-//         .unwrap();
-//     tokio::time::sleep(SLEEP).await;
+    router
+        .0
+        .runtime
+        .router()
+        .tables
+        .regen_interceptors(&config_router)
+        .unwrap();
+    tokio::time::sleep(SLEEP).await;
 
-//     ztimeout!(pub1.put("some_data_1")).unwrap();
-//     tokio::time::sleep(SLEEP).await;
-//     ztimeout!(pub2.put("some_data_2")).unwrap();
-//     let sub2 = ztimeout!(session2.declare_subscriber("test2/cache")).unwrap();
-//     let pub3 = ztimeout!(session1.declare_publisher("test2/cache")).unwrap();
-//     tokio::time::sleep(SLEEP).await;
-//     ztimeout!(pub3.put("some_data_3")).unwrap();
+    ztimeout!(pub1.put("some_data_1")).unwrap();
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(pub2.put("some_data_2")).unwrap();
+    let sub2 = ztimeout!(session2.declare_subscriber("test2/cache")).unwrap();
+    let pub3 = ztimeout!(session1.declare_publisher("test2/cache")).unwrap();
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(pub3.put("some_data_3")).unwrap();
 
-//     let msg1 = ztimeout!(sub.recv_async()).unwrap();
-//     let msg2 = ztimeout!(sub.recv_async()).unwrap();
-//     let msg3 = ztimeout!(sub2.recv_async()).unwrap();
+    let msg1 = ztimeout!(sub.recv_async()).unwrap();
+    let msg2 = ztimeout!(sub.recv_async()).unwrap();
+    let msg3 = ztimeout!(sub2.recv_async()).unwrap();
 
-//     assert_eq!(
-//         msg1.payload().try_to_string().unwrap().as_ref(),
-//         "Cache hit: true, data: 2"
-//     );
-//     assert_eq!(
-//         msg2.payload().try_to_string().unwrap().as_ref(),
-//         "Cache hit: false, data: 2"
-//     );
-//     assert_eq!(
-//         msg3.payload().try_to_string().unwrap().as_ref(),
-//         "Cache hit: true, data: 2"
-//     );
-// }
+    assert_eq!(
+        msg1.payload().try_to_string().unwrap().as_ref(),
+        "Cache hit: true, data: 2"
+    );
+    assert_eq!(
+        msg2.payload().try_to_string().unwrap().as_ref(),
+        "Cache hit: false, data: 2"
+    );
+    assert_eq!(
+        msg3.payload().try_to_string().unwrap().as_ref(),
+        "Cache hit: true, data: 2"
+    );
+}
 
-// #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-// async fn test_interceptors_cache_update_egress_then_ingress() {
-//     let router_id = ZenohId::from_str("a1").unwrap();
-//     let c = TestInterceptorConf {
-//         flow: InterceptorFlow::Egress,
-//         data: "1".to_string(),
-//     };
-//     let f = move || test_interceptor_factories(&vec![c.clone()]);
-//     let _ = crate::net::routing::interceptor::tests::ID_TO_INTERCEPTOR_FACTORIES
-//         .lock()
-//         .unwrap()
-//         .insert(router_id, Box::new(f));
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_interceptors_cache_update_egress_then_ingress() {
+    let router_id = ZenohId::from_str("a1").unwrap();
+    let c = TestInterceptorConf {
+        flow: InterceptorFlow::Egress,
+        data: "1".to_string(),
+    };
+    let f = move || test_interceptor_factories(&vec![c.clone()]);
+    let _ = crate::net::routing::interceptor::tests::ID_TO_INTERCEPTOR_FACTORIES
+        .lock()
+        .unwrap()
+        .insert(router_id, Box::new(f));
 
-//     init_log_from_env_or("error");
-//     let mut config_router = get_basic_router_config(27703).await;
-//     config_router.set_id(Some(router_id)).unwrap();
+    init_log_from_env_or("error");
+    let mut config_router = get_basic_router_config(27703).await;
+    config_router.set_id(Some(router_id)).unwrap();
 
-//     let config_client1 = get_basic_client_config(27703).await;
-//     let config_client2 = get_basic_client_config(27703).await;
+    let config_client1 = get_basic_client_config(27703).await;
+    let config_client2 = get_basic_client_config(27703).await;
 
-//     let router = ztimeout!(open(config_router.clone())).unwrap();
-//     tokio::time::sleep(SLEEP).await;
-//     let session1 = ztimeout!(open(config_client1)).unwrap();
-//     let session2 = ztimeout!(open(config_client2)).unwrap();
-//     tokio::time::sleep(SLEEP).await;
-//     let sub = ztimeout!(session2.declare_subscriber("test/cache")).unwrap();
-//     let pub1 = ztimeout!(session1.declare_publisher("test/cache")).unwrap();
-//     let pub2 = ztimeout!(session1.declare_publisher("test/*")).unwrap();
-//     tokio::time::sleep(SLEEP).await;
-//     ztimeout!(pub1.put("some_data_1")).unwrap();
-//     tokio::time::sleep(SLEEP).await;
-//     ztimeout!(pub2.put("some_data_2")).unwrap();
+    let router = ztimeout!(open(config_router.clone())).unwrap();
+    tokio::time::sleep(SLEEP).await;
+    let session1 = ztimeout!(open(config_client1)).unwrap();
+    let session2 = ztimeout!(open(config_client2)).unwrap();
+    tokio::time::sleep(SLEEP).await;
+    let sub = ztimeout!(session2.declare_subscriber("test/cache")).unwrap();
+    let pub1 = ztimeout!(session1.declare_publisher("test/cache")).unwrap();
+    let pub2 = ztimeout!(session1.declare_publisher("test/*")).unwrap();
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(pub1.put("some_data_1")).unwrap();
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(pub2.put("some_data_2")).unwrap();
 
-//     let msg1 = ztimeout!(sub.recv_async()).unwrap();
-//     let msg2 = ztimeout!(sub.recv_async()).unwrap();
+    let msg1 = ztimeout!(sub.recv_async()).unwrap();
+    let msg2 = ztimeout!(sub.recv_async()).unwrap();
 
-//     assert_eq!(
-//         msg1.payload().try_to_string().unwrap().as_ref(),
-//         "Cache hit: true, data: 1"
-//     );
-//     assert_eq!(
-//         msg2.payload().try_to_string().unwrap().as_ref(),
-//         "Cache hit: false, data: 1"
-//     );
+    assert_eq!(
+        msg1.payload().try_to_string().unwrap().as_ref(),
+        "Cache hit: true, data: 1"
+    );
+    assert_eq!(
+        msg2.payload().try_to_string().unwrap().as_ref(),
+        "Cache hit: false, data: 1"
+    );
 
-//     let c = TestInterceptorConf {
-//         flow: InterceptorFlow::Ingress,
-//         data: "2".to_string(),
-//     };
-//     let f = move || test_interceptor_factories(&vec![c.clone()]);
-//     let _ = crate::net::routing::interceptor::tests::ID_TO_INTERCEPTOR_FACTORIES
-//         .lock()
-//         .unwrap()
-//         .insert(router_id, Box::new(f));
+    let c = TestInterceptorConf {
+        flow: InterceptorFlow::Ingress,
+        data: "2".to_string(),
+    };
+    let f = move || test_interceptor_factories(&vec![c.clone()]);
+    let _ = crate::net::routing::interceptor::tests::ID_TO_INTERCEPTOR_FACTORIES
+        .lock()
+        .unwrap()
+        .insert(router_id, Box::new(f));
 
-//     router
-//         .0
-//         .runtime
-//         .router()
-//         .tables
-//         .regen_interceptors(&config_router)
-//         .unwrap();
-//     tokio::time::sleep(SLEEP).await;
+    router
+        .0
+        .runtime
+        .router()
+        .tables
+        .regen_interceptors(&config_router)
+        .unwrap();
+    tokio::time::sleep(SLEEP).await;
 
-//     ztimeout!(pub1.put("some_data_1")).unwrap();
-//     tokio::time::sleep(SLEEP).await;
-//     ztimeout!(pub2.put("some_data_2")).unwrap();
-//     let sub2 = ztimeout!(session2.declare_subscriber("test2/cache")).unwrap();
-//     let pub3 = ztimeout!(session1.declare_publisher("test2/cache")).unwrap();
-//     tokio::time::sleep(SLEEP).await;
-//     ztimeout!(pub3.put("some_data_3")).unwrap();
+    ztimeout!(pub1.put("some_data_1")).unwrap();
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(pub2.put("some_data_2")).unwrap();
+    let sub2 = ztimeout!(session2.declare_subscriber("test2/cache")).unwrap();
+    let pub3 = ztimeout!(session1.declare_publisher("test2/cache")).unwrap();
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(pub3.put("some_data_3")).unwrap();
 
-//     let msg1 = ztimeout!(sub.recv_async()).unwrap();
-//     let msg2 = ztimeout!(sub.recv_async()).unwrap();
-//     let msg3 = ztimeout!(sub2.recv_async()).unwrap();
+    let msg1 = ztimeout!(sub.recv_async()).unwrap();
+    let msg2 = ztimeout!(sub.recv_async()).unwrap();
+    let msg3 = ztimeout!(sub2.recv_async()).unwrap();
 
-//     assert_eq!(
-//         msg1.payload().try_to_string().unwrap().as_ref(),
-//         "Cache hit: true, data: 2"
-//     );
-//     assert_eq!(
-//         msg2.payload().try_to_string().unwrap().as_ref(),
-//         "Cache hit: false, data: 2"
-//     );
-//     assert_eq!(
-//         msg3.payload().try_to_string().unwrap().as_ref(),
-//         "Cache hit: true, data: 2"
-//     );
-// }
+    assert_eq!(
+        msg1.payload().try_to_string().unwrap().as_ref(),
+        "Cache hit: true, data: 2"
+    );
+    assert_eq!(
+        msg2.payload().try_to_string().unwrap().as_ref(),
+        "Cache hit: false, data: 2"
+    );
+    assert_eq!(
+        msg3.payload().try_to_string().unwrap().as_ref(),
+        "Cache hit: true, data: 2"
+    );
+}

--- a/zenoh/src/tests/interceptor_cache.rs
+++ b/zenoh/src/tests/interceptor_cache.rs
@@ -1,414 +1,414 @@
-//
-// Copyright (c) 2025 ZettaScale Technology
-//
-// This program and the accompanying materials are made available under the
-// terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
-// which is available at https://www.apache.org/licenses/LICENSE-2.0.
-//
-// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
-//
-// Contributors:
-//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
-#![cfg(feature = "internal_config")]
-use std::str::FromStr;
+// //
+// // Copyright (c) 2025 ZettaScale Technology
+// //
+// // This program and the accompanying materials are made available under the
+// // terms of the Eclipse Public License 2.0 which is available at
+// // http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// // which is available at https://www.apache.org/licenses/LICENSE-2.0.
+// //
+// // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// //
+// // Contributors:
+// //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+// //
+// #![cfg(feature = "internal_config")]
+// use std::str::FromStr;
 
-use zenoh_buffers::ZBuf;
-use zenoh_keyexpr::keyexpr;
-use zenoh_protocol::{
-    network::{NetworkBodyMut, NetworkMessageMut, Push},
-    zenoh::PushBody,
-};
-use zenoh_transport::{multicast::TransportMulticast, unicast::TransportUnicast};
+// use zenoh_buffers::ZBuf;
+// use zenoh_keyexpr::keyexpr;
+// use zenoh_protocol::{
+//     network::{NetworkBodyMut, NetworkMessageMut, Push},
+//     zenoh::PushBody,
+// };
+// use zenoh_transport::{multicast::TransportMulticast, unicast::TransportUnicast};
 
-use crate::net::routing::{interceptor::*, RoutingContext};
+// use crate::net::routing::{interceptor::*, RoutingContext};
 
-#[derive(Clone)]
-struct TestInterceptorConf {
-    flow: InterceptorFlow,
-    data: String,
-}
+// #[derive(Clone)]
+// struct TestInterceptorConf {
+//     flow: InterceptorFlow,
+//     data: String,
+// }
 
-fn test_interceptor_factories(config: &Vec<TestInterceptorConf>) -> Vec<InterceptorFactory> {
-    let mut res: Vec<InterceptorFactory> = vec![];
-    for c in config {
-        res.push(Box::new(TestInterceptorFactory::new(c.clone())));
-    }
-    res
-}
+// fn test_interceptor_factories(config: &Vec<TestInterceptorConf>) -> Vec<InterceptorFactory> {
+//     let mut res: Vec<InterceptorFactory> = vec![];
+//     for c in config {
+//         res.push(Box::new(TestInterceptorFactory::new(c.clone())));
+//     }
+//     res
+// }
 
-struct TestInterceptorFactory {
-    conf: TestInterceptorConf,
-}
+// struct TestInterceptorFactory {
+//     conf: TestInterceptorConf,
+// }
 
-impl TestInterceptorFactory {
-    pub fn new(conf: TestInterceptorConf) -> Self {
-        Self { conf }
-    }
-}
+// impl TestInterceptorFactory {
+//     pub fn new(conf: TestInterceptorConf) -> Self {
+//         Self { conf }
+//     }
+// }
 
-impl InterceptorFactoryTrait for TestInterceptorFactory {
-    fn new_transport_unicast(
-        &self,
-        _transport: &TransportUnicast,
-    ) -> (Option<IngressInterceptor>, Option<EgressInterceptor>) {
-        match self.conf.flow {
-            InterceptorFlow::Egress => {
-                (None, Some(Box::new(TestInterceptor::new(&self.conf.data))))
-            }
-            InterceptorFlow::Ingress => {
-                (Some(Box::new(TestInterceptor::new(&self.conf.data))), None)
-            }
-        }
-    }
+// impl InterceptorFactoryTrait for TestInterceptorFactory {
+//     fn new_transport_unicast(
+//         &self,
+//         _transport: &TransportUnicast,
+//     ) -> (Option<IngressInterceptor>, Option<EgressInterceptor>) {
+//         match self.conf.flow {
+//             InterceptorFlow::Egress => {
+//                 (None, Some(Box::new(TestInterceptor::new(&self.conf.data))))
+//             }
+//             InterceptorFlow::Ingress => {
+//                 (Some(Box::new(TestInterceptor::new(&self.conf.data))), None)
+//             }
+//         }
+//     }
 
-    fn new_transport_multicast(
-        &self,
-        _transport: &TransportMulticast,
-    ) -> Option<EgressInterceptor> {
-        None
-    }
+//     fn new_transport_multicast(
+//         &self,
+//         _transport: &TransportMulticast,
+//     ) -> Option<EgressInterceptor> {
+//         None
+//     }
 
-    fn new_peer_multicast(&self, _transport: &TransportMulticast) -> Option<IngressInterceptor> {
-        None
-    }
-}
+//     fn new_peer_multicast(&self, _transport: &TransportMulticast) -> Option<IngressInterceptor> {
+//         None
+//     }
+// }
 
-struct TestInterceptor {
-    data: String,
-}
+// struct TestInterceptor {
+//     data: String,
+// }
 
-impl TestInterceptor {
-    fn new(data: &str) -> Self {
-        TestInterceptor {
-            data: data.to_owned(),
-        }
-    }
-}
+// impl TestInterceptor {
+//     fn new(data: &str) -> Self {
+//         TestInterceptor {
+//             data: data.to_owned(),
+//         }
+//     }
+// }
 
-impl InterceptorTrait for TestInterceptor {
-    fn compute_keyexpr_cache(&self, _key_expr: &keyexpr) -> Option<Box<dyn Any + Send + Sync>> {
-        Some(Box::new(self.data.clone()))
-    }
+// impl InterceptorTrait for TestInterceptor {
+//     fn compute_keyexpr_cache(&self, _key_expr: &keyexpr) -> Option<Box<dyn Any + Send + Sync>> {
+//         Some(Box::new(self.data.clone()))
+//     }
 
-    fn intercept(
-        &self,
-        ctx: &mut RoutingContext<NetworkMessageMut<'_>>,
-        cache: Option<&Box<dyn Any + Send + Sync>>,
-    ) -> bool {
-        if let NetworkBodyMut::Push(&mut Push {
-            payload: PushBody::Put(ref mut p),
-            ..
-        }) = &mut ctx.msg.body
-        {
-            let out = format!("Cache hit: {}, data: {}", cache.is_some(), &self.data);
-            p.payload = ZBuf::from(out.as_bytes().to_owned());
-        }
-        true
-    }
-}
+//     fn intercept(
+//         &self,
+//         ctx: &mut RoutingContext<NetworkMessageMut<'_>>,
+//         cache: Option<&Box<dyn Any + Send + Sync>>,
+//     ) -> bool {
+//         if let NetworkBodyMut::Push(&mut Push {
+//             payload: PushBody::Put(ref mut p),
+//             ..
+//         }) = &mut ctx.msg.body
+//         {
+//             let out = format!("Cache hit: {}, data: {}", cache.is_some(), &self.data);
+//             p.payload = ZBuf::from(out.as_bytes().to_owned());
+//         }
+//         true
+//     }
+// }
 
-use std::{any::Any, time::Duration};
+// use std::{any::Any, time::Duration};
 
-use zenoh_config::{InterceptorFlow, ZenohId};
-use zenoh_core::ztimeout;
+// use zenoh_config::{InterceptorFlow, ZenohId};
+// use zenoh_core::ztimeout;
 
-use crate::{config::WhatAmI, init_log_from_env_or, open, Config};
+// use crate::{config::WhatAmI, init_log_from_env_or, open, Config};
 
-const TIMEOUT: Duration = Duration::from_secs(60);
-const SLEEP: Duration = Duration::from_secs(1);
+// const TIMEOUT: Duration = Duration::from_secs(60);
+// const SLEEP: Duration = Duration::from_secs(1);
 
-async fn get_basic_router_config(port: u16) -> Config {
-    let mut config = Config::default();
-    config.set_mode(Some(WhatAmI::Router)).unwrap();
-    config
-        .listen
-        .endpoints
-        .set(vec![format!("tcp/127.0.0.1:{port}").parse().unwrap()])
-        .unwrap();
-    config.scouting.multicast.set_enabled(Some(false)).unwrap();
-    config
-}
+// async fn get_basic_router_config(port: u16) -> Config {
+//     let mut config = Config::default();
+//     config.set_mode(Some(WhatAmI::Router)).unwrap();
+//     config
+//         .listen
+//         .endpoints
+//         .set(vec![format!("tcp/127.0.0.1:{port}").parse().unwrap()])
+//         .unwrap();
+//     config.scouting.multicast.set_enabled(Some(false)).unwrap();
+//     config
+// }
 
-async fn get_basic_client_config(port: u16) -> Config {
-    let mut config = Config::default();
-    config.set_mode(Some(WhatAmI::Client)).unwrap();
-    config
-        .connect
-        .endpoints
-        .set(vec![format!("tcp/127.0.0.1:{port}").parse().unwrap()])
-        .unwrap();
-    config.scouting.multicast.set_enabled(Some(false)).unwrap();
-    config
-}
+// async fn get_basic_client_config(port: u16) -> Config {
+//     let mut config = Config::default();
+//     config.set_mode(Some(WhatAmI::Client)).unwrap();
+//     config
+//         .connect
+//         .endpoints
+//         .set(vec![format!("tcp/127.0.0.1:{port}").parse().unwrap()])
+//         .unwrap();
+//     config.scouting.multicast.set_enabled(Some(false)).unwrap();
+//     config
+// }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn test_interceptors_cache_update_ingress() {
-    let router_id = ZenohId::from_str("a1").unwrap();
-    let c = TestInterceptorConf {
-        flow: InterceptorFlow::Ingress,
-        data: "1".to_string(),
-    };
-    let f = move || test_interceptor_factories(&vec![c.clone()]);
-    let _ = crate::net::routing::interceptor::tests::ID_TO_INTERCEPTOR_FACTORIES
-        .lock()
-        .unwrap()
-        .insert(router_id, Box::new(f));
+// #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+// async fn test_interceptors_cache_update_ingress() {
+//     let router_id = ZenohId::from_str("a1").unwrap();
+//     let c = TestInterceptorConf {
+//         flow: InterceptorFlow::Ingress,
+//         data: "1".to_string(),
+//     };
+//     let f = move || test_interceptor_factories(&vec![c.clone()]);
+//     let _ = crate::net::routing::interceptor::tests::ID_TO_INTERCEPTOR_FACTORIES
+//         .lock()
+//         .unwrap()
+//         .insert(router_id, Box::new(f));
 
-    init_log_from_env_or("error");
-    let mut config_router = get_basic_router_config(27701).await;
-    config_router.set_id(Some(router_id)).unwrap();
+//     init_log_from_env_or("error");
+//     let mut config_router = get_basic_router_config(27701).await;
+//     config_router.set_id(Some(router_id)).unwrap();
 
-    let config_client1 = get_basic_client_config(27701).await;
-    let config_client2 = get_basic_client_config(27701).await;
+//     let config_client1 = get_basic_client_config(27701).await;
+//     let config_client2 = get_basic_client_config(27701).await;
 
-    let router = ztimeout!(open(config_router.clone())).unwrap();
-    tokio::time::sleep(SLEEP).await;
-    let session1 = ztimeout!(open(config_client1)).unwrap();
-    let session2 = ztimeout!(open(config_client2)).unwrap();
-    tokio::time::sleep(SLEEP).await;
-    let sub = ztimeout!(session2.declare_subscriber("test/cache")).unwrap();
-    let pub1 = ztimeout!(session1.declare_publisher("test/cache")).unwrap();
-    let pub2 = ztimeout!(session1.declare_publisher("test/*")).unwrap();
-    tokio::time::sleep(SLEEP).await;
-    ztimeout!(pub1.put("some_data_1")).unwrap();
-    tokio::time::sleep(SLEEP).await;
-    ztimeout!(pub2.put("some_data_2")).unwrap();
+//     let router = ztimeout!(open(config_router.clone())).unwrap();
+//     tokio::time::sleep(SLEEP).await;
+//     let session1 = ztimeout!(open(config_client1)).unwrap();
+//     let session2 = ztimeout!(open(config_client2)).unwrap();
+//     tokio::time::sleep(SLEEP).await;
+//     let sub = ztimeout!(session2.declare_subscriber("test/cache")).unwrap();
+//     let pub1 = ztimeout!(session1.declare_publisher("test/cache")).unwrap();
+//     let pub2 = ztimeout!(session1.declare_publisher("test/*")).unwrap();
+//     tokio::time::sleep(SLEEP).await;
+//     ztimeout!(pub1.put("some_data_1")).unwrap();
+//     tokio::time::sleep(SLEEP).await;
+//     ztimeout!(pub2.put("some_data_2")).unwrap();
 
-    let msg1 = ztimeout!(sub.recv_async()).unwrap();
-    let msg2 = ztimeout!(sub.recv_async()).unwrap();
+//     let msg1 = ztimeout!(sub.recv_async()).unwrap();
+//     let msg2 = ztimeout!(sub.recv_async()).unwrap();
 
-    assert_eq!(
-        msg1.payload().try_to_string().unwrap().as_ref(),
-        "Cache hit: true, data: 1"
-    );
-    assert_eq!(
-        msg2.payload().try_to_string().unwrap().as_ref(),
-        "Cache hit: false, data: 1"
-    );
+//     assert_eq!(
+//         msg1.payload().try_to_string().unwrap().as_ref(),
+//         "Cache hit: true, data: 1"
+//     );
+//     assert_eq!(
+//         msg2.payload().try_to_string().unwrap().as_ref(),
+//         "Cache hit: false, data: 1"
+//     );
 
-    let c = TestInterceptorConf {
-        flow: InterceptorFlow::Ingress,
-        data: "2".to_string(),
-    };
-    let f = move || test_interceptor_factories(&vec![c.clone()]);
-    let _ = crate::net::routing::interceptor::tests::ID_TO_INTERCEPTOR_FACTORIES
-        .lock()
-        .unwrap()
-        .insert(router_id, Box::new(f));
+//     let c = TestInterceptorConf {
+//         flow: InterceptorFlow::Ingress,
+//         data: "2".to_string(),
+//     };
+//     let f = move || test_interceptor_factories(&vec![c.clone()]);
+//     let _ = crate::net::routing::interceptor::tests::ID_TO_INTERCEPTOR_FACTORIES
+//         .lock()
+//         .unwrap()
+//         .insert(router_id, Box::new(f));
 
-    router
-        .0
-        .runtime
-        .router()
-        .tables
-        .regen_interceptors(&config_router)
-        .unwrap();
-    tokio::time::sleep(SLEEP).await;
+//     router
+//         .0
+//         .runtime
+//         .router()
+//         .tables
+//         .regen_interceptors(&config_router)
+//         .unwrap();
+//     tokio::time::sleep(SLEEP).await;
 
-    ztimeout!(pub1.put("some_data_1")).unwrap();
-    tokio::time::sleep(SLEEP).await;
-    ztimeout!(pub2.put("some_data_2")).unwrap();
-    let sub2 = ztimeout!(session2.declare_subscriber("test2/cache")).unwrap();
-    let pub3 = ztimeout!(session1.declare_publisher("test2/cache")).unwrap();
-    tokio::time::sleep(SLEEP).await;
-    ztimeout!(pub3.put("some_data_3")).unwrap();
+//     ztimeout!(pub1.put("some_data_1")).unwrap();
+//     tokio::time::sleep(SLEEP).await;
+//     ztimeout!(pub2.put("some_data_2")).unwrap();
+//     let sub2 = ztimeout!(session2.declare_subscriber("test2/cache")).unwrap();
+//     let pub3 = ztimeout!(session1.declare_publisher("test2/cache")).unwrap();
+//     tokio::time::sleep(SLEEP).await;
+//     ztimeout!(pub3.put("some_data_3")).unwrap();
 
-    let msg1 = ztimeout!(sub.recv_async()).unwrap();
-    let msg2 = ztimeout!(sub.recv_async()).unwrap();
-    let msg3 = ztimeout!(sub2.recv_async()).unwrap();
+//     let msg1 = ztimeout!(sub.recv_async()).unwrap();
+//     let msg2 = ztimeout!(sub.recv_async()).unwrap();
+//     let msg3 = ztimeout!(sub2.recv_async()).unwrap();
 
-    assert_eq!(
-        msg1.payload().try_to_string().unwrap().as_ref(),
-        "Cache hit: true, data: 2"
-    );
-    assert_eq!(
-        msg2.payload().try_to_string().unwrap().as_ref(),
-        "Cache hit: false, data: 2"
-    );
-    assert_eq!(
-        msg3.payload().try_to_string().unwrap().as_ref(),
-        "Cache hit: true, data: 2"
-    );
-}
+//     assert_eq!(
+//         msg1.payload().try_to_string().unwrap().as_ref(),
+//         "Cache hit: true, data: 2"
+//     );
+//     assert_eq!(
+//         msg2.payload().try_to_string().unwrap().as_ref(),
+//         "Cache hit: false, data: 2"
+//     );
+//     assert_eq!(
+//         msg3.payload().try_to_string().unwrap().as_ref(),
+//         "Cache hit: true, data: 2"
+//     );
+// }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn test_interceptors_cache_update_egress() {
-    let router_id = ZenohId::from_str("a1").unwrap();
-    let c = TestInterceptorConf {
-        flow: InterceptorFlow::Egress,
-        data: "1".to_string(),
-    };
-    let f = move || test_interceptor_factories(&vec![c.clone()]);
-    let _ = crate::net::routing::interceptor::tests::ID_TO_INTERCEPTOR_FACTORIES
-        .lock()
-        .unwrap()
-        .insert(router_id, Box::new(f));
+// #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+// async fn test_interceptors_cache_update_egress() {
+//     let router_id = ZenohId::from_str("a1").unwrap();
+//     let c = TestInterceptorConf {
+//         flow: InterceptorFlow::Egress,
+//         data: "1".to_string(),
+//     };
+//     let f = move || test_interceptor_factories(&vec![c.clone()]);
+//     let _ = crate::net::routing::interceptor::tests::ID_TO_INTERCEPTOR_FACTORIES
+//         .lock()
+//         .unwrap()
+//         .insert(router_id, Box::new(f));
 
-    init_log_from_env_or("error");
-    let mut config_router = get_basic_router_config(27702).await;
-    config_router.set_id(Some(router_id)).unwrap();
+//     init_log_from_env_or("error");
+//     let mut config_router = get_basic_router_config(27702).await;
+//     config_router.set_id(Some(router_id)).unwrap();
 
-    let config_client1 = get_basic_client_config(27702).await;
-    let config_client2 = get_basic_client_config(27702).await;
+//     let config_client1 = get_basic_client_config(27702).await;
+//     let config_client2 = get_basic_client_config(27702).await;
 
-    let router = ztimeout!(open(config_router.clone())).unwrap();
-    tokio::time::sleep(SLEEP).await;
-    let session1 = ztimeout!(open(config_client1)).unwrap();
-    let session2 = ztimeout!(open(config_client2)).unwrap();
-    tokio::time::sleep(SLEEP).await;
-    let sub = ztimeout!(session2.declare_subscriber("test/cache")).unwrap();
-    let pub1 = ztimeout!(session1.declare_publisher("test/cache")).unwrap();
-    let pub2 = ztimeout!(session1.declare_publisher("test/*")).unwrap();
-    tokio::time::sleep(SLEEP).await;
-    ztimeout!(pub1.put("some_data_1")).unwrap();
-    tokio::time::sleep(SLEEP).await;
-    ztimeout!(pub2.put("some_data_2")).unwrap();
+//     let router = ztimeout!(open(config_router.clone())).unwrap();
+//     tokio::time::sleep(SLEEP).await;
+//     let session1 = ztimeout!(open(config_client1)).unwrap();
+//     let session2 = ztimeout!(open(config_client2)).unwrap();
+//     tokio::time::sleep(SLEEP).await;
+//     let sub = ztimeout!(session2.declare_subscriber("test/cache")).unwrap();
+//     let pub1 = ztimeout!(session1.declare_publisher("test/cache")).unwrap();
+//     let pub2 = ztimeout!(session1.declare_publisher("test/*")).unwrap();
+//     tokio::time::sleep(SLEEP).await;
+//     ztimeout!(pub1.put("some_data_1")).unwrap();
+//     tokio::time::sleep(SLEEP).await;
+//     ztimeout!(pub2.put("some_data_2")).unwrap();
 
-    let msg1 = ztimeout!(sub.recv_async()).unwrap();
-    let msg2 = ztimeout!(sub.recv_async()).unwrap();
+//     let msg1 = ztimeout!(sub.recv_async()).unwrap();
+//     let msg2 = ztimeout!(sub.recv_async()).unwrap();
 
-    assert_eq!(
-        msg1.payload().try_to_string().unwrap().as_ref(),
-        "Cache hit: true, data: 1"
-    );
-    assert_eq!(
-        msg2.payload().try_to_string().unwrap().as_ref(),
-        "Cache hit: false, data: 1"
-    );
+//     assert_eq!(
+//         msg1.payload().try_to_string().unwrap().as_ref(),
+//         "Cache hit: true, data: 1"
+//     );
+//     assert_eq!(
+//         msg2.payload().try_to_string().unwrap().as_ref(),
+//         "Cache hit: false, data: 1"
+//     );
 
-    let c = TestInterceptorConf {
-        flow: InterceptorFlow::Egress,
-        data: "2".to_string(),
-    };
-    let f = move || test_interceptor_factories(&vec![c.clone()]);
-    let _ = crate::net::routing::interceptor::tests::ID_TO_INTERCEPTOR_FACTORIES
-        .lock()
-        .unwrap()
-        .insert(router_id, Box::new(f));
+//     let c = TestInterceptorConf {
+//         flow: InterceptorFlow::Egress,
+//         data: "2".to_string(),
+//     };
+//     let f = move || test_interceptor_factories(&vec![c.clone()]);
+//     let _ = crate::net::routing::interceptor::tests::ID_TO_INTERCEPTOR_FACTORIES
+//         .lock()
+//         .unwrap()
+//         .insert(router_id, Box::new(f));
 
-    router
-        .0
-        .runtime
-        .router()
-        .tables
-        .regen_interceptors(&config_router)
-        .unwrap();
-    tokio::time::sleep(SLEEP).await;
+//     router
+//         .0
+//         .runtime
+//         .router()
+//         .tables
+//         .regen_interceptors(&config_router)
+//         .unwrap();
+//     tokio::time::sleep(SLEEP).await;
 
-    ztimeout!(pub1.put("some_data_1")).unwrap();
-    tokio::time::sleep(SLEEP).await;
-    ztimeout!(pub2.put("some_data_2")).unwrap();
-    let sub2 = ztimeout!(session2.declare_subscriber("test2/cache")).unwrap();
-    let pub3 = ztimeout!(session1.declare_publisher("test2/cache")).unwrap();
-    tokio::time::sleep(SLEEP).await;
-    ztimeout!(pub3.put("some_data_3")).unwrap();
+//     ztimeout!(pub1.put("some_data_1")).unwrap();
+//     tokio::time::sleep(SLEEP).await;
+//     ztimeout!(pub2.put("some_data_2")).unwrap();
+//     let sub2 = ztimeout!(session2.declare_subscriber("test2/cache")).unwrap();
+//     let pub3 = ztimeout!(session1.declare_publisher("test2/cache")).unwrap();
+//     tokio::time::sleep(SLEEP).await;
+//     ztimeout!(pub3.put("some_data_3")).unwrap();
 
-    let msg1 = ztimeout!(sub.recv_async()).unwrap();
-    let msg2 = ztimeout!(sub.recv_async()).unwrap();
-    let msg3 = ztimeout!(sub2.recv_async()).unwrap();
+//     let msg1 = ztimeout!(sub.recv_async()).unwrap();
+//     let msg2 = ztimeout!(sub.recv_async()).unwrap();
+//     let msg3 = ztimeout!(sub2.recv_async()).unwrap();
 
-    assert_eq!(
-        msg1.payload().try_to_string().unwrap().as_ref(),
-        "Cache hit: true, data: 2"
-    );
-    assert_eq!(
-        msg2.payload().try_to_string().unwrap().as_ref(),
-        "Cache hit: false, data: 2"
-    );
-    assert_eq!(
-        msg3.payload().try_to_string().unwrap().as_ref(),
-        "Cache hit: true, data: 2"
-    );
-}
+//     assert_eq!(
+//         msg1.payload().try_to_string().unwrap().as_ref(),
+//         "Cache hit: true, data: 2"
+//     );
+//     assert_eq!(
+//         msg2.payload().try_to_string().unwrap().as_ref(),
+//         "Cache hit: false, data: 2"
+//     );
+//     assert_eq!(
+//         msg3.payload().try_to_string().unwrap().as_ref(),
+//         "Cache hit: true, data: 2"
+//     );
+// }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn test_interceptors_cache_update_egress_then_ingress() {
-    let router_id = ZenohId::from_str("a1").unwrap();
-    let c = TestInterceptorConf {
-        flow: InterceptorFlow::Egress,
-        data: "1".to_string(),
-    };
-    let f = move || test_interceptor_factories(&vec![c.clone()]);
-    let _ = crate::net::routing::interceptor::tests::ID_TO_INTERCEPTOR_FACTORIES
-        .lock()
-        .unwrap()
-        .insert(router_id, Box::new(f));
+// #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+// async fn test_interceptors_cache_update_egress_then_ingress() {
+//     let router_id = ZenohId::from_str("a1").unwrap();
+//     let c = TestInterceptorConf {
+//         flow: InterceptorFlow::Egress,
+//         data: "1".to_string(),
+//     };
+//     let f = move || test_interceptor_factories(&vec![c.clone()]);
+//     let _ = crate::net::routing::interceptor::tests::ID_TO_INTERCEPTOR_FACTORIES
+//         .lock()
+//         .unwrap()
+//         .insert(router_id, Box::new(f));
 
-    init_log_from_env_or("error");
-    let mut config_router = get_basic_router_config(27703).await;
-    config_router.set_id(Some(router_id)).unwrap();
+//     init_log_from_env_or("error");
+//     let mut config_router = get_basic_router_config(27703).await;
+//     config_router.set_id(Some(router_id)).unwrap();
 
-    let config_client1 = get_basic_client_config(27703).await;
-    let config_client2 = get_basic_client_config(27703).await;
+//     let config_client1 = get_basic_client_config(27703).await;
+//     let config_client2 = get_basic_client_config(27703).await;
 
-    let router = ztimeout!(open(config_router.clone())).unwrap();
-    tokio::time::sleep(SLEEP).await;
-    let session1 = ztimeout!(open(config_client1)).unwrap();
-    let session2 = ztimeout!(open(config_client2)).unwrap();
-    tokio::time::sleep(SLEEP).await;
-    let sub = ztimeout!(session2.declare_subscriber("test/cache")).unwrap();
-    let pub1 = ztimeout!(session1.declare_publisher("test/cache")).unwrap();
-    let pub2 = ztimeout!(session1.declare_publisher("test/*")).unwrap();
-    tokio::time::sleep(SLEEP).await;
-    ztimeout!(pub1.put("some_data_1")).unwrap();
-    tokio::time::sleep(SLEEP).await;
-    ztimeout!(pub2.put("some_data_2")).unwrap();
+//     let router = ztimeout!(open(config_router.clone())).unwrap();
+//     tokio::time::sleep(SLEEP).await;
+//     let session1 = ztimeout!(open(config_client1)).unwrap();
+//     let session2 = ztimeout!(open(config_client2)).unwrap();
+//     tokio::time::sleep(SLEEP).await;
+//     let sub = ztimeout!(session2.declare_subscriber("test/cache")).unwrap();
+//     let pub1 = ztimeout!(session1.declare_publisher("test/cache")).unwrap();
+//     let pub2 = ztimeout!(session1.declare_publisher("test/*")).unwrap();
+//     tokio::time::sleep(SLEEP).await;
+//     ztimeout!(pub1.put("some_data_1")).unwrap();
+//     tokio::time::sleep(SLEEP).await;
+//     ztimeout!(pub2.put("some_data_2")).unwrap();
 
-    let msg1 = ztimeout!(sub.recv_async()).unwrap();
-    let msg2 = ztimeout!(sub.recv_async()).unwrap();
+//     let msg1 = ztimeout!(sub.recv_async()).unwrap();
+//     let msg2 = ztimeout!(sub.recv_async()).unwrap();
 
-    assert_eq!(
-        msg1.payload().try_to_string().unwrap().as_ref(),
-        "Cache hit: true, data: 1"
-    );
-    assert_eq!(
-        msg2.payload().try_to_string().unwrap().as_ref(),
-        "Cache hit: false, data: 1"
-    );
+//     assert_eq!(
+//         msg1.payload().try_to_string().unwrap().as_ref(),
+//         "Cache hit: true, data: 1"
+//     );
+//     assert_eq!(
+//         msg2.payload().try_to_string().unwrap().as_ref(),
+//         "Cache hit: false, data: 1"
+//     );
 
-    let c = TestInterceptorConf {
-        flow: InterceptorFlow::Ingress,
-        data: "2".to_string(),
-    };
-    let f = move || test_interceptor_factories(&vec![c.clone()]);
-    let _ = crate::net::routing::interceptor::tests::ID_TO_INTERCEPTOR_FACTORIES
-        .lock()
-        .unwrap()
-        .insert(router_id, Box::new(f));
+//     let c = TestInterceptorConf {
+//         flow: InterceptorFlow::Ingress,
+//         data: "2".to_string(),
+//     };
+//     let f = move || test_interceptor_factories(&vec![c.clone()]);
+//     let _ = crate::net::routing::interceptor::tests::ID_TO_INTERCEPTOR_FACTORIES
+//         .lock()
+//         .unwrap()
+//         .insert(router_id, Box::new(f));
 
-    router
-        .0
-        .runtime
-        .router()
-        .tables
-        .regen_interceptors(&config_router)
-        .unwrap();
-    tokio::time::sleep(SLEEP).await;
+//     router
+//         .0
+//         .runtime
+//         .router()
+//         .tables
+//         .regen_interceptors(&config_router)
+//         .unwrap();
+//     tokio::time::sleep(SLEEP).await;
 
-    ztimeout!(pub1.put("some_data_1")).unwrap();
-    tokio::time::sleep(SLEEP).await;
-    ztimeout!(pub2.put("some_data_2")).unwrap();
-    let sub2 = ztimeout!(session2.declare_subscriber("test2/cache")).unwrap();
-    let pub3 = ztimeout!(session1.declare_publisher("test2/cache")).unwrap();
-    tokio::time::sleep(SLEEP).await;
-    ztimeout!(pub3.put("some_data_3")).unwrap();
+//     ztimeout!(pub1.put("some_data_1")).unwrap();
+//     tokio::time::sleep(SLEEP).await;
+//     ztimeout!(pub2.put("some_data_2")).unwrap();
+//     let sub2 = ztimeout!(session2.declare_subscriber("test2/cache")).unwrap();
+//     let pub3 = ztimeout!(session1.declare_publisher("test2/cache")).unwrap();
+//     tokio::time::sleep(SLEEP).await;
+//     ztimeout!(pub3.put("some_data_3")).unwrap();
 
-    let msg1 = ztimeout!(sub.recv_async()).unwrap();
-    let msg2 = ztimeout!(sub.recv_async()).unwrap();
-    let msg3 = ztimeout!(sub2.recv_async()).unwrap();
+//     let msg1 = ztimeout!(sub.recv_async()).unwrap();
+//     let msg2 = ztimeout!(sub.recv_async()).unwrap();
+//     let msg3 = ztimeout!(sub2.recv_async()).unwrap();
 
-    assert_eq!(
-        msg1.payload().try_to_string().unwrap().as_ref(),
-        "Cache hit: true, data: 2"
-    );
-    assert_eq!(
-        msg2.payload().try_to_string().unwrap().as_ref(),
-        "Cache hit: false, data: 2"
-    );
-    assert_eq!(
-        msg3.payload().try_to_string().unwrap().as_ref(),
-        "Cache hit: true, data: 2"
-    );
-}
+//     assert_eq!(
+//         msg1.payload().try_to_string().unwrap().as_ref(),
+//         "Cache hit: true, data: 2"
+//     );
+//     assert_eq!(
+//         msg2.payload().try_to_string().unwrap().as_ref(),
+//         "Cache hit: false, data: 2"
+//     );
+//     assert_eq!(
+//         msg3.payload().try_to_string().unwrap().as_ref(),
+//         "Cache hit: true, data: 2"
+//     );
+// }

--- a/zenoh/src/tests/link_weights.rs
+++ b/zenoh/src/tests/link_weights.rs
@@ -1,826 +1,826 @@
-//
-// Copyright (c) 2025 ZettaScale Technology
-//
-// This program and the accompanying materials are made available under the
-// terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
-// which is available at https://www.apache.org/licenses/LICENSE-2.0.
-//
-// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
-//
-// Contributors:
-//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
-#![cfg(feature = "internal_config")]
-
-use std::{
-    any::Any,
-    collections::HashMap,
-    str::{self, FromStr},
-};
-
-use zenoh_buffers::ZBuf;
-use zenoh_config::{InterceptorFlow, TransportWeight};
-use zenoh_keyexpr::keyexpr;
-use zenoh_protocol::{
-    core::ZenohIdProto,
-    network::{NetworkBodyMut, NetworkMessageMut, Push},
-    zenoh::PushBody,
-};
-use zenoh_transport::{multicast::TransportMulticast, unicast::TransportUnicast};
-
-use crate::{
-    net::{
-        protocol::linkstate::LinkInfo,
-        routing::{interceptor::*, RoutingContext},
-    },
-    Session,
-};
-
-#[derive(Clone)]
-struct LinkTraceInterceptorConf {
-    flow: InterceptorFlow,
-}
-
-fn link_trace_interceptor_factories(
-    config: &Vec<LinkTraceInterceptorConf>,
-) -> Vec<InterceptorFactory> {
-    let mut res: Vec<InterceptorFactory> = vec![];
-    for c in config {
-        res.push(Box::new(LinkTraceInterceptorFactory::new(c.clone())));
-    }
-    res
-}
-
-struct LinkTraceInterceptorFactory {
-    conf: LinkTraceInterceptorConf,
-}
-
-impl LinkTraceInterceptorFactory {
-    pub fn new(conf: LinkTraceInterceptorConf) -> Self {
-        Self { conf }
-    }
-}
-
-impl InterceptorFactoryTrait for LinkTraceInterceptorFactory {
-    fn new_transport_unicast(
-        &self,
-        transport: &TransportUnicast,
-    ) -> (Option<IngressInterceptor>, Option<EgressInterceptor>) {
-        let zid = transport
-            .get_zid()
-            .map(|z| z.to_string())
-            .unwrap_or_default();
-        match self.conf.flow {
-            InterceptorFlow::Egress => (
-                None,
-                Some(Box::new(LinkTraceInterceptor { zid: zid.clone() })),
-            ),
-            InterceptorFlow::Ingress => (
-                Some(Box::new(LinkTraceInterceptor { zid: zid.clone() })),
-                None,
-            ),
-        }
-    }
-
-    fn new_transport_multicast(
-        &self,
-        _transport: &TransportMulticast,
-    ) -> Option<EgressInterceptor> {
-        None
-    }
-
-    fn new_peer_multicast(&self, _transport: &TransportMulticast) -> Option<IngressInterceptor> {
-        None
-    }
-}
-
-struct LinkTraceInterceptor {
-    zid: String,
-}
-
-impl InterceptorTrait for LinkTraceInterceptor {
-    fn compute_keyexpr_cache(&self, _key_expr: &keyexpr) -> Option<Box<dyn Any + Send + Sync>> {
-        None
-    }
-
-    fn intercept(
-        &self,
-        ctx: &mut RoutingContext<NetworkMessageMut<'_>>,
-        _cache: Option<&Box<dyn Any + Send + Sync>>,
-    ) -> bool {
-        if let NetworkBodyMut::Push(&mut Push {
-            payload: PushBody::Put(ref mut p),
-            ..
-        }) = &mut ctx.msg.body
-        {
-            let s = str::from_utf8(p.payload.to_zslice().as_slice())
-                .unwrap()
-                .to_string();
-            let s = s + "->" + &self.zid;
-            p.payload = ZBuf::from(s.as_bytes().to_owned());
-        }
-        true
-    }
-}
-
-use std::time::Duration;
-
-use zenoh_config::ZenohId;
-use zenoh_core::ztimeout;
-
-use crate::{config::WhatAmI, init_log_from_env_or, open, Config};
-
-const TIMEOUT: Duration = Duration::from_secs(60);
-const SLEEP: Duration = Duration::from_secs(1);
-
-async fn get_basic_router_config(
-    listen_ports: &[u16],
-    connect_ports: &[u16],
-    wai: WhatAmI,
-) -> Config {
-    let mut config = Config::default();
-    config.set_mode(Some(wai)).unwrap();
-    config
-        .listen
-        .endpoints
-        .set(
-            listen_ports
-                .iter()
-                .map(|p| format!("tcp/127.0.0.1:{p}").parse().unwrap())
-                .collect::<Vec<_>>(),
-        )
-        .unwrap();
-    config
-        .connect
-        .endpoints
-        .set(
-            connect_ports
-                .iter()
-                .map(|p| format!("tcp/127.0.0.1:{p}").parse().unwrap())
-                .collect::<Vec<_>>(),
-        )
-        .unwrap();
-    config.scouting.multicast.set_enabled(Some(false)).unwrap();
-    config.scouting.gossip.set_enabled(Some(false)).unwrap();
-    config
-}
-
-async fn get_basic_client_config(port: u16) -> Config {
-    let mut config = Config::default();
-    config.set_mode(Some(WhatAmI::Client)).unwrap();
-    config
-        .connect
-        .endpoints
-        .set(vec![format!("tcp/127.0.0.1:{port}").parse().unwrap()])
-        .unwrap();
-    config.scouting.multicast.set_enabled(Some(false)).unwrap();
-    config
-}
-
-struct Net {
-    routers: Vec<Session>,
-    source: Session,
-    dest: Session,
-    wai: WhatAmI,
-}
-
-impl Net {
-    #[allow(clippy::type_complexity)]
-    async fn update_weights(&mut self, net: Vec<(u16, Vec<(u16, Option<u16>)>)>) {
-        for (i, v) in net.iter().enumerate() {
-            let weights =
-                v.1.iter()
-                    .filter_map(|(e, w)| {
-                        w.map(|w| TransportWeight {
-                            dst_zid: ZenohId::from_str(&e.to_string()).unwrap(),
-                            weight: w.try_into().unwrap(),
-                        })
-                    })
-                    .collect::<Vec<_>>();
-
-            match self.wai {
-                WhatAmI::Router => self.routers[i]
-                    .0
-                    .runtime
-                    .config()
-                    .lock()
-                    .routing
-                    .router
-                    .linkstate
-                    .set_transport_weights(weights)
-                    .unwrap(),
-                WhatAmI::Peer => self.routers[i]
-                    .0
-                    .runtime
-                    .config()
-                    .lock()
-                    .routing
-                    .peer
-                    .linkstate
-                    .set_transport_weights(weights)
-                    .unwrap(),
-                WhatAmI::Client => unreachable!(),
-            };
-            self.routers[i].0.runtime.update_network().unwrap();
-        }
-    }
-}
-
-#[allow(clippy::type_complexity)]
-async fn create_routers_net(
-    net: Vec<(u16, Vec<(u16, Option<u16>)>)>,
-    source: u16,
-    dest: u16,
-    port_offset: u16,
-) -> Net {
-    create_net(net, source, dest, port_offset, WhatAmI::Router).await
-}
-
-#[allow(clippy::type_complexity)]
-async fn create_peers_net(
-    net: Vec<(u16, Vec<(u16, Option<u16>)>)>,
-    source: u16,
-    dest: u16,
-    port_offset: u16,
-) -> Net {
-    create_net(net, source, dest, port_offset, WhatAmI::Peer).await
-}
-
-#[allow(clippy::type_complexity)]
-async fn create_net(
-    net: Vec<(u16, Vec<(u16, Option<u16>)>)>,
-    source: u16,
-    dest: u16,
-    port_offset: u16,
-    wai: WhatAmI,
-) -> Net {
-    let start_id = ZenohId::from_str("a").unwrap();
-    let end_id = ZenohId::from_str("b").unwrap();
-
-    {
-        let c = LinkTraceInterceptorConf {
-            flow: InterceptorFlow::Egress,
-        };
-        let f = move || link_trace_interceptor_factories(&vec![c.clone()]);
-        let mut lk = crate::net::routing::interceptor::tests::ID_TO_INTERCEPTOR_FACTORIES
-            .lock()
-            .unwrap();
-
-        lk.insert(start_id, Box::new(f.clone()));
-
-        for v in &net {
-            let zid = ZenohId::from_str(&v.0.to_string()).unwrap();
-            lk.insert(zid, Box::new(f.clone()));
-        }
-    }
-    let mut routers = Vec::new();
-
-    for v in &net {
-        let zid = ZenohId::from_str(&v.0.to_string()).unwrap();
-        let connect =
-            v.1.iter()
-                .map(|(id, _)| id + port_offset)
-                .collect::<Vec<_>>();
-        let mut config = get_basic_router_config(&[port_offset + v.0], &connect, wai).await;
-        config.set_id(Some(zid)).unwrap();
-        let weights =
-            v.1.iter()
-                .filter_map(|(e, w)| {
-                    w.map(|w| TransportWeight {
-                        dst_zid: ZenohId::from_str(&e.to_string()).unwrap(),
-                        weight: w.try_into().unwrap(),
-                    })
-                })
-                .collect::<Vec<_>>();
-        match wai {
-            WhatAmI::Router => {
-                config
-                    .routing
-                    .router
-                    .linkstate
-                    .set_transport_weights(weights)
-                    .unwrap();
-            }
-            WhatAmI::Peer => {
-                config
-                    .routing
-                    .peer
-                    .linkstate
-                    .set_transport_weights(weights)
-                    .unwrap();
-                config
-                    .routing
-                    .peer
-                    .set_mode(Some("linkstate".to_string()))
-                    .unwrap();
-            }
-            WhatAmI::Client => unreachable!(),
-        }
-
-        let router = ztimeout!(open(config)).unwrap();
-        routers.push(router);
-    }
-
-    let mut config_client_a = get_basic_client_config(source + port_offset).await;
-    config_client_a.set_id(Some(start_id)).unwrap();
-    let mut config_client_b = get_basic_client_config(dest + port_offset).await;
-    config_client_b.set_id(Some(end_id)).unwrap();
-
-    let session_a = ztimeout!(open(config_client_a)).unwrap();
-    let session_b = ztimeout!(open(config_client_b)).unwrap();
-    tokio::time::sleep(SLEEP).await;
-
-    Net {
-        routers,
-        source: session_a,
-        dest: session_b,
-        wai,
-    }
-}
-
-#[allow(clippy::type_complexity)]
-async fn test_link_weights_inner(
-    net: Vec<(u16, Vec<(u16, Option<u16>)>)>,
-    source: u16,
-    dest: u16,
-    port_offset: u16,
-) -> String {
-    let net = create_routers_net(net, source, dest, port_offset).await;
-
-    let sub = ztimeout!(net.dest.declare_subscriber("test/link_weights")).unwrap();
-
-    tokio::time::sleep(3 * SLEEP).await;
-    ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
-
-    let msg = ztimeout!(sub.recv_async()).unwrap();
-
-    msg.payload().try_to_string().unwrap().to_string()
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn test_link_weights_diamond() {
-    init_log_from_env_or("error");
-    //       2
-    //      / \
-    // a - 1   4 - b
-    //      \ /
-    //       3
-
-    let res = test_link_weights_inner(
-        vec![
-            (1, vec![(2, Some(10)), (3, None)]),
-            (2, vec![(4, None)]),
-            (3, vec![(4, None)]),
-            (4, vec![]),
-        ],
-        1,
-        4,
-        28000,
-    )
-    .await;
-
-    assert_eq!(res, "a->1->2->4->b");
-
-    let res = test_link_weights_inner(
-        vec![
-            (1, vec![(3, None)]),
-            (2, vec![(1, Some(10)), (4, None)]),
-            (3, vec![(4, None)]),
-            (4, vec![]),
-        ],
-        1,
-        4,
-        28100,
-    )
-    .await;
-
-    assert_eq!(res, "a->1->2->4->b");
-
-    let res = test_link_weights_inner(
-        vec![
-            (1, vec![(2, None), (3, None)]),
-            (2, vec![(4, None)]),
-            (3, vec![]),
-            (4, vec![(3, Some(10))]),
-        ],
-        1,
-        4,
-        28200,
-    )
-    .await;
-
-    assert_eq!(res, "a->1->3->4->b");
-
-    let res = test_link_weights_inner(
-        vec![
-            (1, vec![(2, None), (3, None)]),
-            (2, vec![(4, None)]),
-            (3, vec![(4, Some(10))]),
-            (4, vec![]),
-        ],
-        1,
-        4,
-        28300,
-    )
-    .await;
-
-    assert_eq!(res, "a->1->3->4->b");
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn test_link_weights_triangle() {
-    init_log_from_env_or("error");
-    //       2
-    //      / \
-    // a - 1 - 3 - b
-
-    let res = test_link_weights_inner(
-        vec![
-            (1, vec![(2, Some(10)), (3, None)]),
-            (2, vec![(3, Some(10))]),
-            (3, vec![]),
-        ],
-        1,
-        3,
-        29000,
-    )
-    .await;
-
-    assert_eq!(res, "a->1->2->3->b");
-
-    let res = test_link_weights_inner(
-        vec![
-            (1, vec![(2, None), (3, Some(300))]),
-            (2, vec![(3, None)]),
-            (3, vec![]),
-        ],
-        1,
-        3,
-        29100,
-    )
-    .await;
-
-    assert_eq!(res, "a->1->2->3->b");
-
-    let res = test_link_weights_inner(
-        vec![
-            (1, vec![(2, None), (3, None)]),
-            (2, vec![(3, None)]),
-            (3, vec![]),
-        ],
-        1,
-        3,
-        29200,
-    )
-    .await;
-
-    assert_eq!(res, "a->1->3->b");
-
-    // should resolve weights to 55 on 1-2 and 2-3, so will pick 1-3 path (with default cost of 100)
-    let res = test_link_weights_inner(
-        vec![
-            (1, vec![(2, Some(10)), (3, None)]),
-            (2, vec![(1, Some(55)), (3, Some(10))]),
-            (3, vec![(2, Some(55))]),
-        ],
-        1,
-        3,
-        29300,
-    )
-    .await;
-
-    assert_eq!(res, "a->1->3->b");
-
-    // should resolve weights to 45 on 1-2 and 2-3, so will pick 1-2-3 path with total cost of 2 * 45 = 90
-    let res = test_link_weights_inner(
-        vec![
-            (1, vec![(2, Some(45)), (3, None)]),
-            (2, vec![(1, Some(10)), (3, Some(45))]),
-            (3, vec![(2, Some(10))]),
-        ],
-        1,
-        3,
-        29400,
-    )
-    .await;
-
-    assert_eq!(res, "a->1->2->3->b");
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn test_link_weights_hexagon() {
-    init_log_from_env_or("error");
-    //       2 - 5
-    //      / \ / \
-    // a - 1 - 4 - 7 - b
-    //      \ / \ /
-    //       3 - 6
-
-    let res = test_link_weights_inner(
-        vec![
-            (1, vec![(2, Some(1)), (3, None), (4, None)]),
-            (2, vec![(4, Some(1)), (5, None)]),
-            (3, vec![(4, None), (6, None)]),
-            (4, vec![(5, None), (6, Some(1)), (7, None)]),
-            (5, vec![(7, None)]),
-            (6, vec![(7, Some(1))]),
-            (7, vec![]),
-        ],
-        1,
-        7,
-        30000,
-    )
-    .await;
-
-    assert_eq!(res, "a->1->2->4->6->7->b");
-
-    let res = test_link_weights_inner(
-        vec![
-            (1, vec![(2, None), (3, None), (4, None)]),
-            (2, vec![(4, None), (5, None)]),
-            (3, vec![(4, None), (6, None)]),
-            (4, vec![(5, None), (6, None), (7, None)]),
-            (5, vec![(7, None)]),
-            (6, vec![(7, None)]),
-            (7, vec![]),
-        ],
-        1,
-        7,
-        30100,
-    )
-    .await;
-
-    assert_eq!(res, "a->1->4->7->b");
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn test_link_weights_update_diamond() {
-    init_log_from_env_or("error");
-    //       2
-    //      / \
-    // a - 1   4 - b
-    //      \ /
-    //       3
-
-    let mut net = create_routers_net(
-        vec![
-            (1, vec![(2, Some(10)), (3, None)]),
-            (2, vec![(4, None)]),
-            (3, vec![(4, None)]),
-            (4, vec![]),
-        ],
-        1,
-        4,
-        31000,
-    )
-    .await;
-
-    let sub = ztimeout!(net.dest.declare_subscriber("test/link_weights")).unwrap();
-
-    tokio::time::sleep(3 * SLEEP).await;
-    ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
-
-    let msg = ztimeout!(sub.recv_async())
-        .unwrap()
-        .payload()
-        .try_to_string()
-        .unwrap()
-        .to_string();
-    assert_eq!(msg, "a->1->2->4->b");
-
-    ztimeout!(net.update_weights(vec![
-        (1, vec![(2, None), (3, Some(10))]),
-        (2, vec![(4, None)]),
-        (3, vec![(4, None)]),
-        (4, vec![]),
-    ]));
-
-    tokio::time::sleep(3 * SLEEP).await;
-    ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
-
-    let msg = ztimeout!(sub.recv_async())
-        .unwrap()
-        .payload()
-        .try_to_string()
-        .unwrap()
-        .to_string();
-    assert_eq!(msg, "a->1->3->4->b");
-
-    ztimeout!(net.update_weights(vec![
-        (1, vec![(2, None), (3, Some(200))]),
-        (2, vec![(4, None)]),
-        (3, vec![(4, None)]),
-        (4, vec![]),
-    ]));
-
-    tokio::time::sleep(3 * SLEEP).await;
-    ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
-
-    let msg = ztimeout!(sub.recv_async())
-        .unwrap()
-        .payload()
-        .try_to_string()
-        .unwrap()
-        .to_string();
-    assert_eq!(msg, "a->1->2->4->b");
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn test_link_weights_update_hexagon() {
-    init_log_from_env_or("error");
-    //       2 - 5
-    //      / \ / \
-    // a - 1 - 4 - 7 - b
-    //      \ / \ /
-    //       3 - 6
-
-    let mut net = create_routers_net(
-        vec![
-            (1, vec![(2, Some(1)), (3, None), (4, None)]),
-            (2, vec![(4, Some(1)), (5, None)]),
-            (3, vec![(4, None), (6, None)]),
-            (4, vec![(5, None), (6, Some(1)), (7, None)]),
-            (5, vec![(7, None)]),
-            (6, vec![(7, Some(1))]),
-            (7, vec![]),
-        ],
-        1,
-        7,
-        32000,
-    )
-    .await;
-
-    let sub = ztimeout!(net.dest.declare_subscriber("test/link_weights")).unwrap();
-
-    tokio::time::sleep(3 * SLEEP).await;
-    ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
-
-    let msg = ztimeout!(sub.recv_async())
-        .unwrap()
-        .payload()
-        .try_to_string()
-        .unwrap()
-        .to_string();
-
-    assert_eq!(msg, "a->1->2->4->6->7->b");
-
-    ztimeout!(net.update_weights(vec![
-        (1, vec![(2, None), (3, None), (4, None)]),
-        (2, vec![(4, None), (5, None)]),
-        (3, vec![(4, None), (6, None)]),
-        (4, vec![(5, None), (6, None), (7, None)]),
-        (5, vec![(7, None)]),
-        (6, vec![(7, None)]),
-        (7, vec![]),
-    ],));
-
-    tokio::time::sleep(3 * SLEEP).await;
-    ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
-
-    let msg = ztimeout!(sub.recv_async())
-        .unwrap()
-        .payload()
-        .try_to_string()
-        .unwrap()
-        .to_string();
-
-    assert_eq!(msg, "a->1->4->7->b");
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn test_link_weights_update_diamond_peers() {
-    init_log_from_env_or("error");
-    //       2
-    //      / \
-    // a - 1   4 - b
-    //      \ /
-    //       3
-
-    let mut net = create_peers_net(
-        vec![
-            (1, vec![(2, Some(10)), (3, None)]),
-            (2, vec![(4, None)]),
-            (3, vec![(4, None)]),
-            (4, vec![]),
-        ],
-        1,
-        4,
-        33000,
-    )
-    .await;
-
-    let sub = ztimeout!(net.dest.declare_subscriber("test/link_weights")).unwrap();
-
-    tokio::time::sleep(3 * SLEEP).await;
-    ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
-
-    let msg = ztimeout!(sub.recv_async())
-        .unwrap()
-        .payload()
-        .try_to_string()
-        .unwrap()
-        .to_string();
-    assert_eq!(msg, "a->1->2->4->b");
-
-    ztimeout!(net.update_weights(vec![
-        (1, vec![(2, None), (3, Some(10))]),
-        (2, vec![(4, None)]),
-        (3, vec![(4, None)]),
-        (4, vec![]),
-    ]));
-
-    tokio::time::sleep(3 * SLEEP).await;
-    ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
-
-    let msg = ztimeout!(sub.recv_async())
-        .unwrap()
-        .payload()
-        .try_to_string()
-        .unwrap()
-        .to_string();
-    assert_eq!(msg, "a->1->3->4->b");
-
-    ztimeout!(net.update_weights(vec![
-        (1, vec![(2, None), (3, Some(200))]),
-        (2, vec![(4, None)]),
-        (3, vec![(4, None)]),
-        (4, vec![]),
-    ]));
-
-    tokio::time::sleep(3 * SLEEP).await;
-    ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
-
-    let msg = ztimeout!(sub.recv_async())
-        .unwrap()
-        .payload()
-        .try_to_string()
-        .unwrap()
-        .to_string();
-    assert_eq!(msg, "a->1->2->4->b");
-}
-
-async fn test_link_weights_info_diamond_inner(port_offset: u16, wai: WhatAmI) {
-    //       2
-    //      / \
-    // a - 1 - 4 - b
-    //      \ /
-    //       3
-
-    let net = create_net(
-        vec![
-            (1, vec![(2, Some(10)), (3, None), (4, Some(20))]),
-            (2, vec![(4, None)]),
-            (3, vec![(4, None)]),
-            (4, vec![(1, Some(30))]),
-        ],
-        1,
-        4,
-        port_offset,
-        wai,
-    )
-    .await;
-
-    let info = net.routers[0].0.runtime.get_links_info();
-
-    let expected = HashMap::from([
-        (
-            ZenohIdProto::from_str("2").unwrap(),
-            LinkInfo {
-                src_weight: Some(10),
-                dst_weight: None,
-                actual_weight: 10,
-            },
-        ),
-        (
-            ZenohIdProto::from_str("3").unwrap(),
-            LinkInfo {
-                src_weight: None,
-                dst_weight: None,
-                actual_weight: 100,
-            },
-        ),
-        (
-            ZenohIdProto::from_str("4").unwrap(),
-            LinkInfo {
-                src_weight: Some(20),
-                dst_weight: Some(30),
-                actual_weight: 30,
-            },
-        ),
-    ]);
-
-    assert_eq!(info, expected);
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn test_link_weights_info_diamond_routers() {
-    init_log_from_env_or("error");
-    test_link_weights_info_diamond_inner(36000, WhatAmI::Router).await;
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn test_link_weights_info_diamond_peers() {
-    init_log_from_env_or("error");
-    test_link_weights_info_diamond_inner(35000, WhatAmI::Peer).await;
-}
+// //
+// // Copyright (c) 2025 ZettaScale Technology
+// //
+// // This program and the accompanying materials are made available under the
+// // terms of the Eclipse Public License 2.0 which is available at
+// // http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// // which is available at https://www.apache.org/licenses/LICENSE-2.0.
+// //
+// // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// //
+// // Contributors:
+// //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+// //
+// #![cfg(feature = "internal_config")]
+
+// use std::{
+//     any::Any,
+//     collections::HashMap,
+//     str::{self, FromStr},
+// };
+
+// use zenoh_buffers::ZBuf;
+// use zenoh_config::{InterceptorFlow, TransportWeight};
+// use zenoh_keyexpr::keyexpr;
+// use zenoh_protocol::{
+//     core::ZenohIdProto,
+//     network::{NetworkBodyMut, NetworkMessageMut, Push},
+//     zenoh::PushBody,
+// };
+// use zenoh_transport::{multicast::TransportMulticast, unicast::TransportUnicast};
+
+// use crate::{
+//     net::{
+//         protocol::linkstate::LinkInfo,
+//         routing::{interceptor::*, RoutingContext},
+//     },
+//     Session,
+// };
+
+// #[derive(Clone)]
+// struct LinkTraceInterceptorConf {
+//     flow: InterceptorFlow,
+// }
+
+// fn link_trace_interceptor_factories(
+//     config: &Vec<LinkTraceInterceptorConf>,
+// ) -> Vec<InterceptorFactory> {
+//     let mut res: Vec<InterceptorFactory> = vec![];
+//     for c in config {
+//         res.push(Box::new(LinkTraceInterceptorFactory::new(c.clone())));
+//     }
+//     res
+// }
+
+// struct LinkTraceInterceptorFactory {
+//     conf: LinkTraceInterceptorConf,
+// }
+
+// impl LinkTraceInterceptorFactory {
+//     pub fn new(conf: LinkTraceInterceptorConf) -> Self {
+//         Self { conf }
+//     }
+// }
+
+// impl InterceptorFactoryTrait for LinkTraceInterceptorFactory {
+//     fn new_transport_unicast(
+//         &self,
+//         transport: &TransportUnicast,
+//     ) -> (Option<IngressInterceptor>, Option<EgressInterceptor>) {
+//         let zid = transport
+//             .get_zid()
+//             .map(|z| z.to_string())
+//             .unwrap_or_default();
+//         match self.conf.flow {
+//             InterceptorFlow::Egress => (
+//                 None,
+//                 Some(Box::new(LinkTraceInterceptor { zid: zid.clone() })),
+//             ),
+//             InterceptorFlow::Ingress => (
+//                 Some(Box::new(LinkTraceInterceptor { zid: zid.clone() })),
+//                 None,
+//             ),
+//         }
+//     }
+
+//     fn new_transport_multicast(
+//         &self,
+//         _transport: &TransportMulticast,
+//     ) -> Option<EgressInterceptor> {
+//         None
+//     }
+
+//     fn new_peer_multicast(&self, _transport: &TransportMulticast) -> Option<IngressInterceptor> {
+//         None
+//     }
+// }
+
+// struct LinkTraceInterceptor {
+//     zid: String,
+// }
+
+// impl InterceptorTrait for LinkTraceInterceptor {
+//     fn compute_keyexpr_cache(&self, _key_expr: &keyexpr) -> Option<Box<dyn Any + Send + Sync>> {
+//         None
+//     }
+
+//     fn intercept(
+//         &self,
+//         ctx: &mut RoutingContext<NetworkMessageMut<'_>>,
+//         _cache: Option<&Box<dyn Any + Send + Sync>>,
+//     ) -> bool {
+//         if let NetworkBodyMut::Push(&mut Push {
+//             payload: PushBody::Put(ref mut p),
+//             ..
+//         }) = &mut ctx.msg.body
+//         {
+//             let s = str::from_utf8(p.payload.to_zslice().as_slice())
+//                 .unwrap()
+//                 .to_string();
+//             let s = s + "->" + &self.zid;
+//             p.payload = ZBuf::from(s.as_bytes().to_owned());
+//         }
+//         true
+//     }
+// }
+
+// use std::time::Duration;
+
+// use zenoh_config::ZenohId;
+// use zenoh_core::ztimeout;
+
+// use crate::{config::WhatAmI, init_log_from_env_or, open, Config};
+
+// const TIMEOUT: Duration = Duration::from_secs(60);
+// const SLEEP: Duration = Duration::from_secs(1);
+
+// async fn get_basic_router_config(
+//     listen_ports: &[u16],
+//     connect_ports: &[u16],
+//     wai: WhatAmI,
+// ) -> Config {
+//     let mut config = Config::default();
+//     config.set_mode(Some(wai)).unwrap();
+//     config
+//         .listen
+//         .endpoints
+//         .set(
+//             listen_ports
+//                 .iter()
+//                 .map(|p| format!("tcp/127.0.0.1:{p}").parse().unwrap())
+//                 .collect::<Vec<_>>(),
+//         )
+//         .unwrap();
+//     config
+//         .connect
+//         .endpoints
+//         .set(
+//             connect_ports
+//                 .iter()
+//                 .map(|p| format!("tcp/127.0.0.1:{p}").parse().unwrap())
+//                 .collect::<Vec<_>>(),
+//         )
+//         .unwrap();
+//     config.scouting.multicast.set_enabled(Some(false)).unwrap();
+//     config.scouting.gossip.set_enabled(Some(false)).unwrap();
+//     config
+// }
+
+// async fn get_basic_client_config(port: u16) -> Config {
+//     let mut config = Config::default();
+//     config.set_mode(Some(WhatAmI::Client)).unwrap();
+//     config
+//         .connect
+//         .endpoints
+//         .set(vec![format!("tcp/127.0.0.1:{port}").parse().unwrap()])
+//         .unwrap();
+//     config.scouting.multicast.set_enabled(Some(false)).unwrap();
+//     config
+// }
+
+// struct Net {
+//     routers: Vec<Session>,
+//     source: Session,
+//     dest: Session,
+//     wai: WhatAmI,
+// }
+
+// impl Net {
+//     #[allow(clippy::type_complexity)]
+//     async fn update_weights(&mut self, net: Vec<(u16, Vec<(u16, Option<u16>)>)>) {
+//         for (i, v) in net.iter().enumerate() {
+//             let weights =
+//                 v.1.iter()
+//                     .filter_map(|(e, w)| {
+//                         w.map(|w| TransportWeight {
+//                             dst_zid: ZenohId::from_str(&e.to_string()).unwrap(),
+//                             weight: w.try_into().unwrap(),
+//                         })
+//                     })
+//                     .collect::<Vec<_>>();
+
+//             match self.wai {
+//                 WhatAmI::Router => self.routers[i]
+//                     .0
+//                     .runtime
+//                     .config()
+//                     .lock()
+//                     .routing
+//                     .router
+//                     .linkstate
+//                     .set_transport_weights(weights)
+//                     .unwrap(),
+//                 WhatAmI::Peer => self.routers[i]
+//                     .0
+//                     .runtime
+//                     .config()
+//                     .lock()
+//                     .routing
+//                     .peer
+//                     .linkstate
+//                     .set_transport_weights(weights)
+//                     .unwrap(),
+//                 WhatAmI::Client => unreachable!(),
+//             };
+//             self.routers[i].0.runtime.update_network().unwrap();
+//         }
+//     }
+// }
+
+// #[allow(clippy::type_complexity)]
+// async fn create_routers_net(
+//     net: Vec<(u16, Vec<(u16, Option<u16>)>)>,
+//     source: u16,
+//     dest: u16,
+//     port_offset: u16,
+// ) -> Net {
+//     create_net(net, source, dest, port_offset, WhatAmI::Router).await
+// }
+
+// #[allow(clippy::type_complexity)]
+// async fn create_peers_net(
+//     net: Vec<(u16, Vec<(u16, Option<u16>)>)>,
+//     source: u16,
+//     dest: u16,
+//     port_offset: u16,
+// ) -> Net {
+//     create_net(net, source, dest, port_offset, WhatAmI::Peer).await
+// }
+
+// #[allow(clippy::type_complexity)]
+// async fn create_net(
+//     net: Vec<(u16, Vec<(u16, Option<u16>)>)>,
+//     source: u16,
+//     dest: u16,
+//     port_offset: u16,
+//     wai: WhatAmI,
+// ) -> Net {
+//     let start_id = ZenohId::from_str("a").unwrap();
+//     let end_id = ZenohId::from_str("b").unwrap();
+
+//     {
+//         let c = LinkTraceInterceptorConf {
+//             flow: InterceptorFlow::Egress,
+//         };
+//         let f = move || link_trace_interceptor_factories(&vec![c.clone()]);
+//         let mut lk = crate::net::routing::interceptor::tests::ID_TO_INTERCEPTOR_FACTORIES
+//             .lock()
+//             .unwrap();
+
+//         lk.insert(start_id, Box::new(f.clone()));
+
+//         for v in &net {
+//             let zid = ZenohId::from_str(&v.0.to_string()).unwrap();
+//             lk.insert(zid, Box::new(f.clone()));
+//         }
+//     }
+//     let mut routers = Vec::new();
+
+//     for v in &net {
+//         let zid = ZenohId::from_str(&v.0.to_string()).unwrap();
+//         let connect =
+//             v.1.iter()
+//                 .map(|(id, _)| id + port_offset)
+//                 .collect::<Vec<_>>();
+//         let mut config = get_basic_router_config(&[port_offset + v.0], &connect, wai).await;
+//         config.set_id(Some(zid)).unwrap();
+//         let weights =
+//             v.1.iter()
+//                 .filter_map(|(e, w)| {
+//                     w.map(|w| TransportWeight {
+//                         dst_zid: ZenohId::from_str(&e.to_string()).unwrap(),
+//                         weight: w.try_into().unwrap(),
+//                     })
+//                 })
+//                 .collect::<Vec<_>>();
+//         match wai {
+//             WhatAmI::Router => {
+//                 config
+//                     .routing
+//                     .router
+//                     .linkstate
+//                     .set_transport_weights(weights)
+//                     .unwrap();
+//             }
+//             WhatAmI::Peer => {
+//                 config
+//                     .routing
+//                     .peer
+//                     .linkstate
+//                     .set_transport_weights(weights)
+//                     .unwrap();
+//                 config
+//                     .routing
+//                     .peer
+//                     .set_mode(Some("linkstate".to_string()))
+//                     .unwrap();
+//             }
+//             WhatAmI::Client => unreachable!(),
+//         }
+
+//         let router = ztimeout!(open(config)).unwrap();
+//         routers.push(router);
+//     }
+
+//     let mut config_client_a = get_basic_client_config(source + port_offset).await;
+//     config_client_a.set_id(Some(start_id)).unwrap();
+//     let mut config_client_b = get_basic_client_config(dest + port_offset).await;
+//     config_client_b.set_id(Some(end_id)).unwrap();
+
+//     let session_a = ztimeout!(open(config_client_a)).unwrap();
+//     let session_b = ztimeout!(open(config_client_b)).unwrap();
+//     tokio::time::sleep(SLEEP).await;
+
+//     Net {
+//         routers,
+//         source: session_a,
+//         dest: session_b,
+//         wai,
+//     }
+// }
+
+// #[allow(clippy::type_complexity)]
+// async fn test_link_weights_inner(
+//     net: Vec<(u16, Vec<(u16, Option<u16>)>)>,
+//     source: u16,
+//     dest: u16,
+//     port_offset: u16,
+// ) -> String {
+//     let net = create_routers_net(net, source, dest, port_offset).await;
+
+//     let sub = ztimeout!(net.dest.declare_subscriber("test/link_weights")).unwrap();
+
+//     tokio::time::sleep(3 * SLEEP).await;
+//     ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
+
+//     let msg = ztimeout!(sub.recv_async()).unwrap();
+
+//     msg.payload().try_to_string().unwrap().to_string()
+// }
+
+// #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+// async fn test_link_weights_diamond() {
+//     init_log_from_env_or("error");
+//     //       2
+//     //      / \
+//     // a - 1   4 - b
+//     //      \ /
+//     //       3
+
+//     let res = test_link_weights_inner(
+//         vec![
+//             (1, vec![(2, Some(10)), (3, None)]),
+//             (2, vec![(4, None)]),
+//             (3, vec![(4, None)]),
+//             (4, vec![]),
+//         ],
+//         1,
+//         4,
+//         28000,
+//     )
+//     .await;
+
+//     assert_eq!(res, "a->1->2->4->b");
+
+//     let res = test_link_weights_inner(
+//         vec![
+//             (1, vec![(3, None)]),
+//             (2, vec![(1, Some(10)), (4, None)]),
+//             (3, vec![(4, None)]),
+//             (4, vec![]),
+//         ],
+//         1,
+//         4,
+//         28100,
+//     )
+//     .await;
+
+//     assert_eq!(res, "a->1->2->4->b");
+
+//     let res = test_link_weights_inner(
+//         vec![
+//             (1, vec![(2, None), (3, None)]),
+//             (2, vec![(4, None)]),
+//             (3, vec![]),
+//             (4, vec![(3, Some(10))]),
+//         ],
+//         1,
+//         4,
+//         28200,
+//     )
+//     .await;
+
+//     assert_eq!(res, "a->1->3->4->b");
+
+//     let res = test_link_weights_inner(
+//         vec![
+//             (1, vec![(2, None), (3, None)]),
+//             (2, vec![(4, None)]),
+//             (3, vec![(4, Some(10))]),
+//             (4, vec![]),
+//         ],
+//         1,
+//         4,
+//         28300,
+//     )
+//     .await;
+
+//     assert_eq!(res, "a->1->3->4->b");
+// }
+
+// #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+// async fn test_link_weights_triangle() {
+//     init_log_from_env_or("error");
+//     //       2
+//     //      / \
+//     // a - 1 - 3 - b
+
+//     let res = test_link_weights_inner(
+//         vec![
+//             (1, vec![(2, Some(10)), (3, None)]),
+//             (2, vec![(3, Some(10))]),
+//             (3, vec![]),
+//         ],
+//         1,
+//         3,
+//         29000,
+//     )
+//     .await;
+
+//     assert_eq!(res, "a->1->2->3->b");
+
+//     let res = test_link_weights_inner(
+//         vec![
+//             (1, vec![(2, None), (3, Some(300))]),
+//             (2, vec![(3, None)]),
+//             (3, vec![]),
+//         ],
+//         1,
+//         3,
+//         29100,
+//     )
+//     .await;
+
+//     assert_eq!(res, "a->1->2->3->b");
+
+//     let res = test_link_weights_inner(
+//         vec![
+//             (1, vec![(2, None), (3, None)]),
+//             (2, vec![(3, None)]),
+//             (3, vec![]),
+//         ],
+//         1,
+//         3,
+//         29200,
+//     )
+//     .await;
+
+//     assert_eq!(res, "a->1->3->b");
+
+//     // should resolve weights to 55 on 1-2 and 2-3, so will pick 1-3 path (with default cost of 100)
+//     let res = test_link_weights_inner(
+//         vec![
+//             (1, vec![(2, Some(10)), (3, None)]),
+//             (2, vec![(1, Some(55)), (3, Some(10))]),
+//             (3, vec![(2, Some(55))]),
+//         ],
+//         1,
+//         3,
+//         29300,
+//     )
+//     .await;
+
+//     assert_eq!(res, "a->1->3->b");
+
+//     // should resolve weights to 45 on 1-2 and 2-3, so will pick 1-2-3 path with total cost of 2 * 45 = 90
+//     let res = test_link_weights_inner(
+//         vec![
+//             (1, vec![(2, Some(45)), (3, None)]),
+//             (2, vec![(1, Some(10)), (3, Some(45))]),
+//             (3, vec![(2, Some(10))]),
+//         ],
+//         1,
+//         3,
+//         29400,
+//     )
+//     .await;
+
+//     assert_eq!(res, "a->1->2->3->b");
+// }
+
+// #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+// async fn test_link_weights_hexagon() {
+//     init_log_from_env_or("error");
+//     //       2 - 5
+//     //      / \ / \
+//     // a - 1 - 4 - 7 - b
+//     //      \ / \ /
+//     //       3 - 6
+
+//     let res = test_link_weights_inner(
+//         vec![
+//             (1, vec![(2, Some(1)), (3, None), (4, None)]),
+//             (2, vec![(4, Some(1)), (5, None)]),
+//             (3, vec![(4, None), (6, None)]),
+//             (4, vec![(5, None), (6, Some(1)), (7, None)]),
+//             (5, vec![(7, None)]),
+//             (6, vec![(7, Some(1))]),
+//             (7, vec![]),
+//         ],
+//         1,
+//         7,
+//         30000,
+//     )
+//     .await;
+
+//     assert_eq!(res, "a->1->2->4->6->7->b");
+
+//     let res = test_link_weights_inner(
+//         vec![
+//             (1, vec![(2, None), (3, None), (4, None)]),
+//             (2, vec![(4, None), (5, None)]),
+//             (3, vec![(4, None), (6, None)]),
+//             (4, vec![(5, None), (6, None), (7, None)]),
+//             (5, vec![(7, None)]),
+//             (6, vec![(7, None)]),
+//             (7, vec![]),
+//         ],
+//         1,
+//         7,
+//         30100,
+//     )
+//     .await;
+
+//     assert_eq!(res, "a->1->4->7->b");
+// }
+
+// #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+// async fn test_link_weights_update_diamond() {
+//     init_log_from_env_or("error");
+//     //       2
+//     //      / \
+//     // a - 1   4 - b
+//     //      \ /
+//     //       3
+
+//     let mut net = create_routers_net(
+//         vec![
+//             (1, vec![(2, Some(10)), (3, None)]),
+//             (2, vec![(4, None)]),
+//             (3, vec![(4, None)]),
+//             (4, vec![]),
+//         ],
+//         1,
+//         4,
+//         31000,
+//     )
+//     .await;
+
+//     let sub = ztimeout!(net.dest.declare_subscriber("test/link_weights")).unwrap();
+
+//     tokio::time::sleep(3 * SLEEP).await;
+//     ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
+
+//     let msg = ztimeout!(sub.recv_async())
+//         .unwrap()
+//         .payload()
+//         .try_to_string()
+//         .unwrap()
+//         .to_string();
+//     assert_eq!(msg, "a->1->2->4->b");
+
+//     ztimeout!(net.update_weights(vec![
+//         (1, vec![(2, None), (3, Some(10))]),
+//         (2, vec![(4, None)]),
+//         (3, vec![(4, None)]),
+//         (4, vec![]),
+//     ]));
+
+//     tokio::time::sleep(3 * SLEEP).await;
+//     ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
+
+//     let msg = ztimeout!(sub.recv_async())
+//         .unwrap()
+//         .payload()
+//         .try_to_string()
+//         .unwrap()
+//         .to_string();
+//     assert_eq!(msg, "a->1->3->4->b");
+
+//     ztimeout!(net.update_weights(vec![
+//         (1, vec![(2, None), (3, Some(200))]),
+//         (2, vec![(4, None)]),
+//         (3, vec![(4, None)]),
+//         (4, vec![]),
+//     ]));
+
+//     tokio::time::sleep(3 * SLEEP).await;
+//     ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
+
+//     let msg = ztimeout!(sub.recv_async())
+//         .unwrap()
+//         .payload()
+//         .try_to_string()
+//         .unwrap()
+//         .to_string();
+//     assert_eq!(msg, "a->1->2->4->b");
+// }
+
+// #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+// async fn test_link_weights_update_hexagon() {
+//     init_log_from_env_or("error");
+//     //       2 - 5
+//     //      / \ / \
+//     // a - 1 - 4 - 7 - b
+//     //      \ / \ /
+//     //       3 - 6
+
+//     let mut net = create_routers_net(
+//         vec![
+//             (1, vec![(2, Some(1)), (3, None), (4, None)]),
+//             (2, vec![(4, Some(1)), (5, None)]),
+//             (3, vec![(4, None), (6, None)]),
+//             (4, vec![(5, None), (6, Some(1)), (7, None)]),
+//             (5, vec![(7, None)]),
+//             (6, vec![(7, Some(1))]),
+//             (7, vec![]),
+//         ],
+//         1,
+//         7,
+//         32000,
+//     )
+//     .await;
+
+//     let sub = ztimeout!(net.dest.declare_subscriber("test/link_weights")).unwrap();
+
+//     tokio::time::sleep(3 * SLEEP).await;
+//     ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
+
+//     let msg = ztimeout!(sub.recv_async())
+//         .unwrap()
+//         .payload()
+//         .try_to_string()
+//         .unwrap()
+//         .to_string();
+
+//     assert_eq!(msg, "a->1->2->4->6->7->b");
+
+//     ztimeout!(net.update_weights(vec![
+//         (1, vec![(2, None), (3, None), (4, None)]),
+//         (2, vec![(4, None), (5, None)]),
+//         (3, vec![(4, None), (6, None)]),
+//         (4, vec![(5, None), (6, None), (7, None)]),
+//         (5, vec![(7, None)]),
+//         (6, vec![(7, None)]),
+//         (7, vec![]),
+//     ],));
+
+//     tokio::time::sleep(3 * SLEEP).await;
+//     ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
+
+//     let msg = ztimeout!(sub.recv_async())
+//         .unwrap()
+//         .payload()
+//         .try_to_string()
+//         .unwrap()
+//         .to_string();
+
+//     assert_eq!(msg, "a->1->4->7->b");
+// }
+
+// #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+// async fn test_link_weights_update_diamond_peers() {
+//     init_log_from_env_or("error");
+//     //       2
+//     //      / \
+//     // a - 1   4 - b
+//     //      \ /
+//     //       3
+
+//     let mut net = create_peers_net(
+//         vec![
+//             (1, vec![(2, Some(10)), (3, None)]),
+//             (2, vec![(4, None)]),
+//             (3, vec![(4, None)]),
+//             (4, vec![]),
+//         ],
+//         1,
+//         4,
+//         33000,
+//     )
+//     .await;
+
+//     let sub = ztimeout!(net.dest.declare_subscriber("test/link_weights")).unwrap();
+
+//     tokio::time::sleep(3 * SLEEP).await;
+//     ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
+
+//     let msg = ztimeout!(sub.recv_async())
+//         .unwrap()
+//         .payload()
+//         .try_to_string()
+//         .unwrap()
+//         .to_string();
+//     assert_eq!(msg, "a->1->2->4->b");
+
+//     ztimeout!(net.update_weights(vec![
+//         (1, vec![(2, None), (3, Some(10))]),
+//         (2, vec![(4, None)]),
+//         (3, vec![(4, None)]),
+//         (4, vec![]),
+//     ]));
+
+//     tokio::time::sleep(3 * SLEEP).await;
+//     ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
+
+//     let msg = ztimeout!(sub.recv_async())
+//         .unwrap()
+//         .payload()
+//         .try_to_string()
+//         .unwrap()
+//         .to_string();
+//     assert_eq!(msg, "a->1->3->4->b");
+
+//     ztimeout!(net.update_weights(vec![
+//         (1, vec![(2, None), (3, Some(200))]),
+//         (2, vec![(4, None)]),
+//         (3, vec![(4, None)]),
+//         (4, vec![]),
+//     ]));
+
+//     tokio::time::sleep(3 * SLEEP).await;
+//     ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
+
+//     let msg = ztimeout!(sub.recv_async())
+//         .unwrap()
+//         .payload()
+//         .try_to_string()
+//         .unwrap()
+//         .to_string();
+//     assert_eq!(msg, "a->1->2->4->b");
+// }
+
+// async fn test_link_weights_info_diamond_inner(port_offset: u16, wai: WhatAmI) {
+//     //       2
+//     //      / \
+//     // a - 1 - 4 - b
+//     //      \ /
+//     //       3
+
+//     let net = create_net(
+//         vec![
+//             (1, vec![(2, Some(10)), (3, None), (4, Some(20))]),
+//             (2, vec![(4, None)]),
+//             (3, vec![(4, None)]),
+//             (4, vec![(1, Some(30))]),
+//         ],
+//         1,
+//         4,
+//         port_offset,
+//         wai,
+//     )
+//     .await;
+
+//     let info = net.routers[0].0.runtime.get_links_info();
+
+//     let expected = HashMap::from([
+//         (
+//             ZenohIdProto::from_str("2").unwrap(),
+//             LinkInfo {
+//                 src_weight: Some(10),
+//                 dst_weight: None,
+//                 actual_weight: 10,
+//             },
+//         ),
+//         (
+//             ZenohIdProto::from_str("3").unwrap(),
+//             LinkInfo {
+//                 src_weight: None,
+//                 dst_weight: None,
+//                 actual_weight: 100,
+//             },
+//         ),
+//         (
+//             ZenohIdProto::from_str("4").unwrap(),
+//             LinkInfo {
+//                 src_weight: Some(20),
+//                 dst_weight: Some(30),
+//                 actual_weight: 30,
+//             },
+//         ),
+//     ]);
+
+//     assert_eq!(info, expected);
+// }
+
+// #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+// async fn test_link_weights_info_diamond_routers() {
+//     init_log_from_env_or("error");
+//     test_link_weights_info_diamond_inner(36000, WhatAmI::Router).await;
+// }
+
+// #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+// async fn test_link_weights_info_diamond_peers() {
+//     init_log_from_env_or("error");
+//     test_link_weights_info_diamond_inner(35000, WhatAmI::Peer).await;
+// }

--- a/zenoh/src/tests/link_weights.rs
+++ b/zenoh/src/tests/link_weights.rs
@@ -1,826 +1,819 @@
-// //
-// // Copyright (c) 2025 ZettaScale Technology
-// //
-// // This program and the accompanying materials are made available under the
-// // terms of the Eclipse Public License 2.0 which is available at
-// // http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
-// // which is available at https://www.apache.org/licenses/LICENSE-2.0.
-// //
-// // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
-// //
-// // Contributors:
-// //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-// //
-// #![cfg(feature = "internal_config")]
-
-// use std::{
-//     any::Any,
-//     collections::HashMap,
-//     str::{self, FromStr},
-// };
-
-// use zenoh_buffers::ZBuf;
-// use zenoh_config::{InterceptorFlow, TransportWeight};
-// use zenoh_keyexpr::keyexpr;
-// use zenoh_protocol::{
-//     core::ZenohIdProto,
-//     network::{NetworkBodyMut, NetworkMessageMut, Push},
-//     zenoh::PushBody,
-// };
-// use zenoh_transport::{multicast::TransportMulticast, unicast::TransportUnicast};
-
-// use crate::{
-//     net::{
-//         protocol::linkstate::LinkInfo,
-//         routing::{interceptor::*, RoutingContext},
-//     },
-//     Session,
-// };
-
-// #[derive(Clone)]
-// struct LinkTraceInterceptorConf {
-//     flow: InterceptorFlow,
-// }
-
-// fn link_trace_interceptor_factories(
-//     config: &Vec<LinkTraceInterceptorConf>,
-// ) -> Vec<InterceptorFactory> {
-//     let mut res: Vec<InterceptorFactory> = vec![];
-//     for c in config {
-//         res.push(Box::new(LinkTraceInterceptorFactory::new(c.clone())));
-//     }
-//     res
-// }
-
-// struct LinkTraceInterceptorFactory {
-//     conf: LinkTraceInterceptorConf,
-// }
-
-// impl LinkTraceInterceptorFactory {
-//     pub fn new(conf: LinkTraceInterceptorConf) -> Self {
-//         Self { conf }
-//     }
-// }
-
-// impl InterceptorFactoryTrait for LinkTraceInterceptorFactory {
-//     fn new_transport_unicast(
-//         &self,
-//         transport: &TransportUnicast,
-//     ) -> (Option<IngressInterceptor>, Option<EgressInterceptor>) {
-//         let zid = transport
-//             .get_zid()
-//             .map(|z| z.to_string())
-//             .unwrap_or_default();
-//         match self.conf.flow {
-//             InterceptorFlow::Egress => (
-//                 None,
-//                 Some(Box::new(LinkTraceInterceptor { zid: zid.clone() })),
-//             ),
-//             InterceptorFlow::Ingress => (
-//                 Some(Box::new(LinkTraceInterceptor { zid: zid.clone() })),
-//                 None,
-//             ),
-//         }
-//     }
-
-//     fn new_transport_multicast(
-//         &self,
-//         _transport: &TransportMulticast,
-//     ) -> Option<EgressInterceptor> {
-//         None
-//     }
-
-//     fn new_peer_multicast(&self, _transport: &TransportMulticast) -> Option<IngressInterceptor> {
-//         None
-//     }
-// }
-
-// struct LinkTraceInterceptor {
-//     zid: String,
-// }
-
-// impl InterceptorTrait for LinkTraceInterceptor {
-//     fn compute_keyexpr_cache(&self, _key_expr: &keyexpr) -> Option<Box<dyn Any + Send + Sync>> {
-//         None
-//     }
-
-//     fn intercept(
-//         &self,
-//         ctx: &mut RoutingContext<NetworkMessageMut<'_>>,
-//         _cache: Option<&Box<dyn Any + Send + Sync>>,
-//     ) -> bool {
-//         if let NetworkBodyMut::Push(&mut Push {
-//             payload: PushBody::Put(ref mut p),
-//             ..
-//         }) = &mut ctx.msg.body
-//         {
-//             let s = str::from_utf8(p.payload.to_zslice().as_slice())
-//                 .unwrap()
-//                 .to_string();
-//             let s = s + "->" + &self.zid;
-//             p.payload = ZBuf::from(s.as_bytes().to_owned());
-//         }
-//         true
-//     }
-// }
-
-// use std::time::Duration;
-
-// use zenoh_config::ZenohId;
-// use zenoh_core::ztimeout;
-
-// use crate::{config::WhatAmI, init_log_from_env_or, open, Config};
-
-// const TIMEOUT: Duration = Duration::from_secs(60);
-// const SLEEP: Duration = Duration::from_secs(1);
-
-// async fn get_basic_router_config(
-//     listen_ports: &[u16],
-//     connect_ports: &[u16],
-//     wai: WhatAmI,
-// ) -> Config {
-//     let mut config = Config::default();
-//     config.set_mode(Some(wai)).unwrap();
-//     config
-//         .listen
-//         .endpoints
-//         .set(
-//             listen_ports
-//                 .iter()
-//                 .map(|p| format!("tcp/127.0.0.1:{p}").parse().unwrap())
-//                 .collect::<Vec<_>>(),
-//         )
-//         .unwrap();
-//     config
-//         .connect
-//         .endpoints
-//         .set(
-//             connect_ports
-//                 .iter()
-//                 .map(|p| format!("tcp/127.0.0.1:{p}").parse().unwrap())
-//                 .collect::<Vec<_>>(),
-//         )
-//         .unwrap();
-//     config.scouting.multicast.set_enabled(Some(false)).unwrap();
-//     config.scouting.gossip.set_enabled(Some(false)).unwrap();
-//     config
-// }
-
-// async fn get_basic_client_config(port: u16) -> Config {
-//     let mut config = Config::default();
-//     config.set_mode(Some(WhatAmI::Client)).unwrap();
-//     config
-//         .connect
-//         .endpoints
-//         .set(vec![format!("tcp/127.0.0.1:{port}").parse().unwrap()])
-//         .unwrap();
-//     config.scouting.multicast.set_enabled(Some(false)).unwrap();
-//     config
-// }
-
-// struct Net {
-//     routers: Vec<Session>,
-//     source: Session,
-//     dest: Session,
-//     wai: WhatAmI,
-// }
-
-// impl Net {
-//     #[allow(clippy::type_complexity)]
-//     async fn update_weights(&mut self, net: Vec<(u16, Vec<(u16, Option<u16>)>)>) {
-//         for (i, v) in net.iter().enumerate() {
-//             let weights =
-//                 v.1.iter()
-//                     .filter_map(|(e, w)| {
-//                         w.map(|w| TransportWeight {
-//                             dst_zid: ZenohId::from_str(&e.to_string()).unwrap(),
-//                             weight: w.try_into().unwrap(),
-//                         })
-//                     })
-//                     .collect::<Vec<_>>();
-
-//             match self.wai {
-//                 WhatAmI::Router => self.routers[i]
-//                     .0
-//                     .runtime
-//                     .config()
-//                     .lock()
-//                     .routing
-//                     .router
-//                     .linkstate
-//                     .set_transport_weights(weights)
-//                     .unwrap(),
-//                 WhatAmI::Peer => self.routers[i]
-//                     .0
-//                     .runtime
-//                     .config()
-//                     .lock()
-//                     .routing
-//                     .peer
-//                     .linkstate
-//                     .set_transport_weights(weights)
-//                     .unwrap(),
-//                 WhatAmI::Client => unreachable!(),
-//             };
-//             self.routers[i].0.runtime.update_network().unwrap();
-//         }
-//     }
-// }
-
-// #[allow(clippy::type_complexity)]
-// async fn create_routers_net(
-//     net: Vec<(u16, Vec<(u16, Option<u16>)>)>,
-//     source: u16,
-//     dest: u16,
-//     port_offset: u16,
-// ) -> Net {
-//     create_net(net, source, dest, port_offset, WhatAmI::Router).await
-// }
-
-// #[allow(clippy::type_complexity)]
-// async fn create_peers_net(
-//     net: Vec<(u16, Vec<(u16, Option<u16>)>)>,
-//     source: u16,
-//     dest: u16,
-//     port_offset: u16,
-// ) -> Net {
-//     create_net(net, source, dest, port_offset, WhatAmI::Peer).await
-// }
-
-// #[allow(clippy::type_complexity)]
-// async fn create_net(
-//     net: Vec<(u16, Vec<(u16, Option<u16>)>)>,
-//     source: u16,
-//     dest: u16,
-//     port_offset: u16,
-//     wai: WhatAmI,
-// ) -> Net {
-//     let start_id = ZenohId::from_str("a").unwrap();
-//     let end_id = ZenohId::from_str("b").unwrap();
-
-//     {
-//         let c = LinkTraceInterceptorConf {
-//             flow: InterceptorFlow::Egress,
-//         };
-//         let f = move || link_trace_interceptor_factories(&vec![c.clone()]);
-//         let mut lk = crate::net::routing::interceptor::tests::ID_TO_INTERCEPTOR_FACTORIES
-//             .lock()
-//             .unwrap();
-
-//         lk.insert(start_id, Box::new(f.clone()));
-
-//         for v in &net {
-//             let zid = ZenohId::from_str(&v.0.to_string()).unwrap();
-//             lk.insert(zid, Box::new(f.clone()));
-//         }
-//     }
-//     let mut routers = Vec::new();
-
-//     for v in &net {
-//         let zid = ZenohId::from_str(&v.0.to_string()).unwrap();
-//         let connect =
-//             v.1.iter()
-//                 .map(|(id, _)| id + port_offset)
-//                 .collect::<Vec<_>>();
-//         let mut config = get_basic_router_config(&[port_offset + v.0], &connect, wai).await;
-//         config.set_id(Some(zid)).unwrap();
-//         let weights =
-//             v.1.iter()
-//                 .filter_map(|(e, w)| {
-//                     w.map(|w| TransportWeight {
-//                         dst_zid: ZenohId::from_str(&e.to_string()).unwrap(),
-//                         weight: w.try_into().unwrap(),
-//                     })
-//                 })
-//                 .collect::<Vec<_>>();
-//         match wai {
-//             WhatAmI::Router => {
-//                 config
-//                     .routing
-//                     .router
-//                     .linkstate
-//                     .set_transport_weights(weights)
-//                     .unwrap();
-//             }
-//             WhatAmI::Peer => {
-//                 config
-//                     .routing
-//                     .peer
-//                     .linkstate
-//                     .set_transport_weights(weights)
-//                     .unwrap();
-//                 config
-//                     .routing
-//                     .peer
-//                     .set_mode(Some("linkstate".to_string()))
-//                     .unwrap();
-//             }
-//             WhatAmI::Client => unreachable!(),
-//         }
-
-//         let router = ztimeout!(open(config)).unwrap();
-//         routers.push(router);
-//     }
-
-//     let mut config_client_a = get_basic_client_config(source + port_offset).await;
-//     config_client_a.set_id(Some(start_id)).unwrap();
-//     let mut config_client_b = get_basic_client_config(dest + port_offset).await;
-//     config_client_b.set_id(Some(end_id)).unwrap();
-
-//     let session_a = ztimeout!(open(config_client_a)).unwrap();
-//     let session_b = ztimeout!(open(config_client_b)).unwrap();
-//     tokio::time::sleep(SLEEP).await;
-
-//     Net {
-//         routers,
-//         source: session_a,
-//         dest: session_b,
-//         wai,
-//     }
-// }
-
-// #[allow(clippy::type_complexity)]
-// async fn test_link_weights_inner(
-//     net: Vec<(u16, Vec<(u16, Option<u16>)>)>,
-//     source: u16,
-//     dest: u16,
-//     port_offset: u16,
-// ) -> String {
-//     let net = create_routers_net(net, source, dest, port_offset).await;
-
-//     let sub = ztimeout!(net.dest.declare_subscriber("test/link_weights")).unwrap();
-
-//     tokio::time::sleep(3 * SLEEP).await;
-//     ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
-
-//     let msg = ztimeout!(sub.recv_async()).unwrap();
-
-//     msg.payload().try_to_string().unwrap().to_string()
-// }
-
-// #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-// async fn test_link_weights_diamond() {
-//     init_log_from_env_or("error");
-//     //       2
-//     //      / \
-//     // a - 1   4 - b
-//     //      \ /
-//     //       3
-
-//     let res = test_link_weights_inner(
-//         vec![
-//             (1, vec![(2, Some(10)), (3, None)]),
-//             (2, vec![(4, None)]),
-//             (3, vec![(4, None)]),
-//             (4, vec![]),
-//         ],
-//         1,
-//         4,
-//         28000,
-//     )
-//     .await;
-
-//     assert_eq!(res, "a->1->2->4->b");
-
-//     let res = test_link_weights_inner(
-//         vec![
-//             (1, vec![(3, None)]),
-//             (2, vec![(1, Some(10)), (4, None)]),
-//             (3, vec![(4, None)]),
-//             (4, vec![]),
-//         ],
-//         1,
-//         4,
-//         28100,
-//     )
-//     .await;
-
-//     assert_eq!(res, "a->1->2->4->b");
-
-//     let res = test_link_weights_inner(
-//         vec![
-//             (1, vec![(2, None), (3, None)]),
-//             (2, vec![(4, None)]),
-//             (3, vec![]),
-//             (4, vec![(3, Some(10))]),
-//         ],
-//         1,
-//         4,
-//         28200,
-//     )
-//     .await;
-
-//     assert_eq!(res, "a->1->3->4->b");
-
-//     let res = test_link_weights_inner(
-//         vec![
-//             (1, vec![(2, None), (3, None)]),
-//             (2, vec![(4, None)]),
-//             (3, vec![(4, Some(10))]),
-//             (4, vec![]),
-//         ],
-//         1,
-//         4,
-//         28300,
-//     )
-//     .await;
-
-//     assert_eq!(res, "a->1->3->4->b");
-// }
-
-// #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-// async fn test_link_weights_triangle() {
-//     init_log_from_env_or("error");
-//     //       2
-//     //      / \
-//     // a - 1 - 3 - b
-
-//     let res = test_link_weights_inner(
-//         vec![
-//             (1, vec![(2, Some(10)), (3, None)]),
-//             (2, vec![(3, Some(10))]),
-//             (3, vec![]),
-//         ],
-//         1,
-//         3,
-//         29000,
-//     )
-//     .await;
-
-//     assert_eq!(res, "a->1->2->3->b");
-
-//     let res = test_link_weights_inner(
-//         vec![
-//             (1, vec![(2, None), (3, Some(300))]),
-//             (2, vec![(3, None)]),
-//             (3, vec![]),
-//         ],
-//         1,
-//         3,
-//         29100,
-//     )
-//     .await;
-
-//     assert_eq!(res, "a->1->2->3->b");
-
-//     let res = test_link_weights_inner(
-//         vec![
-//             (1, vec![(2, None), (3, None)]),
-//             (2, vec![(3, None)]),
-//             (3, vec![]),
-//         ],
-//         1,
-//         3,
-//         29200,
-//     )
-//     .await;
-
-//     assert_eq!(res, "a->1->3->b");
-
-//     // should resolve weights to 55 on 1-2 and 2-3, so will pick 1-3 path (with default cost of 100)
-//     let res = test_link_weights_inner(
-//         vec![
-//             (1, vec![(2, Some(10)), (3, None)]),
-//             (2, vec![(1, Some(55)), (3, Some(10))]),
-//             (3, vec![(2, Some(55))]),
-//         ],
-//         1,
-//         3,
-//         29300,
-//     )
-//     .await;
-
-//     assert_eq!(res, "a->1->3->b");
-
-//     // should resolve weights to 45 on 1-2 and 2-3, so will pick 1-2-3 path with total cost of 2 * 45 = 90
-//     let res = test_link_weights_inner(
-//         vec![
-//             (1, vec![(2, Some(45)), (3, None)]),
-//             (2, vec![(1, Some(10)), (3, Some(45))]),
-//             (3, vec![(2, Some(10))]),
-//         ],
-//         1,
-//         3,
-//         29400,
-//     )
-//     .await;
-
-//     assert_eq!(res, "a->1->2->3->b");
-// }
-
-// #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-// async fn test_link_weights_hexagon() {
-//     init_log_from_env_or("error");
-//     //       2 - 5
-//     //      / \ / \
-//     // a - 1 - 4 - 7 - b
-//     //      \ / \ /
-//     //       3 - 6
-
-//     let res = test_link_weights_inner(
-//         vec![
-//             (1, vec![(2, Some(1)), (3, None), (4, None)]),
-//             (2, vec![(4, Some(1)), (5, None)]),
-//             (3, vec![(4, None), (6, None)]),
-//             (4, vec![(5, None), (6, Some(1)), (7, None)]),
-//             (5, vec![(7, None)]),
-//             (6, vec![(7, Some(1))]),
-//             (7, vec![]),
-//         ],
-//         1,
-//         7,
-//         30000,
-//     )
-//     .await;
-
-//     assert_eq!(res, "a->1->2->4->6->7->b");
-
-//     let res = test_link_weights_inner(
-//         vec![
-//             (1, vec![(2, None), (3, None), (4, None)]),
-//             (2, vec![(4, None), (5, None)]),
-//             (3, vec![(4, None), (6, None)]),
-//             (4, vec![(5, None), (6, None), (7, None)]),
-//             (5, vec![(7, None)]),
-//             (6, vec![(7, None)]),
-//             (7, vec![]),
-//         ],
-//         1,
-//         7,
-//         30100,
-//     )
-//     .await;
-
-//     assert_eq!(res, "a->1->4->7->b");
-// }
-
-// #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-// async fn test_link_weights_update_diamond() {
-//     init_log_from_env_or("error");
-//     //       2
-//     //      / \
-//     // a - 1   4 - b
-//     //      \ /
-//     //       3
-
-//     let mut net = create_routers_net(
-//         vec![
-//             (1, vec![(2, Some(10)), (3, None)]),
-//             (2, vec![(4, None)]),
-//             (3, vec![(4, None)]),
-//             (4, vec![]),
-//         ],
-//         1,
-//         4,
-//         31000,
-//     )
-//     .await;
-
-//     let sub = ztimeout!(net.dest.declare_subscriber("test/link_weights")).unwrap();
-
-//     tokio::time::sleep(3 * SLEEP).await;
-//     ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
-
-//     let msg = ztimeout!(sub.recv_async())
-//         .unwrap()
-//         .payload()
-//         .try_to_string()
-//         .unwrap()
-//         .to_string();
-//     assert_eq!(msg, "a->1->2->4->b");
-
-//     ztimeout!(net.update_weights(vec![
-//         (1, vec![(2, None), (3, Some(10))]),
-//         (2, vec![(4, None)]),
-//         (3, vec![(4, None)]),
-//         (4, vec![]),
-//     ]));
-
-//     tokio::time::sleep(3 * SLEEP).await;
-//     ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
-
-//     let msg = ztimeout!(sub.recv_async())
-//         .unwrap()
-//         .payload()
-//         .try_to_string()
-//         .unwrap()
-//         .to_string();
-//     assert_eq!(msg, "a->1->3->4->b");
-
-//     ztimeout!(net.update_weights(vec![
-//         (1, vec![(2, None), (3, Some(200))]),
-//         (2, vec![(4, None)]),
-//         (3, vec![(4, None)]),
-//         (4, vec![]),
-//     ]));
-
-//     tokio::time::sleep(3 * SLEEP).await;
-//     ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
-
-//     let msg = ztimeout!(sub.recv_async())
-//         .unwrap()
-//         .payload()
-//         .try_to_string()
-//         .unwrap()
-//         .to_string();
-//     assert_eq!(msg, "a->1->2->4->b");
-// }
-
-// #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-// async fn test_link_weights_update_hexagon() {
-//     init_log_from_env_or("error");
-//     //       2 - 5
-//     //      / \ / \
-//     // a - 1 - 4 - 7 - b
-//     //      \ / \ /
-//     //       3 - 6
-
-//     let mut net = create_routers_net(
-//         vec![
-//             (1, vec![(2, Some(1)), (3, None), (4, None)]),
-//             (2, vec![(4, Some(1)), (5, None)]),
-//             (3, vec![(4, None), (6, None)]),
-//             (4, vec![(5, None), (6, Some(1)), (7, None)]),
-//             (5, vec![(7, None)]),
-//             (6, vec![(7, Some(1))]),
-//             (7, vec![]),
-//         ],
-//         1,
-//         7,
-//         32000,
-//     )
-//     .await;
-
-//     let sub = ztimeout!(net.dest.declare_subscriber("test/link_weights")).unwrap();
-
-//     tokio::time::sleep(3 * SLEEP).await;
-//     ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
-
-//     let msg = ztimeout!(sub.recv_async())
-//         .unwrap()
-//         .payload()
-//         .try_to_string()
-//         .unwrap()
-//         .to_string();
-
-//     assert_eq!(msg, "a->1->2->4->6->7->b");
-
-//     ztimeout!(net.update_weights(vec![
-//         (1, vec![(2, None), (3, None), (4, None)]),
-//         (2, vec![(4, None), (5, None)]),
-//         (3, vec![(4, None), (6, None)]),
-//         (4, vec![(5, None), (6, None), (7, None)]),
-//         (5, vec![(7, None)]),
-//         (6, vec![(7, None)]),
-//         (7, vec![]),
-//     ],));
-
-//     tokio::time::sleep(3 * SLEEP).await;
-//     ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
-
-//     let msg = ztimeout!(sub.recv_async())
-//         .unwrap()
-//         .payload()
-//         .try_to_string()
-//         .unwrap()
-//         .to_string();
-
-//     assert_eq!(msg, "a->1->4->7->b");
-// }
-
-// #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-// async fn test_link_weights_update_diamond_peers() {
-//     init_log_from_env_or("error");
-//     //       2
-//     //      / \
-//     // a - 1   4 - b
-//     //      \ /
-//     //       3
-
-//     let mut net = create_peers_net(
-//         vec![
-//             (1, vec![(2, Some(10)), (3, None)]),
-//             (2, vec![(4, None)]),
-//             (3, vec![(4, None)]),
-//             (4, vec![]),
-//         ],
-//         1,
-//         4,
-//         33000,
-//     )
-//     .await;
-
-//     let sub = ztimeout!(net.dest.declare_subscriber("test/link_weights")).unwrap();
-
-//     tokio::time::sleep(3 * SLEEP).await;
-//     ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
-
-//     let msg = ztimeout!(sub.recv_async())
-//         .unwrap()
-//         .payload()
-//         .try_to_string()
-//         .unwrap()
-//         .to_string();
-//     assert_eq!(msg, "a->1->2->4->b");
-
-//     ztimeout!(net.update_weights(vec![
-//         (1, vec![(2, None), (3, Some(10))]),
-//         (2, vec![(4, None)]),
-//         (3, vec![(4, None)]),
-//         (4, vec![]),
-//     ]));
-
-//     tokio::time::sleep(3 * SLEEP).await;
-//     ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
-
-//     let msg = ztimeout!(sub.recv_async())
-//         .unwrap()
-//         .payload()
-//         .try_to_string()
-//         .unwrap()
-//         .to_string();
-//     assert_eq!(msg, "a->1->3->4->b");
-
-//     ztimeout!(net.update_weights(vec![
-//         (1, vec![(2, None), (3, Some(200))]),
-//         (2, vec![(4, None)]),
-//         (3, vec![(4, None)]),
-//         (4, vec![]),
-//     ]));
-
-//     tokio::time::sleep(3 * SLEEP).await;
-//     ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
-
-//     let msg = ztimeout!(sub.recv_async())
-//         .unwrap()
-//         .payload()
-//         .try_to_string()
-//         .unwrap()
-//         .to_string();
-//     assert_eq!(msg, "a->1->2->4->b");
-// }
-
-// async fn test_link_weights_info_diamond_inner(port_offset: u16, wai: WhatAmI) {
-//     //       2
-//     //      / \
-//     // a - 1 - 4 - b
-//     //      \ /
-//     //       3
-
-//     let net = create_net(
-//         vec![
-//             (1, vec![(2, Some(10)), (3, None), (4, Some(20))]),
-//             (2, vec![(4, None)]),
-//             (3, vec![(4, None)]),
-//             (4, vec![(1, Some(30))]),
-//         ],
-//         1,
-//         4,
-//         port_offset,
-//         wai,
-//     )
-//     .await;
-
-//     let info = net.routers[0].0.runtime.get_links_info();
-
-//     let expected = HashMap::from([
-//         (
-//             ZenohIdProto::from_str("2").unwrap(),
-//             LinkInfo {
-//                 src_weight: Some(10),
-//                 dst_weight: None,
-//                 actual_weight: 10,
-//             },
-//         ),
-//         (
-//             ZenohIdProto::from_str("3").unwrap(),
-//             LinkInfo {
-//                 src_weight: None,
-//                 dst_weight: None,
-//                 actual_weight: 100,
-//             },
-//         ),
-//         (
-//             ZenohIdProto::from_str("4").unwrap(),
-//             LinkInfo {
-//                 src_weight: Some(20),
-//                 dst_weight: Some(30),
-//                 actual_weight: 30,
-//             },
-//         ),
-//     ]);
-
-//     assert_eq!(info, expected);
-// }
-
-// #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-// async fn test_link_weights_info_diamond_routers() {
-//     init_log_from_env_or("error");
-//     test_link_weights_info_diamond_inner(36000, WhatAmI::Router).await;
-// }
-
-// #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-// async fn test_link_weights_info_diamond_peers() {
-//     init_log_from_env_or("error");
-//     test_link_weights_info_diamond_inner(35000, WhatAmI::Peer).await;
-// }
+//
+// Copyright (c) 2025 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+#![cfg(feature = "internal_config")]
+
+use std::{
+    any::Any,
+    collections::HashMap,
+    str::{self, FromStr},
+};
+
+use zenoh_buffers::ZBuf;
+use zenoh_config::{InterceptorFlow, TransportWeight};
+use zenoh_keyexpr::keyexpr;
+use zenoh_protocol::{
+    core::ZenohIdProto,
+    network::{NetworkBodyMut, NetworkMessageMut, Push},
+    zenoh::PushBody,
+};
+use zenoh_transport::{multicast::TransportMulticast, unicast::TransportUnicast};
+
+use crate::{
+    net::{protocol::linkstate::LinkInfo, routing::interceptor::*},
+    Session,
+};
+
+#[derive(Clone)]
+struct LinkTraceInterceptorConf {
+    flow: InterceptorFlow,
+}
+
+fn link_trace_interceptor_factories(
+    config: &Vec<LinkTraceInterceptorConf>,
+) -> Vec<InterceptorFactory> {
+    let mut res: Vec<InterceptorFactory> = vec![];
+    for c in config {
+        res.push(Box::new(LinkTraceInterceptorFactory::new(c.clone())));
+    }
+    res
+}
+
+struct LinkTraceInterceptorFactory {
+    conf: LinkTraceInterceptorConf,
+}
+
+impl LinkTraceInterceptorFactory {
+    pub fn new(conf: LinkTraceInterceptorConf) -> Self {
+        Self { conf }
+    }
+}
+
+impl InterceptorFactoryTrait for LinkTraceInterceptorFactory {
+    fn new_transport_unicast(
+        &self,
+        transport: &TransportUnicast,
+    ) -> (Option<IngressInterceptor>, Option<EgressInterceptor>) {
+        let zid = transport
+            .get_zid()
+            .map(|z| z.to_string())
+            .unwrap_or_default();
+        match self.conf.flow {
+            InterceptorFlow::Egress => (
+                None,
+                Some(Box::new(LinkTraceInterceptor { zid: zid.clone() })),
+            ),
+            InterceptorFlow::Ingress => (
+                Some(Box::new(LinkTraceInterceptor { zid: zid.clone() })),
+                None,
+            ),
+        }
+    }
+
+    fn new_transport_multicast(
+        &self,
+        _transport: &TransportMulticast,
+    ) -> Option<EgressInterceptor> {
+        None
+    }
+
+    fn new_peer_multicast(&self, _transport: &TransportMulticast) -> Option<IngressInterceptor> {
+        None
+    }
+}
+
+struct LinkTraceInterceptor {
+    zid: String,
+}
+
+impl InterceptorTrait for LinkTraceInterceptor {
+    fn compute_keyexpr_cache(&self, _key_expr: &keyexpr) -> Option<Box<dyn Any + Send + Sync>> {
+        None
+    }
+
+    fn intercept(&self, msg: &mut NetworkMessageMut, _ctx: &mut dyn InterceptorContext) -> bool {
+        if let NetworkBodyMut::Push(&mut Push {
+            payload: PushBody::Put(ref mut p),
+            ..
+        }) = &mut msg.body
+        {
+            let s = str::from_utf8(p.payload.to_zslice().as_slice())
+                .unwrap()
+                .to_string();
+            let s = s + "->" + &self.zid;
+            p.payload = ZBuf::from(s.as_bytes().to_owned());
+        }
+        true
+    }
+}
+
+use std::time::Duration;
+
+use zenoh_config::ZenohId;
+use zenoh_core::ztimeout;
+
+use crate::{config::WhatAmI, init_log_from_env_or, open, Config};
+
+const TIMEOUT: Duration = Duration::from_secs(60);
+const SLEEP: Duration = Duration::from_secs(1);
+
+async fn get_basic_router_config(
+    listen_ports: &[u16],
+    connect_ports: &[u16],
+    wai: WhatAmI,
+) -> Config {
+    let mut config = Config::default();
+    config.set_mode(Some(wai)).unwrap();
+    config
+        .listen
+        .endpoints
+        .set(
+            listen_ports
+                .iter()
+                .map(|p| format!("tcp/127.0.0.1:{p}").parse().unwrap())
+                .collect::<Vec<_>>(),
+        )
+        .unwrap();
+    config
+        .connect
+        .endpoints
+        .set(
+            connect_ports
+                .iter()
+                .map(|p| format!("tcp/127.0.0.1:{p}").parse().unwrap())
+                .collect::<Vec<_>>(),
+        )
+        .unwrap();
+    config.scouting.multicast.set_enabled(Some(false)).unwrap();
+    config.scouting.gossip.set_enabled(Some(false)).unwrap();
+    config
+}
+
+async fn get_basic_client_config(port: u16) -> Config {
+    let mut config = Config::default();
+    config.set_mode(Some(WhatAmI::Client)).unwrap();
+    config
+        .connect
+        .endpoints
+        .set(vec![format!("tcp/127.0.0.1:{port}").parse().unwrap()])
+        .unwrap();
+    config.scouting.multicast.set_enabled(Some(false)).unwrap();
+    config
+}
+
+struct Net {
+    routers: Vec<Session>,
+    source: Session,
+    dest: Session,
+    wai: WhatAmI,
+}
+
+impl Net {
+    #[allow(clippy::type_complexity)]
+    async fn update_weights(&mut self, net: Vec<(u16, Vec<(u16, Option<u16>)>)>) {
+        for (i, v) in net.iter().enumerate() {
+            let weights =
+                v.1.iter()
+                    .filter_map(|(e, w)| {
+                        w.map(|w| TransportWeight {
+                            dst_zid: ZenohId::from_str(&e.to_string()).unwrap(),
+                            weight: w.try_into().unwrap(),
+                        })
+                    })
+                    .collect::<Vec<_>>();
+
+            match self.wai {
+                WhatAmI::Router => self.routers[i]
+                    .0
+                    .runtime
+                    .config()
+                    .lock()
+                    .routing
+                    .router
+                    .linkstate
+                    .set_transport_weights(weights)
+                    .unwrap(),
+                WhatAmI::Peer => self.routers[i]
+                    .0
+                    .runtime
+                    .config()
+                    .lock()
+                    .routing
+                    .peer
+                    .linkstate
+                    .set_transport_weights(weights)
+                    .unwrap(),
+                WhatAmI::Client => unreachable!(),
+            };
+            self.routers[i].0.runtime.update_network().unwrap();
+        }
+    }
+}
+
+#[allow(clippy::type_complexity)]
+async fn create_routers_net(
+    net: Vec<(u16, Vec<(u16, Option<u16>)>)>,
+    source: u16,
+    dest: u16,
+    port_offset: u16,
+) -> Net {
+    create_net(net, source, dest, port_offset, WhatAmI::Router).await
+}
+
+#[allow(clippy::type_complexity)]
+async fn create_peers_net(
+    net: Vec<(u16, Vec<(u16, Option<u16>)>)>,
+    source: u16,
+    dest: u16,
+    port_offset: u16,
+) -> Net {
+    create_net(net, source, dest, port_offset, WhatAmI::Peer).await
+}
+
+#[allow(clippy::type_complexity)]
+async fn create_net(
+    net: Vec<(u16, Vec<(u16, Option<u16>)>)>,
+    source: u16,
+    dest: u16,
+    port_offset: u16,
+    wai: WhatAmI,
+) -> Net {
+    let start_id = ZenohId::from_str("a").unwrap();
+    let end_id = ZenohId::from_str("b").unwrap();
+
+    {
+        let c = LinkTraceInterceptorConf {
+            flow: InterceptorFlow::Egress,
+        };
+        let f = move || link_trace_interceptor_factories(&vec![c.clone()]);
+        let mut lk = crate::net::routing::interceptor::tests::ID_TO_INTERCEPTOR_FACTORIES
+            .lock()
+            .unwrap();
+
+        lk.insert(start_id, Box::new(f.clone()));
+
+        for v in &net {
+            let zid = ZenohId::from_str(&v.0.to_string()).unwrap();
+            lk.insert(zid, Box::new(f.clone()));
+        }
+    }
+    let mut routers = Vec::new();
+
+    for v in &net {
+        let zid = ZenohId::from_str(&v.0.to_string()).unwrap();
+        let connect =
+            v.1.iter()
+                .map(|(id, _)| id + port_offset)
+                .collect::<Vec<_>>();
+        let mut config = get_basic_router_config(&[port_offset + v.0], &connect, wai).await;
+        config.set_id(Some(zid)).unwrap();
+        let weights =
+            v.1.iter()
+                .filter_map(|(e, w)| {
+                    w.map(|w| TransportWeight {
+                        dst_zid: ZenohId::from_str(&e.to_string()).unwrap(),
+                        weight: w.try_into().unwrap(),
+                    })
+                })
+                .collect::<Vec<_>>();
+        match wai {
+            WhatAmI::Router => {
+                config
+                    .routing
+                    .router
+                    .linkstate
+                    .set_transport_weights(weights)
+                    .unwrap();
+            }
+            WhatAmI::Peer => {
+                config
+                    .routing
+                    .peer
+                    .linkstate
+                    .set_transport_weights(weights)
+                    .unwrap();
+                config
+                    .routing
+                    .peer
+                    .set_mode(Some("linkstate".to_string()))
+                    .unwrap();
+            }
+            WhatAmI::Client => unreachable!(),
+        }
+
+        let router = ztimeout!(open(config)).unwrap();
+        routers.push(router);
+    }
+
+    let mut config_client_a = get_basic_client_config(source + port_offset).await;
+    config_client_a.set_id(Some(start_id)).unwrap();
+    let mut config_client_b = get_basic_client_config(dest + port_offset).await;
+    config_client_b.set_id(Some(end_id)).unwrap();
+
+    let session_a = ztimeout!(open(config_client_a)).unwrap();
+    let session_b = ztimeout!(open(config_client_b)).unwrap();
+    tokio::time::sleep(SLEEP).await;
+
+    Net {
+        routers,
+        source: session_a,
+        dest: session_b,
+        wai,
+    }
+}
+
+#[allow(clippy::type_complexity)]
+async fn test_link_weights_inner(
+    net: Vec<(u16, Vec<(u16, Option<u16>)>)>,
+    source: u16,
+    dest: u16,
+    port_offset: u16,
+) -> String {
+    let net = create_routers_net(net, source, dest, port_offset).await;
+
+    let sub = ztimeout!(net.dest.declare_subscriber("test/link_weights")).unwrap();
+
+    tokio::time::sleep(3 * SLEEP).await;
+    ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
+
+    let msg = ztimeout!(sub.recv_async()).unwrap();
+
+    msg.payload().try_to_string().unwrap().to_string()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_link_weights_diamond() {
+    init_log_from_env_or("error");
+    //       2
+    //      / \
+    // a - 1   4 - b
+    //      \ /
+    //       3
+
+    let res = test_link_weights_inner(
+        vec![
+            (1, vec![(2, Some(10)), (3, None)]),
+            (2, vec![(4, None)]),
+            (3, vec![(4, None)]),
+            (4, vec![]),
+        ],
+        1,
+        4,
+        28000,
+    )
+    .await;
+
+    assert_eq!(res, "a->1->2->4->b");
+
+    let res = test_link_weights_inner(
+        vec![
+            (1, vec![(3, None)]),
+            (2, vec![(1, Some(10)), (4, None)]),
+            (3, vec![(4, None)]),
+            (4, vec![]),
+        ],
+        1,
+        4,
+        28100,
+    )
+    .await;
+
+    assert_eq!(res, "a->1->2->4->b");
+
+    let res = test_link_weights_inner(
+        vec![
+            (1, vec![(2, None), (3, None)]),
+            (2, vec![(4, None)]),
+            (3, vec![]),
+            (4, vec![(3, Some(10))]),
+        ],
+        1,
+        4,
+        28200,
+    )
+    .await;
+
+    assert_eq!(res, "a->1->3->4->b");
+
+    let res = test_link_weights_inner(
+        vec![
+            (1, vec![(2, None), (3, None)]),
+            (2, vec![(4, None)]),
+            (3, vec![(4, Some(10))]),
+            (4, vec![]),
+        ],
+        1,
+        4,
+        28300,
+    )
+    .await;
+
+    assert_eq!(res, "a->1->3->4->b");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_link_weights_triangle() {
+    init_log_from_env_or("error");
+    //       2
+    //      / \
+    // a - 1 - 3 - b
+
+    let res = test_link_weights_inner(
+        vec![
+            (1, vec![(2, Some(10)), (3, None)]),
+            (2, vec![(3, Some(10))]),
+            (3, vec![]),
+        ],
+        1,
+        3,
+        29000,
+    )
+    .await;
+
+    assert_eq!(res, "a->1->2->3->b");
+
+    let res = test_link_weights_inner(
+        vec![
+            (1, vec![(2, None), (3, Some(300))]),
+            (2, vec![(3, None)]),
+            (3, vec![]),
+        ],
+        1,
+        3,
+        29100,
+    )
+    .await;
+
+    assert_eq!(res, "a->1->2->3->b");
+
+    let res = test_link_weights_inner(
+        vec![
+            (1, vec![(2, None), (3, None)]),
+            (2, vec![(3, None)]),
+            (3, vec![]),
+        ],
+        1,
+        3,
+        29200,
+    )
+    .await;
+
+    assert_eq!(res, "a->1->3->b");
+
+    // should resolve weights to 55 on 1-2 and 2-3, so will pick 1-3 path (with default cost of 100)
+    let res = test_link_weights_inner(
+        vec![
+            (1, vec![(2, Some(10)), (3, None)]),
+            (2, vec![(1, Some(55)), (3, Some(10))]),
+            (3, vec![(2, Some(55))]),
+        ],
+        1,
+        3,
+        29300,
+    )
+    .await;
+
+    assert_eq!(res, "a->1->3->b");
+
+    // should resolve weights to 45 on 1-2 and 2-3, so will pick 1-2-3 path with total cost of 2 * 45 = 90
+    let res = test_link_weights_inner(
+        vec![
+            (1, vec![(2, Some(45)), (3, None)]),
+            (2, vec![(1, Some(10)), (3, Some(45))]),
+            (3, vec![(2, Some(10))]),
+        ],
+        1,
+        3,
+        29400,
+    )
+    .await;
+
+    assert_eq!(res, "a->1->2->3->b");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_link_weights_hexagon() {
+    init_log_from_env_or("error");
+    //       2 - 5
+    //      / \ / \
+    // a - 1 - 4 - 7 - b
+    //      \ / \ /
+    //       3 - 6
+
+    let res = test_link_weights_inner(
+        vec![
+            (1, vec![(2, Some(1)), (3, None), (4, None)]),
+            (2, vec![(4, Some(1)), (5, None)]),
+            (3, vec![(4, None), (6, None)]),
+            (4, vec![(5, None), (6, Some(1)), (7, None)]),
+            (5, vec![(7, None)]),
+            (6, vec![(7, Some(1))]),
+            (7, vec![]),
+        ],
+        1,
+        7,
+        30000,
+    )
+    .await;
+
+    assert_eq!(res, "a->1->2->4->6->7->b");
+
+    let res = test_link_weights_inner(
+        vec![
+            (1, vec![(2, None), (3, None), (4, None)]),
+            (2, vec![(4, None), (5, None)]),
+            (3, vec![(4, None), (6, None)]),
+            (4, vec![(5, None), (6, None), (7, None)]),
+            (5, vec![(7, None)]),
+            (6, vec![(7, None)]),
+            (7, vec![]),
+        ],
+        1,
+        7,
+        30100,
+    )
+    .await;
+
+    assert_eq!(res, "a->1->4->7->b");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_link_weights_update_diamond() {
+    init_log_from_env_or("error");
+    //       2
+    //      / \
+    // a - 1   4 - b
+    //      \ /
+    //       3
+
+    let mut net = create_routers_net(
+        vec![
+            (1, vec![(2, Some(10)), (3, None)]),
+            (2, vec![(4, None)]),
+            (3, vec![(4, None)]),
+            (4, vec![]),
+        ],
+        1,
+        4,
+        31000,
+    )
+    .await;
+
+    let sub = ztimeout!(net.dest.declare_subscriber("test/link_weights")).unwrap();
+
+    tokio::time::sleep(3 * SLEEP).await;
+    ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
+
+    let msg = ztimeout!(sub.recv_async())
+        .unwrap()
+        .payload()
+        .try_to_string()
+        .unwrap()
+        .to_string();
+    assert_eq!(msg, "a->1->2->4->b");
+
+    ztimeout!(net.update_weights(vec![
+        (1, vec![(2, None), (3, Some(10))]),
+        (2, vec![(4, None)]),
+        (3, vec![(4, None)]),
+        (4, vec![]),
+    ]));
+
+    tokio::time::sleep(3 * SLEEP).await;
+    ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
+
+    let msg = ztimeout!(sub.recv_async())
+        .unwrap()
+        .payload()
+        .try_to_string()
+        .unwrap()
+        .to_string();
+    assert_eq!(msg, "a->1->3->4->b");
+
+    ztimeout!(net.update_weights(vec![
+        (1, vec![(2, None), (3, Some(200))]),
+        (2, vec![(4, None)]),
+        (3, vec![(4, None)]),
+        (4, vec![]),
+    ]));
+
+    tokio::time::sleep(3 * SLEEP).await;
+    ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
+
+    let msg = ztimeout!(sub.recv_async())
+        .unwrap()
+        .payload()
+        .try_to_string()
+        .unwrap()
+        .to_string();
+    assert_eq!(msg, "a->1->2->4->b");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_link_weights_update_hexagon() {
+    init_log_from_env_or("error");
+    //       2 - 5
+    //      / \ / \
+    // a - 1 - 4 - 7 - b
+    //      \ / \ /
+    //       3 - 6
+
+    let mut net = create_routers_net(
+        vec![
+            (1, vec![(2, Some(1)), (3, None), (4, None)]),
+            (2, vec![(4, Some(1)), (5, None)]),
+            (3, vec![(4, None), (6, None)]),
+            (4, vec![(5, None), (6, Some(1)), (7, None)]),
+            (5, vec![(7, None)]),
+            (6, vec![(7, Some(1))]),
+            (7, vec![]),
+        ],
+        1,
+        7,
+        32000,
+    )
+    .await;
+
+    let sub = ztimeout!(net.dest.declare_subscriber("test/link_weights")).unwrap();
+
+    tokio::time::sleep(3 * SLEEP).await;
+    ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
+
+    let msg = ztimeout!(sub.recv_async())
+        .unwrap()
+        .payload()
+        .try_to_string()
+        .unwrap()
+        .to_string();
+
+    assert_eq!(msg, "a->1->2->4->6->7->b");
+
+    ztimeout!(net.update_weights(vec![
+        (1, vec![(2, None), (3, None), (4, None)]),
+        (2, vec![(4, None), (5, None)]),
+        (3, vec![(4, None), (6, None)]),
+        (4, vec![(5, None), (6, None), (7, None)]),
+        (5, vec![(7, None)]),
+        (6, vec![(7, None)]),
+        (7, vec![]),
+    ],));
+
+    tokio::time::sleep(3 * SLEEP).await;
+    ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
+
+    let msg = ztimeout!(sub.recv_async())
+        .unwrap()
+        .payload()
+        .try_to_string()
+        .unwrap()
+        .to_string();
+
+    assert_eq!(msg, "a->1->4->7->b");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_link_weights_update_diamond_peers() {
+    init_log_from_env_or("error");
+    //       2
+    //      / \
+    // a - 1   4 - b
+    //      \ /
+    //       3
+
+    let mut net = create_peers_net(
+        vec![
+            (1, vec![(2, Some(10)), (3, None)]),
+            (2, vec![(4, None)]),
+            (3, vec![(4, None)]),
+            (4, vec![]),
+        ],
+        1,
+        4,
+        33000,
+    )
+    .await;
+
+    let sub = ztimeout!(net.dest.declare_subscriber("test/link_weights")).unwrap();
+
+    tokio::time::sleep(3 * SLEEP).await;
+    ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
+
+    let msg = ztimeout!(sub.recv_async())
+        .unwrap()
+        .payload()
+        .try_to_string()
+        .unwrap()
+        .to_string();
+    assert_eq!(msg, "a->1->2->4->b");
+
+    ztimeout!(net.update_weights(vec![
+        (1, vec![(2, None), (3, Some(10))]),
+        (2, vec![(4, None)]),
+        (3, vec![(4, None)]),
+        (4, vec![]),
+    ]));
+
+    tokio::time::sleep(3 * SLEEP).await;
+    ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
+
+    let msg = ztimeout!(sub.recv_async())
+        .unwrap()
+        .payload()
+        .try_to_string()
+        .unwrap()
+        .to_string();
+    assert_eq!(msg, "a->1->3->4->b");
+
+    ztimeout!(net.update_weights(vec![
+        (1, vec![(2, None), (3, Some(200))]),
+        (2, vec![(4, None)]),
+        (3, vec![(4, None)]),
+        (4, vec![]),
+    ]));
+
+    tokio::time::sleep(3 * SLEEP).await;
+    ztimeout!(net.source.put("test/link_weights", "a")).unwrap();
+
+    let msg = ztimeout!(sub.recv_async())
+        .unwrap()
+        .payload()
+        .try_to_string()
+        .unwrap()
+        .to_string();
+    assert_eq!(msg, "a->1->2->4->b");
+}
+
+async fn test_link_weights_info_diamond_inner(port_offset: u16, wai: WhatAmI) {
+    //       2
+    //      / \
+    // a - 1 - 4 - b
+    //      \ /
+    //       3
+
+    let net = create_net(
+        vec![
+            (1, vec![(2, Some(10)), (3, None), (4, Some(20))]),
+            (2, vec![(4, None)]),
+            (3, vec![(4, None)]),
+            (4, vec![(1, Some(30))]),
+        ],
+        1,
+        4,
+        port_offset,
+        wai,
+    )
+    .await;
+
+    let info = net.routers[0].0.runtime.get_links_info();
+
+    let expected = HashMap::from([
+        (
+            ZenohIdProto::from_str("2").unwrap(),
+            LinkInfo {
+                src_weight: Some(10),
+                dst_weight: None,
+                actual_weight: 10,
+            },
+        ),
+        (
+            ZenohIdProto::from_str("3").unwrap(),
+            LinkInfo {
+                src_weight: None,
+                dst_weight: None,
+                actual_weight: 100,
+            },
+        ),
+        (
+            ZenohIdProto::from_str("4").unwrap(),
+            LinkInfo {
+                src_weight: Some(20),
+                dst_weight: Some(30),
+                actual_weight: 30,
+            },
+        ),
+    ]);
+
+    assert_eq!(info, expected);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_link_weights_info_diamond_routers() {
+    init_log_from_env_or("error");
+    test_link_weights_info_diamond_inner(36000, WhatAmI::Router).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_link_weights_info_diamond_peers() {
+    init_log_from_env_or("error");
+    test_link_weights_info_diamond_inner(35000, WhatAmI::Peer).await;
+}


### PR DESCRIPTION
Improve interceptors performances for interceptors that don't need to access cache nor key_expr.

On a host where 
```
z_pub_thr 8
z_sub_thr

=> 7.2 Mmsgs/s
```

Using the following config:
```
{
   qos: {
     network: [
       {
         messages: ["put"],
         overwrite: {
           priority: "data",
         },
       },
     ],
   },
}
```

### Before the changes,
```
z_pub_thr 8 -c configs/qosoverwrite.js
z_sub_thr

=> 5.3 Mmsgs/s
```

```
z_pub_thr 8
z_sub_thr -c configs/qosoverwrite.js

=> 5.5 Mmsgs/s
```

### After the changes,
```
z_pub_thr 8 -c configs/qosoverwrite.js
z_sub_thr

=> 7.1 Mmsgs/s
```

```
z_pub_thr 8
z_sub_thr -c configs/qosoverwrite.js

=> 6.8 Mmsgs/s
```
