### PR TITLE
feat(examples): add key expression argument to z_pub_thr and z_sub_thr

### DIFF
--- a/examples/examples/z_pub_shm_thr.rs
+++ b/examples/examples/z_pub_shm_thr.rs
@@ -12,14 +12,16 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use clap::Parser;
-use zenoh::{bytes::ZBytes, qos::CongestionControl, shm::ShmProviderBuilder, Config, Wait};
+use zenoh::{
+    bytes::ZBytes, key_expr::KeyExpr, qos::CongestionControl, shm::ShmProviderBuilder, Config, Wait,
+};
 use zenoh_examples::CommonArgs;
 
 #[tokio::main]
 async fn main() {
     // initiate logging
     zenoh::init_log_from_env_or("error");
-    let (config, sm_size, size) = parse_args();
+    let (config, sm_size, size, key_expr) = parse_args();
 
     let z = zenoh::open(config).await.unwrap();
 
@@ -37,7 +39,7 @@ async fn main() {
     }
 
     let publisher = z
-        .declare_publisher("test/thr")
+        .declare_publisher(key_expr)
         // Make sure to not drop messages because of congestion control
         .congestion_control(CongestionControl::Block)
         .await
@@ -59,13 +61,17 @@ struct Args {
     shared_memory: usize,
     /// Sets the size of the payload to publish.
     payload_size: usize,
+    /// The key expression to be used for the throuput test
+    #[arg(short, long, default_value = "test/thr")]
+    key_expr: KeyExpr<'static>,
+    ///Common args for all examples
     #[command(flatten)]
     common: CommonArgs,
 }
 
-fn parse_args() -> (Config, usize, usize) {
+fn parse_args() -> (Config, usize, usize, KeyExpr<'static>) {
     let args = Args::parse();
     let sm_size = args.shared_memory * 1024 * 1024;
     let size = args.payload_size;
-    (args.common.into(), sm_size, size)
+    (args.common.into(), sm_size, size, args.key_expr)
 }

--- a/examples/examples/z_pub_shm_thr.rs
+++ b/examples/examples/z_pub_shm_thr.rs
@@ -61,7 +61,7 @@ struct Args {
     shared_memory: usize,
     /// Sets the size of the payload to publish.
     payload_size: usize,
-    /// The key expression to be used for the throuput test
+    /// The key expression to be used for the throughput test
     #[arg(short, long, default_value = "test/thr")]
     key_expr: KeyExpr<'static>,
     ///Common args for all examples

--- a/examples/examples/z_pub_thr.rs
+++ b/examples/examples/z_pub_thr.rs
@@ -17,6 +17,7 @@ use std::convert::TryInto;
 use clap::Parser;
 use zenoh::{
     bytes::ZBytes,
+    key_expr::KeyExpr,
     qos::{CongestionControl, Priority},
     Wait,
 };
@@ -42,7 +43,7 @@ fn main() {
     let session = zenoh::open(args.common).wait().unwrap();
 
     let publisher = session
-        .declare_publisher("test/thr")
+        .declare_publisher(args.key_expr)
         .congestion_control(CongestionControl::Block)
         .priority(prio)
         .express(args.express)
@@ -84,6 +85,10 @@ struct Args {
     number: usize,
     /// Sets the size of the payload to publish
     payload_size: usize,
+    /// The key expression to be used for the throuput test
+    #[arg(short, long, default_value = "test/thr")]
+    key_expr: KeyExpr<'static>,
+    ///Common args for all examples
     #[command(flatten)]
     common: CommonArgs,
 }

--- a/examples/examples/z_pub_thr.rs
+++ b/examples/examples/z_pub_thr.rs
@@ -85,7 +85,7 @@ struct Args {
     number: usize,
     /// Sets the size of the payload to publish
     payload_size: usize,
-    /// The key expression to be used for the throuput test
+    /// The key expression to be used for the throughput test
     #[arg(short, long, default_value = "test/thr")]
     key_expr: KeyExpr<'static>,
     ///Common args for all examples

--- a/examples/examples/z_sub_thr.rs
+++ b/examples/examples/z_sub_thr.rs
@@ -14,7 +14,7 @@
 use std::time::Instant;
 
 use clap::Parser;
-use zenoh::{Config, Wait};
+use zenoh::{key_expr::KeyExpr, Wait};
 use zenoh_examples::CommonArgs;
 
 struct Stats {
@@ -71,24 +71,22 @@ fn main() {
     // initiate logging
     zenoh::init_log_from_env_or("error");
 
-    let (config, m, n) = parse_args();
+    let args = Args::parse();
 
-    let session = zenoh::open(config).wait().unwrap();
+    let session = zenoh::open(args.common).wait().unwrap();
 
-    let key_expr = "test/thr";
-
-    let mut stats = Stats::new(n);
+    let mut stats = Stats::new(args.number);
     session
-        .declare_subscriber(key_expr)
+        .declare_subscriber(args.key_expr)
         .callback_mut(move |_sample| {
             stats.increment();
-            if stats.finished_rounds >= m {
+            if stats.finished_rounds >= args.samples {
                 std::process::exit(0)
             }
         })
         .background()
         .wait()
-        .unwrap();
+        .expect("Failed to open Zenoh session");
 
     println!("Press CTRL-C to quit...");
     std::thread::park();
@@ -102,11 +100,10 @@ struct Args {
     #[arg(short, long, default_value = "100000")]
     /// Number of messages in each throughput measurements.
     number: usize,
+    /// The key expression to be used for the throuput test
+    #[arg(short, long, default_value = "test/thr")]
+    key_expr: KeyExpr<'static>,
+    ///Common args for all examples
     #[command(flatten)]
     common: CommonArgs,
-}
-
-fn parse_args() -> (Config, usize, usize) {
-    let args = Args::parse();
-    (args.common.into(), args.samples, args.number)
 }

--- a/examples/examples/z_sub_thr.rs
+++ b/examples/examples/z_sub_thr.rs
@@ -100,7 +100,7 @@ struct Args {
     #[arg(short, long, default_value = "100000")]
     /// Number of messages in each throughput measurements.
     number: usize,
-    /// The key expression to be used for the throuput test
+    /// The key expression to be used for the throughput test
     #[arg(short, long, default_value = "test/thr")]
     key_expr: KeyExpr<'static>,
     ///Common args for all examples


### PR DESCRIPTION
## Description
Allow users to specify a custom key expression for the throughput examples via a CLI argument. This makes it possible to benchmark router throughput scaling across multiple instances using either shared or distinct key expressions without modifying the source.

### What does this PR do?
See above.

### Why is this change needed?
Because otherwise it is not possible to run throughput test on a user specified key-expr.

### Related Issues
Closes #2548

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `new feature`

## 🆕 New Feature Requirements

Since this PR adds a new feature:

- [ ] **Feature scope documented** - Clear description of what the feature does and why it's needed
- [ ] **Minimum necessary code** - Implementation is as simple as possible, doesn't overcomplicate the system
- [ ] **New APIs well-designed** - Public APIs are intuitive, consistent with existing APIs
- [ ] **Comprehensive tests** - All functionality is tested (happy path + edge cases + error cases)
- [ ] **Examples provided** - Usage examples in code comments or separate example files
- [ ] **Documentation added** - New docs explaining the feature, its use cases, and API
- [ ] **Feature flag considered** - Can the feature be enabled/disabled for gradual rollout?
- [ ] **Performance impact assessed** - Memory, CPU, storage implications measured
- [ ] **Integration tested** - Feature works with existing features

**Consider:** Can this feature be split into smaller, incremental PRs?

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->