### PR TITLE
Precommit SHM pages

### DIFF
--- a/commons/zenoh-shm/src/shm/windows.rs
+++ b/commons/zenoh-shm/src/shm/windows.rs
@@ -36,7 +36,7 @@ impl<ID: SegmentID> SegmentImpl<ID> {
             tracing::trace!(
                 "CreateFileMapping({:?}, NULL, {:X}, {}, {}, '{}')",
                 INVALID_HANDLE_VALUE,
-                PAGE_READWRITE.0,
+                PAGE_READWRITE.0 | SEC_COMMIT.0,
                 high_size,
                 low_size,
                 id,
@@ -47,7 +47,7 @@ impl<ID: SegmentID> SegmentImpl<ID> {
             let fd = CreateFileMapping(
                 INVALID_HANDLE_VALUE,
                 None,
-                PAGE_READWRITE,
+                PAGE_READWRITE | SEC_COMMIT,
                 high_size,
                 low_size,
                 id.as_str(),

--- a/commons/zenoh-shm/tests/shm.rs
+++ b/commons/zenoh-shm/tests/shm.rs
@@ -93,3 +93,10 @@ fn recreate_many_times() {
 
     assert!(Segment::open(id).is_err());
 }
+
+#[test]
+fn expect_no_overcommit() {
+    let id = (line!() as u64) + ((std::process::id() as u64) << 32);
+    let len = (1024 * 1024 * 1024 * 1024 * 1024).try_into().unwrap(); // 1 PB of memory
+    assert!(Segment::create(id, len).is_err());
+}


### PR DESCRIPTION
Make sure all SHM pages are committed and locked in RAM.