### PR TITLE
Use ZRuntime.Application instead of futures::executor

### DIFF
--- a/zenoh/src/api/cancellation.rs
+++ b/zenoh/src/api/cancellation.rs
@@ -28,6 +28,7 @@ use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use zenoh_core::{Resolvable, Wait};
 #[cfg(feature = "unstable")]
 use zenoh_result::ZResult;
+use zenoh_runtime::ZRuntime;
 
 #[zenoh_macros::pub_visibility_if_internal]
 #[derive(Debug)]
@@ -72,7 +73,7 @@ impl SyncGroup {
     #[zenoh_macros::pub_visibility_if_internal]
     pub(crate) fn wait(&self) {
         let s = self.semaphore.clone();
-        let _p = futures::executor::block_on(s.acquire_many(Self::max_permits()));
+        let _p = ZRuntime::Application.block_in_place(s.acquire_many(Self::max_permits()));
         self.close();
     }
 


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->
Use ZRuntime.Application instead of futures::executor

### What does this PR do?
<!-- Describe the changes and their purpose -->
Use ZRuntime.Application instead of futures::executor

### Why is this change needed?
<!-- Explain the motivation or problem being solved -->
futures::executor causes Valgrind to report false memory leaks

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->