### PR TITLE
chore: pin ntex packages for 1.75 compatibility

### DIFF
--- a/commons/zenoh-pinned-deps-1-75/Cargo.toml
+++ b/commons/zenoh-pinned-deps-1-75/Cargo.toml
@@ -37,9 +37,12 @@ librocksdb-sys = "=0.17.1"
 litemap = "=0.7.4"
 lz4_flex = "=0.11.3"
 nonempty-collections = "=0.3.1"
-ntex = "=2.13.1"
+ntex = { version = "=2.7.0", features = ["rustls", "tokio"] }
 ntex-bytes = "=0.1.28"
-ntex-io = "=2.13.2"
+ntex-io = "=2.14.0"
+ntex-mqtt = "=3.1.0"
+ntex-net = "=2.8.1"
+ntex-tls = "=2.2.0"
 pest = "=2.8.0"
 pest_derive = "=2.8.0"
 pest_generator = "=2.8.0"
@@ -75,6 +78,9 @@ ignored = [
   "ntex",
   "ntex-bytes",
   "ntex-io",
+  "ntex-mqtt",
+  "ntex-net",
+  "ntex-tls",
   "pest",
   "pest_derive",
   "pest_generator",


### PR DESCRIPTION
These pins are to be able to build zenoh-plugin-mqtt with zenoh's Cargo.lock in the sync cargo lock workflow: https://github.com/eclipse-zenoh/zenoh/actions/runs/19251793291/job/55038106290#step:10:450

zenoh-plugin-mqtt PR: https://github.com/eclipse-zenoh/zenoh-plugin-mqtt/pull/535