### PR TITLE
chore: allow use of deprecated set_linger()

### DIFF
--- a/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
@@ -62,10 +62,7 @@ impl LinkUnicastTcp {
         }
 
         // Set the TCP linger option
-        #[allow(
-            deprecated,
-            reason = "set_linger is deprecated but we want to have more control over the socket options. See https://github.com/tokio-rs/tokio/issues/7751"
-        )]
+        #[allow(deprecated)]
         if let Err(err) = socket.set_linger(Some(Duration::from_secs(
             (*TCP_LINGER_TIMEOUT).try_into().unwrap(),
         ))) {

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -98,10 +98,7 @@ impl LinkUnicastTls {
         }
 
         // Set the TLS linger option
-        #[allow(
-            deprecated,
-            reason = "set_linger is deprecated but we want to have more control over the socket options. See https://github.com/tokio-rs/tokio/issues/7751"
-        )]
+        #[allow(deprecated)]
         if let Err(err) = tcp_stream.set_linger(Some(Duration::from_secs(
             (*TLS_LINGER_TIMEOUT).try_into().unwrap(),
         ))) {


### PR DESCRIPTION
Tokio's TcpStream::set_linger can block and has been deprecated but we want to have more control over the socket options.

See https://github.com/tokio-rs/tokio/issues/7751