### PR TITLE
clap_lex locked to 1.0.0

### DIFF
--- a/commons/zenoh-pinned-deps-1-75/Cargo.toml
+++ b/commons/zenoh-pinned-deps-1-75/Cargo.toml
@@ -29,6 +29,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 async-lock = "=3.4.1"
 base64ct = "=1.6.0"
+clap_lex = "=1.0.0"
 derive_more = { version = "=2.0.1", features = ["as_ref"] }
 generic-array = "=0.14.7"
 home = "=0.5.9"
@@ -71,6 +72,7 @@ security-framework = "=3.6.0"
 ignored = [
   "async-lock",
   "base64ct",
+  "clap_lex",
   "derive_more",
   "generic-array",
   "home",


### PR DESCRIPTION
## Description

The https://crates.io/crates/clap_lex/versions library bumped MSRV to 1.85 in 1.1.0. Locking it to 1.0.0 for rust 1.75

### Why is this change needed?

To build zenoh with rust 1.75

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->