### PR TITLE
Remove `key_expr.ends_with('/')` checks

### DIFF
--- a/zenoh/src/net/routing/hat/client/pubsub.rs
+++ b/zenoh/src/net/routing/hat/client/pubsub.rs
@@ -396,9 +396,7 @@ impl HatPubSubTrait for HatCode {
         key_expr: &KeyExpr<'_>,
     ) -> HashMap<usize, Arc<FaceState>> {
         let mut matching_subscriptions = HashMap::new();
-        if key_expr.ends_with('/') {
-            return matching_subscriptions;
-        }
+
         tracing::trace!("get_matching_subscriptions({})", key_expr,);
 
         let res = Resource::get_resource(&tables.root_res, key_expr);

--- a/zenoh/src/net/routing/hat/client/queries.rs
+++ b/zenoh/src/net/routing/hat/client/queries.rs
@@ -408,9 +408,7 @@ impl HatQueriesTrait for HatCode {
         complete: bool,
     ) -> HashMap<usize, Arc<FaceState>> {
         let mut matching_queryables = HashMap::new();
-        if key_expr.ends_with('/') {
-            return matching_queryables;
-        }
+
         tracing::trace!(
             "get_matching_queryables({}; complete: {})",
             key_expr,

--- a/zenoh/src/net/routing/hat/linkstate_peer/pubsub.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/pubsub.rs
@@ -931,9 +931,7 @@ impl HatPubSubTrait for HatCode {
         }
 
         let mut matching_subscriptions = HashMap::new();
-        if key_expr.ends_with('/') {
-            return matching_subscriptions;
-        }
+
         tracing::trace!("get_matching_subscriptions({})", key_expr,);
 
         let res = Resource::get_resource(&tables.root_res, key_expr);

--- a/zenoh/src/net/routing/hat/linkstate_peer/queries.rs
+++ b/zenoh/src/net/routing/hat/linkstate_peer/queries.rs
@@ -1009,9 +1009,7 @@ impl HatQueriesTrait for HatCode {
         complete: bool,
     ) -> HashMap<usize, Arc<FaceState>> {
         let mut matching_queryables = HashMap::new();
-        if key_expr.ends_with('/') {
-            return matching_queryables;
-        }
+
         tracing::trace!(
             "get_matching_queryables({}; complete: {})",
             key_expr,

--- a/zenoh/src/net/routing/hat/p2p_peer/pubsub.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/pubsub.rs
@@ -605,9 +605,7 @@ impl HatPubSubTrait for HatCode {
         key_expr: &KeyExpr<'_>,
     ) -> HashMap<usize, Arc<FaceState>> {
         let mut matching_subscriptions = HashMap::new();
-        if key_expr.ends_with('/') {
-            return matching_subscriptions;
-        }
+
         tracing::trace!("get_matching_subscriptions({})", key_expr,);
         let res = Resource::get_resource(&tables.root_res, key_expr);
         let matches = res

--- a/zenoh/src/net/routing/hat/p2p_peer/queries.rs
+++ b/zenoh/src/net/routing/hat/p2p_peer/queries.rs
@@ -629,9 +629,6 @@ impl HatQueriesTrait for HatCode {
         complete: bool,
     ) -> HashMap<usize, Arc<FaceState>> {
         let mut matching_queryables = HashMap::new();
-        if key_expr.ends_with('/') {
-            return matching_queryables;
-        }
         tracing::trace!(
             "get_matching_queryables({}; complete: {})",
             key_expr,

--- a/zenoh/src/net/routing/hat/router/pubsub.rs
+++ b/zenoh/src/net/routing/hat/router/pubsub.rs
@@ -1253,9 +1253,7 @@ impl HatPubSubTrait for HatCode {
         }
 
         let mut matching_subscriptions = HashMap::new();
-        if key_expr.ends_with('/') {
-            return matching_subscriptions;
-        }
+
         tracing::trace!("get_matching_subscriptions({})", key_expr,);
 
         let res = Resource::get_resource(&tables.root_res, key_expr);

--- a/zenoh/src/net/routing/hat/router/queries.rs
+++ b/zenoh/src/net/routing/hat/router/queries.rs
@@ -1419,9 +1419,7 @@ impl HatQueriesTrait for HatCode {
         complete: bool,
     ) -> HashMap<usize, Arc<FaceState>> {
         let mut matching_queryables = HashMap::new();
-        if key_expr.ends_with('/') {
-            return matching_queryables;
-        }
+
         tracing::trace!(
             "get_matching_queryables({}; complete: {})",
             key_expr,


### PR DESCRIPTION
At some point, key expression started forbidding trailing slashes. Thus these checks never fail in sound programs. Their performance impact is likely negligeable, but their impact on readability is not.