### PR TITLE
Make cancellation of rx/tx tasks more explicit in the code for TransportUnicastUniversal

### DIFF
--- a/commons/zenoh-task/src/lib.rs
+++ b/commons/zenoh-task/src/lib.rs
@@ -41,39 +41,19 @@ impl Default for TaskController {
     }
 }
 
-#[derive(Debug)]
-pub struct TaskCancelledError;
-impl std::fmt::Display for TaskCancelledError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "task was cancelled")
-    }
-}
-impl std::error::Error for TaskCancelledError {}
-
 impl TaskController {
     /// Converts a task to abortable one, which can later be terminated by call to [`TaskController::terminate_all()`].
-    pub fn into_abortable<'a, F, T>(
-        &self,
-        future: F,
-    ) -> impl Future<Output = Result<T, TaskCancelledError>> + Send + 'a
+    pub fn into_abortable<'a, F, T>(&self, future: F) -> impl Future<Output = Option<T>> + Send + 'a
     where
         F: Future<Output = T> + Send + 'a,
         T: Send + 'static,
     {
-        let token = self.token.child_token();
-        let task = async move {
-            tokio::select! {
-                _ = token.cancelled() => { Err(TaskCancelledError) },
-                res = future => { Ok(res) }
-            }
-        };
-
-        task
+        self.token.child_token().run_until_cancelled_owned(future)
     }
 
     /// Spawns a task that can be later terminated by call to [`TaskController::terminate_all()`].
     /// Task output is ignored.
-    pub fn spawn_abortable<F, T>(&self, future: F) -> JoinHandle<Result<T, TaskCancelledError>>
+    pub fn spawn_abortable<F, T>(&self, future: F) -> JoinHandle<Option<T>>
     where
         F: Future<Output = T> + Send + 'static,
         T: Send + 'static,
@@ -85,11 +65,7 @@ impl TaskController {
     }
 
     /// Spawns a task using a specified runtime that can be later terminated by call to [`TaskController::terminate_all()`].
-    pub fn spawn_abortable_with_rt<F, T>(
-        &self,
-        rt: ZRuntime,
-        future: F,
-    ) -> JoinHandle<Result<T, TaskCancelledError>>
+    pub fn spawn_abortable_with_rt<F, T>(&self, rt: ZRuntime, future: F) -> JoinHandle<Option<T>>
     where
         F: Future<Output = T> + Send + 'static,
         T: Send + 'static,

--- a/io/zenoh-transport/src/unicast/universal/link.rs
+++ b/io/zenoh-transport/src/unicast/universal/link.rs
@@ -13,6 +13,7 @@
 //
 use std::time::Duration;
 
+use tokio_util::sync::CancellationToken;
 use zenoh_buffers::ZSliceBuffer;
 use zenoh_link::Link;
 #[cfg(feature = "unstable")]
@@ -126,13 +127,13 @@ impl TransportLinkUnicastUniversal {
         let mut tx = self.link.tx();
         #[cfg(feature = "stats")]
         let stats = self.stats.clone();
-        let tc = self.task_controller.clone();
+        let ct = self.task_controller.get_cancellation_token();
         let task = async move {
             let res = tx_task(
                 consumer,
                 &mut tx,
                 keep_alive,
-                tc,
+                ct,
                 #[cfg(feature = "stats")]
                 stats,
             )
@@ -156,22 +157,25 @@ impl TransportLinkUnicastUniversal {
         let priorities = self.link.config.priorities.clone();
         let reliability = self.link.config.reliability;
         let mut rx = self.link.rx();
+        let cancellation_token = self.task_controller.get_cancellation_token();
         #[cfg(feature = "stats")]
         let stats = self.stats.clone();
         let task = async move {
             // Start the consume task
-            let res = rx_task(
-                &mut rx,
-                transport.clone(),
-                lease,
-                transport.manager.config.link_rx_buffer_size,
-                #[cfg(feature = "stats")]
-                stats,
-            )
-            .await;
+            let res = cancellation_token
+                .run_until_cancelled(rx_task(
+                    &mut rx,
+                    transport.clone(),
+                    lease,
+                    transport.manager.config.link_rx_buffer_size,
+                    #[cfg(feature = "stats")]
+                    stats,
+                ))
+                .await;
 
             // TODO(yuyuan): improve this callback
-            if let Err(e) = res {
+            if let Some(Err(e)) = res {
+                // process error if task was not cancelled
                 tracing::debug!("RX task failed: {}", e);
 
                 // Spawn a task to avoid a deadlock waiting for this same task
@@ -194,7 +198,7 @@ impl TransportLinkUnicastUniversal {
         };
         // WARN: If this is on ZRuntime::TX, a deadlock would occur.
         self.task_controller
-            .spawn_abortable_with_rt(zenoh_runtime::ZRuntime::RX, task);
+            .spawn_with_rt(zenoh_runtime::ZRuntime::RX, task);
     }
 
     pub(super) async fn close(self) -> ZResult<()> {
@@ -213,7 +217,7 @@ async fn tx_task(
     mut pipeline: TransmissionPipelineConsumer,
     link: &mut TransportLinkUnicastTx,
     keep_alive: Duration,
-    task_controller: TaskController,
+    cancellation_token: CancellationToken,
     #[cfg(feature = "stats")] stats: zenoh_stats::LinkStats,
 ) -> ZResult<()> {
     let task = async {
@@ -254,7 +258,7 @@ async fn tx_task(
         }
         ZResult::Ok(())
     };
-    if let Ok(result) = task_controller.into_abortable(task).await {
+    if let Some(result) = cancellation_token.run_until_cancelled(task).await {
         result?;
     }
 

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -395,10 +395,7 @@ impl RuntimeState {
 
     /// Spawns a task within runtime.
     /// Upon runtime close the task will be automatically aborted.
-    fn spawn_abortable<F, T>(
-        &self,
-        future: F,
-    ) -> JoinHandle<Result<T, zenoh_task::TaskCancelledError>>
+    fn spawn_abortable<F, T>(&self, future: F) -> JoinHandle<Option<T>>
     where
         F: Future<Output = T> + Send + 'static,
         T: Send + 'static,
@@ -737,10 +734,7 @@ impl Runtime {
 
     /// Spawns a task within runtime.
     /// Upon runtime close the task will be automatically aborted.
-    pub(crate) fn spawn_abortable<F, T>(
-        &self,
-        future: F,
-    ) -> JoinHandle<Result<T, zenoh_task::TaskCancelledError>>
+    pub(crate) fn spawn_abortable<F, T>(&self, future: F) -> JoinHandle<Option<T>>
     where
         F: Future<Output = T> + Send + 'static,
         T: Send + 'static,


### PR DESCRIPTION
## Description
Make cancellation of rx/tx tasks more explicit in the code for TransportUnicastUniversal

### What does this PR do?
<!-- Describe the changes and their purpose -->
Makes cancellation of rx/tx tasks more explicit in the code for TransportUnicastUniversal

### Why is this change needed?
<!-- Explain the motivation or problem being solved -->
Improve code readability

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->