### PR TITLE
Add 'so_linger' configuration parameter

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -713,6 +713,8 @@
         // so_rcvbuf: 123456,
         /// Configure TCP write buffer size (bytes)
         // so_sndbuf: 123456,
+        /// Configure TCP linger timeout (seconds)
+        // so_linger: 10,
       },
       // // Configure optional TCP link specific parameters
       // tcp: {
@@ -722,6 +724,8 @@
       //   // so_rcvbuf: 123456,
       //   /// Configure TCP write buffer size (bytes)
       //   // so_sndbuf: 123456,
+      //   /// Configure TCP linger timeout (seconds)
+      //   // so_linger: 10,
       // },
     },
     /// Shared memory configuration.

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -768,6 +768,8 @@ validated_struct::validator! {
                     pub so_sndbuf: Option<u32>,
                     /// Configure TCP read buffer size
                     pub so_rcvbuf: Option<u32>,
+                    /// Configure TCP linger timeout
+                    pub so_linger: Option<u32>,
                     // Skip serializing field because they contain secrets
                     #[serde(skip_serializing)]
                     root_ca_certificate_base64: Option<SecretValue>,
@@ -786,6 +788,8 @@ validated_struct::validator! {
                     pub so_sndbuf: Option<u32>,
                     /// Configure TCP read buffer size
                     pub so_rcvbuf: Option<u32>,
+                    /// Configure TCP linger timeout
+                    pub so_linger: Option<u32>,
                 },
                 pub unixpipe: #[derive(Default)]
                 UnixPipeConf {

--- a/io/zenoh-link-commons/src/lib.rs
+++ b/io/zenoh-link-commons/src/lib.rs
@@ -52,6 +52,10 @@ pub const BIND_SOCKET: &str = "bind";
 pub const BIND_INTERFACE: &str = "iface";
 pub const TCP_SO_SND_BUF: &str = "so_sndbuf";
 pub const TCP_SO_RCV_BUF: &str = "so_rcvbuf";
+// The LINGER option causes the shutdown() call to block until (1) all application data is delivered
+// to the remote end or (2) a timeout expires. The timeout is expressed in seconds.
+// More info on the LINGER option and its dynamics can be found at:
+// https://blog.netherlabs.nl/articles/2009/01/18/the-ultimate-so_linger-page-or-why-is-my-tcp-not-reliable
 pub const TCP_SO_LINGER: &str = "so_linger";
 pub const DSCP: &str = "dscp";
 

--- a/io/zenoh-link-commons/src/lib.rs
+++ b/io/zenoh-link-commons/src/lib.rs
@@ -52,6 +52,7 @@ pub const BIND_SOCKET: &str = "bind";
 pub const BIND_INTERFACE: &str = "iface";
 pub const TCP_SO_SND_BUF: &str = "so_sndbuf";
 pub const TCP_SO_RCV_BUF: &str = "so_rcvbuf";
+pub const TCP_SO_LINGER: &str = "so_linger";
 pub const DSCP: &str = "dscp";
 
 #[derive(Clone, Debug, Serialize, Hash, PartialEq, Eq)]

--- a/io/zenoh-link-commons/src/tcp.rs
+++ b/io/zenoh-link-commons/src/tcp.rs
@@ -21,6 +21,7 @@ use crate::set_dscp;
 pub struct TcpSocketConfig<'a> {
     tx_buffer_size: Option<u32>,
     rx_buffer_size: Option<u32>,
+    linger_timeout: Option<u32>,
     iface: Option<&'a str>,
     bind_socket: Option<SocketAddr>,
     dscp: Option<u32>,
@@ -30,6 +31,7 @@ impl<'a> TcpSocketConfig<'a> {
     pub fn new(
         tx_buffer_size: Option<u32>,
         rx_buffer_size: Option<u32>,
+        linger_timeout: Option<u32>,
         iface: Option<&'a str>,
         bind_socket: Option<SocketAddr>,
         dscp: Option<u32>,
@@ -37,6 +39,7 @@ impl<'a> TcpSocketConfig<'a> {
         Self {
             tx_buffer_size,
             rx_buffer_size,
+            linger_timeout,
             iface,
             bind_socket,
             dscp,
@@ -121,6 +124,10 @@ impl<'a> TcpSocketConfig<'a> {
         }
         if let Some(size) = self.rx_buffer_size {
             socket.set_recv_buffer_size(size)?;
+        }
+        if let Some(timeout) = self.linger_timeout {
+            #[allow(deprecated)]
+            socket.set_linger(Some(std::time::Duration::from_secs(timeout as u64)))?;
         }
         if let Some(dscp) = self.dscp {
             set_dscp(&socket, *addr, dscp)?;

--- a/io/zenoh-links/zenoh-link-quic/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/lib.rs
@@ -73,11 +73,6 @@ impl LocatorInspector for QuicLocatorInspector {
 zconfigurable! {
     // Default MTU (QUIC PDU) in bytes.
     static ref QUIC_DEFAULT_MTU: BatchSize = QUIC_MAX_MTU;
-    // The LINGER option causes the shutdown() call to block until (1) all application data is delivered
-    // to the remote end or (2) a timeout expires. The timeout is expressed in seconds.
-    // More info on the LINGER option and its dynamics can be found at:
-    // https://blog.netherlabs.nl/articles/2009/01/18/the-ultimate-so_linger-page-or-why-is-my-tcp-not-reliable
-    static ref QUIC_LINGER_TIMEOUT: i32 = 10;
     // Amount of time in microseconds to throttle the accept loop upon an error.
     // Default set to 100 ms.
     static ref QUIC_ACCEPT_THROTTLE_TIME: u64 = 100_000;

--- a/io/zenoh-links/zenoh-link-quic_datagram/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-quic_datagram/src/lib.rs
@@ -74,11 +74,6 @@ impl LocatorInspector for QuicDatagramLocatorInspector {
 zconfigurable! {
     // Default MTU (QUIC PDU) in bytes.
     static ref QUIC_DATAGRAM_DEFAULT_MTU: BatchSize = QUIC_DATAGRAM_MAX_MTU;
-    // The LINGER option causes the shutdown() call to block until (1) all application data is delivered
-    // to the remote end or (2) a timeout expires. The timeout is expressed in seconds.
-    // More info on the LINGER option and its dynamics can be found at:
-    // https://blog.netherlabs.nl/articles/2009/01/18/the-ultimate-so_linger-page-or-why-is-my-tcp-not-reliable
-    static ref QUIC_DATAGRAM_LINGER_TIMEOUT: i32 = 10;
     // Amount of time in microseconds to throttle the accept loop upon an error.
     // Default set to 100 ms.
     static ref QUIC_DATAGRAM_ACCEPT_THROTTLE_TIME: u64 = 100_000;

--- a/io/zenoh-links/zenoh-link-tcp/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/lib.rs
@@ -74,11 +74,6 @@ impl LocatorInspector for TcpLocatorInspector {
 zconfigurable! {
     // Default MTU (TCP PDU) in bytes.
     static ref TCP_DEFAULT_MTU: BatchSize = TCP_MAX_MTU;
-    // The LINGER option causes the shutdown() call to block until (1) all application data is delivered
-    // to the remote end or (2) a timeout expires. The timeout is expressed in seconds.
-    // More info on the LINGER option and its dynamics can be found at:
-    // https://blog.netherlabs.nl/articles/2009/01/18/the-ultimate-so_linger-page-or-why-is-my-tcp-not-reliable
-    static ref TCP_LINGER_TIMEOUT: i32 = 10;
     // Amount of time in microseconds to throttle the accept loop upon an error.
     // Default set to 100 ms.
     static ref TCP_ACCEPT_THROTTLE_TIME: u64 = 100_000;

--- a/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
@@ -11,7 +11,7 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use std::{cell::UnsafeCell, convert::TryInto, fmt, net::SocketAddr, sync::Arc, time::Duration};
+use std::{cell::UnsafeCell, fmt, net::SocketAddr, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use tokio::{
@@ -31,7 +31,7 @@ use zenoh_result::{bail, zerror, Error as ZError, ZResult};
 
 use crate::{
     get_tcp_addrs, utils::TcpLinkConfig, TCP_ACCEPT_THROTTLE_TIME, TCP_DEFAULT_MTU,
-    TCP_LINGER_TIMEOUT, TCP_LOCATOR_PREFIX,
+    TCP_LOCATOR_PREFIX,
 };
 
 pub struct LinkUnicastTcp {
@@ -55,19 +55,6 @@ impl LinkUnicastTcp {
         if let Err(err) = socket.set_nodelay(true) {
             tracing::warn!(
                 "Unable to set NODEALY option on TCP link {} => {}: {}",
-                src_addr,
-                dst_addr,
-                err
-            );
-        }
-
-        // Set the TCP linger option
-        #[allow(deprecated)]
-        if let Err(err) = socket.set_linger(Some(Duration::from_secs(
-            (*TCP_LINGER_TIMEOUT).try_into().unwrap(),
-        ))) {
-            tracing::warn!(
-                "Unable to set LINGER option on TCP link {} => {}: {}",
                 src_addr,
                 dst_addr,
                 err

--- a/io/zenoh-links/zenoh-link-tcp/src/utils.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/utils.rs
@@ -16,7 +16,7 @@ use std::net::SocketAddr;
 use zenoh_config::Config as ZenohConfig;
 use zenoh_link_commons::{
     parse_dscp, tcp::TcpSocketConfig, ConfigurationInspector, BIND_INTERFACE, BIND_SOCKET,
-    TCP_SO_RCV_BUF, TCP_SO_SND_BUF,
+    TCP_SO_RCV_BUF, TCP_SO_SND_BUF, TCP_SO_LINGER
 };
 use zenoh_protocol::core::{parameters, Address, Config};
 use zenoh_result::{zerror, ZResult};
@@ -41,6 +41,11 @@ impl ConfigurationInspector<ZenohConfig> for TcpConfigurator {
             tx_buffer_size = size.to_string();
             ps.push((TCP_SO_SND_BUF, &tx_buffer_size));
         }
+        let linger_timeout;
+        if let Some(timeout) = c.so_linger() {
+            linger_timeout = timeout.to_string();
+            ps.push((TCP_SO_LINGER, &linger_timeout));
+        }
 
         Ok(parameters::from_iter(ps.drain(..)))
     }
@@ -49,6 +54,7 @@ impl ConfigurationInspector<ZenohConfig> for TcpConfigurator {
 pub(crate) struct TcpLinkConfig<'a> {
     pub(crate) rx_buffer_size: Option<u32>,
     pub(crate) tx_buffer_size: Option<u32>,
+    pub(crate) linger_timeout: Option<u32>,
     pub(crate) bind_iface: Option<&'a str>,
     pub(crate) bind_socket: Option<SocketAddr>,
     pub(crate) dscp: Option<u32>,
@@ -64,6 +70,7 @@ impl<'a> TcpLinkConfig<'a> {
         let mut tcp_config = Self {
             rx_buffer_size: None,
             tx_buffer_size: None,
+            linger_timeout: None,
             bind_iface: config.get(BIND_INTERFACE),
             bind_socket,
             dscp: parse_dscp(config)?,
@@ -81,6 +88,12 @@ impl<'a> TcpLinkConfig<'a> {
                     .map_err(|_| zerror!("Unknown TCP write buffer size argument: {}", size))?,
             );
         };
+        if let Some(timeout) = config.get(TCP_SO_LINGER) {
+            tcp_config.linger_timeout = Some(
+                timeout.parse()
+                    .map_err(|_| zerror!("Unknown TCP linger timeout argument: {}", timeout))?,
+            );
+        };
 
         Ok(tcp_config)
     }
@@ -91,6 +104,7 @@ impl<'a> From<TcpLinkConfig<'a>> for TcpSocketConfig<'a> {
         Self::new(
             value.tx_buffer_size,
             value.rx_buffer_size,
+            value.linger_timeout,
             value.bind_iface,
             value.bind_socket,
             value.dscp,

--- a/io/zenoh-links/zenoh-link-tls/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/lib.rs
@@ -73,11 +73,6 @@ impl LocatorInspector for TlsLocatorInspector {
 zconfigurable! {
     // Default MTU (TLS PDU) in bytes.
     static ref TLS_DEFAULT_MTU: BatchSize = TLS_MAX_MTU;
-    // The LINGER option causes the shutdown() call to block until (1) all application data is delivered
-    // to the remote end or (2) a timeout expires. The timeout is expressed in seconds.
-    // More info on the LINGER option and its dynamics can be found at:
-    // https://blog.netherlabs.nl/articles/2009/01/18/the-ultimate-so_linger-page-or-why-is-my-tcp-not-reliable
-    static ref TLS_LINGER_TIMEOUT: i32 = 10;
     // Amount of time in microseconds to throttle the accept loop upon an error.
     // Default set to 100 ms.
     static ref TLS_ACCEPT_THROTTLE_TIME: u64 = 100_000;

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -13,7 +13,6 @@
 //
 use std::{
     cell::UnsafeCell,
-    convert::TryInto,
     fmt::{self, Debug},
     net::SocketAddr,
     sync::Arc,
@@ -45,7 +44,7 @@ use zenoh_result::{zerror, ZResult};
 
 use crate::{
     utils::{get_tls_addr, get_tls_host, get_tls_server_name, TlsClientConfig, TlsServerConfig},
-    TLS_ACCEPT_THROTTLE_TIME, TLS_DEFAULT_MTU, TLS_LINGER_TIMEOUT, TLS_LOCATOR_PREFIX,
+    TLS_ACCEPT_THROTTLE_TIME, TLS_DEFAULT_MTU, TLS_LOCATOR_PREFIX,
 };
 
 #[derive(Default, Debug, PartialEq, Eq, Hash)]
@@ -91,19 +90,6 @@ impl LinkUnicastTls {
         if let Err(err) = tcp_stream.set_nodelay(true) {
             tracing::warn!(
                 "Unable to set NODEALY option on TLS link {} => {}: {}",
-                src_addr,
-                dst_addr,
-                err
-            );
-        }
-
-        // Set the TLS linger option
-        #[allow(deprecated)]
-        if let Err(err) = tcp_stream.set_linger(Some(Duration::from_secs(
-            (*TLS_LINGER_TIMEOUT).try_into().unwrap(),
-        ))) {
-            tracing::warn!(
-                "Unable to set LINGER option on TLS link {} => {}: {}",
                 src_addr,
                 dst_addr,
                 err

--- a/io/zenoh-links/zenoh-link-tls/src/utils.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/utils.rs
@@ -38,7 +38,7 @@ use zenoh_link_commons::{
         config::{self, *},
         WebPkiVerifierAnyServerName,
     },
-    ConfigurationInspector, BIND_INTERFACE, BIND_SOCKET, TCP_SO_RCV_BUF, TCP_SO_SND_BUF,
+    ConfigurationInspector, BIND_INTERFACE, BIND_SOCKET, TCP_SO_RCV_BUF, TCP_SO_SND_BUF, TCP_SO_LINGER,
 };
 use zenoh_protocol::core::{
     endpoint::{Address, Config},
@@ -168,6 +168,12 @@ impl ConfigurationInspector<ZenohConfig> for TlsConfigurator {
             ps.push((TCP_SO_SND_BUF, &tx_buffer_size));
         }
 
+        let linger_timeout;
+        if let Some(timeout) = c.so_linger() {
+            linger_timeout = timeout.to_string();
+            ps.push((TCP_SO_LINGER, &linger_timeout));
+        }
+
         Ok(parameters::from_iter(ps.drain(..)))
     }
 }
@@ -274,6 +280,13 @@ impl<'a> TlsServerConfig<'a> {
                     .map_err(|_| zerror!("Unknown TCP write buffer size argument: {}", size))?,
             );
         };
+        let mut linger_timeout = None;
+        if let Some(timeout) = config.get(TCP_SO_LINGER) {
+            linger_timeout = Some(
+                timeout.parse()
+                    .map_err(|_| zerror!("Unknown TCP linger timeout argument: {}", timeout))?,
+            );
+        }
         let mut bind_socket = None;
         if let Some(bind_socket_str) = config.get(BIND_SOCKET) {
             bind_socket = Some(get_tls_addr(&Address::from(bind_socket_str)).await?);
@@ -286,6 +299,7 @@ impl<'a> TlsServerConfig<'a> {
             tcp_socket_config: TcpSocketConfig::new(
                 tcp_tx_buffer_size,
                 tcp_rx_buffer_size,
+                linger_timeout,
                 config.get(BIND_INTERFACE),
                 bind_socket,
                 parse_dscp(config)?,
@@ -447,6 +461,13 @@ impl<'a> TlsClientConfig<'a> {
                     .map_err(|_| zerror!("Unknown TCP write buffer size argument: {}", size))?,
             );
         };
+        let mut linger_timeout = None;
+        if let Some(timeout) = config.get(TCP_SO_LINGER) {
+            linger_timeout = Some(
+                timeout.parse()
+                    .map_err(|_| zerror!("Unknown TCP linger timeout argument: {}", timeout))?,
+            );
+        }
         let mut bind_socket = None;
         if let Some(bind_socket_str) = config.get(BIND_SOCKET) {
             bind_socket = Some(get_tls_addr(&Address::from(bind_socket_str)).await?);
@@ -458,6 +479,7 @@ impl<'a> TlsClientConfig<'a> {
             tcp_socket_config: TcpSocketConfig::new(
                 tcp_tx_buffer_size,
                 tcp_rx_buffer_size,
+                linger_timeout,
                 config.get(BIND_INTERFACE),
                 bind_socket,
                 parse_dscp(config)?,


### PR DESCRIPTION
## Description
Adding the 'so_linger' parameter to set the SO_LINGER of the TCP sockets using config files or locator expressions.

### What does this PR do?
Making configurable the SO_LINGER parameter for TCP connections, the default value is None.

### Why is this change needed?
The current version sets statically the SO_LINGER to 10 seconds.

### Related Issues
Motivated by my concern in [this Discord thread](https://discord.com/channels/914168414178779197/1451977572471668839) and related to #2350 issue.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `enhancement`

## ✨ Enhancement Requirements

Since this PR enhances existing functionality:

- [ ] **Enhancement scope documented** - Clear description of what is being improved
- [ ] **Minimum necessary code** - Implementation is as simple as possible, doesn't overcomplicate the system
- [ ] **Backwards compatible** - Existing code/APIs still work unchanged
- [ ] **No new APIs added** - Only improving existing functionality
- [ ] **Tests updated** - Existing tests pass, new test cases added if needed
- [ ] **Performance improvement measured** - If applicable, before/after metrics provided
- [ ] **Documentation updated** - Existing docs updated to reflect improvements
- [ ] **User impact documented** - How users benefit from this enhancement

**Remember:** Enhancements should not introduce new APIs or breaking changes.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->