### PR TITLE
Review the unsafe fn (2nd round).

### DIFF
--- a/commons/zenoh-keyexpr/src/key_expr/borrowed.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/borrowed.rs
@@ -175,6 +175,7 @@ impl keyexpr {
     pub fn get_nonwild_prefix(&self) -> Option<&keyexpr> {
         match self.0.find('*') {
             Some(i) => match self.0[..i].rfind('/') {
+                // SAFETY: upheld by the surrounding invariants and prior validation.
                 Some(j) => unsafe { Some(keyexpr::from_str_unchecked(&self.0[..j])) },
                 None => None, // wildcard in the first segment => no invariant prefix
             },
@@ -265,6 +266,7 @@ impl keyexpr {
                     // if remaining is "**" return only this since it covers all
                     if remaining.as_bytes() == b"**" {
                         result.clear();
+                        // SAFETY: upheld by the surrounding invariants and prior validation.
                         result.push(unsafe { keyexpr::from_str_unchecked(remaining) });
                         return result;
                     }
@@ -375,6 +377,7 @@ impl keyexpr {
                                 }
                             }
                         }
+                        // SAFETY: upheld by the surrounding invariants and prior validation.
                         None => unsafe {
                             // "**" can match all remaining non-verbatim chunks
                             Some(keyexpr::from_str_unchecked(core::str::from_utf8_unchecked(
@@ -392,7 +395,7 @@ impl keyexpr {
                     return None;
                 }
                 if prefix_end == prefix_bytes.len() {
-                    // Safety: every chunk of keyexpr is also a valid keyexpr
+                    // SAFETY: every chunk of keyexpr is also a valid keyexpr
                     return unsafe {
                         Some(keyexpr::from_str_unchecked(core::str::from_utf8_unchecked(
                             &target_bytes[(target_end + 1)..],
@@ -421,7 +424,8 @@ impl keyexpr {
     /// Much like [`core::str::from_utf8_unchecked`], this is memory-safe, but calling this without maintaining
     /// [`keyexpr`]'s invariants yourself may lead to unexpected behaviors, the Zenoh network dropping your messages.
     pub const unsafe fn from_str_unchecked(s: &str) -> &Self {
-        core::mem::transmute(s)
+        // SAFETY: `keyexpr` is `repr(transparent)` over `str`.
+        unsafe { core::mem::transmute(s) }
     }
 
     /// # Safety
@@ -430,7 +434,8 @@ impl keyexpr {
     /// Much like [`core::str::from_utf8_unchecked`], this is memory-safe, but calling this without maintaining
     /// [`keyexpr`]'s invariants yourself may lead to unexpected behaviors, the Zenoh network dropping your messages.
     pub unsafe fn from_slice_unchecked(s: &[u8]) -> &Self {
-        core::mem::transmute(s)
+        // SAFETY: `keyexpr` is `repr(transparent)` over `str` and caller guarantees valid UTF-8 keyexpr bytes.
+        unsafe { core::mem::transmute(s) }
     }
 
     #[cfg(feature = "internal")]
@@ -452,6 +457,7 @@ impl keyexpr {
         self.as_str().get(..i).and_then(|s| s.rfind('/'))
     }
     pub(crate) fn first_byte(&self) -> u8 {
+        // SAFETY: upheld by the surrounding invariants and prior validation.
         unsafe { *self.as_bytes().get_unchecked(0) }
     }
     pub(crate) fn iter_splits_ltr(&self) -> SplitsLeftToRight<'_> {
@@ -634,6 +640,7 @@ impl<'a> Chunks<'a> {
     pub const fn as_keyexpr(self) -> Option<&'a keyexpr> {
         match self.inner.is_empty() {
             true => None,
+            // SAFETY: upheld by the surrounding invariants and prior validation.
             _ => Some(unsafe { keyexpr::from_str_unchecked(self.inner) }),
         }
     }
@@ -642,6 +649,7 @@ impl<'a> Chunks<'a> {
         if self.inner.is_empty() {
             None
         } else {
+            // SAFETY: upheld by the surrounding invariants and prior validation.
             Some(unsafe {
                 keyexpr::from_str_unchecked(
                     &self.inner[..self.inner.find('/').unwrap_or(self.inner.len())],
@@ -654,6 +662,7 @@ impl<'a> Chunks<'a> {
         if self.inner.is_empty() {
             None
         } else {
+            // SAFETY: upheld by the surrounding invariants and prior validation.
             Some(unsafe {
                 keyexpr::from_str_unchecked(
                     &self.inner[self.inner.rfind('/').map_or(0, |i| i + 1)..],
@@ -670,6 +679,7 @@ impl<'a> Iterator for Chunks<'a> {
         }
         let (next, inner) = self.inner.split_once('/').unwrap_or((self.inner, ""));
         self.inner = inner;
+        // SAFETY: upheld by the surrounding invariants and prior validation.
         Some(unsafe { keyexpr::from_str_unchecked(next) })
     }
 }
@@ -680,6 +690,7 @@ impl DoubleEndedIterator for Chunks<'_> {
         }
         let (inner, next) = self.inner.rsplit_once('/').unwrap_or(("", self.inner));
         self.inner = inner;
+        // SAFETY: upheld by the surrounding invariants and prior validation.
         Some(unsafe { keyexpr::from_str_unchecked(next) })
     }
 }
@@ -864,6 +875,7 @@ impl<'a> TryFrom<&'a str> for &'a keyexpr {
                 _ => i += 1,
             }
         }
+        // SAFETY: upheld by the surrounding invariants and prior validation.
         Ok(unsafe { keyexpr::from_str_unchecked(value) })
     }
 }
@@ -910,6 +922,7 @@ fn autocanon() {
 impl Deref for keyexpr {
     type Target = str;
     fn deref(&self) -> &Self::Target {
+        // SAFETY: upheld by the surrounding invariants and prior validation.
         unsafe { core::mem::transmute(self) }
     }
 }
@@ -969,7 +982,8 @@ impl nonwild_keyexpr {
     /// Much like [`core::str::from_utf8_unchecked`], this is memory-safe, but calling this without maintaining
     /// [`nonwild_keyexpr`]'s invariants yourself may lead to unexpected behaviors, the Zenoh network dropping your messages.
     pub const unsafe fn from_str_unchecked(s: &str) -> &Self {
-        core::mem::transmute(s)
+        // SAFETY: `nonwild_keyexpr` is `repr(transparent)` over `keyexpr`/`str`.
+        unsafe { core::mem::transmute(s) }
     }
 }
 
@@ -986,6 +1000,7 @@ impl<'a> TryFrom<&'a keyexpr> for &'a nonwild_keyexpr {
         if value.is_wild_impl() {
             bail!("nonwild_keyexpr can not contain any wild chunks")
         }
+        // SAFETY: upheld by the surrounding invariants and prior validation.
         Ok(unsafe { core::mem::transmute::<&keyexpr, &nonwild_keyexpr>(value) })
     }
 }

--- a/commons/zenoh-keyexpr/src/key_expr/format/mod.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/format/mod.rs
@@ -184,11 +184,16 @@ pub mod macro_support {
         source: &'static str,
         segments: [SegmentBuilder; N],
     ) -> KeFormat<'static, [Segment<'static>; N]> {
+        /// # Safety
+        /// `start..end` must be in-bounds for `source`, and delimit UTF-8 boundaries.
         const unsafe fn substr(source: &'static str, start: usize, end: usize) -> &'static str {
-            core::str::from_utf8_unchecked(core::slice::from_raw_parts(
-                source.as_ptr().add(start),
-                end - start,
-            ))
+            // SAFETY: guaranteed by `const_new` caller and macro-generated offsets.
+            unsafe {
+                core::str::from_utf8_unchecked(core::slice::from_raw_parts(
+                    source.as_ptr().add(start),
+                    end - start,
+                ))
+            }
         }
         let mut storage = [Segment {
             prefix: "",
@@ -202,9 +207,11 @@ pub mod macro_support {
         let mut i = 0;
         while i < N {
             let segment = segments[i];
-            let prefix = substr(source, segment.segment_start, segment.prefix_end);
+            // SAFETY: macro-generated indices point to valid UTF-8 segment boundaries.
+            let prefix = unsafe { substr(source, segment.segment_start, segment.prefix_end) };
             let spec = Spec {
-                spec: substr(source, segment.spec_start, segment.spec_end),
+                // SAFETY: macro-generated indices point to valid UTF-8 segment boundaries.
+                spec: unsafe { substr(source, segment.spec_start, segment.spec_end) },
                 id_end: segment.id_end,
                 pattern_end: segment.pattern_end,
             };
@@ -212,7 +219,8 @@ pub mod macro_support {
             suffix_start = segment.segment_end;
             i += 1;
         }
-        let suffix = substr(source, suffix_start, source.len());
+        // SAFETY: `suffix_start` is derived from macro-generated segment ends.
+        let suffix = unsafe { substr(source, suffix_start, source.len()) };
         KeFormat { storage, suffix }
     }
 }
@@ -422,6 +430,7 @@ impl<'s, Storage: IKeFormatStorage<'s>> TryFrom<&KeFormatter<'s, Storage>> for O
             } else if let Some(default) = segments[i].spec.default() {
                 concatenate(default)
             } else {
+                // SAFETY: upheld by the surrounding invariants and prior validation.
                 unsafe { core::hint::unreachable_unchecked() }
             };
         }
@@ -558,6 +567,7 @@ impl<Storage: IKeFormatStorage<'static> + 'static> TryFrom<Box<str>> for OwnedKe
     type Error = <KeFormat<'static, Storage> as TryFrom<&'static str>>::Error;
     fn try_from(value: Box<str>) -> Result<Self, Self::Error> {
         let owner = value;
+        // SAFETY: upheld by the surrounding invariants and prior validation.
         let format: KeFormat<'static, Storage> = unsafe {
             // This is safe because
             core::mem::transmute::<&str, &'static str>(&owner)

--- a/commons/zenoh-keyexpr/src/key_expr/format/parsing.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/format/parsing.rs
@@ -116,6 +116,7 @@ impl<'s, Storage: IKeFormatStorage<'s> + 's> KeFormat<'s, Storage> {
     pub fn parse(&'s self, target: &'s keyexpr) -> ZResult<Parsed<'s, Storage>> {
         let segments = self.storage.segments();
         if segments.is_empty()
+            // SAFETY: upheld by the surrounding invariants and prior validation.
             && !target.intersects(unsafe { keyexpr::from_str_unchecked(self.suffix) })
         {
             bail!("{target} does not intersect with {self}")
@@ -127,6 +128,7 @@ impl<'s, Storage: IKeFormatStorage<'s> + 's> KeFormat<'s, Storage> {
             match self.suffix.as_bytes() {
                 [] => do_parse(Some(target), segments, results_mut),
                 [b'/', suffix @ ..] => {
+                    // SAFETY: upheld by the surrounding invariants and prior validation.
                     let suffix = unsafe { keyexpr::from_slice_unchecked(suffix) };
                     for (target, candidate) in target.iter_splits_rtl() {
                         if suffix.intersects(candidate)

--- a/commons/zenoh-keyexpr/src/key_expr/format/support.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/format/support.rs
@@ -55,6 +55,7 @@ impl Spec<'_> {
         &self.spec[..self.id_end as usize]
     }
     pub fn pattern(&self) -> &keyexpr {
+        // SAFETY: upheld by the surrounding invariants and prior validation.
         unsafe {
             keyexpr::from_str_unchecked(if self.pattern_end != u16::MAX {
                 &self.spec[(self.id_end + 1) as usize..self.pattern_end as usize]
@@ -66,6 +67,7 @@ impl Spec<'_> {
     pub fn default(&self) -> Option<&keyexpr> {
         let pattern_end = self.pattern_end as usize;
         (self.spec.len() > pattern_end)
+            // SAFETY: upheld by the surrounding invariants and prior validation.
             .then(|| unsafe { keyexpr::from_str_unchecked(&self.spec[(pattern_end + 1)..]) })
     }
 }
@@ -98,6 +100,7 @@ impl Segment<'_> {
     pub fn prefix(&self) -> Option<&keyexpr> {
         match self.prefix {
             "" | "/" => None,
+            // SAFETY: upheld by the surrounding invariants and prior validation.
             _ => Some(unsafe {
                 keyexpr::from_str_unchecked(trim_suffix_slash(trim_prefix_slash(self.prefix)))
             }),
@@ -170,6 +173,7 @@ impl<'s, const N: usize> IKeFormatStorage<'s> for [Segment<'s>; N] {
                 this[n] = core::mem::MaybeUninit::new(segment);
                 n += 1;
                 if n == N {
+                    // SAFETY: upheld by the surrounding invariants and prior validation.
                     IterativeConstructor::Complete(this.map(|e| unsafe { e.assume_init() }))
                 } else {
                     IterativeConstructor::Partial((this, n as u16))
@@ -218,9 +222,11 @@ impl<T, const N: usize> PartialSlice<T, N> {
 impl<T, const N: usize> TryFrom<PartialSlice<T, N>> for [T; N] {
     type Error = PartialSlice<T, N>;
     fn try_from(value: PartialSlice<T, N>) -> Result<Self, Self::Error> {
+        // SAFETY: upheld by the surrounding invariants and prior validation.
         let buffer = unsafe { core::ptr::read(&value.buffer) };
         if value.n as usize == N {
             core::mem::forget(value);
+            // SAFETY: upheld by the surrounding invariants and prior validation.
             Ok(buffer.map(|v| unsafe { v.assume_init() }))
         } else {
             Err(value)
@@ -230,6 +236,7 @@ impl<T, const N: usize> TryFrom<PartialSlice<T, N>> for [T; N] {
 impl<T, const N: usize> Drop for PartialSlice<T, N> {
     fn drop(&mut self) {
         for i in 0..self.n as usize {
+            // SAFETY: upheld by the surrounding invariants and prior validation.
             unsafe { core::mem::MaybeUninit::assume_init_drop(&mut self.buffer[i]) }
         }
     }
@@ -251,6 +258,7 @@ impl<'s> IKeFormatStorage<'s> for Vec<Segment<'s>> {
         #[allow(irrefutable_let_patterns)]
         let IterativeConstructor::Complete(mut this) = constructor
         else {
+            // SAFETY: upheld by the surrounding invariants and prior validation.
             unsafe { core::hint::unreachable_unchecked() }
         };
         this.push(segment);

--- a/commons/zenoh-keyexpr/src/key_expr/include.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/include.rs
@@ -71,9 +71,7 @@ impl LTRIncluder {
     fn non_double_wild_chunk_includes(&self, lchunk: &[u8], rchunk: &[u8]) -> bool {
         if lchunk == rchunk {
             true
-        } else if unsafe {
-            lchunk.has_direct_verbatim_non_empty() || rchunk.has_direct_verbatim_non_empty()
-        } {
+        } else if lchunk.has_direct_verbatim_non_empty() || rchunk.has_direct_verbatim_non_empty() {
             false
         } else if lchunk == b"*" {
             true

--- a/commons/zenoh-keyexpr/src/key_expr/intersect/classical.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/intersect/classical.rs
@@ -89,7 +89,7 @@ fn it_intersect<const STAR_DSL: bool>(mut it1: &[u8], mut it2: &[u8]) -> bool {
                 if advanced1.is_empty() {
                     return !it2.has_verbatim();
                 }
-                return (!unsafe { current2.has_direct_verbatim_non_empty() }
+                return (!current2.has_direct_verbatim_non_empty()
                     && it_intersect::<STAR_DSL>(it1, advanced2))
                     || it_intersect::<STAR_DSL>(advanced1, it2);
             }
@@ -97,7 +97,7 @@ fn it_intersect<const STAR_DSL: bool>(mut it1: &[u8], mut it2: &[u8]) -> bool {
                 if advanced2.is_empty() {
                     return !it1.has_verbatim();
                 }
-                return (!unsafe { current1.has_direct_verbatim_non_empty() }
+                return (!current1.has_direct_verbatim_non_empty()
                     && it_intersect::<STAR_DSL>(advanced1, it2))
                     || it_intersect::<STAR_DSL>(it1, advanced2);
             }

--- a/commons/zenoh-keyexpr/src/key_expr/intersect/mod.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/intersect/mod.rs
@@ -83,7 +83,7 @@ impl<
 pub(crate) trait MayHaveVerbatim {
     fn has_verbatim(&self) -> bool;
     fn has_direct_verbatim(&self) -> bool;
-    unsafe fn has_direct_verbatim_non_empty(&self) -> bool {
+    fn has_direct_verbatim_non_empty(&self) -> bool {
         self.has_direct_verbatim()
     }
 }
@@ -96,7 +96,7 @@ impl MayHaveVerbatim for [u8] {
         self.split(|c| *c == DELIMITER)
             .any(MayHaveVerbatim::has_direct_verbatim)
     }
-    unsafe fn has_direct_verbatim_non_empty(&self) -> bool {
-        unsafe { *self.get_unchecked(0) == b'@' }
+    fn has_direct_verbatim_non_empty(&self) -> bool {
+        self.first() == Some(&b'@')
     }
 }

--- a/commons/zenoh-keyexpr/src/key_expr/owned.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/owned.rs
@@ -71,8 +71,10 @@ impl OwnedKeyExpr {
     /// Key Expressions must follow some rules to be accepted by a Zenoh network.
     /// Messages addressed with invalid key expressions will be dropped.
     pub unsafe fn from_string_unchecked(s: String) -> Self {
-        Self::from_boxed_str_unchecked(s.into_boxed_str())
+        // SAFETY: caller upholds key expression invariants for `s`.
+        unsafe { Self::from_boxed_str_unchecked(s.into_boxed_str()) }
     }
+
     /// Constructs an OwnedKeyExpr without checking [`keyexpr`]'s invariants
     /// # Safety
     /// Key Expressions must follow some rules to be accepted by a Zenoh network.
@@ -122,6 +124,7 @@ impl fmt::Display for OwnedKeyExpr {
 impl Deref for OwnedKeyExpr {
     type Target = keyexpr;
     fn deref(&self) -> &Self::Target {
+        // SAFETY: upheld by the surrounding invariants and prior validation.
         unsafe { keyexpr::from_str_unchecked(&self.0) }
     }
 }
@@ -199,6 +202,7 @@ impl<'a> From<&'a nonwild_keyexpr> for OwnedNonWildKeyExpr {
 impl Deref for OwnedNonWildKeyExpr {
     type Target = nonwild_keyexpr;
     fn deref(&self) -> &Self::Target {
+        // SAFETY: upheld by the surrounding invariants and prior validation.
         unsafe { nonwild_keyexpr::from_str_unchecked(&self.0) }
     }
 }

--- a/commons/zenoh-keyexpr/src/key_expr/utils.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/utils.rs
@@ -194,6 +194,7 @@ pub(crate) trait Utf {
 #[allow(dead_code)]
 impl Utf for [u8] {
     fn utf(&self) -> &str {
+        // SAFETY: upheld by the surrounding invariants and prior validation.
         unsafe { ::core::str::from_utf8_unchecked(self) }
     }
 }

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/arc_tree.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/arc_tree.rs
@@ -154,6 +154,7 @@ where
             let as_node: &Arc<
                 TokenCell<KeArcTreeNode<Weight, Weak<()>, Wildness, Children, Token>, Token>,
             > = node.as_node();
+            // SAFETY: upheld by the surrounding invariants and prior validation.
             node = unsafe { (*as_node.get()).children.child_at(chunk)? };
         }
         Some((node.as_node(), token))
@@ -161,6 +162,7 @@ where
     // tags{ketree.arc.node.mut}
     fn node_mut(&'a self, token: &'a mut Token, at: &keyexpr) -> Option<Self::NodeMut> {
         self.node(
+            // SAFETY: upheld by the surrounding invariants and prior validation.
             unsafe { core::mem::transmute::<&Token, &Token>(&*token) },
             at,
         )
@@ -173,6 +175,7 @@ where
             inner.wildness.set(true);
         }
         let inner: &mut KeArcTreeInner<Weight, Wildness, Children, Token> =
+            // SAFETY: upheld by the surrounding invariants and prior validation.
             unsafe { core::mem::transmute(inner) };
         let construct_node = |k: &keyexpr, parent| {
             Arc::new(TokenCell::new(
@@ -194,6 +197,7 @@ where
             let as_node: &Arc<
                 TokenCell<KeArcTreeNode<Weight, Weak<()>, Wildness, Children, Token>, Token>,
             > = node.as_node();
+            // SAFETY: upheld by the surrounding invariants and prior validation.
             node = unsafe {
                 (*as_node.get())
                     .children
@@ -240,6 +244,7 @@ where
     fn tree_iter_mut(&'a self, token: &'a mut Token) -> Self::TreeIterMut {
         let inner = ketree_borrow(&self.inner, token);
         TokenPacker {
+            // SAFETY: upheld by the surrounding invariants and prior validation.
             iter: TreeIter::new(unsafe {
                 core::mem::transmute::<&Children::Assoc, &Children::Assoc>(&inner.children)
             }),
@@ -295,6 +300,7 @@ where
         if inner.wildness.get() || key.is_wild_impl() {
             IterOrOption::Iter(TokenPacker {
                 iter: Intersection::new(
+                    // SAFETY: upheld by the surrounding invariants and prior validation.
                     unsafe {
                         core::mem::transmute::<&Children::Assoc, &Children::Assoc>(&inner.children)
                     },
@@ -349,6 +355,7 @@ where
     fn included_nodes_mut(&'a self, token: &'a mut Token, key: &'a keyexpr) -> Self::InclusionMut {
         let inner = ketree_borrow(&self.inner, token);
         if inner.wildness.get() || key.is_wild_impl() {
+            // SAFETY: upheld by the surrounding invariants and prior validation.
             unsafe {
                 IterOrOption::Iter(TokenPacker {
                     iter: Inclusion::new(
@@ -405,6 +412,7 @@ where
     fn nodes_including_mut(&'a self, token: &'a mut Token, key: &'a keyexpr) -> Self::IncluderMut {
         let inner = ketree_borrow(&self.inner, token);
         if inner.wildness.get() || key.is_wild_impl() {
+            // SAFETY: upheld by the surrounding invariants and prior validation.
             unsafe {
                 IterOrOption::Iter(TokenPacker {
                     iter: Includer::new(
@@ -429,6 +437,7 @@ where
         let mut wild = false;
         let inner = ketree_borrow_mut(&self.inner, token);
         inner.children.filter_out(
+            // SAFETY: upheld by the surrounding invariants and prior validation.
             &mut |child| match unsafe { (*child.get()).prune(&mut predicate) } {
                 PruneResult::Delete => Arc::strong_count(child) <= 1,
                 PruneResult::NonWild => false,
@@ -452,34 +461,40 @@ pub(crate) mod sealed {
     impl<T, Token: TokenTrait> Deref for Tokenized<&TokenCell<T, Token>, &Token> {
         type Target = T;
         fn deref(&self) -> &Self::Target {
+            // SAFETY: upheld by the surrounding invariants and prior validation.
             unsafe { &*self.0.get() }
         }
     }
     impl<T, Token: TokenTrait> Deref for Tokenized<&TokenCell<T, Token>, &mut Token> {
         type Target = T;
         fn deref(&self) -> &Self::Target {
+            // SAFETY: upheld by the surrounding invariants and prior validation.
             unsafe { &*self.0.get() }
         }
     }
     impl<T, Token: TokenTrait> DerefMut for Tokenized<&TokenCell<T, Token>, &mut Token> {
         fn deref_mut(&mut self) -> &mut Self::Target {
+            // SAFETY: upheld by the surrounding invariants and prior validation.
             unsafe { &mut *self.0.get() }
         }
     }
     impl<T, Token: TokenTrait> Deref for Tokenized<&Arc<TokenCell<T, Token>>, &Token> {
         type Target = T;
         fn deref(&self) -> &Self::Target {
+            // SAFETY: upheld by the surrounding invariants and prior validation.
             unsafe { &*self.0.get() }
         }
     }
     impl<T, Token: TokenTrait> Deref for Tokenized<&Arc<TokenCell<T, Token>>, &mut Token> {
         type Target = T;
         fn deref(&self) -> &Self::Target {
+            // SAFETY: upheld by the surrounding invariants and prior validation.
             unsafe { &*self.0.get() }
         }
     }
     impl<T, Token: TokenTrait> DerefMut for Tokenized<&Arc<TokenCell<T, Token>>, &mut Token> {
         fn deref_mut(&mut self) -> &mut Self::Target {
+            // SAFETY: upheld by the surrounding invariants and prior validation.
             unsafe { &mut *self.0.get() }
         }
     }
@@ -504,6 +519,7 @@ pub(crate) mod sealed {
         type Item = Tokenized<I::Item, &'a mut T>;
         fn next(&mut self) -> Option<Self::Item> {
             self.iter.next().map(|i| {
+                // SAFETY: upheld by the surrounding invariants and prior validation.
                 Tokenized(i, unsafe {
                     // SAFETY: while this makes it possible for multiple mutable references to the Token to exist,
                     // it prevents them from being extracted and thus used to create multiple mutable references to
@@ -585,6 +601,7 @@ where
     fn prune<F: FnMut(&mut Self) -> bool>(&mut self, predicate: &mut F) -> PruneResult {
         let mut result = PruneResult::NonWild;
         self.children.filter_out(&mut |child| {
+            // SAFETY: upheld by the surrounding invariants and prior validation.
             let c = unsafe { &mut *child.get() };
             match c.prune(predicate) {
                 PruneResult::Delete => Arc::strong_count(child) <= 1,
@@ -622,16 +639,25 @@ where
     type Parent = <KeArcTreeNode<Weight, Parent, Wildness, Children, Token> as UIKeyExprTreeNode<
         Weight,
     >>::Parent;
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __parent(&self) -> Option<&Self::Parent> {
-        (*self.get()).parent()
+        // SAFETY: token guarantees exclusive/valid access to the inner node.
+        unsafe { (*self.get()).parent() }
     }
 
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __keyexpr(&self) -> OwnedKeyExpr {
-        (*self.get()).keyexpr()
+        // SAFETY: token guarantees exclusive/valid access to the inner node.
+        unsafe { (*self.get()).keyexpr() }
     }
 
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __weight(&self) -> Option<&Weight> {
-        (*self.get()).weight()
+        // SAFETY: token guarantees exclusive/valid access to the inner node.
+        unsafe { (*self.get()).weight() }
     }
 
     type Child = <KeArcTreeNode<Weight, Parent, Wildness, Children, Token> as UIKeyExprTreeNode<
@@ -642,8 +668,11 @@ where
     Weight,
 >>::Children;
 
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __children(&self) -> &Self::Children {
-        (*self.get()).children()
+        // SAFETY: token guarantees exclusive/valid access to the inner node.
+        unsafe { (*self.get()).children() }
     }
 }
 
@@ -694,22 +723,31 @@ where
 {
     type Parent =
         Parent::Ptr<TokenCell<KeArcTreeNode<Weight, Weak<()>, Wildness, Children, Token>, Token>>;
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __parent(&self) -> Option<&Self::Parent> {
         self.parent.as_ref()
     }
     /// May panic if the node has been zombified (see [`Self::is_zombie`])
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __keyexpr(&self) -> OwnedKeyExpr {
+        // SAFETY: upheld by the surrounding invariants and prior validation.
         unsafe {
             // self._keyexpr is guaranteed to return a valid KE, so no checks are necessary
             OwnedKeyExpr::from_string_unchecked(self._keyexpr(0))
         }
     }
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __weight(&self) -> Option<&Weight> {
         self.weight.as_ref()
     }
 
     type Child = Arc<TokenCell<KeArcTreeNode<Weight, Weak<()>, Wildness, Children, Token>, Token>>;
     type Children = Children::Assoc;
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __children(&self) -> &Self::Children {
         &self.children
     }
@@ -767,6 +805,7 @@ where
     pub fn is_zombie(&self) -> bool {
         match &self.parent {
             Some(parent) => match parent.upgrade() {
+                // SAFETY: upheld by the surrounding invariants and prior validation.
                 Some(parent) => unsafe { &*parent.get() }.is_zombie(),
                 None => true,
             },
@@ -792,6 +831,7 @@ where
     fn _keyexpr(&self, capacity: usize) -> String {
         let mut s = match self.parent() {
             Some(parent) => {
+                // SAFETY: upheld by the surrounding invariants and prior validation.
                 let parent = unsafe {
                     &*parent
                         .upgrade()

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/box_tree.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/box_tree.rs
@@ -158,9 +158,11 @@ where
         if !node.children.is_empty() {
             node.weight.take()
         } else {
+            // SAFETY: upheld by the surrounding invariants and prior validation.
             let chunk = unsafe { core::mem::transmute::<&keyexpr, &keyexpr>(node.chunk()) };
             match node.parent {
                 None => &mut self.children,
+                // SAFETY: upheld by the surrounding invariants and prior validation.
                 Some(parent) => unsafe { &mut (*parent.as_ptr()).children },
             }
             .remove(chunk)
@@ -288,24 +290,34 @@ where
     Children::Assoc: IChildren<Box<Self>>,
 {
     type Parent = Self;
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __parent(&self) -> Option<&Self> {
+        // SAFETY: upheld by the surrounding invariants and prior validation.
         self.parent.as_ref().map(|node| unsafe {
             // this is safe, as a mutable reference to the parent was needed to get a mutable reference to this node in the first place.
             node.as_ref()
         })
     }
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __keyexpr(&self) -> OwnedKeyExpr {
+        // SAFETY: upheld by the surrounding invariants and prior validation.
         unsafe {
             // self._keyexpr is guaranteed to return a valid KE, so no checks are necessary
             OwnedKeyExpr::from_string_unchecked(self._keyexpr(0))
         }
     }
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __weight(&self) -> Option<&Weight> {
         self.weight.as_ref()
     }
     type Child = Box<Self>;
     type Children = Children::Assoc;
 
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __children(&self) -> &Self::Children {
         &self.children
     }
@@ -318,6 +330,7 @@ where
     fn parent_mut(&mut self) -> Option<&mut Self> {
         match &mut self.parent {
             None => None,
+            // SAFETY: upheld by the surrounding invariants and prior validation.
             Some(node) => Some(unsafe {
                 // this is safe, as a mutable reference to the parent was needed to get a mutable reference to this node in the first place.
                 node.as_mut()

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/impls/hashmap_impl.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/impls/hashmap_impl.rs
@@ -46,6 +46,7 @@ impl<'a: 'b, 'b, T: HasChunk, S: core::hash::BuildHasher> IEntry<'a, 'b, T>
     fn get_or_insert_with<F: FnOnce(&'b keyexpr) -> T>(self, f: F) -> &'a mut T {
         match self {
             Entry::Vacant(entry) => {
+                // SAFETY: upheld by the surrounding invariants and prior validation.
                 let value = unsafe { f(core::mem::transmute::<&keyexpr, &keyexpr>(entry.key())) };
                 entry.insert(value)
             }
@@ -58,6 +59,7 @@ impl<'a: 'b, 'b, T: HasChunk> IEntry<'a, 'b, T> for Entry<'a, OwnedKeyExpr, T> {
     fn get_or_insert_with<F: FnOnce(&'b keyexpr) -> T>(self, f: F) -> &'a mut T {
         match self {
             Entry::Vacant(entry) => {
+                // SAFETY: upheld by the surrounding invariants and prior validation.
                 let value = unsafe { f(core::mem::transmute::<&keyexpr, &keyexpr>(entry.key())) };
                 entry.insert(value)
             }

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/impls/keyed_set_impl.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/impls/keyed_set_impl.rs
@@ -54,6 +54,7 @@ impl<T: HasChunk + AsNode<T> + AsNodeMut<T>> IChildren<T> for KeyedSet<T, ChunkE
     }
     fn child_at_mut(&mut self, chunk: &keyexpr) -> Option<&mut T> {
         // Unicity is guaranteed by &mut self
+        // SAFETY: upheld by the surrounding invariants and prior validation.
         unsafe { self.get_mut_unguarded(&chunk) }
     }
     fn remove(&mut self, chunk: &keyexpr) -> Option<T> {

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/impls/vec_set_impl.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/impls/vec_set_impl.rs
@@ -73,6 +73,7 @@ impl<T: HasChunk + AsNode<T> + AsNodeMut<T> + 'static> IChildren<T> for Vec<T> {
         'a: 'b,
         T: 'b,
     {
+        // SAFETY: upheld by the surrounding invariants and prior validation.
         let this = unsafe { &mut *(self as *mut Self) };
         match self.child_at_mut(chunk) {
             Some(entry) => Entry::Occupied(entry),

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/iters/includer.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/iters/includer.rs
@@ -96,6 +96,7 @@ where
                         };
                     }
                     let chunk = node.chunk();
+                    // SAFETY: upheld by the surrounding invariants and prior validation.
                     unsafe { node.as_node().__keyexpr() };
                     let chunk_is_super = chunk == "**";
                     if chunk_is_super {
@@ -132,16 +133,19 @@ where
                                 break;
                             }
                             let key = &self.key.as_bytes()[kec_start..];
+                            // SAFETY: upheld by the surrounding invariants and prior validation.
                             unsafe { keyexpr::from_slice_unchecked(key) };
                             match key.iter().position(|&c| c == b'/') {
                                 Some(kec_end) => {
                                     let subkey =
+                                        // SAFETY: upheld by the surrounding invariants and prior validation.
                                         unsafe { keyexpr::from_slice_unchecked(&key[..kec_end]) };
                                     if chunk.includes(subkey) {
                                         push!(kec_start + kec_end + 1);
                                     }
                                 }
                                 None => {
+                                    // SAFETY: upheld by the surrounding invariants and prior validation.
                                     let key = unsafe { keyexpr::from_slice_unchecked(key) };
                                     if chunk.includes(key) {
                                         push!(self.key.len());
@@ -152,6 +156,7 @@ where
                         }
                     }
                     if new_end > new_start {
+                        // SAFETY: upheld by the surrounding invariants and prior validation.
                         let iterator = unsafe { node.as_node().__children() }.children();
                         self.iterators.push(StackFrame {
                             iterator,
@@ -293,16 +298,19 @@ where
                                 break;
                             }
                             let key = &self.key.as_bytes()[kec_start..];
+                            // SAFETY: upheld by the surrounding invariants and prior validation.
                             unsafe { keyexpr::from_slice_unchecked(key) };
                             match key.iter().position(|&c| c == b'/') {
                                 Some(kec_end) => {
                                     let subkey =
+                                        // SAFETY: upheld by the surrounding invariants and prior validation.
                                         unsafe { keyexpr::from_slice_unchecked(&key[..kec_end]) };
                                     if chunk.includes(subkey) {
                                         push!(kec_start + kec_end + 1);
                                     }
                                 }
                                 None => {
+                                    // SAFETY: upheld by the surrounding invariants and prior validation.
                                     let key = unsafe { keyexpr::from_slice_unchecked(key) };
                                     if chunk.includes(key) {
                                         push!(self.key.len());
@@ -313,6 +321,7 @@ where
                         }
                     }
                     if new_end > new_start {
+                        // SAFETY: upheld by the surrounding invariants and prior validation.
                         let iterator = unsafe { &mut *(node.as_node_mut() as *mut Node) }
                             .children_mut()
                             .children_mut();

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/iters/inclusion.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/iters/inclusion.rs
@@ -108,6 +108,7 @@ where
                         match key.iter().position(|&c| c == b'/') {
                             Some(kec_end) => {
                                 let subkey =
+                                    // SAFETY: upheld by the surrounding invariants and prior validation.
                                     unsafe { keyexpr::from_slice_unchecked(&key[..kec_end]) };
                                 if unlikely(subkey == "**") {
                                     if !chunk_is_verbatim {
@@ -117,6 +118,7 @@ where
                                     let post_key = &key[kec_end + 1..];
                                     match post_key.iter().position(|&c| c == b'/') {
                                         Some(sec_end) => {
+                                            // SAFETY: upheld by the surrounding invariants and prior validation.
                                             let post_key = unsafe {
                                                 keyexpr::from_slice_unchecked(&post_key[..sec_end])
                                             };
@@ -125,6 +127,7 @@ where
                                             }
                                         }
                                         None => {
+                                            // SAFETY: upheld by the surrounding invariants and prior validation.
                                             if unsafe { keyexpr::from_slice_unchecked(post_key) }
                                                 .includes(chunk)
                                             {
@@ -137,6 +140,7 @@ where
                                 }
                             }
                             None => {
+                                // SAFETY: upheld by the surrounding invariants and prior validation.
                                 let key = unsafe { keyexpr::from_slice_unchecked(key) };
                                 if unlikely(key == "**") && chunk.first_byte() != b'@' {
                                     push!(kec_start);
@@ -155,6 +159,7 @@ where
                                 break;
                             }
                         }
+                        // SAFETY: upheld by the surrounding invariants and prior validation.
                         let iterator = unsafe { node.as_node().__children() }.children();
                         self.iterators.push(StackFrame {
                             iterator,
@@ -271,6 +276,7 @@ where
                         match key.iter().position(|&c| c == b'/') {
                             Some(kec_end) => {
                                 let subkey =
+                                    // SAFETY: upheld by the surrounding invariants and prior validation.
                                     unsafe { keyexpr::from_slice_unchecked(&key[..kec_end]) };
                                 if unlikely(subkey == "**") {
                                     if !chunk_is_verbatim {
@@ -280,6 +286,7 @@ where
                                     let post_key = &key[kec_end + 1..];
                                     match post_key.iter().position(|&c| c == b'/') {
                                         Some(sec_end) => {
+                                            // SAFETY: upheld by the surrounding invariants and prior validation.
                                             let post_key = unsafe {
                                                 keyexpr::from_slice_unchecked(&post_key[..sec_end])
                                             };
@@ -288,6 +295,7 @@ where
                                             }
                                         }
                                         None => {
+                                            // SAFETY: upheld by the surrounding invariants and prior validation.
                                             if unsafe { keyexpr::from_slice_unchecked(post_key) }
                                                 .includes(chunk)
                                             {
@@ -300,6 +308,7 @@ where
                                 }
                             }
                             None => {
+                                // SAFETY: upheld by the surrounding invariants and prior validation.
                                 let key = unsafe { keyexpr::from_slice_unchecked(key) };
                                 if unlikely(key == "**") && chunk.first_byte() != b'@' {
                                     push!(kec_start);
@@ -318,6 +327,7 @@ where
                                 break;
                             }
                         }
+                        // SAFETY: upheld by the surrounding invariants and prior validation.
                         let iterator = unsafe { &mut *(node.as_node_mut() as *mut Node) }
                             .children_mut()
                             .children_mut();

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/iters/intersection.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/iters/intersection.rs
@@ -132,6 +132,7 @@ where
                                 Some(kec_end) => {
                                     // If we aren't in the last chunk
                                     let subkey =
+                                        // SAFETY: upheld by the surrounding invariants and prior validation.
                                         unsafe { keyexpr::from_slice_unchecked(&key[..kec_end]) };
                                     if unlikely(subkey.as_bytes() == b"**") {
                                         if !chunk_is_verbatim {
@@ -144,6 +145,7 @@ where
                                         let post_key = &key[kec_end + 1..];
                                         match post_key.iter().position(|&c| c == b'/') {
                                             Some(sec_end) => {
+                                                // SAFETY: upheld by the surrounding invariants and prior validation.
                                                 let post_key = unsafe {
                                                     keyexpr::from_slice_unchecked(
                                                         &post_key[..sec_end],
@@ -154,6 +156,7 @@ where
                                                 }
                                             }
                                             None => {
+                                                // SAFETY: upheld by the surrounding invariants and prior validation.
                                                 if unsafe {
                                                     keyexpr::from_slice_unchecked(post_key)
                                                 }
@@ -170,6 +173,7 @@ where
                                 }
                                 None => {
                                     // If it's the last chunk of the query, check whether it's `**`
+                                    // SAFETY: upheld by the surrounding invariants and prior validation.
                                     let key = unsafe { keyexpr::from_slice_unchecked(key) };
                                     if unlikely(key.as_bytes() == b"**") && !chunk_is_verbatim {
                                         // If yes, it automatically matches, and must be reused from now on for iteration.
@@ -195,6 +199,7 @@ where
                             }
                         }
                         // Prepare the next children
+                        // SAFETY: upheld by the surrounding invariants and prior validation.
                         let iterator = unsafe { node.as_node().__children() }.children();
                         self.iterators.push(StackFrame {
                             iterator,
@@ -332,6 +337,7 @@ where
                                 Some(kec_end) => {
                                     // If we aren't in the last chunk
                                     let subkey =
+                                        // SAFETY: upheld by the surrounding invariants and prior validation.
                                         unsafe { keyexpr::from_slice_unchecked(&key[..kec_end]) };
                                     if unlikely(subkey.as_bytes() == b"**") {
                                         if !chunk_is_verbatim {
@@ -344,6 +350,7 @@ where
                                         let post_key = &key[kec_end + 1..];
                                         match post_key.iter().position(|&c| c == b'/') {
                                             Some(sec_end) => {
+                                                // SAFETY: upheld by the surrounding invariants and prior validation.
                                                 let post_key = unsafe {
                                                     keyexpr::from_slice_unchecked(
                                                         &post_key[..sec_end],
@@ -354,6 +361,7 @@ where
                                                 }
                                             }
                                             None => {
+                                                // SAFETY: upheld by the surrounding invariants and prior validation.
                                                 if unsafe {
                                                     keyexpr::from_slice_unchecked(post_key)
                                                 }
@@ -370,6 +378,7 @@ where
                                 }
                                 None => {
                                     // If it's the last chunk of the query, check whether it's `**`
+                                    // SAFETY: upheld by the surrounding invariants and prior validation.
                                     let key = unsafe { keyexpr::from_slice_unchecked(key) };
                                     if unlikely(key.as_bytes() == b"**") && !chunk_is_verbatim {
                                         // If yes, it automatically matches, and must be reused from now on for iteration.
@@ -392,6 +401,7 @@ where
                                 break;
                             }
                         }
+                        // SAFETY: upheld by the surrounding invariants and prior validation.
                         let iterator = unsafe { &mut *(node.as_node_mut() as *mut Node) }
                             .children_mut()
                             .children_mut();

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/iters/tree_iter.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/iters/tree_iter.rs
@@ -57,6 +57,7 @@ where
         loop {
             match self.iterators.last_mut()?.next() {
                 Some(node) => {
+                    // SAFETY: upheld by the surrounding invariants and prior validation.
                     let iterator = unsafe { node.as_node().__children() }.children();
                     self.iterators.push(iterator);
                     return Some(node.as_node());
@@ -110,6 +111,7 @@ where
         loop {
             match self.iterators.last_mut()?.next() {
                 Some(node) => {
+                    // SAFETY: upheld by the surrounding invariants and prior validation.
                     let iterator = unsafe { &mut *(node.as_node_mut() as *mut Node) }
                         .children_mut()
                         .children_mut();
@@ -140,8 +142,10 @@ where
             let depth = self.0.iterators.len();
             match self.0.iterators.last_mut()?.next() {
                 Some(node) => {
+                    // SAFETY: upheld by the surrounding invariants and prior validation.
                     let iterator = unsafe { node.as_node().__children() }.children();
                     self.0.iterators.push(iterator);
+                    // SAFETY: upheld by the surrounding invariants and prior validation.
                     return Some((unsafe { NonZeroUsize::new_unchecked(depth) }, node));
                 }
                 None => {

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/traits/default_impls.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/traits/default_impls.rs
@@ -40,6 +40,7 @@ impl<T: HasChunk> HasChunk for Arc<T> {
 }
 impl<T: HasChunk, Token: TokenTrait> HasChunk for TokenCell<T, Token> {
     fn chunk(&self) -> &keyexpr {
+        // SAFETY: upheld by the surrounding invariants and prior validation.
         T::chunk(unsafe { &*self.get() })
     }
 }
@@ -71,61 +72,85 @@ impl<T> AsNodeMut<T> for &mut T {
 impl<T: IKeyExprTreeNode<Weight>, Weight> IKeyExprTreeNode<Weight> for &T {}
 impl<T: IKeyExprTreeNode<Weight>, Weight> UIKeyExprTreeNode<Weight> for &T {
     type Parent = T::Parent;
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __parent(&self) -> Option<&Self::Parent> {
-        T::__parent(self)
+        T::parent(self)
     }
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __keyexpr(&self) -> OwnedKeyExpr {
-        T::__keyexpr(self)
+        T::keyexpr(self)
     }
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __weight(&self) -> Option<&Weight> {
-        T::__weight(self)
+        T::weight(self)
     }
 
     type Child = T::Child;
     type Children = T::Children;
 
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __children(&self) -> &Self::Children {
-        T::__children(self)
+        T::children(self)
     }
 }
 impl<T: IKeyExprTreeNode<Weight>, Weight> IKeyExprTreeNode<Weight> for &mut T {}
 impl<T: IKeyExprTreeNode<Weight>, Weight> UIKeyExprTreeNode<Weight> for &mut T {
     type Parent = T::Parent;
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __parent(&self) -> Option<&Self::Parent> {
-        T::__parent(self)
+        T::parent(self)
     }
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __keyexpr(&self) -> OwnedKeyExpr {
-        T::__keyexpr(self)
+        T::keyexpr(self)
     }
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __weight(&self) -> Option<&Weight> {
-        T::__weight(self)
+        T::weight(self)
     }
 
     type Child = T::Child;
     type Children = T::Children;
 
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __children(&self) -> &Self::Children {
-        T::__children(self)
+        T::children(self)
     }
 }
 impl<T: IKeyExprTreeNode<Weight>, Weight> IKeyExprTreeNode<Weight> for Box<T> {}
 impl<T: IKeyExprTreeNode<Weight>, Weight> UIKeyExprTreeNode<Weight> for Box<T> {
     type Parent = T::Parent;
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __parent(&self) -> Option<&Self::Parent> {
-        T::__parent(self)
+        T::parent(self)
     }
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __keyexpr(&self) -> OwnedKeyExpr {
-        T::__keyexpr(self)
+        T::keyexpr(self)
     }
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __weight(&self) -> Option<&Weight> {
-        T::__weight(self)
+        T::weight(self)
     }
 
     type Child = T::Child;
     type Children = T::Children;
 
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __children(&self) -> &Self::Children {
-        T::__children(self)
+        T::children(self)
     }
 }
 
@@ -175,33 +200,41 @@ impl<T: IKeyExprTreeNode<Weight>, Weight, Token: TokenTrait> UIKeyExprTreeNode<W
     for (&TokenCell<T, Token>, &Token)
 {
     type Parent = T::Parent;
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __parent(&self) -> Option<&Self::Parent> {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__parent()
+            .parent()
     }
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __keyexpr(&self) -> OwnedKeyExpr {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__keyexpr()
+            .keyexpr()
     }
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __weight(&self) -> Option<&Weight> {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__weight()
+            .weight()
     }
 
     type Child = T::Child;
     type Children = T::Children;
 
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __children(&self) -> &Self::Children {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__children()
+            .children()
     }
 }
 
@@ -213,33 +246,41 @@ impl<T: IKeyExprTreeNode<Weight>, Weight, Token: TokenTrait> UIKeyExprTreeNode<W
     for (&TokenCell<T, Token>, &mut Token)
 {
     type Parent = T::Parent;
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __parent(&self) -> Option<&Self::Parent> {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__parent()
+            .parent()
     }
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __keyexpr(&self) -> OwnedKeyExpr {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__keyexpr()
+            .keyexpr()
     }
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __weight(&self) -> Option<&Weight> {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__weight()
+            .weight()
     }
 
     type Child = T::Child;
     type Children = T::Children;
 
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __children(&self) -> &Self::Children {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__children()
+            .children()
     }
 }
 
@@ -287,33 +328,41 @@ impl<T: IKeyExprTreeNode<Weight>, Weight, Token: TokenTrait> UIKeyExprTreeNode<W
     for (&Arc<TokenCell<T, Token>>, &Token)
 {
     type Parent = T::Parent;
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __parent(&self) -> Option<&Self::Parent> {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__parent()
+            .parent()
     }
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __keyexpr(&self) -> OwnedKeyExpr {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__keyexpr()
+            .keyexpr()
     }
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __weight(&self) -> Option<&Weight> {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__weight()
+            .weight()
     }
 
     type Child = T::Child;
     type Children = T::Children;
 
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __children(&self) -> &Self::Children {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__children()
+            .children()
     }
 }
 
@@ -325,33 +374,41 @@ impl<T: IKeyExprTreeNode<Weight>, Weight, Token: TokenTrait> UIKeyExprTreeNode<W
     for (&Arc<TokenCell<T, Token>>, &mut Token)
 {
     type Parent = T::Parent;
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __parent(&self) -> Option<&Self::Parent> {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__parent()
+            .parent()
     }
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __keyexpr(&self) -> OwnedKeyExpr {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__keyexpr()
+            .keyexpr()
     }
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __weight(&self) -> Option<&Weight> {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__weight()
+            .weight()
     }
 
     type Child = T::Child;
     type Children = T::Children;
 
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __children(&self) -> &Self::Children {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__children()
+            .children()
     }
 }
 
@@ -400,33 +457,41 @@ impl<T: IKeyExprTreeNode<Weight>, Weight, Token: TokenTrait> UIKeyExprTreeNode<W
     for Tokenized<&TokenCell<T, Token>, &Token>
 {
     type Parent = T::Parent;
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __parent(&self) -> Option<&Self::Parent> {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__parent()
+            .parent()
     }
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __keyexpr(&self) -> OwnedKeyExpr {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__keyexpr()
+            .keyexpr()
     }
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __weight(&self) -> Option<&Weight> {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__weight()
+            .weight()
     }
 
     type Child = T::Child;
     type Children = T::Children;
 
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __children(&self) -> &Self::Children {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__children()
+            .children()
     }
 }
 
@@ -438,33 +503,41 @@ impl<T: IKeyExprTreeNode<Weight>, Weight, Token: TokenTrait> UIKeyExprTreeNode<W
     for Tokenized<&TokenCell<T, Token>, &mut Token>
 {
     type Parent = T::Parent;
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __parent(&self) -> Option<&Self::Parent> {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__parent()
+            .parent()
     }
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __keyexpr(&self) -> OwnedKeyExpr {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__keyexpr()
+            .keyexpr()
     }
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __weight(&self) -> Option<&Weight> {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__weight()
+            .weight()
     }
 
     type Child = T::Child;
     type Children = T::Children;
 
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __children(&self) -> &Self::Children {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__children()
+            .children()
     }
 }
 
@@ -512,33 +585,41 @@ impl<T: IKeyExprTreeNode<Weight>, Weight, Token: TokenTrait> UIKeyExprTreeNode<W
     for Tokenized<&Arc<TokenCell<T, Token>>, &Token>
 {
     type Parent = T::Parent;
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __parent(&self) -> Option<&Self::Parent> {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__parent()
+            .parent()
     }
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __keyexpr(&self) -> OwnedKeyExpr {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__keyexpr()
+            .keyexpr()
     }
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __weight(&self) -> Option<&Weight> {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__weight()
+            .weight()
     }
 
     type Child = T::Child;
     type Children = T::Children;
 
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __children(&self) -> &Self::Children {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__children()
+            .children()
     }
 }
 
@@ -550,33 +631,41 @@ impl<T: IKeyExprTreeNode<Weight>, Weight, Token: TokenTrait> UIKeyExprTreeNode<W
     for Tokenized<&Arc<TokenCell<T, Token>>, &mut Token>
 {
     type Parent = T::Parent;
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __parent(&self) -> Option<&Self::Parent> {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__parent()
+            .parent()
     }
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __keyexpr(&self) -> OwnedKeyExpr {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__keyexpr()
+            .keyexpr()
     }
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __weight(&self) -> Option<&Weight> {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__weight()
+            .weight()
     }
 
     type Child = T::Child;
     type Children = T::Children;
 
+    /// # Safety
+    /// Callers must uphold the invariants required by this unsafe API.
     unsafe fn __children(&self) -> &Self::Children {
         self.0
             .try_borrow(self.1)
             .unwrap_or_else(|_| panic!("Used wrong token to access TokenCell"))
-            .__children()
+            .children()
     }
 }
 

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/traits/mod.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/traits/mod.rs
@@ -55,6 +55,7 @@ pub trait IKeyExprTree<'a, Weight> {
         Self::TreeIterItem: AsNode<Box<Self::Node>>,
     {
         self.tree_iter().filter_map(|node| {
+            // SAFETY: upheld by the surrounding invariants and prior validation.
             unsafe {
                 core::mem::transmute::<Option<&Weight>, Option<&Weight>>(node.as_node().weight())
             }
@@ -350,6 +351,7 @@ pub trait ITokenKeyExprTree<'a, Weight, Token> {
 pub trait IKeyExprTreeNode<Weight>: UIKeyExprTreeNode<Weight> {
     /// Access the parent node if it exists (the node isn't the first chunk of a key-expression).
     fn parent(&self) -> Option<&Self::Parent> {
+        // SAFETY: upheld by the surrounding invariants and prior validation.
         unsafe { self.__parent() }
     }
     /// Compute this node's full key expression.
@@ -358,6 +360,7 @@ pub trait IKeyExprTreeNode<Weight>: UIKeyExprTreeNode<Weight> {
     /// If you need to repeatedly access a node's full key expression, it is suggested
     /// to store that key expression as part of the node's `Weight` (it's optional value).
     fn keyexpr(&self) -> OwnedKeyExpr {
+        // SAFETY: upheld by the surrounding invariants and prior validation.
         unsafe { self.__keyexpr() }
     }
 
@@ -369,11 +372,13 @@ pub trait IKeyExprTreeNode<Weight>: UIKeyExprTreeNode<Weight> {
     /// - The node is a parent to other nodes, but was never assigned a weight itself (or that weight has been removed).
     /// - The node is a leaf of the KeTree whose value was [`IKeyExprTreeMut::remove`]d, but [`IKeyExprTreeMut::prune`] hasn't been called yet.
     fn weight(&self) -> Option<&Weight> {
+        // SAFETY: upheld by the surrounding invariants and prior validation.
         unsafe { self.__weight() }
     }
 
     /// Access a node's children.
     fn children(&self) -> &Self::Children {
+        // SAFETY: upheld by the surrounding invariants and prior validation.
         unsafe { self.__children() }
     }
 }
@@ -381,11 +386,23 @@ pub trait IKeyExprTreeNode<Weight>: UIKeyExprTreeNode<Weight> {
 #[doc(hidden)]
 pub trait UIKeyExprTreeNode<Weight> {
     type Parent;
+    /// # Safety
+    /// Implementations may return references derived from internal raw pointers or token-guarded state.
+    /// Callers must uphold the implementation-specific aliasing and lifetime guarantees.
     unsafe fn __parent(&self) -> Option<&Self::Parent>;
+    /// # Safety
+    /// Implementations may reconstruct the full key expression from internal state that must remain valid.
+    /// Callers must ensure the node is in a readable, non-invalidated state.
     unsafe fn __keyexpr(&self) -> OwnedKeyExpr;
+    /// # Safety
+    /// Implementations may expose internal references whose validity depends on external synchronization/token rules.
+    /// Callers must uphold those rules.
     unsafe fn __weight(&self) -> Option<&Weight>;
     type Child;
     type Children: IChildren<Self::Child>;
+    /// # Safety
+    /// Implementations may expose references to internal child collections that require external synchronization/token rules.
+    /// Callers must uphold those rules.
     unsafe fn __children(&self) -> &Self::Children;
 }
 


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->
The PR is the 2nd round review dealing with #1684.
We're focusing on the files inside the zenoh-keyexpr crate.

We wanted to make sure
1. Don't use `unsafe fn` if we can avoid the UB inside the function
2. Every `unsafe fn` should include `/// # Safety`
3. Enable `unsafe_op_in_unsafe_fn`, which will be enabled by default in [Edition 2024](https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html)
4. Having `// SAFETY` before an unsafe block.

### What does this PR do?
<!-- Describe the changes and their purpose -->
Fix the `unsafe fn` usage inside Zenoh

### Why is this change needed?
<!-- Explain the motivation or problem being solved -->
Ensure that we are using unsafe correctly.

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->
https://github.com/eclipse-zenoh/zenoh/issues/1684

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `enhancement`

## ✨ Enhancement Requirements

Since this PR enhances existing functionality:

- [x] **Enhancement scope documented** - Clear description of what is being improved
- [x] **Minimum necessary code** - Implementation is as simple as possible, doesn't overcomplicate the system
- [x] **Backwards compatible** - Existing code/APIs still work unchanged
- [x] **No new APIs added** - Only improving existing functionality
- [x] **Tests updated** - Existing tests pass, new test cases added if needed
- [x] **Performance improvement measured** - If applicable, before/after metrics provided
- [x] **Documentation updated** - Existing docs updated to reflect improvements
- [x] **User impact documented** - How users benefit from this enhancement

**Remember:** Enhancements should not introduce new APIs or breaking changes.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->