### PR TITLE
Replace RwLock by OnceLock for transport callback

### DIFF
--- a/io/zenoh-transport/src/unicast/universal/rx.rs
+++ b/io/zenoh-transport/src/unicast/universal/rx.rs
@@ -11,7 +11,7 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use std::sync::{atomic::Ordering, MutexGuard};
+use std::sync::MutexGuard;
 
 use zenoh_buffers::ZSlice;
 use zenoh_codec::transport::frame::FrameReader;
@@ -108,11 +108,7 @@ impl TransportUnicastUniversal {
             // Drop invalid message and continue
             return Ok(());
         }
-        if let Some(callback) = self
-            .callback
-            .get()
-            .filter(|_| !self.closed.load(Ordering::Relaxed))
-        {
+        if let Some(callback) = self.callback.get() {
             for mut msg in frame {
                 self.trigger_callback(
                     callback.as_ref(),
@@ -193,11 +189,7 @@ impl TransportUnicastUniversal {
         if !more {
             // When shared-memory feature is disabled, msg does not need to be mutable
             if let Some(mut msg) = guard.defrag.defragment() {
-                if let Some(callback) = self
-                    .callback
-                    .get()
-                    .filter(|_| !self.closed.load(Ordering::Relaxed))
-                {
+                if let Some(callback) = self.callback.get() {
                     return self.trigger_callback(
                         callback.as_ref(),
                         msg.as_mut(),

--- a/io/zenoh-transport/src/unicast/universal/transport.rs
+++ b/io/zenoh-transport/src/unicast/universal/transport.rs
@@ -46,6 +46,35 @@ use crate::{
     TransportManager, TransportPeerEventHandler,
 };
 
+pub(crate) struct ClosableCallback {
+    callback: OnceLock<Arc<dyn TransportPeerEventHandler>>,
+    closed: AtomicBool,
+}
+
+impl ClosableCallback {
+    pub(crate) fn new() -> Self {
+        ClosableCallback {
+            callback: OnceLock::new(),
+            closed: AtomicBool::new(false),
+        }
+    }
+
+    pub(crate) fn set(&self, cb: Arc<dyn TransportPeerEventHandler>) {
+        let _ = self.callback.set(cb);
+    }
+
+    pub(crate) fn get(&self) -> Option<&Arc<dyn TransportPeerEventHandler>> {
+        self.callback
+            .get()
+            .filter(|_| !self.closed.load(Ordering::Relaxed))
+    }
+
+    pub(crate) fn close(&self) -> Option<&Arc<dyn TransportPeerEventHandler>> {
+        self.closed.store(true, Ordering::Relaxed);
+        self.callback.get()
+    }
+}
+
 /*************************************/
 /*        UNIVERSAL TRANSPORT        */
 /*************************************/
@@ -64,8 +93,7 @@ pub(crate) struct TransportUnicastUniversal {
     // The links associated to the channel
     pub(super) links: Arc<RwLock<TransportLinks>>,
     // The callback
-    pub(super) callback: Arc<OnceLock<Arc<dyn TransportPeerEventHandler>>>,
-    pub(super) closed: Arc<AtomicBool>,
+    pub(super) callback: Arc<ClosableCallback>,
     // Mutex for notification
     pub(super) status: Arc<AsyncMutex<TransportStatus>>,
     // Transport statistics
@@ -109,8 +137,7 @@ impl TransportUnicastUniversal {
             priority_tx: priority_tx.into_boxed_slice().into(),
             priority_rx: priority_rx.into_boxed_slice().into(),
             links: Arc::new(RwLock::new(TransportLinks::default())),
-            callback: Arc::new(OnceLock::new()),
-            closed: Arc::new(AtomicBool::new(false)),
+            callback: Arc::new(ClosableCallback::new()),
             status: Arc::new(AsyncMutex::new(TransportStatus::Uninitialized)),
             #[cfg(feature = "stats")]
             stats,
@@ -135,8 +162,7 @@ impl TransportUnicastUniversal {
         // to avoid concurrent new_transport and closing/closed notifications
         let mut status_guard = self.get_status().await;
         *status_guard = TransportStatus::Closed;
-        self.closed.store(true, Ordering::Relaxed);
-        let callback = self.callback.get().cloned();
+        let callback = self.callback.close();
 
         // Close all the links
         let mut links = zwrite!(self.links).take();
@@ -324,7 +350,7 @@ impl TransportUnicastTrait for TransportUnicastUniversal {
     /*            ACCESSORS              */
     /*************************************/
     fn set_callback(&self, callback: Arc<dyn TransportPeerEventHandler>) {
-        let _ = self.callback.set(callback);
+        self.callback.set(callback)
     }
 
     async fn get_status(&self) -> AsyncMutexGuard<'_, TransportStatus> {

--- a/io/zenoh-transport/src/unicast/universal/transport.rs
+++ b/io/zenoh-transport/src/unicast/universal/transport.rs
@@ -14,7 +14,10 @@
 use std::{
     fmt::DebugStruct,
     ops::{Deref, Not},
-    sync::{Arc, RwLock},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, OnceLock, RwLock,
+    },
     time::Duration,
 };
 
@@ -61,7 +64,8 @@ pub(crate) struct TransportUnicastUniversal {
     // The links associated to the channel
     pub(super) links: Arc<RwLock<TransportLinks>>,
     // The callback
-    pub(super) callback: Arc<RwLock<Option<Arc<dyn TransportPeerEventHandler>>>>,
+    pub(super) callback: Arc<OnceLock<Arc<dyn TransportPeerEventHandler>>>,
+    pub(super) closed: Arc<AtomicBool>,
     // Mutex for notification
     pub(super) status: Arc<AsyncMutex<TransportStatus>>,
     // Transport statistics
@@ -105,7 +109,8 @@ impl TransportUnicastUniversal {
             priority_tx: priority_tx.into_boxed_slice().into(),
             priority_rx: priority_rx.into_boxed_slice().into(),
             links: Arc::new(RwLock::new(TransportLinks::default())),
-            callback: Arc::new(RwLock::new(None)),
+            callback: Arc::new(OnceLock::new()),
+            closed: Arc::new(AtomicBool::new(false)),
             status: Arc::new(AsyncMutex::new(TransportStatus::Uninitialized)),
             #[cfg(feature = "stats")]
             stats,
@@ -130,7 +135,8 @@ impl TransportUnicastUniversal {
         // to avoid concurrent new_transport and closing/closed notifications
         let mut status_guard = self.get_status().await;
         *status_guard = TransportStatus::Closed;
-        let callback = zwrite!(self.callback).take();
+        self.closed.store(true, Ordering::Relaxed);
+        let callback = self.callback.get().cloned();
 
         // Close all the links
         let mut links = zwrite!(self.links).take();
@@ -139,7 +145,7 @@ impl TransportUnicastUniversal {
         }
 
         // Notify the callback that we have closed the transport
-        if let Some(cb) = callback.as_ref() {
+        if let Some(cb) = callback {
             cb.closed();
         }
         // Delete the transport on the manager - this should be the last step to ensure that no new transport to the same peer can be added while we are closing this transport.
@@ -161,8 +167,7 @@ impl TransportUnicastUniversal {
         };
 
         // Notify the callback
-        let cb = zread!(self.callback).clone();
-        if let Some(callback) = cb {
+        if let Some(callback) = self.callback.get().cloned() {
             let associated_link = associated_link.clone();
             tokio::task::spawn_blocking(move || {
                 callback.del_link(link);
@@ -319,7 +324,7 @@ impl TransportUnicastTrait for TransportUnicastUniversal {
     /*            ACCESSORS              */
     /*************************************/
     fn set_callback(&self, callback: Arc<dyn TransportPeerEventHandler>) {
-        *zwrite!(self.callback) = Some(callback);
+        let _ = self.callback.set(callback);
     }
 
     async fn get_status(&self) -> AsyncMutexGuard<'_, TransportStatus> {
@@ -352,7 +357,7 @@ impl TransportUnicastTrait for TransportUnicastUniversal {
     }
 
     fn get_callback(&self) -> Option<Arc<dyn TransportPeerEventHandler>> {
-        zread!(self.callback).clone()
+        self.callback.get().cloned()
     }
 
     fn get_config(&self) -> &TransportConfigUnicast {


### PR DESCRIPTION
Callback is set only once after the transport creation. Using the right primitive, e.g. a OnceLock gives better performance, as it just do an atomic load instead of a atomic RMWs of RwLock.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->