### PR TITLE
Pin rustc-hash

### DIFF
--- a/commons/zenoh-pinned-deps-1-75/Cargo.toml
+++ b/commons/zenoh-pinned-deps-1-75/Cargo.toml
@@ -47,6 +47,7 @@ pest_meta = "=2.8.0"
 potential_utf = "=0.1.0"
 prost = "=0.14.1"
 prost-derive = "=0.14.1"
+rustc-hash = "=2.1.1"
 serde_spanned = "=1.0.1"
 serde_with = "=3.14.1"
 serde_with_macros = "=3.14.1"
@@ -91,6 +92,7 @@ ignored = [
   "potential_utf",
   "prost",
   "prost-derive",
+  "rustc-hash",
   "security-framework",
   "serde_spanned",
   "serde_with",


### PR DESCRIPTION
Description

Pin rustc-hash to version 2.1.1

Why is this change needed?

To build zenoh with rust 1.75