### PR TITLE
Allow to set explicit nigltly compiler version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ env:
   CARGO_SEMVER_CHECKS_BASELINE_VERSION: 1.3.0
   # Nightly toolchain identifier used by cargo invocations
   # Normally keep it "nightly" to always use the latest nightly, but in case of a regression in the Rust compiler, 
-  #it can be useful to fix it to a specific nightly version that is known to work.
+  # it can be useful to fix it to a specific nightly version that is known to work.
   NIGHTLY_TOOLCHAIN: "nightly-2026-02-21"
 
 jobs:


### PR DESCRIPTION
## Description

Add variable in the ci.yml with specific nightly rust compiler version

### What does this PR do?
Add variable in the ci.yml with specific nightly rust compiler version and select it instead of just "+ninghtly"

### Why is this change needed?

Sometimes nightly rust compiler causes regression, like this happened here: https://github.com/eclipse-zenoh/zenoh/actions/runs/22288504487/job/64471398375?pr=2437. This update allows to lock the nightly rust version to last working one

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->