### PR TITLE
Fix client and peer queryable distance

### DIFF
--- a/commons/zenoh-protocol/src/network/declare.rs
+++ b/commons/zenoh-protocol/src/network/declare.rs
@@ -456,7 +456,7 @@ pub mod queryable {
         #[derive(Debug, Clone, Copy, PartialEq, Eq)]
         pub struct QueryableInfoType {
             pub complete: bool, // Default false: incomplete
-            pub distance: u16,  // Default 0: no distance
+            pub distance: u16,  // Default 0: distance is null (e.g. intra-process communication)
         }
 
         impl QueryableInfoType {
@@ -557,7 +557,7 @@ pub mod token {
     /// +-+-+-+-+-+-+-+-+
     /// |Z|M|N|  D_TKN  |
     /// +---------------+
-    /// ~ token_id:z32  ~  
+    /// ~ token_id:z32  ~
     /// +---------------+
     /// ~ key_scope:z16 ~
     /// +---------------+
@@ -596,7 +596,7 @@ pub mod token {
     /// +-+-+-+-+-+-+-+-+
     /// |Z|X|X|  U_TKN  |
     /// +---------------+
-    /// ~ token_id:z32  ~  
+    /// ~ token_id:z32  ~
     /// +---------------+
     /// ~  [decl_exts]  ~  if Z==1
     /// +---------------+

--- a/zenoh/src/net/routing/dispatcher/face.rs
+++ b/zenoh/src/net/routing/dispatcher/face.rs
@@ -60,6 +60,8 @@ pub(crate) struct InterestState {
     pub(crate) finalized: bool,
 }
 
+pub(crate) type FaceId = usize;
+
 pub struct FaceState {
     pub(crate) id: usize,
     pub(crate) zid: ZenohIdProto,

--- a/zenoh/src/net/routing/hat/client/queries.rs
+++ b/zenoh/src/net/routing/hat/client/queries.rs
@@ -407,16 +407,9 @@ impl HatQueriesTrait for HatCode {
         for mres in matches.iter() {
             let mres = mres.upgrade().unwrap();
             let complete = DEFAULT_INCLUDER.includes(mres.expr().as_bytes(), key_expr.as_bytes());
-            for (sid, context) in &mres.session_ctxs {
-                let key_expr = Resource::get_best_key(expr.prefix, expr.suffix, *sid);
-                if let Some(qabl_info) = context.qabl.as_ref() {
-                    route.push(QueryTargetQabl {
-                        direction: (context.face.clone(), key_expr.to_owned(), NodeId::default()),
-                        info: Some(QueryableInfoType {
-                            complete: complete && qabl_info.complete,
-                            distance: 1,
-                        }),
-                    });
+            for face_ctx in &mres.session_ctxs {
+                if let Some(qabl) = QueryTargetQabl::new(face_ctx, expr, complete) {
+                    route.push(qabl);
                 }
             }
         }

--- a/zenoh/src/net/routing/hat/linkstate_peer/queries.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/queries.rs
@@ -1028,21 +1028,10 @@ impl HatQueriesTrait for HatCode {
                 complete,
             );
 
-            for (sid, context) in &mres.session_ctxs {
-                if source_type == WhatAmI::Client || context.face.whatami == WhatAmI::Client {
-                    let key_expr = Resource::get_best_key(expr.prefix, expr.suffix, *sid);
-                    if let Some(qabl_info) = context.qabl.as_ref() {
-                        route.push(QueryTargetQabl {
-                            direction: (
-                                context.face.clone(),
-                                key_expr.to_owned(),
-                                NodeId::default(),
-                            ),
-                            info: Some(QueryableInfoType {
-                                complete: complete && qabl_info.complete,
-                                distance: 1,
-                            }),
-                        });
+            for face_ctx @ (_, ctx) in &mres.session_ctxs {
+                if source_type == WhatAmI::Client || ctx.face.whatami == WhatAmI::Client {
+                    if let Some(qabl) = QueryTargetQabl::new(face_ctx, expr, complete) {
+                        route.push(qabl);
                     }
                 }
             }

--- a/zenoh/src/net/routing/hat/p2p_peer/queries.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/queries.rs
@@ -674,21 +674,10 @@ impl HatQueriesTrait for HatCode {
         for mres in matches.iter() {
             let mres = mres.upgrade().unwrap();
             let complete = DEFAULT_INCLUDER.includes(mres.expr().as_bytes(), key_expr.as_bytes());
-            for (sid, context) in &mres.session_ctxs {
-                if source_type == WhatAmI::Client || context.face.whatami == WhatAmI::Client {
-                    let key_expr = Resource::get_best_key(expr.prefix, expr.suffix, *sid);
-                    if let Some(qabl_info) = context.qabl.as_ref() {
-                        route.push(QueryTargetQabl {
-                            direction: (
-                                context.face.clone(),
-                                key_expr.to_owned(),
-                                NodeId::default(),
-                            ),
-                            info: Some(QueryableInfoType {
-                                complete: complete && qabl_info.complete,
-                                distance: 1,
-                            }),
-                        });
+            for face_ctx @ (_, ctx) in &mres.session_ctxs {
+                if source_type == WhatAmI::Client || ctx.face.whatami == WhatAmI::Client {
+                    if let Some(qabl) = QueryTargetQabl::new(face_ctx, expr, complete) {
+                        route.push(qabl);
                     }
                 }
             }

--- a/zenoh/src/net/routing/hat/router/queries.rs
+++ b/zenoh/src/net/routing/hat/router/queries.rs
@@ -1497,21 +1497,10 @@ impl HatQueriesTrait for HatCode {
             }
 
             if master || source_type == WhatAmI::Router {
-                for (sid, context) in &mres.session_ctxs {
-                    if context.face.whatami != WhatAmI::Router {
-                        let key_expr = Resource::get_best_key(expr.prefix, expr.suffix, *sid);
-                        if let Some(qabl_info) = context.qabl.as_ref() {
-                            route.push(QueryTargetQabl {
-                                direction: (
-                                    context.face.clone(),
-                                    key_expr.to_owned(),
-                                    NodeId::default(),
-                                ),
-                                info: Some(QueryableInfoType {
-                                    complete: complete && qabl_info.complete,
-                                    distance: 1,
-                                }),
-                            });
+                for face_ctx @ (_, ctx) in &mres.session_ctxs {
+                    if ctx.face.whatami != WhatAmI::Router {
+                        if let Some(qabl) = QueryTargetQabl::new(face_ctx, expr, complete) {
+                            route.push(qabl);
                         }
                     }
                 }


### PR DESCRIPTION
When a client is connected to a router for instance, the router's queryables and the client's queryables were considered by the router to be of the same distance. But this behavior is not what we want; remote clients are clearly "farther away".