### PR TITLE
fix: consistently use the snake case

### DIFF
--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -99,7 +99,7 @@ pub struct TransportWeight {
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, Eq, PartialEq)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum InterceptorFlow {
     Egress,
     Ingress,
@@ -365,7 +365,7 @@ pub enum AclMessage {
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, Hash, PartialEq)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum Permission {
     Allow,
     Deny,

--- a/commons/zenoh-config/src/qos.rs
+++ b/commons/zenoh-config/src/qos.rs
@@ -51,7 +51,7 @@ pub struct PublisherQoSConfig {
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum CongestionControlConf {
     Drop,
     Block,


### PR DESCRIPTION
This PR fixes the incorrect format, such as requiring `congestion_control: "blockfirst"`. The desired format should be "block_first".