### PR TITLE
Rename with_cancellation_token -> cancellation_token

### DIFF
--- a/zenoh/src/api/builders/querier.rs
+++ b/zenoh/src/api/builders/querier.rs
@@ -267,7 +267,7 @@ impl<Handler> CancellationTokenBuilderTrait for QuerierGetBuilder<'_, '_, Handle
     /// let _ = querier
     ///     .get()
     ///     .callback(|reply| {println!("Received {:?}", reply.result());})
-    ///     .with_cancellation_token(ct.clone())
+    ///     .cancellation_token(ct.clone())
     ///     .await
     ///     .unwrap();
     ///
@@ -278,7 +278,7 @@ impl<Handler> CancellationTokenBuilderTrait for QuerierGetBuilder<'_, '_, Handle
     /// # }
     /// ```
     #[zenoh_macros::unstable_doc]
-    fn with_cancellation_token(
+    fn cancellation_token(
         self,
         cancellation_token: crate::api::cancellation::CancellationToken,
     ) -> Self {

--- a/zenoh/src/api/builders/query.rs
+++ b/zenoh/src/api/builders/query.rs
@@ -147,7 +147,7 @@ impl<Handler> CancellationTokenBuilderTrait for SessionGetBuilder<'_, '_, Handle
     /// let query = session
     ///     .get("key/expression")
     ///     .callback(|reply| {println!("Received {:?}", reply.result());})
-    ///     .with_cancellation_token(ct.clone())
+    ///     .cancellation_token(ct.clone())
     ///     .await
     ///     .unwrap();
     ///
@@ -158,7 +158,7 @@ impl<Handler> CancellationTokenBuilderTrait for SessionGetBuilder<'_, '_, Handle
     /// # }
     /// ```
     #[zenoh_macros::unstable_doc]
-    fn with_cancellation_token(
+    fn cancellation_token(
         self,
         cancellation_token: crate::api::cancellation::CancellationToken,
     ) -> Self {

--- a/zenoh/src/api/cancellation.rs
+++ b/zenoh/src/api/cancellation.rs
@@ -82,7 +82,7 @@ struct CancellationTokenInner {
 /// let queryable = session
 ///     .get("key/expression")
 ///     .callback_mut(move |reply| {n += 1;})
-///     .with_cancellation_token(cancellation_token.clone())
+///     .cancellation_token(cancellation_token.clone())
 ///     .await
 ///     .unwrap();
 ///
@@ -194,5 +194,5 @@ impl fmt::Debug for CancellationTokenInner {
 }
 
 pub trait CancellationTokenBuilderTrait {
-    fn with_cancellation_token(self, cancellation_token: CancellationToken) -> Self;
+    fn cancellation_token(self, cancellation_token: CancellationToken) -> Self;
 }

--- a/zenoh/src/api/liveliness.rs
+++ b/zenoh/src/api/liveliness.rs
@@ -786,7 +786,7 @@ impl<Handler> CancellationTokenBuilderTrait for LivelinessGetBuilder<'_, '_, Han
     ///     .liveliness()
     ///     .get("key/expression")
     ///     .with(flume::bounded(32))
-    ///     .with_cancellation_token(ct.clone())
+    ///     .cancellation_token(ct.clone())
     ///     .await
     ///     .unwrap();
     /// tokio::task::spawn(async move {
@@ -799,7 +799,7 @@ impl<Handler> CancellationTokenBuilderTrait for LivelinessGetBuilder<'_, '_, Han
     /// # }
     /// ```
     #[zenoh_macros::unstable_doc]
-    fn with_cancellation_token(
+    fn cancellation_token(
         self,
         cancellation_token: crate::api::cancellation::CancellationToken,
     ) -> Self {

--- a/zenoh/tests/cancellation.rs
+++ b/zenoh/tests/cancellation.rs
@@ -57,7 +57,7 @@ async fn test_cancellation_get() {
 
     let replies = ztimeout!(session2
         .get("test/query_cancellation")
-        .with_cancellation_token(cancellation_token.clone()))
+        .cancellation_token(cancellation_token.clone()))
     .unwrap();
 
     tokio::time::sleep(Duration::from_secs(1)).await;
@@ -75,7 +75,7 @@ async fn test_cancellation_get() {
     let n_clone = n.clone();
     ztimeout!(session2
         .get("test/query_cancellation")
-        .with_cancellation_token(cancellation_token.clone())
+        .cancellation_token(cancellation_token.clone())
         .callback(move |_| {
             std::thread::sleep(Duration::from_secs(5));
             n_clone.fetch_or(true, std::sync::atomic::Ordering::SeqCst);
@@ -94,7 +94,7 @@ async fn test_cancellation_get() {
     assert!(cancellation_token.is_cancelled());
     let replies = ztimeout!(session2
         .get("test/query_cancellation")
-        .with_cancellation_token(cancellation_token.clone()))
+        .cancellation_token(cancellation_token.clone()))
     .unwrap();
     assert!(replies.is_disconnected());
 }
@@ -116,7 +116,7 @@ async fn test_cancellation_liveliness_get() {
     ztimeout!(session2
         .liveliness()
         .get("test/liveliness_query_cancellation")
-        .with_cancellation_token(cancellation_token.clone())
+        .cancellation_token(cancellation_token.clone())
         .callback(move |_| {
             std::thread::sleep(Duration::from_secs(5));
             n_clone.fetch_or(true, std::sync::atomic::Ordering::SeqCst);
@@ -131,7 +131,7 @@ async fn test_cancellation_liveliness_get() {
     let replies = ztimeout!(session2
         .liveliness()
         .get("test/liveliness_query_cancellation")
-        .with_cancellation_token(cancellation_token.clone()))
+        .cancellation_token(cancellation_token.clone()))
     .unwrap();
     assert!(replies.is_disconnected());
 }
@@ -147,10 +147,7 @@ async fn test_cancellation_querier_get() {
 
     let cancellation_token = zenoh::cancellation::CancellationToken::default();
 
-    let replies = ztimeout!(querier
-        .get()
-        .with_cancellation_token(cancellation_token.clone()))
-    .unwrap();
+    let replies = ztimeout!(querier.get().cancellation_token(cancellation_token.clone())).unwrap();
 
     tokio::time::sleep(Duration::from_secs(1)).await;
     cancellation_token.cancel().await.unwrap();
@@ -167,7 +164,7 @@ async fn test_cancellation_querier_get() {
     let n_clone = n.clone();
     ztimeout!(querier
         .get()
-        .with_cancellation_token(cancellation_token.clone())
+        .cancellation_token(cancellation_token.clone())
         .callback(move |_| {
             std::thread::sleep(Duration::from_secs(5));
             n_clone.fetch_or(true, std::sync::atomic::Ordering::SeqCst);
@@ -184,9 +181,6 @@ async fn test_cancellation_querier_get() {
 
     // check that cancelled token cancels operation automatically
     assert!(cancellation_token.is_cancelled());
-    let replies = ztimeout!(querier
-        .get()
-        .with_cancellation_token(cancellation_token.clone()))
-    .unwrap();
+    let replies = ztimeout!(querier.get().cancellation_token(cancellation_token.clone())).unwrap();
     assert!(replies.is_disconnected());
 }


### PR DESCRIPTION
rename with_cancellation_token -> cancellation_token, to keep naming consistent with other options