### PR TITLE
fix cancellation test on windows by auto assigning port

### DIFF
--- a/zenoh/tests/cancellation.rs
+++ b/zenoh/tests/cancellation.rs
@@ -16,7 +16,6 @@
 use core::time::Duration;
 use std::sync::{atomic::AtomicBool, Arc};
 
-use tokio::net::TcpListener;
 use zenoh::{handlers::CallbackDrop, Session};
 use zenoh_config::{ModeDependentValue, WhatAmI};
 use zenoh_core::ztimeout;


### PR DESCRIPTION
Description

The test_cancellation_get on windows fails because of locked ports:
https://github.com/eclipse-zenoh/zenoh/actions/runs/21872831600/job/63132926781?pr=2412

This pr adds auto selection of port for this test to avoid this

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [x] **Reproduction test added** - Test that fails on main branch without the fix
- [x] **Test passes with fix** - The reproduction test passes with your changes
- [x] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->