### PR TITLE
fix(test): replace should_panic with explicit failure assert for IPv6 mismatch tests

### DIFF
--- a/io/zenoh-transport/tests/unicast_bind.rs
+++ b/io/zenoh-transport/tests/unicast_bind.rs
@@ -83,6 +83,58 @@ impl TransportEventHandler for SHClientOpenClose {
     }
 }
 
+/// Like `openclose_transport` but asserts that the transport open FAILS.
+///
+/// Use for tests where the connect endpoint is expected to be rejected
+/// (e.g. IPv6 bind address to an IPv4 listen endpoint).
+async fn openclose_transport_expect_failure(
+    listen_endpoint: &EndPoint,
+    connect_endpoint: &EndPoint,
+    lowlatency_transport: bool,
+) {
+    let router_id = ZenohIdProto::try_from([1]).unwrap();
+    let router_handler = Arc::new(SHRouterOpenClose);
+    let unicast = make_transport_manager_builder(
+        #[cfg(feature = "transport_multilink")]
+        2,
+        lowlatency_transport,
+    )
+    .max_sessions(1);
+    let router_manager = TransportManager::builder()
+        .whatami(WhatAmI::Router)
+        .zid(router_id)
+        .unicast(unicast)
+        .build_test(router_handler.clone())
+        .unwrap();
+
+    let client01_id = ZenohIdProto::try_from([2]).unwrap();
+    let unicast = make_transport_manager_builder(
+        #[cfg(feature = "transport_multilink")]
+        2,
+        lowlatency_transport,
+    )
+    .max_sessions(1);
+    let client01_manager = TransportManager::builder()
+        .whatami(WhatAmI::Client)
+        .zid(client01_id)
+        .unicast(unicast)
+        .build_test(Arc::new(SHClientOpenClose::new()))
+        .unwrap();
+
+    let router_res = ztimeout!(router_manager.add_listener(listen_endpoint.clone()));
+    assert!(router_res.is_ok());
+
+    let open_res =
+        ztimeout_expected!(client01_manager.open_transport_unicast(connect_endpoint.clone()));
+    assert!(
+        open_res.is_err(),
+        "expected transport open to fail (protocol mismatch), but it succeeded: {open_res:?}"
+    );
+
+    ztimeout!(router_manager.close());
+    ztimeout!(client01_manager.close());
+}
+
 async fn openclose_transport(
     listen_endpoint: &EndPoint,
     connect_endpoint: &EndPoint,
@@ -316,7 +368,6 @@ async fn openclose_tcp_only_connect_with_bind_restriction() {
 }
 
 #[cfg(feature = "transport_tcp")]
-#[should_panic(expected = "assertion failed: open_res.is_ok()")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn openclose_tcp_only_connect_with_bind_restriction_mismatch_protocols() {
     use zenoh_util::net::get_ipv6_ipaddrs;
@@ -324,24 +375,26 @@ async fn openclose_tcp_only_connect_with_bind_restriction_mismatch_protocols() {
     let addrs = get_ipv4_ipaddrs(None);
     let addrs_v6 = get_ipv6_ipaddrs(None);
 
+    if addrs_v6.is_empty() {
+        // No IPv6 addresses on this host; test requires IPv6 to produce a protocol mismatch.
+        return;
+    }
+
     let bind_addr_str = format!("{}:{}", addrs_v6[0], 13006);
-    let bind_addr = Address::from(bind_addr_str.as_str());
 
     zenoh_util::init_log_from_env_or("error");
 
     let listen_endpoint: EndPoint = format!("tcp/{}:{}", addrs[0], 13005).parse().unwrap();
 
-    // Bind to different port on same IP address
+    // Connecting to an IPv4 endpoint while binding to an IPv6 address should fail.
     let connect_endpoint: EndPoint = format!("tcp/{}:{}#bind={}", addrs[0], 13005, bind_addr_str)
         .parse()
         .unwrap();
 
-    // should not connect to local interface and external address
-    openclose_transport(&listen_endpoint, &connect_endpoint, &bind_addr, false).await;
+    openclose_transport_expect_failure(&listen_endpoint, &connect_endpoint, false).await;
 }
 
 #[cfg(feature = "transport_udp")]
-#[should_panic(expected = "assertion failed: open_res.is_ok()")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn openclose_udp_only_connect_with_bind_restriction_mismatch_protocols() {
     use zenoh_util::net::get_ipv6_ipaddrs;
@@ -349,20 +402,23 @@ async fn openclose_udp_only_connect_with_bind_restriction_mismatch_protocols() {
     let addrs = get_ipv4_ipaddrs(None);
     let addrs_v6 = get_ipv6_ipaddrs(None);
 
+    if addrs_v6.is_empty() {
+        // No IPv6 addresses on this host; test requires IPv6 to produce a protocol mismatch.
+        return;
+    }
+
     let bind_addr_str = format!("{}:{}", addrs_v6[0], 13006);
-    let bind_addr = Address::from(bind_addr_str.as_str());
 
     zenoh_util::init_log_from_env_or("error");
 
     let listen_endpoint: EndPoint = format!("udp/{}:{}", addrs[0], 13005).parse().unwrap();
 
-    // Bind to different port on same IP address
+    // Connecting to an IPv4 endpoint while binding to an IPv6 address should fail.
     let connect_endpoint: EndPoint = format!("udp/{}:{}#bind={}", addrs[0], 13005, bind_addr_str)
         .parse()
         .unwrap();
 
-    // should not connect to local interface and external address
-    openclose_transport(&listen_endpoint, &connect_endpoint, &bind_addr, false).await;
+    openclose_transport_expect_failure(&listen_endpoint, &connect_endpoint, false).await;
 }
 
 #[cfg(feature = "transport_udp")]


### PR DESCRIPTION
## Summary

### Root cause

`openclose_tcp/udp_only_connect_with_bind_restriction_mismatch_protocols` used `#[should_panic(expected = "assertion failed: open_res.is_ok()")]` to verify that connecting with an IPv6 bind address to an IPv4 endpoint fails.

On hosts/containers with no IPv6 interfaces (common in Docker CI), `get_ipv6_ipaddrs(None)` returns an empty `Vec`. Indexing `addrs_v6[0]` then panics with an **index-out-of-bounds** error — which does **not** match the expected `"assertion failed: open_res.is_ok()"` message, so `#[should_panic]` marks the test as **FAILED** instead of silently passing.

This caused intermittent test failures in Docker-based CI environments (confirmed on `feat/mem-transport` CUDA CI run in a container without IPv6 networking).

### Fix

- Add `openclose_transport_expect_failure` helper that calls `assert!(open_res.is_err())` directly — no `#[should_panic]` fragility.
- Guard both tests with `if addrs_v6.is_empty() { return; }` so they are skipped cleanly on hosts without IPv6.
- Remove `#[should_panic]` from both TCP and UDP variants.
- Verified no similar `addrs_v6[0]` index without guard exists in related test files (`unicast_openclose.rs` uses only IPv4 addresses in its `#[should_panic]` tests).

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - `addrs_v6[0]` index panic on Docker hosts without IPv6 produces wrong panic message, silently breaking `#[should_panic(expected = ...)]`
- [x] **Reproduction test added** - The two modified tests reproduce the failure: on a host without IPv6 they panic with an index-out-of-bounds message that does not match the expected string, causing the `#[should_panic]` test to report FAILED
- [x] **Test passes with fix** - With the IPv6 guard and `openclose_transport_expect_failure` helper the tests pass on both IPv6-capable and IPv6-less hosts
- [x] **Regression prevention** - The new `openclose_transport_expect_failure` helper uses `assert!(open_res.is_err())` — any future regression where the connection unexpectedly succeeds will produce a clear assertion failure with the actual result printed
- [x] **Fix is minimal** - Only `io/zenoh-transport/tests/unicast_bind.rs` is changed; no production code modified
- [x] **Related bugs checked** - `unicast_openclose.rs` has similar `#[should_panic]` patterns but uses only IPv4 addresses (no `addrs_v6` indexing) and is `#[cfg(target_os = "linux")]`-gated; not affected

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->