### PR TITLE
Fix multicast transports cleanup on `Session:close`

### DIFF
--- a/io/zenoh-transport/src/manager.rs
+++ b/io/zenoh-transport/src/manager.rs
@@ -481,6 +481,7 @@ impl TransportManager {
 
     pub async fn close(&self) {
         self.close_unicast().await;
+        self.close_multicast().await;
         self.task_controller.terminate_all_async().await;
     }
 


### PR DESCRIPTION
Transport manager was not cleaning-up multicast transports. This PR fixes it.

Closes https://github.com/eclipse-zenoh/zenoh/issues/2038