### PR TITLE
chore: pin indexmap@2.11.4 for comp with 1.75

### DIFF
--- a/commons/zenoh-pinned-deps-1-75/Cargo.toml
+++ b/commons/zenoh-pinned-deps-1-75/Cargo.toml
@@ -31,6 +31,7 @@ base64ct = "=1.6.0"
 generic-array = "=0.14.7"
 home = "=0.5.9"
 icu_normalizer = "=1.5.0"
+indexmap = "=2.11.4"
 librocksdb-sys = "=0.17.1"
 litemap = "=0.7.4"
 lz4_flex = "=0.11.3"
@@ -56,6 +57,7 @@ ignored = [
   "generic-array",
   "home",
   "icu_normalizer",
+  "indexmap",
   "librocksdb-sys",
   "litemap",
   "lz4_flex",


### PR DESCRIPTION
Fix https://github.com/eclipse-zenoh/zenoh/actions/runs/18638024160/job/53167839120