### PR TITLE
Fix Clippy lints from Rust 1.89

### DIFF
--- a/commons/zenoh-core/src/macros.rs
+++ b/commons/zenoh-core/src/macros.rs
@@ -117,21 +117,21 @@ macro_rules! zasyncrecv {
 #[macro_export]
 macro_rules! zconfigurable {
     ($(#[$attr:meta])* static ref $N:ident : $T:ty = $e:expr; $($t:tt)*) => {
-        $crate::lazy_static!($(#[$attr])* static ref $N : $T = match option_env!(stringify!($N)) {
+        $(#[$attr])* $crate::lazy_static!(static ref $N : $T = match option_env!(stringify!($N)) {
             Some(value) => {value.parse().unwrap()}
             None => {$e}
         };) ;
         $crate::zconfigurable!($($t)*);
     };
     ($(#[$attr:meta])* pub static ref $N:ident : $T:ty = $e:expr; $($t:tt)*) => {
-        $crate::lazy_static!($(#[$attr])* pub static ref $N : $T = match option_env!(stringify!($N)) {
+        $(#[$attr])* $crate::lazy_static!(pub static ref $N : $T = match option_env!(stringify!($N)) {
             Some(value) => {value.parse().unwrap()}
             None => {$e}
         };) ;
         $crate::zconfigurable!($($t)*);
     };
     ($(#[$attr:meta])* pub ($($vis:tt)+) static ref $N:ident : $T:ty = $e:expr; $($t:tt)*) => {
-        $crate::lazy_static!($(#[$attr])* pub ($($vis)+) static ref $N : $T = match option_env!(stringify!($N)) {
+        $(#[$attr])* $crate::lazy_static!(pub ($($vis)+) static ref $N : $T = match option_env!(stringify!($N)) {
             Some(value) => {value.parse().unwrap()}
             None => {$e}
         };) ;

--- a/examples/examples/z_queryable_shm.rs
+++ b/examples/examples/z_queryable_shm.rs
@@ -118,7 +118,7 @@ fn parse_args() -> (Config, KeyExpr<'static>, String, bool) {
     (args.common.into(), args.key, args.payload, args.complete)
 }
 
-fn handle_bytes(bytes: &ZBytes) -> (&str, Cow<str>) {
+fn handle_bytes(bytes: &ZBytes) -> (&str, Cow<'_, str>) {
     // Determine buffer type for indication purpose
     let bytes_type = {
         // if Zenoh is built without SHM support, the only buffer type it can receive is RAW

--- a/examples/examples/z_sub_shm.rs
+++ b/examples/examples/z_sub_shm.rs
@@ -65,7 +65,7 @@ fn parse_args() -> (Config, KeyExpr<'static>) {
     (args.common.into(), args.key)
 }
 
-fn handle_bytes(bytes: &mut ZBytes) -> (&str, Cow<str>) {
+fn handle_bytes(bytes: &mut ZBytes) -> (&str, Cow<'_, str>) {
     // Determine buffer type for indication purpose
     let bytes_type = {
         // if Zenoh is built without SHM support, the only buffer type it can receive is RAW

--- a/io/zenoh-links/zenoh-link-unixsock_stream/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-unixsock_stream/src/lib.rs
@@ -38,17 +38,21 @@ pub use unicast::*;
 //       adopted in Zenoh and the usage of 16 bits in Zenoh to encode the
 //       payload length in byte-streamed, the UNIXSOCKSTREAM MTU is constrained to
 //       2^16 - 1 bytes (i.e., 65535).
+#[cfg(target_family = "unix")]
 const UNIXSOCKSTREAM_MAX_MTU: BatchSize = BatchSize::MAX;
 
 pub const UNIXSOCKSTREAM_LOCATOR_PREFIX: &str = "unixsock-stream";
 
+#[cfg(target_family = "unix")]
 const IS_RELIABLE: bool = true;
 
 zconfigurable! {
     // Default MTU (UNIXSOCKSTREAM PDU) in bytes.
+    #[cfg(target_family = "unix")]
     static ref UNIXSOCKSTREAM_DEFAULT_MTU: BatchSize = UNIXSOCKSTREAM_MAX_MTU;
     // Amount of time in microseconds to throttle the accept loop upon an error.
     // Default set to 100 ms.
+    #[cfg(target_family = "unix")]
     static ref UNIXSOCKSTREAM_ACCEPT_THROTTLE_TIME: u64 = 100_000;
 }
 

--- a/io/zenoh-links/zenoh-link-unixsock_stream/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-unixsock_stream/src/lib.rs
@@ -43,7 +43,6 @@ const UNIXSOCKSTREAM_MAX_MTU: BatchSize = BatchSize::MAX;
 
 pub const UNIXSOCKSTREAM_LOCATOR_PREFIX: &str = "unixsock-stream";
 
-#[cfg(target_family = "unix")]
 const IS_RELIABLE: bool = true;
 
 zconfigurable! {

--- a/io/zenoh-links/zenoh-link-unixsock_stream/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-unixsock_stream/src/lib.rs
@@ -22,11 +22,11 @@ use std::str::FromStr;
 use async_trait::async_trait;
 use zenoh_core::zconfigurable;
 use zenoh_link_commons::LocatorInspector;
-use zenoh_protocol::{
-    core::{endpoint::Address, Locator, Metadata, Reliability},
-    transport::BatchSize,
-};
+use zenoh_protocol::core::{endpoint::Address, Locator, Metadata, Reliability};
+#[cfg(target_family = "unix")]
+use zenoh_protocol::transport::BatchSize;
 use zenoh_result::ZResult;
+
 #[cfg(target_family = "unix")]
 mod unicast;
 #[cfg(target_family = "unix")]

--- a/plugins/zenoh-backend-traits/src/config.rs
+++ b/plugins/zenoh-backend-traits/src/config.rs
@@ -212,7 +212,7 @@ impl<S: Into<String> + AsRef<str>, V: AsObject> TryFrom<(S, &V)> for PluginConfi
         // TODO(fuzzypixelz): refactor this function's interface to get access to the configuration
         // source, this we can support spec syntax in the lib search dir.
         let backend_search_dirs = match value.get("backend_search_dirs") {
-            Some(serde_json::Value::String(path)) => LibSearchDirs::from_paths(&[path.clone()]),
+            Some(serde_json::Value::String(path)) => LibSearchDirs::from_paths(&[path.as_str()]),
             Some(serde_json::Value::Array(paths)) => {
                 let mut specs = Vec::with_capacity(paths.len());
                 for path in paths {


### PR DESCRIPTION
See https://rust-lang.github.io/rust-clippy/master/index.html#cloned_ref_to_slice_refs.