### PR TITLE
chore: pin tls-listener to 0.11.0

### DIFF
--- a/commons/zenoh-pinned-deps-1-75/Cargo.toml
+++ b/commons/zenoh-pinned-deps-1-75/Cargo.toml
@@ -56,6 +56,7 @@ static_init = "=1.0.3"
 thread-priority = "=1.2.0"
 time = "=0.3.41"
 tinystr = "=0.8.0"
+tls-listener = "=0.11.0"
 toml = "=0.9.6"
 toml_datetime = "=0.7.1"
 toml_parser = "=1.0.2"
@@ -94,6 +95,7 @@ ignored = [
   "thread-priority",
   "time",
   "tinystr",
+  "tls-listener",
   "toml",
   "toml_datetime",
   "toml_parser",


### PR DESCRIPTION
tls-listener 0.11.1 doesn't compile on windows and newer versions `>0.11.1` will require rust edition 2024

~~Fix https://github.com/eclipse-zenoh/zenoh/actions/runs/19555241578/job/55996089049~~