### PR TITLE
Split `matching::zenoh_querier_matching_status` into multiple test cases

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -26,3 +26,10 @@ test(=zenoh_querier_matching_status)
 """
 slow-timeout = { period = "60s", terminate-after = 6 }
 threads-required = 'num-cpus'
+
+[test-groups]
+serial = { max-threads = 1 }
+
+[[profile.default.overrides]]
+filter = 'test(zenoh_querier_matching_status::)'
+test-group = 'serial'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5870,6 +5870,7 @@ dependencies = [
  "serde",
  "serde_json",
  "socket2 0.5.10",
+ "test-case",
  "tokio",
  "tokio-util",
  "tracing",

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -131,6 +131,7 @@ zenoh-util = { workspace = true }
 
 [dev-dependencies]
 libc = { workspace = true }
+test-case = { workspace = true }
 tokio = { workspace = true }
 zenoh-protocol = { workspace = true, features = ["test"] }
 


### PR DESCRIPTION
The original test ran for over 3mins which is significantly over the slowness threshold of 1min. Moreover, this test was difficult to debug as the only way to tell which test case failed was to scroll up the logs (especially with the debug/trace tracing levels).

I added a `serial` test group in the cargo-next config to ensure that all the test cases don't run in parallel, otherwise test cases would step over each other's 18002 listener port. Note that the original test ran all test cases serially as well. See https://nexte.st/docs/configuration/test-groups/?h=serial#configuring-test-groups.