### PR TITLE
Connectivity adminspace test

### DIFF
--- a/zenoh/tests/adminspace.rs
+++ b/zenoh/tests/adminspace.rs
@@ -522,7 +522,7 @@ async fn test_adminspace_transports_and_links() {
 
     // Create router1 with adminspace enabled
     let router1 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh_config::Config::default();
         c.set_mode(Some(WhatAmI::Router)).unwrap();
         c.listen
             .endpoints
@@ -574,7 +574,7 @@ async fn test_adminspace_transports_and_links() {
 
     // Create router2 that connects to router1 (creates unicast transport)
     let router2 = {
-        let mut c = zenoh::Config::default();
+        let mut c = zenoh_config::Config::default();
         c.set_mode(Some(WhatAmI::Router)).unwrap();
         c.listen.endpoints.set(vec![]).unwrap();
         c.connect


### PR DESCRIPTION
Test for json created by adminspace at `@/zid/session/transport/**`
The goal of the test is to control that the connectivity api and adminspace rework https://github.com/eclipse-zenoh/zenoh/pull/2301 doesn't change adminspace output.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->