### PR TITLE
Fix typo in docs and add .typos.toml to whitelist libc identifiers

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,14 @@
+# typos configuration to whitelist known libc identifiers that appear in the codebase
+# This avoids false positives from the crate-ci/typos action
+
+[extend_identifiers]
+words = [
+  "controllen",
+  "msg_controllen",
+]
+
+[extend_words]
+words = [
+  "controllen",
+  "msg_controllen",
+]

--- a/commons/zenoh-buffers/src/lib.rs
+++ b/commons/zenoh-buffers/src/lib.rs
@@ -98,7 +98,7 @@ pub mod buffer {
         /// Gets all the slices of this buffer.
         fn slices(&self) -> Self::Slices<'_>;
 
-        /// Returns all the bytes of this buffer in a conitguous slice.
+        /// Returns all the bytes of this buffer in a contiguous slice.
         /// This may require allocation and copy if the original buffer
         /// is not contiguous.
         fn contiguous(&self) -> Cow<'_, [u8]> {


### PR DESCRIPTION
fix typos. Internal PR into branch ci/zenoh_1_75. Based on https://github.com/milyin-zenoh-zbobr/zenoh/pull/6

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

**No specific label requirements detected.**

Current labels: _No labels_

Add one of these labels to this PR to see relevant checklist items: `api-sync`, `breaking-change`, `bug`, `ci`, `dependencies`, `documentation`, `enhancement`, `new feature`, `internal`

*This section updates automatically when labels change.*

<!-- 🏷️ Label-Based Checklist END -->