### PR TITLE
CDLA-PERMISSIVE-2.0 confirmed

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,7 @@ allow = [
   "BSD-3-Clause",
   "BSL-1.0",
   "CC0-1.0",
+  "CDLA-Permissive-2.0",
   "EPL-2.0",
   "ISC",
   "MIT",
@@ -15,7 +16,6 @@ allow = [
   "Unicode-3.0",
   "Unicode-DFS-2016",
   "Zlib",
-  "CDLA-Permissive-2.0",
 ]
 
 # This was copied from https://github.com/EmbarkStudios/cargo-deny/blob/main/deny.toml#L64


### PR DESCRIPTION
The `crate/cratesio/-/webpki-roots/0.26.9` is approved by Eclipse
https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/22432