### PR TITLE
Handle ignored cases in `Interest::options`

### DIFF
--- a/commons/zenoh-protocol/src/network/interest.rs
+++ b/commons/zenoh-protocol/src/network/interest.rs
@@ -202,10 +202,16 @@ impl Interest {
             interest += InterestOptions::RESTRICTED;
             if we.has_suffix() {
                 interest += InterestOptions::NAMED;
+            } else {
+                interest -= InterestOptions::NAMED;
             }
             if let Mapping::Sender = we.mapping {
                 interest += InterestOptions::MAPPING;
+            } else {
+                interest -= InterestOptions::MAPPING;
             }
+        } else {
+            interest -= InterestOptions::RESTRICTED;
         }
         interest.options
     }


### PR DESCRIPTION
This function is meant to rectify the values of the `R`, `N` and `M` interest options during encoding.

Unforunately, it only sets an option if it should be set but isn't: i.e. it doesn't unset an option if it's not supposed to be set.

Consider the following scenario: node X receives an interest with `N` set and a non-empty suffix (as expected), then it forwards it to node Y with an empty suffix; the `Interest::options` function will not unset the original `N` flag during encoding on X, thus node Y will receive an invalid message.

Thus these options should be set _if and only if_ their respective conditions are met.