### PR TITLE
chore(deps): bump dependencies for license compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ humantime = "2.1.0"
 itertools = "0.13.0"
 json5 = "0.4.1"
 jsonschema = { version = "0.20", default-features = false }
-keyed-set = "1.0.0"
+keyed-set = "1.1.0"
 lazy_static = "1.5.0"
 leb128 = "0.2"
 libc = "0.2.158"
@@ -141,7 +141,7 @@ rand_chacha = "0.3.1"
 rcgen = "0.13.1"
 ref-cast = "1.0.23"
 regex = "1.10.6"
-ringbuffer-spsc = "0.1.9"
+ringbuffer-spsc = "0.1.15"
 ron = "0.8.1"
 rsa = "0.9"
 rustc_version = "0.4.1"
@@ -173,7 +173,7 @@ syn = "2.0"
 test-case = "3.3.1"
 tide = "0.16.0"
 time = "0.3.36"
-token-cell = { version = "1.5.0", default-features = false }
+token-cell = { version = "2.0.0", default-features = false }
 tokio = { version = "1.40.0", default-features = false } # Default features are disabled due to some crates' requirements
 tokio-rustls = { version = "0.26.0", default-features = false }
 tokio-tungstenite = "0.24.0"
@@ -193,7 +193,7 @@ urlencoding = "2.1.3"
 uuid = { version = "1.10.0", default-features = false, features = [
   "v4",
 ] } # Default features are disabled due to usage in no_std crates
-validated_struct = "2.1.0"
+validated_struct = "2.2.0"
 vec_map = "0.8.2"
 webpki-roots = "0.26.5"
 win-sys = "0.3"


### PR DESCRIPTION
This PR updates the dependencies to ensure Zenoh is compatible with the GPL license, addressing the request from [eclipse-zenoh/zenoh-dissector](https://github.com/eclipse-zenoh/zenoh-dissector).