### PR TITLE
Remove incorrect unstable feature gate from query.accept_any_replies check

### DIFF
--- a/zenoh/src/api/queryable.rs
+++ b/zenoh/src/api/queryable.rs
@@ -544,8 +544,7 @@ impl IntoFuture for ReplySample<'_> {
 
 impl Query {
     pub(crate) fn _reply_sample(&self, sample: Sample) -> ZResult<()> {
-        let c = zcondfeat!("unstable", !self._accepts_any_replies(), true);
-        if c && !self.key_expr().intersects(&sample.key_expr) {
+        if !self._accepts_any_replies() && !self.key_expr().intersects(&sample.key_expr) {
             bail!("Attempted to reply on `{}`, which does not intersect with query `{}`, despite query only allowing replies on matching key expressions", sample.key_expr, self.key_expr())
         }
         #[cfg(not(feature = "unstable"))]

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -108,7 +108,7 @@ use crate::{
         },
         queryable::{Query, QueryInner, QueryableState, ReplyPrimitives},
         sample::{Locality, QoS, Sample, SampleKind},
-        selector::Selector,
+        selector::{Selector, REPLY_KEY_EXPR_ANY_SEL_PARAM},
         subscriber::{SubscriberKind, SubscriberState},
         Id,
     },
@@ -3239,9 +3239,9 @@ impl Primitives for WeakSession {
                 };
                 match state.queries.get_mut(&msg.rid) {
                     Some(query) => {
-                        let c =
-                            zcondfeat!("unstable", !query.parameters.reply_key_expr_any(), true);
-                        if c && !query.key_expr.intersects(&key_expr) {
+                        if !query.parameters.contains_key(REPLY_KEY_EXPR_ANY_SEL_PARAM)
+                            && !query.key_expr.intersects(&key_expr)
+                        {
                             tracing::warn!(
                                 "Received Reply for `{}` from `{:?}`, which didn't match query `{}?{}`: dropping Reply.",
                                 key_expr,

--- a/zenoh/tests/queryable.rs
+++ b/zenoh/tests/queryable.rs
@@ -17,7 +17,7 @@ use std::{time::Duration, vec};
 use futures::StreamExt;
 use zenoh::{
     handlers::DefaultHandler,
-    query::{ConsolidationMode, Query, QueryTarget, QueryableBuilder, Reply},
+    query::{ConsolidationMode, Query, QueryTarget, QueryableBuilder, Reply, ReplyKeyExpr},
     sample::SampleKind,
     session::SessionGetBuilder,
     Session,
@@ -310,4 +310,170 @@ async fn test_queryable_same_session() {
     test_queryable_impl(&s1, &s1, "same session", "test/queryable/same_session").await;
 
     ztimeout!(s1.close()).expect("Failed to close session s1");
+}
+
+/// Tests for `Session::get` builder `accept_replies` setter.
+///
+/// `accept_replies(ReplyKeyExpr::MatchingQuery)` (the default) means the queryable's
+/// reply is silently dropped if its key expression does not intersect with the query key expression.
+/// `accept_replies(ReplyKeyExpr::Any)` lifts that restriction.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_accept_replies() {
+    zenoh::init_log_from_env_or("error");
+
+    let s1 = ztimeout!(zenoh::open(zenoh::Config::default())).expect("Failed to open session s1");
+    let s2 = ztimeout!(zenoh::open(zenoh::Config::default())).expect("Failed to open session s2");
+    tokio::time::sleep(SLEEP).await;
+    // -----------------------------------------------------------------------
+    // 1. Default (MatchingQuery): queryable replies on the *same* key expression
+    //    -> reply is accepted.
+    // -----------------------------------------------------------------------
+    {
+        let queryable = ztimeout!(s1.declare_queryable("test/accept_replies/matching"))
+            .expect("Failed to declare queryable");
+        tokio::time::sleep(SLEEP).await;
+
+        let replies = ztimeout!(s2
+            .get("test/accept_replies/matching")
+            .consolidation(ConsolidationMode::None))
+        .expect("get failed");
+
+        // Receive and answer the query via the channel.
+        let query = ztimeout!(queryable.recv_async()).expect("queryable did not receive query");
+        ztimeout!(query.reply("test/accept_replies/matching", "value")).expect("reply failed");
+        assert_eq!(
+            query.accepts_replies(),
+            ReplyKeyExpr::MatchingQuery,
+            "Query::accepts_replies() should return MatchingQuery by default"
+        );
+        drop(query);
+
+        let received: Vec<RKind> = replies
+            .into_stream()
+            .then(|r| async move { RKind::from(r) })
+            .collect()
+            .await;
+
+        assert_eq!(
+            received,
+            vec![RKind::Reply],
+            "Default accept_replies: expected reply on matching key expr to be received"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // 2. Default (MatchingQuery): queryable replies on a *disjoint* key expression
+    //    -> reply is silently dropped, getter receives nothing.
+    // -----------------------------------------------------------------------
+    {
+        let queryable = ztimeout!(s1.declare_queryable("test/accept_replies/query_key"))
+            .expect("Failed to declare queryable");
+        tokio::time::sleep(SLEEP).await;
+
+        let replies = ztimeout!(s2
+            .get("test/accept_replies/query_key")
+            .consolidation(ConsolidationMode::None))
+        .expect("get failed");
+
+        // Reply on a key that does NOT intersect the query key expression.
+        // This should be silently rejected by the session.
+        let query = ztimeout!(queryable.recv_async()).expect("queryable did not receive query");
+        let _ = ztimeout!(query.reply("test/accept_replies/disjoint_key", "value"));
+        assert_eq!(
+            query.accepts_replies(),
+            ReplyKeyExpr::MatchingQuery,
+            "Query::accepts_replies() should return MatchingQuery by default"
+        );
+        drop(query);
+
+        let received: Vec<RKind> = replies
+            .into_stream()
+            .then(|r| async move { RKind::from(r) })
+            .collect()
+            .await;
+
+        assert_eq!(
+            received,
+            vec![],
+            "Default accept_replies (MatchingQuery): reply on disjoint key expr should be dropped"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // 3. Explicit MatchingQuery: same as default, reply on disjoint key is dropped.
+    // -----------------------------------------------------------------------
+    {
+        let queryable = ztimeout!(s1.declare_queryable("test/accept_replies/explicit_matching"))
+            .expect("Failed to declare queryable");
+        tokio::time::sleep(SLEEP).await;
+
+        let replies = ztimeout!(s2
+            .get("test/accept_replies/explicit_matching")
+            .accept_replies(ReplyKeyExpr::MatchingQuery)
+            .consolidation(ConsolidationMode::None))
+        .expect("get failed");
+
+        let query = ztimeout!(queryable.recv_async()).expect("queryable did not receive query");
+        assert_eq!(
+            query.accepts_replies(),
+            ReplyKeyExpr::MatchingQuery,
+            "Query::accepts_replies() should return MatchingQuery if set explicitly"
+        );
+        let _ = ztimeout!(query.reply("test/accept_replies/disjoint_key", "value"));
+        drop(query);
+
+        let received: Vec<RKind> = replies
+            .into_stream()
+            .then(|r| async move { RKind::from(r) })
+            .collect()
+            .await;
+
+        assert_eq!(
+            received,
+            vec![],
+            "Explicit MatchingQuery: reply on disjoint key expr should be dropped"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // 4. accept_replies(Any): queryable replies on a *disjoint* key expression
+    //    -> reply IS accepted because the getter opted in to any key expression.
+    // -----------------------------------------------------------------------
+    {
+        let queryable = ztimeout!(s1.declare_queryable("test/accept_replies/any_key"))
+            .expect("Failed to declare queryable");
+        tokio::time::sleep(SLEEP).await;
+
+        let replies = ztimeout!(s2
+            .get("test/accept_replies/any_key")
+            .accept_replies(ReplyKeyExpr::Any)
+            .consolidation(ConsolidationMode::None))
+        .expect("get failed");
+
+        // The query was sent with ReplyKeyExpr::Any, so the reply on a disjoint
+        // key expression goes through.
+        let query = ztimeout!(queryable.recv_async()).expect("queryable did not receive query");
+        assert_eq!(
+            query.accepts_replies(),
+            ReplyKeyExpr::Any,
+            "Query::accepts_replies() should return Any when get was called with accept_replies(Any)"
+        );
+        ztimeout!(query.reply("test/accept_replies/disjoint_key", "value")).expect("reply failed");
+        drop(query);
+
+        let received: Vec<RKind> = replies
+            .into_stream()
+            .then(|r| async move { RKind::from(r) })
+            .collect()
+            .await;
+
+        assert_eq!(
+            received,
+            vec![RKind::Reply],
+            "accept_replies(Any): reply on disjoint key expr should be received"
+        );
+    }
+
+    ztimeout!(s1.close()).expect("Failed to close session");
+    ztimeout!(s2.close()).expect("Failed to close session");
 }


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->
Remove incorrect unstable feature gate from query.accept_any_replies check

### What does this PR do?
<!-- Describe the changes and their purpose -->
Remove incorrect unstable feature gate from query.accept_any_replies check

### Why is this change needed?
<!-- Explain the motivation or problem being solved -->
It is a bug 

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->