### PR TITLE
chore: fix typo in sessions.rs doc

### DIFF
--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -629,7 +629,7 @@ impl Drop for Session {
 /// When all `Session` instances are dropped, [`Session::close`] is called and cleans
 /// the reference cycles, allowing the underlying `Arc` to be properly reclaimed.
 ///
-/// (Although it was planed to be used initially, `Weak` was in fact causing errors in the session
+/// (Although it was planned to be used initially, `Weak` was in fact causing errors in the session
 /// closing, because the primitive implementation seemed to be used in the closing operation.)
 #[derive(Clone)]
 pub(crate) struct WeakSession(Arc<SessionInner>);


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->
Fix typo in sessions.rs so CI will pass for release 1.7.2 and it'll unblock https://github.com/eclipse-zenoh/zenoh/pull/2354

See https://github.com/eclipse-zenoh/zenoh/actions/runs/20810978240/job/59774907486

### What does this PR do?

Fix a typo in sessions.rs 

### Why is this change needed?

Keep the CI passing for typos checking and unblocks the recreate Cargo.lock PR

### Related Issues
N/A

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->