### PR TITLE
Fix data race in `FaceState::pending_queries`

### DIFF
--- a/zenoh/src/net/routing/dispatcher/face.rs
+++ b/zenoh/src/net/routing/dispatcher/face.rs
@@ -114,6 +114,12 @@ pub struct FaceState {
     pub(crate) local_mappings: IntHashMap<ExprId, Arc<Resource>>,
     pub(crate) remote_mappings: IntHashMap<ExprId, Arc<Resource>>,
     pub(crate) next_qid: RequestId,
+    /// Pending queries sent to this face.
+    ///
+    /// # Safety
+    /// Access to this field is synchronized across all faces with
+    /// [`super::tables::TablesLock::queries_lock`]; it is unsound to read/write this field without
+    /// acquiring the lock.
     pub(crate) pending_queries: HashMap<RequestId, (Arc<Query>, CancellationToken)>,
     pub(crate) mcast_group: Option<TransportMulticast>,
     pub(crate) in_interceptors: Option<Arc<ArcSwap<InterceptorsChain>>>,


### PR DESCRIPTION
Access to `pending_queries` is synchronized using
`TablesLock::queries_lock`, which is properly acquired/release in `route_send_response`.

However, the `Query` object obtained from `pending_queries` is a **borrow** and not an owned value. Thus, the reference may be invalidated as soon as the lock is dropped.

I have observed this scenario in a setup with heavy query traffic at startup where the Zenoh process was getting a SIGSEGV from Darwin at the `observe_payload` call—here's a backtrace of the access violation from LLDB:

```
* thread #16, name = 'rx-4', stop reason = EXC_BAD_ACCESS (code=1, address=0x76)
  * frame #0: 0x0000000101947014 nuze-regions`_$LT$alloc..sync..Arc$LT$T$C$A$GT$$u20$as$u20$core..ops..deref..Deref$GT$::deref::hd81390341cb93fce [inlined] core::ptr::non_null::NonNull$LT$T$GT$::as_ref::h7dcbbace637a2b36 at non_null.rs:444:20
    frame #1: 0x0000000101947014 nuze-regions`_$LT$alloc..sync..Arc$LT$T$C$A$GT$$u20$as$u20$core..ops..deref..Deref$GT$::deref::hd81390341cb93fce [inlined] alloc::sync::Arc$LT$T$C$A$GT$::inner::h941100592a53d53d(self=0x0000000000000076) at sync.rs:1917:27
    frame #2: 0x0000000101947014 nuze-regions`_$LT$alloc..sync..Arc$LT$T$C$A$GT$$u20$as$u20$core..ops..deref..Deref$GT$::deref::hd81390341cb93fce(self=0x0000000000000076) at sync.rs:2232:15
    frame #3: 0x0000000101caf0f0 nuze-regions`zenoh::net::routing::dispatcher::queries::route_send_response::h20ad9fa77f496f10(tables_ref=0x000060000345ae50, face=0x0000000171ca6d38, msg=0x0000000171ca93a0) at queries.rs:694:75
    frame #4: 0x0000000101b2e40c nuze-regions`_$LT$zenoh..net..routing..dispatcher..face..Face$u20$as$u20$zenoh..net..primitives..Primitives$GT$::send_response::_$u7b$$u7b$closure$u7d$$u7d$::hf479d691a5485f46 at face.rs:535:9
    frame #5: 0x0000000101b4c354 nuze-regions`_$LT$zenoh..net..routing..dispatcher..face..Face$u20$as$u20$zenoh..net..primitives..Primitives$GT$::send_response::hf3bb4f9b453622c3(self=0x000060000345ae50, msg=0x0000000171ca93a0) at face.rs:533:5
    frame #6: 0x0000000101948b6c nuze-regions`_$LT$zenoh..net..primitives..demux..DeMux$u20$as$u20$zenoh_transport..TransportPeerEventHandler$GT$::handle_message::h1e42d16c7564472c(self=0x000060000345ae50, msg=(body = zenoh_protocol::network::NetworkBodyMut @ 0x0000000171ca8c70, reliability = Reliable)) at demux.rs:164:54
    frame #7: 0x0000000101accdb0 nuze-regions`_$LT$zenoh..net..runtime..RuntimeSession$u20$as$u20$zenoh_transport..TransportPeerEventHandler$GT$::handle_message::h1eca52cad2cb3c31(self=0x0000600000f4f890, msg=(body = zenoh_protocol::network::NetworkBodyMut @ 0x0000000171ca8c70, reliability = Reliable)) at mod.rs:959:27
    frame #8: 0x0000000101f6d2f8 nuze-regions`zenoh_transport::unicast::universal::rx::_$LT$impl$u20$zenoh_transport..unicast..universal..transport..TransportUnicastUniversal$GT$::trigger_callback::h0bba4e996a955f0a(self=0x000000012f0257a8, callback=&dyn zenoh_transport::TransportPeerEventHandler @ 0x0000000171ca8c98, msg=(body = zenoh_protocol::network::NetworkBodyMut @ 0x0000000171ca9510, reliability = Reliable), stats=0x000000012f025840) at rx.rs:64:18
    frame #9: 0x0000000101f68458 nuze-regions`zenoh_transport::unicast::universal::rx::_$LT$impl$u20$zenoh_transport..unicast..universal..transport..TransportUnicastUniversal$GT$::handle_frame::h04ce3d6c841b89cb(self=0x000000012f0257a8, frame=FrameReader<zenoh_buffers::zslice::ZSlice> @ 0x0000000171caa0f0, stats=0x000000012f025840) at rx.rs:114:22
    frame #10: 0x0000000101f694bc nuze-regions`zenoh_transport::unicast::universal::rx::_$LT$impl$u20$zenoh_transport..unicast..universal..transport..TransportUnicastUniversal$GT$::read_messages::hf2e89247bc1e5c0c(self=0x000000012f0257a8, batch=RBatch @ 0x0000000171cabd30, link=0x000000012f025860, stats=0x000000012f025840) at rx.rs:250:22
    frame #11: 0x0000000101ffac88 nuze-regions`zenoh_transport::unicast::universal::link::rx_task::_$u7b$$u7b$closure$u7d$$u7d$::h9cd337938148db2d at link.rs:329:27
    frame #12: 0x0000000101ff82cc nuze-regions`zenoh_transport::unicast::universal::link::TransportLinkUnicastUniversal::start_rx::_$u7b$$u7b$closure$u7d$$u7d$::hafdf078013c50ca0 at link.rs:174:14
    frame #13: 0x000000010202fe8c nuze-regions`_$LT$tokio_util..task..task_tracker..TrackedFuture$LT$F$GT$$u20$as$u20$core..future..future..Future$GT$::poll::hc8bb990297786392(self=Pin<&mut tokio_util::task::task_tracker::TrackedFuture<zenoh_transport::unicast::universal::link::{impl#0}::start_rx::{async_block_env#0}>> @ 0x0000000171cad110, cx=0x0000000171cad280) at task_tracker.rs:680:31
```

(Tokio frames have been omitted).

This patch maintains a valid `Query` object by cloning the `Arc` reference; this was sufficient to solve the SIGSEGV I observed.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [ ] **Reproduction test added** - Test that fails on main branch without the fix
- [ ] **Test passes with fix** - The reproduction test passes with your changes
- [ ] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->