### PR TITLE
tempfile filbrary bumped to 3.27

### DIFF
--- a/commons/zenoh-pinned-deps-1-75/Cargo.toml
+++ b/commons/zenoh-pinned-deps-1-75/Cargo.toml
@@ -51,7 +51,6 @@ serde_spanned = "=1.0.1"
 serde_with = "=3.14.1"
 serde_with_macros = "=3.14.1"
 static_init = "=1.0.3"
-tempfile = "=3.27.0"
 thread-priority = "=1.2.0"
 time = "=0.3.41"
 tinystr = "=0.8.0"
@@ -96,7 +95,6 @@ ignored = [
   "serde_with",
   "serde_with_macros",
   "static_init",
-  "tempfile",
   "thread-priority",
   "time",
   "tinystr",


### PR DESCRIPTION
## Description

The tempfile by itself have MSRV=1.63, maybe we don't need to lock it

### Why is this change needed?
Conflicts withe tempfile 3.24 and 3.27 selection

### Related Issues
https://github.com/eclipse-zenoh/zenoh/pull/2392

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [ ] **No API changes** - Public APIs unchanged
- [ ] **No behavior changes** - External behavior identical
- [ ] **Refactoring/maintenance** - Code improvements only
- [ ] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->