### PR TITLE
Report proper whatami for adminspace entities

### DIFF
--- a/zenoh/src/net/routing/hat/p2p_peer/pubsub.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/pubsub.rs
@@ -564,15 +564,20 @@ impl HatPubSubTrait for HatCode {
     fn get_subscriptions(&self, tables: &Tables) -> Vec<(Arc<Resource>, Sources)> {
         // Compute the list of known suscriptions (keys)
         let mut subs = HashMap::new();
-        for src_face in tables.faces.values() {
-            for sub in face_hat!(src_face).remote_subs.values() {
+        for face in tables.faces.values() {
+            for sub in face_hat!(face).remote_subs.values() {
                 // Insert the key in the list of known suscriptions
                 let srcs = subs.entry(sub.clone()).or_insert_with(Sources::empty);
                 // Append src_face as a suscription source in the proper list
-                match src_face.whatami {
-                    WhatAmI::Router => srcs.routers.push(src_face.zid),
-                    WhatAmI::Peer => srcs.peers.push(src_face.zid),
-                    WhatAmI::Client => srcs.clients.push(src_face.zid),
+                let whatami = if face.is_local {
+                    tables.whatami
+                } else {
+                    face.whatami
+                };
+                match whatami {
+                    WhatAmI::Router => srcs.routers.push(face.zid),
+                    WhatAmI::Peer => srcs.peers.push(face.zid),
+                    WhatAmI::Client => srcs.clients.push(face.zid),
                 }
             }
         }
@@ -586,7 +591,12 @@ impl HatPubSubTrait for HatCode {
                 if interest.options.subscribers() {
                     if let Some(res) = interest.res.as_ref() {
                         let sources = result.entry(res.clone()).or_insert_with(Sources::default);
-                        match face.whatami {
+                        let whatami = if face.is_local {
+                            tables.whatami
+                        } else {
+                            face.whatami
+                        };
+                        match whatami {
                             WhatAmI::Router => sources.routers.push(face.zid),
                             WhatAmI::Peer => sources.peers.push(face.zid),
                             WhatAmI::Client => sources.clients.push(face.zid),

--- a/zenoh/src/net/routing/hat/p2p_peer/queries.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/queries.rs
@@ -554,15 +554,20 @@ impl HatQueriesTrait for HatCode {
     fn get_queryables(&self, tables: &Tables) -> Vec<(Arc<Resource>, Sources)> {
         // Compute the list of known queryables (keys)
         let mut qabls = HashMap::new();
-        for src_face in tables.faces.values() {
-            for qabl in face_hat!(src_face).remote_qabls.values() {
+        for face in tables.faces.values() {
+            for qabl in face_hat!(face).remote_qabls.values() {
                 // Insert the key in the list of known queryables
                 let srcs = qabls.entry(qabl.clone()).or_insert_with(Sources::empty);
                 // Append src_face as a queryable source in the proper list
-                match src_face.whatami {
-                    WhatAmI::Router => srcs.routers.push(src_face.zid),
-                    WhatAmI::Peer => srcs.peers.push(src_face.zid),
-                    WhatAmI::Client => srcs.clients.push(src_face.zid),
+                let whatami = if face.is_local {
+                    tables.whatami
+                } else {
+                    face.whatami
+                };
+                match whatami {
+                    WhatAmI::Router => srcs.routers.push(face.zid),
+                    WhatAmI::Peer => srcs.peers.push(face.zid),
+                    WhatAmI::Client => srcs.clients.push(face.zid),
                 }
             }
         }
@@ -576,7 +581,12 @@ impl HatQueriesTrait for HatCode {
                 if interest.options.queryables() {
                     if let Some(res) = interest.res.as_ref() {
                         let sources = result.entry(res.clone()).or_insert_with(Sources::default);
-                        match face.whatami {
+                        let whatami = if face.is_local {
+                            tables.whatami
+                        } else {
+                            face.whatami
+                        };
+                        match whatami {
                             WhatAmI::Router => sources.routers.push(face.zid),
                             WhatAmI::Peer => sources.peers.push(face.zid),
                             WhatAmI::Client => sources.clients.push(face.zid),

--- a/zenoh/src/net/routing/hat/router/pubsub.rs
+++ b/zenoh/src/net/routing/hat/router/pubsub.rs
@@ -15,7 +15,6 @@ use std::{
     borrow::Cow,
     collections::{HashMap, HashSet},
     sync::{atomic::Ordering, Arc},
-    vec,
 };
 
 use petgraph::graph::NodeIndex;

--- a/zenoh/src/net/routing/hat/router/pubsub.rs
+++ b/zenoh/src/net/routing/hat/router/pubsub.rs
@@ -15,6 +15,7 @@ use std::{
     borrow::Cow,
     collections::{HashMap, HashSet},
     sync::{atomic::Ordering, Arc},
+    vec,
 };
 
 use petgraph::graph::NodeIndex;
@@ -1152,31 +1153,36 @@ impl HatPubSubTrait for HatCode {
             .router_subs
             .iter()
             .map(|s| {
+                // Compute the list of routers, peers and clients that are known
+                // sources of those subscriptions
+                let routers = Vec::from_iter(res_hat!(s).router_subs.iter().cloned());
+                let mut peers = if hat!(tables).full_net(WhatAmI::Peer) {
+                    Vec::from_iter(res_hat!(s).linkstatepeer_subs.iter().cloned())
+                } else {
+                    vec![]
+                };
+                let mut clients = vec![];
+                for ctx in s
+                    .session_ctxs
+                    .values()
+                    .filter(|ctx| ctx.subs.is_some() && !ctx.face.is_local)
+                {
+                    match ctx.face.whatami {
+                        WhatAmI::Router => (),
+                        WhatAmI::Peer => {
+                            if !hat!(tables).full_net(WhatAmI::Peer) {
+                                peers.push(ctx.face.zid);
+                            }
+                        }
+                        WhatAmI::Client => clients.push(ctx.face.zid),
+                    }
+                }
                 (
                     s.clone(),
-                    // Compute the list of routers, peers and clients that are known
-                    // sources of those subscriptions
                     Sources {
-                        routers: Vec::from_iter(res_hat!(s).router_subs.iter().cloned()),
-                        peers: if hat!(tables).full_net(WhatAmI::Peer) {
-                            Vec::from_iter(res_hat!(s).linkstatepeer_subs.iter().cloned())
-                        } else {
-                            s.session_ctxs
-                                .values()
-                                .filter_map(|f| {
-                                    (f.face.whatami == WhatAmI::Peer && f.subs.is_some())
-                                        .then_some(f.face.zid)
-                                })
-                                .collect()
-                        },
-                        clients: s
-                            .session_ctxs
-                            .values()
-                            .filter_map(|f| {
-                                (f.face.whatami == WhatAmI::Client && f.subs.is_some())
-                                    .then_some(f.face.zid)
-                            })
-                            .collect(),
+                        routers,
+                        peers,
+                        clients,
                     },
                 )
             })
@@ -1190,7 +1196,12 @@ impl HatPubSubTrait for HatCode {
                 if interest.options.subscribers() {
                     if let Some(res) = interest.res.as_ref() {
                         let sources = result.entry(res.clone()).or_insert_with(Sources::default);
-                        match face.whatami {
+                        let whatami = if face.is_local {
+                            tables.whatami
+                        } else {
+                            face.whatami
+                        };
+                        match whatami {
                             WhatAmI::Router => sources.routers.push(face.zid),
                             WhatAmI::Peer => sources.peers.push(face.zid),
                             WhatAmI::Client => sources.clients.push(face.zid),

--- a/zenoh/src/net/routing/hat/router/queries.rs
+++ b/zenoh/src/net/routing/hat/router/queries.rs
@@ -1363,31 +1363,36 @@ impl HatQueriesTrait for HatCode {
             .router_qabls
             .iter()
             .map(|s| {
+                // Compute the list of routers, peers and clients that are known
+                // sources of those queryables
+                let routers = Vec::from_iter(res_hat!(s).router_qabls.keys().cloned());
+                let mut peers = if hat!(tables).full_net(WhatAmI::Peer) {
+                    Vec::from_iter(res_hat!(s).linkstatepeer_qabls.keys().cloned())
+                } else {
+                    vec![]
+                };
+                let mut clients = vec![];
+                for ctx in s
+                    .session_ctxs
+                    .values()
+                    .filter(|ctx| ctx.qabl.is_some() && !ctx.face.is_local)
+                {
+                    match ctx.face.whatami {
+                        WhatAmI::Router => (),
+                        WhatAmI::Peer => {
+                            if !hat!(tables).full_net(WhatAmI::Peer) {
+                                peers.push(ctx.face.zid);
+                            }
+                        }
+                        WhatAmI::Client => clients.push(ctx.face.zid),
+                    }
+                }
                 (
                     s.clone(),
-                    // Compute the list of routers, peers and clients that are known
-                    // sources of those queryables
                     Sources {
-                        routers: Vec::from_iter(res_hat!(s).router_qabls.keys().cloned()),
-                        peers: if hat!(tables).full_net(WhatAmI::Peer) {
-                            Vec::from_iter(res_hat!(s).linkstatepeer_qabls.keys().cloned())
-                        } else {
-                            s.session_ctxs
-                                .values()
-                                .filter_map(|f| {
-                                    (f.face.whatami == WhatAmI::Peer && f.qabl.is_some())
-                                        .then_some(f.face.zid)
-                                })
-                                .collect()
-                        },
-                        clients: s
-                            .session_ctxs
-                            .values()
-                            .filter_map(|f| {
-                                (f.face.whatami == WhatAmI::Client && f.qabl.is_some())
-                                    .then_some(f.face.zid)
-                            })
-                            .collect(),
+                        routers,
+                        peers,
+                        clients,
                     },
                 )
             })
@@ -1401,7 +1406,12 @@ impl HatQueriesTrait for HatCode {
                 if interest.options.queryables() {
                     if let Some(res) = interest.res.as_ref() {
                         let sources = result.entry(res.clone()).or_insert_with(Sources::default);
-                        match face.whatami {
+                        let whatami = if face.is_local {
+                            tables.whatami
+                        } else {
+                            face.whatami
+                        };
+                        match whatami {
                             WhatAmI::Router => sources.routers.push(face.zid),
                             WhatAmI::Peer => sources.peers.push(face.zid),
                             WhatAmI::Client => sources.clients.push(face.zid),


### PR DESCRIPTION
Router and peers were reporting entities from a local session with their own zid and whatami client (as local sessions are considered as clients internally). This was confusing for users, as zids were reported as clients while they were peers or routers.

Downside: The fix prevents to differentiate router subscriptions between 
- Routers that subscribe on behalf of their subsystem
- Routers that themselves subscribe (plugin for example).
But it's probably better to add new fields or explicit way to differentiate those cases rather than relying on fake whatami trickery.
