### PR TITLE
locked version of derive_more to last one supporting rust 1.75

### DIFF
--- a/commons/zenoh-pinned-deps-1-75/Cargo.toml
+++ b/commons/zenoh-pinned-deps-1-75/Cargo.toml
@@ -28,7 +28,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 base64ct = "=1.6.0"
-derive_more = "=2.0.1"
+derive_more = { version = "=2.0.1", features = ["as_ref"] }
 generic-array = "=0.14.7"
 home = "=0.5.9"
 icu_normalizer = "=1.5.0"


### PR DESCRIPTION
Fix for build for rust 1.75: crate https://crates.io/crates/derive_more/ locked to "=2.0.1"