### PR TITLE
locked serde_with for rust 1.75

### DIFF
--- a/commons/zenoh-pinned-deps-1-75/Cargo.toml
+++ b/commons/zenoh-pinned-deps-1-75/Cargo.toml
@@ -39,6 +39,8 @@ pest_generator = "=2.8.0"
 pest_meta = "=2.8.0"
 potential_utf = "=0.1.0"
 rocksdb = "=0.23.0"
+serde_with = "=3.14.1"
+serde_with_macros = "3.14.1"
 static_init = "=1.0.3"
 time = "=0.3.41"
 tinystr = "=0.8.0"
@@ -61,6 +63,8 @@ ignored = [
   "pest_meta",
   "potential_utf",
   "rocksdb",
+  "serde_with",
+  "serde_with_macros",
   "static_init",
   "time",
   "tinystr",


### PR DESCRIPTION
The latest `serde_with` crate requires rust 1.76 now. Locked it lo latest version supporting rust 1.75