### PR TITLE
Fix wrong link kind whitelisting when `QUIC_DATAGRAM` is compiled-out

### DIFF
--- a/io/zenoh-link/src/lib.rs
+++ b/io/zenoh-link/src/lib.rs
@@ -110,7 +110,7 @@ impl LinkKind {
                 #[cfg(all(feature = "transport_quic_datagram", not(feature = "transport_quic")))]
                 QUIC_DATAGRAM_LOCATOR_PREFIX => supported_links.push(LinkKind::QuicDatagram),
                 #[cfg(all(feature = "transport_quic", not(feature = "transport_quic_datagram")))]
-                QUIC_LOCATOR_PREFIX => supported_links.push(LinkKind::QuicDatagram),
+                QUIC_LOCATOR_PREFIX => supported_links.push(LinkKind::Quic),
                 #[cfg(all(feature = "transport_quic", feature = "transport_quic_datagram"))]
                 QUIC_LOCATOR_PREFIX => {
                     supported_links.push(LinkKind::Quic);


### PR DESCRIPTION
## Description
Fix bug in supported links computation for QUIC when QUIC_DATAGRAM transport is not compiled.

### Related Issues
Closes https://github.com/eclipse-zenoh/zenoh/issues/2506