### PR TITLE
Document `LivelinessSubscriberBuilder::history`

### DIFF
--- a/zenoh/src/api/builders/liveliness.rs
+++ b/zenoh/src/api/builders/liveliness.rs
@@ -223,6 +223,14 @@ impl<'a, 'b> LivelinessSubscriberBuilder<'a, 'b, Callback<Sample>> {
 }
 
 impl<Handler, const BACKGROUND: bool> LivelinessSubscriberBuilder<'_, '_, Handler, BACKGROUND> {
+    /// Sets the `history` option.
+    ///
+    /// When set to `true`, Zenoh queries the network for _currently live tokens_[^1] upon declaring the subscriber.
+    ///
+    /// When set to `false`, Zenoh does not query the network for currently live tokens.
+    /// In this mode, currently live tokens may still be delivered to the subscriber.
+    ///
+    /// [^1]: Currently live tokens comprise the set of samples that would be returned by a liveliness GET.
     #[inline]
     pub fn history(mut self, history: bool) -> Self {
         self.history = history;


### PR DESCRIPTION
This patch clarifies the semantics of `LivelinessSubscriberBuilder::history`. In particular, the behavior documented in #2278 and #2283 can no longer be considered an issue.

A stricter liveliness subscriber mode can be implemented later if a use-case for `history = false` with no stale tokens emerges.

Closes #2278.
Closes #2283.