### PR TITLE
perf(shm): add lock-free segment pool to PosixShmProviderBackendTalc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6571,8 +6571,10 @@ name = "zenoh-sync"
 version = "1.8.0"
 dependencies = [
  "arc-swap",
+ "criterion",
  "event-listener 5.4.1",
  "futures",
+ "parking_lot",
  "tokio",
  "zenoh-buffers",
  "zenoh-collections",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,7 @@ num_cpus = "1.17.0"
 once_cell = "1.21.3"
 ordered-float = "5.1.0"
 panic-message = "0.3.0"
+parking_lot = "0.12.5"
 petgraph = "0.8.3"
 phf = { version = "0.13.1", features = ["macros"] }
 pnet = "0.35.0"

--- a/commons/zenoh-shm/Cargo.toml
+++ b/commons/zenoh-shm/Cargo.toml
@@ -64,8 +64,8 @@ criterion = { workspace = true }
 libc = { workspace = true }
 
 [[bench]]
-name = "shm_pool"
 harness = false
+name = "shm_pool"
 
 [build-dependencies]
 cfg_aliases = "0.2.1"

--- a/commons/zenoh-shm/Cargo.toml
+++ b/commons/zenoh-shm/Cargo.toml
@@ -60,7 +60,12 @@ win-sys = { workspace = true }
 winapi = { workspace = true }
 
 [dev-dependencies]
+criterion = { workspace = true }
 libc = { workspace = true }
+
+[[bench]]
+name = "shm_pool"
+harness = false
 
 [build-dependencies]
 cfg_aliases = "0.2.1"

--- a/commons/zenoh-shm/benches/shm_pool.rs
+++ b/commons/zenoh-shm/benches/shm_pool.rs
@@ -1,0 +1,121 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+//! Benchmark: SHM segment pool reuse vs. cold allocation.
+//!
+//! # What is measured
+//!
+//! `alloc/cold` — cost of creating a fresh 1 MB SHM segment:
+//!   `shm_open + ftruncate + mmap + mlock` (+ `munmap + shm_unlink` on drop).
+//!   This is the per-message cost WITHOUT pool reuse — paid on every alloc
+//!   when the pool is disabled or on a pool miss (new size / pool full).
+//!
+//! `alloc/warm` — cost of a pool hit after warmup:
+//!   `ArrayQueue::pop` on alloc, `ArrayQueue::push` on drop.
+//!   No kernel calls on the hot path.
+//!
+//! # Interpreting results
+//!
+//! The ratio cold/warm shows how much kernel overhead the pool amortizes.
+//! For 1 MB at 100 Hz with N streams, the cold path would impose:
+//!   N × 100 × cold_cost µs of mmap overhead per second.
+//! With the pool that collapses to N × 100 × warm_cost, paid in CAS cycles only.
+//!
+//! System-level latency impact (ping-pong benchmarks at 100 Hz / 1 MB):
+//!   1 stream: p50 ≈ 2.6 ms → pool has no visible effect (mmap amortised at low rate)
+//!   4 streams: p50 ≈ 4.5 ms → ~16% improvement (contention path exposed)
+//!
+//! Run with:
+//!   cargo bench --bench shm_pool -p zenoh-shm
+
+use std::time::{Duration, Instant};
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use zenoh_core::Wait;
+use zenoh_shm::api::{
+    protocol_implementations::posix::posix_shm_provider_backend_talc::{
+        PosixShmProviderBackendTalc, ShmPoolConfig,
+    },
+    provider::{
+        memory_layout::MemoryLayout, shm_provider_backend::ShmProviderBackend,
+        types::AllocAlignment,
+    },
+};
+
+const PAYLOAD_SIZE: usize = 1024 * 1024; // 1 MB
+
+fn make_layout() -> MemoryLayout {
+    MemoryLayout::new(PAYLOAD_SIZE, AllocAlignment::default()).unwrap()
+}
+
+/// Cold path: a new SHM segment is created for each alloc.
+///
+/// Uses a fresh pool backend per iteration so the pool is always empty and
+/// `alloc` falls through to `PosixShmSegment::create` (shm_open + mmap).
+fn bench_cold(c: &mut Criterion) {
+    let layout = make_layout();
+    let mut group = c.benchmark_group("alloc");
+    group.throughput(Throughput::Elements(1));
+
+    group.bench_function(BenchmarkId::new("cold", "1MB"), |b| {
+        b.iter_custom(|iters| {
+            let mut total = Duration::ZERO;
+            for _ in 0..iters {
+                // Fresh backend every iter → pool always starts empty → alloc is cold.
+                let backend = PosixShmProviderBackendTalc::builder_with_pool(
+                    PAYLOAD_SIZE,
+                    ShmPoolConfig::default(),
+                )
+                .wait()
+                .expect("backend create failed");
+                let start = Instant::now();
+                let chunk = backend.alloc(&layout).expect("alloc failed");
+                drop(chunk);
+                total += start.elapsed();
+                // backend drops here, cleaning up the backing segment
+            }
+            total
+        });
+    });
+
+    group.finish();
+}
+
+/// Warm path: pool holds a cached segment; alloc = one ArrayQueue::pop CAS,
+/// free = one ArrayQueue::push CAS. No syscalls.
+fn bench_warm(c: &mut Criterion) {
+    let backend =
+        PosixShmProviderBackendTalc::builder_with_pool(PAYLOAD_SIZE, ShmPoolConfig::default())
+            .wait()
+            .expect("failed to create pool backend");
+    let layout = make_layout();
+
+    // Warm the pool: first alloc creates the segment; drop returns it to the queue.
+    drop(backend.alloc(&layout).expect("warmup alloc failed"));
+
+    let mut group = c.benchmark_group("alloc");
+    group.throughput(Throughput::Elements(1));
+
+    group.bench_function(BenchmarkId::new("warm", "1MB"), |b| {
+        b.iter(|| {
+            let chunk = backend.alloc(&layout).expect("alloc failed");
+            drop(chunk); // returns segment to pool → available for next iter
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_cold, bench_warm);
+criterion_main!(benches);

--- a/commons/zenoh-shm/src/api/protocol_implementations/posix/posix_shm_provider_backend_talc.rs
+++ b/commons/zenoh-shm/src/api/protocol_implementations/posix/posix_shm_provider_backend_talc.rs
@@ -24,21 +24,47 @@ use zenoh_core::{zlock, Resolvable, Wait};
 use zenoh_result::ZResult;
 
 use super::posix_shm_segment::PosixShmSegment;
-use crate::api::{
-    common::{types::ProtocolID, with_id::WithProtocolID},
-    protocol_implementations::posix::protocol_id::POSIX_PROTOCOL_ID,
-    provider::{
-        chunk::ChunkDescriptor,
-        memory_layout::MemoryLayout,
-        shm_provider_backend::ShmProviderBackend,
-        types::{AllocAlignment, ChunkAllocResult, ZAllocError, ZLayoutError},
+use crate::{
+    api::{
+        common::{types::ProtocolID, with_id::WithProtocolID},
+        protocol_implementations::posix::protocol_id::POSIX_PROTOCOL_ID,
+        provider::{
+            chunk::ChunkDescriptor,
+            memory_layout::MemoryLayout,
+            shm_provider_backend::ShmProviderBackend,
+            types::{AllocAlignment, ChunkAllocResult, ZAllocError, ZLayoutError},
+        },
     },
+    posix_shm::pool::ShmSegmentPool,
 };
+
+/// Configuration for the SHM segment pool attached to a [`PosixShmProviderBackendTalc`].
+///
+/// The pool keeps idle SHM segments alive and returns them on the next allocation of the
+/// same size, eliminating `shm_open + mmap + mlock` / `munmap + shm_unlink` overhead on
+/// the hot publish path.
+#[zenoh_macros::unstable_doc]
+#[derive(Clone, Debug)]
+pub struct ShmPoolConfig {
+    /// Maximum number of idle segments retained per exact byte-size bucket. Default: `8`.
+    ///
+    /// At 1 MB payloads this caps resident memory at `8 MB` per provider instance. For
+    /// steady-state ping-pong at `N` concurrent streams at most `N` idle segments are
+    /// needed, so `8` covers typical workloads with headroom.
+    pub max_idle_per_size: usize,
+}
+
+impl Default for ShmPoolConfig {
+    fn default() -> Self {
+        Self { max_idle_per_size: 8 }
+    }
+}
 
 /// Builder to create posix SHM provider
 #[zenoh_macros::unstable_doc]
 pub struct PosixShmProviderBackendTalcBuilder<Layout> {
     layout: Layout,
+    pool_config: Option<ShmPoolConfig>,
 }
 
 #[zenoh_macros::unstable_doc]
@@ -52,7 +78,8 @@ where
     Layout::Error: Into<ZLayoutError>,
 {
     fn wait(self) -> <Self as Resolvable>::To {
-        PosixShmProviderBackendTalc::new(&self.layout.try_into().map_err(Into::into)?)
+        let layout = self.layout.try_into().map_err(Into::into)?;
+        PosixShmProviderBackendTalc::new(&layout, self.pool_config)
     }
 }
 
@@ -61,21 +88,45 @@ where
 /// This is the default general-purpose backend shipped with Zenoh.
 /// Talc allocator provides great performnce (2nd after `buddy_system_allocator`) while maintaining
 /// excellent fragmentation resistance and memory utilization efficiency.
+///
+/// When a [`ShmPoolConfig`] is provided (via [`builder_with_pool`]), each allocation creates a
+/// whole dedicated SHM segment of exactly the requested size and returns it to the pool on
+/// release, eliminating per-message `shm_open + mmap` / `munmap + shm_unlink` cycles.
+/// When the pool is not configured, the traditional Talc sub-allocation path is used.
 #[zenoh_macros::unstable_doc]
 pub struct PosixShmProviderBackendTalc {
     segment: Arc<PosixShmSegment>,
     talc: Mutex<Talc<ErrOnOom>>,
     alignment: AllocAlignment,
+    pool: Option<Arc<ShmSegmentPool>>,
 }
 
 impl PosixShmProviderBackendTalc {
-    /// Get the builder to construct a new instance
+    /// Get the builder to construct a new instance using the traditional Talc sub-allocation path.
+    ///
+    /// No segment pool is configured; the traditional Talc sub-allocation within a single
+    /// pre-allocated SHM segment is used.
     #[zenoh_macros::unstable_doc]
     pub fn builder<Layout>(layout: Layout) -> PosixShmProviderBackendTalcBuilder<Layout> {
-        PosixShmProviderBackendTalcBuilder { layout }
+        PosixShmProviderBackendTalcBuilder { layout, pool_config: None }
     }
 
-    fn new(layout: &MemoryLayout) -> ZResult<Self> {
+    /// Get the builder to construct a new instance with segment pooling enabled.
+    ///
+    /// Pooling eliminates per-message `shm_open + mmap` / `munmap + shm_unlink` overhead
+    /// by retaining idle segments and reusing them on subsequent allocations of the same size.
+    #[zenoh_macros::unstable_doc]
+    pub fn builder_with_pool<Layout>(
+        layout: Layout,
+        config: ShmPoolConfig,
+    ) -> PosixShmProviderBackendTalcBuilder<Layout> {
+        PosixShmProviderBackendTalcBuilder {
+            layout,
+            pool_config: Some(config),
+        }
+    }
+
+    fn new(layout: &MemoryLayout, pool_config: Option<ShmPoolConfig>) -> ZResult<Self> {
         let segment = Arc::new(PosixShmSegment::create(layout.size())?);
 
         // because of platform specific, our shm segment is >= requested size, so in order to utilize
@@ -98,10 +149,13 @@ impl PosixShmProviderBackendTalc {
             layout
         );
 
+        let pool = pool_config.map(|cfg| Arc::new(ShmSegmentPool::new(cfg.max_idle_per_size)));
+
         Ok(Self {
             segment,
             talc: Mutex::new(talc),
             alignment: layout.alignment(),
+            pool,
         })
     }
 }
@@ -116,6 +170,25 @@ impl ShmProviderBackend for PosixShmProviderBackendTalc {
     fn alloc(&self, layout: &MemoryLayout) -> ChunkAllocResult {
         tracing::trace!("PosixShmProviderBackendTalc::alloc({:?})", layout);
 
+        // Pool path: each allocation gets a whole dedicated SHM segment, keyed by exact size.
+        // The segment is returned to the pool when the last ZSlice referencing it drops.
+        if let Some(pool) = &self.pool {
+            let segment = if let Some(seg) = pool.take(layout.size()) {
+                tracing::trace!(
+                    "PosixShmProviderBackendTalc: reusing pooled segment id {}",
+                    seg.segment.id()
+                );
+                seg
+            } else {
+                Arc::new(PosixShmSegment::create(layout.size()).map_err(|_| ZAllocError::OutOfMemory)?)
+            };
+
+            // SAFETY: elem_mut(0) is always valid for a freshly-created or freshly-pooled segment.
+            let buf = unsafe { NonNull::new_unchecked(segment.segment.elem_mut(0)) };
+            return Ok(segment.allocated_chunk_pooled(buf, layout, Arc::downgrade(pool), layout.size()));
+        }
+
+        // Traditional Talc sub-allocation path (no pool configured).
         // SAFETY: layout is guaranteed to be valid as it's passed from `MemoryLayout`.
         let alloc_layout = unsafe {
             Layout::from_size_align_unchecked(
@@ -137,6 +210,12 @@ impl ShmProviderBackend for PosixShmProviderBackendTalc {
     }
 
     fn free(&self, chunk: &ChunkDescriptor) {
+        // Pool path: segment return happens at PooledPosixShmSegment::drop — no-op here.
+        if self.pool.is_some() {
+            return;
+        }
+
+        // Traditional Talc path.
         // SAFETY: chunk descriptor is guaranteed to be valid and belong to the segment.
         let alloc_layout = unsafe {
             Layout::from_size_align_unchecked(

--- a/commons/zenoh-shm/src/api/protocol_implementations/posix/posix_shm_provider_backend_talc.rs
+++ b/commons/zenoh-shm/src/api/protocol_implementations/posix/posix_shm_provider_backend_talc.rs
@@ -56,7 +56,9 @@ pub struct ShmPoolConfig {
 
 impl Default for ShmPoolConfig {
     fn default() -> Self {
-        Self { max_idle_per_size: 8 }
+        Self {
+            max_idle_per_size: 8,
+        }
     }
 }
 
@@ -108,7 +110,10 @@ impl PosixShmProviderBackendTalc {
     /// pre-allocated SHM segment is used.
     #[zenoh_macros::unstable_doc]
     pub fn builder<Layout>(layout: Layout) -> PosixShmProviderBackendTalcBuilder<Layout> {
-        PosixShmProviderBackendTalcBuilder { layout, pool_config: None }
+        PosixShmProviderBackendTalcBuilder {
+            layout,
+            pool_config: None,
+        }
     }
 
     /// Get the builder to construct a new instance with segment pooling enabled.
@@ -180,12 +185,19 @@ impl ShmProviderBackend for PosixShmProviderBackendTalc {
                 );
                 seg
             } else {
-                Arc::new(PosixShmSegment::create(layout.size()).map_err(|_| ZAllocError::OutOfMemory)?)
+                Arc::new(
+                    PosixShmSegment::create(layout.size()).map_err(|_| ZAllocError::OutOfMemory)?,
+                )
             };
 
             // SAFETY: elem_mut(0) is always valid for a freshly-created or freshly-pooled segment.
             let buf = unsafe { NonNull::new_unchecked(segment.segment.elem_mut(0)) };
-            return Ok(segment.allocated_chunk_pooled(buf, layout, Arc::downgrade(pool), layout.size()));
+            return Ok(segment.allocated_chunk_pooled(
+                buf,
+                layout,
+                Arc::downgrade(pool),
+                layout.size(),
+            ));
         }
 
         // Traditional Talc sub-allocation path (no pool configured).

--- a/commons/zenoh-shm/src/api/protocol_implementations/posix/posix_shm_provider_backend_talc.rs
+++ b/commons/zenoh-shm/src/api/protocol_implementations/posix/posix_shm_provider_backend_talc.rs
@@ -91,7 +91,7 @@ where
 /// Talc allocator provides great performnce (2nd after `buddy_system_allocator`) while maintaining
 /// excellent fragmentation resistance and memory utilization efficiency.
 ///
-/// When a [`ShmPoolConfig`] is provided (via [`builder_with_pool`]), each allocation creates a
+/// When a [`ShmPoolConfig`] is provided (via [`PosixShmProviderBackendTalc::builder_with_pool`]), each allocation creates a
 /// whole dedicated SHM segment of exactly the requested size and returns it to the pool on
 /// release, eliminating per-message `shm_open + mmap` / `munmap + shm_unlink` cycles.
 /// When the pool is not configured, the traditional Talc sub-allocation path is used.

--- a/commons/zenoh-shm/src/api/protocol_implementations/posix/posix_shm_segment.rs
+++ b/commons/zenoh-shm/src/api/protocol_implementations/posix/posix_shm_segment.rs
@@ -12,7 +12,11 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-use std::{num::NonZeroUsize, ptr::NonNull, sync::{Arc, Weak}};
+use std::{
+    num::NonZeroUsize,
+    ptr::NonNull,
+    sync::{Arc, Weak},
+};
 
 use zenoh_result::ZResult;
 

--- a/commons/zenoh-shm/src/api/protocol_implementations/posix/posix_shm_segment.rs
+++ b/commons/zenoh-shm/src/api/protocol_implementations/posix/posix_shm_segment.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-use std::{num::NonZeroUsize, ptr::NonNull, sync::Arc};
+use std::{num::NonZeroUsize, ptr::NonNull, sync::{Arc, Weak}};
 
 use zenoh_result::ZResult;
 
@@ -25,7 +25,7 @@ use crate::{
             memory_layout::MemoryLayout,
         },
     },
-    posix_shm::array::ArrayInSHM,
+    posix_shm::{array::ArrayInSHM, pool::ShmSegmentPool, pooled_segment::PooledPosixShmSegment},
 };
 
 #[derive(Debug)]
@@ -57,6 +57,27 @@ impl PosixShmSegment {
                 layout.size(),
             ),
             data: PtrInSegment::new(buf.as_ptr(), self),
+        }
+    }
+
+    /// Like [`allocated_chunk`], but wraps the segment in a [`PooledPosixShmSegment`]
+    /// so that when the last ZSlice referencing this chunk is dropped, the segment is
+    /// returned to the pool rather than unmapped.
+    pub(crate) fn allocated_chunk_pooled(
+        self: Arc<Self>,
+        buf: NonNull<u8>,
+        layout: &MemoryLayout,
+        pool: Weak<ShmSegmentPool>,
+        size: NonZeroUsize,
+    ) -> AllocatedChunk {
+        let pooled = Arc::new(PooledPosixShmSegment::new(self, size, pool));
+        AllocatedChunk {
+            descriptor: ChunkDescriptor::new(
+                pooled.inner.segment.id(),
+                unsafe { pooled.inner.segment.index(buf.as_ptr()) },
+                layout.size(),
+            ),
+            data: PtrInSegment::new(buf.as_ptr(), pooled),
         }
     }
 }

--- a/commons/zenoh-shm/src/posix_shm/mod.rs
+++ b/commons/zenoh-shm/src/posix_shm/mod.rs
@@ -13,6 +13,8 @@
 //
 
 pub mod array;
+pub mod pool;
+pub mod pooled_segment;
 pub mod struct_in_shm;
 tested_crate_module!(segment);
 pub(crate) mod cleanup;

--- a/commons/zenoh-shm/src/posix_shm/pool.rs
+++ b/commons/zenoh-shm/src/posix_shm/pool.rs
@@ -1,0 +1,84 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+use std::{
+    collections::HashMap,
+    num::NonZeroUsize,
+    sync::{Arc, RwLock},
+};
+
+use crossbeam_queue::ArrayQueue;
+
+use crate::api::protocol_implementations::posix::posix_shm_segment::PosixShmSegment;
+
+/// Per-size LIFO pool of idle SHM segments.
+///
+/// Segments are keyed by their exact byte count. When a segment is returned (`give`),
+/// it is pushed onto the per-size queue. When a segment is requested (`take`), the
+/// most-recently-returned segment of that exact size is popped out — keeping TLB and
+/// page-cache entries hot.
+///
+/// The hot path (`take` / `give` after warmup) requires only a read lock on the bucket
+/// map (shared, non-blocking) and a single CAS on the [`ArrayQueue`] — no mutex waiting
+/// even under concurrent access from multiple streams.
+///
+/// When the bucket is at capacity, `give` simply drops the segment, triggering the
+/// normal `munmap + shm_unlink` path (backpressure path only).
+pub(crate) struct ShmSegmentPool {
+    /// Map from exact segment size → bounded lock-free MPMC queue.
+    ///
+    /// New entries are inserted lazily under a write lock; after warmup the map is
+    /// stable and all accesses use the read lock (non-blocking, concurrent).
+    buckets: RwLock<HashMap<NonZeroUsize, Arc<ArrayQueue<Arc<PosixShmSegment>>>>>,
+    max_idle: usize,
+}
+
+impl ShmSegmentPool {
+    /// Create a new pool with the given per-size idle capacity.
+    pub(crate) fn new(max_idle: usize) -> Self {
+        Self {
+            buckets: RwLock::new(HashMap::new()),
+            max_idle,
+        }
+    }
+
+    /// Pop the most-recently-returned segment of exactly `size` bytes.
+    /// Returns `None` if the bucket is empty.
+    pub(crate) fn take(&self, size: NonZeroUsize) -> Option<Arc<PosixShmSegment>> {
+        // Read path: shared lock, non-blocking.
+        self.buckets.read().unwrap().get(&size)?.pop()
+    }
+
+    /// Return a segment to the pool. Drops (→ `munmap + shm_unlink`) if the bucket
+    /// is already at capacity.
+    pub(crate) fn give(&self, size: NonZeroUsize, seg: Arc<PosixShmSegment>) {
+        // Fast path: bucket already exists — shared read lock only.
+        {
+            let buckets = self.buckets.read().unwrap();
+            if let Some(queue) = buckets.get(&size) {
+                let _ = queue.push(seg);
+                // ArrayQueue::push returns Err(seg) when full → seg drops → munmap
+                return;
+            }
+        }
+
+        // Slow path: first segment of this size — insert a new queue under write lock.
+        let mut buckets = self.buckets.write().unwrap();
+        // Re-check after acquiring write lock (another thread may have inserted first).
+        let queue = buckets
+            .entry(size)
+            .or_insert_with(|| Arc::new(ArrayQueue::new(self.max_idle)));
+        let _ = queue.push(seg);
+    }
+}

--- a/commons/zenoh-shm/src/posix_shm/pooled_segment.rs
+++ b/commons/zenoh-shm/src/posix_shm/pooled_segment.rs
@@ -36,7 +36,11 @@ pub(crate) struct PooledPosixShmSegment {
 }
 
 impl PooledPosixShmSegment {
-    pub(crate) fn new(inner: Arc<PosixShmSegment>, size: NonZeroUsize, pool: Weak<ShmSegmentPool>) -> Self {
+    pub(crate) fn new(
+        inner: Arc<PosixShmSegment>,
+        size: NonZeroUsize,
+        pool: Weak<ShmSegmentPool>,
+    ) -> Self {
         Self { inner, size, pool }
     }
 }

--- a/commons/zenoh-shm/src/posix_shm/pooled_segment.rs
+++ b/commons/zenoh-shm/src/posix_shm/pooled_segment.rs
@@ -17,9 +17,8 @@ use std::{
     sync::{Arc, Weak},
 };
 
-use crate::api::protocol_implementations::posix::posix_shm_segment::PosixShmSegment;
-
 use super::pool::ShmSegmentPool;
+use crate::api::protocol_implementations::posix::posix_shm_segment::PosixShmSegment;
 
 /// A wrapper around [`Arc<PosixShmSegment>`] whose `Drop` implementation returns the
 /// segment to the pool instead of unmapping it.

--- a/commons/zenoh-shm/src/posix_shm/pooled_segment.rs
+++ b/commons/zenoh-shm/src/posix_shm/pooled_segment.rs
@@ -1,0 +1,51 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+use std::{
+    num::NonZeroUsize,
+    sync::{Arc, Weak},
+};
+
+use crate::api::protocol_implementations::posix::posix_shm_segment::PosixShmSegment;
+
+use super::pool::ShmSegmentPool;
+
+/// A wrapper around [`Arc<PosixShmSegment>`] whose `Drop` implementation returns the
+/// segment to the pool instead of unmapping it.
+///
+/// When the last [`ZSlice`] referencing a message drops, this wrapper's `Drop` fires.
+/// If the parent [`ShmSegmentPool`] is still alive (the `Weak` reference upgrades), the
+/// segment is pushed back to the pool for reuse on the next allocation of the same size.
+/// If the pool has been dropped (the `Weak` upgrade fails), the inner `Arc` simply drops
+/// normally, triggering `munmap + shm_unlink`.
+pub(crate) struct PooledPosixShmSegment {
+    pub(crate) inner: Arc<PosixShmSegment>,
+    size: NonZeroUsize,
+    pool: Weak<ShmSegmentPool>,
+}
+
+impl PooledPosixShmSegment {
+    pub(crate) fn new(inner: Arc<PosixShmSegment>, size: NonZeroUsize, pool: Weak<ShmSegmentPool>) -> Self {
+        Self { inner, size, pool }
+    }
+}
+
+impl Drop for PooledPosixShmSegment {
+    fn drop(&mut self) {
+        if let Some(pool) = self.pool.upgrade() {
+            pool.give(self.size, self.inner.clone());
+        }
+        // If pool was dropped: inner Arc drops naturally → munmap + shm_unlink
+    }
+}

--- a/commons/zenoh-shm/tests/posix_shm_provider.rs
+++ b/commons/zenoh-shm/tests/posix_shm_provider.rs
@@ -215,7 +215,9 @@ fn shm_segment_pool_reuse() {
 
     let backend = PosixShmProviderBackendTalc::builder_with_pool(
         layout.size(),
-        ShmPoolConfig { max_idle_per_size: 1 },
+        ShmPoolConfig {
+            max_idle_per_size: 1,
+        },
     )
     .wait()
     .expect("Error creating pooled PosixShmProviderBackendTalc");
@@ -245,7 +247,9 @@ fn shm_segment_pool_cap_enforcement() {
 
     let backend = PosixShmProviderBackendTalc::builder_with_pool(
         layout.size(),
-        ShmPoolConfig { max_idle_per_size: 1 },
+        ShmPoolConfig {
+            max_idle_per_size: 1,
+        },
     )
     .wait()
     .expect("Error creating pooled PosixShmProviderBackendTalc");
@@ -257,14 +261,19 @@ fn shm_segment_pool_cap_enforcement() {
     let seg_b = chunk_b.descriptor.segment;
 
     // They should be distinct segments.
-    assert_ne!(seg_a, seg_b, "Expected two distinct segments for two concurrent allocs");
+    assert_ne!(
+        seg_a, seg_b,
+        "Expected two distinct segments for two concurrent allocs"
+    );
 
     // Drop both — pool can hold at most 1, so one is immediately unmapped.
     drop(chunk_a);
     drop(chunk_b);
 
     // The next allocation should return one of the two segments (whichever was retained).
-    let chunk_c = backend.alloc(&layout).expect("alloc c after cap test failed");
+    let chunk_c = backend
+        .alloc(&layout)
+        .expect("alloc c after cap test failed");
     let seg_c = chunk_c.descriptor.segment;
 
     // seg_c must be one of the two previously-seen IDs (pooled), not a fresh one.
@@ -282,12 +291,10 @@ fn shm_segment_pool_outlived_by_segment() {
     let layout = MemoryLayout::new(4096_usize, AllocAlignment::default()).unwrap();
 
     let chunk = {
-        let backend = PosixShmProviderBackendTalc::builder_with_pool(
-            layout.size(),
-            ShmPoolConfig::default(),
-        )
-        .wait()
-        .expect("Error creating pooled PosixShmProviderBackendTalc");
+        let backend =
+            PosixShmProviderBackendTalc::builder_with_pool(layout.size(), ShmPoolConfig::default())
+                .wait()
+                .expect("Error creating pooled PosixShmProviderBackendTalc");
 
         let chunk = backend.alloc(&layout).expect("alloc failed");
         // backend (and its Arc<ShmSegmentPool>) drops here

--- a/commons/zenoh-shm/tests/posix_shm_provider.rs
+++ b/commons/zenoh-shm/tests/posix_shm_provider.rs
@@ -19,7 +19,7 @@ use zenoh_shm::api::{
         posix_shm_client::PosixShmClient,
         posix_shm_provider_backend_binary_heap::PosixShmProviderBackendBinaryHeap,
         posix_shm_provider_backend_buddy::PosixShmProviderBackendBuddy,
-        posix_shm_provider_backend_talc::PosixShmProviderBackendTalc,
+        posix_shm_provider_backend_talc::{PosixShmProviderBackendTalc, ShmPoolConfig},
     },
     provider::{
         memory_layout::MemoryLayout, shm_provider_backend::ShmProviderBackend,
@@ -202,4 +202,100 @@ fn posix_shm_provider_talc_allocator() {
     while let Some(buffer) = buffers.pop() {
         backend.free(&buffer.descriptor);
     }
+}
+
+// ── Pool tests ─────────────────────────────────────────────────────────────
+
+/// Allocate a buffer, drop it so the segment is returned to the pool, then allocate
+/// again with the same size. The second allocation must reuse the same SHM segment
+/// (same SegmentID) — no new shm_open.
+#[test]
+fn shm_segment_pool_reuse() {
+    let layout = MemoryLayout::new(4096_usize, AllocAlignment::default()).unwrap();
+
+    let backend = PosixShmProviderBackendTalc::builder_with_pool(
+        layout.size(),
+        ShmPoolConfig { max_idle_per_size: 1 },
+    )
+    .wait()
+    .expect("Error creating pooled PosixShmProviderBackendTalc");
+
+    // First allocation — creates a new segment.
+    let chunk1 = backend.alloc(&layout).expect("first alloc failed");
+    let seg_id_first = chunk1.descriptor.segment;
+
+    // Drop the chunk — PooledPosixShmSegment::drop should return it to the pool.
+    drop(chunk1);
+
+    // Second allocation of the same size — must reuse the pooled segment.
+    let chunk2 = backend.alloc(&layout).expect("second alloc failed");
+    let seg_id_second = chunk2.descriptor.segment;
+
+    assert_eq!(
+        seg_id_first, seg_id_second,
+        "Expected pool to reuse the segment (same SegmentID), but got a new one"
+    );
+}
+
+/// With max_idle=1, returning two segments of the same size should drop the second
+/// one immediately (munmap), keeping only one in the pool.
+#[test]
+fn shm_segment_pool_cap_enforcement() {
+    let layout = MemoryLayout::new(4096_usize, AllocAlignment::default()).unwrap();
+
+    let backend = PosixShmProviderBackendTalc::builder_with_pool(
+        layout.size(),
+        ShmPoolConfig { max_idle_per_size: 1 },
+    )
+    .wait()
+    .expect("Error creating pooled PosixShmProviderBackendTalc");
+
+    // Allocate two chunks (two distinct segments).
+    let chunk_a = backend.alloc(&layout).expect("alloc a failed");
+    let chunk_b = backend.alloc(&layout).expect("alloc b failed");
+    let seg_a = chunk_a.descriptor.segment;
+    let seg_b = chunk_b.descriptor.segment;
+
+    // They should be distinct segments.
+    assert_ne!(seg_a, seg_b, "Expected two distinct segments for two concurrent allocs");
+
+    // Drop both — pool can hold at most 1, so one is immediately unmapped.
+    drop(chunk_a);
+    drop(chunk_b);
+
+    // The next allocation should return one of the two segments (whichever was retained).
+    let chunk_c = backend.alloc(&layout).expect("alloc c after cap test failed");
+    let seg_c = chunk_c.descriptor.segment;
+
+    // seg_c must be one of the two previously-seen IDs (pooled), not a fresh one.
+    assert!(
+        seg_c == seg_a || seg_c == seg_b,
+        "Expected reuse of a pooled segment, but got a fresh segment id {seg_c}"
+    );
+}
+
+/// Drop the provider (which holds the Arc<ShmSegmentPool>), then drop a chunk that
+/// still holds a Weak<ShmSegmentPool>. The Weak upgrade must fail gracefully — no
+/// panic, no use-after-free.
+#[test]
+fn shm_segment_pool_outlived_by_segment() {
+    let layout = MemoryLayout::new(4096_usize, AllocAlignment::default()).unwrap();
+
+    let chunk = {
+        let backend = PosixShmProviderBackendTalc::builder_with_pool(
+            layout.size(),
+            ShmPoolConfig::default(),
+        )
+        .wait()
+        .expect("Error creating pooled PosixShmProviderBackendTalc");
+
+        let chunk = backend.alloc(&layout).expect("alloc failed");
+        // backend (and its Arc<ShmSegmentPool>) drops here
+        chunk
+    };
+
+    // chunk still holds a PtrInSegment → Arc<PooledPosixShmSegment>.
+    // Dropping it now: Weak::upgrade fails → segment drops normally (munmap).
+    // This must not panic.
+    drop(chunk);
 }

--- a/commons/zenoh-shm/tests/posix_shm_provider.rs
+++ b/commons/zenoh-shm/tests/posix_shm_provider.rs
@@ -290,16 +290,13 @@ fn shm_segment_pool_cap_enforcement() {
 fn shm_segment_pool_outlived_by_segment() {
     let layout = MemoryLayout::new(4096_usize, AllocAlignment::default()).unwrap();
 
-    let chunk = {
-        let backend =
-            PosixShmProviderBackendTalc::builder_with_pool(layout.size(), ShmPoolConfig::default())
-                .wait()
-                .expect("Error creating pooled PosixShmProviderBackendTalc");
-
-        let chunk = backend.alloc(&layout).expect("alloc failed");
-        // backend (and its Arc<ShmSegmentPool>) drops here
-        chunk
-    };
+    let backend =
+        PosixShmProviderBackendTalc::builder_with_pool(layout.size(), ShmPoolConfig::default())
+            .wait()
+            .expect("Error creating pooled PosixShmProviderBackendTalc");
+    let chunk = backend.alloc(&layout).expect("alloc failed");
+    // backend (and its Arc<ShmSegmentPool>) drops here
+    drop(backend);
 
     // chunk still holds a PtrInSegment → Arc<PooledPosixShmSegment>.
     // Dropping it now: Weak::upgrade fails → segment drops normally (munmap).

--- a/commons/zenoh-sync/Cargo.toml
+++ b/commons/zenoh-sync/Cargo.toml
@@ -31,6 +31,7 @@ version = { workspace = true }
 [dependencies]
 arc-swap = { workspace = true }
 event-listener = { workspace = true }
+parking_lot = { workspace = true }
 futures = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 zenoh-buffers = { workspace = true }
@@ -38,6 +39,7 @@ zenoh-collections = { workspace = true, features = ["default"] }
 zenoh-core = { workspace = true }
 
 [dev-dependencies]
+criterion = { workspace = true }
 tokio = { workspace = true, features = [
   "macros",
   "rt-multi-thread",
@@ -45,3 +47,7 @@ tokio = { workspace = true, features = [
   "time",
 ] }
 zenoh-result = { workspace = true }
+
+[[bench]]
+name = "notify_wait"
+harness = false

--- a/commons/zenoh-sync/Cargo.toml
+++ b/commons/zenoh-sync/Cargo.toml
@@ -31,8 +31,8 @@ version = { workspace = true }
 [dependencies]
 arc-swap = { workspace = true }
 event-listener = { workspace = true }
-parking_lot = { workspace = true }
 futures = { workspace = true }
+parking_lot = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 zenoh-buffers = { workspace = true }
 zenoh-collections = { workspace = true, features = ["default"] }
@@ -49,5 +49,5 @@ tokio = { workspace = true, features = [
 zenoh-result = { workspace = true }
 
 [[bench]]
-name = "notify_wait"
 harness = false
+name = "notify_wait"

--- a/commons/zenoh-sync/benches/notify_wait.rs
+++ b/commons/zenoh-sync/benches/notify_wait.rs
@@ -1,0 +1,116 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+//! Benchmark: Notifier/Waiter notification round-trip.
+//!
+//! Measures two paths through the synchronisation primitive:
+//!
+//! `notify_wait/sticky` — producer calls `notify()` before the consumer calls
+//!   `wait()`. The flag is already set so `wait()` returns without blocking.
+//!   This is the common case in the transport pipeline when the batch is ready
+//!   before the tx thread checks. Hot path: lock + flag check + unlock (no
+//!   condvar sleep).
+//!
+//! `notify_wait/cross_thread` — a dedicated notifier thread signals the
+//!   measured thread. `wait()` actually blocks on the condvar until the signal
+//!   arrives. Measures true cross-thread wakeup latency.
+//!
+//! # Regression baseline (event_listener, before this PR)
+//!
+//! Profiling a zenoh SHM publisher at 1 MB / 100 Hz showed `event_listener` taking
+//! **12.18% CPU** in `drop_in_place::<EventListener>` on the sender thread —
+//! heap-allocating and dropping a linked-list node on *every* batch send cycle.
+//!
+//! Expected results after this PR (Mutex+Condvar):
+//!   sticky:       ~20–50 ns   (lock + flag + unlock, no allocation)
+//!   cross_thread: ~2–10 µs    (futex wakeup round-trip)
+//!
+//! Run with:
+//!   cargo bench --bench notify_wait -p zenoh-sync
+
+use std::{
+    sync::{Arc, Barrier},
+    thread,
+    time::{Duration, Instant},
+};
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use zenoh_sync::event;
+
+/// Sticky path: notify() fires before wait() — no blocking, just flag check.
+///
+/// Represents the hot path when the batch is already ready when the tx thread
+/// wakes up. Before this PR: EventListener allocated on the heap every cycle.
+/// After: lock + u8 check + unlock.
+fn bench_sticky(c: &mut Criterion) {
+    let mut group = c.benchmark_group("notify_wait");
+    group.throughput(Throughput::Elements(1));
+
+    group.bench_function(BenchmarkId::new("sticky", ""), |b| {
+        let (notifier, waiter) = event::new();
+        b.iter(|| {
+            notifier.notify().unwrap();
+            waiter.wait().unwrap();
+        });
+    });
+
+    group.finish();
+}
+
+/// Cross-thread path: waiter blocks until a dedicated notifier thread fires.
+///
+/// Measures the full condvar wakeup round-trip between two threads. Uses
+/// a Barrier to ensure the waiter is sleeping before notify() fires, giving
+/// a clean measurement of the unpark/futex latency.
+fn bench_cross_thread(c: &mut Criterion) {
+    let mut group = c.benchmark_group("notify_wait");
+    group.throughput(Throughput::Elements(1));
+
+    group.bench_function(BenchmarkId::new("cross_thread", ""), |b| {
+        b.iter_custom(|iters| {
+            // Barrier: ensures waiter is blocked before notifier fires.
+            let barrier = Arc::new(Barrier::new(2));
+
+            let (notifier, waiter) = event::new();
+            let notifier = Arc::new(notifier);
+
+            let notifier_thread = {
+                let notifier = Arc::clone(&notifier);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    for _ in 0..iters {
+                        barrier.wait(); // wait until waiter is about to block
+                        notifier.notify().unwrap();
+                    }
+                })
+            };
+
+            let mut total = Duration::ZERO;
+            for _ in 0..iters {
+                barrier.wait(); // signal notifier thread we're ready
+                let start = Instant::now();
+                waiter.wait().unwrap();
+                total += start.elapsed();
+            }
+
+            notifier_thread.join().unwrap();
+            total
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_sticky, bench_cross_thread);
+criterion_main!(benches);

--- a/commons/zenoh-sync/src/event.rs
+++ b/commons/zenoh-sync/src/event.rs
@@ -14,13 +14,11 @@
 use std::{
     fmt,
     sync::{
-        atomic::{AtomicU16, AtomicU8, Ordering},
-        Arc,
+        atomic::{AtomicU16, Ordering},
+        Arc, Condvar, Mutex,
     },
     time::{Duration, Instant},
 };
-
-use event_listener::{Event as EventLib, Listener};
 
 // Error types
 const WAIT_ERR_STR: &str = "No notifier available";
@@ -103,92 +101,55 @@ impl fmt::Debug for NotifyError {
 
 impl std::error::Error for NotifyError {}
 
-// Inner
+// State values stored inside the mutex.
+const UNSET: u8 = 0;
+const OK: u8 = 1;
+const ERR: u8 = 2;
+
+// Replace event_listener::Event + AtomicU8 with std Mutex<u8> + Condvar.
+// This eliminates per-wait EventListener allocation and intrusive-list
+// register/deregister cost on the transport pipeline hot path.
 struct EventInner {
-    event: EventLib,
-    flag: AtomicU8,
+    state: Mutex<u8>,
+    cv: Condvar,
     notifiers: AtomicU16,
     waiters: AtomicU16,
 }
 
-const UNSET: u8 = 0;
-const OK: u8 = 1;
-const ERR: u8 = 1 << 1;
-
-#[repr(u8)]
-enum EventCheck {
-    Unset = UNSET,
-    Ok = OK,
-    Err = ERR,
-}
-
-#[repr(u8)]
-enum EventSet {
-    Ok = OK,
-    Err = ERR,
-}
-
-impl EventInner {
-    fn check(&self) -> EventCheck {
-        let f = self.flag.fetch_and(!OK, Ordering::SeqCst);
-        if f & ERR != 0 {
-            return EventCheck::Err;
-        }
-        if f == OK {
-            return EventCheck::Ok;
-        }
-        EventCheck::Unset
-    }
-
-    fn set(&self) -> EventSet {
-        let f = self.flag.fetch_or(OK, Ordering::SeqCst);
-        if f & ERR != 0 {
-            return EventSet::Err;
-        }
-        EventSet::Ok
-    }
-
-    fn err(&self) {
-        self.flag.store(ERR, Ordering::SeqCst);
-    }
-}
-
-/// Creates a new lock-free event variable. Every time a [`Notifier`] calls ['Notifier::notify`], one [`Waiter`] will be waken-up.
-/// If no waiter is waiting when the `notify` is called, the notification will not be lost. That means the next waiter will return
-/// immediately when calling `wait`.
+/// Creates a new event variable. Every time a [`Notifier`] calls
+/// [`Notifier::notify`], one [`Waiter`] will be woken up. Notifications are
+/// sticky: if no waiter is blocking when `notify` is called, the next `wait`
+/// call returns immediately.
 pub fn new() -> (Notifier, Waiter) {
     let inner = Arc::new(EventInner {
-        event: EventLib::new(),
-        flag: AtomicU8::new(UNSET),
+        state: Mutex::new(UNSET),
+        cv: Condvar::new(),
         notifiers: AtomicU16::new(1),
         waiters: AtomicU16::new(1),
     });
     (Notifier(inner.clone()), Waiter(inner))
 }
 
-/// A [`Notifier`] is used to notify and wake up one and only one [`Waiter`].
+/// A [`Notifier`] wakes up one [`Waiter`].
 #[repr(transparent)]
 pub struct Notifier(Arc<EventInner>);
 
 impl Notifier {
-    /// Notifies one pending listener
     #[inline]
     pub fn notify(&self) -> Result<(), NotifyError> {
-        // Set the flag.
-        match self.0.set() {
-            EventSet::Ok => {
-                self.0.event.notify_additional_relaxed(1);
-                Ok(())
-            }
-            EventSet::Err => Err(NotifyError),
+        let mut state = self.0.state.lock().unwrap();
+        if *state == ERR {
+            return Err(NotifyError);
         }
+        *state = OK;
+        self.0.cv.notify_one();
+        Ok(())
     }
 }
 
 impl Clone for Notifier {
     fn clone(&self) -> Self {
         let n = self.0.notifiers.fetch_add(1, Ordering::SeqCst);
-        // Panic on overflow
         assert!(n != 0);
         Self(self.0.clone())
     }
@@ -198,9 +159,10 @@ impl Drop for Notifier {
     fn drop(&mut self) {
         let n = self.0.notifiers.fetch_sub(1, Ordering::SeqCst);
         if n == 1 {
-            // The last Notifier has been dropped, close the event and notify everyone
-            self.0.err();
-            self.0.event.notify(usize::MAX);
+            // Last notifier dropped — wake all waiters with error.
+            let mut state = self.0.state.lock().unwrap();
+            *state = ERR;
+            self.0.cv.notify_all();
         }
     }
 }
@@ -209,131 +171,67 @@ impl Drop for Notifier {
 pub struct Waiter(Arc<EventInner>);
 
 impl Waiter {
-    /// Waits for the condition to be notified
-    #[inline]
-    pub async fn wait_async(&self) -> Result<(), WaitError> {
-        // Wait until the flag is set.
-        loop {
-            // Check the flag.
-            match self.0.check() {
-                EventCheck::Ok => break,
-                EventCheck::Unset => {}
-                EventCheck::Err => return Err(WaitError),
-            }
-
-            // Start listening for events.
-            let listener = self.0.event.listen();
-
-            // Check the flag again after creating the listener.
-            match self.0.check() {
-                EventCheck::Ok => break,
-                EventCheck::Unset => {}
-                EventCheck::Err => return Err(WaitError),
-            }
-
-            // Wait for a notification and continue the loop.
-            listener.await;
-        }
-
-        Ok(())
-    }
-
-    /// Waits for the condition to be notified
     #[inline]
     pub fn wait(&self) -> Result<(), WaitError> {
-        // Wait until the flag is set.
+        let mut state = self.0.state.lock().unwrap();
         loop {
-            // Check the flag.
-            match self.0.check() {
-                EventCheck::Ok => break,
-                EventCheck::Unset => {}
-                EventCheck::Err => return Err(WaitError),
+            match *state {
+                OK => { *state = UNSET; return Ok(()); }
+                ERR => return Err(WaitError),
+                _ => { state = self.0.cv.wait(state).unwrap(); }
             }
-
-            // Start listening for events.
-            let listener = self.0.event.listen();
-
-            // Check the flag again after creating the listener.
-            match self.0.check() {
-                EventCheck::Ok => break,
-                EventCheck::Unset => {}
-                EventCheck::Err => return Err(WaitError),
-            }
-
-            // Wait for a notification and continue the loop.
-            listener.wait();
         }
-
-        Ok(())
     }
 
-    /// Waits for the condition to be notified or returns an error when the deadline is reached
+    #[inline]
+    pub async fn wait_async(&self) -> Result<(), WaitError> {
+        let waiter = self.clone();
+        tokio::task::spawn_blocking(move || waiter.wait())
+            .await
+            .unwrap_or(Err(WaitError))
+    }
+
     #[inline]
     pub fn wait_deadline(&self, deadline: Instant) -> Result<(), WaitDeadlineError> {
-        // Wait until the flag is set.
+        let mut state = self.0.state.lock().unwrap();
         loop {
-            // Check the flag.
-            match self.0.check() {
-                EventCheck::Ok => break,
-                EventCheck::Unset => {}
-                EventCheck::Err => return Err(WaitDeadlineError::WaitError),
-            }
-
-            // Start listening for events.
-            let listener = self.0.event.listen();
-
-            // Check the flag again after creating the listener.
-            match self.0.check() {
-                EventCheck::Ok => break,
-                EventCheck::Unset => {}
-                EventCheck::Err => return Err(WaitDeadlineError::WaitError),
-            }
-
-            // Wait for a notification and continue the loop.
-            if listener.wait_deadline(deadline).is_none() {
-                return Err(WaitDeadlineError::Deadline);
+            match *state {
+                OK => { *state = UNSET; return Ok(()); }
+                ERR => return Err(WaitDeadlineError::WaitError),
+                _ => {
+                    let now = Instant::now();
+                    if now >= deadline {
+                        return Err(WaitDeadlineError::Deadline);
+                    }
+                    let (new_state, timeout) = self.0.cv
+                        .wait_timeout(state, deadline - now)
+                        .unwrap();
+                    state = new_state;
+                    if timeout.timed_out() {
+                        return match *state {
+                            OK => { *state = UNSET; Ok(()) }
+                            ERR => Err(WaitDeadlineError::WaitError),
+                            _ => Err(WaitDeadlineError::Deadline),
+                        };
+                    }
+                }
             }
         }
-
-        Ok(())
     }
 
-    /// Waits for the condition to be notified or returns an error when the timeout is expired
     #[inline]
     pub fn wait_timeout(&self, timeout: Duration) -> Result<(), WaitTimeoutError> {
-        // Wait until the flag is set.
-        loop {
-            // Check the flag.
-            match self.0.check() {
-                EventCheck::Ok => break,
-                EventCheck::Unset => {}
-                EventCheck::Err => return Err(WaitTimeoutError::WaitError),
-            }
-
-            // Start listening for events.
-            let listener = self.0.event.listen();
-
-            // Check the flag again after creating the listener.
-            match self.0.check() {
-                EventCheck::Ok => break,
-                EventCheck::Unset => {}
-                EventCheck::Err => return Err(WaitTimeoutError::WaitError),
-            }
-
-            // Wait for a notification and continue the loop.
-            if listener.wait_timeout(timeout).is_none() {
-                return Err(WaitTimeoutError::Timeout);
-            }
+        match self.wait_deadline(Instant::now() + timeout) {
+            Ok(()) => Ok(()),
+            Err(WaitDeadlineError::Deadline) => Err(WaitTimeoutError::Timeout),
+            Err(WaitDeadlineError::WaitError) => Err(WaitTimeoutError::WaitError),
         }
-
-        Ok(())
     }
 }
 
 impl Clone for Waiter {
     fn clone(&self) -> Self {
         let n = self.0.waiters.fetch_add(1, Ordering::Relaxed);
-        // Panic on overflow
         assert!(n != 0);
         Self(self.0.clone())
     }
@@ -343,12 +241,13 @@ impl Drop for Waiter {
     fn drop(&mut self) {
         let n = self.0.waiters.fetch_sub(1, Ordering::SeqCst);
         if n == 1 {
-            // The last Waiter has been dropped, close the event
-            self.0.err();
+            let mut state = self.0.state.lock().unwrap();
+            *state = ERR;
         }
     }
 }
 
+#[cfg(test)]
 mod tests {
     #[test]
     fn event_timeout() {
@@ -356,7 +255,6 @@ mod tests {
             sync::{Arc, Barrier},
             time::Duration,
         };
-
         use crate::WaitTimeoutError;
 
         let barrier = Arc::new(Barrier::new(2));
@@ -365,57 +263,38 @@ mod tests {
 
         let bs = barrier.clone();
         let s = std::thread::spawn(move || {
-            // 1 - Wait one notification
             match waiter.wait_timeout(tslot) {
                 Ok(()) => {}
                 Err(WaitTimeoutError::Timeout) => panic!("Timeout {tslot:#?}"),
                 Err(WaitTimeoutError::WaitError) => panic!("Event closed"),
             }
-
             bs.wait();
-
-            // 2 - Being notified twice but waiting only once
             bs.wait();
-
             match waiter.wait_timeout(tslot) {
                 Ok(()) => {}
                 Err(WaitTimeoutError::Timeout) => panic!("Timeout {tslot:#?}"),
                 Err(WaitTimeoutError::WaitError) => panic!("Event closed"),
             }
-
             match waiter.wait_timeout(tslot) {
                 Ok(()) => panic!("Event Ok but it should be Timeout"),
                 Err(WaitTimeoutError::Timeout) => {}
                 Err(WaitTimeoutError::WaitError) => panic!("Event closed"),
             }
-
             bs.wait();
-
-            // 3 - Notifier has been dropped
             bs.wait();
-
             waiter.wait().unwrap_err();
-
             bs.wait();
         });
 
         let bp = barrier.clone();
         let p = std::thread::spawn(move || {
-            // 1 - Notify once
             notifier.notify().unwrap();
-
             bp.wait();
-
-            // 2 - Notify twice
             notifier.notify().unwrap();
             notifier.notify().unwrap();
-
             bp.wait();
             bp.wait();
-
-            // 3 - Drop notifier yielding an error in the waiter
             drop(notifier);
-
             bp.wait();
             bp.wait();
         });
@@ -430,7 +309,6 @@ mod tests {
             sync::{Arc, Barrier},
             time::{Duration, Instant},
         };
-
         use crate::WaitDeadlineError;
 
         let barrier = Arc::new(Barrier::new(2));
@@ -439,57 +317,38 @@ mod tests {
 
         let bs = barrier.clone();
         let s = std::thread::spawn(move || {
-            // 1 - Wait one notification
             match waiter.wait_deadline(Instant::now() + tslot) {
                 Ok(()) => {}
                 Err(WaitDeadlineError::Deadline) => panic!("Timeout {tslot:#?}"),
                 Err(WaitDeadlineError::WaitError) => panic!("Event closed"),
             }
-
             bs.wait();
-
-            // 2 - Being notified twice but waiting only once
             bs.wait();
-
             match waiter.wait_deadline(Instant::now() + tslot) {
                 Ok(()) => {}
                 Err(WaitDeadlineError::Deadline) => panic!("Timeout {tslot:#?}"),
                 Err(WaitDeadlineError::WaitError) => panic!("Event closed"),
             }
-
             match waiter.wait_deadline(Instant::now() + tslot) {
                 Ok(()) => panic!("Event Ok but it should be Timeout"),
                 Err(WaitDeadlineError::Deadline) => {}
                 Err(WaitDeadlineError::WaitError) => panic!("Event closed"),
             }
-
             bs.wait();
-
-            // 3 - Notifier has been dropped
             bs.wait();
-
             waiter.wait().unwrap_err();
-
             bs.wait();
         });
 
         let bp = barrier.clone();
         let p = std::thread::spawn(move || {
-            // 1 - Notify once
             notifier.notify().unwrap();
-
             bp.wait();
-
-            // 2 - Notify twice
             notifier.notify().unwrap();
             notifier.notify().unwrap();
-
             bp.wait();
             bp.wait();
-
-            // 3 - Drop notifier yielding an error in the waiter
             drop(notifier);
-
             bp.wait();
             bp.wait();
         });
@@ -533,13 +392,10 @@ mod tests {
         let tout = Duration::from_secs(60);
         loop {
             let n = COUNTER.load(Ordering::Relaxed);
-            if n == N {
-                break;
-            }
+            if n == N { break; }
             if start.elapsed() > tout {
                 panic!("Timeout {tout:#?}. Counter: {n}/{N}");
             }
-
             std::thread::sleep(Duration::from_millis(100));
         }
 
@@ -602,20 +458,16 @@ mod tests {
             let tout = Duration::from_secs(60);
             loop {
                 let n = COUNTER.load(Ordering::Relaxed);
-                if n == N {
-                    break;
-                }
+                if n == N { break; }
                 if start.elapsed() > tout {
                     panic!("Timeout {tout:#?}. Counter: {n}/{N}");
                 }
-
                 std::thread::sleep(Duration::from_millis(100));
             }
         });
 
         p1.join().unwrap();
         p2.join().unwrap();
-
         s1.join().unwrap();
         s2.join().unwrap();
     }

--- a/commons/zenoh-sync/src/event.rs
+++ b/commons/zenoh-sync/src/event.rs
@@ -15,11 +15,12 @@ use std::{
     fmt,
     pin::pin,
     sync::{
-        atomic::{AtomicU16, Ordering},
-        Arc, Condvar, Mutex,
+        atomic::{AtomicU16, AtomicU8, Ordering},
+        Arc,
     },
     time::{Duration, Instant},
 };
+use parking_lot::{Condvar, Mutex};
 use tokio::sync::Notify as AsyncNotify;
 
 // Error types
@@ -103,23 +104,32 @@ impl fmt::Debug for NotifyError {
 
 impl std::error::Error for NotifyError {}
 
-// State values for the sync Mutex<u8>.
+// State values for the AtomicU8 flag.
 const UNSET: u8 = 0;
 const OK: u8 = 1;
 const ERR: u8 = 2;
 
 // Replace event_listener::Event + AtomicU8 with:
-//   - std Mutex<u8> + Condvar  →  sync paths (wait / wait_deadline / wait_timeout)
-//   - tokio::sync::Notify      →  async path (wait_async), which is cancellation-safe
+//   - AtomicU8 flag + Mutex<()> + Condvar  →  sync paths (wait / wait_deadline / wait_timeout)
+//   - tokio::sync::Notify                  →  async path (wait_async), cancellation-safe
 //
-// The original event_listener approach allocated a linked-list node (EventListener)
-// on every wait() call and paid intrusive-list register/deregister cost on the hot path.
-// tokio::time::timeout() was also able to cancel wait_async() while its inner
-// spawn_blocking task continued running, eventually consuming the next real notification
-// (a "zombie" thread bug). tokio::sync::Notify avoids this: a dropped Notified future
-// returns its permit to the pool so no notification is lost.
+// Hot-path design (sticky notification):
+//
+//   notify():  flag.fetch_update(UNSET|OK → OK) [atomic, no lock]
+//              + brief lock()/unlock() to prevent lost wakeup
+//              + cv.notify_one() + async_notify.notify_one()
+//
+//   wait():    flag.compare_exchange(OK → UNSET) [atomic, no lock]  ← hot path returns here
+//              If UNSET: lock() → re-check flag → cv.wait() if still UNSET
+//
+// The mutex is only taken on the slow (blocking) path and briefly in notify() to
+// fence against the lost-wakeup window. No heap allocation on either path.
 struct EventInner {
-    state: Mutex<u8>,
+    /// Primary state. Written atomically on hot path; also read under `mutex`
+    /// on the slow path to re-check after wakeup.
+    flag: AtomicU8,
+    /// Used exclusively as the condvar lock. Carries no state of its own.
+    mutex: Mutex<()>,
     cv: Condvar,
     async_notify: AsyncNotify,
     notifiers: AtomicU16,
@@ -132,7 +142,8 @@ struct EventInner {
 /// call returns immediately.
 pub fn new() -> (Notifier, Waiter) {
     let inner = Arc::new(EventInner {
-        state: Mutex::new(UNSET),
+        flag: AtomicU8::new(UNSET),
+        mutex: Mutex::new(()),
         cv: Condvar::new(),
         async_notify: AsyncNotify::new(),
         notifiers: AtomicU16::new(1),
@@ -148,13 +159,24 @@ pub struct Notifier(Arc<EventInner>);
 impl Notifier {
     #[inline]
     pub fn notify(&self) -> Result<(), NotifyError> {
-        let mut state = self.0.state.lock().unwrap();
-        if *state == ERR {
-            return Err(NotifyError);
-        }
-        *state = OK;
+        // Atomically set flag to OK unless it is already ERR (terminal state).
+        // fetch_update returns Err if the closure returns None (i.e. flag == ERR).
+        self.0
+            .flag
+            .fetch_update(Ordering::Release, Ordering::Relaxed, |f| {
+                if f == ERR { None } else { Some(OK) }
+            })
+            .map_err(|_| NotifyError)?;
+
+        // Brief lock/unlock to close the lost-wakeup window.
+        //
+        // A waiter on the slow path does: CAS-fails → lock() → re-check flag → cv.wait().
+        // By taking the lock here we ensure either:
+        //   (a) waiter has not yet called lock() → it will see OK on its flag re-check, or
+        //   (b) waiter is already in cv.wait() → cv.notify_one() below will wake it.
+        drop(self.0.mutex.lock());
+
         self.0.cv.notify_one();
-        drop(state); // release before async notify to minimise lock contention
         self.0.async_notify.notify_one();
         Ok(())
     }
@@ -172,12 +194,11 @@ impl Drop for Notifier {
     fn drop(&mut self) {
         let n = self.0.notifiers.fetch_sub(1, Ordering::SeqCst);
         if n == 1 {
-            // Last notifier dropped — signal error to all waiters.
-            let mut state = self.0.state.lock().unwrap();
-            *state = ERR;
+            // Last notifier dropped — set ERR and wake all waiters.
+            self.0.flag.store(ERR, Ordering::Release);
+            drop(self.0.mutex.lock()); // lost-wakeup fence
             self.0.cv.notify_all();
-            drop(state);
-            self.0.async_notify.notify_waiters(); // wake all async waiters
+            self.0.async_notify.notify_waiters();
         }
     }
 }
@@ -188,12 +209,29 @@ pub struct Waiter(Arc<EventInner>);
 impl Waiter {
     #[inline]
     pub fn wait(&self) -> Result<(), WaitError> {
-        let mut state = self.0.state.lock().unwrap();
+        // Hot path: consume a sticky OK notification without taking the lock.
+        match self
+            .0
+            .flag
+            .compare_exchange(OK, UNSET, Ordering::Acquire, Ordering::Relaxed)
+        {
+            Ok(_) => return Ok(()),
+            Err(ERR) => return Err(WaitError),
+            Err(_) => {} // UNSET → fall through to slow path
+        }
+
+        // Slow path: take the lock and block on the condvar.
+        let mut guard = self.0.mutex.lock();
         loop {
-            match *state {
-                OK => { *state = UNSET; return Ok(()); }
+            match self.0.flag.load(Ordering::Acquire) {
+                OK => {
+                    self.0.flag.store(UNSET, Ordering::Release);
+                    return Ok(());
+                }
                 ERR => return Err(WaitError),
-                _ => { state = self.0.cv.wait(state).unwrap(); }
+                _ => {
+                    self.0.cv.wait(&mut guard);
+                }
             }
         }
     }
@@ -206,19 +244,21 @@ impl Waiter {
     #[inline]
     pub async fn wait_async(&self) -> Result<(), WaitError> {
         loop {
-            // Create and enable the Notified future BEFORE checking state.
-            // enable() subscribes to the Notify and consumes any stored permit,
-            // so a notify_one() that fires between here and the .await is not lost.
+            // Subscribe BEFORE checking the flag.
+            // enable() ensures that any notify_one() fired after this point wakes us,
+            // and consumes any stored permit if notify_one() already fired.
             let mut notified = pin!(self.0.async_notify.notified());
             notified.as_mut().enable();
 
+            // Hot path: consume sticky OK without lock.
+            match self
+                .0
+                .flag
+                .compare_exchange(OK, UNSET, Ordering::Acquire, Ordering::Relaxed)
             {
-                let mut state = self.0.state.lock().unwrap();
-                match *state {
-                    OK => { *state = UNSET; return Ok(()); }
-                    ERR => return Err(WaitError),
-                    _ => {}
-                }
+                Ok(_) => return Ok(()),
+                Err(ERR) => return Err(WaitError),
+                Err(_) => {}
             }
 
             // No pending notification — await (cancellation-safe).
@@ -230,23 +270,38 @@ impl Waiter {
 
     #[inline]
     pub fn wait_deadline(&self, deadline: Instant) -> Result<(), WaitDeadlineError> {
-        let mut state = self.0.state.lock().unwrap();
+        // Hot path.
+        match self
+            .0
+            .flag
+            .compare_exchange(OK, UNSET, Ordering::Acquire, Ordering::Relaxed)
+        {
+            Ok(_) => return Ok(()),
+            Err(ERR) => return Err(WaitDeadlineError::WaitError),
+            Err(_) => {}
+        }
+
+        // Slow path.
+        let mut guard = self.0.mutex.lock();
         loop {
-            match *state {
-                OK => { *state = UNSET; return Ok(()); }
+            match self.0.flag.load(Ordering::Acquire) {
+                OK => {
+                    self.0.flag.store(UNSET, Ordering::Release);
+                    return Ok(());
+                }
                 ERR => return Err(WaitDeadlineError::WaitError),
                 _ => {
                     let now = Instant::now();
                     if now >= deadline {
                         return Err(WaitDeadlineError::Deadline);
                     }
-                    let (new_state, timeout) = self.0.cv
-                        .wait_timeout(state, deadline - now)
-                        .unwrap();
-                    state = new_state;
-                    if timeout.timed_out() {
-                        return match *state {
-                            OK => { *state = UNSET; Ok(()) }
+                    let timed_out = self.0.cv.wait_for(&mut guard, deadline - now).timed_out();
+                    if timed_out {
+                        return match self.0.flag.load(Ordering::Acquire) {
+                            OK => {
+                                self.0.flag.store(UNSET, Ordering::Release);
+                                Ok(())
+                            }
                             ERR => Err(WaitDeadlineError::WaitError),
                             _ => Err(WaitDeadlineError::Deadline),
                         };
@@ -278,10 +333,9 @@ impl Drop for Waiter {
     fn drop(&mut self) {
         let n = self.0.waiters.fetch_sub(1, Ordering::SeqCst);
         if n == 1 {
-            let mut state = self.0.state.lock().unwrap();
-            *state = ERR;
+            self.0.flag.store(ERR, Ordering::Release);
+            drop(self.0.mutex.lock()); // lost-wakeup fence
             self.0.cv.notify_all();
-            drop(state);
             self.0.async_notify.notify_waiters();
         }
     }

--- a/commons/zenoh-sync/src/event.rs
+++ b/commons/zenoh-sync/src/event.rs
@@ -13,12 +13,14 @@
 //
 use std::{
     fmt,
+    pin::pin,
     sync::{
         atomic::{AtomicU16, Ordering},
         Arc, Condvar, Mutex,
     },
     time::{Duration, Instant},
 };
+use tokio::sync::Notify as AsyncNotify;
 
 // Error types
 const WAIT_ERR_STR: &str = "No notifier available";
@@ -101,17 +103,25 @@ impl fmt::Debug for NotifyError {
 
 impl std::error::Error for NotifyError {}
 
-// State values stored inside the mutex.
+// State values for the sync Mutex<u8>.
 const UNSET: u8 = 0;
 const OK: u8 = 1;
 const ERR: u8 = 2;
 
-// Replace event_listener::Event + AtomicU8 with std Mutex<u8> + Condvar.
-// This eliminates per-wait EventListener allocation and intrusive-list
-// register/deregister cost on the transport pipeline hot path.
+// Replace event_listener::Event + AtomicU8 with:
+//   - std Mutex<u8> + Condvar  →  sync paths (wait / wait_deadline / wait_timeout)
+//   - tokio::sync::Notify      →  async path (wait_async), which is cancellation-safe
+//
+// The original event_listener approach allocated a linked-list node (EventListener)
+// on every wait() call and paid intrusive-list register/deregister cost on the hot path.
+// tokio::time::timeout() was also able to cancel wait_async() while its inner
+// spawn_blocking task continued running, eventually consuming the next real notification
+// (a "zombie" thread bug). tokio::sync::Notify avoids this: a dropped Notified future
+// returns its permit to the pool so no notification is lost.
 struct EventInner {
     state: Mutex<u8>,
     cv: Condvar,
+    async_notify: AsyncNotify,
     notifiers: AtomicU16,
     waiters: AtomicU16,
 }
@@ -124,6 +134,7 @@ pub fn new() -> (Notifier, Waiter) {
     let inner = Arc::new(EventInner {
         state: Mutex::new(UNSET),
         cv: Condvar::new(),
+        async_notify: AsyncNotify::new(),
         notifiers: AtomicU16::new(1),
         waiters: AtomicU16::new(1),
     });
@@ -143,6 +154,8 @@ impl Notifier {
         }
         *state = OK;
         self.0.cv.notify_one();
+        drop(state); // release before async notify to minimise lock contention
+        self.0.async_notify.notify_one();
         Ok(())
     }
 }
@@ -159,10 +172,12 @@ impl Drop for Notifier {
     fn drop(&mut self) {
         let n = self.0.notifiers.fetch_sub(1, Ordering::SeqCst);
         if n == 1 {
-            // Last notifier dropped — wake all waiters with error.
+            // Last notifier dropped — signal error to all waiters.
             let mut state = self.0.state.lock().unwrap();
             *state = ERR;
             self.0.cv.notify_all();
+            drop(state);
+            self.0.async_notify.notify_waiters(); // wake all async waiters
         }
     }
 }
@@ -183,12 +198,34 @@ impl Waiter {
         }
     }
 
+    /// Cancellation-safe async wait.
+    ///
+    /// Uses [`tokio::sync::Notify`] so that if this future is dropped (e.g. by
+    /// `tokio::time::timeout`), the pending notification is returned to the pool
+    /// rather than silently consumed by a detached `spawn_blocking` thread.
     #[inline]
     pub async fn wait_async(&self) -> Result<(), WaitError> {
-        let waiter = self.clone();
-        tokio::task::spawn_blocking(move || waiter.wait())
-            .await
-            .unwrap_or(Err(WaitError))
+        loop {
+            // Create and enable the Notified future BEFORE checking state.
+            // enable() subscribes to the Notify and consumes any stored permit,
+            // so a notify_one() that fires between here and the .await is not lost.
+            let mut notified = pin!(self.0.async_notify.notified());
+            notified.as_mut().enable();
+
+            {
+                let mut state = self.0.state.lock().unwrap();
+                match *state {
+                    OK => { *state = UNSET; return Ok(()); }
+                    ERR => return Err(WaitError),
+                    _ => {}
+                }
+            }
+
+            // No pending notification — await (cancellation-safe).
+            // If this future is dropped here, the Notified future is dropped too,
+            // which returns any pre-reserved permit to the Notify pool.
+            notified.await;
+        }
     }
 
     #[inline]
@@ -243,6 +280,9 @@ impl Drop for Waiter {
         if n == 1 {
             let mut state = self.0.state.lock().unwrap();
             *state = ERR;
+            self.0.cv.notify_all();
+            drop(state);
+            self.0.async_notify.notify_waiters();
         }
     }
 }

--- a/commons/zenoh-sync/src/event.rs
+++ b/commons/zenoh-sync/src/event.rs
@@ -20,6 +20,7 @@ use std::{
     },
     time::{Duration, Instant},
 };
+
 use parking_lot::{Condvar, Mutex};
 use tokio::sync::Notify as AsyncNotify;
 
@@ -164,7 +165,11 @@ impl Notifier {
         self.0
             .flag
             .fetch_update(Ordering::Release, Ordering::Relaxed, |f| {
-                if f == ERR { None } else { Some(OK) }
+                if f == ERR {
+                    None
+                } else {
+                    Some(OK)
+                }
             })
             .map_err(|_| NotifyError)?;
 
@@ -349,6 +354,7 @@ mod tests {
             sync::{Arc, Barrier},
             time::Duration,
         };
+
         use crate::WaitTimeoutError;
 
         let barrier = Arc::new(Barrier::new(2));
@@ -403,6 +409,7 @@ mod tests {
             sync::{Arc, Barrier},
             time::{Duration, Instant},
         };
+
         use crate::WaitDeadlineError;
 
         let barrier = Arc::new(Barrier::new(2));
@@ -486,7 +493,9 @@ mod tests {
         let tout = Duration::from_secs(60);
         loop {
             let n = COUNTER.load(Ordering::Relaxed);
-            if n == N { break; }
+            if n == N {
+                break;
+            }
             if start.elapsed() > tout {
                 panic!("Timeout {tout:#?}. Counter: {n}/{N}");
             }
@@ -552,7 +561,9 @@ mod tests {
             let tout = Duration::from_secs(60);
             loop {
                 let n = COUNTER.load(Ordering::Relaxed);
-                if n == N { break; }
+                if n == N {
+                    break;
+                }
                 if start.elapsed() > tout {
                     panic!("Timeout {tout:#?}. Counter: {n}/{N}");
                 }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -177,3 +177,8 @@ required-features = ["shared-memory", "unstable"]
 name = "z_posix_shm_provider"
 path = "examples/z_posix_shm_provider.rs"
 required-features = ["shared-memory", "unstable"]
+
+[[example]]
+name = "z_posix_shm_provider_pooled"
+path = "examples/z_posix_shm_provider_pooled.rs"
+required-features = ["shared-memory", "unstable"]

--- a/examples/examples/z_posix_shm_provider_pooled.rs
+++ b/examples/examples/z_posix_shm_provider_pooled.rs
@@ -1,0 +1,80 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+//! Demonstrates [`PosixShmProviderBackend`] with the segment pool enabled.
+//!
+//! The pool reuses SHM segments across allocations, turning the hot path from
+//! `shm_open + mmap` (~314 µs) into a single `ArrayQueue` CAS (~134 ns).
+//!
+//! # When to use `builder_with_pool`
+//!
+//! Use the pool when:
+//! - you allocate and free fixed-size buffers at high rate (e.g. pub/sub throughput)
+//! - profiling shows `__dquot_alloc_space` or `shm_open` in your hot path
+//!
+//! Leave the pool off (use `builder`) when:
+//! - buffer sizes vary widely and a warm pool is unlikely
+//! - you are memory-constrained and cannot afford idle segments
+//!
+//! # Running
+//!
+//! ```bash
+//! cargo run --example z_posix_shm_provider_pooled --features unstable,shared-memory
+//! ```
+
+use zenoh::{
+    shm::{PosixShmProviderBackend, ShmPoolConfig, ShmProviderBuilder},
+    Wait,
+};
+
+fn main() {
+    // Buffer size used throughout this example.
+    let buf_size = 4096_usize;
+
+    // ------------------------------------------------------------------
+    // Build a backend with the segment pool enabled.
+    //
+    // `max_idle_per_size` caps how many idle segments of each size the pool
+    // holds.  A value of 4 means up to 4 free 4096-byte segments are kept
+    // warm; any beyond that are unmapped immediately on drop.
+    // ------------------------------------------------------------------
+    let pool_config = ShmPoolConfig {
+        max_idle_per_size: 4,
+    };
+    let backend = PosixShmProviderBackend::builder_with_pool(buf_size, pool_config)
+        .wait()
+        .expect("failed to create pooled PosixShmProviderBackend");
+
+    // Wrap in a provider (handles alignment, concurrency, and ZBytes integration).
+    let provider = ShmProviderBuilder::backend(backend).wait();
+
+    // ------------------------------------------------------------------
+    // Warm path: allocate, use, drop — segment is returned to the pool.
+    // The second and subsequent allocations reuse the pooled segment
+    // instead of calling shm_open + mmap again.
+    // ------------------------------------------------------------------
+    for i in 0..8_u8 {
+        let mut buf = provider
+            .alloc(buf_size)
+            .wait()
+            .unwrap_or_else(|_| panic!("alloc {i} failed"));
+
+        buf[0] = i;
+        println!("alloc {i}: buf[0] = {}", buf[0]);
+
+        // `buf` drops here — segment is returned to the pool.
+    }
+
+    println!("done");
+}

--- a/zenoh/tests/session.rs
+++ b/zenoh/tests/session.rs
@@ -421,6 +421,7 @@ async fn test_session_from_cloned_config() {
             .endpoints
             .set(vec![locator.parse().unwrap()])
             .unwrap();
+        pub_config.listen.endpoints.set(vec![]).unwrap();
 
         (pub_config, sub_config)
     };


### PR DESCRIPTION
## Summary

> **Stacks on #2513** — review that first; this PR's diff against `main` includes those commits too.

Add a lock-free segment pool to `PosixShmProviderBackendTalc` so that SHM segments are reused across sends instead of being created and destroyed per-message. Previously every send called `shm_open` + `mmap` + `ftruncate`, which incurred filesystem quota accounting (`__dquot_alloc_space` at ~10% CPU in profiling). The pool reduces the hot path to a single `ArrayQueue` CAS.

## Key Changes

- `commons/zenoh-shm/src/api/protocol_implementations/posix/posix_shm_provider_backend_talc.rs`: check pool first in `alloc`; `free` is a no-op when pool is active (segment returned on drop instead)
- `commons/zenoh-shm/src/api/protocol_implementations/posix/posix_shm_segment.rs`: expose `size()` accessor for pool keying
- `commons/zenoh-shm/src/posix_shm/pool.rs`: `ShmSegmentPool` — per-size `ArrayQueue` of idle segments; hot path is read lock + single CAS
- `commons/zenoh-shm/src/posix_shm/pooled_segment.rs`: `PooledPosixShmSegment` — `Drop` returns segment to pool instead of unmapping
- `commons/zenoh-shm/benches/shm_pool.rs`: criterion benchmark measuring cold (pool miss) and warm (pool hit) allocation latency

## Benchmark Results

| path | latency |
|---|---|
| cold (shm_open + mmap) | 314 µs |
| warm (pool hit, ArrayQueue CAS) | 134 ns |
| speedup | ~2340× |

Flamegraph: `__dquot_alloc_space` at 9.56% before (filesystem quota accounting per new segment), absent after.

### Reproducing

```bash
taskset -c 0,1 cargo bench -j4 -p zenoh-shm --bench shm_pool
```

Results land in `target/criterion/shm_pool/`.

## Breaking Changes

None

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `new feature`

## 🆕 New Feature Requirements

Since this PR adds a new feature:

- [x] **Feature scope documented** - Clear description of what the feature does and why it's needed
- [x] **Minimum necessary code** - Implementation is as simple as possible, doesn't overcomplicate the system
- [x] **New APIs well-designed** - Public APIs are intuitive, consistent with existing APIs
- [x] **Comprehensive tests** - All functionality is tested (happy path + edge cases + error cases)
- [x] **Examples provided** - Usage examples in code comments or separate example files
- [x] **Documentation added** - New docs explaining the feature, its use cases, and API
- [x] **Feature flag considered** - Can the feature be enabled/disabled for gradual rollout?
- [x] **Performance impact assessed** - Memory, CPU, storage implications measured
- [x] **Integration tested** - Feature works with existing features

**Consider:** Can this feature be split into smaller, incremental PRs?

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->