### PR TITLE
zenoh: api: encoding: Add MAVLink

### DIFF
--- a/zenoh/src/api/encoding.rs
+++ b/zenoh/src/api/encoding.rs
@@ -471,6 +471,13 @@ impl Encoding {
         id: 52,
         schema: None,
     });
+    /// A Micro Air Vehicle Link (MAVLink)-encoded data.
+    ///
+    /// Constant alias for string: `"application/mavlink"`.
+    pub const APPLICATION_MAVLINK: Encoding = Self(zenoh_protocol::core::Encoding {
+        id: 53,
+        schema: None,
+    });
 
     const ID_TO_STR: phf::Map<EncodingId, &'static str> = phf_map! {
         0u16 => "zenoh/bytes",
@@ -526,6 +533,7 @@ impl Encoding {
         50u16 => "video/raw",
         51u16 => "video/vp8",
         52u16 => "video/vp9",
+        53u16 => "application/mavlink",
         // The 0xFFFFu16 is used to indicate a custom encoding where both encoding and schema
         // are stored in the schema field.
         0xFFFFu16 => "",
@@ -585,6 +593,7 @@ impl Encoding {
         "video/raw" => 50u16,
         "video/vp8" => 51u16,
         "video/vp9" => 52u16,
+        "application/mavlink" => 53u16,
     };
 
     /// The default [`Encoding`] is [`ZENOH_BYTES`](Encoding::ZENOH_BYTES).


### PR DESCRIPTION
MAVLink is a messaging protocol for communicating with drones (and between onboard drone components).

It would be great for the drone industry (and zenoh adoption) to have the MAVLink protocol as a native encoding option in Zenoh.
I'm working with MAVLink/ArduPilot/BlueOS/PX4 and zenoh integration in the ecosystem, this patch would move things forward exceptionally.

For more information:
  - https://mavlink.io/en/
  - https://github.com/mavlink/mavlink
  - https://ardupilot.org/dev/docs/mavlink-commands.html
  - https://docs.px4.io/main/en/mavlink/#mavlink-overview
    - That already has a initial zenoh integration (https://github.com/PX4/PX4-Autopilot/tree/3e425210e0a625539268709c3ca8b670014785f2/src/modules/zenoh)