### PR TITLE
feat: make CongestionControl and Priority hashable

### DIFF
--- a/commons/zenoh-protocol/src/core/mod.rs
+++ b/commons/zenoh-protocol/src/core/mod.rs
@@ -561,7 +561,7 @@ impl Channel {
 }
 
 /// Congestion control strategy.
-#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Hash, Deserialize)]
 #[repr(u8)]
 pub enum CongestionControl {
     #[default]

--- a/zenoh/src/api/publisher.rs
+++ b/zenoh/src/api/publisher.rs
@@ -419,7 +419,7 @@ impl Sink<Sample> for Publisher<'_> {
 /// If QoS is enabled, Zenoh keeps one transmission queue per [`Priority`] P, where all messages in
 /// the queue have [`Priority`] P. These queues are serviced in the order of their assigned
 /// [`Priority`] (i.e. from [`Priority::RealTime`] to [`Priority::Background`]).
-#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Hash, Deserialize)]
 #[repr(u8)]
 pub enum Priority {
     RealTime = 1,


### PR DESCRIPTION
We would like to use these enums as hash keys and discovered that they were not marked as Hashable