### PR TITLE
chore: fix typos

### DIFF
--- a/io/zenoh-transport/src/common/pipeline.rs
+++ b/io/zenoh-transport/src/common/pipeline.rs
@@ -971,7 +971,7 @@ impl TransmissionPipelineConsumer {
                 }
             }
 
-            // In case of writing many small messages, `recv_async()` will most likely return immedietaly.
+            // In case of writing many small messages, `recv_async()` will most likely return immediately.
             // While trying to pull from the queue, the stage_in `lock()` will most likely taken, leading to
             // a spinning behaviour while attempting to take the lock. Yield the current task to avoid
             // spinning the current task indefinitely.

--- a/plugins/zenoh-plugin-trait/src/manager/dynamic_plugin.rs
+++ b/plugins/zenoh-plugin-trait/src/manager/dynamic_plugin.rs
@@ -23,7 +23,7 @@ pub enum DynamicPluginSource {
     /// Load plugin with the name in String + `.so | .dll | .dylib`
     /// in LibLoader's search paths.
     ByName((LibLoader, String)),
-    /// Load first avalilable plugin from the list of path to plugin files (absolute or relative to the current working directory)
+    /// Load first available plugin from the list of path to plugin files (absolute or relative to the current working directory)
     ByPaths(Vec<String>),
 }
 


### PR DESCRIPTION
typos has been updated to 1.39.0 with a new dictionary, which uncovered some typos in the codebase