### PR TITLE
generic-array locked to 0.14.7

### DIFF
--- a/commons/zenoh-pinned-deps-1-75/Cargo.toml
+++ b/commons/zenoh-pinned-deps-1-75/Cargo.toml
@@ -53,8 +53,8 @@ zerofrom = "=0.1.5"
 [package.metadata.cargo-machete]
 ignored = [
   "base64ct",
-  "home",
   "generic-array",
+  "home",
   "icu_normalizer",
   "librocksdb-sys",
   "litemap",


### PR DESCRIPTION
Added lock for `generic-array` to version 0.14.7 after release https://crates.io/crates/generic-array/0.14.8
which causes this error when compiled with rust 1.75
```sh
error: unsupported output in build script of `generic-array v0.14.8`: `cargo::rustc-check-cfg=cfg(ga_is_deprecated)`
Found a `cargo::key=value` build directive which is reserved for future use.
Either change the directive to `cargo:key=value` syntax (note the single `:`) or upgrade your version of Rust.
See https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script for more information about build script outputs.
```