### PR TITLE
Use inline tables for `package.metadata.deb.assets`

### DIFF
--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -145,7 +145,7 @@ features = ["shared-memory", "unstable"]
 rustdoc-args = ["--cfg", "doc_auto_cfg"]
 
 [package.metadata.deb]
-assets = [["../README.md", "644", "README.md"]]
+assets = [{ source = "../README.md", dest = "README.md", mode = "644" }]
 copyright = "2024 ZettaScale Technology"
 depends = "zenohd (=1.5.0), zenoh-plugin-rest (=1.5.0), zenoh-plugin-storage-manager (=1.5.0)"
 license-file = ["../LICENSE", "0"]

--- a/zenohd/Cargo.toml
+++ b/zenohd/Cargo.toml
@@ -55,11 +55,11 @@ rustc_version = { workspace = true }
 [package.metadata.deb]
 assets = [
   # binary
-  ["/usr/bin/", "755", "target/release/zenohd"],
+  { source = "target/release/zenohd", dest = "/usr/bin/", mode = "755" },
   # config
-  [".service/zenohd.json5", "/etc/zenohd/", "644"],
+  { source = ".service/zenohd.json5", dest = "/etc/zenohd/", mode = "644" },
   # service
-  [".service/zenohd.service", "/lib/systemd/system/zenohd.service", "644"],
+  { source = ".service/zenohd.service", dest = "/lib/systemd/system/zenohd.service", mode = "644" },
 ]
 copyright = "2024 ZettaScale Technology"
 depends = "$auto"


### PR DESCRIPTION
The introduction of Taplo in 9848cb2 broke the `assets` field as cargo-deb uses the ordering of the array to specify values of distinct kind: 'source', 'dest' and 'mode'.