### PR TITLE
feat: accept `TryInto<KeyExpr>` in `SampleBuilder::put` and `::delete`

### DIFF
--- a/zenoh/src/api/builders/sample.rs
+++ b/zenoh/src/api/builders/sample.rs
@@ -90,17 +90,18 @@ pub struct SampleBuilder<T> {
 }
 
 impl SampleBuilder<SampleBuilderPut> {
-    pub fn put<IntoKeyExpr, IntoZBytes>(
-        key_expr: IntoKeyExpr,
+    pub fn put<TryIntoKeyExpr, IntoZBytes>(
+        key_expr: TryIntoKeyExpr,
         payload: IntoZBytes,
     ) -> SampleBuilder<SampleBuilderPut>
     where
-        IntoKeyExpr: Into<KeyExpr<'static>>,
+        TryIntoKeyExpr: TryInto<KeyExpr<'static>>,
+        <TryIntoKeyExpr as TryInto<KeyExpr<'static>>>::Error: Into<zenoh_core::zresult::Error>,
         IntoZBytes: Into<ZBytes>,
     {
         Self {
             sample: Sample {
-                key_expr: key_expr.into(),
+                key_expr: key_expr.try_into().map_err(Into::into).unwrap(),
                 payload: payload.into(),
                 kind: SampleKind::Put,
                 encoding: Encoding::default(),
@@ -126,13 +127,14 @@ impl SampleBuilder<SampleBuilderPut> {
 }
 
 impl SampleBuilder<SampleBuilderDelete> {
-    pub fn delete<IntoKeyExpr>(key_expr: IntoKeyExpr) -> SampleBuilder<SampleBuilderDelete>
+    pub fn delete<TryIntoKeyExpr>(key_expr: TryIntoKeyExpr) -> SampleBuilder<SampleBuilderDelete>
     where
-        IntoKeyExpr: Into<KeyExpr<'static>>,
+        TryIntoKeyExpr: TryInto<KeyExpr<'static>>,
+        <TryIntoKeyExpr as TryInto<KeyExpr<'static>>>::Error: Into<zenoh_core::zresult::Error>,
     {
         Self {
             sample: Sample {
-                key_expr: key_expr.into(),
+                key_expr: key_expr.try_into().map_err(Into::into).unwrap(),
                 payload: ZBytes::new(),
                 kind: SampleKind::Delete,
                 encoding: Encoding::default(),


### PR DESCRIPTION
## Description

### What does this PR do?
Changes `SampleBuilder::put` and `SampleBuilder::delete` to accept `TryInto<KeyExpr<'static>>` instead of `Into<KeyExpr<'static>>`, so `&str` can be used directly:

```rust
// Before (required manual conversion):
let sample = SampleBuilder::put(KeyExpr::try_from("foo/bar").unwrap(), "payload").into();

// After (just works):
let sample: Sample = SampleBuilder::put("foo/bar", "payload").into();
```

### Why is this change needed?
The current API is unnecessarily restrictive. Other `SampleBuilder` constructors already accept fallible conversions, and requiring users to manually convert `&str` → `KeyExpr` is inconvenient. This is a non-breaking change since `Into<T>` implies `TryInto<T>`, so all existing call sites continue to compile.

### Related Issues
Fixes #2172

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

**No specific label requirements detected.**

Current labels: _No labels_

Add one of these labels to this PR to see relevant checklist items: `api-sync`, `breaking-change`, `bug`, `ci`, `dependencies`, `documentation`, `enhancement`, `new feature`, `internal`

*This section updates automatically when labels change.*

<!-- 🏷️ Label-Based Checklist END -->