### PR TITLE
Store slice instead of range in ZSlice

### DIFF
--- a/commons/zenoh-buffers/src/zslice.rs
+++ b/commons/zenoh-buffers/src/zslice.rs
@@ -15,8 +15,10 @@ use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use core::{
     any::Any,
     fmt, iter,
+    mem::ManuallyDrop,
     num::NonZeroUsize,
-    ops::{Bound, Deref, RangeBounds},
+    ops::{Bound, Deref, DerefMut, RangeBounds},
+    ptr::NonNull,
 };
 
 use crate::{
@@ -91,12 +93,15 @@ pub enum ZSliceKind {
 /// A cloneable wrapper to a contiguous slice of bytes.
 #[derive(Clone)]
 pub struct ZSlice {
+    ptr: *const u8,
+    len: usize,
     buf: Arc<dyn ZSliceBuffer>,
-    start: usize,
-    end: usize,
     #[cfg(feature = "shared-memory")]
     pub kind: ZSliceKind,
 }
+
+unsafe impl Send for ZSlice {}
+unsafe impl Sync for ZSlice {}
 
 impl ZSlice {
     #[inline]
@@ -105,11 +110,12 @@ impl ZSlice {
         start: usize,
         end: usize,
     ) -> Result<ZSlice, Arc<dyn ZSliceBuffer>> {
-        if start <= end && end <= buf.as_slice().len() {
+        let slice = buf.as_slice();
+        if start <= end && end <= slice.len() {
             Ok(Self {
+                ptr: unsafe { slice.as_ptr().add(start) },
+                len: end - start,
                 buf,
-                start,
-                end,
                 #[cfg(feature = "shared-memory")]
                 kind: ZSliceKind::Raw,
             })
@@ -131,11 +137,17 @@ impl ZSlice {
 
     /// # Safety
     ///
-    /// Buffer modification must not modify slice range or invalidate the data.
+    /// [`BufferMutGuard`] destructor must be run.
     #[inline]
     #[must_use]
-    pub unsafe fn downcast_mut<T: Any>(&mut self) -> Option<&mut T> {
-        Arc::get_mut(&mut self.buf)?.as_any_mut().downcast_mut()
+    pub unsafe fn downcast_mut<T: Any + AsRef<[u8]>>(&mut self) -> Option<BufferMutGuard<'_, T>> {
+        let mut zslice = NonNull::from(self);
+        let buffer = ManuallyDrop::new(
+            Arc::get_mut(&mut unsafe { zslice.as_mut() }.buf)?
+                .as_any_mut()
+                .downcast_mut()?,
+        );
+        Some(BufferMutGuard { zslice, buffer })
     }
 
     // This method is internal and is only meant to be used in `ZBufWriter`.
@@ -147,10 +159,12 @@ impl ZSlice {
         let vec = Arc::get_mut(&mut self.buf)?
             .as_any_mut()
             .downcast_mut::<Vec<u8>>()?;
-        if self.end == vec.len() {
+        if self.len == vec.len() {
+            debug_assert_eq!(self.ptr, vec.as_ptr());
             Some(ZSliceWriter {
                 vec,
-                end: &mut self.end,
+                ptr: &mut self.ptr,
+                len: &mut self.len,
             })
         } else {
             None
@@ -160,7 +174,7 @@ impl ZSlice {
     #[inline]
     #[must_use]
     pub const fn len(&self) -> usize {
-        self.end - self.start
+        self.len
     }
 
     #[inline]
@@ -172,8 +186,8 @@ impl ZSlice {
     #[inline]
     #[must_use]
     pub fn as_slice(&self) -> &[u8] {
-        // SAFETY: bounds checks are performed at `ZSlice` construction via `new()` or `subslice()`.
-        unsafe { self.buf.as_slice().get_unchecked(self.start..self.end) }
+        // SAFETY: bounds checks are performed at `ZSlice` construction via `make()` or `subslice()`.
+        unsafe { core::slice::from_raw_parts(self.ptr, self.len) }
     }
 
     pub fn subslice(&self, range: impl RangeBounds<usize>) -> Option<Self> {
@@ -189,15 +203,20 @@ impl ZSlice {
         };
         if start <= end && end <= self.len() {
             Some(ZSlice {
+                ptr: unsafe { self.ptr.add(start) },
+                len: end - start,
                 buf: self.buf.clone(),
-                start: self.start + start,
-                end: self.start + end,
                 #[cfg(feature = "shared-memory")]
                 kind: self.kind,
             })
         } else {
             None
         }
+    }
+
+    unsafe fn advance_by(&mut self, n: usize) {
+        self.ptr = unsafe { self.ptr.add(n) };
+        self.len -= n;
     }
 }
 
@@ -248,11 +267,11 @@ where
     T: ZSliceBuffer + 'static,
 {
     fn from(buf: Arc<T>) -> Self {
-        let end = buf.as_slice().len();
+        let slice = buf.as_slice();
         Self {
+            ptr: slice.as_ptr(),
+            len: slice.len(),
             buf,
-            start: 0,
-            end,
             #[cfg(feature = "shared-memory")]
             kind: ZSliceKind::Raw,
         }
@@ -296,16 +315,64 @@ impl SplitBuffer for ZSlice {
     }
 }
 
+pub struct BufferMutGuard<'a, B: AsRef<[u8]>> {
+    zslice: NonNull<ZSlice>,
+    buffer: ManuallyDrop<&'a mut B>,
+}
+
+impl<'a, B: AsRef<[u8]>> BufferMutGuard<'a, B> {
+    /// # Safety
+    ///
+    /// The returned buffer must still be the internal buffer of the zslice.
+    pub unsafe fn map<B2: AsRef<[u8]>>(
+        self,
+        f: impl FnOnce(&mut B) -> &mut B2,
+    ) -> BufferMutGuard<'a, B2> {
+        let mut this = ManuallyDrop::new(self);
+        BufferMutGuard {
+            zslice: this.zslice,
+            buffer: ManuallyDrop::new(f(unsafe { ManuallyDrop::take(&mut this.buffer) })),
+        }
+    }
+}
+
+impl<B: AsRef<[u8]>> Deref for BufferMutGuard<'_, B> {
+    type Target = B;
+    fn deref(&self) -> &Self::Target {
+        &self.buffer
+    }
+}
+
+impl<B: AsRef<[u8]>> DerefMut for BufferMutGuard<'_, B> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.buffer
+    }
+}
+
+impl<B: AsRef<[u8]>> Drop for BufferMutGuard<'_, B> {
+    fn drop(&mut self) {
+        let slice = self.buffer.as_ref();
+        let ptr = slice.as_ptr();
+        let len = slice.len();
+        unsafe {
+            self.zslice.as_mut().ptr = ptr;
+            self.zslice.as_mut().len = len;
+        }
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct ZSliceWriter<'a> {
     vec: &'a mut Vec<u8>,
-    end: &'a mut usize,
+    ptr: &'a mut *const u8,
+    len: &'a mut usize,
 }
 
 impl Writer for ZSliceWriter<'_> {
     fn write(&mut self, bytes: &[u8]) -> Result<NonZeroUsize, DidntWrite> {
         let len = self.vec.write(bytes)?;
-        *self.end += len.get();
+        *self.ptr = self.vec.as_ptr();
+        *self.len = self.vec.len();
         Ok(len)
     }
 
@@ -328,7 +395,8 @@ impl Writer for ZSliceWriter<'_> {
         // SAFETY: Same precondition as this function. Call to `with_slot` is safe because
         // the requirements are passed through.
         let len = unsafe { self.vec.with_slot(len, write) }?;
-        *self.end += len.get();
+        *self.ptr = self.vec.as_ptr();
+        *self.len = self.vec.len();
         Ok(len)
     }
 }
@@ -337,13 +405,13 @@ impl BacktrackableWriter for ZSliceWriter<'_> {
     type Mark = usize;
 
     fn mark(&mut self) -> Self::Mark {
-        *self.end
+        *self.len
     }
 
     fn rewind(&mut self, mark: Self::Mark) -> bool {
         assert!(mark <= self.vec.len());
         self.vec.truncate(mark);
-        *self.end = mark;
+        *self.len = mark;
         true
     }
 }
@@ -363,7 +431,7 @@ impl Reader for ZSlice {
         let mut reader = self.as_slice().reader();
         let len = reader.read(into)?;
         // we trust `Reader` impl for `&[u8]` to not overflow the size of the slice
-        self.start += len.get();
+        unsafe { self.advance_by(len.get()) }
         Ok(len)
     }
 
@@ -372,7 +440,7 @@ impl Reader for ZSlice {
         let mut reader = self.as_slice().reader();
         reader.read_exact(into)?;
         // we trust `Reader` impl for `&[u8]` to not overflow the size of the slice
-        self.start += into.len();
+        unsafe { self.advance_by(into.len()) };
         Ok(())
     }
 
@@ -395,7 +463,7 @@ impl Reader for ZSlice {
     #[inline(always)]
     fn read_zslice(&mut self, len: usize) -> Result<ZSlice, DidntRead> {
         let res = self.subslice(..len).ok_or(DidntRead)?;
-        self.start += len;
+        unsafe { self.advance_by(len) };
         Ok(res)
     }
 
@@ -404,7 +472,7 @@ impl Reader for ZSlice {
         let mut reader = self.as_slice().reader();
         let res = reader.read_u8()?;
         // we trust `Reader` impl for `&[u8]` to not overflow the size of the slice
-        self.start += 1;
+        unsafe { self.advance_by(1) };
         Ok(res)
     }
 
@@ -415,15 +483,14 @@ impl Reader for ZSlice {
 }
 
 impl BacktrackableReader for ZSlice {
-    type Mark = usize;
+    type Mark = (*const u8, usize);
 
     fn mark(&mut self) -> Self::Mark {
-        self.start
+        (self.ptr, self.len)
     }
 
     fn rewind(&mut self, mark: Self::Mark) -> bool {
-        assert!(mark <= self.end);
-        self.start = mark;
+        (self.ptr, self.len) = mark;
         true
     }
 }
@@ -462,10 +529,11 @@ mod tests {
         let mut zslice: ZSlice = buf.clone().into();
         assert_eq!(buf.as_slice(), zslice.as_slice());
 
-        // SAFETY: buffer slice size is not modified.
-        let mut_slice = unsafe { zslice.downcast_mut::<Vec<u8>>() }.unwrap();
+        // SAFETY: buffer slice size is not modified
+        let mut mut_slice = unsafe { zslice.downcast_mut::<Vec<u8>>() }.unwrap();
 
         mut_slice[..buf.len()].clone_from_slice(&buf[..]);
+        drop(mut_slice);
 
         assert_eq!(buf.as_slice(), zslice.as_slice());
     }

--- a/commons/zenoh-buffers/src/zslice.rs
+++ b/commons/zenoh-buffers/src/zslice.rs
@@ -17,7 +17,7 @@ use core::{
     fmt, iter,
     mem::ManuallyDrop,
     num::NonZeroUsize,
-    ops::{Bound, Deref, DerefMut, RangeBounds},
+    ops::{Deref, DerefMut, RangeBounds},
     ptr::NonNull,
 };
 
@@ -90,18 +90,37 @@ pub enum ZSliceKind {
     ShmPtr = 1,
 }
 
+/// A self-referenced raw byte slice stored alongside its origin buffer in [`ZSlice`].
+#[derive(Clone, Copy, Debug)]
+pub struct RawSlice {
+    ptr: NonNull<u8>,
+    len: usize,
+}
+
+impl From<&[u8]> for RawSlice {
+    fn from(s: &[u8]) -> Self {
+        Self {
+            ptr: NonNull::new(s.as_ptr().cast_mut()).expect("slice ptr is non-null"),
+            len: s.len(),
+        }
+    }
+}
+
+// SAFETY: `RawSlice` is equivalent to a `&[u8]` reference into the origin buffer,
+// which is `Send`.
+unsafe impl Send for RawSlice {}
+// SAFETY: `RawSlice` is equivalent to a `&[u8]` reference into the origin buffer,
+// which is `Sync`.
+unsafe impl Sync for RawSlice {}
+
 /// A cloneable wrapper to a contiguous slice of bytes.
 #[derive(Clone)]
 pub struct ZSlice {
-    ptr: *const u8,
-    len: usize,
+    slice: RawSlice,
     buf: Arc<dyn ZSliceBuffer>,
     #[cfg(feature = "shared-memory")]
     pub kind: ZSliceKind,
 }
-
-unsafe impl Send for ZSlice {}
-unsafe impl Sync for ZSlice {}
 
 impl ZSlice {
     #[inline]
@@ -110,11 +129,9 @@ impl ZSlice {
         start: usize,
         end: usize,
     ) -> Result<ZSlice, Arc<dyn ZSliceBuffer>> {
-        let slice = buf.as_slice();
-        if start <= end && end <= slice.len() {
+        if let Some(slice) = buf.as_slice().get(start..end) {
             Ok(Self {
-                ptr: unsafe { slice.as_ptr().add(start) },
-                len: end - start,
+                slice: slice.into(),
                 buf,
                 #[cfg(feature = "shared-memory")]
                 kind: ZSliceKind::Raw,
@@ -159,12 +176,11 @@ impl ZSlice {
         let vec = Arc::get_mut(&mut self.buf)?
             .as_any_mut()
             .downcast_mut::<Vec<u8>>()?;
-        if self.len == vec.len() {
-            debug_assert_eq!(self.ptr, vec.as_ptr());
+        if self.slice.len == vec.len() {
+            debug_assert_eq!(self.slice.ptr.as_ptr(), vec.as_ptr().cast_mut());
             Some(ZSliceWriter {
                 vec,
-                ptr: &mut self.ptr,
-                len: &mut self.len,
+                slice: &mut self.slice,
             })
         } else {
             None
@@ -174,7 +190,7 @@ impl ZSlice {
     #[inline]
     #[must_use]
     pub const fn len(&self) -> usize {
-        self.len
+        self.slice.len
     }
 
     #[inline]
@@ -187,36 +203,23 @@ impl ZSlice {
     #[must_use]
     pub fn as_slice(&self) -> &[u8] {
         // SAFETY: bounds checks are performed at `ZSlice` construction via `make()` or `subslice()`.
-        unsafe { core::slice::from_raw_parts(self.ptr, self.len) }
+        unsafe { core::slice::from_raw_parts(self.slice.ptr.as_ptr(), self.slice.len) }
     }
 
     pub fn subslice(&self, range: impl RangeBounds<usize>) -> Option<Self> {
-        let start = match range.start_bound() {
-            Bound::Included(&n) => n,
-            Bound::Excluded(&n) => n + 1,
-            Bound::Unbounded => 0,
-        };
-        let end = match range.end_bound() {
-            Bound::Included(&n) => n + 1,
-            Bound::Excluded(&n) => n,
-            Bound::Unbounded => self.len(),
-        };
-        if start <= end && end <= self.len() {
-            Some(ZSlice {
-                ptr: unsafe { self.ptr.add(start) },
-                len: end - start,
-                buf: self.buf.clone(),
-                #[cfg(feature = "shared-memory")]
-                kind: self.kind,
-            })
-        } else {
-            None
-        }
+        let start = range.start_bound().cloned();
+        let end = range.end_bound();
+        let slice = self.as_slice().get((start, end.cloned()))?;
+        Some(ZSlice {
+            slice: slice.into(),
+            buf: self.buf.clone(),
+            #[cfg(feature = "shared-memory")]
+            kind: self.kind,
+        })
     }
 
     unsafe fn advance_by(&mut self, n: usize) {
-        self.ptr = unsafe { self.ptr.add(n) };
-        self.len -= n;
+        self.slice = self.as_slice()[n..].into();
     }
 }
 
@@ -267,10 +270,8 @@ where
     T: ZSliceBuffer + 'static,
 {
     fn from(buf: Arc<T>) -> Self {
-        let slice = buf.as_slice();
         Self {
-            ptr: slice.as_ptr(),
-            len: slice.len(),
+            slice: buf.as_slice().into(),
             buf,
             #[cfg(feature = "shared-memory")]
             kind: ZSliceKind::Raw,
@@ -351,12 +352,8 @@ impl<B: AsRef<[u8]>> DerefMut for BufferMutGuard<'_, B> {
 
 impl<B: AsRef<[u8]>> Drop for BufferMutGuard<'_, B> {
     fn drop(&mut self) {
-        let slice = self.buffer.as_ref();
-        let ptr = slice.as_ptr();
-        let len = slice.len();
         unsafe {
-            self.zslice.as_mut().ptr = ptr;
-            self.zslice.as_mut().len = len;
+            self.zslice.as_mut().slice = self.buffer.as_ref().into();
         }
     }
 }
@@ -364,15 +361,13 @@ impl<B: AsRef<[u8]>> Drop for BufferMutGuard<'_, B> {
 #[derive(Debug)]
 pub(crate) struct ZSliceWriter<'a> {
     vec: &'a mut Vec<u8>,
-    ptr: &'a mut *const u8,
-    len: &'a mut usize,
+    slice: &'a mut RawSlice,
 }
 
 impl Writer for ZSliceWriter<'_> {
     fn write(&mut self, bytes: &[u8]) -> Result<NonZeroUsize, DidntWrite> {
         let len = self.vec.write(bytes)?;
-        *self.ptr = self.vec.as_ptr();
-        *self.len = self.vec.len();
+        *self.slice = self.vec.as_slice().into();
         Ok(len)
     }
 
@@ -395,8 +390,7 @@ impl Writer for ZSliceWriter<'_> {
         // SAFETY: Same precondition as this function. Call to `with_slot` is safe because
         // the requirements are passed through.
         let len = unsafe { self.vec.with_slot(len, write) }?;
-        *self.ptr = self.vec.as_ptr();
-        *self.len = self.vec.len();
+        *self.slice = self.vec.as_slice().into();
         Ok(len)
     }
 }
@@ -405,13 +399,13 @@ impl BacktrackableWriter for ZSliceWriter<'_> {
     type Mark = usize;
 
     fn mark(&mut self) -> Self::Mark {
-        *self.len
+        self.slice.len
     }
 
     fn rewind(&mut self, mark: Self::Mark) -> bool {
         assert!(mark <= self.vec.len());
         self.vec.truncate(mark);
-        *self.len = mark;
+        self.slice.len = mark;
         true
     }
 }
@@ -483,14 +477,14 @@ impl Reader for ZSlice {
 }
 
 impl BacktrackableReader for ZSlice {
-    type Mark = (*const u8, usize);
+    type Mark = RawSlice;
 
     fn mark(&mut self) -> Self::Mark {
-        (self.ptr, self.len)
+        self.slice
     }
 
     fn rewind(&mut self, mark: Self::Mark) -> bool {
-        (self.ptr, self.len) = mark;
+        self.slice = mark;
         true
     }
 }

--- a/examples/examples/z_bytes_shm.rs
+++ b/examples/examples/z_bytes_shm.rs
@@ -69,13 +69,13 @@ fn main() {
     // branch to illustrate mutable access to SHM data
     {
         // deserialize ZBytes as mutably borrowed zshm (ZBytes -> &mut zshm)
-        let borrowed_shm_buf = payload.as_shm_mut().unwrap();
+        let mut borrowed_shm_buf = unsafe { payload.as_shm_mut().unwrap() };
 
         // immutable API
-        let _data: &[u8] = borrowed_shm_buf;
+        let _data: &[u8] = &borrowed_shm_buf;
 
         // convert zshm to zshmmut (&mut zshm -> &mut zshmmut)
-        let borrowed_shm_buf_mut: &mut zshmmut = borrowed_shm_buf.try_into().unwrap();
+        let borrowed_shm_buf_mut: &mut zshmmut = (&mut *borrowed_shm_buf).try_into().unwrap();
 
         // mutable and immutable API
         let _data: &[u8] = borrowed_shm_buf_mut;

--- a/examples/examples/z_sub_shm.rs
+++ b/examples/examples/z_sub_shm.rs
@@ -83,9 +83,9 @@ fn handle_bytes(bytes: &mut ZBytes) -> (&str, Cow<'_, str>) {
 
         // if Zenoh is built with SHM support and with SHM API we can detect the exact buffer type
         #[cfg(all(feature = "shared-memory", feature = "unstable"))]
-        match bytes.as_shm_mut() {
+        match unsafe { bytes.as_shm_mut() } {
             // try to mutate SHM buffer to get it's mutability property
-            Some(shm) => match <&mut zshmmut>::try_from(shm) {
+            Some(mut shm) => match <&mut zshmmut>::try_from(&mut *shm) {
                 Ok(_shm_mut) => "SHM (MUT)",
                 Err(_) => "SHM (IMMUT)",
             },

--- a/zenoh/src/api/bytes.rs
+++ b/zenoh/src/api/bytes.rs
@@ -18,7 +18,7 @@ use std::{borrow::Cow, fmt::Debug, mem, str::Utf8Error};
 use zenoh_buffers::{
     buffer::{Buffer, SplitBuffer},
     reader::{HasReader, Reader},
-    BufferMutGuard, ZBuf, ZBufReader, ZSlice, ZSliceBuffer,
+    ZBuf, ZBufReader, ZSlice, ZSliceBuffer,
 };
 use zenoh_protocol::zenoh::ext::AttachmentType;
 
@@ -263,7 +263,7 @@ const _: () = {
             buf.map(Into::into).filter(|_| zslices.next().is_none())
         }
 
-        pub fn as_shm_mut(&mut self) -> Option<BufferMutGuard<'_, zshm>> {
+        pub fn as_shm_mut(&mut self) -> Option<zenoh_buffers::BufferMutGuard<'_, zshm>> {
             let mut zslices = self.0.zslices_mut();
             // SAFETY: ShmBufInner cannot change the size of the slice
             let buf = unsafe { zslices.next()?.downcast_mut::<ShmBufInner>() }

--- a/zenoh/src/api/bytes.rs
+++ b/zenoh/src/api/bytes.rs
@@ -263,7 +263,10 @@ const _: () = {
             buf.map(Into::into).filter(|_| zslices.next().is_none())
         }
 
-        pub fn as_shm_mut(&mut self) -> Option<zenoh_buffers::BufferMutGuard<'_, zshm>> {
+        /// # Safety
+        ///
+        /// Destructor of the returned guard must be executed.
+        pub unsafe fn as_shm_mut(&mut self) -> Option<zenoh_buffers::BufferMutGuard<'_, zshm>> {
             let mut zslices = self.0.zslices_mut();
             // SAFETY: ShmBufInner cannot change the size of the slice
             let buf = unsafe { zslices.next()?.downcast_mut::<ShmBufInner>() }

--- a/zenoh/tests/bytes.rs
+++ b/zenoh/tests/bytes.rs
@@ -57,9 +57,9 @@ fn shm_bytes_single_buf() {
     // branch to illustrate mutable access to SHM data
     {
         // deserialize ZBytes as mutably borrowed zshm (ZBytes -> &mut zshm)
-        let borrowed_shm_buf = payload.as_shm_mut().unwrap();
+        let mut borrowed_shm_buf = unsafe { payload.as_shm_mut().unwrap() };
 
         // convert zshm to zshmmut (&mut zshm -> &mut zshmmut)
-        let _borrowed_shm_buf_mut: &mut zshmmut = borrowed_shm_buf.try_into().unwrap();
+        let _borrowed_shm_buf_mut: &mut zshmmut = (&mut *borrowed_shm_buf).try_into().unwrap();
     }
 }


### PR DESCRIPTION
Dynamic dispatch of `ZSliceBuffer::as_slice` was hurting deserialization performance.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->