### PR TITLE
Fix blocking calls in async transport callback invocations

### DIFF
--- a/io/zenoh-transport/src/multicast/manager.rs
+++ b/io/zenoh-transport/src/multicast/manager.rs
@@ -270,6 +270,16 @@ impl TransportManager {
             .collect()
     }
 
+    pub fn get_transports_multicast_blocking(&self) -> Vec<TransportMulticast> {
+        self.state
+            .multicast
+            .transports
+            .blocking_lock()
+            .values()
+            .map(|t| t.into())
+            .collect()
+    }
+
     pub(super) async fn del_transport_multicast(&self, locator: &Locator) -> ZResult<()> {
         let mut guard = zasynclock!(self.state.multicast.transports);
         let res = guard.remove(locator);

--- a/io/zenoh-transport/src/unicast/manager.rs
+++ b/io/zenoh-transport/src/unicast/manager.rs
@@ -470,15 +470,18 @@ impl TransportManager {
 
         // complete establish procedure
         let c_link = ack.link();
-        let c_t = transport.clone();
-        ack.send_open_ack()
-            .await
-            .map_err(|e| InitTransportError::Transport((e, c_t, close::reason::GENERIC)))?;
+        ack.send_open_ack().await.map_err(|e| {
+            InitTransportError::Transport((e, transport.clone(), close::reason::GENERIC))
+        })?;
 
         start_tx();
 
         // notify transport's callback interface that there is a new link
-        Self::notify_new_link_unicast(&transport, c_link);
+        Self::notify_new_link_unicast(&transport, c_link)
+            .await
+            .map_err(|e| {
+                InitTransportError::Transport((e, transport.clone(), close::reason::GENERIC))
+            })?;
 
         start_rx();
 
@@ -487,10 +490,18 @@ impl TransportManager {
         Ok(transport)
     }
 
-    fn notify_new_link_unicast(transport: &Arc<dyn TransportUnicastTrait>, link: Link) {
-        if let Some(callback) = &transport.get_callback() {
-            callback.new_link(link);
+    async fn notify_new_link_unicast(
+        transport: &Arc<dyn TransportUnicastTrait>,
+        link: Link,
+    ) -> ZResult<()> {
+        if let Some(callback) = transport.get_callback() {
+            tokio::task::spawn_blocking(move || {
+                callback.new_link(link);
+            })
+            .await?;
         }
+
+        Ok(())
     }
 
     fn notify_new_transport_unicast(
@@ -666,7 +677,10 @@ impl TransportManager {
         );
 
         // Notify transport's callback interface that there is a new link
-        Self::notify_new_link_unicast(&t, c_link);
+        transport_error!(
+            Self::notify_new_link_unicast(&t, c_link).await,
+            close::reason::GENERIC
+        );
 
         start_rx();
 
@@ -808,6 +822,16 @@ impl TransportManager {
 
     pub async fn get_transports_unicast(&self) -> Vec<TransportUnicast> {
         zasynclock!(self.state.unicast.transports)
+            .values()
+            .map(|t| TransportUnicast(Arc::downgrade(t)))
+            .collect()
+    }
+
+    pub fn get_transports_unicast_blocking(&self) -> Vec<TransportUnicast> {
+        self.state
+            .unicast
+            .transports
+            .blocking_lock()
             .values()
             .map(|t| TransportUnicast(Arc::downgrade(t)))
             .collect()

--- a/io/zenoh-transport/src/unicast/universal/transport.rs
+++ b/io/zenoh-transport/src/unicast/universal/transport.rs
@@ -187,7 +187,10 @@ impl TransportUnicastUniversal {
         // Notify the callback
         let cb = zread!(self.callback).clone();
         if let Some(callback) = cb {
-            callback.del_link(link);
+            tokio::task::spawn_blocking(move || {
+                callback.del_link(link);
+            })
+            .await?;
         }
         if is_last {
             let r = stl.close().await; // do not return early to ensure that the transport is deleted even if the link close fails

--- a/zenoh/src/api/admin.rs
+++ b/zenoh/src/api/admin.rs
@@ -251,7 +251,8 @@ pub(crate) fn init(session: WeakSession) {
             let transport_zid = &event.link.zid;
             let transport = session
                 .runtime()
-                .get_transports()
+                .get_transports_blocking()
+                .into_iter()
                 .find(|t| t.zid == *transport_zid);
 
             if let Some(transport) = transport {

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -146,6 +146,8 @@ pub trait IRuntime: Send + Sync {
 
     fn get_transports(&self) -> Box<dyn Iterator<Item = Transport> + Send + Sync>;
 
+    fn get_transports_blocking(&self) -> Vec<Transport>;
+
     fn get_links(
         &self,
         transport: Option<&Transport>,
@@ -248,6 +250,22 @@ impl IRuntime for RuntimeState {
             .map(|ref peer| Transport::new(peer, true));
 
         Box::new(unicast_transports.chain(multicast_transports))
+    }
+
+    fn get_transports_blocking(&self) -> Vec<Transport> {
+        self.manager
+            .get_transports_unicast_blocking()
+            .into_iter()
+            .filter_map(|t| t.get_peer().ok())
+            .map(|peer| Transport::new(&peer, false))
+            .chain(
+                self.manager
+                    .get_transports_multicast_blocking()
+                    .into_iter()
+                    .flat_map(|t| t.get_peers().ok().unwrap_or_default())
+                    .map(|peer| Transport::new(&peer, true)),
+            )
+            .collect()
     }
 
     fn get_links(


### PR DESCRIPTION
## Description

Transport callbacks (`new_link`, `del_link`) are synchronous and potentially blocking, but were being invoked directly inside `async` code paths.

The link event callback was caused the deadlock observed in eclipse-zenoh/zenoh#2409 because it used `block_in_place` to acquire an async lock within a sync context. To remedy this, `blocking_lock` is used. Other instances of `block_in_place` use to prevent this issue remain and they are out of the scope of this pull request—eclipse-zenoh/zenoh#2409 should be left open.

The transport manager was blocking its async caller (the orchestrator's scouting future) by calling `ConnectivityPeerHandler`. This patch uses `tokio::spawn_blocking` to avoid this.

### Why is this change needed?
<!-- Explain the motivation or problem being solved -->

See eclipse-zenoh/zenoh#2409.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [ ] **Reproduction test added** - Test that fails on main branch without the fix
- [ ] **Test passes with fix** - The reproduction test passes with your changes
- [ ] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [ ] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->