### PR TITLE
cargo publish fix by adding symlink to DEFAULT_CONFIG.json5

### DIFF
--- a/zenoh/DEFAULT_CONFIG.json5
+++ b/zenoh/DEFAULT_CONFIG.json5
@@ -1,0 +1,1 @@
+../DEFAULT_CONFIG.json5

--- a/zenoh/src/api/config.rs
+++ b/zenoh/src/api/config.rs
@@ -34,7 +34,7 @@ use zenoh_result::{bail, ZResult};
 /// Example configuration file:
 #[doc = concat!(
     "```json5\n",
-    include_str!("../../../DEFAULT_CONFIG.json5"),
+    include_str!("../../DEFAULT_CONFIG.json5"),
     "\n```"
 )]
 ///


### PR DESCRIPTION
The `cargo publish` requires all referenced files to be inside crate directory as it copies the crate sources to separate place.
The zenoh documentation needs `DEFAULT_CONFIG.json5` from workspace root, so it is symlinked to zenoh crate root.

Test with
```sh
cargo publish -p zenoh --dry-run --allow-dirty
```