### PR TITLE
fix: respect `plugins_loading.enabled` config in zenohd

### DIFF
--- a/zenohd/src/main.rs
+++ b/zenohd/src/main.rs
@@ -134,7 +134,12 @@ fn config_from_args(args: &Args) -> Config {
         }
     }
     config.adminspace.set_enabled(true).unwrap();
-    config.plugins_loading.set_enabled(true).unwrap();
+    // Enable plugin loading if CLI args require plugins, but respect the user's
+    // config if no plugin-related CLI args are provided.
+    if !args.plugin.is_empty() || args.rest_http_port.is_some() || !args.plugin_search_dir.is_empty()
+    {
+        config.plugins_loading.set_enabled(true).unwrap();
+    }
     if !args.plugin_search_dir.is_empty() {
         config
             .plugins_loading
@@ -284,6 +289,50 @@ fn init_logging() -> Result<()> {
 
     tracing_sub.init();
     Ok(())
+}
+
+#[test]
+fn test_plugins_loading_respects_config() {
+    // Without plugin-related CLI args, plugins_loading.enabled should remain
+    // at whatever the config specifies (false by default).
+    let args = Args::parse_from(["zenohd"]);
+    let config = config_from_args(&args);
+    assert!(
+        !config.plugins_loading.enabled(),
+        "plugins_loading should be disabled by default without plugin CLI args"
+    );
+
+    // With --plugin, plugins_loading.enabled should be forced on.
+    let args = Args::parse_from(["zenohd", "--plugin", "rest"]);
+    let config = config_from_args(&args);
+    assert!(
+        config.plugins_loading.enabled(),
+        "plugins_loading should be enabled when --plugin is passed"
+    );
+
+    // With --rest-http-port, plugins_loading.enabled should be forced on.
+    let args = Args::parse_from(["zenohd", "--rest-http-port", "8000"]);
+    let config = config_from_args(&args);
+    assert!(
+        config.plugins_loading.enabled(),
+        "plugins_loading should be enabled when --rest-http-port is passed"
+    );
+
+    // With --plugin-search-dir, plugins_loading.enabled should be forced on.
+    let args = Args::parse_from(["zenohd", "--plugin-search-dir", "/tmp"]);
+    let config = config_from_args(&args);
+    assert!(
+        config.plugins_loading.enabled(),
+        "plugins_loading should be enabled when --plugin-search-dir is passed"
+    );
+
+    // When config explicitly enables plugins_loading but no CLI args, it should stay enabled.
+    let args = Args::parse_from(["zenohd", "--cfg", "plugins_loading/enabled:true"]);
+    let config = config_from_args(&args);
+    assert!(
+        config.plugins_loading.enabled(),
+        "plugins_loading should stay enabled when set via --cfg"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Description

### What does this PR do?
Makes `zenohd` respect the user's `plugins_loading.enabled` configuration setting. Previously, `zenohd` unconditionally called `config.plugins_loading.set_enabled(true)`, which overrode the user's config and caused plugins to load even when `plugins_loading.enabled` was not set to `true`.

Now plugin loading is only force-enabled when CLI args require it:
- `--plugin` (explicitly loading a plugin)
- `--rest-http-port` (implicitly requires the REST plugin)
- `--plugin-search-dir` (implies plugin usage)

### Why is this change needed?
The [documented behavior](https://github.com/eclipse-zenoh/zenoh/blob/main/DEFAULT_CONFIG.json5#L802) states that plugins are only loaded if `plugins_loading: { enabled: true }`, but zenohd was ignoring this and always enabling plugin loading. This caused unexpected plugin load attempts and confusing error messages.

### Related Issues
Fixes #2422

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [x] **Reproduction test added** - Test that fails on main branch without the fix
- [x] **Test passes with fix** - The reproduction test passes with your changes
- [x] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->