### PR TITLE
Format TOML files using Taplo

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -21,5 +21,5 @@ test(=header_check_memory_concurrent) |
 test(=header_link_concurrent) |
 test(=header_link_failure_concurrent)
 """
-threads-required = 'num-cpus'
 slow-timeout = { period = "60s", terminate-after = 6 }
+threads-required = 'num-cpus'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,9 @@ jobs:
 
       - name: Install latest cargo-semver-checks
         uses: taiki-e/install-action@cargo-semver-checks
+        
+      - name: Install latest taplo
+        uses: taiki-e/install-action@taplo
 
       - name: Code format check
         run: rustfmt --check --config "unstable_features=true,imports_granularity=Crate,group_imports=StdExternalCrate,skip_children=true" $(git ls-files '*.rs')
@@ -161,6 +164,10 @@ jobs:
 
       - name: Check SemVer Compatibility
         run: cargo +stable semver-checks --verbose --default-features --package zenoh --release-type ${{ env.CARGO_SEMVER_CHECKS_RELEASE_TYPE }} --baseline-version ${{ env.CARGO_SEMVER_CHECKS_BASELINE_VERSION }}
+        
+      - name: Check TOML formatting
+        if: ${{ !contains(matrix.os, 'windows') }}
+        run: taplo fmt --check --diff
 
   test:
     needs: determine-runner

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,8 +14,12 @@
 repos:
   - repo: local
     hooks:
-      - id: fmt
-        name: fmt
+      - id: fmt-rust
+        name: fmt-rust
         entry: bash -c 'rustfmt --config "unstable_features=true,imports_granularity=Crate,group_imports=StdExternalCrate,skip_children=true" $(git ls-files '*.rs')'
         language: system
         types: [rust]
+  - repo: https://github.com/ComPWA/taplo-pre-commit
+    rev: v0.9.3
+    hooks:
+      - id: taplo-format

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,7 @@
+exclude = ["target/**"]
+
+[[rule]]
+
+[rule.formatting]
+reorder_arrays = true
+reorder_keys = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,66 +12,66 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [workspace]
-resolver = "2"
-members = [
-    "commons/zenoh-buffers",
-    "commons/zenoh-codec",
-    "commons/zenoh-collections",
-    "commons/zenoh-config",
-    "commons/zenoh-core",
-    "commons/zenoh-crypto",
-    "commons/zenoh-keyexpr",
-    "commons/zenoh-macros",
-    "commons/zenoh-protocol",
-    "commons/zenoh-result",
-    "commons/zenoh-shm",
-    "commons/zenoh-sync",
-    "commons/zenoh-task",
-    "commons/zenoh-util",
-    "commons/zenoh-runtime",
-    "examples",
-    "io/zenoh-link",
-    "io/zenoh-link-commons",
-    "io/zenoh-links/zenoh-link-quic/",
-    "io/zenoh-links/zenoh-link-quic_datagram/",
-    "io/zenoh-links/zenoh-link-serial",
-    "io/zenoh-links/zenoh-link-tcp/",
-    "io/zenoh-links/zenoh-link-tls/",
-    "io/zenoh-links/zenoh-link-udp/",
-    "io/zenoh-links/zenoh-link-unixsock_stream/",
-    "io/zenoh-links/zenoh-link-ws/",
-    "io/zenoh-links/zenoh-link-unixpipe/",
-    "io/zenoh-links/zenoh-link-vsock/",
-    "io/zenoh-transport",
-    "plugins/zenoh-backend-example",
-    "plugins/zenoh-plugin-example",
-    "plugins/zenoh-backend-traits",
-    "plugins/zenoh-plugin-rest",
-    "plugins/zenoh-plugin-storage-manager",
-    "plugins/zenoh-plugin-trait",
-    "zenoh",
-    "zenoh-ext",
-    "zenoh-ext/examples",
-    "zenohd",
-]
 exclude = ["ci/nostd-check", "ci/valgrind-check"]
+members = [
+  "commons/zenoh-buffers",
+  "commons/zenoh-codec",
+  "commons/zenoh-collections",
+  "commons/zenoh-config",
+  "commons/zenoh-core",
+  "commons/zenoh-crypto",
+  "commons/zenoh-keyexpr",
+  "commons/zenoh-macros",
+  "commons/zenoh-protocol",
+  "commons/zenoh-result",
+  "commons/zenoh-runtime",
+  "commons/zenoh-shm",
+  "commons/zenoh-sync",
+  "commons/zenoh-task",
+  "commons/zenoh-util",
+  "examples",
+  "io/zenoh-link",
+  "io/zenoh-link-commons",
+  "io/zenoh-links/zenoh-link-quic/",
+  "io/zenoh-links/zenoh-link-quic_datagram/",
+  "io/zenoh-links/zenoh-link-serial",
+  "io/zenoh-links/zenoh-link-tcp/",
+  "io/zenoh-links/zenoh-link-tls/",
+  "io/zenoh-links/zenoh-link-udp/",
+  "io/zenoh-links/zenoh-link-unixpipe/",
+  "io/zenoh-links/zenoh-link-unixsock_stream/",
+  "io/zenoh-links/zenoh-link-vsock/",
+  "io/zenoh-links/zenoh-link-ws/",
+  "io/zenoh-transport",
+  "plugins/zenoh-backend-example",
+  "plugins/zenoh-backend-traits",
+  "plugins/zenoh-plugin-example",
+  "plugins/zenoh-plugin-rest",
+  "plugins/zenoh-plugin-storage-manager",
+  "plugins/zenoh-plugin-trait",
+  "zenoh",
+  "zenoh-ext",
+  "zenoh-ext/examples",
+  "zenohd",
+]
+resolver = "2"
 
 [workspace.package]
-rust-version = "1.75.0"
-version = "1.5.0"
-repository = "https://github.com/eclipse-zenoh/zenoh"
-homepage = "http://zenoh.io"
 authors = [
-    "kydos <angelo@icorsaro.net>",
-    "Julien Enoch <julien@enoch.fr>",
-    "Olivier Hécart <olivier.hecart@zettascale.tech>",
-    "Luca Cominardi <luca.cominardi@zettascale.tech>",
-    "Pierre Avital <pierre.avital@zettascale.tech>",
+  "Julien Enoch <julien@enoch.fr>",
+  "Luca Cominardi <luca.cominardi@zettascale.tech>",
+  "Olivier Hécart <olivier.hecart@zettascale.tech>",
+  "Pierre Avital <pierre.avital@zettascale.tech>",
+  "kydos <angelo@icorsaro.net>",
 ]
-edition = "2021"
-license = "EPL-2.0 OR Apache-2.0"
 categories = ["network-programming"]
 description = "Zenoh: The Zero Overhead Pub/Sub/Query Protocol."
+edition = "2021"
+homepage = "http://zenoh.io"
+license = "EPL-2.0 OR Apache-2.0"
+repository = "https://github.com/eclipse-zenoh/zenoh"
+rust-version = "1.75.0"
+version = "1.5.0"
 
 # DEFAULT-FEATURES NOTE: Be careful with default-features and additivity!
 #                        (https://github.com/rust-lang/cargo/issues/11329)
@@ -93,20 +93,18 @@ clap = { version = "4.5.17", features = ["derive"] }
 console-subscriber = "0.4.0"
 const_format = "0.2.33"
 criterion = "0.5"
-crossbeam-utils = "0.8.20"
-crossbeam-queue = "0.3.12"
 crossbeam-channel = "0.5"
-static_assertions = "1.1.0"
-derive_more = { version = "1.0.0", features = ["as_ref"] }
+crossbeam-queue = "0.3.12"
+crossbeam-utils = "0.8.20"
 derive-new = "0.7.0"
-tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
+derive_more = { version = "1.0.0", features = ["as_ref"] }
 event-listener = "5.3.1"
 flume = "0.11"
 form_urlencoded = "1.2.1"
 futures = "0.3.31"
 futures-util = { version = "0.3.31", default-features = false } # Default features are disabled due to some crates' requirements
-git-version = "0.3.9"
 getrandom = { version = "0.2" }
+git-version = "0.3.9"
 hashbrown = "0.14"
 hex = { version = "0.4.3", default-features = false } # Default features are disabled due to usage in no_std crates
 hmac = { version = "0.12.1", features = ["std"] }
@@ -121,12 +119,11 @@ lazy_static = "1.5.0"
 leb128 = "0.2"
 libc = "0.2.158"
 libloading = "0.8"
-tracing = "0.1"
 lz4_flex = "0.11"
 nix = { version = "0.29.0", features = ["fs"] }
 nonempty-collections = { version = "0.3.0", features = ["serde"] }
-num_cpus = "1.16.0"
 num-traits = { version = "0.2.19", default-features = false }
+num_cpus = "1.16.0"
 once_cell = "1.19.0"
 ordered-float = "4.2.2"
 panic-message = "0.3.0"
@@ -143,32 +140,33 @@ rand_chacha = "0.3.1"
 rcgen = "0.13.1"
 ref-cast = "1.0.23"
 regex = "1.10.6"
-ron = "0.8.1"
 ringbuffer-spsc = "0.1.9"
+ron = "0.8.1"
 rsa = "0.9"
 rustc_version = "0.4.1"
 rustls = { version = "0.23.13", default-features = false, features = [
-    "logging",
-    "tls12",
-    "ring",
+  "logging",
+  "ring",
+  "tls12",
 ] }
 rustls-native-certs = "0.8.0"
 rustls-pemfile = "2.1.3"
-rustls-webpki = "0.102.8"
 rustls-pki-types = "1.8.0"
+rustls-webpki = "0.102.8"
 schemars = { version = "0.8.21", features = ["either"] }
-secrecy = { version = "0.8.0", features = ["serde", "alloc"] }
+secrecy = { version = "0.8.0", features = ["alloc", "serde"] }
 serde = { version = "1.0.210", default-features = false, features = [
-    "derive",
+  "derive",
 ] } # Default features are disabled due to usage in no_std crates
 serde_json = "1.0.128"
 serde_with = "3.12.0"
 serde_yaml = "0.9.34"
-static_init = "1.0.3"
-stabby = "36.1.1"
 sha3 = "0.10.8"
 shellexpand = "3.1.0"
 socket2 = { version = "0.5.7", features = ["all"] }
+stabby = "36.1.1"
+static_assertions = "1.1.0"
+static_init = "1.0.3"
 stop-token = "0.7.0"
 syn = "2.0"
 test-case = "3.3.1"
@@ -176,83 +174,85 @@ tide = "0.16.0"
 time = "0.3.36"
 token-cell = { version = "1.5.0", default-features = false }
 tokio = { version = "1.40.0", default-features = false } # Default features are disabled due to some crates' requirements
-tokio-util = "0.7.12"
-tokio-tungstenite = "0.24.0"
 tokio-rustls = { version = "0.26.0", default-features = false }
+tokio-tungstenite = "0.24.0"
+tokio-util = "0.7.12"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 # tokio-vsock = see: io/zenoh-links/zenoh-link-vsock/Cargo.toml (workspaces does not support platform dependent dependencies)
+either = "1.13.0"
+prost = "0.13.2"
 thread-priority = "1.1.0"
+tls-listener = { version = "0.11.0", features = ["rustls-ring"] }
 typenum = "1.17.0"
 uhlc = { version = "0.8.0", default-features = false } # Default features are disabled due to usage in no_std crates
 unzip-n = "0.1.2"
 url = "2.5.2"
 urlencoding = "2.1.3"
 uuid = { version = "1.10.0", default-features = false, features = [
-    "v4",
+  "v4",
 ] } # Default features are disabled due to usage in no_std crates
 validated_struct = "2.1.0"
 vec_map = "0.8.2"
 webpki-roots = "0.26.5"
 win-sys = "0.3"
 winapi = { version = "0.3.9", features = ["iphlpapi", "winerror"] }
+windows-sys = { version = "0.59.0", features = [
+  "Win32_Foundation",
+  "Win32_Networking_WinSock",
+  "Win32_System_IO",
+] }
 x509-parser = "0.16.0"
 z-serial = "0.3.1"
-either = "1.13.0"
-prost = "0.13.2"
-tls-listener = { version = "0.11.0", features = ["rustls-ring"] }
-windows-sys = { version = "0.59.0", features = [
-    "Win32_Foundation",
-    "Win32_Networking_WinSock",
-    "Win32_System_IO",
-] }
-zenoh-ext = { version = "=1.5.0", path = "zenoh-ext", default-features = false }
-zenoh-shm = { version = "=1.5.0", path = "commons/zenoh-shm" }
-zenoh-result = { version = "=1.5.0", path = "commons/zenoh-result", default-features = false }
-zenoh-config = { version = "=1.5.0", path = "commons/zenoh-config" }
-zenoh-protocol = { version = "=1.5.0", path = "commons/zenoh-protocol", default-features = false }
-zenoh-keyexpr = { version = "=1.5.0", path = "commons/zenoh-keyexpr", default-features = false }
-zenoh-core = { version = "=1.5.0", path = "commons/zenoh-core" }
+zenoh = { version = "=1.5.0", path = "zenoh", default-features = false }
 zenoh-buffers = { version = "=1.5.0", path = "commons/zenoh-buffers", default-features = false }
-zenoh-util = { version = "=1.5.0", path = "commons/zenoh-util" }
-zenoh-crypto = { version = "=1.5.0", path = "commons/zenoh-crypto" }
 zenoh-codec = { version = "=1.5.0", path = "commons/zenoh-codec" }
-zenoh-sync = { version = "=1.5.0", path = "commons/zenoh-sync" }
 zenoh-collections = { version = "=1.5.0", path = "commons/zenoh-collections", default-features = false }
-zenoh-macros = { version = "=1.5.0", path = "commons/zenoh-macros" }
-zenoh-plugin-trait = { version = "=1.5.0", path = "plugins/zenoh-plugin-trait", default-features = false }
-zenoh_backend_traits = { version = "=1.5.0", path = "plugins/zenoh-backend-traits", default-features = false }
-zenoh-transport = { version = "=1.5.0", path = "io/zenoh-transport", default-features = false }
-zenoh-link-tls = { version = "=1.5.0", path = "io/zenoh-links/zenoh-link-tls" }
-zenoh-link-tcp = { version = "=1.5.0", path = "io/zenoh-links/zenoh-link-tcp" }
-zenoh-link-unixsock_stream = { version = "=1.5.0", path = "io/zenoh-links/zenoh-link-unixsock_stream" }
-zenoh-link-quic = { version = "=1.5.0", path = "io/zenoh-links/zenoh-link-quic" }
-zenoh-link-quic_datagram = { version = "=1.5.0", path = "io/zenoh-links/zenoh-link-quic_datagram" }
-zenoh-link-udp = { version = "=1.5.0", path = "io/zenoh-links/zenoh-link-udp" }
-zenoh-link-ws = { version = "=1.5.0", path = "io/zenoh-links/zenoh-link-ws" }
-zenoh-link-unixpipe = { version = "=1.5.0", path = "io/zenoh-links/zenoh-link-unixpipe" }
-zenoh-link-serial = { version = "=1.5.0", path = "io/zenoh-links/zenoh-link-serial" }
-zenoh-link-vsock = { version = "=1.5.0", path = "io/zenoh-links/zenoh-link-vsock" }
+zenoh-config = { version = "=1.5.0", path = "commons/zenoh-config" }
+zenoh-core = { version = "=1.5.0", path = "commons/zenoh-core" }
+zenoh-crypto = { version = "=1.5.0", path = "commons/zenoh-crypto" }
+zenoh-examples = { version = "=1.5.0", path = "examples", default-features = false }
+zenoh-ext = { version = "=1.5.0", path = "zenoh-ext", default-features = false }
+zenoh-keyexpr = { version = "=1.5.0", path = "commons/zenoh-keyexpr", default-features = false }
 zenoh-link = { version = "=1.5.0", path = "io/zenoh-link" }
 zenoh-link-commons = { version = "=1.5.0", path = "io/zenoh-link-commons" }
-zenoh = { version = "=1.5.0", path = "zenoh", default-features = false }
+zenoh-link-quic = { version = "=1.5.0", path = "io/zenoh-links/zenoh-link-quic" }
+zenoh-link-quic_datagram = { version = "=1.5.0", path = "io/zenoh-links/zenoh-link-quic_datagram" }
+zenoh-link-serial = { version = "=1.5.0", path = "io/zenoh-links/zenoh-link-serial" }
+zenoh-link-tcp = { version = "=1.5.0", path = "io/zenoh-links/zenoh-link-tcp" }
+zenoh-link-tls = { version = "=1.5.0", path = "io/zenoh-links/zenoh-link-tls" }
+zenoh-link-udp = { version = "=1.5.0", path = "io/zenoh-links/zenoh-link-udp" }
+zenoh-link-unixpipe = { version = "=1.5.0", path = "io/zenoh-links/zenoh-link-unixpipe" }
+zenoh-link-unixsock_stream = { version = "=1.5.0", path = "io/zenoh-links/zenoh-link-unixsock_stream" }
+zenoh-link-vsock = { version = "=1.5.0", path = "io/zenoh-links/zenoh-link-vsock" }
+zenoh-link-ws = { version = "=1.5.0", path = "io/zenoh-links/zenoh-link-ws" }
+zenoh-macros = { version = "=1.5.0", path = "commons/zenoh-macros" }
+zenoh-plugin-trait = { version = "=1.5.0", path = "plugins/zenoh-plugin-trait", default-features = false }
+zenoh-protocol = { version = "=1.5.0", path = "commons/zenoh-protocol", default-features = false }
+zenoh-result = { version = "=1.5.0", path = "commons/zenoh-result", default-features = false }
 zenoh-runtime = { version = "=1.5.0", path = "commons/zenoh-runtime" }
+zenoh-shm = { version = "=1.5.0", path = "commons/zenoh-shm" }
+zenoh-sync = { version = "=1.5.0", path = "commons/zenoh-sync" }
 zenoh-task = { version = "=1.5.0", path = "commons/zenoh-task" }
-zenoh-examples = { version = "=1.5.0", path = "examples", default-features = false }
+zenoh-transport = { version = "=1.5.0", path = "io/zenoh-transport", default-features = false }
+zenoh-util = { version = "=1.5.0", path = "commons/zenoh-util" }
+zenoh_backend_traits = { version = "=1.5.0", path = "plugins/zenoh-backend-traits", default-features = false }
 
 [profile.dev]
 debug = true
 opt-level = 0
 
 [profile.fast]
-inherits = "release"
-opt-level = 3
 debug = true
 debug-assertions = true
-overflow-checks = true
+inherits = "release"
 lto = false
+opt-level = 3
+overflow-checks = true
 
 [profile.release]
+codegen-units = 1
 debug = false     # If you want debug symbol in release mode, set the env variable: RUSTFLAGS=-g
 lto = "fat"
-codegen-units = 1
 opt-level = 3
 panic = "abort"

--- a/Cross.toml
+++ b/Cross.toml
@@ -15,4 +15,3 @@ image = "jenoch/rust-cross:aarch64-unknown-linux-gnu"
 
 [target.aarch64-unknown-linux-musl]
 image = "jenoch/rust-cross:aarch64-unknown-linux-musl"
-

--- a/_typos.toml
+++ b/_typos.toml
@@ -2,8 +2,8 @@
 extend-exclude = [
   # Ignore files containing hexa.
   "io/zenoh-transport/tests/*.rs",
-  "zenoh/tests/open_time.rs",
   "zenoh/tests/authentication.rs",
+  "zenoh/tests/open_time.rs",
 ]
 
 

--- a/ci/nostd-check/Cargo.toml
+++ b/ci/nostd-check/Cargo.toml
@@ -12,15 +12,15 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-name = "nostd-check"
-version = "0.1.0"
-repository = "https://github.com/eclipse-zenoh/zenoh"
-homepage = "http://zenoh.io"
 authors = ["Davide Della Giustina <davide.dellagiustina@zettascale.tech>"]
-edition = "2021"
-license = "EPL-2.0 OR Apache-2.0"
 categories = ["network-programming"]
 description = "Internal crate for zenoh."
+edition = "2021"
+homepage = "http://zenoh.io"
+license = "EPL-2.0 OR Apache-2.0"
+name = "nostd-check"
+repository = "https://github.com/eclipse-zenoh/zenoh"
+version = "0.1.0"
 
 [dependencies]
 getrandom = { version = "0.2.8", features = ["custom"] }

--- a/ci/valgrind-check/Cargo.toml
+++ b/ci/valgrind-check/Cargo.toml
@@ -12,17 +12,17 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-name = "valgrind-check"
-version = "0.1.0"
-repository = "https://github.com/eclipse-zenoh/zenoh"
-homepage = "http://zenoh.io"
-license = "EPL-2.0 OR Apache-2.0"
-edition = "2021"
 categories = ["network-programming"]
 description = "Internal crate for zenoh."
+edition = "2021"
+homepage = "http://zenoh.io"
+license = "EPL-2.0 OR Apache-2.0"
+name = "valgrind-check"
+repository = "https://github.com/eclipse-zenoh/zenoh"
+version = "0.1.0"
 
 [dependencies]
-tokio = { version = "1.35.1", features = ["rt-multi-thread", "time", "io-std"] }
+tokio = { version = "1.35.1", features = ["io-std", "rt-multi-thread", "time"] }
 zenoh = { path = "../../zenoh/" }
 zenoh-runtime = { path = "../../commons/zenoh-runtime/" }
 zenoh-util = { path = "../../commons/zenoh-util/", features = ["test"] }
@@ -36,4 +36,4 @@ name = "queryable_get"
 path = "src/queryable_get/bin/z_queryable_get.rs"
 
 [package.metadata.cargo-machete]
-ignored = ["base64ct", "zerofrom", "litemap"]
+ignored = ["base64ct", "litemap", "zerofrom"]

--- a/clippy.toml
+++ b/clippy.toml
@@ -2,5 +2,5 @@
 # See https://github.com/eclipse-zenoh/zenoh/blob/b55c781220d7ea9f7f117570990f6e4e063e58fe/zenoh/src/net/routing/dispatcher/resource.rs#L193
 # A corresponding comment is present in the `Hash` implementation of `Resource` as a reminder that this configuration is set.
 ignore-interior-mutability = [
-    "zenoh::net::routing::dispatcher::resource::Resource",
+  "zenoh::net::routing::dispatcher::resource::Resource",
 ]

--- a/commons/zenoh-buffers/Cargo.toml
+++ b/commons/zenoh-buffers/Cargo.toml
@@ -12,16 +12,16 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-buffers"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh."
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh-buffers"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]

--- a/commons/zenoh-codec/Cargo.toml
+++ b/commons/zenoh-codec/Cargo.toml
@@ -12,39 +12,34 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-codec"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
 authors = [
-	"kydos <angelo@icorsaro.net>",
-	"Luca Cominardi <luca.cominardi@zettascale.tech>",
-	"Pierre Avital <pierre.avital@zettascale.tech>",
+  "Luca Cominardi <luca.cominardi@zettascale.tech>",
+  "Pierre Avital <pierre.avital@zettascale.tech>",
+  "kydos <angelo@icorsaro.net>",
 ]
-edition = { workspace = true }
-license = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh."
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh-codec"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
 default = ["std"]
-std = [
-    "tracing",
-    "uhlc/std",
-    "zenoh-protocol/std",
-    "zenoh-buffers/std"
-]
 shared-memory = [
-    "std",
-    "zenoh-shm",
-    "zenoh-protocol/shared-memory",
-    "zenoh-buffers/shared-memory"
+  "std",
+  "zenoh-buffers/shared-memory",
+  "zenoh-protocol/shared-memory",
+  "zenoh-shm",
 ]
+std = ["tracing", "uhlc/std", "zenoh-buffers/std", "zenoh-protocol/std"]
 
 [dependencies]
-tracing = {workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
 uhlc = { workspace = true }
 zenoh-buffers = { workspace = true, default-features = false }
 zenoh-protocol = { workspace = true }
@@ -56,8 +51,8 @@ criterion = { workspace = true }
 
 rand = { workspace = true, features = ["default"] }
 zenoh-protocol = { workspace = true, features = ["test"] }
-zenoh-util = {workspace = true }
+zenoh-util = { workspace = true }
 
 [[bench]]
-name = "codec"
 harness = false
+name = "codec"

--- a/commons/zenoh-collections/Cargo.toml
+++ b/commons/zenoh-collections/Cargo.toml
@@ -12,20 +12,20 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-collections"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
 authors = [
-  "kydos <angelo@icorsaro.net>",
   "Luca Cominardi <luca.cominardi@zettascale.tech>",
   "Pierre Avital <pierre.avital@zettascale.tech>",
+  "kydos <angelo@icorsaro.net>",
 ]
-edition = { workspace = true }
-license = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh."
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh-collections"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]

--- a/commons/zenoh-config/Cargo.toml
+++ b/commons/zenoh-config/Cargo.toml
@@ -12,16 +12,16 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-config"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh."
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh-config"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 
 [features]
 internal = []
@@ -29,23 +29,23 @@ transport_tcp = []
 unstable = ["zenoh-protocol/unstable"]
 
 [dependencies]
-tracing = { workspace = true }
 json5 = { workspace = true }
+nonempty-collections = { workspace = true }
 num_cpus = { workspace = true }
+secrecy = { workspace = true }
 serde = { workspace = true, features = ["default"] }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
 serde_yaml = { workspace = true }
+tracing = { workspace = true }
+uhlc = { workspace = true }
 validated_struct = { workspace = true, features = ["json5", "json_get"] }
-nonempty-collections = {workspace = true }
 zenoh-core = { workspace = true }
 zenoh-keyexpr = { workspace = true }
+zenoh-macros = { workspace = true }
 zenoh-protocol = { workspace = true }
 zenoh-result = { workspace = true }
 zenoh-util = { workspace = true }
-zenoh-macros = { workspace = true }
-secrecy = { workspace = true }
-uhlc = { workspace = true }
 
 [package.metadata.cargo-machete]
 ignored = ["tracing"]

--- a/commons/zenoh-core/Cargo.toml
+++ b/commons/zenoh-core/Cargo.toml
@@ -12,28 +12,28 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-core"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
 authors = [
-  "kydos <angelo@icorsaro.net>",
   "Luca Cominardi <luca.cominardi@zettascale.tech>",
   "Pierre Avital <pierre.avital@zettascale.tech>",
+  "kydos <angelo@icorsaro.net>",
 ]
-edition = { workspace = true }
-license = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh."
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh-core"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
-std = []
 default = ["std"]
+std = []
 tracing-instrument = ["zenoh-runtime/tracing-instrument"]
 
 [dependencies]
-tokio = { workspace = true, features = ["rt"] }
 lazy_static = { workspace = true }
+tokio = { workspace = true, features = ["rt"] }
 zenoh-result = { workspace = true }
 zenoh-runtime = { workspace = true }

--- a/commons/zenoh-crypto/Cargo.toml
+++ b/commons/zenoh-crypto/Cargo.toml
@@ -12,20 +12,20 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-crypto"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
 authors = [
-	"kydos <angelo@icorsaro.net>",
-	"Luca Cominardi <luca.cominardi@zettascale.tech>",
-	"Pierre Avital <pierre.avital@zettascale.tech>",
+  "Luca Cominardi <luca.cominardi@zettascale.tech>",
+  "Pierre Avital <pierre.avital@zettascale.tech>",
+  "kydos <angelo@icorsaro.net>",
 ]
-edition = { workspace = true }
-license = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh."
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh-crypto"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/commons/zenoh-keyexpr/Cargo.toml
+++ b/commons/zenoh-keyexpr/Cargo.toml
@@ -12,23 +12,23 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-keyexpr"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh."
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh-keyexpr"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 
 [features]
 default = ["std"]
-std = ["zenoh-result/std", "dep:schemars"]
 internal = []
-unstable = []
 js = ["getrandom/js"]
+std = ["dep:schemars", "zenoh-result/std"]
+unstable = []
 
 [dependencies]
 keyed-set = { workspace = true }
@@ -53,8 +53,8 @@ rand = { workspace = true, features = ["default"] }
 test-case = { workspace = true }
 
 [[bench]]
-name = "keyexpr_tree"
 harness = false
+name = "keyexpr_tree"
 
 # NOTE: for the above reason, we need to explicitly ignore getrandom in the CI because it's an indirect dependency which is not used directly by zenoh.
 [package.metadata.cargo-machete]

--- a/commons/zenoh-macros/Cargo.toml
+++ b/commons/zenoh-macros/Cargo.toml
@@ -12,16 +12,16 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-macros"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
 categories = ["development-tools::procedural-macro-helpers"]
 description = "Internal crate for zenoh."
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh-macros"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/commons/zenoh-protocol/Cargo.toml
+++ b/commons/zenoh-protocol/Cargo.toml
@@ -12,32 +12,32 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-protocol"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh."
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh-protocol"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 
 [features]
 default = ["std"]
-unstable = []
 internal = []
-std = [
-    "rand?/std",
-    "rand?/std_rng",
-    "serde/std",
-    "uhlc/std",
-    "zenoh-keyexpr/std",
-    "zenoh-result/std",
-    "zenoh-buffers/std",
-]
 shared-memory = ["std", "zenoh-buffers/shared-memory"]
+std = [
+  "rand?/std",
+  "rand?/std_rng",
+  "serde/std",
+  "uhlc/std",
+  "zenoh-buffers/std",
+  "zenoh-keyexpr/std",
+  "zenoh-result/std",
+]
 test = ["rand", "zenoh-buffers/test"]
+unstable = []
 
 [dependencies]
 const_format = { workspace = true }

--- a/commons/zenoh-result/Cargo.toml
+++ b/commons/zenoh-result/Cargo.toml
@@ -12,16 +12,16 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-result"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh."
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh-result"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]

--- a/commons/zenoh-runtime/Cargo.toml
+++ b/commons/zenoh-runtime/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name = "zenoh-runtime"
-rust-version = { workspace = true }
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
 categories = { workspace = true }
 description = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh-runtime"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -16,13 +16,21 @@ description = { workspace = true }
 tracing-instrument = []
 
 [dependencies]
-tracing = { workspace = true }
+lazy_static = { workspace = true }
 ron = { workspace = true }
 serde = { workspace = true }
-lazy_static = { workspace = true }
-tokio = { workspace = true, features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
-zenoh-result = { workspace = true, features = ["std"] }
+tokio = { workspace = true, features = [
+  "fs",
+  "io-util",
+  "macros",
+  "net",
+  "rt-multi-thread",
+  "sync",
+  "time",
+] }
+tracing = { workspace = true }
 zenoh-macros = { workspace = true }
+zenoh-result = { workspace = true, features = ["std"] }
 
 [package.metadata.cargo-machete]
 ignored = ["ron"]

--- a/commons/zenoh-shm/Cargo.toml
+++ b/commons/zenoh-shm/Cargo.toml
@@ -12,20 +12,20 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-shm"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
 authors = [
-	"kydos <angelo@icorsaro.net>",
-	"Luca Cominardi <luca.cominardi@zettascale.tech>",
-	"Pierre Avital <pierre.avital@zettascale.tech>",
+  "Luca Cominardi <luca.cominardi@zettascale.tech>",
+  "Pierre Avital <pierre.avital@zettascale.tech>",
+  "kydos <angelo@icorsaro.net>",
 ]
-edition = { workspace = true }
-license = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh."
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh-shm"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
@@ -33,21 +33,21 @@ test = ["num_cpus"]
 
 [dependencies]
 async-trait = { workspace = true }
-tracing = { workspace = true }
-tokio = { workspace = true }
-zenoh-result = { workspace = true }
-zenoh-core = { workspace = true }
-zenoh-macros = { workspace = true }
-zenoh-buffers = { workspace = true }
-rand = { workspace = true, features = ["std", "std_rng"] }
-static_init = { workspace = true }
+crossbeam-channel = { workspace = true }
+crossbeam-queue = { workspace = true }
 num-traits = { workspace = true }
 num_cpus = { workspace = true, optional = true }
-thread-priority = { workspace = true }
+rand = { workspace = true, features = ["std", "std_rng"] }
 stabby = { workspace = true }
-crossbeam-queue = { workspace = true }
-crossbeam-channel = { workspace = true }
 static_assertions = { workspace = true }
+static_init = { workspace = true }
+thread-priority = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+zenoh-buffers = { workspace = true }
+zenoh-core = { workspace = true }
+zenoh-macros = { workspace = true }
+zenoh-result = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 advisory-lock = { workspace = true }

--- a/commons/zenoh-sync/Cargo.toml
+++ b/commons/zenoh-sync/Cargo.toml
@@ -12,20 +12,20 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-sync"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
 authors = [
-  "kydos <angelo@icorsaro.net>",
   "Luca Cominardi <luca.cominardi@zettascale.tech>",
   "Pierre Avital <pierre.avital@zettascale.tech>",
+  "kydos <angelo@icorsaro.net>",
 ]
-edition = { workspace = true }
-license = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh."
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh-sync"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -38,5 +38,10 @@ zenoh-collections = { workspace = true, features = ["default"] }
 zenoh-core = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "sync", "rt-multi-thread", "time"] }
+tokio = { workspace = true, features = [
+  "macros",
+  "rt-multi-thread",
+  "sync",
+  "time",
+] }
 zenoh-result = { workspace = true }

--- a/commons/zenoh-task/Cargo.toml
+++ b/commons/zenoh-task/Cargo.toml
@@ -12,25 +12,25 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-task"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-authors = {workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
+authors = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh."
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh-task"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
 tracing-instrument = ["zenoh-runtime/tracing-instrument"]
 
 [dependencies]
-tokio = { workspace = true, features = ["default", "sync"] }
 futures = { workspace = true }
-tracing = {workspace = true}
+tokio = { workspace = true, features = ["default", "sync"] }
+tokio-util = { workspace = true, features = ["rt"] }
+tracing = { workspace = true }
 zenoh-core = { workspace = true }
 zenoh-runtime = { workspace = true }
-tokio-util = { workspace = true, features = ["rt"] }

--- a/commons/zenoh-util/Cargo.toml
+++ b/commons/zenoh-util/Cargo.toml
@@ -12,20 +12,20 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-util"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
 authors = [
-    "kydos <angelo@icorsaro.net>",
-    "Luca Cominardi <luca.cominardi@zettascale.tech>",
-    "Pierre Avital <pierre.avital@zettascale.tech>",
+  "Luca Cominardi <luca.cominardi@zettascale.tech>",
+  "Pierre Avital <pierre.avital@zettascale.tech>",
+  "kydos <angelo@icorsaro.net>",
 ]
-edition = { workspace = true }
-license = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh."
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh-util"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [badges]
@@ -35,21 +35,21 @@ maintenance = { status = "actively-developed" }
 test = []
 
 [dependencies]
-tokio = { workspace = true, features = ["time", "net"] }
 async-trait = { workspace = true }
+const_format = { workspace = true }
 flume = { workspace = true }
 home = { workspace = true }
 humantime = { workspace = true }
 lazy_static = { workspace = true }
 libloading = { workspace = true }
-tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
-shellexpand = { workspace = true }
-zenoh-core = { workspace = true }
-zenoh-result = { workspace = true, features = ["default"] }
-const_format = { workspace = true }
 serde = { workspace = true, features = ["default"] }
 serde_json = { workspace = true }
+shellexpand = { workspace = true }
+tokio = { workspace = true, features = ["net", "time"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+zenoh-core = { workspace = true }
+zenoh-result = { workspace = true, features = ["default"] }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { workspace = true }

--- a/deny.toml
+++ b/deny.toml
@@ -2,19 +2,19 @@
 # A list of approved third party licenses is available at: https://www.eclipse.org/legal/licenses.php.
 [licenses]
 allow = [
-    "MIT",
-    "Apache-2.0",
-    "EPL-2.0",
-    "ISC",
-    "Unicode-DFS-2016",
-    "Unicode-3.0",
-    "Zlib",
-    "BSD-2-Clause",
-    "BSD-3-Clause",
-    "CC0-1.0",
-    "MPL-2.0",
-    "OpenSSL",
-    "BSL-1.0"
+  "Apache-2.0",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "BSL-1.0",
+  "CC0-1.0",
+  "EPL-2.0",
+  "ISC",
+  "MIT",
+  "MPL-2.0",
+  "OpenSSL",
+  "Unicode-3.0",
+  "Unicode-DFS-2016",
+  "Zlib",
 ]
 
 # This was copied from https://github.com/EmbarkStudios/cargo-deny/blob/main/deny.toml#L64

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,22 +12,22 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-examples"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh."
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh-examples"
 readme = "README.md"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 publish = false
 
 [features]
-default = ["zenoh/default", "zenoh-ext/default"]
+default = ["zenoh-ext/default", "zenoh/default"]
 shared-memory = ["zenoh/shared-memory"]
 unstable = ["zenoh/unstable"]
 
@@ -36,9 +36,11 @@ clap = { workspace = true, features = ["derive"] }
 futures = { workspace = true }
 prost = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "time", "io-std"] }
+tokio = { workspace = true, features = ["io-std", "rt-multi-thread", "time"] }
 zenoh = { workspace = true, default-features = false }
-zenoh-ext = { workspace = true, default-features = false, features = ["unstable"] }
+zenoh-ext = { workspace = true, default-features = false, features = [
+  "unstable",
+] }
 
 [dev-dependencies]
 rand = { workspace = true, features = ["default"] }
@@ -78,7 +80,7 @@ path = "examples/z_pub.rs"
 [[example]]
 name = "z_pub_shm"
 path = "examples/z_pub_shm.rs"
-required-features = ["unstable", "shared-memory"]
+required-features = ["shared-memory", "unstable"]
 
 [[example]]
 name = "z_sub"
@@ -87,7 +89,7 @@ path = "examples/z_sub.rs"
 [[example]]
 name = "z_sub_shm"
 path = "examples/z_sub_shm.rs"
-required-features = ["unstable", "shared-memory"]
+required-features = ["shared-memory", "unstable"]
 
 [[example]]
 name = "z_pull"
@@ -104,7 +106,7 @@ path = "examples/z_queryable.rs"
 [[example]]
 name = "z_queryable_shm"
 path = "examples/z_queryable_shm.rs"
-required-features = ["unstable", "shared-memory"]
+required-features = ["shared-memory", "unstable"]
 
 [[example]]
 name = "z_storage"
@@ -117,7 +119,7 @@ path = "examples/z_get.rs"
 [[example]]
 name = "z_get_shm"
 path = "examples/z_get_shm.rs"
-required-features = ["unstable", "shared-memory"]
+required-features = ["shared-memory", "unstable"]
 
 [[example]]
 name = "z_forward"
@@ -146,7 +148,7 @@ path = "examples/z_sub_thr.rs"
 [[example]]
 name = "z_pub_shm_thr"
 path = "examples/z_pub_shm_thr.rs"
-required-features = ["unstable", "shared-memory"]
+required-features = ["shared-memory", "unstable"]
 
 [[example]]
 name = "z_ping"
@@ -155,7 +157,7 @@ path = "examples/z_ping.rs"
 [[example]]
 name = "z_ping_shm"
 path = "examples/z_ping_shm.rs"
-required-features = ["unstable", "shared-memory"]
+required-features = ["shared-memory", "unstable"]
 
 [[example]]
 name = "z_pong"
@@ -164,14 +166,14 @@ path = "examples/z_pong.rs"
 [[example]]
 name = "z_alloc_shm"
 path = "examples/z_alloc_shm.rs"
-required-features = ["unstable", "shared-memory"]
+required-features = ["shared-memory", "unstable"]
 
 [[example]]
 name = "z_bytes_shm"
 path = "examples/z_bytes_shm.rs"
-required-features = ["unstable", "shared-memory"]
+required-features = ["shared-memory", "unstable"]
 
 [[example]]
 name = "z_posix_shm_provider"
 path = "examples/z_posix_shm_provider.rs"
-required-features = ["unstable", "shared-memory"]
+required-features = ["shared-memory", "unstable"]

--- a/io/zenoh-link-commons/Cargo.toml
+++ b/io/zenoh-link-commons/Cargo.toml
@@ -26,18 +26,18 @@ version = { workspace = true }
 
 [features]
 compression = []
-tls = ["dep:rustls", "dep:rustls-webpki"]
 quic = [
-    "tls",
-    "dep:secrecy",
-    "dep:zenoh-config",
-    "dep:rustls-pemfile",
-    "dep:webpki-roots",
-    "dep:base64",
-    "dep:quinn",
-    "dep:rustls-pki-types",
-    "dep:x509-parser",
+  "dep:base64",
+  "dep:quinn",
+  "dep:rustls-pemfile",
+  "dep:rustls-pki-types",
+  "dep:secrecy",
+  "dep:webpki-roots",
+  "dep:x509-parser",
+  "dep:zenoh-config",
+  "tls",
 ]
+tls = ["dep:rustls", "dep:rustls-webpki"]
 
 [dependencies]
 async-trait = { workspace = true }
@@ -47,18 +47,18 @@ futures = { workspace = true }
 quinn = { workspace = true, optional = true }
 rustls = { workspace = true, optional = true }
 rustls-pemfile = { workspace = true, optional = true }
-rustls-webpki = { workspace = true, optional = true }
 rustls-pki-types = { workspace = true, optional = true }
-serde = { workspace = true, features = ["default"] }
+rustls-webpki = { workspace = true, optional = true }
 secrecy = { workspace = true, optional = true }
+serde = { workspace = true, features = ["default"] }
 socket2 = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true, features = [
-    "fs",
-    "io-util",
-    "net",
-    "sync",
-    "time",
+  "fs",
+  "io-util",
+  "net",
+  "sync",
+  "time",
 ] }
 tokio-util = { workspace = true, features = ["rt"] }
 tracing = { workspace = true }

--- a/io/zenoh-link/Cargo.toml
+++ b/io/zenoh-link/Cargo.toml
@@ -12,32 +12,32 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-link"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh."
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh-link"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
 transport_quic = ["zenoh-link-quic"]
 transport_quic_datagram = ["zenoh-link-quic_datagram"]
-transport_tcp = ["zenoh-link-tcp", "zenoh-config/transport_tcp"]
+transport_serial = ["zenoh-link-serial"]
+transport_tcp = ["zenoh-config/transport_tcp", "zenoh-link-tcp"]
 transport_tls = ["zenoh-link-tls"]
 transport_udp = ["zenoh-link-udp"]
-transport_unixsock-stream = ["zenoh-link-unixsock_stream"]
-transport_ws = ["zenoh-link-ws"]
-transport_serial = ["zenoh-link-serial"]
 transport_unixpipe = [
-    "zenoh-link-unixpipe",
-    "zenoh-link-unixpipe/transport_unixpipe",
+  "zenoh-link-unixpipe",
+  "zenoh-link-unixpipe/transport_unixpipe",
 ]
+transport_unixsock-stream = ["zenoh-link-unixsock_stream"]
 transport_vsock = ["zenoh-link-vsock"]
+transport_ws = ["zenoh-link-ws"]
 
 [dependencies]
 zenoh-config = { workspace = true }
@@ -48,9 +48,9 @@ zenoh-link-serial = { workspace = true, optional = true }
 zenoh-link-tcp = { workspace = true, optional = true }
 zenoh-link-tls = { workspace = true, optional = true }
 zenoh-link-udp = { workspace = true, optional = true }
-zenoh-link-unixsock_stream = { workspace = true, optional = true }
-zenoh-link-ws = { workspace = true, optional = true }
 zenoh-link-unixpipe = { workspace = true, optional = true }
+zenoh-link-unixsock_stream = { workspace = true, optional = true }
 zenoh-link-vsock = { workspace = true, optional = true }
+zenoh-link-ws = { workspace = true, optional = true }
 zenoh-protocol = { workspace = true }
 zenoh-result = { workspace = true }

--- a/io/zenoh-links/zenoh-link-quic/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-quic/Cargo.toml
@@ -34,11 +34,11 @@ rustls-webpki = { workspace = true }
 secrecy = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true, features = [
-    "fs",
-    "io-util",
-    "net",
-    "sync",
-    "time",
+  "fs",
+  "io-util",
+  "net",
+  "sync",
+  "time",
 ] }
 # tokio-rustls = { workspace = true }
 tokio-util = { workspace = true, features = ["rt"] }

--- a/io/zenoh-links/zenoh-link-quic_datagram/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-quic_datagram/Cargo.toml
@@ -31,11 +31,11 @@ rustls = { workspace = true }
 rustls-webpki = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true, features = [
-    "fs",
-    "io-util",
-    "net",
-    "sync",
-    "time",
+  "fs",
+  "io-util",
+  "net",
+  "sync",
+  "time",
 ] }
 # tokio-rustls = { workspace = true }
 tokio-util = { workspace = true, features = ["rt"] }

--- a/io/zenoh-links/zenoh-link-serial/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-serial/Cargo.toml
@@ -12,30 +12,36 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-link-serial"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
 authors = [
-  "kydos <angelo@icorsaro.net>",
+  "Gabriele Baldoni <gabriele.baldoni@zettascale.tech>",
   "Julien Enoch <julien@enoch.fr>",
-  "Olivier Hécart <olivier.hecart@zettascale.tech>",
   "Luca Cominardi <luca.cominardi@zettascale.tech>",
+  "Olivier Hécart <olivier.hecart@zettascale.tech>",
   "Pierre Avital <pierre.avital@zettascale.tech>",
-  "Gabriele Baldoni <gabriele.baldoni@zettascale.tech>"
+  "kydos <angelo@icorsaro.net>",
 ]
-edition = { workspace = true }
-license = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh."
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh-link-serial"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 async-trait = { workspace = true }
-tracing = {workspace = true}
-tokio = { workspace = true, features = ["io-std", "macros", "net", "rt-multi-thread", "time"] }
+tokio = { workspace = true, features = [
+  "io-std",
+  "macros",
+  "net",
+  "rt-multi-thread",
+  "time",
+] }
 tokio-util = { workspace = true, features = ["rt"] }
+tracing = { workspace = true }
 uuid = { workspace = true, default-features = true }
 z-serial = { workspace = true }
 zenoh-core = { workspace = true }

--- a/io/zenoh-links/zenoh-link-tcp/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-tcp/Cargo.toml
@@ -12,24 +12,24 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-link-tcp"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh."
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh-link-tcp"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 async-trait = { workspace = true }
 socket2 = { workspace = true }
-tokio = { workspace = true, features = ["net", "io-util", "rt", "time"] }
+tokio = { workspace = true, features = ["io-util", "net", "rt", "time"] }
 tokio-util = { workspace = true, features = ["rt"] }
-tracing = {workspace = true}
+tracing = { workspace = true }
 zenoh-config = { workspace = true }
 zenoh-core = { workspace = true }
 zenoh-link-commons = { workspace = true }

--- a/io/zenoh-links/zenoh-link-tls/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-tls/Cargo.toml
@@ -33,14 +33,14 @@ rustls-pki-types = { workspace = true }
 rustls-webpki = { workspace = true }
 secrecy = { workspace = true }
 socket2 = { workspace = true }
+time = { workspace = true }
+tls-listener = { workspace = true }
 tokio = { workspace = true, features = ["fs", "io-util", "net", "sync"] }
 tokio-rustls = { workspace = true }
 tokio-util = { workspace = true, features = ["rt"] }
-time = { workspace = true }
 tracing = { workspace = true }
-x509-parser = { workspace = true }
 webpki-roots = { workspace = true }
-tls-listener = { workspace = true }
+x509-parser = { workspace = true }
 zenoh-config = { workspace = true }
 zenoh-core = { workspace = true }
 zenoh-link-commons = { workspace = true, features = ["tls"] }

--- a/io/zenoh-links/zenoh-link-udp/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-udp/Cargo.toml
@@ -12,24 +12,24 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-link-udp"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh."
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh-link-udp"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { workspace = true, features = ["net", "io-util", "rt", "time"] }
-tokio-util = { workspace = true, features = ["rt"] }
 async-trait = { workspace = true }
-tracing = {workspace = true}
 socket2 = { workspace = true }
+tokio = { workspace = true, features = ["io-util", "net", "rt", "time"] }
+tokio-util = { workspace = true, features = ["rt"] }
+tracing = { workspace = true }
 zenoh-buffers = { workspace = true }
 zenoh-core = { workspace = true }
 zenoh-link-commons = { workspace = true }

--- a/io/zenoh-links/zenoh-link-unixpipe/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-unixpipe/Cargo.toml
@@ -12,16 +12,16 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-link-unixpipe"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh."
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh-link-unixpipe"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
@@ -29,21 +29,21 @@ transport_unixpipe = []
 
 [dependencies]
 async-trait = { workspace = true }
-tracing = {workspace = true}
 rand = { workspace = true, features = ["default"] }
-zenoh-core = { workspace = true }
+tokio = { workspace = true, features = ["fs", "io-util", "macros", "sync"] }
+tokio-util = { workspace = true, features = ["rt"] }
+tracing = { workspace = true }
 zenoh-config = { workspace = true }
+zenoh-core = { workspace = true }
 zenoh-link-commons = { workspace = true }
 zenoh-protocol = { workspace = true }
 zenoh-result = { workspace = true }
 zenoh-runtime = { workspace = true }
-tokio = { workspace = true, features = ["sync", "fs", "io-util", "macros"] }
-tokio-util = { workspace = true, features = ["rt"] }
 
 [target.'cfg(unix)'.dependencies]
-unix-named-pipe = "0.2.0"
-nix = { workspace = true }
 filepath = "0.1.2"
+nix = { workspace = true }
+unix-named-pipe = "0.2.0"
 
 [target.'cfg(all(not(target_os="macos"), unix))'.dependencies]
 advisory-lock = { workspace = true }

--- a/io/zenoh-links/zenoh-link-unixsock_stream/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-unixsock_stream/Cargo.toml
@@ -12,31 +12,37 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-link-unixsock_stream"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
 authors = [
-  "kydos <angelo@icorsaro.net>",
+  "Gabriele Baldoni <gabriele.baldoni@zettascale.tech>",
   "Julien Enoch <julien@enoch.fr>",
-  "Olivier Hécart <olivier.hecart@zettascale.tech>",
   "Luca Cominardi <luca.cominardi@zettascale.tech>",
+  "Olivier Hécart <olivier.hecart@zettascale.tech>",
   "Pierre Avital <pierre.avital@zettascale.tech>",
-  "Gabriele Baldoni <gabriele.baldoni@zettascale.tech>"
+  "kydos <angelo@icorsaro.net>",
 ]
-edition = { workspace = true }
-license = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh."
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh-link-unixsock_stream"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 async-trait = { workspace = true }
-tracing = {workspace = true}
 nix = { workspace = true }
-tokio = { workspace = true, features = ["io-std", "macros", "net", "rt-multi-thread", "time"] }
+tokio = { workspace = true, features = [
+  "io-std",
+  "macros",
+  "net",
+  "rt-multi-thread",
+  "time",
+] }
 tokio-util = { workspace = true, features = ["rt"] }
+tracing = { workspace = true }
 uuid = { workspace = true, features = ["default"] }
 zenoh-core = { workspace = true }
 zenoh-link-commons = { workspace = true }

--- a/io/zenoh-links/zenoh-link-vsock/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-vsock/Cargo.toml
@@ -12,24 +12,24 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-link-vsock"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh."
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh-link-vsock"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 async-trait = { workspace = true }
-tokio = { workspace = true, features = ["net", "io-util", "rt", "time"] }
-tokio-util = { workspace = true, features = ["rt"] }
-tracing = {workspace = true}
 libc = { workspace = true }
+tokio = { workspace = true, features = ["io-util", "net", "rt", "time"] }
+tokio-util = { workspace = true, features = ["rt"] }
+tracing = { workspace = true }
 zenoh-core = { workspace = true }
 zenoh-link-commons = { workspace = true }
 zenoh-protocol = { workspace = true }
@@ -39,4 +39,4 @@ zenoh-runtime = { workspace = true }
 # Workspaces does not support platform dependent dependencies, and 
 # tokio-vsock not compiled on other platforms, so we put it there
 [target.'cfg(target_os = "linux")'.dependencies]
-tokio-vsock = "0.5.0" 
+tokio-vsock = "0.5.0"

--- a/io/zenoh-links/zenoh-link-ws/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-ws/Cargo.toml
@@ -12,36 +12,42 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-link-ws"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
 authors = [
-  "kydos <angelo@icorsaro.net>",
+  "Gabriele Baldoni <gabriele.baldoni@zettascale.tech>",
   "Julien Enoch <julien@enoch.fr>",
-  "Olivier Hécart <olivier.hecart@zettascale.tech>",
   "Luca Cominardi <luca.cominardi@zettascale.tech>",
+  "Olivier Hécart <olivier.hecart@zettascale.tech>",
   "Pierre Avital <pierre.avital@zettascale.tech>",
-  "Gabriele Baldoni <gabriele.baldoni@zettascale.tech>"
+  "kydos <angelo@icorsaro.net>",
 ]
-edition = { workspace = true }
-license = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh."
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh-link-ws"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 async-trait = { workspace = true }
 futures-util = { workspace = true, features = ["sink", "std"] }
-tracing = {workspace = true}
-tokio = { workspace = true, features = ["io-std", "macros", "net", "rt-multi-thread", "time"] }
-tokio-util = { workspace = true, features = ["rt"] }
+tokio = { workspace = true, features = [
+  "io-std",
+  "macros",
+  "net",
+  "rt-multi-thread",
+  "time",
+] }
 tokio-tungstenite = { workspace = true }
+tokio-util = { workspace = true, features = ["rt"] }
+tracing = { workspace = true }
 url = { workspace = true }
 zenoh-core = { workspace = true }
 zenoh-link-commons = { workspace = true }
 zenoh-protocol = { workspace = true }
 zenoh-result = { workspace = true }
-zenoh-util = { workspace = true }
 zenoh-runtime = { workspace = true }
+zenoh-util = { workspace = true }

--- a/io/zenoh-transport/Cargo.toml
+++ b/io/zenoh-transport/Cargo.toml
@@ -12,85 +12,85 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-transport"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
 categories = { workspace = true }
 description = "Internal crate for zenoh."
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh-transport"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-shared-memory = [
-    "zenoh-protocol/shared-memory",
-    "zenoh-shm",
-    "zenoh-codec/shared-memory",
-    "zenoh-buffers/shared-memory",
-]
-auth_pubkey = ["transport_auth", "rsa"]
+auth_pubkey = ["rsa", "transport_auth"]
 auth_usrpwd = ["transport_auth"]
+default = ["test", "transport_multilink"]
+shared-memory = [
+  "zenoh-buffers/shared-memory",
+  "zenoh-codec/shared-memory",
+  "zenoh-protocol/shared-memory",
+  "zenoh-shm",
+]
+stats = []
+test = []
 transport_auth = []
+transport_compression = []
 transport_multilink = ["auth_pubkey"]
 transport_quic = ["zenoh-link/transport_quic"]
 transport_quic_datagram = ["zenoh-link/transport_quic_datagram"]
-transport_tcp = ["zenoh-link/transport_tcp", "zenoh-config/transport_tcp"]
+transport_serial = ["zenoh-link/transport_serial"]
+transport_tcp = ["zenoh-config/transport_tcp", "zenoh-link/transport_tcp"]
 transport_tls = ["zenoh-link/transport_tls"]
 transport_udp = ["zenoh-link/transport_udp"]
-transport_unixsock-stream = ["zenoh-link/transport_unixsock-stream"]
-transport_ws = ["zenoh-link/transport_ws"]
-transport_serial = ["zenoh-link/transport_serial"]
-transport_compression = []
 transport_unixpipe = ["zenoh-link/transport_unixpipe"]
+transport_unixsock-stream = ["zenoh-link/transport_unixsock-stream"]
 transport_vsock = ["zenoh-link/transport_vsock"]
-stats = []
-test = []
-unstable = ["zenoh-protocol/unstable", "zenoh-config/unstable"]
-default = ["test", "transport_multilink"]
+transport_ws = ["zenoh-link/transport_ws"]
+unstable = ["zenoh-config/unstable", "zenoh-protocol/unstable"]
 
 [dependencies]
 async-trait = { workspace = true }
 crossbeam-utils = { workspace = true }
-tokio = { workspace = true, features = [
-    "sync",
-    "fs",
-    "time",
-    "macros",
-    "rt-multi-thread",
-    "io-util",
-    "net",
-] }
-lazy_static = { workspace = true }
-tokio-util = { workspace = true, features = ["rt"] }
 flume = { workspace = true }
-tracing = { workspace = true }
+lazy_static = { workspace = true }
 lz4_flex = { workspace = true }
 paste = { workspace = true }
 rand = { workspace = true, features = ["default"] }
 ringbuffer-spsc = { workspace = true }
 rsa = { workspace = true, optional = true }
-sha3 = { workspace = true }
 serde = { workspace = true, features = ["default"] }
+sha3 = { workspace = true }
+tokio = { workspace = true, features = [
+  "fs",
+  "io-util",
+  "macros",
+  "net",
+  "rt-multi-thread",
+  "sync",
+  "time",
+] }
+tokio-util = { workspace = true, features = ["rt"] }
+tracing = { workspace = true }
 zenoh-buffers = { workspace = true }
 zenoh-codec = { workspace = true }
 zenoh-config = { workspace = true }
 zenoh-core = { workspace = true }
 zenoh-crypto = { workspace = true }
 zenoh-link = { workspace = true }
+zenoh-link-commons = { workspace = true }
 zenoh-protocol = { workspace = true }
 zenoh-result = { workspace = true }
+zenoh-runtime = { workspace = true }
 zenoh-shm = { workspace = true, optional = true }
 zenoh-sync = { workspace = true }
-zenoh-util = { workspace = true }
-zenoh-runtime = { workspace = true }
 zenoh-task = { workspace = true }
-zenoh-link-commons = { workspace = true }
+zenoh-util = { workspace = true }
 
 [dev-dependencies]
-futures-util = { workspace = true }
-zenoh-util = { workspace = true }
-zenoh-protocol = { workspace = true, features = ["test"] }
 futures = { workspace = true }
+futures-util = { workspace = true }
+zenoh-protocol = { workspace = true, features = ["test"] }
+zenoh-util = { workspace = true }

--- a/plugins/zenoh-backend-example/Cargo.toml
+++ b/plugins/zenoh-backend-example/Cargo.toml
@@ -12,12 +12,12 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-backend-example"
-version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+name = "zenoh-backend-example"
 publish = false
+rust-version = { workspace = true }
+version = { workspace = true }
 
 [features]
 default = ["dynamic_plugin", "zenoh/default"]

--- a/plugins/zenoh-backend-traits/Cargo.toml
+++ b/plugins/zenoh-backend-traits/Cargo.toml
@@ -12,16 +12,16 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh_backend_traits"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
 categories = { workspace = true }
 description = "Zenoh: traits to be implemented by backends libraries"
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh_backend_traits"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 
 [badges]
 maintenance = { status = "actively-developed" }
@@ -31,12 +31,15 @@ default = ["zenoh/default"]
 
 [dependencies]
 async-trait = { workspace = true }
+const_format = { workspace = true }
 derive_more = { workspace = true }
+either = { workspace = true }
+schemars = { workspace = true }
 serde_json = { workspace = true }
-zenoh = { workspace = true, default-features = false, features = ["unstable", "internal"] }
+zenoh = { workspace = true, default-features = false, features = [
+  "internal",
+  "unstable",
+] }
+zenoh-plugin-trait = { workspace = true }
 zenoh-result = { workspace = true }
 zenoh-util = { workspace = true }
-schemars = { workspace = true }
-zenoh-plugin-trait = { workspace = true }
-const_format = { workspace = true }
-either = { workspace = true }

--- a/plugins/zenoh-plugin-example/Cargo.toml
+++ b/plugins/zenoh-plugin-example/Cargo.toml
@@ -12,12 +12,12 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-plugin-example"
-version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+name = "zenoh-plugin-example"
 publish = false
+rust-version = { workspace = true }
+version = { workspace = true }
 
 [features]
 default = ["dynamic_plugin"]
@@ -34,20 +34,20 @@ name = "zenoh_plugin_example"
 crate-type = ["cdylib"]
 
 [dependencies]
-zenoh-util = { workspace = true }
 futures = { workspace = true }
-lazy_static = { workspace = true }
 git-version = { workspace = true }
-tracing = { workspace = true }
-tokio = { workspace = true }
+lazy_static = { workspace = true }
 serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 zenoh = { workspace = true, features = [
-    "default",
-    "plugins",
-    "internal",
-    "unstable",
+  "default",
+  "internal",
+  "plugins",
+  "unstable",
 ] }
 zenoh-plugin-trait = { workspace = true }
+zenoh-util = { workspace = true }
 
 [package.metadata.cargo-machete]
 ignored = ["git-version"]

--- a/plugins/zenoh-plugin-rest/Cargo.toml
+++ b/plugins/zenoh-plugin-rest/Cargo.toml
@@ -12,16 +12,16 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-plugin-rest"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
 categories = ["network-programming", "web-programming::http-server"]
 description = "The zenoh REST plugin"
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh-plugin-rest"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 
 [features]
 default = ["dynamic_plugin", "zenoh/default"]
@@ -29,37 +29,37 @@ dynamic_plugin = []
 static_plugin = ['async-std']
 
 [lib]
-name = "zenoh_plugin_rest"
 crate-type = ["cdylib", "rlib"]
+name = "zenoh_plugin_rest"
 
 [dependencies]
-async-std = { workspace = true, features = ["tokio1"], optional = true}
 anyhow = { workspace = true, features = ["default"] }
+async-std = { workspace = true, features = ["tokio1"], optional = true }
 base64 = { workspace = true }
 flume = { workspace = true }
 futures = { workspace = true }
 git-version = { workspace = true }
 http-types = { workspace = true }
 lazy_static = { workspace = true }
-tracing = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["default"] }
 serde_json = { workspace = true }
 tide = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 zenoh = { workspace = true, default-features = false, features = [
-    "plugins",
-    "internal",
-    "unstable",
+  "internal",
+  "plugins",
+  "unstable",
 ] }
 zenoh-plugin-trait = { workspace = true }
 
 [build-dependencies]
+jsonschema = { workspace = true }
 rustc_version = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["default"] }
 serde_json = { workspace = true }
-jsonschema = { workspace = true }
 
 [dev-dependencies]
 clap = { workspace = true }
@@ -69,12 +69,12 @@ name = "z_serve_sse"
 path = "examples/z_serve_sse.rs"
 
 [package.metadata.deb]
-name = "zenoh-plugin-rest"
-maintainer = "zenoh-dev@eclipse.org"
 copyright = "2024 ZettaScale Technology"
-section = "net"
-license-file = ["../../LICENSE", "0"]
 depends = "zenohd (=1.5.0)"
+license-file = ["../../LICENSE", "0"]
+maintainer = "zenoh-dev@eclipse.org"
+name = "zenoh-plugin-rest"
+section = "net"
 
 [package.metadata.cargo-machete]
 ignored = ["async-std"]

--- a/plugins/zenoh-plugin-storage-manager/Cargo.toml
+++ b/plugins/zenoh-plugin-storage-manager/Cargo.toml
@@ -12,24 +12,24 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-plugin-storage-manager"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
 categories = { workspace = true }
 description = "The zenoh storages plugin."
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh-plugin-storage-manager"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 
 [features]
 default = ["dynamic_plugin", "zenoh/default"]
 dynamic_plugin = []
 
 [lib]
-name = "zenoh_plugin_storage_manager"
 crate-type = ["cdylib", "rlib"]
+name = "zenoh_plugin_storage_manager"
 
 [dependencies]
 async-trait = { workspace = true }
@@ -46,32 +46,32 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 zenoh = { workspace = true, default-features = false, features = [
-    "plugins",
-    "internal",
-    "unstable",
+  "internal",
+  "plugins",
+  "unstable",
 ] }
 zenoh-plugin-trait = { workspace = true }
 zenoh_backend_traits = { workspace = true }
 
 [build-dependencies]
+jsonschema = { workspace = true }
 rustc_version = { workspace = true }
-zenoh_backend_traits = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["default"] }
 serde_json = { workspace = true }
-jsonschema = { workspace = true }
+zenoh_backend_traits = { workspace = true }
 
 [dev-dependencies]
 async-global-executor = { workspace = true }
 uhlc = { workspace = true }
 
 [package.metadata.deb]
-name = "zenoh-plugin-storage-manager"
-maintainer = "zenoh-dev@eclipse.org"
 copyright = "2024 ZettaScale Technology"
-section = "net"
-license-file = ["../../LICENSE", "0"]
 depends = "zenohd (=1.5.0)"
+license-file = ["../../LICENSE", "0"]
+maintainer = "zenoh-dev@eclipse.org"
+name = "zenoh-plugin-storage-manager"
+section = "net"
 
 [package.metadata.cargo-machete]
 ignored = ["git-version"]

--- a/plugins/zenoh-plugin-trait/Cargo.toml
+++ b/plugins/zenoh-plugin-trait/Cargo.toml
@@ -12,27 +12,27 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-plugin-trait"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
 categories = { workspace = true }
 description = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh-plugin-trait"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 
 [lib]
 name = "zenoh_plugin_trait"
 
 [dependencies]
-libloading = { workspace = true }
-tracing = { workspace = true }
-serde = { workspace = true }
 git-version = { workspace = true }
+libloading = { workspace = true }
+serde = { workspace = true }
+tracing = { workspace = true }
+zenoh-config = { workspace = true }
+zenoh-keyexpr = { workspace = true, features = ["internal", "unstable"] }
 zenoh-macros = { workspace = true }
 zenoh-result = { workspace = true }
 zenoh-util = { workspace = true }
-zenoh-config = { workspace = true }
-zenoh-keyexpr = { workspace = true, features = ["internal", "unstable"] }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,6 @@
 edition = "2021"
-use_try_shorthand = true
 use_field_init_shorthand = true
+use_try_shorthand = true
 
 # Unstable features below
 # unstable_features = true

--- a/zenoh-ext/Cargo.toml
+++ b/zenoh-ext/Cargo.toml
@@ -12,16 +12,16 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-ext"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-authors = ["kydos <angelo@icorsaro.net>", "Julien Enoch <julien@enoch.fr>"]
-edition = { workspace = true }
-license = { workspace = true }
+authors = ["Julien Enoch <julien@enoch.fr>", "kydos <angelo@icorsaro.net>"]
 categories = { workspace = true }
 description = "Zenoh: extensions to the client API."
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh-ext"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 
 [badges]
 maintenance = { status = "actively-developed" }
@@ -29,31 +29,31 @@ maintenance = { status = "actively-developed" }
 [features]
 default = ["zenoh/default"]
 internal = []
-unstable = ["zenoh/unstable", "zenoh/internal"]
+unstable = ["zenoh/internal", "zenoh/unstable"]
 
 [dependencies]
+async-trait = { workspace = true }
+bincode = { workspace = true }
+flume = { workspace = true }
+futures = { workspace = true }
+leb128 = { workspace = true }
+serde = { workspace = true, features = ["default"] }
 tokio = { workspace = true, features = [
+  "io-std",
+  "macros",
   "rt",
   "sync",
   "time",
-  "macros",
-  "io-std",
 ] }
-async-trait = { workspace = true }
-bincode = { workspace = true }
-zenoh-util = { workspace = true }
-flume = { workspace = true }
-futures = { workspace = true }
 tracing = { workspace = true }
-serde = { workspace = true, features = ["default"] }
-leb128 = { workspace = true }
 uhlc = { workspace = true }
 zenoh = { workspace = true, default-features = false }
 zenoh-macros = { workspace = true }
+zenoh-util = { workspace = true }
 
 [dev-dependencies]
-zenoh-config = { workspace = true }
 rand = { workspace = true }
+zenoh-config = { workspace = true }
 
 [package.metadata.docs.rs]
 features = ["unstable"]

--- a/zenoh-ext/examples/Cargo.toml
+++ b/zenoh-ext/examples/Cargo.toml
@@ -12,38 +12,40 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh-ext-examples"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-authors = ["kydos <angelo@icorsaro.net>", "Julien Enoch <julien@enoch.fr>"]
-edition = { workspace = true }
-license = { workspace = true }
+authors = ["Julien Enoch <julien@enoch.fr>", "kydos <angelo@icorsaro.net>"]
 categories = { workspace = true }
 description = "Internal crate for zenoh"
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh-ext-examples"
 publish = false
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 
 [badges]
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["zenoh/default", "zenoh-ext/default", "zenoh-examples/default"]
+default = ["zenoh-examples/default", "zenoh-ext/default", "zenoh/default"]
 unstable = []
 
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
 futures = { workspace = true }
 tokio = { workspace = true, features = [
-    "rt",
-    "sync",
-    "time",
-    "macros",
-    "io-std",
+  "io-std",
+  "macros",
+  "rt",
+  "sync",
+  "time",
 ] }
 zenoh = { workspace = true, default-features = false }
-zenoh-ext = { workspace = true, default-features = false, features = ["unstable"]}
 zenoh-examples = { workspace = true, default-features = false }
+zenoh-ext = { workspace = true, default-features = false, features = [
+  "unstable",
+] }
 
 [dev-dependencies]
 zenoh-config = { workspace = true }

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -12,17 +12,17 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenoh"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
 categories = { workspace = true }
 description = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenoh"
 readme = "../README.md"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [badges]
@@ -32,59 +32,57 @@ maintenance = { status = "actively-developed" }
 auth_pubkey = ["zenoh-transport/auth_pubkey"]
 auth_usrpwd = ["zenoh-transport/auth_usrpwd"]
 default = [
-    "auth_pubkey",
-    "auth_usrpwd",
-    "transport_multilink",
-    "transport_compression",
-    "transport_quic",
-    "transport_quic_datagram",
-    "transport_tcp",
-    "transport_tls",
-    "transport_udp",
-    "transport_unixsock-stream",
-    "transport_ws",
+  "auth_pubkey",
+  "auth_usrpwd",
+  "transport_compression",
+  "transport_multilink",
+  "transport_quic",
+  "transport_quic_datagram",
+  "transport_tcp",
+  "transport_tls",
+  "transport_udp",
+  "transport_unixsock-stream",
+  "transport_ws",
 ]
 internal = [
-    "zenoh-keyexpr/internal",
-    "zenoh-config/internal",
-    "zenoh-protocol/internal",
+  "zenoh-config/internal",
+  "zenoh-keyexpr/internal",
+  "zenoh-protocol/internal",
 ]
+internal_config = []
 plugins = []
 runtime_plugins = ["plugins"]
 shared-memory = [
-    "zenoh-shm",
-    "zenoh-protocol/shared-memory",
-    "zenoh-transport/shared-memory",
-    "zenoh-buffers/shared-memory",
+  "zenoh-buffers/shared-memory",
+  "zenoh-protocol/shared-memory",
+  "zenoh-shm",
+  "zenoh-transport/shared-memory",
 ]
 stats = ["zenoh-transport/stats"]
-transport_multilink = ["zenoh-transport/transport_multilink"]
+tracing-instrument = [
+  "zenoh-runtime/tracing-instrument",
+  "zenoh-task/tracing-instrument",
+]
 transport_compression = ["zenoh-transport/transport_compression"]
+transport_multilink = ["zenoh-transport/transport_multilink"]
 transport_quic = ["zenoh-transport/transport_quic"]
 transport_quic_datagram = ["zenoh-transport/transport_quic_datagram"]
 transport_serial = ["zenoh-transport/transport_serial"]
-transport_unixpipe = ["zenoh-transport/transport_unixpipe"]
-transport_tcp = ["zenoh-transport/transport_tcp", "zenoh-config/transport_tcp"]
+transport_tcp = ["zenoh-config/transport_tcp", "zenoh-transport/transport_tcp"]
 transport_tls = ["zenoh-transport/transport_tls"]
 transport_udp = ["zenoh-transport/transport_udp"]
+transport_unixpipe = ["zenoh-transport/transport_unixpipe"]
 transport_unixsock-stream = ["zenoh-transport/transport_unixsock-stream"]
-transport_ws = ["zenoh-transport/transport_ws"]
 transport_vsock = ["zenoh-transport/transport_vsock"]
+transport_ws = ["zenoh-transport/transport_ws"]
 unstable = [
-    "internal_config",
-    "zenoh-keyexpr/unstable",
-    "zenoh-config/unstable",
-    "zenoh-protocol/unstable",
-]
-internal_config = []
-tracing-instrument = [
-    "zenoh-task/tracing-instrument",
-    "zenoh-runtime/tracing-instrument",
+  "internal_config",
+  "zenoh-config/unstable",
+  "zenoh-keyexpr/unstable",
+  "zenoh-protocol/unstable",
 ]
 
 [dependencies]
-tokio = { workspace = true, features = ["rt", "macros", "time"] }
-tokio-util = { workspace = true }
 ahash = { workspace = true, default-features = true }
 arc-swap = { workspace = true }
 async-trait = { workspace = true }
@@ -94,9 +92,9 @@ futures = { workspace = true }
 git-version = { workspace = true }
 itertools = { workspace = true }
 json5 = { workspace = true }
-nonempty-collections = { workspace = true }
 lazy_static = { workspace = true }
-tracing = { workspace = true }
+nonempty-collections = { workspace = true }
+once_cell = { workspace = true }
 paste = { workspace = true }
 petgraph = { workspace = true }
 phf = { workspace = true }
@@ -105,6 +103,9 @@ ref-cast = { workspace = true }
 serde = { workspace = true, features = ["default"] }
 serde_json = { workspace = true }
 socket2 = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "time"] }
+tokio-util = { workspace = true }
+tracing = { workspace = true }
 uhlc = { workspace = true, features = ["default"] }
 vec_map = { workspace = true }
 zenoh-buffers = { workspace = true, features = ["std"] }
@@ -119,13 +120,12 @@ zenoh-macros = { workspace = true }
 zenoh-plugin-trait = { workspace = true }
 zenoh-protocol = { workspace = true, features = ["std"] }
 zenoh-result = { workspace = true }
+zenoh-runtime = { workspace = true }
 zenoh-shm = { workspace = true, optional = true }
 zenoh-sync = { workspace = true }
+zenoh-task = { workspace = true }
 zenoh-transport = { workspace = true }
 zenoh-util = { workspace = true }
-zenoh-runtime = { workspace = true }
-zenoh-task = { workspace = true }
-once_cell = { workspace = true }
 
 [dev-dependencies]
 libc = { workspace = true }
@@ -141,18 +141,18 @@ name = "zenoh"
 # For doc generation on docs.rs, activate the "unstable" and "shared-memory" feature to generate their documentation
 # NOTE: if you change this, also change it in .github/workflows/release.yml in "doc" job.
 [package.metadata.docs.rs]
-features = ["unstable", "shared-memory"]
+features = ["shared-memory", "unstable"]
 rustdoc-args = ["--cfg", "doc_auto_cfg"]
 
 [package.metadata.deb]
-name = "zenoh"
-maintainer = "zenoh-dev@eclipse.org"
+assets = [["../README.md", "644", "README.md"]]
 copyright = "2024 ZettaScale Technology"
-section = "net"
-license-file = ["../LICENSE", "0"]
 depends = "zenohd (=1.5.0), zenoh-plugin-rest (=1.5.0), zenoh-plugin-storage-manager (=1.5.0)"
+license-file = ["../LICENSE", "0"]
+maintainer = "zenoh-dev@eclipse.org"
 maintainer-scripts = ".deb"
-assets = [["../README.md", "README.md", "644"]]
+name = "zenoh"
+section = "net"
 
 [lints.rust]
 unexpected_cfgs = { level = "allow", check-cfg = ['cfg(doc_auto_cfg)'] }

--- a/zenohd/Cargo.toml
+++ b/zenohd/Cargo.toml
@@ -12,17 +12,17 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 [package]
-rust-version = { workspace = true }
-name = "zenohd"
-version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
 authors = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
 categories = { workspace = true }
 description = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+name = "zenohd"
 readme = "README.md"
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
@@ -31,20 +31,20 @@ shared-memory = ["zenoh/shared-memory"]
 
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
-zenoh-util = { workspace = true }
 git-version = { workspace = true }
 json5 = { workspace = true }
 lazy_static = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 zenoh = { workspace = true, default-features = false, features = [
-  "unstable",
   "internal",
+  "internal_config",
   "plugins",
   "runtime_plugins",
-  "internal_config",
+  "unstable",
 ] }
 zenoh-config = { workspace = true }
+zenoh-util = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true, features = ["default"] }
@@ -53,18 +53,18 @@ rand = { workspace = true, features = ["default"] }
 rustc_version = { workspace = true }
 
 [package.metadata.deb]
-name = "zenohd"
-maintainer = "zenoh-dev@eclipse.org"
-copyright = "2024 ZettaScale Technology"
-section = "net"
-license-file = ["../LICENSE", "0"]
-depends = "$auto"
-maintainer-scripts = ".deb"
 assets = [
   # binary
-  ["target/release/zenohd", "/usr/bin/", "755"],
+  ["/usr/bin/", "755", "target/release/zenohd"],
   # config
   [".service/zenohd.json5", "/etc/zenohd/", "644"],
   # service
   [".service/zenohd.service", "/lib/systemd/system/zenohd.service", "644"],
 ]
+copyright = "2024 ZettaScale Technology"
+depends = "$auto"
+license-file = ["../LICENSE", "0"]
+maintainer = "zenoh-dev@eclipse.org"
+maintainer-scripts = ".deb"
+name = "zenohd"
+section = "net"


### PR DESCRIPTION
Taplo is a TOML toolkit. It is the default LSP implementation used in Zed and the popular "Even Better TOML" VS Code extension.

This commit leverages Taplo to ensure uniform TOML formatting in CI and locally (through precommit hooks), thus removing patch pollution due to TOML formatting changes.

This is a temporary solution until the question of TOML formatting is resolved upstream: https://github.com/rust-lang/rustfmt/issues/4091.