### PR TITLE
Enable unsafe_op_in_unsafe_fn by default.

### DIFF
--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -159,3 +159,5 @@ section = "net"
 unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(nolocal_thread_not_available)',
 ] }
+# This will be enabled by default in Edition 2024
+unsafe_op_in_unsafe_fn = "warn"

--- a/zenoh/src/api/key_expr.rs
+++ b/zenoh/src/api/key_expr.rs
@@ -110,7 +110,8 @@ impl KeyExpr<'static> {
     /// Messages addressed with invalid key expressions will be dropped.
     pub unsafe fn from_string_unchecked(s: String) -> Self {
         Self(KeyExprInner::Owned {
-            key_expr: OwnedKeyExpr::from_string_unchecked(s),
+            // SAFETY: caller upholds key expression invariants for `s`.
+            key_expr: unsafe { OwnedKeyExpr::from_string_unchecked(s) },
             declaration: None,
         })
     }
@@ -121,7 +122,8 @@ impl KeyExpr<'static> {
     /// Messages addressed with invalid key expressions will be dropped.
     pub unsafe fn from_boxed_str_unchecked(s: Box<str>) -> Self {
         Self(KeyExprInner::Owned {
-            key_expr: OwnedKeyExpr::from_boxed_str_unchecked(s),
+            // SAFETY: caller upholds key expression invariants for `s`.
+            key_expr: unsafe { OwnedKeyExpr::from_boxed_str_unchecked(s) },
             declaration: None,
         })
     }
@@ -207,7 +209,8 @@ impl<'a> KeyExpr<'a> {
     /// Key Expressions must follow some rules to be accepted by a Zenoh network.
     /// Messages addressed with invalid key expressions will be dropped.
     pub unsafe fn from_str_unchecked(s: &'a str) -> Self {
-        keyexpr::from_str_unchecked(s).into()
+        // SAFETY: caller upholds key expression invariants for `s`.
+        unsafe { keyexpr::from_str_unchecked(s).into() }
     }
 
     /// Returns the borrowed version of `self`


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->
The PR is to enable `unsafe_op_in_unsafe_fn=warn`, which is the default in Edition 2024.

### What does this PR do?
<!-- Describe the changes and their purpose -->
Fix the `unsafe fn` usage inside Zenoh

### Why is this change needed?
<!-- Explain the motivation or problem being solved -->
Ensure that we are using unsafe correctly.

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->
https://github.com/eclipse-zenoh/zenoh/issues/1684

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `enhancement`

## ✨ Enhancement Requirements

Since this PR enhances existing functionality:

- [x] **Enhancement scope documented** - Clear description of what is being improved
- [x] **Minimum necessary code** - Implementation is as simple as possible, doesn't overcomplicate the system
- [x] **Backwards compatible** - Existing code/APIs still work unchanged
- [x] **No new APIs added** - Only improving existing functionality
- [x] **Tests updated** - Existing tests pass, new test cases added if needed
- [x] **Performance improvement measured** - If applicable, before/after metrics provided
- [x] **Documentation updated** - Existing docs updated to reflect improvements
- [x] **User impact documented** - How users benefit from this enhancement

**Remember:** Enhancements should not introduce new APIs or breaking changes.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->