### PR TITLE
chore: fix formatting for scouting.rs

### DIFF
--- a/zenoh/src/api/builders/scouting.rs
+++ b/zenoh/src/api/builders/scouting.rs
@@ -21,7 +21,7 @@ use zenoh_result::ZResult;
 
 use crate::api::{
     handlers::{locked, Callback, DefaultHandler, IntoHandler},
-    scouting::{Scout, _scout},
+    scouting::{_scout, Scout},
 };
 
 /// A builder for initializing a [`Scout`], returned by the


### PR DESCRIPTION
## Description
As shown in https://github.com/eclipse-zenoh/zenoh/actions/runs/22556089158/job/65333602246, formatting with rustfmt +nightly fails on scounting.rs.

### What does this PR do?
Fix formatting of scouting import line to follow +nightly standard

### Why is this change needed?

Unblocks https://github.com/eclipse-zenoh/zenoh/pull/2447 and make CI green again

### Related Issues
https://github.com/eclipse-zenoh/zenoh/actions/runs/22556089158/job/65333602246

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->