### PR TITLE
always close link removed from transport

### DIFF
--- a/io/zenoh-transport/src/unicast/universal/transport.rs
+++ b/io/zenoh-transport/src/unicast/universal/transport.rs
@@ -189,11 +189,13 @@ impl TransportUnicastUniversal {
         if let Some(callback) = cb {
             callback.del_link(link);
         }
-        stl.close().await?;
         if is_last {
+            let r = stl.close().await; // do not return early to ensure that the transport is deleted even if the link close fails
             self.delete().await?;
+            r
+        } else {
+            stl.close().await
         }
-        Ok(())
     }
 
     async fn sync(&self, initial_sn_rx: TransportSn) -> ZResult<()> {


### PR DESCRIPTION
## Description

Followup to the https://github.com/eclipse-zenoh/zenoh/pull/2367/ : that fix removed problem of double event senting but caused not calling `close()` on the link. 

### What does this PR do?
Always call the `close()` method on the deleted link

### Why is this change needed?
This returns the correct behavior which existed before mentioned fix: the link deletion was skipped and it's `close()` was called on transport deletion. The fix #2367 added removing link without calling `close()` on it

### Related Issues
https://github.com/eclipse-zenoh/zenoh/pull/2367/

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- **Reproduction test added** - Test that fails on main branch without the fix
- **Test passes with fix** - The reproduction test passes with your changes
- **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->

The goal of the update is to restore the original state, there is no test for it, checkboxes removed