### PR TITLE
Take zenoh version from CARGO_PKG_VERSION instead of git tag

### DIFF
--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -87,6 +87,7 @@ ahash = { workspace = true, default-features = true }
 arc-swap = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
+const_format = { workspace = true }
 flume = { workspace = true }
 futures = { workspace = true }
 git-version = { workspace = true }

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -236,11 +236,19 @@ lazy_static::lazy_static!(
     static ref LONG_VERSION: String = format!("{} built with {}", GIT_VERSION, env!("RUSTC_VERSION"));
 );
 
-pub const GIT_VERSION: &str = git_version::git_version!(
-    args = ["--always", "--dirty=-modified", "--abbrev=40"],
-    prefix = "v",
-    cargo_prefix = "v"
+const GIT_COMMIT: &str = git_version::git_version!(
+    args = [
+        "--always",
+        "--dirty=-modified",
+        "--abbrev=40",
+        "--exclude=*"
+    ],
+    fallback = "unknown"
 );
+
+pub const GIT_VERSION: &str =
+    const_format::concatcp!("v", env!("CARGO_PKG_VERSION"), "-", GIT_COMMIT);
+
 #[doc(hidden)]
 pub const FEATURES: &str = zenoh_util::concat_enabled_features!(
     prefix = "zenoh",


### PR DESCRIPTION
Take zenoh version from CARGO_PKG_VERSION instead of git tag, which might not always be available when using zenoh as a dependency