### PR TITLE
Review the unsafe fn (final round).

### DIFF
--- a/commons/zenoh-buffers/src/bbuf.rs
+++ b/commons/zenoh-buffers/src/bbuf.rs
@@ -128,6 +128,10 @@ impl Writer for BBuf {
         self.capacity() - self.len()
     }
 
+    /// # Safety
+    ///
+    /// The `write` closure must return the number of bytes actually written to the slice,
+    /// which must be less than or equal to `len`.
     unsafe fn with_slot<F>(&mut self, len: usize, write: F) -> Result<NonZeroUsize, DidntWrite>
     where
         F: FnOnce(&mut [u8]) -> usize,
@@ -136,8 +140,9 @@ impl Writer for BBuf {
             return Err(DidntWrite);
         }
 
-        // SAFETY: self.remaining() >= len
-        let written = write(unsafe { self.as_writable_slice().get_unchecked_mut(..len) });
+        // SAFETY: `written` <= `len` is guaranteed by the safety contract of this function.
+        // `get_unchecked_mut(..len)` is safe because `self.remaining() >= len`.
+        let written = unsafe { write(self.as_writable_slice().get_unchecked_mut(..len)) };
         self.len += written;
 
         NonZeroUsize::new(written).ok_or(DidntWrite)
@@ -186,7 +191,9 @@ impl<'a> HasReader for &'a BBuf {
 // From impls
 impl From<BBuf> for ZSlice {
     fn from(value: BBuf) -> Self {
-        // SAFETY: buffer length is ensured to be lesser than its capacity
+        // SAFETY: buffer length is ensured to be lesser than its capacity.
+        // unwrap_unchecked() is safe because ZSlice::new only fails if end < start,
+        // which is not the case here (0 and value.len).
         unsafe { ZSlice::new(Arc::new(value.buffer), 0, value.len).unwrap_unchecked() }
     }
 }

--- a/commons/zenoh-buffers/src/lib.rs
+++ b/commons/zenoh-buffers/src/lib.rs
@@ -62,6 +62,7 @@ macro_rules! unsafe_slice {
     ($s:expr,$r:expr) => {{
         let slice = &*$s;
         let index = $r;
+        // SAFETY: the index is guaranteed to be valid by the caller of this macro.
         unsafe { slice.get_unchecked(index) }
     }};
 }
@@ -72,6 +73,7 @@ macro_rules! unsafe_slice_mut {
     ($s:expr,$r:expr) => {{
         let slice = &mut *$s;
         let index = $r;
+        // SAFETY: the index is guaranteed to be valid by the caller of this macro.
         unsafe { slice.get_unchecked_mut(index) }
     }};
 }
@@ -107,7 +109,7 @@ pub mod buffer {
                 0 => Cow::Borrowed(b""),
                 1 => {
                     // SAFETY: unwrap here is safe because we have explicitly checked
-                    //         the iterator has 1 element.
+                    // the iterator has 1 element.
                     Cow::Borrowed(unsafe { slices.next().unwrap_unchecked() })
                 }
                 _ => Cow::Owned(slices.fold(Vec::with_capacity(self.len()), |mut acc, it| {
@@ -148,7 +150,7 @@ pub mod writer {
         /// # Safety
         ///
         /// Caller must ensure that `write` return an integer lesser than or equal to the length of
-        /// the slice passed in argument
+        /// the slice passed in argument.
         unsafe fn with_slot<F>(&mut self, len: usize, write: F) -> Result<NonZeroUsize, DidntWrite>
         where
             F: FnOnce(&mut [u8]) -> usize;
@@ -173,11 +175,15 @@ pub mod writer {
         fn can_write(&self) -> bool {
             (**self).can_write()
         }
+        /// # Safety
+        ///
+        /// Caller must ensure that `write` return an integer lesser than or equal to the length of
+        /// the slice passed in argument.
         unsafe fn with_slot<F>(&mut self, len: usize, write: F) -> Result<NonZeroUsize, DidntWrite>
         where
             F: FnOnce(&mut [u8]) -> usize,
         {
-            // SAFETY: same precondition
+            // SAFETY: same precondition as the trait method.
             unsafe { (**self).with_slot(len, write) }
         }
     }

--- a/commons/zenoh-buffers/src/slice.rs
+++ b/commons/zenoh-buffers/src/slice.rs
@@ -88,6 +88,10 @@ impl Writer for &mut [u8] {
         self.len()
     }
 
+    /// # Safety
+    ///
+    /// The `write` closure must return the number of bytes actually written to the slice,
+    /// which must be less than or equal to `len`.
     unsafe fn with_slot<F>(&mut self, len: usize, write: F) -> Result<NonZeroUsize, DidntWrite>
     where
         F: FnOnce(&mut [u8]) -> usize,
@@ -96,7 +100,7 @@ impl Writer for &mut [u8] {
             return Err(DidntWrite);
         }
         let written = write(&mut self[..len]);
-        // SAFETY: `written` < `len` is guaranteed by function contract
+        // SAFETY: `written` <= `len` is guaranteed by the safety contract of this function.
         *self = unsafe { mem::take(self).get_unchecked_mut(written..) };
         NonZeroUsize::new(written).ok_or(DidntWrite)
     }
@@ -121,7 +125,8 @@ impl<'s> BacktrackableWriter for &'s mut [u8] {
     }
 
     fn rewind(&mut self, mark: Self::Mark) -> bool {
-        // SAFETY: SliceMark's lifetime is bound to the slice's lifetime
+        // SAFETY: SliceMark's lifetime is bound to the slice's lifetime, and the pointer and length
+        // are guaranteed to be valid as they were obtained from a valid slice in `mark()`.
         *self = unsafe { slice::from_raw_parts_mut(mark.ptr as *mut u8, mark.len) };
         true
     }

--- a/commons/zenoh-buffers/src/vec.rs
+++ b/commons/zenoh-buffers/src/vec.rs
@@ -26,6 +26,7 @@ use crate::{
 pub fn uninit(capacity: usize) -> Vec<u8> {
     let mut vbuf = Vec::with_capacity(capacity);
     // SAFETY: this operation is safe since we are setting the length equal to the allocated capacity.
+    // The caller is responsible for ensuring the memory is initialized before reading.
     #[allow(clippy::uninit_vec)]
     unsafe {
         vbuf.set_len(capacity);
@@ -76,7 +77,8 @@ impl Writer for Vec<u8> {
             return Err(DidntWrite);
         }
         self.extend_from_slice(bytes);
-        // SAFETY: this operation is safe since we early return in case bytes is empty
+        // SAFETY: this operation is safe since we early return in case bytes is empty,
+        // so bytes.len() is guaranteed to be non-zero.
         Ok(unsafe { NonZeroUsize::new_unchecked(bytes.len()) })
     }
 
@@ -93,18 +95,23 @@ impl Writer for Vec<u8> {
         Ok(())
     }
 
+    /// # Safety
+    ///
+    /// The `write` closure must return the number of bytes actually written to the slice,
+    /// which must be less than or equal to `len`.
     unsafe fn with_slot<F>(&mut self, mut len: usize, write: F) -> Result<NonZeroUsize, DidntWrite>
     where
         F: FnOnce(&mut [u8]) -> usize,
     {
         self.reserve(len);
 
-        // SAFETY: we already reserved len elements on the vector.
+        // SAFETY: we already reserved `len` elements on the vector.
         let s = crate::unsafe_slice_mut!(self.spare_capacity_mut(), ..len);
-        // SAFETY: converting MaybeUninit<u8> into [u8] is safe because we are going to write on it.
-        //         The returned len tells us how many bytes have been written so as to update the len accordingly.
+        // SAFETY: converting `MaybeUninit<u8>` into `[u8]` is safe because we are going to write to it.
+        // The returned `len` tells us how many bytes have been written so as to update the length accordingly.
         len = unsafe { write(&mut *(s as *mut [mem::MaybeUninit<u8>] as *mut [u8])) };
-        // SAFETY: we already reserved len elements on the vector.
+        // SAFETY: we already reserved `len` elements on the vector and we are setting the length
+        // based on the number of bytes actually written by the closure.
         unsafe { self.set_len(self.len() + len) };
 
         NonZeroUsize::new(len).ok_or(DidntWrite)

--- a/commons/zenoh-buffers/src/zbuf.rs
+++ b/commons/zenoh-buffers/src/zbuf.rs
@@ -491,7 +491,7 @@ impl<'a> ZBufWriter<'a> {
     #[inline]
     fn zslice_writer(&mut self) -> &mut ZSliceWriter<'a> {
         if self.zslice_writer.is_none() {
-            // SAFETY: `self.inner` is valid as guaranteed by `self.writer` borrow
+            // SAFETY: `self.inner` is valid as guaranteed by `self.writer` borrow.
             let zbuf = unsafe { self.inner.as_mut() };
             zbuf.slices.push(ZSlice::empty());
             self.zslice_writer = zbuf.slices.last_mut().unwrap().writer();
@@ -527,17 +527,22 @@ impl Writer for ZBufWriter<'_> {
     fn write_zslice(&mut self, slice: &ZSlice) -> Result<(), DidntWrite> {
         self.zslice_writer = None;
         // SAFETY: `self.inner` is valid as guaranteed by `self.writer` borrow,
-        // and `self.writer` has been overwritten
+        // and `self.writer` has been overwritten.
         unsafe { self.inner.as_mut() }.push_zslice(slice.clone());
         Ok(())
     }
 
+    /// # Safety
+    ///
+    /// The `write` closure must return the number of bytes actually written to the slice,
+    /// which must be less than or equal to `len`.
     unsafe fn with_slot<F>(&mut self, len: usize, write: F) -> Result<NonZeroUsize, DidntWrite>
     where
         F: FnOnce(&mut [u8]) -> usize,
     {
-        // SAFETY: same precondition as the enclosing function
-        self.zslice_writer().with_slot(len, write)
+        // SAFETY: Same precondition as this function. Call to `with_slot` is safe because
+        // the requirements are passed through.
+        unsafe { self.zslice_writer().with_slot(len, write) }
     }
 }
 
@@ -546,7 +551,7 @@ impl BacktrackableWriter for ZBufWriter<'_> {
 
     fn mark(&mut self) -> Self::Mark {
         let byte = self.zslice_writer.as_mut().map(|w| w.mark());
-        // SAFETY: `self.inner` is valid as guaranteed by `self.writer` borrow
+        // SAFETY: `self.inner` is valid as guaranteed by `self.writer` borrow.
         let zbuf = unsafe { self.inner.as_mut() };
         ZBufPos {
             slice: zbuf.slices.len(),
@@ -558,7 +563,7 @@ impl BacktrackableWriter for ZBufWriter<'_> {
 
     fn rewind(&mut self, mark: Self::Mark) -> bool {
         // SAFETY: `self.inner` is valid as guaranteed by `self.writer` borrow,
-        // and `self.writer` is reassigned after modification
+        // and `self.writer` is reassigned after modification.
         let zbuf = unsafe { self.inner.as_mut() };
         zbuf.slices.truncate(mark.slice);
         self.zslice_writer = zbuf.opt_zslice_writer();

--- a/commons/zenoh-buffers/src/zslice.rs
+++ b/commons/zenoh-buffers/src/zslice.rs
@@ -131,7 +131,7 @@ impl ZSlice {
 
     /// # Safety
     ///
-    /// Buffer modification must not modify slice range.
+    /// Buffer modification must not modify slice range or invalidate the data.
     #[inline]
     #[must_use]
     pub unsafe fn downcast_mut<T: Any>(&mut self) -> Option<&mut T> {
@@ -172,7 +172,7 @@ impl ZSlice {
     #[inline]
     #[must_use]
     pub fn as_slice(&self) -> &[u8] {
-        // SAFETY: bounds checks are performed at `ZSlice` construction via `make()` or `subslice()`.
+        // SAFETY: bounds checks are performed at `ZSlice` construction via `new()` or `subslice()`.
         unsafe { self.buf.as_slice().get_unchecked(self.start..self.end) }
     }
 
@@ -317,11 +317,16 @@ impl Writer for ZSliceWriter<'_> {
         self.vec.remaining()
     }
 
+    /// # Safety
+    ///
+    /// The `write` closure must return the number of bytes actually written to the slice,
+    /// which must be less than or equal to `len`.
     unsafe fn with_slot<F>(&mut self, len: usize, write: F) -> Result<NonZeroUsize, DidntWrite>
     where
         F: FnOnce(&mut [u8]) -> usize,
     {
-        // SAFETY: same precondition as the enclosing function
+        // SAFETY: Same precondition as this function. Call to `with_slot` is safe because
+        // the requirements are passed through.
         let len = unsafe { self.vec.with_slot(len, write) }?;
         *self.end += len.get();
         Ok(len)
@@ -457,7 +462,7 @@ mod tests {
         let mut zslice: ZSlice = buf.clone().into();
         assert_eq!(buf.as_slice(), zslice.as_slice());
 
-        // SAFETY: buffer slize size is not modified
+        // SAFETY: buffer slice size is not modified.
         let mut_slice = unsafe { zslice.downcast_mut::<Vec<u8>>() }.unwrap();
 
         mut_slice[..buf.len()].clone_from_slice(&buf[..]);

--- a/commons/zenoh-buffers/tests/readwrite.rs
+++ b/commons/zenoh-buffers/tests/readwrite.rs
@@ -47,7 +47,7 @@ macro_rules! run_write {
 
         writer.write_exact(&WBS4).unwrap();
 
-        // SAFETY: callback returns the length of the buffer
+        // SAFETY: callback returns the length of the buffer, which is guaranteed to be 4.
         unsafe {
             writer.with_slot(4, |mut buffer| {
                 let w = buffer.write(&WBS5).unwrap();

--- a/commons/zenoh-shm/src/api/buffer/typed.rs
+++ b/commons/zenoh-shm/src/api/buffer/typed.rs
@@ -93,7 +93,8 @@ impl<T, Buf> Typed<MaybeUninit<T>, Buf> {
                 1 << (slice.as_ptr() as usize).trailing_zeros()
             );
         }
-        // SAFETY: the layout has been checked, and type is `MaybeUninit`
+        // SAFETY: the layout has been checked, and the type is `MaybeUninit`,
+        // which does not have any further invariants.
         Ok(unsafe { Self::new_unchecked(buf) })
     }
     /// Assumes the underlying data is initialized.
@@ -113,9 +114,9 @@ impl<T, Buf> Typed<MaybeUninit<T>, Buf> {
     where
         Buf: ShmBufMut<[u8]>,
     {
-        // SAFETY: this is safe because we check transmute safety when constructing self
+        // SAFETY: this is safe because we check layout compatibility when constructing `self`.
         unsafe { self.buf.as_mut().as_mut_ptr().cast::<T>().write(value) };
-        // SAFETY: the data has been initialized
+        // SAFETY: the data has just been initialized.
         unsafe { self.assume_init() }
     }
 }
@@ -198,7 +199,8 @@ impl<T: ResideInShm, Buf: ShmBuf<[u8]>> Deref for Typed<T, Buf> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        // SAFETY: this is safe because we check transmute safety when constructing self
+        // SAFETY: this is safe because we check layout compatibility and initialization
+        // when constructing `self`.
         unsafe { &*(self.buf.as_ref().as_ptr() as *const T) }
     }
 }
@@ -211,7 +213,8 @@ impl<T: ResideInShm, Buf: ShmBuf<[u8]>> AsRef<T> for Typed<T, Buf> {
 
 impl<T: ResideInShm, Buf: ShmBufMut<[u8]>> DerefMut for Typed<T, Buf> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        // SAFETY: this is safe because we check transmute safety when constructing self
+        // SAFETY: this is safe because we check layout compatibility and initialization
+        // when constructing `self`.
         unsafe { &mut *(self.buf.as_mut().as_mut_ptr() as *mut T) }
     }
 }
@@ -231,8 +234,13 @@ impl<T: ResideInShm, Buf: ShmBuf<[u8]>> ShmBuf<T> for Typed<T, Buf> {
 impl<T: ResideInShm, Buf: ShmBufMut<[u8]>> ShmBufMut<T> for Typed<T, Buf> {}
 
 impl<T: ResideInShm, Buf: ShmBufUnsafeMut<[u8]>> ShmBufUnsafeMut<T> for Typed<T, Buf> {
+    /// # Safety
+    ///
+    /// The caller must ensure that the `ShmBufInner` is valid and can be uniquely accessed.
     unsafe fn as_mut_unchecked(&mut self) -> &mut T {
-        &mut *(self.buf.as_mut_unchecked().as_mut_ptr() as *mut T)
+        // SAFETY: The internal buffer is assumed to be valid and uniquely accessible
+        // as per the safety contract of this function.
+        unsafe { &mut *(self.buf.as_mut_unchecked().as_mut_ptr() as *mut T) }
     }
 }
 

--- a/commons/zenoh-shm/src/api/buffer/zshm.rs
+++ b/commons/zenoh-shm/src/api/buffer/zshm.rs
@@ -44,21 +44,26 @@ impl ShmBuf<[u8]> for ZShm {
 }
 
 impl ShmBufUnsafeMut<[u8]> for ZShm {
+    /// # Safety
+    ///
+    /// The caller must ensure that the `ShmBufInner` is valid and can be uniquely accessed.
     unsafe fn as_mut_unchecked(&mut self) -> &mut [u8] {
-        self.inner.as_mut_slice_inner()
+        // SAFETY: The internal buffer is assumed to be valid and uniquely accessible
+        // as per the safety contract of this function.
+        unsafe { self.inner.as_mut_slice_inner() }
     }
 }
 
 impl OwnedShmBuf<[u8]> for ZShm {
     fn try_resize(&mut self, new_size: NonZeroUsize) -> Option<()> {
-        // Safety: this is safe because ZShm is an owned representation of SHM buffer and thus
-        // is guaranteed not to be wrapped into ZSlice (see ShmBufInner::try_resize comment)
+        // SAFETY: this is safe because ZShm is an owned representation of SHM buffer and thus
+        // is guaranteed not to be wrapped into ZSlice (see ShmBufInner::try_resize comment).
         unsafe { self.inner.try_resize(new_size) }
     }
 
     fn try_relayout(&mut self, new_layout: MemoryLayout) -> Result<(), BufferRelayoutError> {
-        // Safety: this is safe because ZShm is an owned representation of SHM buffer and thus
-        // is guaranteed not to be wrapped into ZSlice (see ShmBufInner::try_relayout comment)
+        // SAFETY: this is safe because ZShm is an owned representation of SHM buffer and thus
+        // is guaranteed not to be wrapped into ZSlice (see ShmBufInner::try_relayout comment).
         unsafe { self.inner.try_relayout(new_layout) }
     }
 }
@@ -84,7 +89,7 @@ impl PartialEq<ZShmMut> for ZShm {
 impl Borrow<zshm> for ZShm {
     fn borrow(&self) -> &zshm {
         // SAFETY: ZShm, ZShmMut, zshm and zshmmut are #[repr(transparent)]
-        // to ShmBufInner type, so it is safe to transmute them in any direction
+        // to ShmBufInner type, so it is safe to transmute them in any direction.
         unsafe { core::mem::transmute(self) }
     }
 }
@@ -92,7 +97,7 @@ impl Borrow<zshm> for ZShm {
 impl BorrowMut<zshm> for ZShm {
     fn borrow_mut(&mut self) -> &mut zshm {
         // SAFETY: ZShm, ZShmMut, zshm and zshmmut are #[repr(transparent)]
-        // to ShmBufInner type, so it is safe to transmute them in any direction
+        // to ShmBufInner type, so it is safe to transmute them in any direction.
         unsafe { core::mem::transmute(self) }
     }
 }
@@ -129,7 +134,8 @@ impl TryFrom<ZShm> for ZShmMut {
     fn try_from(value: ZShm) -> Result<Self, Self::Error> {
         match value.inner.is_unique() && value.inner.is_valid() {
             // SAFETY: ZShm, ZShmMut, zshm and zshmmut are #[repr(transparent)]
-            // to ShmBufInner type, so it is safe to transmute them in any direction
+            // to ShmBufInner type, so it is safe to transmute them in any direction.
+            // We checked above that the buffer is unique and valid.
             true => Ok(unsafe { std::mem::transmute::<ZShm, ZShmMut>(value) }),
             false => Err(value),
         }
@@ -158,8 +164,13 @@ impl ShmBuf<[u8]> for &mut zshm {
 }
 
 impl ShmBufUnsafeMut<[u8]> for &mut zshm {
+    /// # Safety
+    ///
+    /// The caller must ensure that the `ShmBufInner` is valid and can be uniquely accessed.
     unsafe fn as_mut_unchecked(&mut self) -> &mut [u8] {
-        self.inner.as_mut_slice_inner()
+        // SAFETY: The internal buffer is assumed to be valid and uniquely accessible
+        // as per the safety contract of this function.
+        unsafe { self.inner.as_mut_slice_inner() }
     }
 }
 
@@ -206,7 +217,7 @@ impl ToOwned for zshm {
 impl From<&zshmmut> for &zshm {
     fn from(value: &zshmmut) -> Self {
         // SAFETY: ZShm, ZShmMut, zshm and zshmmut are #[repr(transparent)]
-        // to ShmBufInner type, so it is safe to transmute them in any direction
+        // to ShmBufInner type, so it is safe to transmute them in any direction.
         unsafe { core::mem::transmute::<&zshmmut, &zshm>(value) }
     }
 }
@@ -214,7 +225,7 @@ impl From<&zshmmut> for &zshm {
 impl From<&mut zshmmut> for &mut zshm {
     fn from(value: &mut zshmmut) -> Self {
         // SAFETY: ZShm, ZShmMut, zshm and zshmmut are #[repr(transparent)]
-        // to ShmBufInner type, so it is safe to transmute them in any direction
+        // to ShmBufInner type, so it is safe to transmute them in any direction.
         unsafe { core::mem::transmute::<&mut zshmmut, &mut zshm>(value) }
     }
 }

--- a/commons/zenoh-shm/src/api/buffer/zshmmut.rs
+++ b/commons/zenoh-shm/src/api/buffer/zshmmut.rs
@@ -47,8 +47,13 @@ impl ShmBuf<[u8]> for ZShmMut {
 }
 
 impl ShmBufUnsafeMut<[u8]> for ZShmMut {
+    /// # Safety
+    ///
+    /// The caller must ensure that the `ShmBufInner` is valid and can be uniquely accessed.
     unsafe fn as_mut_unchecked(&mut self) -> &mut [u8] {
-        self.inner.as_mut_slice_inner()
+        // SAFETY: The internal buffer is assumed to be valid and uniquely accessible
+        // as per the safety contract of this function.
+        unsafe { self.inner.as_mut_slice_inner() }
     }
 }
 
@@ -64,14 +69,14 @@ impl ShmBufMut<[u8]> for ZShmMut {}
 
 impl OwnedShmBuf<[u8]> for ZShmMut {
     fn try_resize(&mut self, new_size: NonZeroUsize) -> Option<()> {
-        // Safety: this is safe because ZShmMut is an owned representation of SHM buffer and thus
-        // is guaranteed not to be wrapped into ZSlice (see ShmBufInner::try_resize comment)
+        // SAFETY: this is safe because ZShmMut is an owned representation of SHM buffer and thus
+        // is guaranteed not to be wrapped into ZSlice (see ShmBufInner::try_resize comment).
         unsafe { self.inner.try_resize(new_size) }
     }
 
     fn try_relayout(&mut self, new_layout: MemoryLayout) -> Result<(), BufferRelayoutError> {
-        // Safety: this is safe because ZShmMut is an owned representation of SHM buffer and thus
-        // is guaranteed not to be wrapped into ZSlice (see ShmBufInner::try_resize comment)
+        // SAFETY: this is safe because ZShmMut is an owned representation of SHM buffer and thus
+        // is guaranteed not to be wrapped into ZSlice (see ShmBufInner::try_resize comment).
         unsafe { self.inner.try_relayout(new_layout) }
     }
 }
@@ -85,7 +90,7 @@ impl PartialEq<zshmmut> for &ZShmMut {
 impl Borrow<zshm> for ZShmMut {
     fn borrow(&self) -> &zshm {
         // SAFETY: ZShm, ZShmMut, zshm and zshmmut are #[repr(transparent)]
-        // to ShmBufInner type, so it is safe to transmute them in any direction
+        // to ShmBufInner type, so it is safe to transmute them in any direction.
         unsafe { core::mem::transmute(self) }
     }
 }
@@ -93,7 +98,7 @@ impl Borrow<zshm> for ZShmMut {
 impl BorrowMut<zshm> for ZShmMut {
     fn borrow_mut(&mut self) -> &mut zshm {
         // SAFETY: ZShm, ZShmMut, zshm and zshmmut are #[repr(transparent)]
-        // to ShmBufInner type, so it is safe to transmute them in any direction
+        // to ShmBufInner type, so it is safe to transmute them in any direction.
         unsafe { core::mem::transmute(self) }
     }
 }
@@ -101,7 +106,7 @@ impl BorrowMut<zshm> for ZShmMut {
 impl Borrow<zshmmut> for ZShmMut {
     fn borrow(&self) -> &zshmmut {
         // SAFETY: ZShm, ZShmMut, zshm and zshmmut are #[repr(transparent)]
-        // to ShmBufInner type, so it is safe to transmute them in any direction
+        // to ShmBufInner type, so it is safe to transmute them in any direction.
         unsafe { core::mem::transmute(self) }
     }
 }
@@ -109,7 +114,7 @@ impl Borrow<zshmmut> for ZShmMut {
 impl BorrowMut<zshmmut> for ZShmMut {
     fn borrow_mut(&mut self) -> &mut zshmmut {
         // SAFETY: ZShm, ZShmMut, zshm and zshmmut are #[repr(transparent)]
-        // to ShmBufInner type, so it is safe to transmute them in any direction
+        // to ShmBufInner type, so it is safe to transmute them in any direction.
         unsafe { core::mem::transmute(self) }
     }
 }
@@ -186,8 +191,13 @@ impl ShmBuf<[u8]> for &mut zshmmut {
 }
 
 impl ShmBufUnsafeMut<[u8]> for &mut zshmmut {
+    /// # Safety
+    ///
+    /// The caller must ensure that the `ShmBufInner` is valid and can be uniquely accessed.
     unsafe fn as_mut_unchecked(&mut self) -> &mut [u8] {
-        self.inner.as_mut_slice_inner()
+        // SAFETY: The internal buffer is assumed to be valid and uniquely accessible
+        // as per the safety contract of this function.
+        unsafe { self.inner.as_mut_slice_inner() }
     }
 }
 
@@ -242,7 +252,7 @@ impl TryFrom<&zshm> for &zshmmut {
         match value.inner.is_unique() && value.inner.is_valid() {
             true => {
                 // SAFETY: ZShm, ZShmMut, zshm and zshmmut are #[repr(transparent)]
-                // to ShmBufInner type, so it is safe to transmute them in any direction
+                // to ShmBufInner type, so it is safe to transmute them in any direction.
                 Ok(unsafe { core::mem::transmute::<&zshm, &zshmmut>(value) })
             }
             false => Err(()),
@@ -257,7 +267,7 @@ impl TryFrom<&mut zshm> for &mut zshmmut {
         match value.inner.is_unique() && value.inner.is_valid() {
             true => {
                 // SAFETY: ZShm, ZShmMut, zshm and zshmmut are #[repr(transparent)]
-                // to ShmBufInner type, so it is safe to transmute them in any direction
+                // to ShmBufInner type, so it is safe to transmute them in any direction.
                 Ok(unsafe { core::mem::transmute::<&mut zshm, &mut zshmmut>(value) })
             }
             false => Err(()),
@@ -272,7 +282,7 @@ impl TryFrom<&mut ZShm> for &mut zshmmut {
         match value.inner.is_unique() && value.inner.is_valid() {
             true => {
                 // SAFETY: ZShm, ZShmMut, zshm and zshmmut are #[repr(transparent)]
-                // to ShmBufInner type, so it is safe to transmute them in any direction
+                // to ShmBufInner type, so it is safe to transmute them in any direction.
                 Ok(unsafe { core::mem::transmute::<&mut ZShm, &mut zshmmut>(value) })
             }
             false => Err(()),

--- a/commons/zenoh-shm/src/api/common/types.rs
+++ b/commons/zenoh-shm/src/api/common/types.rs
@@ -46,7 +46,7 @@ impl PtrInSegment {
         self.ptr
     }
 
-    /// # SAFETY
+    /// # Safety
     ///
     /// This function is safe if there is guarantee that there is no concurrent access
     pub unsafe fn ptr_mut(&mut self) -> *mut u8 {

--- a/commons/zenoh-shm/src/api/protocol_implementations/posix/posix_shm_provider_backend_buddy.rs
+++ b/commons/zenoh-shm/src/api/protocol_implementations/posix/posix_shm_provider_backend_buddy.rs
@@ -85,6 +85,7 @@ impl PosixShmProviderBackendBuddy {
 
         let mut heap = Heap::empty();
 
+        // SAFETY: we initialized the segment with `real_size` bytes.
         unsafe { heap.init(segment.segment.elem_mut(0) as usize, real_size) };
 
         tracing::trace!(
@@ -111,6 +112,7 @@ impl ShmProviderBackend for PosixShmProviderBackendBuddy {
     fn alloc(&self, layout: &MemoryLayout) -> ChunkAllocResult {
         tracing::trace!("PosixShmProviderBackendBuddy::alloc({:?})", layout);
 
+        // SAFETY: layout is guaranteed to be valid as it's passed from `MemoryLayout`
         let alloc_layout = unsafe {
             Layout::from_size_align_unchecked(
                 layout.size().get(),
@@ -130,6 +132,7 @@ impl ShmProviderBackend for PosixShmProviderBackendBuddy {
     }
 
     fn free(&self, chunk: &ChunkDescriptor) {
+        // SAFETY: layout is guaranteed to be valid as it's passed from `ChunkDescriptor`
         let alloc_layout = unsafe {
             Layout::from_size_align_unchecked(
                 chunk.len.get(),
@@ -137,8 +140,10 @@ impl ShmProviderBackend for PosixShmProviderBackendBuddy {
             )
         };
 
+        // SAFETY: chunk descriptor is guaranteed to be valid and belong to the segment
         let ptr = unsafe { self.segment.segment.elem_mut(chunk.chunk) };
 
+        // SAFETY: ptr is guaranteed to be non-null and belong to the heap as it's passed from `ChunkDescriptor`
         unsafe { zlock!(self.heap).dealloc(NonNull::new_unchecked(ptr), alloc_layout) };
     }
 

--- a/commons/zenoh-shm/src/api/protocol_implementations/posix/posix_shm_provider_backend_talc.rs
+++ b/commons/zenoh-shm/src/api/protocol_implementations/posix/posix_shm_provider_backend_talc.rs
@@ -81,10 +81,12 @@ impl PosixShmProviderBackendTalc {
         // because of platform specific, our shm segment is >= requested size, so in order to utilize
         // additional memory we re-layout the size
         let real_size = segment.segment.elem_count().get();
+        // SAFETY: the segment is guaranteed to be valid and the index 0 is always valid.
         let ptr = unsafe { segment.segment.elem_mut(0) };
 
         let mut talc = Talc::new(ErrOnOom);
 
+        // SAFETY: the pointer and size are guaranteed to be valid as they represent the whole segment.
         unsafe {
             talc.claim(slice::from_raw_parts_mut(ptr, real_size).into())
                 .map_err(|_| "Error initializing Talc backend!")?;
@@ -114,6 +116,7 @@ impl ShmProviderBackend for PosixShmProviderBackendTalc {
     fn alloc(&self, layout: &MemoryLayout) -> ChunkAllocResult {
         tracing::trace!("PosixShmProviderBackendTalc::alloc({:?})", layout);
 
+        // SAFETY: layout is guaranteed to be valid as it's passed from `MemoryLayout`.
         let alloc_layout = unsafe {
             Layout::from_size_align_unchecked(
                 layout.size().get(),
@@ -123,6 +126,7 @@ impl ShmProviderBackend for PosixShmProviderBackendTalc {
 
         let alloc = {
             let mut lock = zlock!(self.talc);
+            // SAFETY: layout is guaranteed to be valid.
             unsafe { lock.malloc(alloc_layout) }
         };
 
@@ -133,6 +137,7 @@ impl ShmProviderBackend for PosixShmProviderBackendTalc {
     }
 
     fn free(&self, chunk: &ChunkDescriptor) {
+        // SAFETY: chunk descriptor is guaranteed to be valid and belong to the segment.
         let alloc_layout = unsafe {
             Layout::from_size_align_unchecked(
                 chunk.len.get(),
@@ -140,8 +145,10 @@ impl ShmProviderBackend for PosixShmProviderBackendTalc {
             )
         };
 
+        // SAFETY: chunk descriptor is guaranteed to be valid and belong to the segment.
         let ptr = unsafe { self.segment.segment.elem_mut(chunk.chunk) };
 
+        // SAFETY: ptr and layout are guaranteed to be valid as they are passed from `ChunkDescriptor`.
         unsafe { zlock!(self.talc).free(NonNull::new_unchecked(ptr), alloc_layout) };
     }
 

--- a/commons/zenoh-shm/src/api/protocol_implementations/posix/posix_shm_segment.rs
+++ b/commons/zenoh-shm/src/api/protocol_implementations/posix/posix_shm_segment.rs
@@ -52,6 +52,7 @@ impl PosixShmSegment {
         AllocatedChunk {
             descriptor: ChunkDescriptor::new(
                 self.segment.id(),
+                // SAFETY: buf is guaranteed to belong to the segment.
                 unsafe { self.segment.index(buf.as_ptr()) },
                 layout.size(),
             ),
@@ -62,6 +63,7 @@ impl PosixShmSegment {
 
 impl ShmSegment for PosixShmSegment {
     fn map(&self, chunk: ChunkID) -> ZResult<*mut u8> {
+        // SAFETY: chunk descriptor is guaranteed to be valid and belong to the segment.
         Ok(unsafe { self.segment.elem_mut(chunk) })
     }
 }

--- a/commons/zenoh-shm/src/api/provider/memory_layout.rs
+++ b/commons/zenoh-shm/src/api/provider/memory_layout.rs
@@ -61,7 +61,7 @@ impl MemoryLayout {
         }
     }
 
-    /// #SAFETY: this is safe if size is a multiply of alignment
+    /// # Safety: this is safe if size is a multiply of alignment
     /// Note: not intended for public APIs as it is really very unsafe
     const unsafe fn new_unchecked(size: NonZeroUsize, alignment: AllocAlignment) -> Self {
         Self { size, alignment }
@@ -79,6 +79,7 @@ impl MemoryLayout {
         // SAFETY: invariant checked above
         let size = unsafe { NonZeroUsize::new_unchecked(mem::size_of::<T>()) };
         let alignment = AllocAlignment::for_type::<T>();
+        // SAFETY: size and alignment are guaranteed to be compatible as they were obtained from the same type `T`
         unsafe { Self::new_unchecked(size, alignment) }
     }
 

--- a/commons/zenoh-shm/src/api/provider/shm_provider.rs
+++ b/commons/zenoh-shm/src/api/provider/shm_provider.rs
@@ -74,6 +74,9 @@ where
         self.try_into().map_err(Into::into)
     }
 
+    /// # Safety
+    ///
+    /// The buffer must have the layout returned by `memory_layout`
     unsafe fn wrap_buffer(buffer: ZShmMut) -> Self::Buffer {
         buffer
     }
@@ -86,6 +89,9 @@ impl<T> AllocLayout for TypedLayout<T> {
         Ok(MemoryLayout::for_type::<T>())
     }
 
+    /// # Safety
+    ///
+    /// The buffer must have the layout returned by `memory_layout`
     unsafe fn wrap_buffer(buffer: ZShmMut) -> Self::Buffer {
         // SAFETY: same precondition
         unsafe { Typed::new_unchecked(buffer) }
@@ -802,6 +808,7 @@ where
 
         // wrap everything to ShmBufInner
         let wrapped = self.wrap(chunk, len, allocated_metadata, confirmed_metadata);
+        // SAFETY: `wrapped` is guaranteed to be valid as it represents a mapped chunk.
         Ok(unsafe { ZShmMut::new_unchecked(wrapped) })
     }
 
@@ -900,6 +907,7 @@ where
 
         // wrap allocated chunk to ShmBufInner
         let wrapped = self.wrap(chunk, size, allocated_metadata, confirmed_metadata);
+        // SAFETY: `wrapped` is guaranteed to be valid as it represents an allocated chunk.
         Ok(unsafe { ZShmMut::new_unchecked(wrapped) })
     }
 
@@ -988,6 +996,7 @@ where
 
         // wrap allocated chunk to ShmBufInner
         let wrapped = self.wrap(chunk, size, allocated_metadata, confirmed_metadata);
+        // SAFETY: `wrapped` is guaranteed to be valid as it represents an allocated chunk.
         Ok(unsafe { ZShmMut::new_unchecked(wrapped) })
     }
 }

--- a/commons/zenoh-shm/src/lib.rs
+++ b/commons/zenoh-shm/src/lib.rs
@@ -206,9 +206,15 @@ impl ShmBufInner {
     // PRIVATE:
     fn as_slice(&self) -> &[u8] {
         tracing::trace!("ShmBufInner::as_slice() == len = {:?}", self.info.data_len);
+        // SAFETY: The pointer and length are guaranteed to be valid during the lifetime of `ShmBufInner`.
         unsafe { std::slice::from_raw_parts(self.buf.ptr(), self.info.data_len.get()) }
     }
 
+    /// Decrements buffer's reference count
+    ///
+    /// # Safety
+    /// You should understand what you are doing, as underestimation
+    /// of the reference counter can lead to memory being stalled or double-freed.
     unsafe fn dec_ref_count(&self) {
         self.metadata
             .owned
@@ -229,20 +235,24 @@ impl ShmBufInner {
     /// In short, whilst this operation is marked as unsafe, you are safe if you can
     /// guarantee that your in applications only one process at the time will actually write.
     unsafe fn as_mut_slice_inner(&mut self) -> &mut [u8] {
-        std::slice::from_raw_parts_mut(self.buf.ptr_mut(), self.info.data_len.get())
+        // SAFETY: same precondition as described in the function documentation.
+        // SAFETY: the pointer and length are guaranteed to be valid for the lifetime of `self`.
+        unsafe { std::slice::from_raw_parts_mut(self.buf.ptr_mut(), self.info.data_len.get()) }
     }
 }
 
 impl Drop for ShmBufInner {
     fn drop(&mut self) {
-        // SAFETY: obviously, we need to decrement refcount when dropping ShmBufInner instance
+        // SAFETY: obviously, we need to decrement refcount when dropping ShmBufInner instance.
+        // SAFETY: `self` is guaranteed to be valid.
         unsafe { self.dec_ref_count() };
     }
 }
 
 impl Clone for ShmBufInner {
     fn clone(&self) -> Self {
-        // SAFETY: obviously, we need to increment refcount when cloning ShmBufInner instance
+        // SAFETY: obviously, we need to increment refcount when cloning ShmBufInner instance.
+        // SAFETY: `self` is guaranteed to be valid.
         unsafe { self.inc_ref_count() };
         ShmBufInner {
             metadata: self.metadata.clone(),
@@ -262,6 +272,9 @@ impl AsRef<[u8]> for ShmBufInner {
 
 impl AsMut<[u8]> for ShmBufInner {
     fn as_mut(&mut self) -> &mut [u8] {
+        // SAFETY: we have a mutable reference to `ShmBufInner`, and we follow the precautions
+        // mentioned in `as_mut_slice_inner` documentation.
+        // SAFETY: `self` is guaranteed to focus on a valid buffer and the access is unique.
         unsafe { self.as_mut_slice_inner() }
     }
 }
@@ -293,6 +306,9 @@ impl From<ShmBufInner> for ZShm {
 }
 
 impl ZShmMut {
+    /// # Safety
+    ///
+    /// The caller must ensure that the `ShmBufInner` is valid and can be uniquely accessed.
     pub(crate) unsafe fn new_unchecked(inner: ShmBufInner) -> Self {
         Self { inner }
     }
@@ -303,7 +319,8 @@ impl TryFrom<ShmBufInner> for ZShmMut {
 
     fn try_from(value: ShmBufInner) -> Result<Self, Self::Error> {
         match value.is_unique() && value.is_valid() {
-            // SAFETY: we checked above
+            // SAFETY: we checked above that the buffer is unique and valid.
+            // SAFETY: `ShmBufInner` and `ZShmMut` are layout-compatible.
             true => Ok(unsafe { Self::new_unchecked(value) }),
             false => Err(value),
         }
@@ -316,7 +333,9 @@ impl TryFrom<&mut ShmBufInner> for &mut zshmmut {
     fn try_from(value: &mut ShmBufInner) -> Result<Self, Self::Error> {
         match value.is_unique() && value.is_valid() {
             // SAFETY: ZShm, ZShmMut, zshm and zshmmut are #[repr(transparent)]
-            // to ShmBufInner type, so it is safe to transmute them in any direction
+            // to ShmBufInner type, so it is safe to transmute them in any direction.
+            // We checked above that the buffer is unique and valid.
+            // SAFETY: `ShmBufInner` and `zshmmut` are layout-compatible.
             true => Ok(unsafe { core::mem::transmute::<&mut ShmBufInner, &mut zshmmut>(value) }),
             false => Err(()),
         }
@@ -326,7 +345,8 @@ impl TryFrom<&mut ShmBufInner> for &mut zshmmut {
 impl From<&ShmBufInner> for &zshm {
     fn from(value: &ShmBufInner) -> Self {
         // SAFETY: ZShm, ZShmMut, zshm and zshmmut are #[repr(transparent)]
-        // to ShmBufInner type, so it is safe to transmute them in any direction
+        // to ShmBufInner type, so it is safe to transmute them in any direction.
+        // SAFETY: `ShmBufInner` and `zshm` are layout-compatible.
         unsafe { core::mem::transmute::<&ShmBufInner, &zshm>(value) }
     }
 }
@@ -334,7 +354,8 @@ impl From<&ShmBufInner> for &zshm {
 impl From<&mut ShmBufInner> for &mut zshm {
     fn from(value: &mut ShmBufInner) -> Self {
         // SAFETY: ZShm, ZShmMut, zshm and zshmmut are #[repr(transparent)]
-        // to ShmBufInner type, so it is safe to transmute them in any direction
+        // to ShmBufInner type, so it is safe to transmute them in any direction.
+        // SAFETY: `ShmBufInner` and `zshm` are layout-compatible.
         unsafe { core::mem::transmute::<&mut ShmBufInner, &mut zshm>(value) }
     }
 }

--- a/commons/zenoh-shm/src/metadata/descriptor.rs
+++ b/commons/zenoh-shm/src/metadata/descriptor.rs
@@ -33,6 +33,7 @@ pub struct MetadataDescriptor {
 impl From<&OwnedMetadataDescriptor> for MetadataDescriptor {
     fn from(item: &OwnedMetadataDescriptor) -> Self {
         let id = item.segment.data.id();
+        // SAFETY: `item` is guaranteed to belong to the segment.
         let index = unsafe { item.segment.data.fast_index_compute(item.header) };
 
         Self { id, index }

--- a/commons/zenoh-shm/src/metadata/segment.rs
+++ b/commons/zenoh-shm/src/metadata/segment.rs
@@ -27,25 +27,33 @@ pub struct Metadata<const S: usize> {
 }
 
 impl<const S: usize> Metadata<S> {
-    // SAFETY: this is safe if header belongs to current Metadata instance
+    /// # Safety
+    ///
+    /// This is safe if header belongs to current Metadata instance
     pub unsafe fn fast_index_compute(&self, header: *const ChunkHeaderType) -> MetadataIndex {
-        header.offset_from(self.headers.as_ptr()) as MetadataIndex
+        // SAFETY: same precondition as described in the function documentation.
+        unsafe { header.offset_from(self.headers.as_ptr()) as MetadataIndex }
     }
 
-    // SAFETY: this is safe if index is in bounds!
+    /// # Safety
+    ///
+    /// This is safe if index is in bounds!
     pub unsafe fn fast_elem_compute(
         &self,
         index: MetadataIndex,
     ) -> (&'static ChunkHeaderType, OwnedWatchdog) {
         let watchdog_index = index / 64;
         let watchdog_mask_index = index % 64;
-        (
-            &*(self.headers.as_ptr().offset(index as isize)),
-            OwnedWatchdog::new(
-                &*(self.watchdogs.as_ptr().offset(watchdog_index as isize)),
-                1u64 << watchdog_mask_index,
-            ),
-        )
+        // SAFETY: same precondition as described in the function documentation.
+        unsafe {
+            (
+                &*(self.headers.as_ptr().offset(index as isize)),
+                OwnedWatchdog::new(
+                    &*(self.watchdogs.as_ptr().offset(watchdog_index as isize)),
+                    1u64 << watchdog_mask_index,
+                ),
+            )
+        }
     }
 
     #[inline(always)]

--- a/commons/zenoh-shm/src/metadata/storage.rs
+++ b/commons/zenoh-shm/src/metadata/storage.rs
@@ -54,6 +54,7 @@ impl MetadataStorage {
 
         for index in 0..segment.data.count() {
             let (header, watchdog) =
+                // SAFETY: index is guaranteed to be within segment boundaries.
                 unsafe { segment.data.fast_elem_compute(index as MetadataIndex) };
             let descriptor = OwnedMetadataDescriptor::new(segment.clone(), header, watchdog);
 

--- a/commons/zenoh-shm/src/posix_shm/array.rs
+++ b/commons/zenoh-shm/src/posix_shm/array.rs
@@ -87,6 +87,7 @@ where
     pub fn elem_count(&self) -> NonZeroUsize {
         let max: usize = ElemIndex::max_value().as_();
         let actual = self.inner.len().get() / size_of::<Elem>();
+        // SAFETY: the value is guaranteed to be at least 1 since `actual` is at least 1 and `max` is at least 0.
         unsafe { NonZeroUsize::new_unchecked(std::cmp::min(max.saturating_add(1), actual)) }
     }
 
@@ -96,7 +97,8 @@ where
     pub unsafe fn elem(&self, index: ElemIndex) -> *const Elem {
         #[cfg(feature = "test")]
         assert!(self.inner.len().get() > index.as_() * size_of::<Elem>());
-        (self.inner.as_ptr() as *const Elem).add(index.as_())
+        // SAFETY: same precondition as described in the function documentation.
+        unsafe { (self.inner.as_ptr() as *const Elem).add(index.as_()) }
     }
 
     /// # Safety
@@ -105,14 +107,16 @@ where
     pub unsafe fn elem_mut(&self, index: ElemIndex) -> *mut Elem {
         #[cfg(feature = "test")]
         assert!(self.inner.len().get() > index.as_() * size_of::<Elem>());
-        (self.inner.as_ptr() as *mut Elem).add(index.as_())
+        // SAFETY: same precondition as described in the function documentation.
+        unsafe { (self.inner.as_ptr() as *mut Elem).add(index.as_()) }
     }
 
     /// # Safety
     /// Calculates element's index. This is safe if the element belongs to underlying array.
     /// Additional assert is added for "test" feature
     pub unsafe fn index(&self, elem: *const Elem) -> ElemIndex {
-        let index = elem.offset_from(self.inner.as_ptr() as *const Elem);
+        // SAFETY: same precondition as described in the function documentation.
+        let index = unsafe { elem.offset_from(self.inner.as_ptr() as *const Elem) };
         #[cfg(feature = "test")]
         {
             assert!(index >= 0);

--- a/commons/zenoh-shm/src/posix_shm/struct_in_shm.rs
+++ b/commons/zenoh-shm/src/posix_shm/struct_in_shm.rs
@@ -96,6 +96,7 @@ where
     type Target = Elem;
 
     fn deref(&self) -> &Self::Target {
+        // SAFETY: the pointer is guaranteed to be valid and uniquely accessible for the lifetime of `self`.
         unsafe { &*(self.inner.as_ptr() as *const Elem) }
     }
 }
@@ -107,6 +108,7 @@ where
     ID: shm::SegmentID,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
+        // SAFETY: the pointer is guaranteed to be valid and uniquely accessible for the lifetime of `self`.
         unsafe { &mut *(self.inner.as_ptr() as *mut Elem) }
     }
 }

--- a/commons/zenoh-shm/src/shm/unix.rs
+++ b/commons/zenoh-shm/src/shm/unix.rs
@@ -47,6 +47,7 @@ impl<ID: SegmentID> SegmentImpl<ID> {
     pub fn create(id: ID, len: NonZeroUsize) -> ShmCreateResult<Self> {
         // we use separate lockfile on non-tmpfs for bsd
         #[cfg(shm_external_lockfile)]
+        // SAFETY: we know that the file descriptor is valid.
         let lock_fd = unsafe {
             OwnedFd::from_raw_fd({
                 let lockpath = std::env::temp_dir().join(Self::id_str(id));
@@ -119,6 +120,7 @@ impl<ID: SegmentID> SegmentImpl<ID> {
     pub fn open(id: ID) -> ShmOpenResult<Self> {
         // we use separate lockfile on non-tmpfs for bsd
         #[cfg(shm_external_lockfile)]
+        // SAFETY: we know that the file descriptor is valid.
         let lock_fd = unsafe {
             OwnedFd::from_raw_fd({
                 let lockpath = std::env::temp_dir().join(Self::id_str(id));
@@ -210,6 +212,7 @@ impl<ID: SegmentID> SegmentImpl<ID> {
     fn is_dangling_segment(id: ID) -> bool {
         // we use separate lockfile on non-tmpfs for bsd
         #[cfg(shm_external_lockfile)]
+        // SAFETY: we know that the file descriptor is valid.
         let lock_fd = unsafe {
             OwnedFd::from_raw_fd({
                 let lockpath = std::env::temp_dir().join(Self::id_str(id));
@@ -303,6 +306,7 @@ impl<ID: SegmentID> SegmentImpl<ID> {
 impl<ID: SegmentID> Drop for SegmentImpl<ID> {
     fn drop(&mut self) {
         tracing::trace!("munmap(addr={:p},len={})", self.data_ptr, self.len);
+        // SAFETY: data_ptr and len are valid for the mapping.
         if let Err(e) = unsafe { munmap(self.data_ptr, self.len.get()) } {
             tracing::debug!("munmap() failed : {}", e);
         };

--- a/commons/zenoh-shm/src/shm/windows.rs
+++ b/commons/zenoh-shm/src/shm/windows.rs
@@ -61,6 +61,7 @@ impl<ID: SegmentID> SegmentImpl<ID> {
             })?;
 
             // check error
+            // SAFETY: this is safe as it just retrieves the last error code.
             if unsafe { GetLastError() } == ERROR_ALREADY_EXISTS.0 {
                 return Err(SegmentCreateError::SegmentExists);
             }


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->
The PR is the final round review dealing with #1684.
We're focusing on shm and buffer.
We wanted to make sure
1. Don't use `unsafe fn` if we can avoid the UB inside the function
2. Every `unsafe fn` should include `/// # Safety`
3. Enable `unsafe_op_in_unsafe_fn`, which will be enabled by default in [Edition 2024](https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html)
4. Having `// SAFETY` before an unsafe block.

### What does this PR do?
<!-- Describe the changes and their purpose -->
Fix the `unsafe fn` usage inside Zenoh

### Why is this change needed?
<!-- Explain the motivation or problem being solved -->
Ensure that we are using unsafe correctly.

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->
https://github.com/eclipse-zenoh/zenoh/issues/1684

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `enhancement`

## ✨ Enhancement Requirements

Since this PR enhances existing functionality:

- [x] **Enhancement scope documented** - Clear description of what is being improved
- [x] **Minimum necessary code** - Implementation is as simple as possible, doesn't overcomplicate the system
- [x] **Backwards compatible** - Existing code/APIs still work unchanged
- [x] **No new APIs added** - Only improving existing functionality
- [x] **Tests updated** - Existing tests pass, new test cases added if needed
- [x] **Performance improvement measured** - If applicable, before/after metrics provided
- [x] **Documentation updated** - Existing docs updated to reflect improvements
- [x] **User impact documented** - How users benefit from this enhancement

**Remember:** Enhancements should not introduce new APIs or breaking changes.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->