### PR TITLE
make FrameReader consume messages on drop

### DIFF
--- a/commons/zenoh-codec/src/transport/frame.rs
+++ b/commons/zenoh-codec/src/transport/frame.rs
@@ -200,7 +200,7 @@ where
 }
 
 #[derive(Debug)]
-pub struct FrameReader<'a, R> {
+pub struct FrameReader<'a, R: BacktrackableReader> {
     pub reliability: Reliability,
     pub sn: TransportSn,
     pub ext_qos: ext::QoSType,
@@ -235,5 +235,11 @@ impl<R: BacktrackableReader> Iterator for FrameReader<'_, R> {
             self.reader.rewind(mark);
         }
         msg.ok()
+    }
+}
+
+impl<R: BacktrackableReader> Drop for FrameReader<'_, R> {
+    fn drop(&mut self) {
+        for _ in self {}
     }
 }


### PR DESCRIPTION
In case of multicast, it happens that frame's messages are not read, but they still need to be deserialized to advance the reader cursor.