### PR TITLE
Eagerly compute publisher routes.

### DIFF
--- a/zenoh/src/net/routing/dispatcher/interests.rs
+++ b/zenoh/src/net/routing/dispatcher/interests.rs
@@ -37,8 +37,9 @@ use super::{
     tables::{register_expr_interest, Tables, TablesLock},
 };
 use crate::net::routing::{
+    dispatcher::tables::RoutingExpr,
     hat::{HatTrait, SendDeclare},
-    router::{unregister_expr_interest, Resource},
+    router::{get_data_route, unregister_expr_interest, Resource},
     RoutingContext,
 };
 
@@ -258,6 +259,19 @@ pub(crate) fn declare_interest(
                     options,
                     send_declare,
                 );
+                // Cache data route in case of subscribers interest declaration, as it should come
+                // from a publisher declaration, and publisher is expected to use the route.
+                if options.subscribers() {
+                    get_data_route(
+                        hat_code.as_ref(),
+                        &wtables,
+                        face,
+                        &Some(res),
+                        &mut RoutingExpr::new(&prefix, expr.suffix.as_ref()),
+                        ext::NodeIdType::DEFAULT.node_id,
+                        false,
+                    );
+                }
             }
             None => tracing::error!(
                 "{} Declare interest {} for unknown scope {}!",


### PR DESCRIPTION
Publisher declaration comes with a subscribers interest declaration. So this one is used to trigger data route computation. The route will be computed both in the declarer node, and in the router to which it is connected.