### PR TITLE
allowed CDLA-PERMISSIVE-2.0 license

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -18,7 +18,7 @@ allow = [
   # the webpki-roots is under under CDLA-PERMISSIVE-2.0 since version 0.26.9
   # which is not in the list at https://www.eclipse.org/legal/licenses/
   # But it's transitive dependency which can't be avoided, so at least temporarily allowing it
-  "CDLA-PERMISSIVE-2.0",
+  "CDLA-Permissive-2.0",
 ]
 
 # This was copied from https://github.com/EmbarkStudios/cargo-deny/blob/main/deny.toml#L64


### PR DESCRIPTION
The https://crates.io/crates/webpki-roots/versions library switched to CDLA-PERMISSIVE-2.0 at 27 April 2025
We can't avoid it as other libraries depends on it, so we have to allow this license, even if it's not in https://www.eclipse.org/legal/licenses/ list. E.g.

```sh
 cargo deny check licenses
```

```sh
error[rejected]: failed to satisfy license requirements
   ┌─ /Users/milyin/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/webpki-root-certs-1.0.3/Cargo.toml:26:12
   │
26 │ license = "CDLA-Permissive-2.0"
   │            ━━━━━━━━━━━━━━━━━━━
   │            │
   │            rejected: license is not explicitly allowed
   │
   ├ CDLA-Permissive-2.0 - Community Data License Agreement Permissive 2.0:
   ├   - No additional metadata available for license
   ├ webpki-root-certs v1.0.3
     └── rustls-platform-verifier v0.6.2
         └── quinn-proto v0.11.13
             └── quinn v0.11.9
                 ├── zenoh-link-commons v1.6.2
                 │   ├── zenoh v1.6.2
```