### PR TITLE
Fix CongestionControl::BlockFirst

### DIFF
--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -79,6 +79,7 @@ unstable = [
   "zenoh-config/unstable",
   "zenoh-keyexpr/unstable",
   "zenoh-protocol/unstable",
+  "zenoh-transport/unstable",
 ]
 
 [dependencies]


### PR DESCRIPTION
When using Zenoh with `unstable` feature as a dependency from another workspace, as `zenoh/unstable` does not depend on `zenoh-transport/unstable`, this block of code is not included: <https://github.com/eclipse-zenoh/zenoh/blob/cd81675989fd459d1cb0ca568ad0c90a44dfc291/io/zenoh-transport/src/unicast/universal/tx.rs#L159-L160>.
This leads `CongestionControl::BlockFirst` to behave as `CongestionControl::Block`.

This PR fixes this issue by making `zenoh/unstable` depend on `zenoh-transport/unstable`.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [ ] **Reproduction test added** - Test that fails on main branch without the fix
- [x] **Test passes with fix** - The reproduction test passes with your changes
- [ ] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [ ] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->