### PR TITLE
 fix: missing cfg for bind-to-device helpers on iOS

### DIFF
--- a/commons/zenoh-util/src/net/mod.rs
+++ b/commons/zenoh-util/src/net/mod.rs
@@ -449,14 +449,14 @@ pub fn set_bind_to_device_udp_socket(socket: &UdpSocket, iface: &str) -> ZResult
     Ok(())
 }
 
-#[cfg(any(target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "windows"))]
 pub fn set_bind_to_device_tcp_socket(socket: &TcpSocket, iface: &str) -> ZResult<()> {
-    tracing::warn!("Binding the socket {socket:?} to the interface {iface} is not supported on macOS and Windows");
+    tracing::warn!("Binding the socket {socket:?} to the interface {iface} is not supported on macOS, iOS, and Windows");
     Ok(())
 }
 
-#[cfg(any(target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "windows"))]
 pub fn set_bind_to_device_udp_socket(socket: &UdpSocket, iface: &str) -> ZResult<()> {
-    tracing::warn!("Binding the socket {socket:?} to the interface {iface} is not supported on macOS and Windows");
+    tracing::warn!("Binding the socket {socket:?} to the interface {iface} is not supported on macOS, iOS, and Windows");
     Ok(())
 }


### PR DESCRIPTION
## Description

When building Zenoh for iOS targets, compilation fails because
set_bind_to_device_tcp_socket and set_bind_to_device_udp_socket are not available under any cfg condition for target_os = "ios".

As a result, these functions are configured out entirely on iOS, leading to errors such as:
```
error[E0425]: cannot find function `set_bind_to_device_tcp_socket` in module `zenoh_util::net`
  --> io/zenoh-link-commons/src/tcp.rs:117:30
```

### What does this PR do?

This PR adds target_os = "ios" to the existing cfg conditions used for macOS and Windows, making the bind-to-device functions no-ops on iOS as well.

iOS does not support binding sockets to specific network interfaces, so this behavior is consistent with the existing handling on macOS and Windows.

### Why is this change needed?

Without this change, building Zenoh for iOS targets fails at compile time due to missing symbols.
This fix restores successful builds for iOS without changing runtime behavior on supported platforms.

### Notes

This change does not alter behavior on Linux or Android, where interface binding is supported.

Runtime behavior on macOS, Windows, and iOS remains unchanged (bind-to-device is already unsupported on these platforms).

### Related Issues

(None)

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `enhancement`

## ✨ Enhancement Requirements

Since this PR enhances existing functionality:

- [x] **Enhancement scope documented** - Clear description of what is being improved
- [x] **Minimum necessary code** - Implementation is as simple as possible, doesn't overcomplicate the system
- [x] **Backwards compatible** - Existing code/APIs still work unchanged
- [x] **No new APIs added** - Only improving existing functionality
- [x] **Tests updated** - Existing tests pass, new test cases added if needed
- [x] **Performance improvement measured** - If applicable, before/after metrics provided
- [x] **Documentation updated** - Existing docs updated to reflect improvements
- [x] **User impact documented** - How users benefit from this enhancement

**Remember:** Enhancements should not introduce new APIs or breaking changes.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->