### PR TITLE
chore: update pre-commit rustfmt to use nightly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     hooks:
       - id: fmt-rust
         name: fmt-rust
-        entry: bash -c 'rustfmt --config "unstable_features=true,imports_granularity=Crate,group_imports=StdExternalCrate,skip_children=true" $(git ls-files '*.rs')'
+        entry: bash -c 'rustfmt +nightly --config "unstable_features=true,imports_granularity=Crate,group_imports=StdExternalCrate,skip_children=true" $(git ls-files '*.rs')'
         language: system
         types: [rust]
   - repo: https://github.com/ComPWA/taplo-pre-commit


### PR DESCRIPTION
## Description
Update the pre-commit-hook for rustfmt after nightly update. See https://github.com/eclipse-zenoh/zenoh/pull/2448

### What does this PR do?
Update the pre-commit-hook for rustfmt after nightly update.

### Why is this change needed?
Keep CI and pre-commit formatting rules consistent

### Related Issues
https://github.com/eclipse-zenoh/zenoh/pull/2448

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [ ] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->