### PR TITLE
Improve scalability

### DIFF
--- a/zenoh/src/net/routing/hat/client/interests.rs
+++ b/zenoh/src/net/routing/hat/client/interests.rs
@@ -87,13 +87,13 @@ impl HatInterestTrait for HatCode {
         send_declare: &mut SendDeclare,
     ) {
         if options.tokens() {
+            // Note: aggregation is forbidden for tokens. The flag is ignored.
             declare_token_interest(
                 tables,
                 face,
                 id,
                 res.as_deref().cloned().as_mut(),
                 mode,
-                options.aggregate(),
                 send_declare,
             )
         }

--- a/zenoh/src/net/routing/hat/client/queries.rs
+++ b/zenoh/src/net/routing/hat/client/queries.rs
@@ -122,10 +122,10 @@ fn propagate_simple_queryable(
             })
             .unwrap_or(true)
         {
-            if let Some(current) = face_hat!(dst_face).local_qabls.get(res) {
+            if let Some(&(current_id, current_info)) = face_hat!(dst_face).local_qabls.get(res) {
                 let info = local_qabl_info(tables, res, &dst_face);
-                if current.1 != info {
-                    let id = current.0;
+                if current_info != info {
+                    let id = current_id;
                     send_declare_queryable(&mut dst_face, res, id, info, send_declare);
                 }
             } else {

--- a/zenoh/src/net/routing/hat/client/queries.rs
+++ b/zenoh/src/net/routing/hat/client/queries.rs
@@ -50,6 +50,7 @@ fn merge_qabl_infos(mut this: QueryableInfoType, info: &QueryableInfoType) -> Qu
     this
 }
 
+#[inline]
 fn local_qabl_info(
     _tables: &Tables,
     res: &Arc<Resource>,
@@ -74,6 +75,37 @@ fn local_qabl_info(
         .unwrap_or(QueryableInfoType::DEFAULT)
 }
 
+#[inline]
+fn send_declare_queryable(
+    dst_face: &mut Arc<FaceState>,
+    res: &Arc<Resource>,
+    id: u32,
+    info: QueryableInfoType,
+    send_declare: &mut SendDeclare,
+) {
+    face_hat_mut!(dst_face)
+        .local_qabls
+        .insert(res.clone(), (id, info));
+    let key_expr = Resource::decl_key(res, dst_face, true);
+    send_declare(
+        &dst_face.primitives,
+        RoutingContext::with_expr(
+            Declare {
+                interest_id: None,
+                ext_qos: ext::QoSType::DECLARE,
+                ext_tstamp: None,
+                ext_nodeid: ext::NodeIdType::DEFAULT,
+                body: DeclareBody::DeclareQueryable(DeclareQueryable {
+                    id,
+                    wire_expr: key_expr,
+                    ext_info: info,
+                }),
+            },
+            res.expr().to_string(),
+        ),
+    );
+}
+
 fn propagate_simple_queryable(
     tables: &mut Tables,
     res: &Arc<Resource>,
@@ -82,44 +114,25 @@ fn propagate_simple_queryable(
 ) {
     let faces = tables.faces.values().cloned();
     for mut dst_face in faces {
-        let info = local_qabl_info(tables, res, &dst_face);
-        let current = face_hat!(dst_face).local_qabls.get(res);
         if src_face
             .as_ref()
-            .map(|src_face| dst_face.id != src_face.id)
+            .map(|src_face| {
+                dst_face.id != src_face.id
+                    && (src_face.whatami == WhatAmI::Client || dst_face.whatami == WhatAmI::Client)
+            })
             .unwrap_or(true)
-            && (current.is_none() || current.unwrap().1 != info)
-            && src_face
-                .as_ref()
-                .map(|src_face| {
-                    src_face.whatami == WhatAmI::Client || dst_face.whatami == WhatAmI::Client
-                })
-                .unwrap_or(true)
         {
-            let id = current
-                .map(|c| c.0)
-                .unwrap_or(face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst));
-            face_hat_mut!(&mut dst_face)
-                .local_qabls
-                .insert(res.clone(), (id, info));
-            let key_expr = Resource::decl_key(res, &mut dst_face, true);
-            send_declare(
-                &dst_face.primitives,
-                RoutingContext::with_expr(
-                    Declare {
-                        interest_id: None,
-                        ext_qos: ext::QoSType::DECLARE,
-                        ext_tstamp: None,
-                        ext_nodeid: ext::NodeIdType::DEFAULT,
-                        body: DeclareBody::DeclareQueryable(DeclareQueryable {
-                            id,
-                            wire_expr: key_expr,
-                            ext_info: info,
-                        }),
-                    },
-                    res.expr().to_string(),
-                ),
-            );
+            if let Some(current) = face_hat!(dst_face).local_qabls.get(res) {
+                let info = local_qabl_info(tables, res, &dst_face);
+                if current.1 != info {
+                    let id = current.0;
+                    send_declare_queryable(&mut dst_face, res, id, info, send_declare);
+                }
+            } else {
+                let info = local_qabl_info(tables, res, &dst_face);
+                let id = face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst);
+                send_declare_queryable(&mut dst_face, res, id, info, send_declare);
+            }
         }
     }
 }

--- a/zenoh/src/net/routing/hat/client/token.rs
+++ b/zenoh/src/net/routing/hat/client/token.rs
@@ -322,64 +322,35 @@ pub(crate) fn declare_token_interest(
     id: InterestId,
     res: Option<&mut Arc<Resource>>,
     mode: InterestMode,
-    aggregate: bool,
     send_declare: &mut SendDeclare,
 ) {
     if mode.current() {
         let interest_id = (!mode.future()).then_some(id);
         if let Some(res) = res.as_ref() {
-            if aggregate {
-                if tables.faces.values().any(|src_face| {
-                    face_hat!(src_face)
-                        .remote_tokens
-                        .values()
-                        .any(|token| token.context.is_some() && token.matches(res))
-                }) {
-                    let id = make_token_id(res, face, mode);
-                    let wire_expr = Resource::decl_key(res, face, true);
-                    send_declare(
-                        &face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::DeclareToken(DeclareToken { id, wire_expr }),
-                            },
-                            res.expr().to_string(),
-                        ),
-                    );
-                }
-            } else {
-                for src_face in tables
-                    .faces
-                    .values()
-                    .filter(|f| f.whatami == WhatAmI::Client)
-                    .cloned()
-                    .collect::<Vec<Arc<FaceState>>>()
-                {
-                    for token in face_hat!(src_face).remote_tokens.values() {
-                        if token.context.is_some() && token.matches(res) {
-                            let id = make_token_id(token, face, mode);
-                            let wire_expr = Resource::decl_key(token, face, true);
-                            send_declare(
-                                &face.primitives,
-                                RoutingContext::with_expr(
-                                    Declare {
-                                        interest_id,
-                                        ext_qos: ext::QoSType::default(),
-                                        ext_tstamp: None,
-                                        ext_nodeid: ext::NodeIdType::default(),
-                                        body: DeclareBody::DeclareToken(DeclareToken {
-                                            id,
-                                            wire_expr,
-                                        }),
-                                    },
-                                    res.expr().to_string(),
-                                ),
-                            )
-                        }
+            for src_face in tables
+                .faces
+                .values()
+                .filter(|f| f.whatami == WhatAmI::Client)
+                .cloned()
+                .collect::<Vec<Arc<FaceState>>>()
+            {
+                for token in face_hat!(src_face).remote_tokens.values() {
+                    if token.context.is_some() && token.matches(res) {
+                        let id = make_token_id(token, face, mode);
+                        let wire_expr = Resource::decl_key(token, face, true);
+                        send_declare(
+                            &face.primitives,
+                            RoutingContext::with_expr(
+                                Declare {
+                                    interest_id,
+                                    ext_qos: ext::QoSType::default(),
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType::default(),
+                                    body: DeclareBody::DeclareToken(DeclareToken { id, wire_expr }),
+                                },
+                                res.expr().to_string(),
+                            ),
+                        )
                     }
                 }
             }

--- a/zenoh/src/net/routing/hat/linkstate_peer/interests.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/interests.rs
@@ -70,13 +70,13 @@ impl HatInterestTrait for HatCode {
             )
         }
         if options.tokens() {
+            // Note: aggregation is forbidden for tokens. The flag is ignored.
             declare_token_interest(
                 tables,
                 face,
                 id,
                 res.as_ref().map(|r| (*r).clone()).as_mut(),
                 mode,
-                options.aggregate(),
                 send_declare,
             )
         }

--- a/zenoh/src/net/routing/hat/linkstate_peer/queries.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/queries.rs
@@ -213,15 +213,15 @@ fn propagate_simple_queryable(
             .unwrap_or(true)
             && dst_face.whatami == WhatAmI::Client
         {
-            if let Some(current) = face_hat!(dst_face).local_qabls.get(res) {
+            if let Some(&(current_id, current_info)) = face_hat!(dst_face).local_qabls.get(res) {
                 let info = local_qabl_info(tables, res, &dst_face);
-                if current.1 != info
+                if current_info != info
                     && face_hat!(dst_face)
                         .remote_interests
                         .values()
                         .any(|i| i.options.queryables() && i.matches(res))
                 {
-                    let id = current.0;
+                    let id = current_id;
                     send_declare_queryable(&mut dst_face, res, id, info, send_declare);
                 }
             } else if face_hat!(dst_face)

--- a/zenoh/src/net/routing/hat/linkstate_peer/queries.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/queries.rs
@@ -61,6 +61,7 @@ fn merge_qabl_infos(mut this: QueryableInfoType, info: &QueryableInfoType) -> Qu
     this
 }
 
+#[inline]
 fn local_peer_qabl_info(_tables: &Tables, res: &Arc<Resource>) -> QueryableInfoType {
     res.session_ctxs
         .values()
@@ -77,6 +78,7 @@ fn local_peer_qabl_info(_tables: &Tables, res: &Arc<Resource>) -> QueryableInfoT
         .unwrap_or(QueryableInfoType::DEFAULT)
 }
 
+#[inline]
 fn local_qabl_info(
     tables: &Tables,
     res: &Arc<Resource>,
@@ -166,6 +168,37 @@ fn send_sourced_queryable_to_net_children(
     }
 }
 
+#[inline]
+fn send_declare_queryable(
+    dst_face: &mut Arc<FaceState>,
+    res: &Arc<Resource>,
+    id: u32,
+    info: QueryableInfoType,
+    send_declare: &mut SendDeclare,
+) {
+    face_hat_mut!(dst_face)
+        .local_qabls
+        .insert(res.clone(), (id, info));
+    let key_expr = Resource::decl_key(res, dst_face, super::push_declaration_profile(dst_face));
+    send_declare(
+        &dst_face.primitives,
+        RoutingContext::with_expr(
+            Declare {
+                interest_id: None,
+                ext_qos: ext::QoSType::DECLARE,
+                ext_tstamp: None,
+                ext_nodeid: ext::NodeIdType::DEFAULT,
+                body: DeclareBody::DeclareQueryable(DeclareQueryable {
+                    id,
+                    wire_expr: key_expr,
+                    ext_info: info,
+                }),
+            },
+            res.expr().to_string(),
+        ),
+    );
+}
+
 fn propagate_simple_queryable(
     tables: &mut Tables,
     res: &Arc<Resource>,
@@ -174,44 +207,32 @@ fn propagate_simple_queryable(
 ) {
     let faces = tables.faces.values().cloned();
     for mut dst_face in faces {
-        let info = local_qabl_info(tables, res, &dst_face);
-        let current = face_hat!(dst_face).local_qabls.get(res);
         if src_face
             .as_ref()
             .map(|src_face| dst_face.id != src_face.id)
             .unwrap_or(true)
-            && (current.is_none() || current.unwrap().1 != info)
             && dst_face.whatami == WhatAmI::Client
-            && face_hat!(dst_face)
+        {
+            if let Some(current) = face_hat!(dst_face).local_qabls.get(res) {
+                let info = local_qabl_info(tables, res, &dst_face);
+                if current.1 != info
+                    && face_hat!(dst_face)
+                        .remote_interests
+                        .values()
+                        .any(|i| i.options.queryables() && i.matches(res))
+                {
+                    let id = current.0;
+                    send_declare_queryable(&mut dst_face, res, id, info, send_declare);
+                }
+            } else if face_hat!(dst_face)
                 .remote_interests
                 .values()
                 .any(|i| i.options.queryables() && i.matches(res))
-        {
-            let id = current
-                .map(|c| c.0)
-                .unwrap_or(face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst));
-            face_hat_mut!(&mut dst_face)
-                .local_qabls
-                .insert(res.clone(), (id, info));
-            let push_declaration = push_declaration_profile(&dst_face);
-            let key_expr = Resource::decl_key(res, &mut dst_face, push_declaration);
-            send_declare(
-                &dst_face.primitives,
-                RoutingContext::with_expr(
-                    Declare {
-                        interest_id: None,
-                        ext_qos: ext::QoSType::DECLARE,
-                        ext_tstamp: None,
-                        ext_nodeid: ext::NodeIdType::DEFAULT,
-                        body: DeclareBody::DeclareQueryable(DeclareQueryable {
-                            id,
-                            wire_expr: key_expr,
-                            ext_info: info,
-                        }),
-                    },
-                    res.expr().to_string(),
-                ),
-            );
+            {
+                let info = local_qabl_info(tables, res, &dst_face);
+                let id = face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst);
+                send_declare_queryable(&mut dst_face, res, id, info, send_declare);
+            }
         }
     }
 }

--- a/zenoh/src/net/routing/hat/p2p_peer/interests.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/interests.rs
@@ -117,13 +117,13 @@ impl HatInterestTrait for HatCode {
             )
         }
         if options.tokens() {
+            // Note: aggregation is forbidden for tokens. The flag is ignored.
             declare_token_interest(
                 tables,
                 face,
                 id,
                 res.as_deref().cloned().as_mut(),
                 mode,
-                options.aggregate(),
                 send_declare,
             )
         }

--- a/zenoh/src/net/routing/hat/p2p_peer/queries.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/queries.rs
@@ -94,17 +94,17 @@ fn propagate_simple_queryable_to(
         .map(|src_face| dst_face.id != src_face.id)
         .unwrap_or(true)
         && (current.is_none() || current.unwrap().1 != info)
-        && (dst_face.whatami != WhatAmI::Client
-            || face_hat!(dst_face)
-                .remote_interests
-                .values()
-                .any(|i| i.options.queryables() && i.matches(res)))
         && src_face
             .as_ref()
             .map(|src_face| {
                 src_face.whatami == WhatAmI::Client || dst_face.whatami == WhatAmI::Client
             })
             .unwrap_or(true)
+        && (dst_face.whatami != WhatAmI::Client
+            || face_hat!(dst_face)
+                .remote_interests
+                .values()
+                .any(|i| i.options.queryables() && i.matches(res)))
     {
         let id = current
             .map(|c| c.0)

--- a/zenoh/src/net/routing/hat/p2p_peer/queries.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/queries.rs
@@ -127,16 +127,16 @@ fn propagate_simple_queryable_to(
         })
         .unwrap_or(true)
     {
-        if let Some(current) = face_hat!(dst_face).local_qabls.get(res) {
+        if let Some(&(current_id, current_info)) = face_hat!(dst_face).local_qabls.get(res) {
             let info = local_qabl_info(tables, res, dst_face);
-            if current.1 != info
+            if current_info != info
                 && (dst_face.whatami != WhatAmI::Client
                     || face_hat!(dst_face)
                         .remote_interests
                         .values()
                         .any(|i| i.options.queryables() && i.matches(res)))
             {
-                let id = current.0;
+                let id = current_id;
                 send_declare_queryable(dst_face, res, id, info, send_declare);
             }
         } else if dst_face.whatami != WhatAmI::Client

--- a/zenoh/src/net/routing/hat/p2p_peer/queries.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/queries.rs
@@ -55,6 +55,7 @@ fn merge_qabl_infos(mut this: QueryableInfoType, info: &QueryableInfoType) -> Qu
     this
 }
 
+#[inline]
 fn local_qabl_info(
     _tables: &Tables,
     res: &Arc<Resource>,
@@ -80,6 +81,37 @@ fn local_qabl_info(
 }
 
 #[inline]
+fn send_declare_queryable(
+    dst_face: &mut Arc<FaceState>,
+    res: &Arc<Resource>,
+    id: u32,
+    info: QueryableInfoType,
+    send_declare: &mut SendDeclare,
+) {
+    face_hat_mut!(dst_face)
+        .local_qabls
+        .insert(res.clone(), (id, info));
+    let key_expr = Resource::decl_key(res, dst_face, super::push_declaration_profile(dst_face));
+    send_declare(
+        &dst_face.primitives,
+        RoutingContext::with_expr(
+            Declare {
+                interest_id: None,
+                ext_qos: ext::QoSType::DECLARE,
+                ext_tstamp: None,
+                ext_nodeid: ext::NodeIdType::DEFAULT,
+                body: DeclareBody::DeclareQueryable(DeclareQueryable {
+                    id,
+                    wire_expr: key_expr,
+                    ext_info: info,
+                }),
+            },
+            res.expr().to_string(),
+        ),
+    );
+}
+
+#[inline]
 fn propagate_simple_queryable_to(
     tables: &mut Tables,
     dst_face: &mut Arc<FaceState>,
@@ -87,49 +119,36 @@ fn propagate_simple_queryable_to(
     src_face: &Option<&mut Arc<FaceState>>,
     send_declare: &mut SendDeclare,
 ) {
-    let info = local_qabl_info(tables, res, dst_face);
-    let current = face_hat!(dst_face).local_qabls.get(res);
     if src_face
         .as_ref()
-        .map(|src_face| dst_face.id != src_face.id)
+        .map(|src_face| {
+            dst_face.id != src_face.id
+                && (src_face.whatami == WhatAmI::Client || dst_face.whatami == WhatAmI::Client)
+        })
         .unwrap_or(true)
-        && (current.is_none() || current.unwrap().1 != info)
-        && src_face
-            .as_ref()
-            .map(|src_face| {
-                src_face.whatami == WhatAmI::Client || dst_face.whatami == WhatAmI::Client
-            })
-            .unwrap_or(true)
-        && (dst_face.whatami != WhatAmI::Client
+    {
+        if let Some(current) = face_hat!(dst_face).local_qabls.get(res) {
+            let info = local_qabl_info(tables, res, dst_face);
+            if current.1 != info
+                && (dst_face.whatami != WhatAmI::Client
+                    || face_hat!(dst_face)
+                        .remote_interests
+                        .values()
+                        .any(|i| i.options.queryables() && i.matches(res)))
+            {
+                let id = current.0;
+                send_declare_queryable(dst_face, res, id, info, send_declare);
+            }
+        } else if dst_face.whatami != WhatAmI::Client
             || face_hat!(dst_face)
                 .remote_interests
                 .values()
-                .any(|i| i.options.queryables() && i.matches(res)))
-    {
-        let id = current
-            .map(|c| c.0)
-            .unwrap_or(face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst));
-        face_hat_mut!(dst_face)
-            .local_qabls
-            .insert(res.clone(), (id, info));
-        let key_expr = Resource::decl_key(res, dst_face, super::push_declaration_profile(dst_face));
-        send_declare(
-            &dst_face.primitives,
-            RoutingContext::with_expr(
-                Declare {
-                    interest_id: None,
-                    ext_qos: ext::QoSType::DECLARE,
-                    ext_tstamp: None,
-                    ext_nodeid: ext::NodeIdType::DEFAULT,
-                    body: DeclareBody::DeclareQueryable(DeclareQueryable {
-                        id,
-                        wire_expr: key_expr,
-                        ext_info: info,
-                    }),
-                },
-                res.expr().to_string(),
-            ),
-        );
+                .any(|i| i.options.queryables() && i.matches(res))
+        {
+            let info = local_qabl_info(tables, res, dst_face);
+            let id = face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst);
+            send_declare_queryable(dst_face, res, id, info, send_declare);
+        }
     }
 }
 

--- a/zenoh/src/net/routing/hat/p2p_peer/token.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/token.rs
@@ -89,8 +89,8 @@ fn propagate_simple_token_to(
                 .values()
                 .filter(|i| {
                     i.options.tokens()
-                        && i.matches(res)
                         && (i.mode.current() || src_interest_id.is_none())
+                        && i.matches(res)
                 })
                 .cloned()
                 .collect::<Vec<_>>();
@@ -285,7 +285,7 @@ fn propagate_forget_simple_token(
             && face_hat!(face)
                 .remote_interests
                 .values()
-                .any(|i| i.options.tokens() && i.matches(res) && !i.options.aggregate())
+                .any(|i| i.options.tokens() && (!i.options.aggregate()) && i.matches(res))
         {
             // Token has never been declared on this face.
             // Send an Undeclare with a one shot generated id and a WireExpr ext.
@@ -338,7 +338,7 @@ fn propagate_forget_simple_token(
                 } else if face_hat!(face)
                     .remote_interests
                     .values()
-                    .any(|i| i.options.tokens() && i.matches(&res) && !i.options.aggregate())
+                    .any(|i| i.options.tokens() && (!i.options.aggregate()) && i.matches(&res))
                 {
                     // Token has never been declared on this face.
                     // Send an Undeclare with a one shot generated id and a WireExpr ext.

--- a/zenoh/src/net/routing/hat/p2p_peer/token.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/token.rs
@@ -25,7 +25,7 @@ use zenoh_sync::get_mut_unchecked;
 
 use super::{face_hat, face_hat_mut, HatCode, HatFace, INITIAL_INTEREST_ID};
 use crate::net::routing::{
-    dispatcher::{face::FaceState, interests::RemoteInterest, tables::Tables},
+    dispatcher::{face::FaceState, tables::Tables},
     hat::{CurrentFutureTrait, HatTokenTrait, SendDeclare},
     router::{NodeId, Resource, SessionContext},
     RoutingContext,
@@ -61,78 +61,32 @@ fn propagate_simple_token_to(
         && !face_hat!(dst_face).local_tokens.contains_key(res)
         && (src_face.whatami == WhatAmI::Client || dst_face.whatami == WhatAmI::Client)
         && new_token(tables, res, src_face, dst_face)
+        && (dst_face.whatami != WhatAmI::Client
+            || face_hat!(dst_face).remote_interests.values().any(|i| {
+                i.options.tokens()
+                    && (i.mode.current() || src_interest_id.is_none())
+                    && i.matches(res)
+            }))
     {
-        if dst_face.whatami != WhatAmI::Client {
-            let id = face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst);
-            face_hat_mut!(dst_face).local_tokens.insert(res.clone(), id);
-            let key_expr =
-                Resource::decl_key(res, dst_face, super::push_declaration_profile(dst_face));
-            send_declare(
-                &dst_face.primitives,
-                RoutingContext::with_expr(
-                    Declare {
-                        interest_id: dst_interest_id,
-                        ext_qos: ext::QoSType::DECLARE,
-                        ext_tstamp: None,
-                        ext_nodeid: ext::NodeIdType::DEFAULT,
-                        body: DeclareBody::DeclareToken(DeclareToken {
-                            id,
-                            wire_expr: key_expr,
-                        }),
-                    },
-                    res.expr().to_string(),
-                ),
-            );
-        } else {
-            let matching_interests = face_hat!(dst_face)
-                .remote_interests
-                .values()
-                .filter(|i| {
-                    i.options.tokens()
-                        && (i.mode.current() || src_interest_id.is_none())
-                        && i.matches(res)
-                })
-                .cloned()
-                .collect::<Vec<_>>();
-
-            for RemoteInterest {
-                res: int_res,
-                options,
-                ..
-            } in matching_interests
-            {
-                let res = if options.aggregate() {
-                    int_res.as_ref().unwrap_or(res)
-                } else {
-                    res
-                };
-                if !face_hat!(dst_face).local_tokens.contains_key(res) {
-                    let id = face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst);
-                    face_hat_mut!(dst_face).local_tokens.insert(res.clone(), id);
-                    let key_expr = Resource::decl_key(
-                        res,
-                        dst_face,
-                        super::push_declaration_profile(dst_face),
-                    );
-                    send_declare(
-                        &dst_face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id: dst_interest_id,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::DeclareToken(DeclareToken {
-                                    id,
-                                    wire_expr: key_expr,
-                                }),
-                            },
-                            res.expr().to_string(),
-                        ),
-                    );
-                }
-            }
-        }
+        let id = face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst);
+        face_hat_mut!(dst_face).local_tokens.insert(res.clone(), id);
+        let key_expr = Resource::decl_key(res, dst_face, super::push_declaration_profile(dst_face));
+        send_declare(
+            &dst_face.primitives,
+            RoutingContext::with_expr(
+                Declare {
+                    interest_id: dst_interest_id,
+                    ext_qos: ext::QoSType::DECLARE,
+                    ext_tstamp: None,
+                    ext_nodeid: ext::NodeIdType::DEFAULT,
+                    body: DeclareBody::DeclareToken(DeclareToken {
+                        id,
+                        wire_expr: key_expr,
+                    }),
+                },
+                res.expr().to_string(),
+            ),
+        );
     }
 }
 
@@ -249,13 +203,6 @@ fn simple_tokens(res: &Arc<Resource>) -> Vec<Arc<FaceState>> {
         .collect()
 }
 
-#[inline]
-fn remote_simple_tokens(tables: &Tables, res: &Arc<Resource>, face: &Arc<FaceState>) -> bool {
-    res.session_ctxs
-        .values()
-        .any(|ctx| (ctx.face.id != face.id || face.zid == tables.zid) && ctx.token)
-}
-
 fn propagate_forget_simple_token(
     tables: &mut Tables,
     res: &Arc<Resource>,
@@ -285,7 +232,7 @@ fn propagate_forget_simple_token(
             && face_hat!(face)
                 .remote_interests
                 .values()
-                .any(|i| i.options.tokens() && (!i.options.aggregate()) && i.matches(res))
+                .any(|i| i.options.tokens() && i.matches(res))
         {
             // Token has never been declared on this face.
             // Send an Undeclare with a one shot generated id and a WireExpr ext.
@@ -307,61 +254,6 @@ fn propagate_forget_simple_token(
                     res.expr().to_string(),
                 ),
             );
-        }
-        for res in face_hat!(face)
-            .local_tokens
-            .keys()
-            .cloned()
-            .collect::<Vec<Arc<Resource>>>()
-        {
-            if !res.context().matches.iter().any(|m| {
-                m.upgrade()
-                    .is_some_and(|m| m.context.is_some() && remote_simple_tokens(tables, &m, &face))
-            }) {
-                if let Some(id) = face_hat_mut!(&mut face).local_tokens.remove(&res) {
-                    send_declare(
-                        &face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id: None,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::UndeclareToken(UndeclareToken {
-                                    id,
-                                    ext_wire_expr: WireExprType::null(),
-                                }),
-                            },
-                            res.expr().to_string(),
-                        ),
-                    );
-                } else if face_hat!(face)
-                    .remote_interests
-                    .values()
-                    .any(|i| i.options.tokens() && (!i.options.aggregate()) && i.matches(&res))
-                {
-                    // Token has never been declared on this face.
-                    // Send an Undeclare with a one shot generated id and a WireExpr ext.
-                    send_declare(
-                        &face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id: None,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::UndeclareToken(UndeclareToken {
-                                    id: face_hat!(face).next_id.fetch_add(1, Ordering::SeqCst),
-                                    ext_wire_expr: WireExprType {
-                                        wire_expr: Resource::get_best_key(&res, "", face.id),
-                                    },
-                                }),
-                            },
-                            res.expr().to_string(),
-                        ),
-                    );
-                }
-            }
         }
     }
 }
@@ -387,7 +279,7 @@ pub(super) fn undeclare_simple_token(
         }
 
         if simple_tokens.len() == 1 {
-            let mut face = &mut simple_tokens[0];
+            let face = &mut simple_tokens[0];
             if face.whatami != WhatAmI::Client {
                 if let Some(id) = face_hat_mut!(face).local_tokens.remove(res) {
                     send_declare(
@@ -406,37 +298,6 @@ pub(super) fn undeclare_simple_token(
                             res.expr().to_string(),
                         ),
                     );
-                }
-                for res in face_hat!(face)
-                    .local_tokens
-                    .keys()
-                    .cloned()
-                    .collect::<Vec<Arc<Resource>>>()
-                {
-                    if !res.context().matches.iter().any(|m| {
-                        m.upgrade().is_some_and(|m| {
-                            m.context.is_some() && remote_simple_tokens(tables, &m, face)
-                        })
-                    }) {
-                        if let Some(id) = face_hat_mut!(&mut face).local_tokens.remove(&res) {
-                            send_declare(
-                                &face.primitives,
-                                RoutingContext::with_expr(
-                                    Declare {
-                                        interest_id: None,
-                                        ext_qos: ext::QoSType::DECLARE,
-                                        ext_tstamp: None,
-                                        ext_nodeid: ext::NodeIdType::DEFAULT,
-                                        body: DeclareBody::UndeclareToken(UndeclareToken {
-                                            id,
-                                            ext_wire_expr: WireExprType::null(),
-                                        }),
-                                    },
-                                    res.expr().to_string(),
-                                ),
-                            );
-                        }
-                    }
                 }
             }
         }
@@ -509,69 +370,36 @@ pub(crate) fn declare_token_interest(
     id: InterestId,
     res: Option<&mut Arc<Resource>>,
     mode: InterestMode,
-    aggregate: bool,
     send_declare: &mut SendDeclare,
 ) {
     if mode.current() {
         let interest_id = Some(id);
         if let Some(res) = res.as_ref() {
-            if aggregate {
-                if tables.faces.values().any(|src_face| {
-                    face_hat!(src_face)
-                        .remote_tokens
-                        .values()
-                        .any(|token| token.context.is_some() && token.matches(res))
-                }) {
-                    let id = make_token_id(res, face, mode);
-                    let wire_expr =
-                        Resource::decl_key(res, face, super::push_declaration_profile(face));
-                    send_declare(
-                        &face.primitives,
-                        RoutingContext::with_expr(
-                            Declare {
-                                interest_id,
-                                ext_qos: ext::QoSType::DECLARE,
-                                ext_tstamp: None,
-                                ext_nodeid: ext::NodeIdType::DEFAULT,
-                                body: DeclareBody::DeclareToken(DeclareToken { id, wire_expr }),
-                            },
-                            res.expr().to_string(),
-                        ),
-                    );
-                }
-            } else {
-                for src_face in tables
-                    .faces
-                    .values()
-                    .filter(|f| f.whatami != WhatAmI::Router)
-                    .cloned()
-                    .collect::<Vec<Arc<FaceState>>>()
-                {
-                    for token in face_hat!(src_face).remote_tokens.values() {
-                        if token.context.is_some() && token.matches(res) {
-                            let id = make_token_id(token, face, mode);
-                            let wire_expr = Resource::decl_key(
-                                token,
-                                face,
-                                super::push_declaration_profile(face),
-                            );
-                            send_declare(
-                                &face.primitives,
-                                RoutingContext::with_expr(
-                                    Declare {
-                                        interest_id,
-                                        ext_qos: ext::QoSType::DECLARE,
-                                        ext_tstamp: None,
-                                        ext_nodeid: ext::NodeIdType::DEFAULT,
-                                        body: DeclareBody::DeclareToken(DeclareToken {
-                                            id,
-                                            wire_expr,
-                                        }),
-                                    },
-                                    token.expr().to_string(),
-                                ),
-                            );
-                        }
+            for src_face in tables
+                .faces
+                .values()
+                .filter(|f| f.whatami != WhatAmI::Router)
+                .cloned()
+                .collect::<Vec<Arc<FaceState>>>()
+            {
+                for token in face_hat!(src_face).remote_tokens.values() {
+                    if token.context.is_some() && token.matches(res) {
+                        let id = make_token_id(token, face, mode);
+                        let wire_expr =
+                            Resource::decl_key(token, face, super::push_declaration_profile(face));
+                        send_declare(
+                            &face.primitives,
+                            RoutingContext::with_expr(
+                                Declare {
+                                    interest_id,
+                                    ext_qos: ext::QoSType::DECLARE,
+                                    ext_tstamp: None,
+                                    ext_nodeid: ext::NodeIdType::DEFAULT,
+                                    body: DeclareBody::DeclareToken(DeclareToken { id, wire_expr }),
+                                },
+                                token.expr().to_string(),
+                            ),
+                        );
                     }
                 }
             }

--- a/zenoh/src/net/routing/hat/router/interests.rs
+++ b/zenoh/src/net/routing/hat/router/interests.rs
@@ -80,13 +80,13 @@ impl HatInterestTrait for HatCode {
             )
         }
         if options.tokens() {
+            // Note: aggregation is forbidden for tokens. The flag is ignored.
             declare_token_interest(
                 tables,
                 face,
                 id,
                 res.as_ref().map(|r| (*r).clone()).as_mut(),
                 mode,
-                options.aggregate(),
                 send_declare,
             )
         }

--- a/zenoh/src/net/routing/hat/router/queries.rs
+++ b/zenoh/src/net/routing/hat/router/queries.rs
@@ -61,6 +61,7 @@ fn merge_qabl_infos(mut this: QueryableInfoType, info: &QueryableInfoType) -> Qu
     this
 }
 
+#[inline]
 fn local_router_qabl_info(tables: &Tables, res: &Arc<Resource>) -> QueryableInfoType {
     let info = if hat!(tables).full_net(WhatAmI::Peer) {
         res.context.as_ref().and_then(|_| {
@@ -96,6 +97,7 @@ fn local_router_qabl_info(tables: &Tables, res: &Arc<Resource>) -> QueryableInfo
         .unwrap_or(QueryableInfoType::DEFAULT)
 }
 
+#[inline]
 fn local_peer_qabl_info(tables: &Tables, res: &Arc<Resource>) -> QueryableInfoType {
     let info = if res.context.is_some() {
         res_hat!(res)
@@ -129,6 +131,7 @@ fn local_peer_qabl_info(tables: &Tables, res: &Arc<Resource>) -> QueryableInfoTy
         .unwrap_or(QueryableInfoType::DEFAULT)
 }
 
+#[inline]
 fn local_qabl_info(
     tables: &Tables,
     res: &Arc<Resource>,
@@ -234,6 +237,39 @@ fn send_sourced_queryable_to_net_children(
     }
 }
 
+#[inline]
+fn send_declare_queryable(
+    tables: &Tables,
+    dst_face: &mut Arc<FaceState>,
+    res: &Arc<Resource>,
+    id: u32,
+    info: QueryableInfoType,
+    send_declare: &mut SendDeclare,
+) {
+    face_hat_mut!(dst_face)
+        .local_qabls
+        .insert(res.clone(), (id, info));
+    let push_declaration = push_declaration_profile(tables, dst_face);
+    let key_expr = Resource::decl_key(res, dst_face, push_declaration);
+    send_declare(
+        &dst_face.primitives,
+        RoutingContext::with_expr(
+            Declare {
+                interest_id: None,
+                ext_qos: ext::QoSType::DECLARE,
+                ext_tstamp: None,
+                ext_nodeid: ext::NodeIdType::DEFAULT,
+                body: DeclareBody::DeclareQueryable(DeclareQueryable {
+                    id,
+                    wire_expr: key_expr,
+                    ext_info: info,
+                }),
+            },
+            res.expr().to_string(),
+        ),
+    );
+}
+
 fn propagate_simple_queryable(
     tables: &mut Tables,
     res: &Arc<Resource>,
@@ -243,13 +279,10 @@ fn propagate_simple_queryable(
     let full_peers_net = hat!(tables).full_net(WhatAmI::Peer);
     let faces = tables.faces.values().cloned();
     for mut dst_face in faces {
-        let info = local_qabl_info(tables, res, &dst_face);
-        let current = face_hat!(dst_face).local_qabls.get(res);
         if src_face
             .as_ref()
             .map(|src_face| dst_face.id != src_face.id)
             .unwrap_or(true)
-            && (current.is_none() || current.unwrap().1 != info)
             && if full_peers_net {
                 dst_face.whatami == WhatAmI::Client
             } else {
@@ -263,36 +296,27 @@ fn propagate_simple_queryable(
                         })
                         .unwrap_or(true)
             }
-            && face_hat!(dst_face)
+        {
+            if let Some(current) = face_hat!(dst_face).local_qabls.get(res) {
+                let info = local_qabl_info(tables, res, &dst_face);
+                if current.1 != info
+                    && face_hat!(dst_face)
+                        .remote_interests
+                        .values()
+                        .any(|i| i.options.queryables() && i.matches(res))
+                {
+                    let id = current.0;
+                    send_declare_queryable(tables, &mut dst_face, res, id, info, send_declare);
+                }
+            } else if face_hat!(dst_face)
                 .remote_interests
                 .values()
                 .any(|i| i.options.queryables() && i.matches(res))
-        {
-            let id = current
-                .map(|c| c.0)
-                .unwrap_or(face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst));
-            face_hat_mut!(&mut dst_face)
-                .local_qabls
-                .insert(res.clone(), (id, info));
-            let push_declaration = push_declaration_profile(tables, &dst_face);
-            let key_expr = Resource::decl_key(res, &mut dst_face, push_declaration);
-            send_declare(
-                &dst_face.primitives,
-                RoutingContext::with_expr(
-                    Declare {
-                        interest_id: None,
-                        ext_qos: ext::QoSType::DECLARE,
-                        ext_tstamp: None,
-                        ext_nodeid: ext::NodeIdType::DEFAULT,
-                        body: DeclareBody::DeclareQueryable(DeclareQueryable {
-                            id,
-                            wire_expr: key_expr,
-                            ext_info: info,
-                        }),
-                    },
-                    res.expr().to_string(),
-                ),
-            );
+            {
+                let info = local_qabl_info(tables, res, &dst_face);
+                let id = face_hat!(dst_face).next_id.fetch_add(1, Ordering::SeqCst);
+                send_declare_queryable(tables, &mut dst_face, res, id, info, send_declare);
+            }
         }
     }
 }

--- a/zenoh/src/net/routing/hat/router/queries.rs
+++ b/zenoh/src/net/routing/hat/router/queries.rs
@@ -297,15 +297,15 @@ fn propagate_simple_queryable(
                         .unwrap_or(true)
             }
         {
-            if let Some(current) = face_hat!(dst_face).local_qabls.get(res) {
+            if let Some(&(current_id, current_info)) = face_hat!(dst_face).local_qabls.get(res) {
                 let info = local_qabl_info(tables, res, &dst_face);
-                if current.1 != info
+                if current_info != info
                     && face_hat!(dst_face)
                         .remote_interests
                         .values()
                         .any(|i| i.options.queryables() && i.matches(res))
                 {
-                    let id = current.0;
+                    let id = current_id;
                     send_declare_queryable(tables, &mut dst_face, res, id, info, send_declare);
                 }
             } else if face_hat!(dst_face)

--- a/zenoh/src/net/routing/hat/router/queries.rs
+++ b/zenoh/src/net/routing/hat/router/queries.rs
@@ -250,10 +250,6 @@ fn propagate_simple_queryable(
             .map(|src_face| dst_face.id != src_face.id)
             .unwrap_or(true)
             && (current.is_none() || current.unwrap().1 != info)
-            && face_hat!(dst_face)
-                .remote_interests
-                .values()
-                .any(|i| i.options.queryables() && i.matches(res))
             && if full_peers_net {
                 dst_face.whatami == WhatAmI::Client
             } else {
@@ -267,6 +263,10 @@ fn propagate_simple_queryable(
                         })
                         .unwrap_or(true)
             }
+            && face_hat!(dst_face)
+                .remote_interests
+                .values()
+                .any(|i| i.options.queryables() && i.matches(res))
         {
             let id = current
                 .map(|c| c.0)

--- a/zenoh/src/net/routing/hat/router/token.rs
+++ b/zenoh/src/net/routing/hat/router/token.rs
@@ -433,7 +433,7 @@ fn propagate_forget_simple_token(
         }) && face_hat!(face)
             .remote_interests
             .values()
-            .any(|i| i.options.tokens() && i.matches(res) && !i.options.aggregate())
+            .any(|i| i.options.tokens() && (!i.options.aggregate()) && i.matches(res))
         {
             // Token has never been declared on this face.
             // Send an Undeclare with a one shot generated id and a WireExpr ext.
@@ -490,7 +490,7 @@ fn propagate_forget_simple_token(
                 } else if face_hat!(face)
                     .remote_interests
                     .values()
-                    .any(|i| i.options.tokens() && i.matches(&res) && !i.options.aggregate())
+                    .any(|i| i.options.tokens() && (!i.options.aggregate()) && i.matches(&res))
                     && src_face.map_or(true, |src_face| {
                         src_face.whatami != WhatAmI::Peer
                             || face.whatami != WhatAmI::Peer


### PR DESCRIPTION
This PR brings optimizations by changing conditions order:
- Avoid matching interest when possible
- Avoid computing local queryable info when possible

And internal behavior changes:
- Ignore aggregate flag in token interests (that are anyway not allowed in the protocol)
- Push all tokens to local faces (local sessions) in peers (avoids matching interests)