### PR TITLE
Split CI `test` job into multiple jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,46 @@ jobs:
         if: ${{ matrix.os != 'macos-latest' }}
         run: cargo nextest run -p zenoh
 
+      - name: Check for feature leaks
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: cargo nextest run -p zenohd --no-default-features
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  test_unstable:
+    needs: determine-runner
+    name: Unit tests on ${{ matrix.os }} (unstable)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
+
+    steps:
+      - name: Clone this repository
+        uses: actions/checkout@v4
+
+      - name: Install latest Rust toolchain
+        run: rustup show
+
+      - name: Setup rust-cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
+
+      - name: Set rustflags
+        if: ${{ matrix.os == 'windows-latest' }}
+        shell: bash
+        run: |
+            echo "RUSTFLAGS=-Clink-arg=/DEBUG:NONE" >> $GITHUB_ENV
+
+      - name: Install latest nextest
+        uses: taiki-e/install-action@nextest
+
       - name: Run tests with unstable (sudo macos)
         if: ${{ matrix.os == 'macos-latest' }}
         run: |
@@ -243,13 +283,41 @@ jobs:
           cargo build -p zenoh-plugin-rest --lib
           cargo nextest run -F test -F plugins,unstable,internal --exclude zenoh-examples --exclude zenoh-plugin-example --workspace
 
-      - name: Rename junit test report (sudo macos)
-        if: ${{ matrix.os == 'macos-latest' }}
-        run: sudo mv target/nextest/default/junit.xml target/nextest/default/tests.junit.xml
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
-      - name: Rename junit test report
-        if: ${{ matrix.os != 'macos-latest' }}
-        run: mv target/nextest/default/junit.xml target/nextest/default/tests.junit.xml
+  test_shm:
+    needs: determine-runner
+    name: Unit tests on ${{ matrix.os }} (shared memory)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJSON(needs.determine-runner.outputs.runner) }}
+
+    steps:
+      - name: Clone this repository
+        uses: actions/checkout@v4
+
+      - name: Install latest Rust toolchain
+        run: rustup show
+
+      - name: Setup rust-cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
+
+      - name: Set rustflags
+        if: ${{ matrix.os == 'windows-latest' }}
+        shell: bash
+        run: |
+            echo "RUSTFLAGS=-Clink-arg=/DEBUG:NONE" >> $GITHUB_ENV
+
+      - name: Install latest nextest
+        uses: taiki-e/install-action@nextest
 
       - name: Run tests with SHM (sudo macos)
         if: ${{ matrix.os == 'macos-latest' }}
@@ -261,31 +329,11 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' }}
         run: cargo nextest run -F test -F shared-memory -F unstable -E 'not (test(test_default_features) or test(test_adminspace_read))' --exclude zenoh-examples --exclude zenoh-plugin-example --workspace
 
-      - name: Rename junit test report (sudo macos)
-        if: ${{ matrix.os == 'macos-latest' }}
-        run: sudo mv target/nextest/default/junit.xml target/nextest/default/tests-shm.junit.xml
-
-      - name: Rename junit test report
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: mv target/nextest/default/junit.xml target/nextest/default/tests-shm.junit.xml
-
       - name: Run tests with SHM + unixpipe
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
           sudo prlimit --memlock=unlimited --pid=$$
           cargo nextest run -F test -F shared-memory -F unstable -F transport_unixpipe -E 'not (test(test_default_features) or test(test_adminspace_read))' --exclude zenoh-examples --exclude zenoh-plugin-example --workspace
-
-      - name: Rename junit test report
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: mv target/nextest/default/junit.xml target/nextest/default/tests-shm-unixpipe.junit.xml
-
-      - name: Check for feature leaks
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: cargo nextest run -p zenohd --no-default-features
-
-      - name: Rename junit test report
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: mv target/nextest/default/junit.xml target/nextest/default/tests-feature-leaks.junit.xml
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
@@ -364,88 +412,88 @@ jobs:
             --config build.rustdocflags='["--cfg", "docsrs", "-Z", "unstable-options", "--emit=invocation-specific", "--cap-lints", "warn", "--extern-html-root-takes-precedence"]'
 
   coverage:
-        name: Coverage
-        strategy:
-          fail-fast: false
-          matrix:
-            os: [ubuntu-latest]
-            rust: [nightly]
-        runs-on: ${{ matrix.os }}
-        steps:
-          - name: Free Disk Space (Ubuntu)
-            uses: jlumbroso/free-disk-space@main
-            with:
-              tool-cache: false
-              android: true
-              dotnet: true
-              haskell: true
-              large-packages: true
-              docker-images: true
-              swap-storage: true
+    name: Coverage
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        rust: [nightly]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
 
-          - name: Install build-essential (Ubuntu)
-            if: ${{ matrix.os == 'ubuntu-latest' }}
-            run: |
-              sudo apt-get update
-              sudo apt-get install -y build-essential clang libc6-dev
+      - name: Install build-essential (Ubuntu)
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential clang libc6-dev
 
