### PR TITLE
Fix the rustc-hash version 2.1.1 to make it compatible with 1.75

### DIFF
--- a/commons/zenoh-pinned-deps-1-75/Cargo.toml
+++ b/commons/zenoh-pinned-deps-1-75/Cargo.toml
@@ -92,6 +92,7 @@ ignored = [
   "potential_utf",
   "prost",
   "prost-derive",
+  "rustc-hash",
   "security-framework",
   "serde_spanned",
   "serde_with",


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->
While rustc-hash bumps to 2.1.2, it requires building with 1.77.
Fix it to 2.1.1 to make it compatible with 1.75.

### What does this PR do?
<!-- Describe the changes and their purpose -->
In the rustc-hash commit, they include the `rust-version = "1.77"`
https://github.com/rust-lang/rustc-hash/commit/211455cb398aa0a6d7b12e81941d4a062af54d8e
The PR is to deal with this issue.

### Why is this change needed?
<!-- Explain the motivation or problem being solved -->
The CI fails due to the compatibility issue

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->
