### PR TITLE
refactor RoutingExpr to avoid useless allocation

### DIFF
--- a/zenoh/src/net/routing/dispatcher/resource.rs
+++ b/zenoh/src/net/routing/dispatcher/resource.rs
@@ -61,14 +61,14 @@ pub(crate) struct QueryTargetQabl {
 
 impl QueryTargetQabl {
     pub(crate) fn new(
-        (fid, ctx): (&FaceId, &Arc<SessionContext>),
-        expr: &mut RoutingExpr,
+        (&fid, ctx): (&FaceId, &Arc<SessionContext>),
+        expr: &RoutingExpr,
         complete: bool,
     ) -> Option<Self> {
         let qabl = ctx.qabl?;
-        let key_expr = Resource::get_best_key(expr.prefix, expr.suffix, *fid);
+        let wire_expr = expr.get_best_key(fid);
         Some(Self {
-            direction: (ctx.face.clone(), key_expr.to_owned(), NodeId::default()),
+            direction: (ctx.face.clone(), wire_expr.to_owned(), NodeId::default()),
             info: Some(QueryableInfoType {
                 complete: complete && qabl.complete,
                 // NOTE: local client faces are nearer than remote client faces
@@ -522,17 +522,25 @@ impl Resource {
     }
 
     #[inline]
-    pub fn get_resource(mut from: &Arc<Resource>, mut suffix: &str) -> Option<Arc<Resource>> {
+    pub fn get_resource_ref<'a>(
+        mut from: &'a Arc<Resource>,
+        mut suffix: &str,
+    ) -> Option<&'a Arc<Resource>> {
         if !suffix.is_empty() && !suffix.starts_with('/') {
             if let Some(parent) = &from.parent {
-                return Resource::get_resource(parent, &[from.suffix(), suffix].concat());
+                return Resource::get_resource_ref(parent, &[from.suffix(), suffix].concat());
             }
         }
         // do not use recursion as the tree may have arbitrary depth
         while let Some((chunk, rest)) = Self::split_first_chunk(suffix) {
             (from, suffix) = (from.children.get(chunk)?, rest);
         }
-        Some(from.clone())
+        Some(from)
+    }
+
+    #[inline]
+    pub fn get_resource(from: &Arc<Resource>, suffix: &str) -> Option<Arc<Resource>> {
+        Self::get_resource_ref(from, suffix).cloned()
     }
 
     /// Split the suffix at the next '/' (after leading one), returning None if the suffix is empty.

--- a/zenoh/src/net/routing/hat/client/mod.rs
+++ b/zenoh/src/net/routing/hat/client/mod.rs
@@ -249,7 +249,7 @@ impl HatBaseTrait for HatCode {
     }
 
     #[inline]
-    fn ingress_filter(&self, _tables: &Tables, _face: &FaceState, _expr: &mut RoutingExpr) -> bool {
+    fn ingress_filter(&self, _tables: &Tables, _face: &FaceState, _expr: &RoutingExpr) -> bool {
         true
     }
 
@@ -259,7 +259,7 @@ impl HatBaseTrait for HatCode {
         _tables: &Tables,
         src_face: &FaceState,
         out_face: &Arc<FaceState>,
-        _expr: &mut RoutingExpr,
+        _expr: &RoutingExpr,
     ) -> bool {
         src_face.id != out_face.id
             && out_face.mcast_group.is_none()

--- a/zenoh/src/net/routing/hat/client/queries.rs
+++ b/zenoh/src/net/routing/hat/client/queries.rs
@@ -19,10 +19,7 @@ use std::{
 
 use zenoh_protocol::{
     core::{
-        key_expr::{
-            include::{Includer, DEFAULT_INCLUDER},
-            OwnedKeyExpr,
-        },
+        key_expr::include::{Includer, DEFAULT_INCLUDER},
         WhatAmI,
     },
     network::declare::{
@@ -346,28 +343,20 @@ impl HatQueriesTrait for HatCode {
     fn compute_query_route(
         &self,
         tables: &Tables,
-        expr: &mut RoutingExpr,
+        expr: &RoutingExpr,
         source: NodeId,
         source_type: WhatAmI,
     ) -> Arc<QueryTargetQablSet> {
         let mut route = QueryTargetQablSet::new();
-        let key_expr = expr.full_expr();
-        if key_expr.ends_with('/') {
+        let Some(key_expr) = expr.key_expr() else {
             return EMPTY_ROUTE.clone();
-        }
+        };
         tracing::trace!(
             "compute_query_route({}, {:?}, {:?})",
             key_expr,
             source,
             source_type
         );
-        let key_expr = match OwnedKeyExpr::try_from(key_expr) {
-            Ok(ke) => ke,
-            Err(e) => {
-                tracing::warn!("Invalid KE reached the system: {}", e);
-                return EMPTY_ROUTE.clone();
-            }
-        };
 
         if source_type == WhatAmI::Client {
             for face in tables
@@ -381,28 +370,28 @@ impl HatQueriesTrait for HatCode {
                         && interest
                             .res
                             .as_ref()
-                            .map(|res| KeyExpr::keyexpr_include(res.expr(), expr.full_expr()))
+                            .map(|res| KeyExpr::keyexpr_include(res.expr(), key_expr))
                             .unwrap_or(true)
                 }) || face_hat!(face)
                     .remote_qabls
                     .values()
-                    .any(|qbl| KeyExpr::keyexpr_intersect(qbl.expr(), expr.full_expr()))
+                    .any(|qbl| KeyExpr::keyexpr_intersect(qbl.expr(), key_expr))
                 {
-                    let key_expr = Resource::get_best_key(expr.prefix, expr.suffix, face.id);
+                    let wire_expr = expr.get_best_key(face.id);
                     route.push(QueryTargetQabl {
-                        direction: (face.clone(), key_expr.to_owned(), NodeId::default()),
+                        direction: (face.clone(), wire_expr.to_owned(), NodeId::default()),
                         info: None,
                     });
                 }
             }
         }
 
-        let res = Resource::get_resource(expr.prefix, expr.suffix);
-        let matches = res
+        let matches = expr
+            .resource()
             .as_ref()
             .and_then(|res| res.context.as_ref())
             .map(|ctx| Cow::from(&ctx.matches))
-            .unwrap_or_else(|| Cow::from(Resource::get_matches(tables, &key_expr)));
+            .unwrap_or_else(|| Cow::from(Resource::get_matches(tables, key_expr)));
 
         for mres in matches.iter() {
             let mres = mres.upgrade().unwrap();

--- a/zenoh/src/net/routing/hat/linkstate_peer/mod.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/mod.rs
@@ -450,7 +450,7 @@ impl HatBaseTrait for HatCode {
     }
 
     #[inline]
-    fn ingress_filter(&self, _tables: &Tables, _face: &FaceState, _expr: &mut RoutingExpr) -> bool {
+    fn ingress_filter(&self, _tables: &Tables, _face: &FaceState, _expr: &RoutingExpr) -> bool {
         true
     }
 
@@ -460,7 +460,7 @@ impl HatBaseTrait for HatCode {
         _tables: &Tables,
         src_face: &FaceState,
         out_face: &Arc<FaceState>,
-        _expr: &mut RoutingExpr,
+        _expr: &RoutingExpr,
     ) -> bool {
         src_face.id != out_face.id
             && (out_face.mcast_group.is_none() || src_face.mcast_group.is_none())

--- a/zenoh/src/net/routing/hat/linkstate_peer/queries.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/queries.rs
@@ -20,10 +20,7 @@ use std::{
 use petgraph::graph::NodeIndex;
 use zenoh_protocol::{
     core::{
-        key_expr::{
-            include::{Includer, DEFAULT_INCLUDER},
-            OwnedKeyExpr,
-        },
+        key_expr::include::{Includer, DEFAULT_INCLUDER},
         WhatAmI, ZenohIdProto,
     },
     network::{
@@ -699,7 +696,7 @@ pub(super) fn queries_tree_change(tables: &mut Tables, new_children: &[Vec<NodeI
 #[inline]
 fn insert_target_for_qabls(
     route: &mut QueryTargetQablSet,
-    expr: &mut RoutingExpr,
+    expr: &RoutingExpr,
     tables: &Tables,
     net: &Network,
     source: NodeId,
@@ -715,10 +712,9 @@ fn insert_target_for_qabls(
                         if net.graph.contains_node(direction) {
                             if let Some(face) = tables.get_face(&net.graph[direction].zid) {
                                 if net.distances.len() > qabl_idx.index() {
-                                    let key_expr =
-                                        Resource::get_best_key(expr.prefix, expr.suffix, face.id);
+                                    let wire_expr = expr.get_best_key(face.id);
                                     route.push(QueryTargetQabl {
-                                        direction: (face.clone(), key_expr.to_owned(), source),
+                                        direction: (face.clone(), wire_expr.to_owned(), source),
                                         info: Some(QueryableInfoType {
                                             complete: complete && qabl_info.complete,
                                             distance: net.distances[qabl_idx.index()] as u16,
@@ -980,34 +976,26 @@ impl HatQueriesTrait for HatCode {
     fn compute_query_route(
         &self,
         tables: &Tables,
-        expr: &mut RoutingExpr,
+        expr: &RoutingExpr,
         source: NodeId,
         source_type: WhatAmI,
     ) -> Arc<QueryTargetQablSet> {
         let mut route = QueryTargetQablSet::new();
-        let key_expr = expr.full_expr();
-        if key_expr.ends_with('/') {
+        let Some(key_expr) = expr.key_expr() else {
             return EMPTY_ROUTE.clone();
-        }
+        };
         tracing::trace!(
             "compute_query_route({}, {:?}, {:?})",
             key_expr,
             source,
             source_type
         );
-        let key_expr = match OwnedKeyExpr::try_from(key_expr) {
-            Ok(ke) => ke,
-            Err(e) => {
-                tracing::warn!("Invalid KE reached the system: {}", e);
-                return EMPTY_ROUTE.clone();
-            }
-        };
-        let res = Resource::get_resource(expr.prefix, expr.suffix);
-        let matches = res
+        let matches = expr
+            .resource()
             .as_ref()
             .and_then(|res| res.context.as_ref())
             .map(|ctx| Cow::from(&ctx.matches))
-            .unwrap_or_else(|| Cow::from(Resource::get_matches(tables, &key_expr)));
+            .unwrap_or_else(|| Cow::from(Resource::get_matches(tables, key_expr)));
 
         for mres in matches.iter() {
             let mres = mres.upgrade().unwrap();

--- a/zenoh/src/net/routing/hat/mod.rs
+++ b/zenoh/src/net/routing/hat/mod.rs
@@ -122,14 +122,14 @@ pub(crate) trait HatBaseTrait {
         routing_context: NodeId,
     ) -> NodeId;
 
-    fn ingress_filter(&self, tables: &Tables, face: &FaceState, expr: &mut RoutingExpr) -> bool;
+    fn ingress_filter(&self, tables: &Tables, face: &FaceState, expr: &RoutingExpr) -> bool;
 
     fn egress_filter(
         &self,
         tables: &Tables,
         src_face: &FaceState,
         out_face: &Arc<FaceState>,
-        expr: &mut RoutingExpr,
+        expr: &RoutingExpr,
     ) -> bool;
 
     fn info(&self, tables: &Tables, kind: WhatAmI) -> String;
@@ -215,7 +215,7 @@ pub(crate) trait HatPubSubTrait {
     fn compute_data_route(
         &self,
         tables: &Tables,
-        expr: &mut RoutingExpr,
+        expr: &RoutingExpr,
         source: NodeId,
         source_type: WhatAmI,
     ) -> Arc<Route>;
@@ -256,7 +256,7 @@ pub(crate) trait HatQueriesTrait {
     fn compute_query_route(
         &self,
         tables: &Tables,
-        expr: &mut RoutingExpr,
+        expr: &RoutingExpr,
         source: NodeId,
         source_type: WhatAmI,
     ) -> Arc<QueryTargetQablSet>;

--- a/zenoh/src/net/routing/hat/p2p_peer/mod.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/mod.rs
@@ -367,7 +367,7 @@ impl HatBaseTrait for HatCode {
     }
 
     #[inline]
-    fn ingress_filter(&self, _tables: &Tables, _face: &FaceState, _expr: &mut RoutingExpr) -> bool {
+    fn ingress_filter(&self, _tables: &Tables, _face: &FaceState, _expr: &RoutingExpr) -> bool {
         true
     }
 
@@ -377,7 +377,7 @@ impl HatBaseTrait for HatCode {
         _tables: &Tables,
         src_face: &FaceState,
         out_face: &Arc<FaceState>,
-        _expr: &mut RoutingExpr,
+        _expr: &RoutingExpr,
     ) -> bool {
         src_face.id != out_face.id
             && (out_face.mcast_group.is_none()

--- a/zenoh/src/net/routing/hat/p2p_peer/pubsub.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/pubsub.rs
@@ -18,7 +18,7 @@ use std::{
 };
 
 use zenoh_protocol::{
-    core::{key_expr::OwnedKeyExpr, WhatAmI},
+    core::WhatAmI,
     network::{
         declare::{
             common::ext::WireExprType, ext, Declare, DeclareBody, DeclareSubscriber, SubscriberId,
@@ -611,28 +611,20 @@ impl HatPubSubTrait for HatCode {
     fn compute_data_route(
         &self,
         tables: &Tables,
-        expr: &mut RoutingExpr,
+        expr: &RoutingExpr,
         source: NodeId,
         source_type: WhatAmI,
     ) -> Arc<Route> {
         let mut route = RouteBuilder::new();
-        let key_expr = expr.full_expr();
-        if key_expr.ends_with('/') {
+        let Some(key_expr) = expr.key_expr() else {
             return Arc::new(route.build());
-        }
+        };
         tracing::trace!(
             "compute_data_route({}, {:?}, {:?})",
             key_expr,
             source,
             source_type
         );
-        let key_expr = match OwnedKeyExpr::try_from(key_expr) {
-            Ok(ke) => ke,
-            Err(e) => {
-                tracing::warn!("Invalid KE reached the system: {}", e);
-                return Arc::new(route.build());
-            }
-        };
 
         if source_type == WhatAmI::Client {
             for face in tables
@@ -646,16 +638,16 @@ impl HatPubSubTrait for HatCode {
                         && interest
                             .res
                             .as_ref()
-                            .map(|res| KeyExpr::keyexpr_include(res.expr(), expr.full_expr()))
+                            .map(|res| KeyExpr::keyexpr_include(res.expr(), key_expr))
                             .unwrap_or(true)
                 }) || face_hat!(face)
                     .remote_subs
                     .values()
-                    .any(|sub| KeyExpr::keyexpr_intersect(sub.expr(), expr.full_expr()))
+                    .any(|sub| KeyExpr::keyexpr_intersect(sub.expr(), key_expr))
                 {
-                    let key_expr = Resource::get_best_key(expr.prefix, expr.suffix, face.id);
+                    let wire_expr = expr.get_best_key(face.id);
                     route.insert(face.id, || {
-                        (face.clone(), key_expr.to_owned(), NodeId::default())
+                        (face.clone(), wire_expr.to_owned(), NodeId::default())
                     });
                 }
             }
@@ -665,18 +657,18 @@ impl HatPubSubTrait for HatCode {
                     && !initial_interest(f).map(|i| i.finalized).unwrap_or(true)
             }) {
                 route.insert(face.id, || {
-                    let key_expr = Resource::get_best_key(expr.prefix, expr.suffix, face.id);
-                    (face.clone(), key_expr.to_owned(), NodeId::default())
+                    let wire_expr = expr.get_best_key(face.id);
+                    (face.clone(), wire_expr.to_owned(), NodeId::default())
                 });
             }
         }
 
-        let res = Resource::get_resource(expr.prefix, expr.suffix);
-        let matches = res
+        let matches = expr
+            .resource()
             .as_ref()
             .and_then(|res| res.context.as_ref())
             .map(|ctx| Cow::from(&ctx.matches))
-            .unwrap_or_else(|| Cow::from(Resource::get_matches(tables, &key_expr)));
+            .unwrap_or_else(|| Cow::from(Resource::get_matches(tables, key_expr)));
 
         for mres in matches.iter() {
             let mres = mres.upgrade().unwrap();
@@ -686,8 +678,12 @@ impl HatPubSubTrait for HatCode {
                     && (source_type == WhatAmI::Client || context.face.whatami == WhatAmI::Client)
                 {
                     route.insert(*sid, || {
-                        let key_expr = Resource::get_best_key(expr.prefix, expr.suffix, *sid);
-                        (context.face.clone(), key_expr.to_owned(), NodeId::default())
+                        let wire_expr = expr.get_best_key(*sid);
+                        (
+                            context.face.clone(),
+                            wire_expr.to_owned(),
+                            NodeId::default(),
+                        )
                     });
                 }
             }
@@ -696,7 +692,7 @@ impl HatPubSubTrait for HatCode {
             route.insert(mcast_group.id, || {
                 (
                     mcast_group.clone(),
-                    expr.full_expr().to_string().into(),
+                    key_expr.to_string().into(),
                     NodeId::default(),
                 )
             });

--- a/zenoh/src/net/routing/hat/router/mod.rs
+++ b/zenoh/src/net/routing/hat/router/mod.rs
@@ -790,13 +790,13 @@ impl HatBaseTrait for HatCode {
     }
 
     #[inline]
-    fn ingress_filter(&self, tables: &Tables, face: &FaceState, expr: &mut RoutingExpr) -> bool {
+    fn ingress_filter(&self, tables: &Tables, face: &FaceState, expr: &RoutingExpr) -> bool {
         face.whatami != WhatAmI::Peer
             || hat!(tables).linkstatepeers_net.is_none()
             || tables.zid
                 == *hat!(tables).elect_router(
                     &tables.zid,
-                    expr.full_expr(),
+                    expr.key_expr().map_or("", |ke| ke),
                     hat!(tables).get_router_links(face.zid),
                 )
     }
@@ -807,7 +807,7 @@ impl HatBaseTrait for HatCode {
         tables: &Tables,
         src_face: &FaceState,
         out_face: &Arc<FaceState>,
-        expr: &mut RoutingExpr,
+        expr: &RoutingExpr,
     ) -> bool {
         if src_face.id != out_face.id
             && (out_face.mcast_group.is_none() || src_face.mcast_group.is_none())
@@ -817,7 +817,7 @@ impl HatBaseTrait for HatCode {
                 || tables.zid
                     == *hat!(tables).elect_router(
                         &tables.zid,
-                        expr.full_expr(),
+                        expr.key_expr().map_or("", |ke| ke),
                         hat!(tables).get_router_links(out_face.zid),
                     );
 

--- a/zenoh/src/net/routing/hat/router/pubsub.rs
+++ b/zenoh/src/net/routing/hat/router/pubsub.rs
@@ -19,7 +19,7 @@ use std::{
 
 use petgraph::graph::NodeIndex;
 use zenoh_protocol::{
-    core::{key_expr::OwnedKeyExpr, WhatAmI, ZenohIdProto},
+    core::{WhatAmI, ZenohIdProto},
     network::{
         declare::{
             common::ext::WireExprType, ext, Declare, DeclareBody, DeclareSubscriber, SubscriberId,
@@ -1215,7 +1215,7 @@ impl HatPubSubTrait for HatCode {
     fn compute_data_route(
         &self,
         tables: &Tables,
-        expr: &mut RoutingExpr,
+        expr: &RoutingExpr,
         source: NodeId,
         source_type: WhatAmI,
     ) -> Arc<Route> {
@@ -1238,12 +1238,8 @@ impl HatPubSubTrait for HatCode {
                                 if net.graph.contains_node(direction) {
                                     if let Some(face) = tables.get_face(&net.graph[direction].zid) {
                                         route.insert(face.id, || {
-                                            let key_expr = Resource::get_best_key(
-                                                expr.prefix,
-                                                expr.suffix,
-                                                face.id,
-                                            );
-                                            (face.clone(), key_expr.to_owned(), source)
+                                            let wire_expr = expr.get_best_key(face.id);
+                                            (face.clone(), wire_expr.to_owned(), source)
                                         });
                                     }
                                 }
@@ -1257,32 +1253,24 @@ impl HatPubSubTrait for HatCode {
         }
 
         let mut route = RouteBuilder::new();
-        let key_expr = expr.full_expr();
-        if key_expr.ends_with('/') {
+        let Some(key_expr) = expr.key_expr() else {
             return Arc::new(route.build());
-        }
+        };
         tracing::trace!(
             "compute_data_route({}, {:?}, {:?})",
             key_expr,
             source,
             source_type
         );
-        let key_expr = match OwnedKeyExpr::try_from(key_expr) {
-            Ok(ke) => ke,
-            Err(e) => {
-                tracing::warn!("Invalid KE reached the system: {}", e);
-                return Arc::new(route.build());
-            }
-        };
-        let res = Resource::get_resource(expr.prefix, expr.suffix);
-        let matches = res
+        let matches = expr
+            .resource()
             .as_ref()
             .and_then(|res| res.context.as_ref())
             .map(|ctx| Cow::from(&ctx.matches))
-            .unwrap_or_else(|| Cow::from(Resource::get_matches(tables, &key_expr)));
+            .unwrap_or_else(|| Cow::from(Resource::get_matches(tables, key_expr)));
 
         let master = !hat!(tables).full_net(WhatAmI::Peer)
-            || *hat!(tables).elect_router(&tables.zid, &key_expr, hat!(tables).shared_nodes.iter())
+            || *hat!(tables).elect_router(&tables.zid, key_expr, hat!(tables).shared_nodes.iter())
                 == tables.zid;
 
         for mres in matches.iter() {
@@ -1324,8 +1312,12 @@ impl HatPubSubTrait for HatCode {
                 for (sid, context) in &mres.session_ctxs {
                     if context.subs.is_some() && context.face.whatami != WhatAmI::Router {
                         route.insert(*sid, || {
-                            let key_expr = Resource::get_best_key(expr.prefix, expr.suffix, *sid);
-                            (context.face.clone(), key_expr.to_owned(), NodeId::default())
+                            let wire_expr = expr.get_best_key(*sid);
+                            (
+                                context.face.clone(),
+                                wire_expr.to_owned(),
+                                NodeId::default(),
+                            )
                         });
                     }
                 }
@@ -1335,7 +1327,7 @@ impl HatPubSubTrait for HatCode {
             route.insert(mcast_group.id, || {
                 (
                     mcast_group.clone(),
-                    expr.full_expr().to_string().into(),
+                    key_expr.to_string().into(),
                     NodeId::default(),
                 )
             });

--- a/zenoh/src/net/routing/hat/router/queries.rs
+++ b/zenoh/src/net/routing/hat/router/queries.rs
@@ -20,10 +20,7 @@ use std::{
 use petgraph::graph::NodeIndex;
 use zenoh_protocol::{
     core::{
-        key_expr::{
-            include::{Includer, DEFAULT_INCLUDER},
-            OwnedKeyExpr,
-        },
+        key_expr::include::{Includer, DEFAULT_INCLUDER},
         WhatAmI, ZenohIdProto,
     },
     network::{
@@ -1082,7 +1079,7 @@ pub(super) fn queries_tree_change(
 #[inline]
 fn insert_target_for_qabls(
     route: &mut QueryTargetQablSet,
-    expr: &mut RoutingExpr,
+    expr: &RoutingExpr,
     tables: &Tables,
     net: &Network,
     source: NodeId,
@@ -1098,10 +1095,9 @@ fn insert_target_for_qabls(
                         if net.graph.contains_node(direction) {
                             if let Some(face) = tables.get_face(&net.graph[direction].zid) {
                                 if net.distances.len() > qabl_idx.index() {
-                                    let key_expr =
-                                        Resource::get_best_key(expr.prefix, expr.suffix, face.id);
+                                    let wire_expr = expr.get_best_key(face.id);
                                     route.push(QueryTargetQabl {
-                                        direction: (face.clone(), key_expr.to_owned(), source),
+                                        direction: (face.clone(), wire_expr.to_owned(), source),
                                         info: Some(QueryableInfoType {
                                             complete: complete && qabl_info.complete,
                                             distance: net.distances[qabl_idx.index()] as u16,
@@ -1426,37 +1422,29 @@ impl HatQueriesTrait for HatCode {
     fn compute_query_route(
         &self,
         tables: &Tables,
-        expr: &mut RoutingExpr,
+        expr: &RoutingExpr,
         source: NodeId,
         source_type: WhatAmI,
     ) -> Arc<QueryTargetQablSet> {
         let mut route = QueryTargetQablSet::new();
-        let key_expr = expr.full_expr();
-        if key_expr.ends_with('/') {
+        let Some(key_expr) = expr.key_expr() else {
             return EMPTY_ROUTE.clone();
-        }
+        };
         tracing::trace!(
             "compute_query_route({}, {:?}, {:?})",
             key_expr,
             source,
             source_type
         );
-        let key_expr = match OwnedKeyExpr::try_from(key_expr) {
-            Ok(ke) => ke,
-            Err(e) => {
-                tracing::warn!("Invalid KE reached the system: {}", e);
-                return EMPTY_ROUTE.clone();
-            }
-        };
-        let res = Resource::get_resource(expr.prefix, expr.suffix);
-        let matches = res
+        let matches = expr
+            .resource()
             .as_ref()
             .and_then(|res| res.context.as_ref())
             .map(|ctx| Cow::from(&ctx.matches))
-            .unwrap_or_else(|| Cow::from(Resource::get_matches(tables, &key_expr)));
+            .unwrap_or_else(|| Cow::from(Resource::get_matches(tables, key_expr)));
 
         let master = !hat!(tables).full_net(WhatAmI::Peer)
-            || *hat!(tables).elect_router(&tables.zid, &key_expr, hat!(tables).shared_nodes.iter())
+            || *hat!(tables).elect_router(&tables.zid, key_expr, hat!(tables).shared_nodes.iter())
                 == tables.zid;
 
         for mres in matches.iter() {


### PR DESCRIPTION
When there is no suffix, or when a resource exists for the full expr, there is no point in reallocating the full string as it can be obtained from the resource.
The computation of the full expr resource is also cached, as it was done multiple times.

A malicious bug has also been fixed in `route_data`, as the prefix was cloned for no relevant reason, so it was still alive when the table lock was released.