-          - name: Checkout sources
-            uses: actions/checkout@v4
+      - name: Checkout sources
+        uses: actions/checkout@v4
 
-          #
-          # Temporary workaround to remmove transitive dependency
-          # of static-init 1.0.3 which fails with nigtly Rust.
-          # This allows Rust to automatically pick a compatible version 1.0.4
-          # where the issue is fixed.
-          #
-          - name: Remove zenoh-pinned-deps-1-75 dependency and Cargo.lock
-            run: | 
-              sed -i '/zenoh-pinned-deps-1-75/d' Cargo.toml
-              rm -f Cargo.lock
+      #
+      # Temporary workaround to remmove transitive dependency
+      # of static-init 1.0.3 which fails with nigtly Rust.
+      # This allows Rust to automatically pick a compatible version 1.0.4
+      # where the issue is fixed.
+      #
+      - name: Remove zenoh-pinned-deps-1-75 dependency and Cargo.lock
+        run: | 
+          sed -i '/zenoh-pinned-deps-1-75/d' Cargo.toml
+          rm -f Cargo.lock
 
-          - name: Install ${{ matrix.rust }} Rust toolchain
-            run: |
-              rustup override set ${{ matrix.rust }}
-              rustup update ${{ matrix.rust }}
-              rustup component add llvm-tools-preview
+      - name: Install ${{ matrix.rust }} Rust toolchain
+        run: |
+          rustup override set ${{ matrix.rust }}
+          rustup update ${{ matrix.rust }}
+          rustup component add llvm-tools-preview
 
-          - uses: Swatinem/rust-cache@v2
-            with:
-              cache-bin: false
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
 
-          - name: Install cargo-llvm-cov
-            uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
 
-          - name: Generate code coverage
-            run: |
-              sudo prlimit --memlock=unlimited --pid=$$
-              cargo +${{ matrix.rust }} llvm-cov test --features unstable --features test --features shared-memory  \
-              ${{ matrix.rust == 'nightly' && '--doctests' || '' }} --lcov --output-path lcov.info \
-              --no-cfg-coverage --no-cfg-coverage-nightly --ignore-run-fail -- \
-              --skip test_default_features \
-              --skip router_linkstate \
-              --skip three_node_combination  \
-              --skip three_node_combination_multicast \
-              --skip two_node_combination \
-              --skip test_gossip \
-              --skip metadata_alloc_concurrent \
-              --skip metadata_link_concurrent \
-              --skip metadata_link_failure_concurrent
-            env:
-              RUST_LOG: None
+      - name: Generate code coverage
+        run: |
+          sudo prlimit --memlock=unlimited --pid=$$
+          cargo +${{ matrix.rust }} llvm-cov test --features unstable --features test --features shared-memory  \
+          ${{ matrix.rust == 'nightly' && '--doctests' || '' }} --lcov --output-path lcov.info \
+          --no-cfg-coverage --no-cfg-coverage-nightly --ignore-run-fail -- \
+          --skip test_default_features \
+          --skip router_linkstate \
+          --skip three_node_combination  \
+          --skip three_node_combination_multicast \
+          --skip two_node_combination \
+          --skip test_gossip \
+          --skip metadata_alloc_concurrent \
+          --skip metadata_link_concurrent \
+          --skip metadata_link_failure_concurrent
+        env:
+          RUST_LOG: None
 
-          - name: Upload coverage to Codecov
-            uses: codecov/codecov-action@v5
-            with:
-              token: ${{ secrets.CODECOV_TOKEN }}
-              files: lcov.info
-              fail_ci_if_error: true
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          fail_ci_if_error: true
 
-          # Cleanup profraw files to avoid failing during rust-cache
-          # post run cleanup. It requires enough space on disk left to save the cache
-          - name: Cleanup profraw files
-            run: |
-              find . -name "*.profraw" -type f -delete
+      # Cleanup profraw files to avoid failing during rust-cache
+      # post run cleanup. It requires enough space on disk left to save the cache
+      - name: Cleanup profraw files
+        run: |
+          find . -name "*.profraw" -type f -delete
 
   # NOTE: In GitHub repository settings, the "Require status checks to pass
   # before merging" branch protection rule ensures that commits are only merged
@@ -455,7 +503,7 @@ jobs:
   ci:
     name: CI status checks
     runs-on: ubuntu-latest
-    needs: [check_rust, check, test, valgrind, typos, markdown_lint, doc, coverage]
+    needs: [check_rust, check_rust_without_cargo_lock, check, test, test_unstable, test_shm, valgrind, typos, markdown_lint, doc, coverage]
     if: always()
     steps:
       - name: Check whether all jobs pass


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->

Optimize the CI `test` job.

### What does this PR do?
<!-- Describe the changes and their purpose -->

This patch splits the CI `tests` job into three separate jobs.

### Why is this change needed?
<!-- Explain the motivation or problem being solved -->

This has two main benefits:
1. Faster job runs
2. Parallel runs provide more test failure information early on

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

N/A

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->