### PR TITLE
chore: unpin nightly version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ env:
   # Nightly toolchain identifier used by cargo invocations
   # Normally keep it "nightly" to always use the latest nightly, but in case of a regression in the Rust compiler, 
   # it can be useful to fix it to a specific nightly version that is known to work.
-  NIGHTLY_TOOLCHAIN: "nightly-2026-02-21"
+  NIGHTLY_TOOLCHAIN: "nightly"
 
 jobs:
   determine-runner:


### PR DESCRIPTION
## Description
In https://github.com/eclipse-zenoh/zenoh/pull/2440 nightly was pinned due to a version of shellexpand (3.1.1) not working with the current version. A new version of shellexpand has been released which should address the nightly failures.

Fix https://github.com/eclipse-zenoh/zenoh/issues/2441

### What does this PR do?
Revert the pin added on #2440 

### Why is this change needed?
Helps us get early feedback with nightly builds

### Related Issues
Fix https://github.com/eclipse-zenoh/zenoh/issues/2441
Upstream shellexpand fixed in https://gitlab.com/ijackson/rust-shellexpand/-/merge_requests/21/diffs

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->