### PR TITLE
fix: narrow SessionState lock guard scope when MatchingListener drop

### DIFF
--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -2017,11 +2017,16 @@ impl SessionInner {
     }
 
     pub(crate) fn undeclare_matches_listener_inner(&self, sid: Id) -> ZResult<()> {
-        let mut state = zwrite!(self.state);
-        if state.primitives.is_none() {
-            return Ok(());
-        }
-        if let Some(state) = state.matching_listeners.remove(&sid) {
+        let state = {
+            let mut state = zwrite!(self.state);
+            if state.primitives.is_none() {
+                return Ok(());
+            }
+
+            state.matching_listeners.remove(&sid)
+        };
+
+        if let Some(state) = state {
             trace!("undeclare_matches_listener_inner({:?})", state);
             Ok(())
         } else {


### PR DESCRIPTION
Avoid the situation where the lock range of SessionInner held by the MatchingListener variable in its drop overlaps with the lock of SessionInner that may be held by the Callback field of MatchingListenerState.