### PR TITLE
Fix the invalid link of Zenoh-ext.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This repository contains the following elements:
 
 * [Docs.rs for Zenoh](https://docs.rs/zenoh/latest/zenoh/)
 
-* [Docs.rs for Zenoh-ext](https://docs.rs/zenoh/latest/zenoh-ext/)
+* [Docs.rs for Zenoh-ext](https://docs.rs/zenoh-ext/latest/zenoh_ext/)
 
 # Build and run
 


### PR DESCRIPTION
Docs.rs for Zenoh-ext is invalid
https://docs.rs/zenoh/latest/zenoh-ext/
It should be this one
https://docs.rs/zenoh-ext/latest/zenoh_ext/