### PR TITLE
Remove forgotten INFO event in `zenoh::net::protocol`

### DIFF
--- a/zenoh/src/net/protocol/network.rs
+++ b/zenoh/src/net/protocol/network.rs
@@ -717,7 +717,6 @@ impl Network {
                     let node = &mut self.graph[idx];
                     let oldsn = node.sn;
                     if oldsn < ls.sn {
-                        tracing::info!(target: "dbg", x=Option::<u8>::None, ?node.links, ?node.zid, ?ls.links, node.sn, ls.sn);
                         node.sn = ls.sn;
                         // NOTE(regions): only Gossip may send malformed messages with empty
                         // linkstate. These can be safely ignored since they don't occur in "full"


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->

I forgot a tracing INFO event in 84a1a431031a27886d5db2f3784e91b3d405a086.
