### PR TITLE
Apply clippy lints from `rustc 1.91.0-nightly`

### DIFF
--- a/commons/zenoh-buffers/src/zbuf.rs
+++ b/commons/zenoh-buffers/src/zbuf.rs
@@ -79,7 +79,7 @@ impl ZBuf {
     }
 
     #[inline]
-    fn opt_zslice_writer(&mut self) -> Option<ZSliceWriter> {
+    fn opt_zslice_writer(&mut self) -> Option<ZSliceWriter<'_>> {
         self.slices.last_mut().and_then(|s| s.writer())
     }
 }

--- a/commons/zenoh-buffers/src/zslice.rs
+++ b/commons/zenoh-buffers/src/zslice.rs
@@ -142,7 +142,7 @@ impl ZSlice {
     // so it should stay in the same module.
     // See https://github.com/eclipse-zenoh/zenoh/pull/1289#discussion_r1701796640
     #[inline]
-    pub(crate) fn writer(&mut self) -> Option<ZSliceWriter> {
+    pub(crate) fn writer(&mut self) -> Option<ZSliceWriter<'_>> {
         let vec = Arc::get_mut(&mut self.buf)?
             .as_any_mut()
             .downcast_mut::<Vec<u8>>()?;

--- a/commons/zenoh-collections/src/int_hash_map.rs
+++ b/commons/zenoh-collections/src/int_hash_map.rs
@@ -62,7 +62,7 @@ impl<K: Copy + Into<usize> + TryFrom<usize>, V> IntHashMap<K, V> {
     }
 
     #[inline]
-    pub fn iter(&self) -> Iter<K, V> {
+    pub fn iter(&self) -> Iter<'_, K, V> {
         match self {
             Self::Vec { vec, .. } => Iter::Vec(vec.iter()),
             Self::Map(map) => Iter::Map(map.iter()),
@@ -70,7 +70,7 @@ impl<K: Copy + Into<usize> + TryFrom<usize>, V> IntHashMap<K, V> {
     }
 
     #[inline]
-    pub fn values(&self) -> Values<K, V> {
+    pub fn values(&self) -> Values<'_, K, V> {
         match self {
             Self::Vec { vec, .. } => Values::Vec(vec.iter()),
             Self::Map(map) => Values::Map(map.values()),
@@ -78,7 +78,7 @@ impl<K: Copy + Into<usize> + TryFrom<usize>, V> IntHashMap<K, V> {
     }
 
     #[inline]
-    pub fn values_mut(&mut self) -> ValuesMut<K, V> {
+    pub fn values_mut(&mut self) -> ValuesMut<'_, K, V> {
         match self {
             Self::Vec { vec, .. } => ValuesMut::Vec(vec.iter_mut()),
             Self::Map(map) => ValuesMut::Map(map.values_mut()),
@@ -165,7 +165,7 @@ impl<K: Copy + Into<usize> + TryFrom<usize> + Eq + Hash, V> IntHashMap<K, V> {
         }
     }
 
-    pub fn entry(&mut self, key: K) -> Entry<K, V> {
+    pub fn entry(&mut self, key: K) -> Entry<'_, K, V> {
         self.resize(key);
         match self {
             Self::Vec { vec, items } => Entry::Vec {

--- a/commons/zenoh-collections/src/single_or_vec.rs
+++ b/commons/zenoh-collections/src/single_or_vec.rs
@@ -163,7 +163,7 @@ impl<T> SingleOrVec<T> {
             SingleOrVecInner::Vec(v) => v.last_mut(),
         }
     }
-    pub fn drain<Range: RangeBounds<usize>>(&mut self, range: Range) -> Drain<T> {
+    pub fn drain<Range: RangeBounds<usize>>(&mut self, range: Range) -> Drain<'_, T> {
         match &mut self.0 {
             this @ SingleOrVecInner::Single(_) if range.contains(&0) => Drain {
                 inner: DrainInner::Single(this),

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -1174,7 +1174,7 @@ impl Config {
     pub fn get(
         &self,
         key: &str,
-    ) -> Result<<Self as ValidatedMapAssociatedTypes>::Accessor, GetError> {
+    ) -> Result<<Self as ValidatedMapAssociatedTypes<'_>>::Accessor, GetError> {
         <Self as ValidatedMap>::get(self, key)
     }
 

--- a/commons/zenoh-keyexpr/src/key_expr/borrowed.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/borrowed.rs
@@ -33,10 +33,10 @@ use super::{canon::Canonize, OwnedKeyExpr, OwnedNonWildKeyExpr};
 ///
 /// The exact key expression specification can be found [here](https://github.com/eclipse-zenoh/roadmap/blob/main/rfcs/ALL/Key%20Expressions.md). Here are the major lines:
 /// * Key expressions are conceptually a `/`-separated list of UTF-8 string typed chunks. These chunks are not allowed to be empty.
-/// * Key expressions must be valid UTF-8 strings.  
+/// * Key expressions must be valid UTF-8 strings.
 ///   Be aware that Zenoh does not perform UTF normalization for you, so get familiar with that concept if your key expression contains glyphs that may have several unicode representation, such as accented characters.
 /// * Key expressions may never start or end with `'/'`, nor contain `"//"` or any of the following characters: `#$?`
-/// * Key expression must be in canon-form (this ensure that key expressions representing the same set are always the same string).  
+/// * Key expression must be in canon-form (this ensure that key expressions representing the same set are always the same string).
 ///   Note that safe constructors will perform canonization for you if this can be done without extraneous allocations.
 ///
 /// Since Key Expressions define sets of keys, you may want to be aware of the hierarchy of [relations](keyexpr::relation_to) between such sets:
@@ -183,12 +183,12 @@ impl keyexpr {
     }
 
     /// Remove the specified `prefix` from `self`.
-    /// The result is a list of `keyexpr`, since there might be several ways for the prefix to match the beginning of the `self` key expression.  
-    /// For instance, if `self` is `"a/**/c/*" and `prefix` is `a/b/c` then:  
+    /// The result is a list of `keyexpr`, since there might be several ways for the prefix to match the beginning of the `self` key expression.
+    /// For instance, if `self` is `"a/**/c/*" and `prefix` is `a/b/c` then:
     ///   - the `prefix` matches `"a/**/c"` leading to a result of `"*"` when stripped from `self`
     ///   - the `prefix` matches `"a/**"` leading to a result of `"**/c/*"` when stripped from `self`
     ///
-    /// So the result is `["*", "**/c/*"]`.  
+    /// So the result is `["*", "**/c/*"]`.
     /// If `prefix` cannot match the beginning of `self`, an empty list is reuturned.
     ///
     /// See below more examples.
@@ -435,10 +435,10 @@ impl keyexpr {
 
     #[cfg(feature = "internal")]
     #[doc(hidden)]
-    pub const fn chunks(&self) -> Chunks {
+    pub const fn chunks(&self) -> Chunks<'_> {
         self.chunks_impl()
     }
-    pub(crate) const fn chunks_impl(&self) -> Chunks {
+    pub(crate) const fn chunks_impl(&self) -> Chunks<'_> {
         Chunks {
             inner: self.as_str(),
         }
@@ -454,13 +454,13 @@ impl keyexpr {
     pub(crate) fn first_byte(&self) -> u8 {
         unsafe { *self.as_bytes().get_unchecked(0) }
     }
-    pub(crate) fn iter_splits_ltr(&self) -> SplitsLeftToRight {
+    pub(crate) fn iter_splits_ltr(&self) -> SplitsLeftToRight<'_> {
         SplitsLeftToRight {
             inner: self,
             index: 0,
         }
     }
-    pub(crate) fn iter_splits_rtl(&self) -> SplitsRightToLeft {
+    pub(crate) fn iter_splits_rtl(&self) -> SplitsRightToLeft<'_> {
         SplitsRightToLeft {
             inner: self,
             index: self.len(),

--- a/commons/zenoh-keyexpr/src/key_expr/intersect/mod.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/intersect/mod.rs
@@ -38,22 +38,22 @@ pub trait Intersector<Left, Right> {
 }
 
 pub(crate) mod restriction {
-    use core::ops::Deref;
+    // use core::ops::Deref;
 
-    #[repr(transparent)]
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct NoBigWilds<T>(pub T);
+    // #[repr(transparent)]
+    // #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    // pub struct NoBigWilds<T>(pub T);
     #[repr(transparent)]
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct NoSubWilds<T>(pub T);
 
-    impl<T> Deref for NoBigWilds<T> {
-        type Target = T;
+    // impl<T> Deref for NoBigWilds<T> {
+    //     type Target = T;
 
-        fn deref(&self) -> &Self::Target {
-            &self.0
-        }
-    }
+    //     fn deref(&self) -> &Self::Target {
+    //         &self.0
+    //     }
+    // }
 }
 #[repr(u8)]
 enum MatchComplexity {

--- a/commons/zenoh-protocol/src/core/endpoint.rs
+++ b/commons/zenoh-protocol/src/core/endpoint.rs
@@ -517,7 +517,7 @@ impl EndPoint {
         self.inner.as_str()
     }
 
-    pub fn split(&self) -> (Protocol, Address, Metadata, Config) {
+    pub fn split(&self) -> (Protocol<'_>, Address<'_>, Metadata<'_>, Config<'_>) {
         (
             self.protocol(),
             self.address(),
@@ -526,35 +526,35 @@ impl EndPoint {
         )
     }
 
-    pub fn protocol(&self) -> Protocol {
+    pub fn protocol(&self) -> Protocol<'_> {
         Protocol(protocol(self.inner.as_str()))
     }
 
-    pub fn protocol_mut(&mut self) -> ProtocolMut {
+    pub fn protocol_mut(&mut self) -> ProtocolMut<'_> {
         ProtocolMut(self)
     }
 
-    pub fn address(&self) -> Address {
+    pub fn address(&self) -> Address<'_> {
         Address(address(self.inner.as_str()))
     }
 
-    pub fn address_mut(&mut self) -> AddressMut {
+    pub fn address_mut(&mut self) -> AddressMut<'_> {
         AddressMut(self)
     }
 
-    pub fn metadata(&self) -> Metadata {
+    pub fn metadata(&self) -> Metadata<'_> {
         Metadata(metadata(self.inner.as_str()))
     }
 
-    pub fn metadata_mut(&mut self) -> MetadataMut {
+    pub fn metadata_mut(&mut self) -> MetadataMut<'_> {
         MetadataMut(self)
     }
 
-    pub fn config(&self) -> Config {
+    pub fn config(&self) -> Config<'_> {
         Config(config(self.inner.as_str()))
     }
 
-    pub fn config_mut(&mut self) -> ConfigMut {
+    pub fn config_mut(&mut self) -> ConfigMut<'_> {
         ConfigMut(self)
     }
 

--- a/commons/zenoh-protocol/src/core/locator.rs
+++ b/commons/zenoh-protocol/src/core/locator.rs
@@ -37,27 +37,27 @@ impl Locator {
         Ok(Self(ep))
     }
 
-    pub fn protocol(&self) -> Protocol {
+    pub fn protocol(&self) -> Protocol<'_> {
         self.0.protocol()
     }
 
-    pub fn protocol_mut(&mut self) -> ProtocolMut {
+    pub fn protocol_mut(&mut self) -> ProtocolMut<'_> {
         self.0.protocol_mut()
     }
 
-    pub fn address(&self) -> Address {
+    pub fn address(&self) -> Address<'_> {
         self.0.address()
     }
 
-    pub fn address_mut(&mut self) -> AddressMut {
+    pub fn address_mut(&mut self) -> AddressMut<'_> {
         self.0.address_mut()
     }
 
-    pub fn metadata(&self) -> Metadata {
+    pub fn metadata(&self) -> Metadata<'_> {
         self.0.metadata()
     }
 
-    pub fn metadata_mut(&mut self) -> MetadataMut {
+    pub fn metadata_mut(&mut self) -> MetadataMut<'_> {
         self.0.metadata_mut()
     }
 

--- a/commons/zenoh-protocol/src/core/mod.rs
+++ b/commons/zenoh-protocol/src/core/mod.rs
@@ -540,9 +540,9 @@ impl FromStr for Reliability {
         } else if desc == Reliability::Reliable as u8 {
             Ok(Reliability::Reliable)
         } else {
-            return Err(InvalidReliability {
+            Err(InvalidReliability {
                 found: s.to_string(),
-            });
+            })
         }
     }
 }

--- a/commons/zenoh-protocol/src/network/mod.rs
+++ b/commons/zenoh-protocol/src/network/mod.rs
@@ -122,7 +122,7 @@ pub struct NetworkMessageMut<'a> {
 
 pub trait NetworkMessageExt {
     #[doc(hidden)]
-    fn body(&self) -> NetworkBodyRef;
+    fn body(&self) -> NetworkBodyRef<'_>;
 
     #[doc(hidden)]
     fn reliability(&self) -> Reliability;
@@ -177,7 +177,7 @@ pub trait NetworkMessageExt {
     }
 
     #[inline]
-    fn wire_expr(&self) -> Option<&WireExpr> {
+    fn wire_expr(&self) -> Option<&WireExpr<'_>> {
         match &self.body() {
             NetworkBodyRef::Push(m) => Some(&m.wire_expr),
             NetworkBodyRef::Request(m) => Some(&m.wire_expr),
@@ -200,7 +200,7 @@ pub trait NetworkMessageExt {
     }
 
     #[inline]
-    fn as_ref(&self) -> NetworkMessageRef {
+    fn as_ref(&self) -> NetworkMessageRef<'_> {
         NetworkMessageRef {
             body: self.body(),
             reliability: self.reliability(),
@@ -225,7 +225,7 @@ pub trait NetworkMessageExt {
 }
 
 impl NetworkMessageExt for NetworkMessage {
-    fn body(&self) -> NetworkBodyRef {
+    fn body(&self) -> NetworkBodyRef<'_> {
         match &self.body {
             NetworkBody::Push(body) => NetworkBodyRef::Push(body),
             NetworkBody::Request(body) => NetworkBodyRef::Request(body),
@@ -243,7 +243,7 @@ impl NetworkMessageExt for NetworkMessage {
 }
 
 impl NetworkMessageExt for NetworkMessageRef<'_> {
-    fn body(&self) -> NetworkBodyRef {
+    fn body(&self) -> NetworkBodyRef<'_> {
         self.body
     }
 
@@ -253,7 +253,7 @@ impl NetworkMessageExt for NetworkMessageRef<'_> {
 }
 
 impl NetworkMessageExt for NetworkMessageMut<'_> {
-    fn body(&self) -> NetworkBodyRef {
+    fn body(&self) -> NetworkBodyRef<'_> {
         match &self.body {
             NetworkBodyMut::Push(body) => NetworkBodyRef::Push(body),
             NetworkBodyMut::Request(body) => NetworkBodyRef::Request(body),
@@ -291,7 +291,7 @@ impl NetworkMessage {
     }
 
     #[inline]
-    pub fn as_mut(&mut self) -> NetworkMessageMut {
+    pub fn as_mut(&mut self) -> NetworkMessageMut<'_> {
         let body = match &mut self.body {
             NetworkBody::Push(body) => NetworkBodyMut::Push(body),
             NetworkBody::Request(body) => NetworkBodyMut::Request(body),
@@ -310,7 +310,7 @@ impl NetworkMessage {
 
 impl NetworkMessageMut<'_> {
     #[inline]
-    pub fn as_mut(&mut self) -> NetworkMessageMut {
+    pub fn as_mut(&mut self) -> NetworkMessageMut<'_> {
         let body = match &mut self.body {
             NetworkBodyMut::Push(body) => NetworkBodyMut::Push(body),
             NetworkBodyMut::Request(body) => NetworkBodyMut::Request(body),

--- a/commons/zenoh-shm/src/api/provider/shm_provider.rs
+++ b/commons/zenoh-shm/src/api/provider/shm_provider.rs
@@ -748,7 +748,7 @@ where
 {
     /// Rich interface for making allocations
     #[zenoh_macros::unstable_doc]
-    pub fn alloc(&self, size: usize) -> AllocLayoutSizedBuilder<Backend> {
+    pub fn alloc(&self, size: usize) -> AllocLayoutSizedBuilder<'_, Backend> {
         AllocLayoutSizedBuilder::new(self, size)
     }
 

--- a/plugins/zenoh-backend-traits/src/config.rs
+++ b/plugins/zenoh-backend-traits/src/config.rs
@@ -391,7 +391,7 @@ impl VolumeConfig {
                 required,
                 rest: config
                     .iter()
-                    .filter(|&(k, _v)| (!["__path__", "__required__"].contains(&k.as_str())))
+                    .filter(|&(k, _v)| !["__path__", "__required__"].contains(&k.as_str()))
                     .map(|(k, v)| (k.clone(), v.clone()))
                     .collect(),
             })

--- a/plugins/zenoh-backend-traits/src/lib.rs
+++ b/plugins/zenoh-backend-traits/src/lib.rs
@@ -207,7 +207,7 @@ impl StructVersion for VolumeInstance {
 }
 
 impl PluginControl for VolumeInstance {
-    fn plugins_status(&self, _names: &keyexpr) -> Vec<PluginStatusRec> {
+    fn plugins_status(&self, _names: &keyexpr) -> Vec<PluginStatusRec<'_>> {
         Vec::new()
     }
 }

--- a/plugins/zenoh-plugin-storage-manager/src/lib.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/lib.rs
@@ -302,7 +302,7 @@ impl PluginControl for StorageRuntime {
     fn report(&self) -> PluginReport {
         PluginReport::default()
     }
-    fn plugins_status(&self, names: &keyexpr) -> Vec<PluginStatusRec> {
+    fn plugins_status(&self, names: &keyexpr) -> Vec<PluginStatusRec<'_>> {
         let guard = self.0.lock().unwrap();
         guard
             .plugins_manager

--- a/plugins/zenoh-plugin-storage-manager/src/replication/classification.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/replication/classification.rs
@@ -414,7 +414,7 @@ impl SubInterval {
     /// `Older` is returned.
     ///
     /// If this SubInterval contains no Event with the same key expression, `NotFound` is returned.
-    pub(crate) fn lookup(&self, event_to_lookup: &EventMetadata) -> EventLookup {
+    pub(crate) fn lookup(&self, event_to_lookup: &EventMetadata) -> EventLookup<'_> {
         match self.events.get(&event_to_lookup.log_key()) {
             Some(event) => {
                 if event.timestamp >= event_to_lookup.timestamp {

--- a/plugins/zenoh-plugin-trait/src/manager.rs
+++ b/plugins/zenoh-plugin-trait/src/manager.rs
@@ -313,7 +313,7 @@ impl<StartArgs: PluginStartArgs + 'static, Instance: PluginInstance + 'static>
 impl<StartArgs: PluginStartArgs + 'static, Instance: PluginInstance + 'static> PluginControl
     for PluginsManager<StartArgs, Instance>
 {
-    fn plugins_status(&self, names: &keyexpr) -> Vec<PluginStatusRec> {
+    fn plugins_status(&self, names: &keyexpr) -> Vec<PluginStatusRec<'_>> {
         tracing::debug!(
             "Plugin manager with prefix `{}` : requested plugins_status {:?}",
             self.default_lib_prefix,

--- a/plugins/zenoh-plugin-trait/src/plugin.rs
+++ b/plugins/zenoh-plugin-trait/src/plugin.rs
@@ -169,7 +169,7 @@ pub trait PluginControl {
     }
     /// Collects information of sub-plugins matching the `_names` key expression. The information is richer than the one returned by `report()`: it contains external information about the running plugin, such as its name, path on disk, load status, etc.
     /// Returns an empty list by default.
-    fn plugins_status(&self, _names: &keyexpr) -> Vec<PluginStatusRec> {
+    fn plugins_status(&self, _names: &keyexpr) -> Vec<PluginStatusRec<'_>> {
         Vec::new()
     }
 }

--- a/zenoh/src/api/bytes.rs
+++ b/zenoh/src/api/bytes.rs
@@ -113,7 +113,7 @@ impl ZBytes {
     /// In the case `ZBytes` contains non-contiguous regions of memory, an allocation and a copy
     /// will be done, that's why the method returns a [`Cow`].
     /// It's also possible to use [`ZBytes::slices`] instead to avoid this copy.
-    pub fn to_bytes(&self) -> Cow<[u8]> {
+    pub fn to_bytes(&self) -> Cow<'_, [u8]> {
         self.0.contiguous()
     }
 
@@ -123,7 +123,7 @@ impl ZBytes {
     /// will be done, that's why the method returns a [`Cow`].
     /// It's also possible to use [`ZBytes::slices`] instead to avoid this copy, but then the UTF8
     /// check has to be done manually.
-    pub fn try_to_string(&self) -> Result<Cow<str>, Utf8Error> {
+    pub fn try_to_string(&self) -> Result<Cow<'_, str>, Utf8Error> {
         Ok(match self.to_bytes() {
             Cow::Borrowed(s) => std::str::from_utf8(s)?.into(),
             Cow::Owned(v) => String::from_utf8(v).map_err(|err| err.utf8_error())?.into(),
@@ -186,7 +186,7 @@ impl ZBytes {
     /// let out: Vec<u8> = zbytes.slices().fold(Vec::new(), |mut b, x| { b.extend_from_slice(x); b });
     /// // The previous line is the equivalent of
     /// // let out: Vec<u8> = zbs.into();
-    /// assert_eq!(buf, out);    
+    /// assert_eq!(buf, out);
     /// ```
     ///
     /// The example below shows how the [`ZBytesWriter::append`] simply appends the slices of one [`ZBytes`]
@@ -346,7 +346,7 @@ impl std::io::Write for ZBytesWriter {
 /// let out: Vec<u8> = zbytes.slices().fold(Vec::new(), |mut b, x| { b.extend_from_slice(x); b });
 /// // The previous line is the equivalent of
 /// // let out: Vec<u8> = zbs.into();
-/// assert_eq!(buf, out);    
+/// assert_eq!(buf, out);
 /// ```
 #[derive(Debug)]
 pub struct ZBytesSliceIterator<'a>(ZBytesSliceIteratorInner<'a>);

--- a/zenoh/src/api/config.rs
+++ b/zenoh/src/api/config.rs
@@ -222,18 +222,18 @@ impl Notifier<Config> {
         }
     }
 
-    pub fn lock(&self) -> MutexGuard<Config> {
+    pub fn lock(&self) -> MutexGuard<'_, Config> {
         self.lock_config()
     }
 
-    fn lock_subscribers(&self) -> MutexGuard<Vec<flume::Sender<Notification>>> {
+    fn lock_subscribers(&self) -> MutexGuard<'_, Vec<flume::Sender<Notification>>> {
         self.inner
             .subscribers
             .lock()
             .expect("acquiring Notifier's subscribers Mutex should not fail")
     }
 
-    fn lock_config(&self) -> MutexGuard<Config> {
+    fn lock_config(&self) -> MutexGuard<'_, Config> {
         self.inner
             .inner
             .lock()

--- a/zenoh/src/api/plugins.rs
+++ b/zenoh/src/api/plugins.rs
@@ -46,7 +46,7 @@ impl PluginControl for RunningPlugin {
         self.as_ref().report()
     }
 
-    fn plugins_status(&self, names: &keyexpr) -> Vec<PluginStatusRec> {
+    fn plugins_status(&self, names: &keyexpr) -> Vec<PluginStatusRec<'_>> {
         self.as_ref().plugins_status(names)
     }
 }

--- a/zenoh/src/api/query.rs
+++ b/zenoh/src/api/query.rs
@@ -185,7 +185,7 @@ pub(crate) struct QueryState {
 }
 
 impl QueryState {
-    pub(crate) fn selector(&self) -> Selector {
+    pub(crate) fn selector(&self) -> Selector<'_> {
         Selector::borrowed(&self.key_expr, &self.parameters)
     }
 }

--- a/zenoh/src/net/routing/interceptor/mod.rs
+++ b/zenoh/src/net/routing/interceptor/mod.rs
@@ -91,7 +91,7 @@ pub(crate) trait InterceptorContext {
     fn face(&self) -> Option<Face>;
     fn full_expr(&self, msg: &NetworkMessageMut) -> Option<&str>;
     #[inline]
-    fn full_keyexpr(&self, msg: &NetworkMessageMut) -> Option<KeyExpr> {
+    fn full_keyexpr(&self, msg: &NetworkMessageMut) -> Option<KeyExpr<'_>> {
         let full_expr = self.full_expr(msg)?;
         KeyExpr::new(full_expr).ok()
     }
@@ -200,7 +200,7 @@ impl InterceptorContext for ChainContext<'_> {
         self.ctx.full_expr(msg)
     }
 
-    fn full_keyexpr(&self, msg: &NetworkMessageMut) -> Option<KeyExpr> {
+    fn full_keyexpr(&self, msg: &NetworkMessageMut) -> Option<KeyExpr<'_>> {
         self.ctx.full_keyexpr(msg)
     }
 

--- a/zenoh/src/net/tests/tables.rs
+++ b/zenoh/src/net/tests/tables.rs
@@ -506,7 +506,7 @@ impl ClientPrimitives {
     }
 
     #[allow(dead_code)]
-    fn get_last_key(&self) -> Option<WireExpr> {
+    fn get_last_key(&self) -> Option<WireExpr<'_>> {
         self.data.lock().unwrap().as_ref().cloned()
     }
 }


### PR DESCRIPTION
This is useful for two reasons:
1. The code coverage job step uses nightly Rust and is hard to read because of the many warnings (e.g. https://github.com/eclipse-zenoh/zenoh/actions/runs/16727083609/job/47345480281).
2. Using nightly Rust locally (e.g. for `-Zthreads=0`) is cumbersome.