### PR TITLE
Fix race condition that could lead to having more links per transport than allowed by config

### DIFF
--- a/io/zenoh-transport/src/unicast/universal/transport.rs
+++ b/io/zenoh-transport/src/unicast/universal/transport.rs
@@ -210,7 +210,6 @@ impl TransportUnicastUniversal {
 
         match *status_guard {
             TransportStatus::Uninitialized => {
-                *status_guard = TransportStatus::Alive;
                 let csn = PrioritySn {
                     reliable: initial_sn_rx,
                     best_effort: initial_sn_rx,
@@ -218,6 +217,7 @@ impl TransportUnicastUniversal {
                 for c in self.priority_rx.iter() {
                     c.sync(csn)?;
                 }
+                *status_guard = TransportStatus::Alive;
                 Ok(status_guard)
             }
             TransportStatus::Alive => Ok(status_guard),
@@ -241,37 +241,6 @@ impl TransportUnicastTrait for TransportUnicastUniversal {
         other_initial_sn: TransportSn,
         other_lease: Duration,
     ) -> AddLinkResult {
-        // Check if we can add more inbound links
-        {
-            let guard = zread!(self.links);
-            if let TransportLinkUnicastDirection::Inbound = link.inner_config().direction {
-                let count = guard
-                    .iter()
-                    .filter(|l| l.link.config.direction == link.inner_config().direction)
-                    .count();
-
-                let limit = zcondfeat!(
-                    "transport_multilink",
-                    match self.config.multilink {
-                        Some(_) => self.manager.config.unicast.max_links,
-                        None => 1,
-                    },
-                    1
-                );
-
-                if count >= limit {
-                    let e = zerror!(
-                        "Can not add Link {} with peer {}: max num of links reached {}/{}",
-                        link,
-                        self.config.zid,
-                        count,
-                        limit
-                    );
-                    return Err((e.into(), link.fail(), close::reason::MAX_LINKS));
-                }
-            }
-        }
-
         // sync the RX sequence number
         let status_guard = match self.sync(other_initial_sn).await {
             Ok(status_guard) => status_guard,
@@ -285,13 +254,41 @@ impl TransportUnicastTrait for TransportUnicastUniversal {
             }
         };
 
+        // Check if we can add more inbound links
+        let mut guard = zwrite!(self.links);
+        if let TransportLinkUnicastDirection::Inbound = link.inner_config().direction {
+            let count = guard
+                .iter()
+                .filter(|l| l.link.config.direction == link.inner_config().direction)
+                .count();
+
+            let limit = zcondfeat!(
+                "transport_multilink",
+                match self.config.multilink {
+                    Some(_) => self.manager.config.unicast.max_links,
+                    None => 1,
+                },
+                1
+            );
+
+            if count >= limit {
+                let e = zerror!(
+                    "Can not add Link {} with peer {}: max num of links reached {}/{}",
+                    link,
+                    self.config.zid,
+                    count,
+                    limit
+                );
+                return Err((e.into(), link.fail(), close::reason::MAX_LINKS));
+            }
+        }
+
         // Wrap the link
         let (link, ack) = link.unpack();
         let (mut link, consumer) =
             TransportLinkUnicastUniversal::new(self, link, &self.priority_tx);
 
         // Add the link to the channel
-        let mut guard = zwrite!(self.links);
         let mut links = Vec::with_capacity(guard.len() + 1);
         links.extend_from_slice(&guard);
         links.push(link.clone());


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->
Fix race condition that could lead to having more links per transport than allowed by config

### What does this PR do?
Fix race condition that could lead to having more links per transport than allowed by config

### Why is this change needed?
It fixes a race condition introduced by #2438 

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->