### PR TITLE
Avoid port collision with the common test framework (final round)

### DIFF
--- a/zenoh/tests/acl.rs
+++ b/zenoh/tests/acl.rs
@@ -14,13 +14,17 @@
 
 #![cfg(feature = "unstable")]
 #![cfg(target_family = "unix")]
+mod common;
+
 use std::{
     sync::{atomic::AtomicBool, Arc, Mutex},
     time::Duration,
 };
 
+use common::TestSessions;
 use tokio::runtime::Handle;
-use zenoh::{config::WhatAmI, sample::SampleKind, Config, Session};
+use zenoh::{config::WhatAmI, sample::SampleKind};
+use zenoh_config::Config;
 use zenoh_core::{zlock, ztimeout};
 
 const TIMEOUT: Duration = Duration::from_secs(60);
@@ -32,105 +36,105 @@ const VALUE: &str = "zenoh";
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_acl_config() {
     zenoh::init_log_from_env_or("error");
-    test_acl_config_format(27446).await;
+    test_acl_config_format().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_acl_pub_sub() {
     zenoh::init_log_from_env_or("error");
-    test_pub_sub_deny(27447).await;
-    test_pub_sub_allow(27447).await;
-    test_pub_sub_deny_then_allow(27447).await;
-    test_pub_sub_allow_then_deny(27447).await;
+    test_pub_sub_deny().await;
+    test_pub_sub_allow().await;
+    test_pub_sub_deny_then_allow().await;
+    test_pub_sub_allow_then_deny().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_acl_get_queryable() {
     zenoh::init_log_from_env_or("error");
-    test_get_qbl_deny(27448).await;
-    test_get_qbl_allow(27448).await;
-    test_get_qbl_allow_then_deny(27448).await;
-    test_get_qbl_deny_then_allow(27448).await;
+    test_get_qbl_deny().await;
+    test_get_qbl_allow().await;
+    test_get_qbl_allow_then_deny().await;
+    test_get_qbl_deny_then_allow().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_acl_queryable_reply() {
     zenoh::init_log_from_env_or("error");
     // Only test cases not covered by `test_acl_get_queryable`
-    test_reply_deny(27449).await;
-    test_reply_allow_then_deny(27449).await;
+    test_reply_deny().await;
+    test_reply_allow_then_deny().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_acl_liveliness() {
     zenoh::init_log_from_env_or("error");
 
-    test_liveliness_allow(27450).await;
-    test_liveliness_deny(27450).await;
+    test_liveliness_allow().await;
+    test_liveliness_deny().await;
 
-    test_liveliness_allow_deny_token(27450).await;
-    test_liveliness_deny_allow_token(27450).await;
+    test_liveliness_allow_deny_token().await;
+    test_liveliness_deny_allow_token().await;
 
-    test_liveliness_allow_deny_sub(27450).await;
-    test_liveliness_deny_allow_sub(27450).await;
+    test_liveliness_allow_deny_sub().await;
+    test_liveliness_deny_allow_sub().await;
 
-    test_liveliness_allow_deny_query(27450).await;
-    test_liveliness_deny_allow_query(27450).await;
+    test_liveliness_allow_deny_query().await;
+    test_liveliness_deny_allow_query().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_acl_interface_names() {
     zenoh::init_log_from_env_or("error");
 
-    test_pub_sub_network_interface(27451).await;
+    test_pub_sub_network_interface().await;
 }
 
-async fn get_basic_router_config(port: u16) -> Config {
+async fn get_basic_router_config() -> Config {
     let mut config = Config::default();
     config.set_mode(Some(WhatAmI::Router)).unwrap();
     config
         .listen
         .endpoints
-        .set(vec![format!("tcp/127.0.0.1:{port}").parse().unwrap()])
+        .set(vec!["tcp/127.0.0.1:0".parse().unwrap()])
         .unwrap();
     config.scouting.multicast.set_enabled(Some(false)).unwrap();
     config
 }
 
-async fn get_basic_client_config(port: u16) -> Config {
-    let mut config = Config::default();
+fn get_basic_client_config(test_context: &TestSessions) -> Config {
+    let mut config = test_context.get_connector_config();
     config.set_mode(Some(WhatAmI::Client)).unwrap();
     config
-        .connect
-        .endpoints
-        .set(vec![format!("tcp/127.0.0.1:{port}").parse().unwrap()])
-        .unwrap();
-    config.scouting.multicast.set_enabled(Some(false)).unwrap();
+}
+
+fn get_loopback_client_config(test_context: &TestSessions) -> Config {
+    let loopback_locators = test_context
+        .locators()
+        .into_iter()
+        .filter_map(|locator| {
+            let port = locator.address().as_str().rsplit(':').next()?;
+            format!("tcp/127.0.0.1:{port}").parse().ok()
+        })
+        .collect();
+    let mut config = test_context.get_connector_config_with_endpoint(loopback_locators);
+    config.set_mode(Some(WhatAmI::Client)).unwrap();
     config
 }
 
-async fn close_router_session(s: Session) {
-    println!("Closing router session");
-    ztimeout!(s.close()).unwrap();
-}
-
-async fn get_client_sessions(port: u16) -> (Session, Session) {
+async fn get_client_sessions(test_context: &mut TestSessions) -> (zenoh::Session, zenoh::Session) {
     println!("Opening client sessions");
-
-    let s01 = ztimeout!(zenoh::open(get_basic_client_config(port).await)).unwrap();
-    let s02 = ztimeout!(zenoh::open(get_basic_client_config(port).await)).unwrap();
+    let s01 = test_context
+        .open_connector_with_cfg(get_basic_client_config(test_context))
+        .await;
+    let s02 = test_context
+        .open_connector_with_cfg(get_basic_client_config(test_context))
+        .await;
     (s01, s02)
 }
 
-async fn close_sessions(s01: Session, s02: Session) {
-    println!("Closing client sessions");
-    ztimeout!(s01.close()).unwrap();
-    ztimeout!(s02.close()).unwrap();
-}
-
-async fn test_acl_config_format(port: u16) {
+async fn test_acl_config_format() {
     println!("test_acl_config_format");
-    let mut config_router = get_basic_router_config(port).await;
+    let mut config_router = get_basic_router_config().await;
 
     // missing lists
     config_router
@@ -379,10 +383,11 @@ async fn test_acl_config_format(port: u16) {
         .is_err());
 }
 
-async fn test_pub_sub_deny(port: u16) {
+async fn test_pub_sub_deny() {
     println!("test_pub_sub_deny");
+    let mut test_context = TestSessions::new();
 
-    let mut config_router = get_basic_router_config(port).await;
+    let mut config_router = get_basic_router_config().await;
     config_router
         .insert_json5(
             "access_control",
@@ -397,9 +402,14 @@ async fn test_pub_sub_deny(port: u16) {
         .unwrap();
     println!("Opening router session");
 
-    let session = ztimeout!(zenoh::open(config_router)).unwrap();
-
-    let (sub_session, pub_session) = get_client_sessions(port).await;
+    let _session = test_context.open_listener_with_cfg(config_router).await;
+    println!("Opening client sessions");
+    let sub_session = test_context
+        .open_connector_with_cfg(get_loopback_client_config(&test_context))
+        .await;
+    let pub_session = test_context
+        .open_connector_with_cfg(get_loopback_client_config(&test_context))
+        .await;
     {
         let publisher = pub_session.declare_publisher(KEY_EXPR).await.unwrap();
         let received_value = Arc::new(Mutex::new(String::new()));
@@ -431,13 +441,13 @@ async fn test_pub_sub_deny(port: u16) {
         assert!(!(*zlock!(deleted)));
         ztimeout!(subscriber.undeclare()).unwrap();
     }
-    close_sessions(sub_session, pub_session).await;
-    close_router_session(session).await;
+    test_context.close().await;
 }
 
-async fn test_pub_sub_allow(port: u16) {
+async fn test_pub_sub_allow() {
     println!("test_pub_sub_allow");
-    let mut config_router = get_basic_router_config(port).await;
+    let mut test_context = TestSessions::new();
+    let mut config_router = get_basic_router_config().await;
     config_router
         .insert_json5(
             "access_control",
@@ -452,8 +462,14 @@ async fn test_pub_sub_allow(port: u16) {
         .unwrap();
     println!("Opening router session");
 
-    let session = ztimeout!(zenoh::open(config_router)).unwrap();
-    let (sub_session, pub_session) = get_client_sessions(port).await;
+    let _session = test_context.open_listener_with_cfg(config_router).await;
+    println!("Opening client sessions");
+    let sub_session = test_context
+        .open_connector_with_cfg(get_loopback_client_config(&test_context))
+        .await;
+    let pub_session = test_context
+        .open_connector_with_cfg(get_loopback_client_config(&test_context))
+        .await;
     {
         let publisher = ztimeout!(pub_session.declare_publisher(KEY_EXPR)).unwrap();
         let received_value = Arc::new(Mutex::new(String::new()));
@@ -486,14 +502,14 @@ async fn test_pub_sub_allow(port: u16) {
         ztimeout!(subscriber.undeclare()).unwrap();
     }
 
-    close_sessions(sub_session, pub_session).await;
-    close_router_session(session).await;
+    test_context.close().await;
 }
 
-async fn test_pub_sub_allow_then_deny(port: u16) {
+async fn test_pub_sub_allow_then_deny() {
     println!("test_pub_sub_allow_then_deny");
+    let mut test_context = TestSessions::new();
 
-    let mut config_router = get_basic_router_config(port).await;
+    let mut config_router = get_basic_router_config().await;
     config_router
         .insert_json5(
             "access_control",
@@ -534,8 +550,14 @@ async fn test_pub_sub_allow_then_deny(port: u16) {
         .unwrap();
     println!("Opening router session");
 
-    let session = ztimeout!(zenoh::open(config_router)).unwrap();
-    let (sub_session, pub_session) = get_client_sessions(port).await;
+    let _session = test_context.open_listener_with_cfg(config_router).await;
+    println!("Opening client sessions");
+    let sub_session = test_context
+        .open_connector_with_cfg(get_loopback_client_config(&test_context))
+        .await;
+    let pub_session = test_context
+        .open_connector_with_cfg(get_loopback_client_config(&test_context))
+        .await;
     {
         let publisher = ztimeout!(pub_session.declare_publisher(KEY_EXPR)).unwrap();
         let received_value = Arc::new(Mutex::new(String::new()));
@@ -567,14 +589,14 @@ async fn test_pub_sub_allow_then_deny(port: u16) {
         assert!(!(*zlock!(deleted)));
         ztimeout!(subscriber.undeclare()).unwrap();
     }
-    close_sessions(sub_session, pub_session).await;
-    close_router_session(session).await;
+    test_context.close().await;
 }
 
-async fn test_pub_sub_deny_then_allow(port: u16) {
+async fn test_pub_sub_deny_then_allow() {
     println!("test_pub_sub_deny_then_allow");
+    let mut test_context = TestSessions::new();
 
-    let mut config_router = get_basic_router_config(port).await;
+    let mut config_router = get_basic_router_config().await;
     config_router
         .insert_json5(
             "access_control",
@@ -615,8 +637,8 @@ async fn test_pub_sub_deny_then_allow(port: u16) {
         .unwrap();
     println!("Opening router session");
 
-    let session = ztimeout!(zenoh::open(config_router)).unwrap();
-    let (sub_session, pub_session) = get_client_sessions(port).await;
+    let _session = test_context.open_listener_with_cfg(config_router).await;
+    let (sub_session, pub_session) = get_client_sessions(&mut test_context).await;
     {
         let publisher = ztimeout!(pub_session.declare_publisher(KEY_EXPR)).unwrap();
         let received_value = Arc::new(Mutex::new(String::new()));
@@ -648,14 +670,14 @@ async fn test_pub_sub_deny_then_allow(port: u16) {
         assert!(*zlock!(deleted));
         ztimeout!(subscriber.undeclare()).unwrap();
     }
-    close_sessions(sub_session, pub_session).await;
-    close_router_session(session).await;
+    test_context.close().await;
 }
 
-async fn test_get_qbl_deny(port: u16) {
+async fn test_get_qbl_deny() {
     println!("test_get_qbl_deny");
+    let mut test_context = TestSessions::new();
 
-    let mut config_router = get_basic_router_config(port).await;
+    let mut config_router = get_basic_router_config().await;
     config_router
         .insert_json5(
             "access_control",
@@ -685,9 +707,8 @@ async fn test_get_qbl_deny(port: u16) {
         .unwrap();
     println!("Opening router session");
 
-    let session = ztimeout!(zenoh::open(config_router)).unwrap();
-
-    let (get_session, qbl_session) = get_client_sessions(port).await;
+    let _session = test_context.open_listener_with_cfg(config_router).await;
+    let (get_session, qbl_session) = get_client_sessions(&mut test_context).await;
     {
         let mut received_value = String::new();
 
@@ -716,14 +737,14 @@ async fn test_get_qbl_deny(port: u16) {
         assert_ne!(received_value, VALUE);
         ztimeout!(qbl.undeclare()).unwrap();
     }
-    close_sessions(get_session, qbl_session).await;
-    close_router_session(session).await;
+    test_context.close().await;
 }
 
-async fn test_get_qbl_allow(port: u16) {
+async fn test_get_qbl_allow() {
     println!("test_get_qbl_allow");
+    let mut test_context = TestSessions::new();
 
-    let mut config_router = get_basic_router_config(port).await;
+    let mut config_router = get_basic_router_config().await;
     config_router
         .insert_json5(
             "access_control",
@@ -738,9 +759,8 @@ async fn test_get_qbl_allow(port: u16) {
         .unwrap();
     println!("Opening router session");
 
-    let session = ztimeout!(zenoh::open(config_router)).unwrap();
-
-    let (get_session, qbl_session) = get_client_sessions(port).await;
+    let _session = test_context.open_listener_with_cfg(config_router).await;
+    let (get_session, qbl_session) = get_client_sessions(&mut test_context).await;
     {
         let mut received_value = String::new();
 
@@ -769,14 +789,14 @@ async fn test_get_qbl_allow(port: u16) {
         assert_eq!(received_value, VALUE);
         ztimeout!(qbl.undeclare()).unwrap();
     }
-    close_sessions(get_session, qbl_session).await;
-    close_router_session(session).await;
+    test_context.close().await;
 }
 
-async fn test_get_qbl_deny_then_allow(port: u16) {
+async fn test_get_qbl_deny_then_allow() {
     println!("test_get_qbl_deny_then_allow");
+    let mut test_context = TestSessions::new();
 
-    let mut config_router = get_basic_router_config(port).await;
+    let mut config_router = get_basic_router_config().await;
     config_router
         .insert_json5(
             "access_control",
@@ -818,9 +838,8 @@ async fn test_get_qbl_deny_then_allow(port: u16) {
 
     println!("Opening router session");
 
-    let session = ztimeout!(zenoh::open(config_router)).unwrap();
-
-    let (get_session, qbl_session) = get_client_sessions(port).await;
+    let _session = test_context.open_listener_with_cfg(config_router).await;
+    let (get_session, qbl_session) = get_client_sessions(&mut test_context).await;
     {
         let mut received_value = String::new();
 
@@ -849,14 +868,14 @@ async fn test_get_qbl_deny_then_allow(port: u16) {
         assert_eq!(received_value, VALUE);
         ztimeout!(qbl.undeclare()).unwrap();
     }
-    close_sessions(get_session, qbl_session).await;
-    close_router_session(session).await;
+    test_context.close().await;
 }
 
-async fn test_get_qbl_allow_then_deny(port: u16) {
+async fn test_get_qbl_allow_then_deny() {
     println!("test_get_qbl_allow_then_deny");
+    let mut test_context = TestSessions::new();
 
-    let mut config_router = get_basic_router_config(port).await;
+    let mut config_router = get_basic_router_config().await;
     config_router
         .insert_json5(
             "access_control",
@@ -896,9 +915,8 @@ async fn test_get_qbl_allow_then_deny(port: u16) {
         .unwrap();
     println!("Opening router session");
 
-    let session = ztimeout!(zenoh::open(config_router)).unwrap();
-
-    let (get_session, qbl_session) = get_client_sessions(port).await;
+    let _session = test_context.open_listener_with_cfg(config_router).await;
+    let (get_session, qbl_session) = get_client_sessions(&mut test_context).await;
     {
         let mut received_value = String::new();
 
@@ -927,14 +945,14 @@ async fn test_get_qbl_allow_then_deny(port: u16) {
         assert_ne!(received_value, VALUE);
         ztimeout!(qbl.undeclare()).unwrap();
     }
-    close_sessions(get_session, qbl_session).await;
-    close_router_session(session).await;
+    test_context.close().await;
 }
 
-async fn test_reply_deny(port: u16) {
+async fn test_reply_deny() {
     println!("test_reply_deny");
+    let mut test_context = TestSessions::new();
 
-    let mut config_router = get_basic_router_config(port).await;
+    let mut config_router = get_basic_router_config().await;
     config_router
         .insert_json5(
             "access_control",
@@ -963,9 +981,8 @@ async fn test_reply_deny(port: u16) {
         .unwrap();
     println!("Opening router session");
 
-    let session = ztimeout!(zenoh::open(config_router)).unwrap();
-
-    let (get_session, qbl_session) = get_client_sessions(port).await;
+    let _session = test_context.open_listener_with_cfg(config_router).await;
+    let (get_session, qbl_session) = get_client_sessions(&mut test_context).await;
     {
         let mut received_value = String::new();
 
@@ -994,14 +1011,14 @@ async fn test_reply_deny(port: u16) {
         assert_ne!(received_value, VALUE);
         ztimeout!(qbl.undeclare()).unwrap();
     }
-    close_sessions(get_session, qbl_session).await;
-    close_router_session(session).await;
+    test_context.close().await;
 }
 
-async fn test_reply_allow_then_deny(port: u16) {
+async fn test_reply_allow_then_deny() {
     println!("test_reply_allow_then_deny");
+    let mut test_context = TestSessions::new();
 
-    let mut config_router = get_basic_router_config(port).await;
+    let mut config_router = get_basic_router_config().await;
     config_router
         .insert_json5(
             "access_control",
@@ -1036,9 +1053,8 @@ async fn test_reply_allow_then_deny(port: u16) {
         .unwrap();
     println!("Opening router session");
 
-    let session = ztimeout!(zenoh::open(config_router)).unwrap();
-
-    let (get_session, qbl_session) = get_client_sessions(port).await;
+    let _session = test_context.open_listener_with_cfg(config_router).await;
+    let (get_session, qbl_session) = get_client_sessions(&mut test_context).await;
     {
         let mut received_value = String::new();
 
@@ -1067,14 +1083,14 @@ async fn test_reply_allow_then_deny(port: u16) {
         assert_ne!(received_value, VALUE);
         ztimeout!(qbl.undeclare()).unwrap();
     }
-    close_sessions(get_session, qbl_session).await;
-    close_router_session(session).await;
+    test_context.close().await;
 }
 
-async fn test_liveliness_deny(port: u16) {
+async fn test_liveliness_deny() {
     println!("test_liveliness_deny");
+    let mut test_context = TestSessions::new();
 
-    let mut config_router = get_basic_router_config(port).await;
+    let mut config_router = get_basic_router_config().await;
     config_router
         .insert_json5(
             "access_control",
@@ -1089,8 +1105,8 @@ async fn test_liveliness_deny(port: u16) {
         .unwrap();
     println!("Opening router session");
 
-    let session = ztimeout!(zenoh::open(config_router)).unwrap();
-    let (reader_session, writer_session) = get_client_sessions(port).await;
+    let _session = test_context.open_listener_with_cfg(config_router).await;
+    let (reader_session, writer_session) = get_client_sessions(&mut test_context).await;
 
     let received_token = Arc::new(AtomicBool::new(false));
     let dropped_token = Arc::new(AtomicBool::new(false));
@@ -1145,14 +1161,14 @@ async fn test_liveliness_deny(port: u16) {
     assert!(!dropped_token.load(std::sync::atomic::Ordering::Relaxed));
 
     ztimeout!(subscriber.undeclare()).unwrap();
-    close_sessions(reader_session, writer_session).await;
-    close_router_session(session).await;
+    test_context.close().await;
 }
 
-async fn test_liveliness_allow(port: u16) {
+async fn test_liveliness_allow() {
     println!("test_liveliness_allow");
+    let mut test_context = TestSessions::new();
 
-    let mut config_router = get_basic_router_config(port).await;
+    let mut config_router = get_basic_router_config().await;
     config_router
         .insert_json5(
             "access_control",
@@ -1167,8 +1183,8 @@ async fn test_liveliness_allow(port: u16) {
         .unwrap();
     println!("Opening router session");
 
-    let session = ztimeout!(zenoh::open(config_router)).unwrap();
-    let (reader_session, writer_session) = get_client_sessions(port).await;
+    let _session = test_context.open_listener_with_cfg(config_router).await;
+    let (reader_session, writer_session) = get_client_sessions(&mut test_context).await;
 
     let received_token = Arc::new(AtomicBool::new(false));
     let dropped_token = Arc::new(AtomicBool::new(false));
@@ -1223,14 +1239,14 @@ async fn test_liveliness_allow(port: u16) {
     assert!(dropped_token.load(std::sync::atomic::Ordering::Relaxed));
 
     ztimeout!(subscriber.undeclare()).unwrap();
-    close_sessions(reader_session, writer_session).await;
-    close_router_session(session).await;
+    test_context.close().await;
 }
 
-async fn test_liveliness_allow_deny_token(port: u16) {
+async fn test_liveliness_allow_deny_token() {
     println!("test_liveliness_allow_deny_token");
+    let mut test_context = TestSessions::new();
 
-    let mut config_router = get_basic_router_config(port).await;
+    let mut config_router = get_basic_router_config().await;
     config_router
         .insert_json5(
             "access_control",
@@ -1260,8 +1276,8 @@ async fn test_liveliness_allow_deny_token(port: u16) {
         .unwrap();
     println!("Opening router session");
 
-    let session = ztimeout!(zenoh::open(config_router)).unwrap();
-    let (reader_session, writer_session) = get_client_sessions(port).await;
+    let _session = test_context.open_listener_with_cfg(config_router).await;
+    let (reader_session, writer_session) = get_client_sessions(&mut test_context).await;
 
     let received_token = Arc::new(AtomicBool::new(false));
     let dropped_token = Arc::new(AtomicBool::new(false));
@@ -1316,14 +1332,14 @@ async fn test_liveliness_allow_deny_token(port: u16) {
     assert!(!dropped_token.load(std::sync::atomic::Ordering::Relaxed));
 
     ztimeout!(subscriber.undeclare()).unwrap();
-    close_sessions(reader_session, writer_session).await;
-    close_router_session(session).await;
+    test_context.close().await;
 }
 
-async fn test_liveliness_deny_allow_token(port: u16) {
+async fn test_liveliness_deny_allow_token() {
     println!("test_liveliness_deny_allow_token");
+    let mut test_context = TestSessions::new();
 
-    let mut config_router = get_basic_router_config(port).await;
+    let mut config_router = get_basic_router_config().await;
     config_router
         .insert_json5(
             "access_control",
@@ -1353,8 +1369,8 @@ async fn test_liveliness_deny_allow_token(port: u16) {
         .unwrap();
     println!("Opening router session");
 
-    let session = ztimeout!(zenoh::open(config_router)).unwrap();
-    let (reader_session, writer_session) = get_client_sessions(port).await;
+    let _session = test_context.open_listener_with_cfg(config_router).await;
+    let (reader_session, writer_session) = get_client_sessions(&mut test_context).await;
 
     let received_token = Arc::new(AtomicBool::new(false));
     let dropped_token = Arc::new(AtomicBool::new(false));
@@ -1409,14 +1425,14 @@ async fn test_liveliness_deny_allow_token(port: u16) {
     assert!(!dropped_token.load(std::sync::atomic::Ordering::Relaxed));
 
     ztimeout!(subscriber.undeclare()).unwrap();
-    close_sessions(reader_session, writer_session).await;
-    close_router_session(session).await;
+    test_context.close().await;
 }
 
-async fn test_liveliness_allow_deny_sub(port: u16) {
+async fn test_liveliness_allow_deny_sub() {
     println!("test_liveliness_allow_deny_sub");
+    let mut test_context = TestSessions::new();
 
-    let mut config_router = get_basic_router_config(port).await;
+    let mut config_router = get_basic_router_config().await;
     config_router
         .insert_json5(
             "access_control",
@@ -1446,8 +1462,8 @@ async fn test_liveliness_allow_deny_sub(port: u16) {
         .unwrap();
     println!("Opening router session");
 
-    let session = ztimeout!(zenoh::open(config_router)).unwrap();
-    let (reader_session, writer_session) = get_client_sessions(port).await;
+    let _session = test_context.open_listener_with_cfg(config_router).await;
+    let (reader_session, writer_session) = get_client_sessions(&mut test_context).await;
 
     let received_token = Arc::new(AtomicBool::new(false));
     let dropped_token = Arc::new(AtomicBool::new(false));
@@ -1502,14 +1518,14 @@ async fn test_liveliness_allow_deny_sub(port: u16) {
     assert!(!dropped_token.load(std::sync::atomic::Ordering::Relaxed));
 
     ztimeout!(subscriber.undeclare()).unwrap();
-    close_sessions(reader_session, writer_session).await;
-    close_router_session(session).await;
+    test_context.close().await;
 }
 
-async fn test_liveliness_deny_allow_sub(port: u16) {
+async fn test_liveliness_deny_allow_sub() {
     println!("test_liveliness_deny_allow_sub");
+    let mut test_context = TestSessions::new();
 
-    let mut config_router = get_basic_router_config(port).await;
+    let mut config_router = get_basic_router_config().await;
     config_router
         .insert_json5(
             "access_control",
@@ -1539,8 +1555,8 @@ async fn test_liveliness_deny_allow_sub(port: u16) {
         .unwrap();
     println!("Opening router session");
 
-    let session = ztimeout!(zenoh::open(config_router)).unwrap();
-    let (reader_session, writer_session) = get_client_sessions(port).await;
+    let _session = test_context.open_listener_with_cfg(config_router).await;
+    let (reader_session, writer_session) = get_client_sessions(&mut test_context).await;
 
     let received_token = Arc::new(AtomicBool::new(false));
     let dropped_token = Arc::new(AtomicBool::new(false));
@@ -1605,14 +1621,14 @@ async fn test_liveliness_deny_allow_sub(port: u16) {
     assert!(dropped_token.load(std::sync::atomic::Ordering::Relaxed));
 
     ztimeout!(subscriber.undeclare()).unwrap();
-    close_sessions(reader_session, writer_session).await;
-    close_router_session(session).await;
+    test_context.close().await;
 }
 
-async fn test_liveliness_allow_deny_query(port: u16) {
+async fn test_liveliness_allow_deny_query() {
     println!("test_liveliness_allow_deny_query");
+    let mut test_context = TestSessions::new();
 
-    let mut config_router = get_basic_router_config(port).await;
+    let mut config_router = get_basic_router_config().await;
     config_router
         .insert_json5(
             "access_control",
@@ -1642,8 +1658,8 @@ async fn test_liveliness_allow_deny_query(port: u16) {
         .unwrap();
     println!("Opening router session");
 
-    let session = ztimeout!(zenoh::open(config_router)).unwrap();
-    let (reader_session, writer_session) = get_client_sessions(port).await;
+    let _session = test_context.open_listener_with_cfg(config_router).await;
+    let (reader_session, writer_session) = get_client_sessions(&mut test_context).await;
 
     let received_token = Arc::new(AtomicBool::new(false));
     let dropped_token = Arc::new(AtomicBool::new(false));
@@ -1708,14 +1724,14 @@ async fn test_liveliness_allow_deny_query(port: u16) {
     assert!(dropped_token.load(std::sync::atomic::Ordering::Relaxed));
 
     ztimeout!(subscriber.undeclare()).unwrap();
-    close_sessions(reader_session, writer_session).await;
-    close_router_session(session).await;
+    test_context.close().await;
 }
 
-async fn test_liveliness_deny_allow_query(port: u16) {
+async fn test_liveliness_deny_allow_query() {
     println!("test_liveliness_deny_allow_query");
+    let mut test_context = TestSessions::new();
 
-    let mut config_router = get_basic_router_config(port).await;
+    let mut config_router = get_basic_router_config().await;
     config_router
         .insert_json5(
             "access_control",
@@ -1745,8 +1761,8 @@ async fn test_liveliness_deny_allow_query(port: u16) {
         .unwrap();
     println!("Opening router session");
 
-    let session = ztimeout!(zenoh::open(config_router)).unwrap();
-    let (reader_session, writer_session) = get_client_sessions(port).await;
+    let _session = test_context.open_listener_with_cfg(config_router).await;
+    let (reader_session, writer_session) = get_client_sessions(&mut test_context).await;
 
     let received_token = Arc::new(AtomicBool::new(false));
     let dropped_token = Arc::new(AtomicBool::new(false));
@@ -1801,14 +1817,14 @@ async fn test_liveliness_deny_allow_query(port: u16) {
     assert!(!dropped_token.load(std::sync::atomic::Ordering::Relaxed));
 
     ztimeout!(subscriber.undeclare()).unwrap();
-    close_sessions(reader_session, writer_session).await;
-    close_router_session(session).await;
+    test_context.close().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_acl_query_ingress_deny() {
     zenoh::init_log_from_env_or("error");
-    let mut config_router = get_basic_router_config(27501).await;
+    let mut test_context = TestSessions::new();
+    let mut config_router = get_basic_router_config().await;
     config_router
         .insert_json5(
             "access_control",
@@ -1837,8 +1853,8 @@ async fn test_acl_query_ingress_deny() {
         )
         .unwrap();
 
-    let _router = ztimeout!(zenoh::open(config_router)).unwrap();
-    let (session1, session2) = get_client_sessions(27501).await;
+    let _router = test_context.open_listener_with_cfg(config_router).await;
+    let (session1, session2) = get_client_sessions(&mut test_context).await;
     tokio::time::sleep(SLEEP).await;
 
     let _qbl = session1.declare_queryable("test/ingress").await.unwrap();
@@ -1847,12 +1863,14 @@ async fn test_acl_query_ingress_deny() {
     let replies = session2.get("test/ingress").await.unwrap();
 
     assert!(replies.recv_async().await.is_err());
+    test_context.close().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_acl_query_egress_deny() {
     zenoh::init_log_from_env_or("error");
-    let mut config_router = get_basic_router_config(27502).await;
+    let mut test_context = TestSessions::new();
+    let mut config_router = get_basic_router_config().await;
     config_router
         .insert_json5(
             "access_control",
@@ -1881,8 +1899,8 @@ async fn test_acl_query_egress_deny() {
         )
         .unwrap();
 
-    let _router = ztimeout!(zenoh::open(config_router)).unwrap();
-    let (session1, session2) = get_client_sessions(27502).await;
+    let _router = test_context.open_listener_with_cfg(config_router).await;
+    let (session1, session2) = get_client_sessions(&mut test_context).await;
     tokio::time::sleep(SLEEP).await;
 
     let _qbl = session1.declare_queryable("test/egress").await.unwrap();
@@ -1890,12 +1908,14 @@ async fn test_acl_query_egress_deny() {
     let replies = session2.get("test/egress").await.unwrap();
 
     assert!(replies.recv_async().await.is_err());
+    test_context.close().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_acl_liveliness_query_ingress_deny() {
     zenoh::init_log_from_env_or("error");
-    let mut config_router = get_basic_router_config(27503).await;
+    let mut test_context = TestSessions::new();
+    let mut config_router = get_basic_router_config().await;
     config_router
         .insert_json5(
             "access_control",
@@ -1924,9 +1944,9 @@ async fn test_acl_liveliness_query_ingress_deny() {
         )
         .unwrap();
 
-    let _router = ztimeout!(zenoh::open(config_router)).unwrap();
+    let _router = test_context.open_listener_with_cfg(config_router).await;
     tokio::time::sleep(SLEEP).await;
-    let (session1, session2) = get_client_sessions(27503).await;
+    let (session1, session2) = get_client_sessions(&mut test_context).await;
     tokio::time::sleep(SLEEP).await;
 
     let _token = session1
@@ -1944,14 +1964,17 @@ async fn test_acl_liveliness_query_ingress_deny() {
         .unwrap();
 
     assert!(replies.recv_timeout(Duration::from_secs(1)).is_err());
+    test_context.close().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_acl_liveliness_query_egress_deny() {
     zenoh::init_log_from_env_or("error");
-    let config_router = get_basic_router_config(27504).await;
-    let mut config_client1 = get_basic_client_config(27504).await;
-    let config_client2 = get_basic_client_config(27504).await;
+    let mut test_context = TestSessions::new();
+    let config_router = get_basic_router_config().await;
+    let _router = test_context.open_listener_with_cfg(config_router).await;
+    tokio::time::sleep(SLEEP).await;
+    let mut config_client1 = get_basic_client_config(&test_context);
     config_client1
         .insert_json5(
             "access_control",
@@ -1979,11 +2002,10 @@ async fn test_acl_liveliness_query_egress_deny() {
           }"#,
         )
         .unwrap();
-
-    let _router = ztimeout!(zenoh::open(config_router)).unwrap();
-    tokio::time::sleep(SLEEP).await;
-    let session1 = ztimeout!(zenoh::open(config_client1)).unwrap();
-    let session2 = ztimeout!(zenoh::open(config_client2)).unwrap();
+    let session1 = test_context.open_connector_with_cfg(config_client1).await;
+    let session2 = test_context
+        .open_connector_with_cfg(get_basic_client_config(&test_context))
+        .await;
     tokio::time::sleep(SLEEP).await;
 
     let _token = session2
@@ -2000,17 +2022,19 @@ async fn test_acl_liveliness_query_egress_deny() {
         .unwrap();
 
     assert!(replies.recv_timeout(Duration::from_secs(1)).is_err());
+    test_context.close().await;
 }
 
-async fn test_pub_sub_network_interface(port: u16) {
+async fn test_pub_sub_network_interface() {
     println!("test_pub_sub_network_interface");
+    let mut test_context = TestSessions::new();
 
     let mut config_router = Config::default();
     config_router.set_mode(Some(WhatAmI::Router)).unwrap();
     config_router
         .listen
         .endpoints
-        .set(vec![format!("tcp/[::]:{port}").parse().unwrap()])
+        .set(vec!["tcp/[::]:0".parse().unwrap()])
         .unwrap();
     config_router
         .scouting
@@ -2050,9 +2074,14 @@ async fn test_pub_sub_network_interface(port: u16) {
         .unwrap();
     println!("Opening router session");
 
-    let session = ztimeout!(zenoh::open(config_router)).unwrap();
-
-    let (sub_session, pub_session) = get_client_sessions(port).await;
+    let _session = test_context.open_listener_with_cfg(config_router).await;
+    println!("Opening client sessions");
+    let sub_session = test_context
+        .open_connector_with_cfg(get_loopback_client_config(&test_context))
+        .await;
+    let pub_session = test_context
+        .open_connector_with_cfg(get_loopback_client_config(&test_context))
+        .await;
     {
         let publisher = pub_session.declare_publisher(KEY_EXPR).await.unwrap();
         let received_value = Arc::new(Mutex::new(String::new()));
@@ -2084,6 +2113,5 @@ async fn test_pub_sub_network_interface(port: u16) {
         assert!(*zlock!(deleted));
         ztimeout!(subscriber.undeclare()).unwrap();
     }
-    close_sessions(sub_session, pub_session).await;
-    close_router_session(session).await;
+    test_context.close().await;
 }

--- a/zenoh/tests/adminspace.rs
+++ b/zenoh/tests/adminspace.rs
@@ -11,8 +11,12 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
+#![cfg(feature = "unstable")]
+mod common;
+
 use std::time::Duration;
 
+use common::TestSessions;
 use zenoh_config::WhatAmI;
 use zenoh_core::ztimeout;
 use zenoh_link::EndPoint;
@@ -47,19 +51,18 @@ async fn test_adminspace_wonly() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_adminspace_read() {
     const TIMEOUT: Duration = Duration::from_secs(60);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:31000";
-    const MULTICAST_ENDPOINT: &str = "udp/224.0.0.224:31000";
 
     zenoh_util::init_log_from_env_or("error");
 
+    // Open router with dynamic TCP + UDP ports (port 0 → OS assigns)
     let router = {
         let mut c = zenoh_config::Config::default();
         c.set_mode(Some(WhatAmI::Router)).unwrap();
         c.listen
             .endpoints
             .set(vec![
-                ROUTER_ENDPOINT.parse::<EndPoint>().unwrap(),
-                MULTICAST_ENDPOINT.parse::<EndPoint>().unwrap(),
+                "tcp/127.0.0.1:0".parse::<EndPoint>().unwrap(),
+                "udp/224.0.0.224:0".parse::<EndPoint>().unwrap(),
             ])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
@@ -83,24 +86,32 @@ async fn test_adminspace_read() {
         s
     };
     let zid = router.zid();
+
+    // Resolve the actual TCP endpoint assigned by the OS
+    let router_locators = TestSessions::get_locators_from_session(&router).await;
+    let tcp_locator = router_locators
+        .iter()
+        .find(|ep| ep.to_string().starts_with("tcp/"))
+        .expect("Expected a TCP listener endpoint from router")
+        .clone();
+    let udp_locator = router_locators
+        .iter()
+        .find(|ep| ep.to_string().starts_with("udp/"))
+        .expect("Expected a UDP listener endpoint from router")
+        .clone();
+
     let router2 = {
         let mut c = zenoh_config::Config::default();
         c.set_mode(Some(WhatAmI::Router)).unwrap();
         c.listen.endpoints.set(vec![]).unwrap();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.connect.endpoints.set(vec![tcp_locator.clone()]).unwrap();
         ztimeout!(zenoh::open(c)).unwrap()
     };
     let zid2 = router2.zid();
     let peer = {
         let mut c = zenoh_config::Config::default();
         c.set_mode(Some(WhatAmI::Peer)).unwrap();
-        c.listen
-            .endpoints
-            .set(vec![MULTICAST_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.listen.endpoints.set(vec![udp_locator.clone()]).unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         ztimeout!(zenoh::open(c)).unwrap()
     };
@@ -317,9 +328,9 @@ async fn test_adminspace_read() {
     let count = router.get("@/*/**").await.unwrap().iter().count();
     assert!(count > 0);
 
-    peer.close().await.unwrap();
-    router2.close().await.unwrap();
-    router.close().await.unwrap();
+    ztimeout!(peer.close()).unwrap();
+    ztimeout!(router2.close()).unwrap();
+    ztimeout!(router.close()).unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -495,18 +506,16 @@ macro_rules! assert_json_field {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_adminspace_transports_and_links() {
     const TIMEOUT: Duration = Duration::from_secs(60);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:31001";
-    const ROUTER_CONNECT_ENDPOINT: &str = "tcp/localhost:31001?rel=1;prio=1-7";
 
     zenoh_util::init_log_from_env_or("error");
 
-    // Create router1 with adminspace enabled
+    // Create router1 with adminspace enabled, listening on a dynamic port
     let router1 = {
         let mut c = zenoh_config::Config::default();
         c.set_mode(Some(WhatAmI::Router)).unwrap();
         c.listen
             .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec!["tcp/127.0.0.1:0".parse::<EndPoint>().unwrap()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         c.adminspace.set_enabled(true).unwrap();
@@ -517,6 +526,17 @@ async fn test_adminspace_transports_and_links() {
         ztimeout!(zenoh::open(c)).unwrap()
     };
     let zid1 = router1.zid();
+
+    // Resolve the actual TCP endpoint assigned by the OS, then append QoS metadata
+    let router1_tcp_addr = TestSessions::get_locators_from_session(&router1)
+        .await
+        .into_iter()
+        .find(|ep| ep.to_string().starts_with("tcp/"))
+        .expect("Expected a TCP listener endpoint from router1");
+    // Preserve the original connect-side metadata (?rel=1;prio=1-7)
+    let router_connect_endpoint: EndPoint = format!("{}?rel=1;prio=1-7", router1_tcp_addr)
+        .parse()
+        .unwrap();
 
     // Test 1: Query transports when none exist (except self-connections)
     let transports_unicast: Vec<String> = router1
@@ -559,7 +579,7 @@ async fn test_adminspace_transports_and_links() {
         c.listen.endpoints.set(vec![]).unwrap();
         c.connect
             .endpoints
-            .set(vec![ROUTER_CONNECT_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec![router_connect_endpoint])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         // Enable QoS for priorities and reliability support
@@ -777,26 +797,24 @@ async fn test_adminspace_transports_and_links() {
     link_subscriber.undeclare().await.unwrap();
 
     // Cleanup
-    router2.close().await.unwrap();
-    router1.close().await.unwrap();
+    ztimeout!(router2.close()).unwrap();
+    ztimeout!(router1.close()).unwrap();
 }
 
 #[cfg(feature = "stats")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_adminspace_regression_1() {
     const TIMEOUT: Duration = Duration::from_secs(60);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:31002";
-    const ROUTER_CONNECT_ENDPOINT: &str = "tcp/localhost:31002?rel=1;prio=1-7";
 
     zenoh_util::init_log_from_env_or("error");
 
-    // Create router1 with adminspace enabled
+    // Create router1 with adminspace enabled, listening on a dynamic port
     let router1 = {
         let mut c = zenoh_config::Config::default();
         c.set_mode(Some(WhatAmI::Router)).unwrap();
         c.listen
             .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec!["tcp/127.0.0.1:0".parse::<EndPoint>().unwrap()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         c.adminspace.set_enabled(true).unwrap();
@@ -808,14 +826,24 @@ async fn test_adminspace_regression_1() {
     };
     let zid1 = router1.zid();
 
+    // Resolve the actual TCP endpoint assigned by the OS, then append QoS metadata
+    let router1_tcp_addr = TestSessions::get_locators_from_session(&router1)
+        .await
+        .into_iter()
+        .find(|ep| ep.to_string().starts_with("tcp/"))
+        .expect("Expected a TCP listener endpoint from router1");
+    let router_connect_endpoint: EndPoint = format!("{}?rel=1;prio=1-7", router1_tcp_addr)
+        .parse()
+        .unwrap();
+
     // Create router2 that connects to router1 (creates unicast transport)
-    let _router2 = {
+    let router2 = {
         let mut c = zenoh_config::Config::default();
         c.set_mode(Some(WhatAmI::Router)).unwrap();
         c.listen.endpoints.set(vec![]).unwrap();
         c.connect
             .endpoints
-            .set(vec![ROUTER_CONNECT_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec![router_connect_endpoint])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         // Enable QoS for priorities and reliability support
@@ -875,4 +903,8 @@ async fn test_adminspace_regression_1() {
 
     assert_eq!(rx_t_bytes, rx_l_bytes);
     assert_eq!(tx_t_bytes, tx_l_bytes);
+
+    // Cleanup
+    ztimeout!(router2.close()).unwrap();
+    ztimeout!(router1.close()).unwrap();
 }

--- a/zenoh/tests/authentication.rs
+++ b/zenoh/tests/authentication.rs
@@ -12,6 +12,9 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
+#![cfg(feature = "unstable")]
+mod common;
+
 mod test {
     use std::{
         fs,
@@ -25,10 +28,12 @@ mod test {
     use tokio::runtime::Handle;
     use zenoh::{
         config::{WhatAmI, ZenohId},
-        Config, Session,
+        Session,
     };
-    use zenoh_config::{EndPoint, ModeDependentValue};
+    use zenoh_config::{Config, EndPoint, ModeDependentValue};
     use zenoh_core::{zlock, ztimeout};
+
+    use crate::common::TestSessions;
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
@@ -43,10 +48,10 @@ mod test {
         create_new_files(TESTFILES_PATH.to_path_buf())
             .await
             .unwrap();
-        test_pub_sub_deny_then_allow_usrpswd(29447).await;
-        test_pub_sub_allow_then_deny_usrpswd(29447).await;
-        test_get_qbl_allow_then_deny_usrpswd(29447).await;
-        test_get_qbl_deny_then_allow_usrpswd(29447).await;
+        test_pub_sub_deny_then_allow_usrpswd().await;
+        test_pub_sub_allow_then_deny_usrpswd().await;
+        test_get_qbl_allow_then_deny_usrpswd().await;
+        test_get_qbl_deny_then_allow_usrpswd().await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -55,10 +60,10 @@ mod test {
         create_new_files(TESTFILES_PATH.to_path_buf())
             .await
             .unwrap();
-        test_pub_sub_deny_then_allow_tls(29448, false).await;
-        test_pub_sub_allow_then_deny_tls(29449).await;
-        test_get_qbl_allow_then_deny_tls(29450).await;
-        test_get_qbl_deny_then_allow_tls(29451).await;
+        test_pub_sub_deny_then_allow_tls(false).await;
+        test_pub_sub_allow_then_deny_tls().await;
+        test_get_qbl_allow_then_deny_tls().await;
+        test_get_qbl_deny_then_allow_tls().await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -67,10 +72,10 @@ mod test {
         create_new_files(TESTFILES_PATH.to_path_buf())
             .await
             .unwrap();
-        test_pub_sub_deny_then_allow_quic(29452).await;
-        test_pub_sub_allow_then_deny_quic(29453).await;
-        test_get_qbl_deny_then_allow_quic(29454).await;
-        test_get_qbl_allow_then_deny_quic(29455).await;
+        test_pub_sub_deny_then_allow_quic().await;
+        test_pub_sub_allow_then_deny_quic().await;
+        test_get_qbl_deny_then_allow_quic().await;
+        test_get_qbl_allow_then_deny_quic().await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -80,7 +85,7 @@ mod test {
         create_new_files(TESTFILES_PATH.to_path_buf())
             .await
             .unwrap();
-        test_pub_sub_deny_then_allow_tls(29456, true).await;
+        test_pub_sub_deny_then_allow_tls(true).await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -89,20 +94,20 @@ mod test {
         create_new_files(TESTFILES_PATH.to_path_buf())
             .await
             .unwrap();
-        test_deny_allow_combination(29457).await;
-        test_allow_deny_combination(29458).await;
+        test_deny_allow_combination().await;
+        test_allow_deny_combination().await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn test_authentication_link_protocols() {
         zenoh_util::init_log_from_env_or("error");
-        test_pub_sub_auth_link_protocol(1234).await
+        test_pub_sub_auth_link_protocol().await
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn test_authentication_zid() {
         zenoh_util::init_log_from_env_or("error");
-        test_pub_sub_auth_zid(29459).await
+        test_pub_sub_auth_zid().await
     }
 
     #[allow(clippy::all)]
@@ -277,14 +282,23 @@ client2name:client2passwd";
         Ok(())
     }
 
-    async fn get_basic_router_config_tls(port: u16, lowlatency: bool) -> Config {
+    fn get_locators_by_protocol(test_context: &TestSessions, protocol: &str) -> Vec<EndPoint> {
+        test_context
+            .locators()
+            .iter()
+            .filter(|endpoint| endpoint.protocol().as_str() == protocol)
+            .cloned()
+            .collect()
+    }
+
+    async fn get_basic_router_config_tls(lowlatency: bool) -> Config {
         let cert_path = TESTFILES_PATH.to_string_lossy();
         let mut config = zenoh_config::Config::default();
         config.set_mode(Some(WhatAmI::Router)).unwrap();
         config
             .listen
             .endpoints
-            .set(vec![format!("tls/127.0.0.1:{port}").parse().unwrap()])
+            .set(vec!["tls/127.0.0.1:0".parse().unwrap()])
             .unwrap();
         config.scouting.multicast.set_enabled(Some(false)).unwrap();
         config
@@ -328,16 +342,16 @@ client2name:client2passwd";
             .qos
             .set_enabled(!lowlatency)
             .unwrap();
-        config.into()
+        config
     }
-    async fn get_basic_router_config_quic(port: u16) -> Config {
+    async fn get_basic_router_config_quic() -> Config {
         let cert_path = TESTFILES_PATH.to_string_lossy();
         let mut config = zenoh_config::Config::default();
         config.set_mode(Some(WhatAmI::Router)).unwrap();
         config
             .listen
             .endpoints
-            .set(vec![format!("quic/127.0.0.1:{port}").parse().unwrap()])
+            .set(vec!["quic/127.0.0.1:0".parse().unwrap()])
             .unwrap();
         config.scouting.multicast.set_enabled(Some(false)).unwrap();
         config
@@ -374,16 +388,16 @@ client2name:client2passwd";
             .tls
             .set_root_ca_certificate(Some(format!("{cert_path}/ca.pem")))
             .unwrap();
-        config.into()
+        config
     }
 
-    async fn get_basic_router_config_usrpswd(port: u16) -> Config {
+    async fn get_basic_router_config_usrpswd() -> Config {
         let mut config = zenoh_config::Config::default();
         config.set_mode(Some(WhatAmI::Router)).unwrap();
         config
             .listen
             .endpoints
-            .set(vec![format!("tcp/127.0.0.1:{port}").parse().unwrap()])
+            .set(vec!["tcp/127.0.0.1:0".parse().unwrap()])
             .unwrap();
         config.scouting.multicast.set_enabled(Some(false)).unwrap();
         config
@@ -408,14 +422,9 @@ client2name:client2passwd";
                 TESTFILES_PATH.to_string_lossy()
             )))
             .unwrap();
-        config.into()
+        config
     }
-    async fn close_router_session(s: Session) {
-        println!("Closing router session");
-        ztimeout!(s.close()).unwrap();
-    }
-
-    async fn get_basic_router_config_quic_usrpswd(port: u16) -> Config {
+    async fn get_basic_router_config_quic_usrpswd() -> Config {
         let cert_path = TESTFILES_PATH.to_string_lossy();
         let mut config = zenoh_config::Config::default();
         config.set_mode(Some(WhatAmI::Router)).unwrap();
@@ -423,8 +432,8 @@ client2name:client2passwd";
             .listen
             .endpoints
             .set(vec![
-                format!("quic/127.0.0.1:{port}").parse().unwrap(),
-                format!("tcp/127.0.0.1:{port}").parse().unwrap(),
+                "quic/127.0.0.1:0".parse().unwrap(),
+                "tcp/127.0.0.1:0".parse().unwrap(),
             ])
             .unwrap();
         config.scouting.multicast.set_enabled(Some(false)).unwrap();
@@ -477,22 +486,18 @@ client2name:client2passwd";
             .tls
             .set_root_ca_certificate(Some(format!("{cert_path}/ca.pem")))
             .unwrap();
-        config.into()
+        config
     }
 
-    async fn get_client_sessions_tls(port: u16, lowlatency: bool) -> (Session, Session) {
+    async fn get_client_sessions_tls(
+        test_context: &mut TestSessions,
+        lowlatency: bool,
+    ) -> (Session, Session) {
         let cert_path = TESTFILES_PATH.to_string_lossy();
         println!("Opening client sessions");
-        let mut config = zenoh_config::Config::default();
+        let locators = get_locators_by_protocol(test_context, "tls");
+        let mut config = test_context.get_connector_config_with_endpoint(locators.clone());
         config.set_mode(Some(WhatAmI::Client)).unwrap();
-        config
-            .connect
-            .set_endpoints(ModeDependentValue::Unique(vec![format!(
-                "tls/127.0.0.1:{port}"
-            )
-            .parse::<EndPoint>()
-            .unwrap()]))
-            .unwrap();
         config
             .insert_json5(
                 "transport",
@@ -534,18 +539,10 @@ client2name:client2passwd";
             .qos
             .set_enabled(!lowlatency)
             .unwrap();
-        let s01 = ztimeout!(zenoh::open(config)).unwrap();
+        let s01 = test_context.open_connector_with_cfg(config).await;
 
-        let mut config = zenoh_config::Config::default();
+        let mut config = test_context.get_connector_config_with_endpoint(locators);
         config.set_mode(Some(WhatAmI::Client)).unwrap();
-        config
-            .connect
-            .set_endpoints(ModeDependentValue::Unique(vec![format!(
-                "tls/127.0.0.1:{port}"
-            )
-            .parse::<EndPoint>()
-            .unwrap()]))
-            .unwrap();
         config
             .insert_json5(
                 "transport",
@@ -587,23 +584,16 @@ client2name:client2passwd";
             .qos
             .set_enabled(!lowlatency)
             .unwrap();
-        let s02 = ztimeout!(zenoh::open(config)).unwrap();
+        let s02 = test_context.open_connector_with_cfg(config).await;
         (s01, s02)
     }
 
-    async fn get_client_sessions_quic(port: u16) -> (Session, Session) {
+    async fn get_client_sessions_quic(test_context: &mut TestSessions) -> (Session, Session) {
         let cert_path = TESTFILES_PATH.to_string_lossy();
         println!("Opening client sessions");
-        let mut config = zenoh_config::Config::default();
+        let locators = get_locators_by_protocol(test_context, "quic");
+        let mut config = test_context.get_connector_config_with_endpoint(locators.clone());
         config.set_mode(Some(WhatAmI::Client)).unwrap();
-        config
-            .connect
-            .set_endpoints(ModeDependentValue::Unique(vec![format!(
-                "quic/127.0.0.1:{port}"
-            )
-            .parse::<EndPoint>()
-            .unwrap()]))
-            .unwrap();
         config
             .insert_json5(
                 "transport",
@@ -638,17 +628,9 @@ client2name:client2passwd";
             .tls
             .set_root_ca_certificate(Some(format!("{cert_path}/ca.pem")))
             .unwrap();
-        let s01 = ztimeout!(zenoh::open(config)).unwrap();
-        let mut config = zenoh_config::Config::default();
+        let s01 = test_context.open_connector_with_cfg(config).await;
+        let mut config = test_context.get_connector_config_with_endpoint(locators);
         config.set_mode(Some(WhatAmI::Client)).unwrap();
-        config
-            .connect
-            .set_endpoints(ModeDependentValue::Unique(vec![format!(
-                "quic/127.0.0.1:{port}"
-            )
-            .parse::<EndPoint>()
-            .unwrap()]))
-            .unwrap();
         config
             .insert_json5(
                 "transport",
@@ -683,22 +665,15 @@ client2name:client2passwd";
             .tls
             .set_root_ca_certificate(Some(format!("{cert_path}/ca.pem")))
             .unwrap();
-        let s02 = ztimeout!(zenoh::open(config)).unwrap();
+        let s02 = test_context.open_connector_with_cfg(config).await;
         (s01, s02)
     }
 
-    async fn get_client_sessions_usrpswd(port: u16) -> (Session, Session) {
+    async fn get_client_sessions_usrpswd(test_context: &mut TestSessions) -> (Session, Session) {
         println!("Opening client sessions");
-        let mut config = zenoh_config::Config::default();
+        let locators = get_locators_by_protocol(test_context, "tcp");
+        let mut config = test_context.get_connector_config_with_endpoint(locators.clone());
         config.set_mode(Some(WhatAmI::Client)).unwrap();
-        config
-            .connect
-            .set_endpoints(ModeDependentValue::Unique(vec![format!(
-                "tcp/127.0.0.1:{port}"
-            )
-            .parse::<EndPoint>()
-            .unwrap()]))
-            .unwrap();
         config
             .insert_json5(
                 "transport",
@@ -712,17 +687,9 @@ client2name:client2passwd";
                 }"#,
             )
             .unwrap();
-        let s01 = ztimeout!(zenoh::open(config)).unwrap();
-        let mut config = zenoh_config::Config::default();
+        let s01 = test_context.open_connector_with_cfg(config).await;
+        let mut config = test_context.get_connector_config_with_endpoint(locators);
         config.set_mode(Some(WhatAmI::Client)).unwrap();
-        config
-            .connect
-            .set_endpoints(ModeDependentValue::Unique(vec![format!(
-                "tcp/127.0.0.1:{port}"
-            )
-            .parse::<EndPoint>()
-            .unwrap()]))
-            .unwrap();
         config
             .insert_json5(
                 "transport",
@@ -736,23 +703,18 @@ client2name:client2passwd";
                 }"#,
             )
             .unwrap();
-        let s02 = ztimeout!(zenoh::open(config)).unwrap();
+        let s02 = test_context.open_connector_with_cfg(config).await;
         (s01, s02)
     }
 
-    async fn get_client_sessions_quic_usrpswd(port: u16) -> (Session, Session) {
+    async fn get_client_sessions_quic_usrpswd(
+        test_context: &mut TestSessions,
+    ) -> (Session, Session) {
         let cert_path = TESTFILES_PATH.to_string_lossy();
         println!("Opening client sessions");
-        let mut config = zenoh_config::Config::default();
+        let locators = get_locators_by_protocol(test_context, "quic");
+        let mut config = test_context.get_connector_config_with_endpoint(locators.clone());
         config.set_mode(Some(WhatAmI::Client)).unwrap();
-        config
-            .connect
-            .set_endpoints(ModeDependentValue::Unique(vec![format!(
-                "quic/127.0.0.1:{port}"
-            )
-            .parse::<EndPoint>()
-            .unwrap()]))
-            .unwrap();
         config
             .insert_json5(
                 "transport",
@@ -793,18 +755,10 @@ client2name:client2passwd";
             .tls
             .set_root_ca_certificate(Some(format!("{cert_path}/ca.pem")))
             .unwrap();
-        let s01 = ztimeout!(zenoh::open(config)).unwrap();
+        let s01 = test_context.open_connector_with_cfg(config).await;
 
-        let mut config = zenoh_config::Config::default();
+        let mut config = test_context.get_connector_config_with_endpoint(locators);
         config.set_mode(Some(WhatAmI::Client)).unwrap();
-        config
-            .connect
-            .set_endpoints(ModeDependentValue::Unique(vec![format!(
-                "quic/127.0.0.1:{port}"
-            )
-            .parse::<EndPoint>()
-            .unwrap()]))
-            .unwrap();
         config
             .insert_json5(
                 "transport",
@@ -845,7 +799,7 @@ client2name:client2passwd";
             .tls
             .set_root_ca_certificate(Some(format!("{cert_path}/ca.pem")))
             .unwrap();
-        let s02 = ztimeout!(zenoh::open(config)).unwrap();
+        let s02 = test_context.open_connector_with_cfg(config).await;
         (s01, s02)
     }
 
@@ -855,10 +809,11 @@ client2name:client2passwd";
         ztimeout!(s02.close()).unwrap();
     }
 
-    async fn test_pub_sub_deny_then_allow_tls(port: u16, lowlatency: bool) {
+    async fn test_pub_sub_deny_then_allow_tls(lowlatency: bool) {
         println!("test_pub_sub_deny_then_allow_tls");
+        let mut test_context = TestSessions::new();
 
-        let mut config_router = get_basic_router_config_tls(port, lowlatency).await;
+        let mut config_router = get_basic_router_config_tls(lowlatency).await;
 
         config_router
             .insert_json5(
@@ -898,10 +853,9 @@ client2name:client2passwd";
             )
             .unwrap();
         println!("Opening router session");
-
-        let session = ztimeout!(zenoh::open(config_router)).unwrap();
-
-        let (sub_session, pub_session) = get_client_sessions_tls(port, lowlatency).await;
+        let _session = test_context.open_listener_with_cfg(config_router).await;
+        let (sub_session, pub_session) =
+            get_client_sessions_tls(&mut test_context, lowlatency).await;
         {
             let publisher = pub_session.declare_publisher(KEY_EXPR).await.unwrap();
             let received_value = Arc::new(Mutex::new(String::new()));
@@ -921,13 +875,13 @@ client2name:client2passwd";
             assert_eq!(*zlock!(received_value), VALUE);
             ztimeout!(subscriber.undeclare()).unwrap();
         }
-        close_sessions(sub_session, pub_session).await;
-        close_router_session(session).await;
+        test_context.close().await;
     }
 
-    async fn test_pub_sub_allow_then_deny_tls(port: u16) {
+    async fn test_pub_sub_allow_then_deny_tls() {
         println!("test_pub_sub_allow_then_deny_tls");
-        let mut config_router = get_basic_router_config_tls(port, false).await;
+        let mut test_context = TestSessions::new();
+        let mut config_router = get_basic_router_config_tls(false).await;
         config_router
             .insert_json5(
                 "access_control",
@@ -966,9 +920,8 @@ client2name:client2passwd";
             )
             .unwrap();
         println!("Opening router session");
-
-        let session = ztimeout!(zenoh::open(config_router)).unwrap();
-        let (sub_session, pub_session) = get_client_sessions_tls(port, false).await;
+        let _session = test_context.open_listener_with_cfg(config_router).await;
+        let (sub_session, pub_session) = get_client_sessions_tls(&mut test_context, false).await;
         {
             let publisher = ztimeout!(pub_session.declare_publisher(KEY_EXPR)).unwrap();
             let received_value = Arc::new(Mutex::new(String::new()));
@@ -990,14 +943,14 @@ client2name:client2passwd";
             assert_ne!(*zlock!(received_value), VALUE);
             ztimeout!(subscriber.undeclare()).unwrap();
         }
-        close_sessions(sub_session, pub_session).await;
-        close_router_session(session).await;
+        test_context.close().await;
     }
 
-    async fn test_get_qbl_deny_then_allow_tls(port: u16) {
+    async fn test_get_qbl_deny_then_allow_tls() {
         println!("test_get_qbl_deny_then_allow_tls");
+        let mut test_context = TestSessions::new();
 
-        let mut config_router = get_basic_router_config_tls(port, false).await;
+        let mut config_router = get_basic_router_config_tls(false).await;
         config_router
             .insert_json5(
                 "access_control",
@@ -1038,10 +991,8 @@ client2name:client2passwd";
             .unwrap();
 
         println!("Opening router session");
-
-        let session = ztimeout!(zenoh::open(config_router)).unwrap();
-
-        let (get_session, qbl_session) = get_client_sessions_tls(port, false).await;
+        let _session = test_context.open_listener_with_cfg(config_router).await;
+        let (get_session, qbl_session) = get_client_sessions_tls(&mut test_context, false).await;
         {
             let mut received_value = String::new();
 
@@ -1076,14 +1027,14 @@ client2name:client2passwd";
             assert_eq!(received_value, VALUE);
             ztimeout!(qbl.undeclare()).unwrap();
         }
-        close_sessions(get_session, qbl_session).await;
-        close_router_session(session).await;
+        test_context.close().await;
     }
 
-    async fn test_get_qbl_allow_then_deny_tls(port: u16) {
+    async fn test_get_qbl_allow_then_deny_tls() {
         println!("test_get_qbl_allow_then_deny_tls");
+        let mut test_context = TestSessions::new();
 
-        let mut config_router = get_basic_router_config_tls(port, false).await;
+        let mut config_router = get_basic_router_config_tls(false).await;
         config_router
             .insert_json5(
                 "access_control",
@@ -1123,10 +1074,8 @@ client2name:client2passwd";
             )
             .unwrap();
         println!("Opening router session");
-
-        let session = ztimeout!(zenoh::open(config_router)).unwrap();
-
-        let (get_session, qbl_session) = get_client_sessions_tls(port, false).await;
+        let _session = test_context.open_listener_with_cfg(config_router).await;
+        let (get_session, qbl_session) = get_client_sessions_tls(&mut test_context, false).await;
         {
             let mut received_value = String::new();
 
@@ -1161,14 +1110,14 @@ client2name:client2passwd";
             assert_ne!(received_value, VALUE);
             ztimeout!(qbl.undeclare()).unwrap();
         }
-        close_sessions(get_session, qbl_session).await;
-        close_router_session(session).await;
+        test_context.close().await;
     }
 
-    async fn test_pub_sub_deny_then_allow_quic(port: u16) {
+    async fn test_pub_sub_deny_then_allow_quic() {
         println!("test_pub_sub_deny_then_allow_quic");
+        let mut test_context = TestSessions::new();
 
-        let mut config_router = get_basic_router_config_quic(port).await;
+        let mut config_router = get_basic_router_config_quic().await;
 
         config_router
             .insert_json5(
@@ -1208,10 +1157,8 @@ client2name:client2passwd";
             )
             .unwrap();
         println!("Opening router session");
-
-        let session = ztimeout!(zenoh::open(config_router)).unwrap();
-
-        let (sub_session, pub_session) = get_client_sessions_quic(port).await;
+        let _session = test_context.open_listener_with_cfg(config_router).await;
+        let (sub_session, pub_session) = get_client_sessions_quic(&mut test_context).await;
         {
             let publisher = pub_session.declare_publisher(KEY_EXPR).await.unwrap();
             let received_value = Arc::new(Mutex::new(String::new()));
@@ -1231,15 +1178,15 @@ client2name:client2passwd";
             assert_eq!(*zlock!(received_value), VALUE);
             ztimeout!(subscriber.undeclare()).unwrap();
         }
-        close_sessions(sub_session, pub_session).await;
-        close_router_session(session).await;
+        test_context.close().await;
     }
 
     #[allow(unused)]
-    async fn test_pub_sub_allow_then_deny_quic(port: u16) {
+    async fn test_pub_sub_allow_then_deny_quic() {
         println!("test_pub_sub_allow_then_deny_quic");
+        let mut test_context = TestSessions::new();
 
-        let mut config_router = get_basic_router_config_quic(port).await;
+        let mut config_router = get_basic_router_config_quic().await;
         config_router
             .insert_json5(
                 "access_control",
@@ -1278,9 +1225,8 @@ client2name:client2passwd";
             )
             .unwrap();
         println!("Opening router session");
-
-        let session = ztimeout!(zenoh::open(config_router)).unwrap();
-        let (sub_session, pub_session) = get_client_sessions_quic(port).await;
+        let _session = test_context.open_listener_with_cfg(config_router).await;
+        let (sub_session, pub_session) = get_client_sessions_quic(&mut test_context).await;
         {
             let publisher = ztimeout!(pub_session.declare_publisher(KEY_EXPR)).unwrap();
             let received_value = Arc::new(Mutex::new(String::new()));
@@ -1302,15 +1248,15 @@ client2name:client2passwd";
             assert_ne!(*zlock!(received_value), VALUE);
             ztimeout!(subscriber.undeclare()).unwrap();
         }
-        close_sessions(sub_session, pub_session).await;
-        close_router_session(session).await;
+        test_context.close().await;
     }
 
     #[allow(unused)]
-    async fn test_get_qbl_deny_then_allow_quic(port: u16) {
+    async fn test_get_qbl_deny_then_allow_quic() {
         println!("test_get_qbl_deny_then_allow_quic");
+        let mut test_context = TestSessions::new();
 
-        let mut config_router = get_basic_router_config_quic(port).await;
+        let mut config_router = get_basic_router_config_quic().await;
         config_router
             .insert_json5(
                 "access_control",
@@ -1351,10 +1297,8 @@ client2name:client2passwd";
             .unwrap();
 
         println!("Opening router session");
-
-        let session = ztimeout!(zenoh::open(config_router)).unwrap();
-
-        let (get_session, qbl_session) = get_client_sessions_quic(port).await;
+        let _session = test_context.open_listener_with_cfg(config_router).await;
+        let (get_session, qbl_session) = get_client_sessions_quic(&mut test_context).await;
         {
             let mut received_value = String::new();
 
@@ -1389,15 +1333,15 @@ client2name:client2passwd";
             assert_eq!(received_value, VALUE);
             ztimeout!(qbl.undeclare()).unwrap();
         }
-        close_sessions(get_session, qbl_session).await;
-        close_router_session(session).await;
+        test_context.close().await;
     }
 
     #[allow(unused)]
-    async fn test_get_qbl_allow_then_deny_quic(port: u16) {
+    async fn test_get_qbl_allow_then_deny_quic() {
         println!("test_get_qbl_allow_then_deny_quic");
+        let mut test_context = TestSessions::new();
 
-        let mut config_router = get_basic_router_config_quic(port).await;
+        let mut config_router = get_basic_router_config_quic().await;
         config_router
             .insert_json5(
                 "access_control",
@@ -1437,10 +1381,8 @@ client2name:client2passwd";
             )
             .unwrap();
         println!("Opening router session");
-
-        let session = ztimeout!(zenoh::open(config_router)).unwrap();
-
-        let (get_session, qbl_session) = get_client_sessions_quic(port).await;
+        let _session = test_context.open_listener_with_cfg(config_router).await;
+        let (get_session, qbl_session) = get_client_sessions_quic(&mut test_context).await;
         {
             let mut received_value = String::new();
 
@@ -1475,14 +1417,14 @@ client2name:client2passwd";
             assert_ne!(received_value, VALUE);
             ztimeout!(qbl.undeclare()).unwrap();
         }
-        close_sessions(get_session, qbl_session).await;
-        close_router_session(session).await;
+        test_context.close().await;
     }
 
-    async fn test_pub_sub_deny_then_allow_usrpswd(port: u16) {
+    async fn test_pub_sub_deny_then_allow_usrpswd() {
         println!("test_pub_sub_deny_then_allow_usrpswd");
+        let mut test_context = TestSessions::new();
 
-        let mut config_router = get_basic_router_config_usrpswd(port).await;
+        let mut config_router = get_basic_router_config_usrpswd().await;
 
         config_router
             .insert_json5(
@@ -1523,10 +1465,8 @@ client2name:client2passwd";
             )
             .unwrap();
         println!("Opening router session");
-
-        let session = ztimeout!(zenoh::open(config_router)).unwrap();
-
-        let (sub_session, pub_session) = get_client_sessions_usrpswd(port).await;
+        let _session = test_context.open_listener_with_cfg(config_router).await;
+        let (sub_session, pub_session) = get_client_sessions_usrpswd(&mut test_context).await;
         {
             let publisher = pub_session.declare_publisher(KEY_EXPR).await.unwrap();
             let received_value = Arc::new(Mutex::new(String::new()));
@@ -1546,14 +1486,14 @@ client2name:client2passwd";
             assert_eq!(*zlock!(received_value), VALUE);
             ztimeout!(subscriber.undeclare()).unwrap();
         }
-        close_sessions(sub_session, pub_session).await;
-        close_router_session(session).await;
+        test_context.close().await;
     }
 
-    async fn test_pub_sub_allow_then_deny_usrpswd(port: u16) {
+    async fn test_pub_sub_allow_then_deny_usrpswd() {
         println!("test_pub_sub_allow_then_deny_usrpswd");
+        let mut test_context = TestSessions::new();
 
-        let mut config_router = get_basic_router_config_usrpswd(port).await;
+        let mut config_router = get_basic_router_config_usrpswd().await;
         config_router
             .insert_json5(
                 "access_control",
@@ -1593,9 +1533,8 @@ client2name:client2passwd";
             )
             .unwrap();
         println!("Opening router session");
-
-        let session = ztimeout!(zenoh::open(config_router)).unwrap();
-        let (sub_session, pub_session) = get_client_sessions_usrpswd(port).await;
+        let _session = test_context.open_listener_with_cfg(config_router).await;
+        let (sub_session, pub_session) = get_client_sessions_usrpswd(&mut test_context).await;
         {
             let publisher = ztimeout!(pub_session.declare_publisher(KEY_EXPR)).unwrap();
             let received_value = Arc::new(Mutex::new(String::new()));
@@ -1617,14 +1556,14 @@ client2name:client2passwd";
             assert_ne!(*zlock!(received_value), VALUE);
             ztimeout!(subscriber.undeclare()).unwrap();
         }
-        close_sessions(sub_session, pub_session).await;
-        close_router_session(session).await;
+        test_context.close().await;
     }
 
-    async fn test_get_qbl_deny_then_allow_usrpswd(port: u16) {
+    async fn test_get_qbl_deny_then_allow_usrpswd() {
         println!("test_get_qbl_deny_then_allow_usrpswd");
+        let mut test_context = TestSessions::new();
 
-        let mut config_router = get_basic_router_config_usrpswd(port).await;
+        let mut config_router = get_basic_router_config_usrpswd().await;
         config_router
             .insert_json5(
                 "access_control",
@@ -1666,10 +1605,8 @@ client2name:client2passwd";
             .unwrap();
 
         println!("Opening router session");
-
-        let session = ztimeout!(zenoh::open(config_router)).unwrap();
-
-        let (get_session, qbl_session) = get_client_sessions_usrpswd(port).await;
+        let _session = test_context.open_listener_with_cfg(config_router).await;
+        let (get_session, qbl_session) = get_client_sessions_usrpswd(&mut test_context).await;
         {
             let mut received_value = String::new();
 
@@ -1704,14 +1641,14 @@ client2name:client2passwd";
             assert_eq!(received_value, VALUE);
             ztimeout!(qbl.undeclare()).unwrap();
         }
-        close_sessions(get_session, qbl_session).await;
-        close_router_session(session).await;
+        test_context.close().await;
     }
 
-    async fn test_get_qbl_allow_then_deny_usrpswd(port: u16) {
+    async fn test_get_qbl_allow_then_deny_usrpswd() {
         println!("test_get_qbl_allow_then_deny_usrpswd");
+        let mut test_context = TestSessions::new();
 
-        let mut config_router = get_basic_router_config_usrpswd(port).await;
+        let mut config_router = get_basic_router_config_usrpswd().await;
         config_router
             .insert_json5(
                 "access_control",
@@ -1752,10 +1689,8 @@ client2name:client2passwd";
             )
             .unwrap();
         println!("Opening router session");
-
-        let session = ztimeout!(zenoh::open(config_router)).unwrap();
-
-        let (get_session, qbl_session) = get_client_sessions_usrpswd(port).await;
+        let _session = test_context.open_listener_with_cfg(config_router).await;
+        let (get_session, qbl_session) = get_client_sessions_usrpswd(&mut test_context).await;
         {
             let mut received_value = String::new();
 
@@ -1790,14 +1725,14 @@ client2name:client2passwd";
             assert_ne!(received_value, VALUE);
             ztimeout!(qbl.undeclare()).unwrap();
         }
-        close_sessions(get_session, qbl_session).await;
-        close_router_session(session).await;
+        test_context.close().await;
     }
 
-    async fn test_deny_allow_combination(port: u16) {
+    async fn test_deny_allow_combination() {
         println!("test_deny_allow_combination");
+        let mut test_context = TestSessions::new();
 
-        let mut config_router = get_basic_router_config_quic_usrpswd(port).await;
+        let mut config_router = get_basic_router_config_quic_usrpswd().await;
         config_router
             .insert_json5(
                 "access_control",
@@ -1841,8 +1776,8 @@ client2name:client2passwd";
             .unwrap();
 
         println!("Opening router session");
-        let session = ztimeout!(zenoh::open(config_router)).unwrap();
-        let (sub_session, pub_session) = get_client_sessions_usrpswd(port).await;
+        let _session = test_context.open_listener_with_cfg(config_router).await;
+        let (sub_session, pub_session) = get_client_sessions_usrpswd(&mut test_context).await;
         {
             let publisher = ztimeout!(pub_session.declare_publisher(KEY_EXPR)).unwrap();
             let received_value = Arc::new(Mutex::new(String::new()));
@@ -1865,7 +1800,7 @@ client2name:client2passwd";
             ztimeout!(subscriber.undeclare()).unwrap();
         }
         close_sessions(sub_session, pub_session).await;
-        let (sub_session, pub_session) = get_client_sessions_quic_usrpswd(port).await;
+        let (sub_session, pub_session) = get_client_sessions_quic_usrpswd(&mut test_context).await;
         {
             let publisher = ztimeout!(pub_session.declare_publisher(KEY_EXPR)).unwrap();
             let received_value = Arc::new(Mutex::new(String::new()));
@@ -1887,13 +1822,14 @@ client2name:client2passwd";
             assert_eq!(*zlock!(received_value), VALUE);
             ztimeout!(subscriber.undeclare()).unwrap();
         }
-        close_router_session(session).await;
+        test_context.close().await;
     }
 
-    async fn test_allow_deny_combination(port: u16) {
+    async fn test_allow_deny_combination() {
         println!("test_allow_deny_combination");
+        let mut test_context = TestSessions::new();
 
-        let mut config_router = get_basic_router_config_quic_usrpswd(port).await;
+        let mut config_router = get_basic_router_config_quic_usrpswd().await;
         config_router
             .insert_json5(
                 "access_control",
@@ -1937,8 +1873,8 @@ client2name:client2passwd";
             .unwrap();
 
         println!("Opening router session");
-        let session = ztimeout!(zenoh::open(config_router)).unwrap();
-        let (sub_session, pub_session) = get_client_sessions_usrpswd(port).await;
+        let _session = test_context.open_listener_with_cfg(config_router).await;
+        let (sub_session, pub_session) = get_client_sessions_usrpswd(&mut test_context).await;
         {
             let publisher = ztimeout!(pub_session.declare_publisher(KEY_EXPR)).unwrap();
             let received_value = Arc::new(Mutex::new(String::new()));
@@ -1961,7 +1897,7 @@ client2name:client2passwd";
             ztimeout!(subscriber.undeclare()).unwrap();
         }
         close_sessions(sub_session, pub_session).await;
-        let (sub_session, pub_session) = get_client_sessions_quic_usrpswd(port).await;
+        let (sub_session, pub_session) = get_client_sessions_quic_usrpswd(&mut test_context).await;
         {
             let publisher = ztimeout!(pub_session.declare_publisher(KEY_EXPR)).unwrap();
             let received_value = Arc::new(Mutex::new(String::new()));
@@ -1983,18 +1919,19 @@ client2name:client2passwd";
             assert_ne!(*zlock!(received_value), VALUE);
             ztimeout!(subscriber.undeclare()).unwrap();
         }
-        close_router_session(session).await;
+        test_context.close().await;
     }
 
-    async fn test_pub_sub_auth_link_protocol(port: u16) {
+    async fn test_pub_sub_auth_link_protocol() {
         let key_expr = "acl_auth_test/pubsub/by_protocols";
+        let mut test_context = TestSessions::new();
 
-        let mut config_listener = zenoh_config::Config::default();
+        let mut config_listener = test_context.get_listener_config("tcp/127.0.0.1:0", 2);
         config_listener
             .listen
             .set_endpoints(ModeDependentValue::Unique(vec![
-                format!("tcp/127.0.0.1:{port}").parse().unwrap(),
-                format!("udp/127.0.0.1:{port}").parse().unwrap(),
+                "tcp/127.0.0.1:0".parse().unwrap(),
+                "udp/127.0.0.1:0".parse().unwrap(),
             ]))
             .unwrap();
         config_listener
@@ -2043,10 +1980,11 @@ client2name:client2passwd";
             )
             .unwrap();
 
-        let listener_session = zenoh::open(config_listener).await.unwrap();
+        let listener_session = test_context.open_listener_with_cfg(config_listener).await;
         tokio::time::sleep(SLEEP).await;
 
-        let mut config_connect = zenoh_config::Config::default();
+        let mut config_connect = test_context
+            .get_connector_config_with_endpoint(get_locators_by_protocol(&test_context, "tcp"));
         config_connect.set_mode(Some(WhatAmI::Client)).unwrap();
         config_connect
             .scouting
@@ -2059,18 +1997,28 @@ client2name:client2passwd";
             .set_enabled(Some(false))
             .unwrap();
         config_connect
-            .connect
-            .endpoints
-            .set(vec![format!("tcp/127.0.0.1:{port}").parse().unwrap()])
+            .scouting
+            .gossip
+            .set_enabled(Some(false))
             .unwrap();
-        let session_denied = zenoh::open(config_connect.clone()).await.unwrap();
+        let session_denied = test_context
+            .open_connector_with_cfg(config_connect.clone())
+            .await;
 
+        let mut config_connect = test_context
+            .get_connector_config_with_endpoint(get_locators_by_protocol(&test_context, "udp"));
+        config_connect.set_mode(Some(WhatAmI::Client)).unwrap();
         config_connect
-            .connect
-            .endpoints
-            .set(vec![format!("udp/127.0.0.1:{port}").parse().unwrap()])
+            .scouting
+            .multicast
+            .set_enabled(Some(false))
             .unwrap();
-        let session_allowed = zenoh::open(config_connect).await.unwrap();
+        config_connect
+            .scouting
+            .gossip
+            .set_enabled(Some(false))
+            .unwrap();
+        let session_allowed = test_context.open_connector_with_cfg(config_connect).await;
 
         let sub = listener_session.declare_subscriber(key_expr).await.unwrap();
 
@@ -2087,24 +2035,15 @@ client2name:client2passwd";
         assert!(payload.eq("ALLOWED"));
 
         sub.undeclare().await.unwrap();
-        session_allowed.close().await.unwrap();
-        session_denied.close().await.unwrap();
-        listener_session.close().await.unwrap();
+        test_context.close().await;
     }
 
-    async fn test_pub_sub_auth_zid(port: u16) {
+    async fn test_pub_sub_auth_zid() {
         let key_expr = "acl_auth_test/pubsub/by_zid";
         let test_zid = "abcdef";
+        let mut test_context = TestSessions::new();
 
-        let mut config_listener = zenoh_config::Config::default();
-        config_listener
-            .listen
-            .set_endpoints(ModeDependentValue::Unique(vec![format!(
-                "tcp/127.0.0.1:{port}"
-            )
-            .parse()
-            .unwrap()]))
-            .unwrap();
+        let mut config_listener = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
         config_listener
             .scouting
             .gossip
@@ -2151,10 +2090,11 @@ client2name:client2passwd";
             )
             .unwrap();
 
-        let listener_session = zenoh::open(config_listener).await.unwrap();
+        let listener_session = test_context.open_listener_with_cfg(config_listener).await;
         tokio::time::sleep(SLEEP).await;
 
-        let mut config_connect = zenoh_config::Config::default();
+        let mut config_connect = test_context
+            .get_connector_config_with_endpoint(get_locators_by_protocol(&test_context, "tcp"));
         config_connect.set_mode(Some(WhatAmI::Client)).unwrap();
         config_connect
             .scouting
@@ -2167,16 +2107,18 @@ client2name:client2passwd";
             .set_enabled(Some(false))
             .unwrap();
         config_connect
-            .connect
-            .endpoints
-            .set(vec![format!("tcp/127.0.0.1:{port}").parse().unwrap()])
+            .scouting
+            .gossip
+            .set_enabled(Some(false))
             .unwrap();
-        let session_allowed = zenoh::open(config_connect.clone()).await.unwrap();
+        let session_allowed = test_context
+            .open_connector_with_cfg(config_connect.clone())
+            .await;
 
         config_connect
             .set_id(Some(ZenohId::from_str(test_zid).unwrap()))
             .unwrap();
-        let session_denied = zenoh::open(config_connect).await.unwrap();
+        let session_denied = test_context.open_connector_with_cfg(config_connect).await;
 
         let sub = listener_session.declare_subscriber(key_expr).await.unwrap();
 
@@ -2193,8 +2135,6 @@ client2name:client2passwd";
         assert!(payload.eq("ALLOWED"));
 
         sub.undeclare().await.unwrap();
-        session_allowed.close().await.unwrap();
-        session_denied.close().await.unwrap();
-        listener_session.close().await.unwrap();
+        test_context.close().await;
     }
 }

--- a/zenoh/tests/common/mod.rs
+++ b/zenoh/tests/common/mod.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 #![allow(dead_code)] // because every test doesn't use the whole common features
-use std::time::Duration;
+use std::{net::TcpListener, time::Duration};
 
 #[cfg(feature = "internal")]
 use zenoh::internal::runtime::{Runtime, RuntimeBuilder};
@@ -22,6 +22,25 @@ use zenoh_core::ztimeout;
 use zenoh_link::EndPoint;
 
 const TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Binds to a random TCP port on loopback and returns the assigned port number.
+/// The port is briefly released before Zenoh binds it; races are negligible on localhost.
+pub fn get_free_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.local_addr().unwrap().port()
+}
+
+/// Returns the first TCP [`EndPoint`] exposed by `session`.
+///
+/// Combines [`TestSessions::get_locators_from_session`] with a TCP filter so callers
+/// get a ready-to-use connect address after opening a listener with port `0`.
+pub async fn get_tcp_locator(session: &Session) -> EndPoint {
+    TestSessions::get_locators_from_session(session)
+        .await
+        .into_iter()
+        .find(|ep| ep.to_string().starts_with("tcp/"))
+        .expect("Expected a TCP listener endpoint from session")
+}
 
 pub async fn close_session(peer01: Session, peer02: Session) {
     println!("[  ][01d] Closing peer01 session");

--- a/zenoh/tests/common/mod.rs
+++ b/zenoh/tests/common/mod.rs
@@ -86,6 +86,10 @@ impl TestSessions {
         self.get_connector_config_with_endpoint(self.locators.clone())
     }
 
+    pub fn locators(&self) -> Vec<EndPoint> {
+        self.locators.clone()
+    }
+
     pub async fn get_locators_from_session(session: &Session) -> Vec<EndPoint> {
         session
             .info()

--- a/zenoh/tests/interceptors.rs
+++ b/zenoh/tests/interceptors.rs
@@ -13,6 +13,8 @@
 //
 
 #![cfg(unix)]
+#![cfg(feature = "unstable")]
+mod common;
 
 use std::{
     collections::HashMap,
@@ -22,10 +24,11 @@ use std::{
     },
 };
 
+use common::TestSessions;
 use nonempty_collections::nev;
-use zenoh::{key_expr::KeyExpr, query::ConsolidationMode, Config, Wait};
+use zenoh::{key_expr::KeyExpr, query::ConsolidationMode, Wait};
 use zenoh_config::{
-    DownsamplingItemConf, DownsamplingMessage, DownsamplingRuleConf, InterceptorFlow,
+    Config, DownsamplingItemConf, DownsamplingMessage, DownsamplingRuleConf, InterceptorFlow,
 };
 
 // Tokio's time granularity on different platforms
@@ -37,47 +40,41 @@ static MINIMAL_SLEEP_INTERVAL_MS: u64 = 2;
 static REPEAT: usize = 3;
 static WARMUP_MS: u64 = 500;
 
-fn build_config(
-    locator: &str,
+fn should_apply_downsampling(flow: InterceptorFlow, is_sender: bool) -> bool {
+    match flow {
+        InterceptorFlow::Egress => is_sender,
+        InterceptorFlow::Ingress => !is_sender,
+    }
+}
+
+fn build_listener_config(
     ds_config: Vec<DownsamplingItemConf>,
     flow: InterceptorFlow,
-) -> (Config, Config) {
-    let mut sender_config = zenoh_config::Config::default();
-    sender_config
-        .scouting
-        .multicast
-        .set_enabled(Some(false))
-        .unwrap();
+    is_sender: bool,
+) -> Config {
+    let mut config = TestSessions::new().get_listener_config("tcp/127.0.0.1:0", 1);
+    if should_apply_downsampling(flow, is_sender) {
+        config.set_downsampling(ds_config).unwrap();
+    }
+    config
+}
 
-    let mut receiver_config = zenoh_config::Config::default();
-    receiver_config
-        .scouting
-        .multicast
-        .set_enabled(Some(false))
-        .unwrap();
-
-    receiver_config
-        .listen
-        .endpoints
-        .set(vec![locator.parse().unwrap()])
-        .unwrap();
-    sender_config
-        .connect
-        .endpoints
-        .set(vec![locator.parse().unwrap()])
-        .unwrap();
-
-    match flow {
-        InterceptorFlow::Egress => sender_config.set_downsampling(ds_config).unwrap(),
-        InterceptorFlow::Ingress => receiver_config.set_downsampling(ds_config).unwrap(),
-    };
-
-    (sender_config.into(), receiver_config.into())
+fn build_connector_config(
+    test_context: &TestSessions,
+    ds_config: Vec<DownsamplingItemConf>,
+    flow: InterceptorFlow,
+    is_sender: bool,
+) -> Config {
+    let mut config = test_context.get_connector_config();
+    if should_apply_downsampling(flow, is_sender) {
+        config.set_downsampling(ds_config).unwrap();
+    }
+    config
 }
 
 fn downsampling_pub_sub_test<F>(
-    pub_config: Config,
-    sub_config: Config,
+    flow: InterceptorFlow,
+    ds_config: Vec<DownsamplingItemConf>,
     ke_prefix: &str,
     ke_of_rates: Vec<KeyExpr<'static>>,
     rate_check: F,
@@ -93,7 +90,12 @@ fn downsampling_pub_sub_test<F>(
             .collect(),
     );
 
-    let sub_session = zenoh::open(sub_config).wait().unwrap();
+    let mut test_context = TestSessions::new();
+    let sub_session = test_context.open_listener_with_cfg_sync(build_listener_config(
+        ds_config.clone(),
+        flow,
+        false,
+    ));
     let _sub = sub_session
         .declare_subscriber(format!("{ke_prefix}/*"))
         .callback({
@@ -109,8 +111,13 @@ fn downsampling_pub_sub_test<F>(
 
     let is_terminated = Arc::new(AtomicBool::new(false));
     let c_is_terminated = is_terminated.clone();
+    let pub_session = test_context.open_connector_with_cfg_sync(build_connector_config(
+        &test_context,
+        ds_config,
+        flow,
+        true,
+    ));
     let handle = std::thread::spawn(move || {
-        let pub_session = zenoh::open(pub_config).wait().unwrap();
         let publishers: Vec<_> = ke_of_rates
             .into_iter()
             .map(|ke| pub_session.declare_publisher(ke).wait().unwrap())
@@ -143,11 +150,11 @@ fn downsampling_pub_sub_test<F>(
     if let Err(err) = handle.join() {
         panic!("Failed to join the handle due to {err:?}");
     }
+    test_context.close_sync();
 }
 
 fn downsampling_by_keyexpr_impl(flow: InterceptorFlow) {
     let ke_prefix = "test/downsamples_by_keyexp";
-    let locator = "tcp/127.0.0.1:31445";
 
     let ke_10hz: KeyExpr = format!("{ke_prefix}/10hz").try_into().unwrap();
     let ke_20hz: KeyExpr = format!("{ke_prefix}/20hz").try_into().unwrap();
@@ -188,9 +195,7 @@ fn downsampling_by_keyexpr_impl(flow: InterceptorFlow) {
         }
     };
 
-    let (pub_config, sub_config) = build_config(locator, vec![ds_config], flow);
-
-    downsampling_pub_sub_test(pub_config, sub_config, ke_prefix, ke_of_rates, rate_check);
+    downsampling_pub_sub_test(flow, vec![ds_config], ke_prefix, ke_of_rates, rate_check);
 }
 
 #[test]
@@ -203,7 +208,6 @@ fn downsampling_by_keyexpr() {
 #[cfg(unix)]
 fn downsampling_by_interface_impl(flow: InterceptorFlow) {
     let ke_prefix = "test/downsamples_by_interface";
-    let locator = "tcp/127.0.0.1:31446";
 
     let ke_10hz: KeyExpr = format!("{ke_prefix}/10hz").try_into().unwrap();
     let ke_no_effect: KeyExpr = format!("{ke_prefix}/no_effect").try_into().unwrap();
@@ -246,9 +250,7 @@ fn downsampling_by_interface_impl(flow: InterceptorFlow) {
         }
     };
 
-    let (pub_config, sub_config) = build_config(locator, ds_config, flow);
-
-    downsampling_pub_sub_test(pub_config, sub_config, ke_prefix, ke_of_rates, rate_check);
+    downsampling_pub_sub_test(flow, ds_config, ke_prefix, ke_of_rates, rate_check);
 }
 
 #[cfg(unix)]
@@ -264,7 +266,6 @@ fn downsampling_by_protocol_impl(flow: InterceptorFlow) {
     use zenoh_config::InterceptorLink;
 
     let ke_prefix = "test/downsamples_by_interface";
-    let locator = "tcp/127.0.0.1:31447";
 
     let ke_10hz: KeyExpr = format!("{ke_prefix}/10hz").try_into().unwrap();
     let ke_no_effect: KeyExpr = format!("{ke_prefix}/no_effect").try_into().unwrap();
@@ -307,9 +308,7 @@ fn downsampling_by_protocol_impl(flow: InterceptorFlow) {
         }
     };
 
-    let (pub_config, sub_config) = build_config(locator, ds_config, flow);
-
-    downsampling_pub_sub_test(pub_config, sub_config, ke_prefix, ke_of_rates, rate_check);
+    downsampling_pub_sub_test(flow, ds_config, ke_prefix, ke_of_rates, rate_check);
 }
 
 #[test]
@@ -382,14 +381,25 @@ fn downsampling_config_error_repeated_id() {
 }
 
 fn downsampling_query_reply_test(
-    query_config: Config,
-    queryable_config: Config,
+    flow: InterceptorFlow,
+    ds_config: Vec<DownsamplingItemConf>,
     queryable_ke: &str,
     reply_counter: Arc<AtomicUsize>,
     nb_queries: usize,
+    listener_is_sender: bool,
 ) {
-    let query_session = zenoh::open(query_config).wait().unwrap();
-    let queryable_session = zenoh::open(queryable_config).wait().unwrap();
+    let mut test_context = TestSessions::new();
+    let queryable_session = test_context.open_listener_with_cfg_sync(build_listener_config(
+        ds_config.clone(),
+        flow,
+        listener_is_sender,
+    ));
+    let query_session = test_context.open_connector_with_cfg_sync(build_connector_config(
+        &test_context,
+        ds_config,
+        flow,
+        !listener_is_sender,
+    ));
 
     let response_ke = queryable_ke.to_owned();
     queryable_session
@@ -426,13 +436,11 @@ fn downsampling_query_reply_test(
     for handle in handles {
         handle.join().unwrap();
     }
-    query_session.close().wait().unwrap();
-    queryable_session.close().wait().unwrap();
+    test_context.close_sync();
 }
 
 fn downsampling_query_rate_test(flow: InterceptorFlow) {
     let queryable_ke = "test/downsamples_query";
-    let locator = "tcp/127.0.0.1:31448";
 
     let ds_config = DownsamplingItemConf {
         id: None,
@@ -446,21 +454,20 @@ fn downsampling_query_rate_test(flow: InterceptorFlow) {
         }],
     };
 
-    let (query_config, queryable_config) = build_config(locator, vec![ds_config], flow);
     let reply_counter = Arc::new(AtomicUsize::new(0));
     downsampling_query_reply_test(
-        query_config,
-        queryable_config,
+        flow,
+        vec![ds_config],
         queryable_ke,
         reply_counter.clone(),
         2,
+        false,
     );
     assert!(reply_counter.load(Ordering::SeqCst) == 1);
 }
 
 fn downsampling_reply_rate_test(flow: InterceptorFlow) {
     let queryable_ke = "test/downsamples_reply";
-    let locator = "tcp/127.0.0.1:31449";
 
     let ds_config = DownsamplingItemConf {
         id: None,
@@ -474,14 +481,14 @@ fn downsampling_reply_rate_test(flow: InterceptorFlow) {
         }],
     };
 
-    let (queryable_config, query_config) = build_config(locator, vec![ds_config], flow);
     let reply_counter = Arc::new(AtomicUsize::new(0));
     downsampling_query_reply_test(
-        query_config,
-        queryable_config,
+        flow,
+        vec![ds_config],
         queryable_ke,
         reply_counter.clone(),
         2,
+        true,
     );
 
     assert!(reply_counter.load(Ordering::SeqCst) == 1);

--- a/zenoh/tests/liveliness.rs
+++ b/zenoh/tests/liveliness.rs
@@ -11,46 +11,34 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
+#![cfg(feature = "unstable")]
+mod common;
+
 use zenoh_core::ztimeout;
+
+use crate::common::TestSessions;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_liveliness_subscriber_clique() {
     use std::time::Duration;
 
     use zenoh::{config::WhatAmI, sample::SampleKind};
-    use zenoh_config::EndPoint;
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const PEER1_ENDPOINT: &str = "tcp/localhost:27347";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subscriber/clique";
 
     zenoh_util::init_log_from_env_or("error");
 
-    let peer1 = {
-        let mut c = zenoh_config::Config::default();
-        c.listen
-            .endpoints
-            .set(vec![PEER1_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Peer));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Peer (1) ZID: {}", s.zid());
-        s
-    };
+    let mut test_context = TestSessions::new();
+    let mut config_peer1 = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config_peer1.set_mode(Some(WhatAmI::Peer)).unwrap();
+    let peer1 = test_context.open_listener_with_cfg(config_peer1).await;
+    tracing::info!("Peer (1) ZID: {}", peer1.zid());
 
-    let peer2 = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![PEER1_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Peer));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Peer (2) ZID: {}", s.zid());
-        s
-    };
+    let mut config_peer2 = test_context.get_connector_config();
+    config_peer2.set_mode(Some(WhatAmI::Client)).unwrap();
+    let peer2 = test_context.open_connector_with_cfg(config_peer2).await;
+    tracing::info!("Peer (2) ZID: {}", peer2.zid());
 
     let sub = ztimeout!(peer1.liveliness().declare_subscriber(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
@@ -71,8 +59,7 @@ async fn test_liveliness_subscriber_clique() {
 
     sub.undeclare().await.unwrap();
 
-    peer1.close().await.unwrap();
-    peer2.close().await.unwrap();
+    test_context.close().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -81,39 +68,22 @@ async fn test_liveliness_query_clique() {
 
     use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
-    use zenoh_link::EndPoint;
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const PEER1_ENDPOINT: &str = "tcp/localhost:27348";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/query/clique";
 
     zenoh_util::init_log_from_env_or("error");
 
-    let peer1 = {
-        let mut c = zenoh_config::Config::default();
-        c.listen
-            .endpoints
-            .set(vec![PEER1_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Peer));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Peer (1) ZID: {}", s.zid());
-        s
-    };
+    let mut test_context = TestSessions::new();
+    let mut config_peer1 = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config_peer1.set_mode(Some(WhatAmI::Peer)).unwrap();
+    let peer1 = test_context.open_listener_with_cfg(config_peer1).await;
+    tracing::info!("Peer (1) ZID: {}", peer1.zid());
 
-    let peer2 = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![PEER1_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Peer));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Peer (2) ZID: {}", s.zid());
-        s
-    };
+    let mut config_peer2 = test_context.get_connector_config();
+    config_peer2.set_mode(Some(WhatAmI::Peer)).unwrap();
+    let peer2 = test_context.open_connector_with_cfg(config_peer2).await;
+    tracing::info!("Peer (2) ZID: {}", peer2.zid());
 
     let token = ztimeout!(peer1.liveliness().declare_token(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
@@ -127,8 +97,7 @@ async fn test_liveliness_query_clique() {
 
     token.undeclare().await.unwrap();
 
-    peer1.close().await.unwrap();
-    peer2.close().await.unwrap();
+    test_context.close().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -137,53 +106,28 @@ async fn test_liveliness_subscriber_brokered() {
 
     use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
-    use zenoh_link::EndPoint;
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:27350";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subscriber/brokered";
 
     zenoh_util::init_log_from_env_or("error");
 
-    let router = {
-        let mut c = zenoh_config::Config::default();
-        c.listen
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Router));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Router ZID: {}", s.zid());
-        s
-    };
+    let mut test_context = TestSessions::new();
+    let mut config_router = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config_router.set_mode(Some(WhatAmI::Router)).unwrap();
+    let router = test_context.open_listener_with_cfg(config_router).await;
+    tracing::info!("Router ZID: {}", router.zid());
 
-    let client1 = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (1) ZID: {}", s.zid());
-        s
-    };
+    let mut config_client1 = test_context.get_connector_config();
+    config_client1.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client1 = test_context.open_connector_with_cfg(config_client1).await;
+    tracing::info!("Client (1) ZID: {}", client1.zid());
 
-    let client2 = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (2) ZID: {}", s.zid());
-        s
-    };
+    let mut config_client2 = test_context.get_connector_config();
+    config_client2.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client2 = test_context.open_connector_with_cfg(config_client2).await;
+    tracing::info!("Client (2) ZID: {}", client2.zid());
 
     let sub = ztimeout!(client1.liveliness().declare_subscriber(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
@@ -204,9 +148,7 @@ async fn test_liveliness_subscriber_brokered() {
 
     sub.undeclare().await.unwrap();
 
-    router.close().await.unwrap();
-    client1.close().await.unwrap();
-    client2.close().await.unwrap();
+    test_context.close().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -215,52 +157,27 @@ async fn test_liveliness_query_brokered() {
 
     use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
-    use zenoh_link::EndPoint;
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:27451";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/query/brokered";
 
     zenoh_util::init_log_from_env_or("error");
 
-    let router = {
-        let mut c = zenoh_config::Config::default();
-        c.listen
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Router));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Router ZID: {}", s.zid());
-        s
-    };
+    let mut test_context = TestSessions::new();
+    let mut config_router = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config_router.set_mode(Some(WhatAmI::Router)).unwrap();
+    let router = test_context.open_listener_with_cfg(config_router).await;
+    tracing::info!("Router ZID: {}", router.zid());
 
-    let client1 = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (1) ZID: {}", s.zid());
-        s
-    };
+    let mut config_client1 = test_context.get_connector_config();
+    config_client1.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client1 = test_context.open_connector_with_cfg(config_client1).await;
+    tracing::info!("Client (1) ZID: {}", client1.zid());
 
-    let client2 = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (2) ZID: {}", s.zid());
-        s
-    };
+    let mut config_client2 = test_context.get_connector_config();
+    config_client2.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client2 = test_context.open_connector_with_cfg(config_client2).await;
+    tracing::info!("Client (2) ZID: {}", client2.zid());
 
     let token = ztimeout!(client1.liveliness().declare_token(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
@@ -274,9 +191,7 @@ async fn test_liveliness_query_brokered() {
 
     token.undeclare().await.unwrap();
 
-    router.close().await.unwrap();
-    client1.close().await.unwrap();
-    client2.close().await.unwrap();
+    test_context.close().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -360,39 +275,22 @@ async fn test_liveliness_after_close() {
     use std::time::Duration;
 
     use zenoh::{config::WhatAmI, sample::SampleKind};
-    use zenoh_config::EndPoint;
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const PEER1_ENDPOINT: &str = "tcp/localhost:27452";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subscriber/clique";
 
     zenoh_util::init_log_from_env_or("error");
 
-    let peer1 = {
-        let mut c = zenoh_config::Config::default();
-        c.listen
-            .endpoints
-            .set(vec![PEER1_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Peer));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Peer (1) ZID: {}", s.zid());
-        s
-    };
+    let mut test_context = TestSessions::new();
+    let mut config_peer1 = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config_peer1.set_mode(Some(WhatAmI::Peer)).unwrap();
+    let peer1 = test_context.open_listener_with_cfg(config_peer1).await;
+    tracing::info!("Peer (1) ZID: {}", peer1.zid());
 
-    let peer2 = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![PEER1_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Peer));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Peer (2) ZID: {}", s.zid());
-        s
-    };
+    let mut config_peer2 = test_context.get_connector_config();
+    config_peer2.set_mode(Some(WhatAmI::Peer)).unwrap();
+    let peer2 = test_context.open_connector_with_cfg(config_peer2).await;
+    tracing::info!("Peer (2) ZID: {}", peer2.zid());
 
     let sub = ztimeout!(peer1.liveliness().declare_subscriber(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
@@ -407,7 +305,9 @@ async fn test_liveliness_after_close() {
     peer1.close().await.unwrap();
     tokio::time::sleep(SLEEP).await;
 
-    assert!(sub.try_recv().is_err())
+    assert!(sub.try_recv().is_err());
+
+    test_context.close().await;
 }
 
 /// -------------------------------------------------------
@@ -419,56 +319,35 @@ async fn test_liveliness_subscriber_double_client_before() {
 
     use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
-    use zenoh_link::EndPoint;
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:27453";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subscriber/double/client/before";
 
     zenoh_util::init_log_from_env_or("error");
 
-    let router = {
-        let mut c = zenoh_config::Config::default();
-        c.listen
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Router));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Router ZID: {}", s.zid());
-        s
-    };
+    let mut test_context = TestSessions::new();
+    let mut config_router = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config_router.set_mode(Some(WhatAmI::Router)).unwrap();
+    let router = test_context.open_listener_with_cfg(config_router).await;
+    tracing::info!("Router ZID: {}", router.zid());
 
-    let client_tok = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (token) ZID: {}", s.zid());
-        s
-    };
+    let mut config_client_tok = test_context.get_connector_config();
+    config_client_tok.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_tok = test_context
+        .open_connector_with_cfg(config_client_tok)
+        .await;
+    tracing::info!("Client (token) ZID: {}", client_tok.zid());
 
     let token = ztimeout!(client_tok.liveliness().declare_token(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
 
-    let client_sub = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (sub) ZID: {}", s.zid());
-        s
-    };
+    let mut config_client_sub = test_context.get_connector_config();
+    config_client_sub.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_sub = test_context
+        .open_connector_with_cfg(config_client_sub)
+        .await;
+    tracing::info!("Client (sub) ZID: {}", client_sub.zid());
 
     let sub1 = ztimeout!(client_sub
         .liveliness()
@@ -502,9 +381,7 @@ async fn test_liveliness_subscriber_double_client_before() {
     sub1.undeclare().await.unwrap();
     sub2.undeclare().await.unwrap();
 
-    client_tok.close().await.unwrap();
-    client_sub.close().await.unwrap();
-    router.close().await.unwrap();
+    test_context.close().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -513,40 +390,25 @@ async fn test_liveliness_subscriber_double_client_middle() {
 
     use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
-    use zenoh_link::EndPoint;
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:27454";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subscriber/double/client/middle";
 
     zenoh_util::init_log_from_env_or("error");
 
-    let router = {
-        let mut c = zenoh_config::Config::default();
-        c.listen
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Router));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Router ZID: {}", s.zid());
-        s
-    };
+    let mut test_context = TestSessions::new();
+    let mut config_router = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config_router.set_mode(Some(WhatAmI::Router)).unwrap();
+    let router = test_context.open_listener_with_cfg(config_router).await;
+    tracing::info!("Router ZID: {}", router.zid());
 
-    let client_sub = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (sub) ZID: {}", s.zid());
-        s
-    };
+    let mut config_client_sub = test_context.get_connector_config();
+    config_client_sub.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_sub = test_context
+        .open_connector_with_cfg(config_client_sub)
+        .await;
+    tracing::info!("Client (sub) ZID: {}", client_sub.zid());
 
     let sub1 = ztimeout!(client_sub
         .liveliness()
@@ -554,18 +416,12 @@ async fn test_liveliness_subscriber_double_client_middle() {
     .unwrap();
     tokio::time::sleep(SLEEP).await;
 
-    let client_tok = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (token) ZID: {}", s.zid());
-        s
-    };
+    let mut config_client_tok = test_context.get_connector_config();
+    config_client_tok.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_tok = test_context
+        .open_connector_with_cfg(config_client_tok)
+        .await;
+    tracing::info!("Client (token) ZID: {}", client_tok.zid());
 
     let token = ztimeout!(client_tok.liveliness().declare_token(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
@@ -599,9 +455,7 @@ async fn test_liveliness_subscriber_double_client_middle() {
     sub1.undeclare().await.unwrap();
     sub2.undeclare().await.unwrap();
 
-    client_tok.close().await.unwrap();
-    client_sub.close().await.unwrap();
-    router.close().await.unwrap();
+    test_context.close().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -610,40 +464,25 @@ async fn test_liveliness_subscriber_double_client_after() {
 
     use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
-    use zenoh_link::EndPoint;
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:27354";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subscriber/double/client/after";
 
     zenoh_util::init_log_from_env_or("error");
 
-    let router = {
-        let mut c = zenoh_config::Config::default();
-        c.listen
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Router));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Router ZID: {}", s.zid());
-        s
-    };
+    let mut test_context = TestSessions::new();
+    let mut config_router = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config_router.set_mode(Some(WhatAmI::Router)).unwrap();
+    let router = test_context.open_listener_with_cfg(config_router).await;
+    tracing::info!("Router ZID: {}", router.zid());
 
-    let client_sub = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (sub) ZID: {}", s.zid());
-        s
-    };
+    let mut config_client_sub = test_context.get_connector_config();
+    config_client_sub.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_sub = test_context
+        .open_connector_with_cfg(config_client_sub)
+        .await;
+    tracing::info!("Client (sub) ZID: {}", client_sub.zid());
 
     let sub1 = ztimeout!(client_sub
         .liveliness()
@@ -656,18 +495,12 @@ async fn test_liveliness_subscriber_double_client_after() {
     .unwrap();
     tokio::time::sleep(SLEEP).await;
 
-    let client_tok = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (token) ZID: {}", s.zid());
-        s
-    };
+    let mut config_client_tok = test_context.get_connector_config();
+    config_client_tok.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_tok = test_context
+        .open_connector_with_cfg(config_client_tok)
+        .await;
+    tracing::info!("Client (token) ZID: {}", client_tok.zid());
 
     let token = ztimeout!(client_tok.liveliness().declare_token(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
@@ -698,9 +531,7 @@ async fn test_liveliness_subscriber_double_client_after() {
     sub1.undeclare().await.unwrap();
     sub2.undeclare().await.unwrap();
 
-    client_tok.close().await.unwrap();
-    client_sub.close().await.unwrap();
-    router.close().await.unwrap();
+    test_context.close().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -709,56 +540,35 @@ async fn test_liveliness_subscriber_double_client_history_before() {
 
     use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
-    use zenoh_link::EndPoint;
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:27455";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subscriber/double/client/history/before";
 
     zenoh_util::init_log_from_env_or("error");
 
-    let router = {
-        let mut c = zenoh_config::Config::default();
-        c.listen
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Router));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Router ZID: {}", s.zid());
-        s
-    };
+    let mut test_context = TestSessions::new();
+    let mut config_router = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config_router.set_mode(Some(WhatAmI::Router)).unwrap();
+    let router = test_context.open_listener_with_cfg(config_router).await;
+    tracing::info!("Router ZID: {}", router.zid());
 
-    let client_tok = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (token) ZID: {}", s.zid());
-        s
-    };
+    let mut config_client_tok = test_context.get_connector_config();
+    config_client_tok.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_tok = test_context
+        .open_connector_with_cfg(config_client_tok)
+        .await;
+    tracing::info!("Client (token) ZID: {}", client_tok.zid());
 
     let token = ztimeout!(client_tok.liveliness().declare_token(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
 
-    let client_sub = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (sub) ZID: {}", s.zid());
-        s
-    };
+    let mut config_client_sub = test_context.get_connector_config();
+    config_client_sub.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_sub = test_context
+        .open_connector_with_cfg(config_client_sub)
+        .await;
+    tracing::info!("Client (sub) ZID: {}", client_sub.zid());
 
     let sub1 = ztimeout!(client_sub
         .liveliness()
@@ -800,9 +610,7 @@ async fn test_liveliness_subscriber_double_client_history_before() {
     sub1.undeclare().await.unwrap();
     sub2.undeclare().await.unwrap();
 
-    client_tok.close().await.unwrap();
-    client_sub.close().await.unwrap();
-    router.close().await.unwrap();
+    test_context.close().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -811,40 +619,25 @@ async fn test_liveliness_subscriber_double_client_history_middle() {
 
     use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
-    use zenoh_link::EndPoint;
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:27456";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subscriber/double/client/history/middle";
 
     zenoh_util::init_log_from_env_or("error");
 
-    let router = {
-        let mut c = zenoh_config::Config::default();
-        c.listen
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Router));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Router ZID: {}", s.zid());
-        s
-    };
+    let mut test_context = TestSessions::new();
+    let mut config_router = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config_router.set_mode(Some(WhatAmI::Router)).unwrap();
+    let router = test_context.open_listener_with_cfg(config_router).await;
+    tracing::info!("Router ZID: {}", router.zid());
 
-    let client_sub = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (sub) ZID: {}", s.zid());
-        s
-    };
+    let mut config_client_sub = test_context.get_connector_config();
+    config_client_sub.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_sub = test_context
+        .open_connector_with_cfg(config_client_sub)
+        .await;
+    tracing::info!("Client (sub) ZID: {}", client_sub.zid());
 
     let sub1 = ztimeout!(client_sub
         .liveliness()
@@ -853,18 +646,12 @@ async fn test_liveliness_subscriber_double_client_history_middle() {
     .unwrap();
     tokio::time::sleep(SLEEP).await;
 
-    let client_tok = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (token) ZID: {}", s.zid());
-        s
-    };
+    let mut config_client_tok = test_context.get_connector_config();
+    config_client_tok.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_tok = test_context
+        .open_connector_with_cfg(config_client_tok)
+        .await;
+    tracing::info!("Client (token) ZID: {}", client_tok.zid());
 
     let token = ztimeout!(client_tok.liveliness().declare_token(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
@@ -902,9 +689,7 @@ async fn test_liveliness_subscriber_double_client_history_middle() {
     sub1.undeclare().await.unwrap();
     sub2.undeclare().await.unwrap();
 
-    client_tok.close().await.unwrap();
-    client_sub.close().await.unwrap();
-    router.close().await.unwrap();
+    test_context.close().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -913,40 +698,25 @@ async fn test_liveliness_subscriber_double_client_history_after() {
 
     use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
-    use zenoh_link::EndPoint;
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:27357";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subscriber/double/client/history/after";
 
     zenoh_util::init_log_from_env_or("error");
 
-    let router = {
-        let mut c = zenoh_config::Config::default();
-        c.listen
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Router));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Router ZID: {}", s.zid());
-        s
-    };
+    let mut test_context = TestSessions::new();
+    let mut config_router = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config_router.set_mode(Some(WhatAmI::Router)).unwrap();
+    let router = test_context.open_listener_with_cfg(config_router).await;
+    tracing::info!("Router ZID: {}", router.zid());
 
-    let client_sub = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (sub) ZID: {}", s.zid());
-        s
-    };
+    let mut config_client_sub = test_context.get_connector_config();
+    config_client_sub.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_sub = test_context
+        .open_connector_with_cfg(config_client_sub)
+        .await;
+    tracing::info!("Client (sub) ZID: {}", client_sub.zid());
 
     let sub1 = ztimeout!(client_sub
         .liveliness()
@@ -961,18 +731,12 @@ async fn test_liveliness_subscriber_double_client_history_after() {
     .unwrap();
     tokio::time::sleep(SLEEP).await;
 
-    let client_tok = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (token) ZID: {}", s.zid());
-        s
-    };
+    let mut config_client_tok = test_context.get_connector_config();
+    config_client_tok.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_tok = test_context
+        .open_connector_with_cfg(config_client_tok)
+        .await;
+    tracing::info!("Client (token) ZID: {}", client_tok.zid());
 
     let token = ztimeout!(client_tok.liveliness().declare_token(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
@@ -1003,9 +767,7 @@ async fn test_liveliness_subscriber_double_client_history_after() {
     sub1.undeclare().await.unwrap();
     sub2.undeclare().await.unwrap();
 
-    client_tok.close().await.unwrap();
-    client_sub.close().await.unwrap();
-    router.close().await.unwrap();
+    test_context.close().await;
 }
 
 /// -------------------------------------------------------
@@ -1017,56 +779,33 @@ async fn test_liveliness_subscriber_double_peer_before() {
 
     use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
-    use zenoh_link::EndPoint;
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:27458";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subscriber/double/peer/before";
 
     zenoh_util::init_log_from_env_or("error");
 
-    let router = {
-        let mut c = zenoh_config::Config::default();
-        c.listen
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Router));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Router ZID: {}", s.zid());
-        s
-    };
+    let mut test_context = TestSessions::new();
+    let mut config_router = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config_router.set_mode(Some(WhatAmI::Router)).unwrap();
+    let router = test_context.open_listener_with_cfg(config_router).await;
+    tracing::info!("Router ZID: {}", router.zid());
 
-    let client_tok = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (token) ZID: {}", s.zid());
-        s
-    };
+    let mut config_client_tok = test_context.get_connector_config();
+    config_client_tok.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_tok = test_context
+        .open_connector_with_cfg(config_client_tok)
+        .await;
+    tracing::info!("Client (token) ZID: {}", client_tok.zid());
 
     let token = ztimeout!(client_tok.liveliness().declare_token(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
 
-    let peer_sub = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Peer));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Peer (sub) ZID: {}", s.zid());
-        s
-    };
+    let mut config_peer_sub = test_context.get_connector_config();
+    config_peer_sub.set_mode(Some(WhatAmI::Peer)).unwrap();
+    let peer_sub = test_context.open_connector_with_cfg(config_peer_sub).await;
+    tracing::info!("Peer (sub) ZID: {}", peer_sub.zid());
 
     let sub1 = ztimeout!(peer_sub.liveliness().declare_subscriber(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
@@ -1094,9 +833,7 @@ async fn test_liveliness_subscriber_double_peer_before() {
     sub1.undeclare().await.unwrap();
     sub2.undeclare().await.unwrap();
 
-    client_tok.close().await.unwrap();
-    peer_sub.close().await.unwrap();
-    router.close().await.unwrap();
+    test_context.close().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -1105,56 +842,33 @@ async fn test_liveliness_subscriber_double_peer_middle() {
 
     use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
-    use zenoh_link::EndPoint;
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:27459";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subscriber/double/peer/middle";
 
     zenoh_util::init_log_from_env_or("error");
 
-    let router = {
-        let mut c = zenoh_config::Config::default();
-        c.listen
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Router));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Router ZID: {}", s.zid());
-        s
-    };
+    let mut test_context = TestSessions::new();
+    let mut config_router = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config_router.set_mode(Some(WhatAmI::Router)).unwrap();
+    let router = test_context.open_listener_with_cfg(config_router).await;
+    tracing::info!("Router ZID: {}", router.zid());
 
-    let peer_sub = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Peer));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Peer (sub) ZID: {}", s.zid());
-        s
-    };
+    let mut config_peer_sub = test_context.get_connector_config();
+    config_peer_sub.set_mode(Some(WhatAmI::Peer)).unwrap();
+    let peer_sub = test_context.open_connector_with_cfg(config_peer_sub).await;
+    tracing::info!("Peer (sub) ZID: {}", peer_sub.zid());
 
     let sub1 = ztimeout!(peer_sub.liveliness().declare_subscriber(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
 
-    let client_tok = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (token) ZID: {}", s.zid());
-        s
-    };
+    let mut config_client_tok = test_context.get_connector_config();
+    config_client_tok.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_tok = test_context
+        .open_connector_with_cfg(config_client_tok)
+        .await;
+    tracing::info!("Client (token) ZID: {}", client_tok.zid());
 
     let token = ztimeout!(client_tok.liveliness().declare_token(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
@@ -1185,9 +899,7 @@ async fn test_liveliness_subscriber_double_peer_middle() {
     sub1.undeclare().await.unwrap();
     sub2.undeclare().await.unwrap();
 
-    client_tok.close().await.unwrap();
-    peer_sub.close().await.unwrap();
-    router.close().await.unwrap();
+    test_context.close().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -1196,58 +908,35 @@ async fn test_liveliness_subscriber_double_peer_after() {
 
     use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
-    use zenoh_link::EndPoint;
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:27460";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subscriber/double/peer/after";
 
     zenoh_util::init_log_from_env_or("error");
 
-    let router = {
-        let mut c = zenoh_config::Config::default();
-        c.listen
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Router));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Router ZID: {}", s.zid());
-        s
-    };
+    let mut test_context = TestSessions::new();
+    let mut config_router = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config_router.set_mode(Some(WhatAmI::Router)).unwrap();
+    let router = test_context.open_listener_with_cfg(config_router).await;
+    tracing::info!("Router ZID: {}", router.zid());
 
-    let peer_sub = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Peer));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Peer (sub) ZID: {}", s.zid());
-        s
-    };
+    let mut config_peer_sub = test_context.get_connector_config();
+    config_peer_sub.set_mode(Some(WhatAmI::Peer)).unwrap();
+    let peer_sub = test_context.open_connector_with_cfg(config_peer_sub).await;
+    tracing::info!("Peer (sub) ZID: {}", peer_sub.zid());
 
     let sub1 = ztimeout!(peer_sub.liveliness().declare_subscriber(LIVELINESS_KEYEXPR)).unwrap();
 
     let sub2 = ztimeout!(peer_sub.liveliness().declare_subscriber(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
 
-    let client_tok = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (token) ZID: {}", s.zid());
-        s
-    };
+    let mut config_client_tok = test_context.get_connector_config();
+    config_client_tok.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_tok = test_context
+        .open_connector_with_cfg(config_client_tok)
+        .await;
+    tracing::info!("Client (token) ZID: {}", client_tok.zid());
 
     let token = ztimeout!(client_tok.liveliness().declare_token(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
@@ -1278,9 +967,7 @@ async fn test_liveliness_subscriber_double_peer_after() {
     sub1.undeclare().await.unwrap();
     sub2.undeclare().await.unwrap();
 
-    client_tok.close().await.unwrap();
-    peer_sub.close().await.unwrap();
-    router.close().await.unwrap();
+    test_context.close().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -1289,56 +976,33 @@ async fn test_liveliness_subscriber_double_peer_history_before() {
 
     use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
-    use zenoh_link::EndPoint;
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:27461";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subscriber/double/peer/history/before";
 
     zenoh_util::init_log_from_env_or("error");
 
-    let router = {
-        let mut c = zenoh_config::Config::default();
-        c.listen
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Router));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Router ZID: {}", s.zid());
-        s
-    };
+    let mut test_context = TestSessions::new();
+    let mut config_router = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config_router.set_mode(Some(WhatAmI::Router)).unwrap();
+    let router = test_context.open_listener_with_cfg(config_router).await;
+    tracing::info!("Router ZID: {}", router.zid());
 
-    let client_tok = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (token) ZID: {}", s.zid());
-        s
-    };
+    let mut config_client_tok = test_context.get_connector_config();
+    config_client_tok.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_tok = test_context
+        .open_connector_with_cfg(config_client_tok)
+        .await;
+    tracing::info!("Client (token) ZID: {}", client_tok.zid());
 
     let token = ztimeout!(client_tok.liveliness().declare_token(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
 
-    let peer_sub = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Peer));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Peer (sub) ZID: {}", s.zid());
-        s
-    };
+    let mut config_peer_sub = test_context.get_connector_config();
+    config_peer_sub.set_mode(Some(WhatAmI::Peer)).unwrap();
+    let peer_sub = test_context.open_connector_with_cfg(config_peer_sub).await;
+    tracing::info!("Peer (sub) ZID: {}", peer_sub.zid());
 
     let sub1 = ztimeout!(peer_sub
         .liveliness()
@@ -1380,9 +1044,7 @@ async fn test_liveliness_subscriber_double_peer_history_before() {
     sub1.undeclare().await.unwrap();
     sub2.undeclare().await.unwrap();
 
-    client_tok.close().await.unwrap();
-    peer_sub.close().await.unwrap();
-    router.close().await.unwrap();
+    test_context.close().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -1391,40 +1053,23 @@ async fn test_liveliness_subscriber_double_peer_history_middle() {
 
     use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
-    use zenoh_link::EndPoint;
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:27462";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subscriber/double/peer/history/middle";
 
     zenoh_util::init_log_from_env_or("error");
 
-    let router = {
-        let mut c = zenoh_config::Config::default();
-        c.listen
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Router));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Router ZID: {}", s.zid());
-        s
-    };
+    let mut test_context = TestSessions::new();
+    let mut config_router = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config_router.set_mode(Some(WhatAmI::Router)).unwrap();
+    let router = test_context.open_listener_with_cfg(config_router).await;
+    tracing::info!("Router ZID: {}", router.zid());
 
-    let peer_sub = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Peer));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Peer (sub) ZID: {}", s.zid());
-        s
-    };
+    let mut config_peer_sub = test_context.get_connector_config();
+    config_peer_sub.set_mode(Some(WhatAmI::Peer)).unwrap();
+    let peer_sub = test_context.open_connector_with_cfg(config_peer_sub).await;
+    tracing::info!("Peer (sub) ZID: {}", peer_sub.zid());
 
     let sub1 = ztimeout!(peer_sub
         .liveliness()
@@ -1433,18 +1078,12 @@ async fn test_liveliness_subscriber_double_peer_history_middle() {
     .unwrap();
     tokio::time::sleep(SLEEP).await;
 
-    let client_tok = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (token) ZID: {}", s.zid());
-        s
-    };
+    let mut config_client_tok = test_context.get_connector_config();
+    config_client_tok.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_tok = test_context
+        .open_connector_with_cfg(config_client_tok)
+        .await;
+    tracing::info!("Client (token) ZID: {}", client_tok.zid());
 
     let token = ztimeout!(client_tok.liveliness().declare_token(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
@@ -1482,9 +1121,7 @@ async fn test_liveliness_subscriber_double_peer_history_middle() {
     sub1.undeclare().await.unwrap();
     sub2.undeclare().await.unwrap();
 
-    client_tok.close().await.unwrap();
-    peer_sub.close().await.unwrap();
-    router.close().await.unwrap();
+    test_context.close().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -1493,40 +1130,23 @@ async fn test_liveliness_subscriber_double_peer_history_after() {
 
     use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
-    use zenoh_link::EndPoint;
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:27463";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subscriber/double/peer/history/after";
 
     zenoh_util::init_log_from_env_or("error");
 
-    let router = {
-        let mut c = zenoh_config::Config::default();
-        c.listen
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Router));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Router ZID: {}", s.zid());
-        s
-    };
+    let mut test_context = TestSessions::new();
+    let mut config_router = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config_router.set_mode(Some(WhatAmI::Router)).unwrap();
+    let router = test_context.open_listener_with_cfg(config_router).await;
+    tracing::info!("Router ZID: {}", router.zid());
 
-    let peer_sub = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Peer));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Peer (sub) ZID: {}", s.zid());
-        s
-    };
+    let mut config_peer_sub = test_context.get_connector_config();
+    config_peer_sub.set_mode(Some(WhatAmI::Peer)).unwrap();
+    let peer_sub = test_context.open_connector_with_cfg(config_peer_sub).await;
+    tracing::info!("Peer (sub) ZID: {}", peer_sub.zid());
 
     let sub1 = ztimeout!(peer_sub
         .liveliness()
@@ -1541,18 +1161,12 @@ async fn test_liveliness_subscriber_double_peer_history_after() {
     .unwrap();
     tokio::time::sleep(SLEEP).await;
 
-    let client_tok = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (token) ZID: {}", s.zid());
-        s
-    };
+    let mut config_client_tok = test_context.get_connector_config();
+    config_client_tok.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_tok = test_context
+        .open_connector_with_cfg(config_client_tok)
+        .await;
+    tracing::info!("Client (token) ZID: {}", client_tok.zid());
 
     let token = ztimeout!(client_tok.liveliness().declare_token(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
@@ -1583,9 +1197,7 @@ async fn test_liveliness_subscriber_double_peer_history_after() {
     sub1.undeclare().await.unwrap();
     sub2.undeclare().await.unwrap();
 
-    client_tok.close().await.unwrap();
-    peer_sub.close().await.unwrap();
-    router.close().await.unwrap();
+    test_context.close().await;
 }
 
 /// -------------------------------------------------------
@@ -2942,56 +2554,31 @@ async fn test_liveliness_subget_client_before() {
 
     use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
-    use zenoh_link::EndPoint;
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:30488";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subget/client/before";
 
     zenoh_util::init_log_from_env_or("error");
 
-    let router = {
-        let mut c = zenoh_config::Config::default();
-        c.listen
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Router));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Router ZID: {}", s.zid());
-        s
-    };
+    let mut test_context = TestSessions::new();
+    let mut config_router = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config_router.set_mode(Some(WhatAmI::Router)).unwrap();
+    let router = test_context.open_listener_with_cfg(config_router).await;
+    tracing::info!("Router ZID: {}", router.zid());
 
-    let client_tok = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (token) ZID: {}", s.zid());
-        s
-    };
+    let mut config_tok = test_context.get_connector_config();
+    config_tok.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_tok = test_context.open_connector_with_cfg(config_tok).await;
+    tracing::info!("Client (token) ZID: {}", client_tok.zid());
 
     let token = ztimeout!(client_tok.liveliness().declare_token(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
 
-    let client_subget = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (subget) ZID: {}", s.zid());
-        s
-    };
+    let mut config_subget = test_context.get_connector_config();
+    config_subget.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_subget = test_context.open_connector_with_cfg(config_subget).await;
+    tracing::info!("Client (subget) ZID: {}", client_subget.zid());
 
     let sub = ztimeout!(client_subget
         .liveliness()
@@ -3023,9 +2610,7 @@ async fn test_liveliness_subget_client_before() {
 
     sub.undeclare().await.unwrap();
 
-    client_tok.close().await.unwrap();
-    client_subget.close().await.unwrap();
-    router.close().await.unwrap();
+    test_context.close().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -3034,40 +2619,23 @@ async fn test_liveliness_subget_client_middle() {
 
     use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
-    use zenoh_link::EndPoint;
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:30489";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subget/client/middle";
 
     zenoh_util::init_log_from_env_or("error");
 
-    let router = {
-        let mut c = zenoh_config::Config::default();
-        c.listen
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Router));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Router ZID: {}", s.zid());
-        s
-    };
+    let mut test_context = TestSessions::new();
+    let mut config_router = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config_router.set_mode(Some(WhatAmI::Router)).unwrap();
+    let router = test_context.open_listener_with_cfg(config_router).await;
+    tracing::info!("Router ZID: {}", router.zid());
 
-    let client_subget = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (subget) ZID: {}", s.zid());
-        s
-    };
+    let mut config_subget = test_context.get_connector_config();
+    config_subget.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_subget = test_context.open_connector_with_cfg(config_subget).await;
+    tracing::info!("Client (subget) ZID: {}", client_subget.zid());
 
     let sub = ztimeout!(client_subget
         .liveliness()
@@ -3077,18 +2645,10 @@ async fn test_liveliness_subget_client_middle() {
 
     assert!(sub.try_recv().unwrap().is_none());
 
-    let client_tok = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (token) ZID: {}", s.zid());
-        s
-    };
+    let mut config_tok = test_context.get_connector_config();
+    config_tok.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_tok = test_context.open_connector_with_cfg(config_tok).await;
+    tracing::info!("Client (token) ZID: {}", client_tok.zid());
 
     let token = ztimeout!(client_tok.liveliness().declare_token(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
@@ -3120,9 +2680,7 @@ async fn test_liveliness_subget_client_middle() {
 
     sub.undeclare().await.unwrap();
 
-    client_tok.close().await.unwrap();
-    client_subget.close().await.unwrap();
-    router.close().await.unwrap();
+    test_context.close().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -3131,56 +2689,31 @@ async fn test_liveliness_subget_client_history_before() {
 
     use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
-    use zenoh_link::EndPoint;
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:30490";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subget/client/history/before";
 
     zenoh_util::init_log_from_env_or("error");
 
-    let router = {
-        let mut c = zenoh_config::Config::default();
-        c.listen
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Router));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Router ZID: {}", s.zid());
-        s
-    };
+    let mut test_context = TestSessions::new();
+    let mut config_router = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config_router.set_mode(Some(WhatAmI::Router)).unwrap();
+    let router = test_context.open_listener_with_cfg(config_router).await;
+    tracing::info!("Router ZID: {}", router.zid());
 
-    let client_tok = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (token) ZID: {}", s.zid());
-        s
-    };
+    let mut config_tok = test_context.get_connector_config();
+    config_tok.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_tok = test_context.open_connector_with_cfg(config_tok).await;
+    tracing::info!("Client (token) ZID: {}", client_tok.zid());
 
     let token = ztimeout!(client_tok.liveliness().declare_token(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
 
-    let client_subget = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (subget) ZID: {}", s.zid());
-        s
-    };
+    let mut config_subget = test_context.get_connector_config();
+    config_subget.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_subget = test_context.open_connector_with_cfg(config_subget).await;
+    tracing::info!("Client (subget) ZID: {}", client_subget.zid());
 
     let sub = ztimeout!(client_subget
         .liveliness()
@@ -3216,9 +2749,7 @@ async fn test_liveliness_subget_client_history_before() {
 
     sub.undeclare().await.unwrap();
 
-    client_tok.close().await.unwrap();
-    client_subget.close().await.unwrap();
-    router.close().await.unwrap();
+    test_context.close().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -3227,40 +2758,23 @@ async fn test_liveliness_subget_client_history_middle() {
 
     use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
-    use zenoh_link::EndPoint;
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:30491";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subget/client/history/middle";
 
     zenoh_util::init_log_from_env_or("error");
 
-    let router = {
-        let mut c = zenoh_config::Config::default();
-        c.listen
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Router));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Router ZID: {}", s.zid());
-        s
-    };
+    let mut test_context = TestSessions::new();
+    let mut config_router = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config_router.set_mode(Some(WhatAmI::Router)).unwrap();
+    let router = test_context.open_listener_with_cfg(config_router).await;
+    tracing::info!("Router ZID: {}", router.zid());
 
-    let client_subget = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (subget) ZID: {}", s.zid());
-        s
-    };
+    let mut config_subget = test_context.get_connector_config();
+    config_subget.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_subget = test_context.open_connector_with_cfg(config_subget).await;
+    tracing::info!("Client (subget) ZID: {}", client_subget.zid());
 
     let sub = ztimeout!(client_subget
         .liveliness()
@@ -3271,18 +2785,10 @@ async fn test_liveliness_subget_client_history_middle() {
 
     assert!(sub.try_recv().unwrap().is_none());
 
-    let client_tok = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (token) ZID: {}", s.zid());
-        s
-    };
+    let mut config_tok = test_context.get_connector_config();
+    config_tok.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_tok = test_context.open_connector_with_cfg(config_tok).await;
+    tracing::info!("Client (token) ZID: {}", client_tok.zid());
 
     let token = ztimeout!(client_tok.liveliness().declare_token(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
@@ -3314,9 +2820,7 @@ async fn test_liveliness_subget_client_history_middle() {
 
     sub.undeclare().await.unwrap();
 
-    client_tok.close().await.unwrap();
-    client_subget.close().await.unwrap();
-    router.close().await.unwrap();
+    test_context.close().await;
 }
 
 // -------------------------------------------------------
@@ -3330,56 +2834,31 @@ async fn test_liveliness_subget_peer_before() {
 
     use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
-    use zenoh_link::EndPoint;
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:30492";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subget/peer/before";
 
     zenoh_util::init_log_from_env_or("error");
 
-    let router = {
-        let mut c = zenoh_config::Config::default();
-        c.listen
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Router));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Router ZID: {}", s.zid());
-        s
-    };
+    let mut test_context = TestSessions::new();
+    let mut config_router = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config_router.set_mode(Some(WhatAmI::Router)).unwrap();
+    let router = test_context.open_listener_with_cfg(config_router).await;
+    tracing::info!("Router ZID: {}", router.zid());
 
-    let client_tok = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (token) ZID: {}", s.zid());
-        s
-    };
+    let mut config_tok = test_context.get_connector_config();
+    config_tok.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_tok = test_context.open_connector_with_cfg(config_tok).await;
+    tracing::info!("Client (token) ZID: {}", client_tok.zid());
 
     let token = ztimeout!(client_tok.liveliness().declare_token(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
 
-    let peer_subget = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Peer));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Peer (subget) ZID: {}", s.zid());
-        s
-    };
+    let mut config_subget = test_context.get_connector_config();
+    config_subget.set_mode(Some(WhatAmI::Peer)).unwrap();
+    let peer_subget = test_context.open_connector_with_cfg(config_subget).await;
+    tracing::info!("Peer (subget) ZID: {}", peer_subget.zid());
 
     let sub = ztimeout!(peer_subget
         .liveliness()
@@ -3411,9 +2890,7 @@ async fn test_liveliness_subget_peer_before() {
 
     sub.undeclare().await.unwrap();
 
-    client_tok.close().await.unwrap();
-    peer_subget.close().await.unwrap();
-    router.close().await.unwrap();
+    test_context.close().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -3422,40 +2899,23 @@ async fn test_liveliness_subget_peer_middle() {
 
     use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
-    use zenoh_link::EndPoint;
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:30493";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subget/peer/middle";
 
     zenoh_util::init_log_from_env_or("error");
 
-    let router = {
-        let mut c = zenoh_config::Config::default();
-        c.listen
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Router));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Router ZID: {}", s.zid());
-        s
-    };
+    let mut test_context = TestSessions::new();
+    let mut config_router = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config_router.set_mode(Some(WhatAmI::Router)).unwrap();
+    let router = test_context.open_listener_with_cfg(config_router).await;
+    tracing::info!("Router ZID: {}", router.zid());
 
-    let peer_subget = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Peer));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Peer (subget) ZID: {}", s.zid());
-        s
-    };
+    let mut config_subget = test_context.get_connector_config();
+    config_subget.set_mode(Some(WhatAmI::Peer)).unwrap();
+    let peer_subget = test_context.open_connector_with_cfg(config_subget).await;
+    tracing::info!("Peer (subget) ZID: {}", peer_subget.zid());
 
     let sub = ztimeout!(peer_subget
         .liveliness()
@@ -3465,18 +2925,10 @@ async fn test_liveliness_subget_peer_middle() {
 
     assert!(sub.try_recv().unwrap().is_none());
 
-    let client_tok = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (token) ZID: {}", s.zid());
-        s
-    };
+    let mut config_tok = test_context.get_connector_config();
+    config_tok.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_tok = test_context.open_connector_with_cfg(config_tok).await;
+    tracing::info!("Client (token) ZID: {}", client_tok.zid());
 
     let token = ztimeout!(client_tok.liveliness().declare_token(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
@@ -3508,9 +2960,7 @@ async fn test_liveliness_subget_peer_middle() {
 
     sub.undeclare().await.unwrap();
 
-    client_tok.close().await.unwrap();
-    peer_subget.close().await.unwrap();
-    router.close().await.unwrap();
+    test_context.close().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -3519,56 +2969,31 @@ async fn test_liveliness_subget_peer_history_before() {
 
     use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
-    use zenoh_link::EndPoint;
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:30494";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subget/peer/history/before";
 
     zenoh_util::init_log_from_env_or("error");
 
-    let router = {
-        let mut c = zenoh_config::Config::default();
-        c.listen
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Router));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Router ZID: {}", s.zid());
-        s
-    };
+    let mut test_context = TestSessions::new();
+    let mut config_router = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config_router.set_mode(Some(WhatAmI::Router)).unwrap();
+    let router = test_context.open_listener_with_cfg(config_router).await;
+    tracing::info!("Router ZID: {}", router.zid());
 
-    let client_tok = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (token) ZID: {}", s.zid());
-        s
-    };
+    let mut config_tok = test_context.get_connector_config();
+    config_tok.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_tok = test_context.open_connector_with_cfg(config_tok).await;
+    tracing::info!("Client (token) ZID: {}", client_tok.zid());
 
     let token = ztimeout!(client_tok.liveliness().declare_token(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
 
-    let peer_subget = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Peer));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Peer (subget) ZID: {}", s.zid());
-        s
-    };
+    let mut config_subget = test_context.get_connector_config();
+    config_subget.set_mode(Some(WhatAmI::Peer)).unwrap();
+    let peer_subget = test_context.open_connector_with_cfg(config_subget).await;
+    tracing::info!("Peer (subget) ZID: {}", peer_subget.zid());
 
     let sub = ztimeout!(peer_subget
         .liveliness()
@@ -3604,9 +3029,7 @@ async fn test_liveliness_subget_peer_history_before() {
 
     sub.undeclare().await.unwrap();
 
-    client_tok.close().await.unwrap();
-    peer_subget.close().await.unwrap();
-    router.close().await.unwrap();
+    test_context.close().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -3615,40 +3038,23 @@ async fn test_liveliness_subget_peer_history_middle() {
 
     use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
-    use zenoh_link::EndPoint;
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:30495";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subget/peer/history/middle";
 
     zenoh_util::init_log_from_env_or("error");
 
-    let router = {
-        let mut c = zenoh_config::Config::default();
-        c.listen
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Router));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Router ZID: {}", s.zid());
-        s
-    };
+    let mut test_context = TestSessions::new();
+    let mut config_router = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config_router.set_mode(Some(WhatAmI::Router)).unwrap();
+    let router = test_context.open_listener_with_cfg(config_router).await;
+    tracing::info!("Router ZID: {}", router.zid());
 
-    let peer_subget = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Peer));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Peer (subget) ZID: {}", s.zid());
-        s
-    };
+    let mut config_subget = test_context.get_connector_config();
+    config_subget.set_mode(Some(WhatAmI::Peer)).unwrap();
+    let peer_subget = test_context.open_connector_with_cfg(config_subget).await;
+    tracing::info!("Peer (subget) ZID: {}", peer_subget.zid());
 
     let sub = ztimeout!(peer_subget
         .liveliness()
@@ -3659,18 +3065,10 @@ async fn test_liveliness_subget_peer_history_middle() {
 
     assert!(sub.try_recv().unwrap().is_none());
 
-    let client_tok = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (token) ZID: {}", s.zid());
-        s
-    };
+    let mut config_tok = test_context.get_connector_config();
+    config_tok.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_tok = test_context.open_connector_with_cfg(config_tok).await;
+    tracing::info!("Client (token) ZID: {}", client_tok.zid());
 
     let token = ztimeout!(client_tok.liveliness().declare_token(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
@@ -3702,9 +3100,7 @@ async fn test_liveliness_subget_peer_history_middle() {
 
     sub.undeclare().await.unwrap();
 
-    client_tok.close().await.unwrap();
-    peer_subget.close().await.unwrap();
-    router.close().await.unwrap();
+    test_context.close().await;
 }
 
 /// -------------------------------------------------------

--- a/zenoh/tests/liveliness.rs
+++ b/zenoh/tests/liveliness.rs
@@ -36,7 +36,7 @@ async fn test_liveliness_subscriber_clique() {
     tracing::info!("Peer (1) ZID: {}", peer1.zid());
 
     let mut config_peer2 = test_context.get_connector_config();
-    config_peer2.set_mode(Some(WhatAmI::Client)).unwrap();
+    config_peer2.set_mode(Some(WhatAmI::Peer)).unwrap();
     let peer2 = test_context.open_connector_with_cfg(config_peer2).await;
     tracing::info!("Peer (2) ZID: {}", peer2.zid());
 

--- a/zenoh/tests/liveliness.rs
+++ b/zenoh/tests/liveliness.rs
@@ -16,7 +16,7 @@ mod common;
 
 use zenoh_core::ztimeout;
 
-use crate::common::TestSessions;
+use crate::common::{get_tcp_locator, TestSessions};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_liveliness_subscriber_clique() {
@@ -1213,8 +1213,8 @@ async fn test_liveliness_subscriber_double_router_before() {
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:30464";
-    const ROUTER_SUB_ENDPOINT: &str = "tcp/localhost:30465";
+    const ROUTER_ENDPOINT: &str = "tcp/localhost:0";
+    const ROUTER_SUB_ENDPOINT: &str = "tcp/localhost:0";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subscriber/double/router/before";
 
     zenoh_util::init_log_from_env_or("error");
@@ -1231,12 +1231,13 @@ async fn test_liveliness_subscriber_double_router_before() {
         tracing::info!("Router ZID: {}", s.zid());
         s
     };
+    let router_endpoint = get_tcp_locator(&router).await;
 
     let client_tok = {
         let mut c = zenoh_config::Config::default();
         c.connect
             .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec![router_endpoint.clone()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Client));
@@ -1254,10 +1255,7 @@ async fn test_liveliness_subscriber_double_router_before() {
             .endpoints
             .set(vec![ROUTER_SUB_ENDPOINT.parse::<EndPoint>().unwrap()])
             .unwrap();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.connect.endpoints.set(vec![router_endpoint]).unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Router));
         let s = ztimeout!(zenoh::open(c)).unwrap();
@@ -1312,8 +1310,8 @@ async fn test_liveliness_subscriber_double_router_middle() {
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:27466";
-    const ROUTER_SUB_ENDPOINT: &str = "tcp/localhost:27467";
+    const ROUTER_ENDPOINT: &str = "tcp/localhost:0";
+    const ROUTER_SUB_ENDPOINT: &str = "tcp/localhost:0";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subscriber/double/router/middle";
 
     zenoh_util::init_log_from_env_or("error");
@@ -1330,6 +1328,7 @@ async fn test_liveliness_subscriber_double_router_middle() {
         tracing::info!("Router ZID: {}", s.zid());
         s
     };
+    let router_endpoint = get_tcp_locator(&router).await;
 
     let router_sub = {
         let mut c = zenoh_config::Config::default();
@@ -1339,7 +1338,7 @@ async fn test_liveliness_subscriber_double_router_middle() {
             .unwrap();
         c.connect
             .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec![router_endpoint.clone()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Router));
@@ -1356,10 +1355,7 @@ async fn test_liveliness_subscriber_double_router_middle() {
 
     let client_tok = {
         let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.connect.endpoints.set(vec![router_endpoint]).unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Client));
         let s = ztimeout!(zenoh::open(c)).unwrap();
@@ -1414,8 +1410,8 @@ async fn test_liveliness_subscriber_double_router_after() {
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:27468";
-    const ROUTER_SUB_ENDPOINT: &str = "tcp/localhost:27469";
+    const ROUTER_ENDPOINT: &str = "tcp/localhost:0";
+    const ROUTER_SUB_ENDPOINT: &str = "tcp/localhost:0";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subscriber/double/router/after";
 
     zenoh_util::init_log_from_env_or("error");
@@ -1432,6 +1428,7 @@ async fn test_liveliness_subscriber_double_router_after() {
         tracing::info!("Router ZID: {}", s.zid());
         s
     };
+    let router_endpoint = get_tcp_locator(&router).await;
 
     let router_sub = {
         let mut c = zenoh_config::Config::default();
@@ -1441,7 +1438,7 @@ async fn test_liveliness_subscriber_double_router_after() {
             .unwrap();
         c.connect
             .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec![router_endpoint.clone()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Router));
@@ -1463,10 +1460,7 @@ async fn test_liveliness_subscriber_double_router_after() {
 
     let client_tok = {
         let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.connect.endpoints.set(vec![router_endpoint]).unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Client));
         let s = ztimeout!(zenoh::open(c)).unwrap();
@@ -1518,8 +1512,8 @@ async fn test_liveliness_subscriber_double_router_history_before() {
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:27470";
-    const ROUTER_SUB_ENDPOINT: &str = "tcp/localhost:27471";
+    const ROUTER_ENDPOINT: &str = "tcp/localhost:0";
+    const ROUTER_SUB_ENDPOINT: &str = "tcp/localhost:0";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subscriber/double/router/history/before";
 
     zenoh_util::init_log_from_env_or("error");
@@ -1536,12 +1530,13 @@ async fn test_liveliness_subscriber_double_router_history_before() {
         tracing::info!("Router ZID: {}", s.zid());
         s
     };
+    let router_endpoint = get_tcp_locator(&router).await;
 
     let client_tok = {
         let mut c = zenoh_config::Config::default();
         c.connect
             .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec![router_endpoint.clone()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Client));
@@ -1559,10 +1554,7 @@ async fn test_liveliness_subscriber_double_router_history_before() {
             .endpoints
             .set(vec![ROUTER_SUB_ENDPOINT.parse::<EndPoint>().unwrap()])
             .unwrap();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.connect.endpoints.set(vec![router_endpoint]).unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Router));
         let s = ztimeout!(zenoh::open(c)).unwrap();
@@ -1625,8 +1617,8 @@ async fn test_liveliness_subscriber_double_router_history_middle() {
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:27472";
-    const ROUTER_SUB_ENDPOINT: &str = "tcp/localhost:27473";
+    const ROUTER_ENDPOINT: &str = "tcp/localhost:0";
+    const ROUTER_SUB_ENDPOINT: &str = "tcp/localhost:0";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subscriber/double/router/history/middle";
 
     zenoh_util::init_log_from_env_or("error");
@@ -1643,6 +1635,7 @@ async fn test_liveliness_subscriber_double_router_history_middle() {
         tracing::info!("Router ZID: {}", s.zid());
         s
     };
+    let router_endpoint = get_tcp_locator(&router).await;
 
     let router_sub = {
         let mut c = zenoh_config::Config::default();
@@ -1652,7 +1645,7 @@ async fn test_liveliness_subscriber_double_router_history_middle() {
             .unwrap();
         c.connect
             .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec![router_endpoint.clone()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Router));
@@ -1670,10 +1663,7 @@ async fn test_liveliness_subscriber_double_router_history_middle() {
 
     let client_tok = {
         let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.connect.endpoints.set(vec![router_endpoint]).unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Client));
         let s = ztimeout!(zenoh::open(c)).unwrap();
@@ -1732,8 +1722,8 @@ async fn test_liveliness_subscriber_double_router_history_after() {
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:27474";
-    const ROUTER_SUB_ENDPOINT: &str = "tcp/localhost:27475";
+    const ROUTER_ENDPOINT: &str = "tcp/localhost:0";
+    const ROUTER_SUB_ENDPOINT: &str = "tcp/localhost:0";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subscriber/double/router/history/after";
 
     zenoh_util::init_log_from_env_or("error");
@@ -1750,6 +1740,7 @@ async fn test_liveliness_subscriber_double_router_history_after() {
         tracing::info!("Router ZID: {}", s.zid());
         s
     };
+    let router_endpoint = get_tcp_locator(&router).await;
 
     let router_sub = {
         let mut c = zenoh_config::Config::default();
@@ -1759,7 +1750,7 @@ async fn test_liveliness_subscriber_double_router_history_after() {
             .unwrap();
         c.connect
             .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec![router_endpoint.clone()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Router));
@@ -1783,10 +1774,7 @@ async fn test_liveliness_subscriber_double_router_history_after() {
 
     let client_tok = {
         let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.connect.endpoints.set(vec![router_endpoint]).unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Client));
         let s = ztimeout!(zenoh::open(c)).unwrap();
@@ -1841,8 +1829,8 @@ async fn test_liveliness_subscriber_double_clientviapeer_before() {
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:27476";
-    const PEER_DUMMY_ENDPOINT: &str = "tcp/localhost:27477";
+    const ROUTER_ENDPOINT: &str = "tcp/localhost:0";
+    const PEER_DUMMY_ENDPOINT: &str = "tcp/localhost:0";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subscriber/double/clientviapeer/before";
 
     zenoh_util::init_log_from_env_or("error");
@@ -1859,6 +1847,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_before() {
         tracing::info!("Router ZID: {}", s.zid());
         s
     };
+    let router_endpoint = get_tcp_locator(&router).await;
 
     let peer_dummy = {
         let mut c = zenoh_config::Config::default();
@@ -1868,7 +1857,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_before() {
             .unwrap();
         c.connect
             .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec![router_endpoint.clone()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Peer));
@@ -1876,13 +1865,11 @@ async fn test_liveliness_subscriber_double_clientviapeer_before() {
         tracing::info!("Peer (dummy) ZID: {}", s.zid());
         s
     };
+    let peer_dummy_endpoint = get_tcp_locator(&peer_dummy).await;
 
     let client_tok = {
         let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.connect.endpoints.set(vec![router_endpoint]).unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Client));
         let s = ztimeout!(zenoh::open(c)).unwrap();
@@ -1895,10 +1882,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_before() {
 
     let client_sub = {
         let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![PEER_DUMMY_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.connect.endpoints.set(vec![peer_dummy_endpoint]).unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Client));
         let s = ztimeout!(zenoh::open(c)).unwrap();
@@ -1956,8 +1940,8 @@ async fn test_liveliness_subscriber_double_clientviapeer_middle() {
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:27478";
-    const PEER_DUMMY_ENDPOINT: &str = "tcp/localhost:27479";
+    const ROUTER_ENDPOINT: &str = "tcp/localhost:0";
+    const PEER_DUMMY_ENDPOINT: &str = "tcp/localhost:0";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subscriber/double/clientviapeer/middle";
 
     zenoh_util::init_log_from_env_or("error");
@@ -1974,6 +1958,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_middle() {
         tracing::info!("Router ZID: {}", s.zid());
         s
     };
+    let router_endpoint = get_tcp_locator(&router).await;
 
     let peer_dummy = {
         let mut c = zenoh_config::Config::default();
@@ -1983,7 +1968,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_middle() {
             .unwrap();
         c.connect
             .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec![router_endpoint.clone()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Peer));
@@ -1991,13 +1976,11 @@ async fn test_liveliness_subscriber_double_clientviapeer_middle() {
         tracing::info!("Peer (dummy) ZID: {}", s.zid());
         s
     };
+    let peer_dummy_endpoint = get_tcp_locator(&peer_dummy).await;
 
     let client_sub = {
         let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![PEER_DUMMY_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.connect.endpoints.set(vec![peer_dummy_endpoint]).unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Client));
         let s = ztimeout!(zenoh::open(c)).unwrap();
@@ -2013,10 +1996,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_middle() {
 
     let client_tok = {
         let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.connect.endpoints.set(vec![router_endpoint]).unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Client));
         let s = ztimeout!(zenoh::open(c)).unwrap();
@@ -2072,8 +2052,8 @@ async fn test_liveliness_subscriber_double_clientviapeer_after() {
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:27480";
-    const PEER_DUMMY_ENDPOINT: &str = "tcp/localhost:27481";
+    const ROUTER_ENDPOINT: &str = "tcp/localhost:0";
+    const PEER_DUMMY_ENDPOINT: &str = "tcp/localhost:0";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subscriber/double/clientviapeer/after";
 
     zenoh_util::init_log_from_env_or("error");
@@ -2090,6 +2070,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_after() {
         tracing::info!("Router ZID: {}", s.zid());
         s
     };
+    let router_endpoint = get_tcp_locator(&router).await;
 
     let peer_dummy = {
         let mut c = zenoh_config::Config::default();
@@ -2099,7 +2080,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_after() {
             .unwrap();
         c.connect
             .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec![router_endpoint.clone()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Peer));
@@ -2107,13 +2088,11 @@ async fn test_liveliness_subscriber_double_clientviapeer_after() {
         tracing::info!("Peer (dummy) ZID: {}", s.zid());
         s
     };
+    let peer_dummy_endpoint = get_tcp_locator(&peer_dummy).await;
 
     let client_sub = {
         let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![PEER_DUMMY_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.connect.endpoints.set(vec![peer_dummy_endpoint]).unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Client));
         let s = ztimeout!(zenoh::open(c)).unwrap();
@@ -2134,10 +2113,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_after() {
 
     let client_tok = {
         let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.connect.endpoints.set(vec![router_endpoint]).unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Client));
         let s = ztimeout!(zenoh::open(c)).unwrap();
@@ -2190,8 +2166,8 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_before() {
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:27482";
-    const PEER_DUMMY_ENDPOINT: &str = "tcp/localhost:27483";
+    const ROUTER_ENDPOINT: &str = "tcp/localhost:0";
+    const PEER_DUMMY_ENDPOINT: &str = "tcp/localhost:0";
     const LIVELINESS_KEYEXPR: &str =
         "test/liveliness/subscriber/double/clientviapeer/history/before";
 
@@ -2209,6 +2185,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_before() {
         tracing::info!("Router ZID: {}", s.zid());
         s
     };
+    let router_endpoint = get_tcp_locator(&router).await;
 
     let peer_dummy = {
         let mut c = zenoh_config::Config::default();
@@ -2218,7 +2195,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_before() {
             .unwrap();
         c.connect
             .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec![router_endpoint.clone()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Peer));
@@ -2226,13 +2203,11 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_before() {
         tracing::info!("Peer (dummy) ZID: {}", s.zid());
         s
     };
+    let peer_dummy_endpoint = get_tcp_locator(&peer_dummy).await;
 
     let client_tok = {
         let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.connect.endpoints.set(vec![router_endpoint]).unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Client));
         let s = ztimeout!(zenoh::open(c)).unwrap();
@@ -2245,10 +2220,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_before() {
 
     let client_sub = {
         let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![PEER_DUMMY_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.connect.endpoints.set(vec![peer_dummy_endpoint]).unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Client));
         let s = ztimeout!(zenoh::open(c)).unwrap();
@@ -2312,8 +2284,8 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_middle() {
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:30484";
-    const PEER_DUMMY_ENDPOINT: &str = "tcp/localhost:30485";
+    const ROUTER_ENDPOINT: &str = "tcp/localhost:0";
+    const PEER_DUMMY_ENDPOINT: &str = "tcp/localhost:0";
     const LIVELINESS_KEYEXPR: &str =
         "test/liveliness/subscriber/double/clientviapeer/history/middle";
 
@@ -2331,6 +2303,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_middle() {
         tracing::info!("Router ZID: {}", s.zid());
         s
     };
+    let router_endpoint = get_tcp_locator(&router).await;
 
     let peer_dummy = {
         let mut c = zenoh_config::Config::default();
@@ -2340,7 +2313,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_middle() {
             .unwrap();
         c.connect
             .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec![router_endpoint.clone()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Peer));
@@ -2348,13 +2321,11 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_middle() {
         tracing::info!("Peer (dummy) ZID: {}", s.zid());
         s
     };
+    let peer_dummy_endpoint = get_tcp_locator(&peer_dummy).await;
 
     let client_sub = {
         let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![PEER_DUMMY_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.connect.endpoints.set(vec![peer_dummy_endpoint]).unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Client));
         let s = ztimeout!(zenoh::open(c)).unwrap();
@@ -2371,10 +2342,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_middle() {
 
     let client_tok = {
         let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.connect.endpoints.set(vec![router_endpoint]).unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Client));
         let s = ztimeout!(zenoh::open(c)).unwrap();
@@ -2434,8 +2402,8 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_after() {
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:30486";
-    const PEER_DUMMY_ENDPOINT: &str = "tcp/localhost:30487";
+    const ROUTER_ENDPOINT: &str = "tcp/localhost:0";
+    const PEER_DUMMY_ENDPOINT: &str = "tcp/localhost:0";
     const LIVELINESS_KEYEXPR: &str =
         "test/liveliness/subscriber/double/clientviapeer/history/after";
 
@@ -2453,6 +2421,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_after() {
         tracing::info!("Router ZID: {}", s.zid());
         s
     };
+    let router_endpoint = get_tcp_locator(&router).await;
 
     let peer_dummy = {
         let mut c = zenoh_config::Config::default();
@@ -2462,7 +2431,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_after() {
             .unwrap();
         c.connect
             .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec![router_endpoint.clone()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Peer));
@@ -2470,13 +2439,11 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_after() {
         tracing::info!("Peer (dummy) ZID: {}", s.zid());
         s
     };
+    let peer_dummy_endpoint = get_tcp_locator(&peer_dummy).await;
 
     let client_sub = {
         let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![PEER_DUMMY_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.connect.endpoints.set(vec![peer_dummy_endpoint]).unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Client));
         let s = ztimeout!(zenoh::open(c)).unwrap();
@@ -2499,10 +2466,7 @@ async fn test_liveliness_subscriber_double_clientviapeer_history_after() {
 
     let client_tok = {
         let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.connect.endpoints.set(vec![router_endpoint]).unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Client));
         let s = ztimeout!(zenoh::open(c)).unwrap();
@@ -3116,8 +3080,8 @@ async fn test_liveliness_subget_router_before() {
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:30496";
-    const ROUTER_SUBGET_ENDPOINT: &str = "tcp/localhost:27497";
+    const ROUTER_ENDPOINT: &str = "tcp/localhost:0";
+    const ROUTER_SUBGET_ENDPOINT: &str = "tcp/localhost:0";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subget/router/before";
 
     zenoh_util::init_log_from_env_or("error");
@@ -3134,12 +3098,13 @@ async fn test_liveliness_subget_router_before() {
         tracing::info!("Router ZID: {}", s.zid());
         s
     };
+    let router_endpoint = get_tcp_locator(&router).await;
 
     let client_tok = {
         let mut c = zenoh_config::Config::default();
         c.connect
             .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec![router_endpoint.clone()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Client));
@@ -3157,10 +3122,7 @@ async fn test_liveliness_subget_router_before() {
             .endpoints
             .set(vec![ROUTER_SUBGET_ENDPOINT.parse::<EndPoint>().unwrap()])
             .unwrap();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.connect.endpoints.set(vec![router_endpoint]).unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Router));
         let s = ztimeout!(zenoh::open(c)).unwrap();
@@ -3213,8 +3175,8 @@ async fn test_liveliness_subget_router_middle() {
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:30498";
-    const ROUTER_SUBGET_ENDPOINT: &str = "tcp/localhost:30499";
+    const ROUTER_ENDPOINT: &str = "tcp/localhost:0";
+    const ROUTER_SUBGET_ENDPOINT: &str = "tcp/localhost:0";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subget/router/middle";
 
     zenoh_util::init_log_from_env_or("error");
@@ -3231,6 +3193,7 @@ async fn test_liveliness_subget_router_middle() {
         tracing::info!("Router ZID: {}", s.zid());
         s
     };
+    let router_endpoint = get_tcp_locator(&router).await;
 
     let router_subget = {
         let mut c = zenoh_config::Config::default();
@@ -3240,7 +3203,7 @@ async fn test_liveliness_subget_router_middle() {
             .unwrap();
         c.connect
             .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec![router_endpoint.clone()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Router));
@@ -3259,10 +3222,7 @@ async fn test_liveliness_subget_router_middle() {
 
     let client_tok = {
         let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.connect.endpoints.set(vec![router_endpoint]).unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Client));
         let s = ztimeout!(zenoh::open(c)).unwrap();
@@ -3315,8 +3275,8 @@ async fn test_liveliness_subget_router_history_before() {
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:30500";
-    const ROUTER_SUBGET_ENDPOINT: &str = "tcp/localhost:30501";
+    const ROUTER_ENDPOINT: &str = "tcp/localhost:0";
+    const ROUTER_SUBGET_ENDPOINT: &str = "tcp/localhost:0";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subget/router/history/before";
 
     zenoh_util::init_log_from_env_or("error");
@@ -3333,12 +3293,13 @@ async fn test_liveliness_subget_router_history_before() {
         tracing::info!("Router ZID: {}", s.zid());
         s
     };
+    let router_endpoint = get_tcp_locator(&router).await;
 
     let client_tok = {
         let mut c = zenoh_config::Config::default();
         c.connect
             .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec![router_endpoint.clone()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Client));
@@ -3356,10 +3317,7 @@ async fn test_liveliness_subget_router_history_before() {
             .endpoints
             .set(vec![ROUTER_SUBGET_ENDPOINT.parse::<EndPoint>().unwrap()])
             .unwrap();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.connect.endpoints.set(vec![router_endpoint]).unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Router));
         let s = ztimeout!(zenoh::open(c)).unwrap();
@@ -3416,8 +3374,8 @@ async fn test_liveliness_subget_router_history_middle() {
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:30502";
-    const ROUTER_SUBGET_ENDPOINT: &str = "tcp/localhost:30503";
+    const ROUTER_ENDPOINT: &str = "tcp/localhost:0";
+    const ROUTER_SUBGET_ENDPOINT: &str = "tcp/localhost:0";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/subget/router/history/middle";
 
     zenoh_util::init_log_from_env_or("error");
@@ -3434,6 +3392,7 @@ async fn test_liveliness_subget_router_history_middle() {
         tracing::info!("Router ZID: {}", s.zid());
         s
     };
+    let router_endpoint = get_tcp_locator(&router).await;
 
     let router_subget = {
         let mut c = zenoh_config::Config::default();
@@ -3443,7 +3402,7 @@ async fn test_liveliness_subget_router_history_middle() {
             .unwrap();
         c.connect
             .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec![router_endpoint.clone()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Router));
@@ -3463,10 +3422,7 @@ async fn test_liveliness_subget_router_history_middle() {
 
     let client_tok = {
         let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.connect.endpoints.set(vec![router_endpoint]).unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Client));
         let s = ztimeout!(zenoh::open(c)).unwrap();
@@ -3519,8 +3475,8 @@ async fn test_liveliness_regression_1() {
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:30504";
-    const PEER_TOK_ENDPOINT: &str = "tcp/localhost:30505";
+    const ROUTER_ENDPOINT: &str = "tcp/localhost:0";
+    const PEER_TOK_ENDPOINT: &str = "tcp/localhost:0";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/regression/1";
 
     zenoh_util::init_log_from_env_or("error");
@@ -3537,6 +3493,7 @@ async fn test_liveliness_regression_1() {
         tracing::info!("Router ZID: {}", s.zid());
         s
     };
+    let router_endpoint = get_tcp_locator(&router).await;
 
     let peer_tok = {
         let mut c = zenoh_config::Config::default();
@@ -3546,7 +3503,7 @@ async fn test_liveliness_regression_1() {
             .unwrap();
         c.connect
             .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec![router_endpoint.clone()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Peer));
@@ -3554,6 +3511,7 @@ async fn test_liveliness_regression_1() {
         tracing::info!("Peer (token) ZID: {}", s.zid());
         s
     };
+    let peer_tok_endpoint = get_tcp_locator(&peer_tok).await;
 
     let token = ztimeout!(peer_tok.liveliness().declare_token(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
@@ -3562,10 +3520,7 @@ async fn test_liveliness_regression_1() {
         let mut c = zenoh_config::Config::default();
         c.connect
             .endpoints
-            .set(vec![
-                ROUTER_ENDPOINT.parse::<EndPoint>().unwrap(),
-                PEER_TOK_ENDPOINT.parse::<EndPoint>().unwrap(),
-            ])
+            .set(vec![router_endpoint, peer_tok_endpoint])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Peer));
@@ -3603,8 +3558,8 @@ async fn test_liveliness_regression_2() {
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const PEER_TOK1_ENDPOINT: &str = "tcp/localhost:30506";
-    const PEER_SUB_ENDPOINT: &str = "tcp/localhost:30507";
+    const PEER_TOK1_ENDPOINT: &str = "tcp/localhost:0";
+    const PEER_SUB_ENDPOINT: &str = "tcp/localhost:0";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/regression/2";
 
     zenoh_util::init_log_from_env_or("error");
@@ -3621,6 +3576,7 @@ async fn test_liveliness_regression_2() {
         tracing::info!("Peer (token 1) ZID: {}", s.zid());
         s
     };
+    let peer_tok1_endpoint = get_tcp_locator(&peer_tok1).await;
 
     let token1 = ztimeout!(peer_tok1.liveliness().declare_token(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
@@ -3633,7 +3589,7 @@ async fn test_liveliness_regression_2() {
             .unwrap();
         c.connect
             .endpoints
-            .set(vec![PEER_TOK1_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec![peer_tok1_endpoint.clone()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Peer));
@@ -3641,6 +3597,7 @@ async fn test_liveliness_regression_2() {
         tracing::info!("Peer (sub) ZID: {}", s.zid());
         s
     };
+    let peer_sub_endpoint = get_tcp_locator(&peer_sub).await;
 
     let sub = ztimeout!(peer_sub.liveliness().declare_subscriber(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
@@ -3651,10 +3608,7 @@ async fn test_liveliness_regression_2() {
         let mut c = zenoh_config::Config::default();
         c.connect
             .endpoints
-            .set(vec![
-                PEER_TOK1_ENDPOINT.parse::<EndPoint>().unwrap(),
-                PEER_SUB_ENDPOINT.parse::<EndPoint>().unwrap(),
-            ])
+            .set(vec![peer_tok1_endpoint, peer_sub_endpoint])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Peer));
@@ -3696,8 +3650,8 @@ async fn test_liveliness_regression_2_history() {
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const PEER_TOK1_ENDPOINT: &str = "tcp/localhost:30508";
-    const PEER_SUB_ENDPOINT: &str = "tcp/localhost:30509";
+    const PEER_TOK1_ENDPOINT: &str = "tcp/localhost:0";
+    const PEER_SUB_ENDPOINT: &str = "tcp/localhost:0";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/regression/2/history";
 
     zenoh_util::init_log_from_env_or("error");
@@ -3714,6 +3668,7 @@ async fn test_liveliness_regression_2_history() {
         tracing::info!("Peer (token 1) ZID: {}", s.zid());
         s
     };
+    let peer_tok1_endpoint = get_tcp_locator(&peer_tok1).await;
 
     let token1 = ztimeout!(peer_tok1.liveliness().declare_token(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
@@ -3726,7 +3681,7 @@ async fn test_liveliness_regression_2_history() {
             .unwrap();
         c.connect
             .endpoints
-            .set(vec![PEER_TOK1_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec![peer_tok1_endpoint.clone()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Peer));
@@ -3734,6 +3689,7 @@ async fn test_liveliness_regression_2_history() {
         tracing::info!("Peer (sub) ZID: {}", s.zid());
         s
     };
+    let peer_sub_endpoint = get_tcp_locator(&peer_sub).await;
 
     let sub = ztimeout!(peer_sub
         .liveliness()
@@ -3751,10 +3707,7 @@ async fn test_liveliness_regression_2_history() {
         let mut c = zenoh_config::Config::default();
         c.connect
             .endpoints
-            .set(vec![
-                PEER_TOK1_ENDPOINT.parse::<EndPoint>().unwrap(),
-                PEER_SUB_ENDPOINT.parse::<EndPoint>().unwrap(),
-            ])
+            .set(vec![peer_tok1_endpoint, peer_sub_endpoint])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Peer));
@@ -3796,8 +3749,8 @@ async fn test_liveliness_regression_3() {
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:30510";
-    const PEER_TOK_ENDPOINT: &str = "tcp/localhost:30511";
+    const ROUTER_ENDPOINT: &str = "tcp/localhost:0";
+    const PEER_TOK_ENDPOINT: &str = "tcp/localhost:0";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/regression/3";
 
     zenoh_util::init_log_from_env_or("error");
@@ -3814,6 +3767,7 @@ async fn test_liveliness_regression_3() {
         tracing::info!("Router ZID: {}", s.zid());
         s
     };
+    let router_endpoint = get_tcp_locator(&router).await;
 
     let peer_tok1 = {
         let mut c = zenoh_config::Config::default();
@@ -3823,7 +3777,7 @@ async fn test_liveliness_regression_3() {
             .unwrap();
         c.connect
             .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec![router_endpoint.clone()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Peer));
@@ -3831,6 +3785,7 @@ async fn test_liveliness_regression_3() {
         tracing::info!("Peer (token 1) ZID: {}", s.zid());
         s
     };
+    let peer_tok_endpoint = get_tcp_locator(&peer_tok1).await;
 
     let token1 = ztimeout!(peer_tok1.liveliness().declare_token(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
@@ -3839,7 +3794,7 @@ async fn test_liveliness_regression_3() {
         let mut c = zenoh_config::Config::default();
         c.connect
             .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec![router_endpoint.clone()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Peer));
@@ -3855,10 +3810,7 @@ async fn test_liveliness_regression_3() {
         let mut c = zenoh_config::Config::default();
         c.connect
             .endpoints
-            .set(vec![
-                ROUTER_ENDPOINT.parse::<EndPoint>().unwrap(),
-                PEER_TOK_ENDPOINT.parse::<EndPoint>().unwrap(),
-            ])
+            .set(vec![router_endpoint, peer_tok_endpoint])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Peer));
@@ -3903,9 +3855,9 @@ async fn test_liveliness_issue_1470() {
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER0_ENDPOINT: &str = "tcp/localhost:30512";
-    const ROUTER1_ENDPOINT: &str = "tcp/localhost:30513";
-    const PEER_ENDPOINT: &str = "tcp/localhost:30514";
+    const ROUTER0_ENDPOINT: &str = "tcp/localhost:0";
+    const ROUTER1_ENDPOINT: &str = "tcp/localhost:0";
+    const PEER_ENDPOINT: &str = "tcp/localhost:0";
     const LIVELINESS_KEYEXPR_PREFIX: &str = "test/liveliness/issue/1470/*";
     const LIVELINESS_KEYEXPR_ROUTER0: &str = "test/liveliness/issue/1470/a0";
     const LIVELINESS_KEYEXPR_ROUTER1: &str = "test/liveliness/issue/1470/a1";
@@ -3924,6 +3876,7 @@ async fn test_liveliness_issue_1470() {
         let _ = c.set_mode(Some(WhatAmI::Router));
         ztimeout!(zenoh::open(c)).unwrap()
     };
+    let router0_endpoint = get_tcp_locator(&router0).await;
 
     let _token_a0 = ztimeout!(router0
         .liveliness()
@@ -3940,12 +3893,13 @@ async fn test_liveliness_issue_1470() {
             .unwrap();
         c.connect
             .endpoints
-            .set(vec![ROUTER0_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec![router0_endpoint.clone()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Router));
         ztimeout!(zenoh::open(c)).unwrap()
     };
+    let router1_endpoint = get_tcp_locator(&router1).await;
 
     let _token_a1 = ztimeout!(router1
         .liveliness()
@@ -3962,15 +3916,13 @@ async fn test_liveliness_issue_1470() {
             .unwrap();
         c.connect
             .endpoints
-            .set(vec![
-                ROUTER0_ENDPOINT.parse::<EndPoint>().unwrap(),
-                ROUTER1_ENDPOINT.parse::<EndPoint>().unwrap(),
-            ])
+            .set(vec![router0_endpoint, router1_endpoint])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Peer));
         ztimeout!(zenoh::open(c)).unwrap()
     };
+    let peer_endpoint = get_tcp_locator(&peer).await;
 
     let _token_b = ztimeout!(peer.liveliness().declare_token(LIVELINESS_KEYEXPR_PEER)).unwrap();
     tokio::time::sleep(SLEEP).await;
@@ -3980,7 +3932,7 @@ async fn test_liveliness_issue_1470() {
         c.set_id(Some(ZenohId::from_str("c0").unwrap())).unwrap();
         c.connect
             .endpoints
-            .set(vec![PEER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec![peer_endpoint.clone()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Client));
@@ -4024,10 +3976,7 @@ async fn test_liveliness_issue_1470() {
     let client1 = {
         let mut c = zenoh_config::Config::default();
         c.set_id(Some(ZenohId::from_str("c1").unwrap())).unwrap();
-        c.connect
-            .endpoints
-            .set(vec![PEER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.connect.endpoints.set(vec![peer_endpoint]).unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Client));
         ztimeout!(zenoh::open(c)).unwrap()
@@ -4080,39 +4029,22 @@ async fn test_liveliness_double_undeclare_clique() {
     use std::time::Duration;
 
     use zenoh::{config::WhatAmI, sample::SampleKind};
-    use zenoh_config::EndPoint;
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const PEER1_ENDPOINT: &str = "tcp/localhost:30515";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/double/undeclare/clique";
 
     zenoh_util::init_log_from_env_or("error");
 
-    let peer1 = {
-        let mut c = zenoh_config::Config::default();
-        c.listen
-            .endpoints
-            .set(vec![PEER1_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Peer));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Peer (1) ZID: {}", s.zid());
-        s
-    };
+    let mut test_context = TestSessions::new();
+    let mut config_peer1 = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config_peer1.set_mode(Some(WhatAmI::Peer)).unwrap();
+    let peer1 = test_context.open_listener_with_cfg(config_peer1).await;
+    tracing::info!("Peer (1) ZID: {}", peer1.zid());
 
-    let peer2 = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![PEER1_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Peer));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Peer (2) ZID: {}", s.zid());
-        s
-    };
+    let mut config_peer2 = test_context.get_connector_config();
+    config_peer2.set_mode(Some(WhatAmI::Peer)).unwrap();
+    let peer2 = test_context.open_connector_with_cfg(config_peer2).await;
+    tracing::info!("Peer (2) ZID: {}", peer2.zid());
 
     let sub = ztimeout!(peer1.liveliness().declare_subscriber(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
@@ -4143,8 +4075,7 @@ async fn test_liveliness_double_undeclare_clique() {
 
     sub.undeclare().await.unwrap();
 
-    peer1.close().await.unwrap();
-    peer2.close().await.unwrap();
+    test_context.close().await;
 }
 
 #[ignore = "https://github.com/eclipse-zenoh/zenoh/pull/2289"]
@@ -4155,56 +4086,35 @@ async fn test_liveliness_sub_history_conflict() {
 
     use zenoh::sample::SampleKind;
     use zenoh_config::WhatAmI;
-    use zenoh_link::EndPoint;
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:30516";
     const LIVELINESS_KEYEXPR: &str = "test/liveliness/history/conflict";
 
     zenoh_util::init_log_from_env_or("error");
 
-    let router = {
-        let mut c = zenoh_config::Config::default();
-        c.listen
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Router));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Router ZID: {}", s.zid());
-        s
-    };
+    let mut test_context = TestSessions::new();
+    let mut config_router = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config_router.set_mode(Some(WhatAmI::Router)).unwrap();
+    let router = test_context.open_listener_with_cfg(config_router).await;
+    tracing::info!("Router ZID: {}", router.zid());
 
-    let client_tok = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Peer));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (token) ZID: {}", s.zid());
-        s
-    };
+    let mut config_client_tok = test_context.get_connector_config();
+    config_client_tok.set_mode(Some(WhatAmI::Peer)).unwrap();
+    let client_tok = test_context
+        .open_connector_with_cfg(config_client_tok)
+        .await;
+    tracing::info!("Client (token) ZID: {}", client_tok.zid());
 
     let token = ztimeout!(client_tok.liveliness().declare_token(LIVELINESS_KEYEXPR)).unwrap();
     tokio::time::sleep(SLEEP).await;
 
-    let client_subs = {
-        let mut c = zenoh_config::Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
-        c.scouting.multicast.set_enabled(Some(false)).unwrap();
-        let _ = c.set_mode(Some(WhatAmI::Client));
-        let s = ztimeout!(zenoh::open(c)).unwrap();
-        tracing::info!("Client (subs) ZID: {}", s.zid());
-        s
-    };
+    let mut config_client_subs = test_context.get_connector_config();
+    config_client_subs.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client_subs = test_context
+        .open_connector_with_cfg(config_client_subs)
+        .await;
+    tracing::info!("Client (subs) ZID: {}", client_subs.zid());
 
     let sub_no_history = ztimeout!(client_subs
         .liveliness()
@@ -4240,7 +4150,5 @@ async fn test_liveliness_sub_history_conflict() {
     assert!(sample.kind() == SampleKind::Delete);
     assert!(sample.key_expr().as_str() == LIVELINESS_KEYEXPR);
 
-    client_tok.close().await.unwrap();
-    client_subs.close().await.unwrap();
-    router.close().await.unwrap();
+    test_context.close().await;
 }

--- a/zenoh/tests/matching.rs
+++ b/zenoh/tests/matching.rs
@@ -11,6 +11,9 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
+#![cfg(feature = "unstable")]
+mod common;
+
 use std::time::Duration;
 
 use zenoh::{
@@ -19,8 +22,10 @@ use zenoh::{
     sample::Locality,
     Result as ZResult, Session,
 };
-use zenoh_config::{ModeDependentValue, WhatAmI};
+use zenoh_config::WhatAmI;
 use zenoh_core::ztimeout;
+
+use crate::common::TestSessions;
 
 const TIMEOUT: Duration = Duration::from_secs(60);
 const RECV_TIMEOUT: Duration = Duration::from_secs(1);
@@ -36,62 +41,57 @@ enum TestType {
     RouterClient,
 }
 
-async fn create_session_pair(locator: &str, modes: (WhatAmI, WhatAmI)) -> (Session, Session) {
-    let mut config1 = zenoh_config::Config::default();
-    config1.set_mode(Some(modes.0)).unwrap();
-    config1.scouting.multicast.set_enabled(Some(false)).unwrap();
-
-    let mut config2 = zenoh_config::Config::default();
-    config2.set_mode(Some(modes.1)).unwrap();
-    config2.scouting.multicast.set_enabled(Some(false)).unwrap();
+async fn create_direct_session_pair(modes: (WhatAmI, WhatAmI)) -> (Session, Session) {
+    let mut test_context = TestSessions::new();
 
     match modes {
         (WhatAmI::Peer, WhatAmI::Peer)
         | (WhatAmI::Router, WhatAmI::Router)
         | (WhatAmI::Peer, WhatAmI::Client)
         | (WhatAmI::Router, WhatAmI::Client) => {
-            config1
-                .listen
-                .endpoints
-                .set(vec![locator.parse().unwrap()])
-                .unwrap();
-            config2
-                .connect
-                .set_endpoints(ModeDependentValue::Unique(vec![locator.parse().unwrap()]))
-                .unwrap();
-            let session1 = ztimeout!(zenoh::open(config1)).unwrap();
-            let session2 = ztimeout!(zenoh::open(config2)).unwrap();
+            let mut listener_config = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+            listener_config.set_mode(Some(modes.0)).unwrap();
+            let session1 = test_context.open_listener_with_cfg(listener_config).await;
+
+            let mut connector_config = test_context.get_connector_config();
+            connector_config.set_mode(Some(modes.1)).unwrap();
+            // We need to clear the listen endpoints if both of them are routers. Router mode will bind tcp/[::]:7447 automatically.
+            if modes.0 == WhatAmI::Router && modes.1 == WhatAmI::Router {
+                connector_config.listen.endpoints.set(vec![]).unwrap();
+            }
+            let session2 = test_context.open_connector_with_cfg(connector_config).await;
             (session1, session2)
         }
         (WhatAmI::Client, WhatAmI::Peer) => {
-            config2
-                .listen
-                .endpoints
-                .set(vec![locator.parse().unwrap()])
-                .unwrap();
-            config1
-                .connect
-                .set_endpoints(ModeDependentValue::Unique(vec![locator.parse().unwrap()]))
-                .unwrap();
-            let session2 = ztimeout!(zenoh::open(config2)).unwrap();
-            let session1 = ztimeout!(zenoh::open(config1)).unwrap();
-            (session1, session2)
-        }
-        (WhatAmI::Client, WhatAmI::Client) => {
-            config2
-                .connect
-                .set_endpoints(ModeDependentValue::Unique(vec![locator.parse().unwrap()]))
-                .unwrap();
-            config1
-                .connect
-                .set_endpoints(ModeDependentValue::Unique(vec![locator.parse().unwrap()]))
-                .unwrap();
-            let session1 = ztimeout!(zenoh::open(config1)).unwrap();
-            let session2 = ztimeout!(zenoh::open(config2)).unwrap();
+            let mut listener_config = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+            listener_config.set_mode(Some(modes.1)).unwrap();
+            let session2 = test_context.open_listener_with_cfg(listener_config).await;
+
+            let mut connector_config = test_context.get_connector_config();
+            connector_config.set_mode(Some(modes.0)).unwrap();
+            let session1 = test_context.open_connector_with_cfg(connector_config).await;
             (session1, session2)
         }
         _ => unreachable!(),
     }
+}
+
+async fn create_routed_client_pair() -> (Session, Session, Session) {
+    let mut test_context = TestSessions::new();
+
+    let mut router_config = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    router_config.set_mode(Some(WhatAmI::Router)).unwrap();
+    let router = test_context.open_listener_with_cfg(router_config).await;
+
+    let mut client1_config = test_context.get_connector_config();
+    client1_config.set_mode(Some(WhatAmI::Client)).unwrap();
+    let session1 = test_context.open_connector_with_cfg(client1_config).await;
+
+    let mut client2_config = test_context.get_connector_config();
+    client2_config.set_mode(Some(WhatAmI::Client)).unwrap();
+    let session2 = test_context.open_connector_with_cfg(client2_config).await;
+
+    (session1, session2, router)
 }
 
 fn get_matching_listener_status(
@@ -130,15 +130,9 @@ async fn zenoh_querier_matching_status(querier_locality: Locality, test_type: Te
 
     let mut _router;
     let (session1, session2) = match test_type {
-        TestType::ClientPeer => {
-            create_session_pair("tcp/127.0.0.1:18002", (WhatAmI::Client, WhatAmI::Peer)).await
-        }
-        TestType::PeerClient => {
-            create_session_pair("tcp/127.0.0.1:18002", (WhatAmI::Peer, WhatAmI::Client)).await
-        }
-        TestType::PeerPeer => {
-            create_session_pair("tcp/127.0.0.1:18002", (WhatAmI::Peer, WhatAmI::Peer)).await
-        }
+        TestType::ClientPeer => create_direct_session_pair((WhatAmI::Client, WhatAmI::Peer)).await,
+        TestType::PeerClient => create_direct_session_pair((WhatAmI::Peer, WhatAmI::Client)).await,
+        TestType::PeerPeer => create_direct_session_pair((WhatAmI::Peer, WhatAmI::Peer)).await,
         TestType::SameSession => {
             let mut config = zenoh_config::Config::default();
             config.scouting.multicast.set_enabled(Some(false)).unwrap();
@@ -147,21 +141,15 @@ async fn zenoh_querier_matching_status(querier_locality: Locality, test_type: Te
             (s1, s2)
         }
         TestType::ClientRouterClient => {
-            let mut c = zenoh_config::Config::default();
-            c.set_mode(Some(WhatAmI::Router)).unwrap();
-            c.listen
-                .set_endpoints(ModeDependentValue::Unique(vec!["tcp/127.0.0.1:18002"
-                    .parse()
-                    .unwrap()]))
-                .unwrap();
-            _router = Some(ztimeout!(zenoh::open(c)).unwrap());
-            create_session_pair("tcp/127.0.0.1:18002", (WhatAmI::Client, WhatAmI::Client)).await
+            let (s1, s2, router) = create_routed_client_pair().await;
+            _router = Some(router);
+            (s1, s2)
         }
         TestType::RouterRouter => {
-            create_session_pair("tcp/127.0.0.1:18002", (WhatAmI::Router, WhatAmI::Router)).await
+            create_direct_session_pair((WhatAmI::Router, WhatAmI::Router)).await
         }
         TestType::RouterClient => {
-            create_session_pair("tcp/127.0.0.1:18002", (WhatAmI::Router, WhatAmI::Client)).await
+            create_direct_session_pair((WhatAmI::Router, WhatAmI::Client)).await
         }
     };
     let locality_compatible = is_locality_compatible(querier_locality, same_session);
@@ -270,7 +258,7 @@ async fn zenoh_publisher_matching_status_inner(publisher_locality: Locality, sam
     };
 
     let (session1, session2) = match same_session {
-        false => create_session_pair("tcp/127.0.0.1:18001", (WhatAmI::Peer, WhatAmI::Client)).await,
+        false => create_direct_session_pair((WhatAmI::Peer, WhatAmI::Client)).await,
         true => {
             let mut config = zenoh_config::Config::default();
             config.scouting.multicast.set_enabled(Some(false)).unwrap();
@@ -354,25 +342,13 @@ async fn zenoh_querier_matching_status_session_drop_inner(test_type: TestType) {
 
     let mut router = None;
     let (session1, session2) = match test_type {
-        TestType::ClientPeer => {
-            create_session_pair("tcp/127.0.0.1:18003", (WhatAmI::Client, WhatAmI::Peer)).await
-        }
-        TestType::PeerClient => {
-            create_session_pair("tcp/127.0.0.1:18003", (WhatAmI::Peer, WhatAmI::Client)).await
-        }
-        TestType::PeerPeer => {
-            create_session_pair("tcp/127.0.0.1:18003", (WhatAmI::Peer, WhatAmI::Peer)).await
-        }
+        TestType::ClientPeer => create_direct_session_pair((WhatAmI::Client, WhatAmI::Peer)).await,
+        TestType::PeerClient => create_direct_session_pair((WhatAmI::Peer, WhatAmI::Client)).await,
+        TestType::PeerPeer => create_direct_session_pair((WhatAmI::Peer, WhatAmI::Peer)).await,
         TestType::ClientRouterClient => {
-            let mut c = zenoh_config::Config::default();
-            c.set_mode(Some(WhatAmI::Router)).unwrap();
-            c.listen
-                .set_endpoints(ModeDependentValue::Unique(vec!["tcp/127.0.0.1:18003"
-                    .parse()
-                    .unwrap()]))
-                .unwrap();
-            router = Some(ztimeout!(zenoh::open(c)).unwrap());
-            create_session_pair("tcp/127.0.0.1:18003", (WhatAmI::Client, WhatAmI::Client)).await
+            let (s1, s2, routed_router) = create_routed_client_pair().await;
+            router = Some(routed_router);
+            (s1, s2)
         }
         _ => unreachable!(),
     };

--- a/zenoh/tests/namespace.rs
+++ b/zenoh/tests/namespace.rs
@@ -11,81 +11,63 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
+#![cfg(feature = "unstable")]
+mod common;
+
 use std::time::Duration;
 
 use zenoh::{sample::Locality, Result as ZResult, Session};
-use zenoh_config::{ModeDependentValue, WhatAmI};
+use zenoh_config::WhatAmI;
 use zenoh_core::ztimeout;
 use zenoh_keyexpr::{keyexpr, OwnedNonWildKeyExpr};
 use zenoh_macros::{ke, nonwild_ke};
+
+use crate::common::TestSessions;
 
 const TIMEOUT: Duration = Duration::from_secs(60);
 const SLEEP: Duration = Duration::from_secs(1);
 
 async fn create_peer_client_pair(
-    locator: &str,
     namespaces: &[Option<OwnedNonWildKeyExpr>; 2],
 ) -> (Session, Session) {
-    let config1 = {
-        let mut config = zenoh_config::Config::default();
-        config.scouting.multicast.set_enabled(Some(false)).unwrap();
-        config
-            .listen
-            .endpoints
-            .set(vec![locator.parse().unwrap()])
-            .unwrap();
-        config.namespace = namespaces[0].clone();
-        config
-    };
-    let mut config2 = zenoh_config::Config::default();
+    let mut test_context = TestSessions::new();
+
+    let mut config1 = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config1.namespace = namespaces[0].clone();
+
+    let session1 = test_context.open_listener_with_cfg(config1).await;
+
+    let mut config2 = test_context.get_connector_config();
     config2.set_mode(Some(WhatAmI::Client)).unwrap();
-    config2
-        .connect
-        .set_endpoints(ModeDependentValue::Unique(vec![locator.parse().unwrap()]))
-        .unwrap();
     config2.namespace = namespaces[1].clone();
 
-    let session1 = zenoh::open(config1).await.unwrap();
-    let session2 = zenoh::open(config2).await.unwrap();
+    let session2 = test_context.open_connector_with_cfg(config2).await;
+
     (session1, session2)
 }
 
 async fn create_routed_clients_pair(
-    locator: &str,
     namespaces: &[Option<OwnedNonWildKeyExpr>; 2],
 ) -> (Session, Session, Session) {
-    let config_router = {
-        let mut config = zenoh_config::Config::default();
-        config.scouting.multicast.set_enabled(Some(false)).unwrap();
-        config.set_mode(Some(WhatAmI::Router)).unwrap();
-        config
-            .listen
-            .endpoints
-            .set(vec![locator.parse().unwrap()])
-            .unwrap();
-        config.namespace = namespaces[0].clone();
-        config
-    };
+    let mut test_context = TestSessions::new();
 
-    let mut config1 = zenoh_config::Config::default();
+    let mut config_router = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config_router.set_mode(Some(WhatAmI::Router)).unwrap();
+    config_router.namespace = namespaces[0].clone();
+
+    let router = test_context.open_listener_with_cfg(config_router).await;
+
+    let mut config1 = test_context.get_connector_config();
     config1.set_mode(Some(WhatAmI::Client)).unwrap();
-    config1
-        .connect
-        .set_endpoints(ModeDependentValue::Unique(vec![locator.parse().unwrap()]))
-        .unwrap();
     config1.namespace = namespaces[0].clone();
 
-    let mut config2 = zenoh_config::Config::default();
+    let mut config2 = test_context.get_connector_config();
     config2.set_mode(Some(WhatAmI::Client)).unwrap();
-    config2
-        .connect
-        .set_endpoints(ModeDependentValue::Unique(vec![locator.parse().unwrap()]))
-        .unwrap();
     config2.namespace = namespaces[1].clone();
 
-    let router = zenoh::open(config_router).await.unwrap();
-    let session1 = zenoh::open(config1).await.unwrap();
-    let session2 = zenoh::open(config2).await.unwrap();
+    let session1 = test_context.open_connector_with_cfg(config1).await;
+    let session2 = test_context.open_connector_with_cfg(config2).await;
+
     (session1, session2, router)
 }
 
@@ -206,13 +188,10 @@ async fn zenoh_namespace_queryable_get_inner(
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn zenoh_namespace_pub_sub_peer_client_nested() -> ZResult<()> {
     zenoh_util::init_log_from_env_or("error");
-    let (s1, s2) = ztimeout!(create_peer_client_pair(
-        "tcp/127.0.0.1:19101",
-        &[
-            Some(nonwild_ke!("ext/ns1").to_owned()),
-            Some(nonwild_ke!("ext").to_owned())
-        ]
-    ));
+    let (s1, s2) = ztimeout!(create_peer_client_pair(&[
+        Some(nonwild_ke!("ext/ns1").to_owned()),
+        Some(nonwild_ke!("ext").to_owned())
+    ]));
     ztimeout!(zenoh_namespace_pub_sub_inner(
         s1,
         s2,
@@ -221,13 +200,10 @@ async fn zenoh_namespace_pub_sub_peer_client_nested() -> ZResult<()> {
         Locality::Any
     ));
 
-    let (s1, s2) = ztimeout!(create_peer_client_pair(
-        "tcp/127.0.0.1:19101",
-        &[
-            Some(nonwild_ke!("ext/ns2").to_owned()),
-            Some(nonwild_ke!("ext/ns2").to_owned())
-        ]
-    ));
+    let (s1, s2) = ztimeout!(create_peer_client_pair(&[
+        Some(nonwild_ke!("ext/ns2").to_owned()),
+        Some(nonwild_ke!("ext/ns2").to_owned())
+    ]));
     ztimeout!(zenoh_namespace_pub_sub_inner(
         s1,
         s2,
@@ -236,13 +212,10 @@ async fn zenoh_namespace_pub_sub_peer_client_nested() -> ZResult<()> {
         Locality::Any
     ));
 
-    let (s1, s2) = ztimeout!(create_peer_client_pair(
-        "tcp/127.0.0.1:19101",
-        &[
-            Some(nonwild_ke!("ext").to_owned()),
-            Some(nonwild_ke!("ext/ns3").to_owned())
-        ]
-    ));
+    let (s1, s2) = ztimeout!(create_peer_client_pair(&[
+        Some(nonwild_ke!("ext").to_owned()),
+        Some(nonwild_ke!("ext/ns3").to_owned())
+    ]));
     ztimeout!(zenoh_namespace_pub_sub_inner(
         s1,
         s2,
@@ -284,13 +257,10 @@ async fn zenoh_namespace_pub_sub_local_nested() -> ZResult<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn zenoh_namespace_pub_sub_routed_clients_nested() -> ZResult<()> {
     zenoh_util::init_log_from_env_or("error");
-    let (s1, s2, _router) = ztimeout!(create_routed_clients_pair(
-        "tcp/127.0.0.1:19103",
-        &[
-            Some(nonwild_ke!("ext/ns4").to_owned()),
-            Some(nonwild_ke!("ext").to_owned())
-        ]
-    ));
+    let (s1, s2, _router) = ztimeout!(create_routed_clients_pair(&[
+        Some(nonwild_ke!("ext/ns4").to_owned()),
+        Some(nonwild_ke!("ext").to_owned())
+    ]));
     ztimeout!(zenoh_namespace_pub_sub_inner(
         s1,
         s2,
@@ -299,13 +269,10 @@ async fn zenoh_namespace_pub_sub_routed_clients_nested() -> ZResult<()> {
         Locality::Any
     ));
 
-    let (s1, s2, _router) = ztimeout!(create_routed_clients_pair(
-        "tcp/127.0.0.1:19105",
-        &[
-            Some(nonwild_ke!("ext/ns5").to_owned()),
-            Some(nonwild_ke!("ext/ns5").to_owned())
-        ]
-    ));
+    let (s1, s2, _router) = ztimeout!(create_routed_clients_pair(&[
+        Some(nonwild_ke!("ext/ns5").to_owned()),
+        Some(nonwild_ke!("ext/ns5").to_owned())
+    ]));
     ztimeout!(zenoh_namespace_pub_sub_inner(
         s1,
         s2,
@@ -314,13 +281,10 @@ async fn zenoh_namespace_pub_sub_routed_clients_nested() -> ZResult<()> {
         Locality::Any
     ));
 
-    let (s1, s2, _router) = ztimeout!(create_routed_clients_pair(
-        "tcp/127.0.0.1:19107",
-        &[
-            Some(nonwild_ke!("ext").to_owned()),
-            Some(nonwild_ke!("ext/ns6").to_owned())
-        ]
-    ));
+    let (s1, s2, _router) = ztimeout!(create_routed_clients_pair(&[
+        Some(nonwild_ke!("ext").to_owned()),
+        Some(nonwild_ke!("ext/ns6").to_owned())
+    ]));
     ztimeout!(zenoh_namespace_pub_sub_inner(
         s1,
         s2,
@@ -334,13 +298,10 @@ async fn zenoh_namespace_pub_sub_routed_clients_nested() -> ZResult<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn zenoh_namespace_queryable_get_peer_client_nested() -> ZResult<()> {
     zenoh_util::init_log_from_env_or("error");
-    let (s1, s2) = ztimeout!(create_peer_client_pair(
-        "tcp/127.0.0.1:19102",
-        &[
-            Some(nonwild_ke!("ext/ns1").to_owned()),
-            Some(nonwild_ke!("ext").to_owned())
-        ]
-    ));
+    let (s1, s2) = ztimeout!(create_peer_client_pair(&[
+        Some(nonwild_ke!("ext/ns1").to_owned()),
+        Some(nonwild_ke!("ext").to_owned())
+    ]));
     ztimeout!(zenoh_namespace_queryable_get_inner(
         s1,
         s2,
@@ -349,13 +310,10 @@ async fn zenoh_namespace_queryable_get_peer_client_nested() -> ZResult<()> {
         Locality::Any
     ));
 
-    let (s1, s2) = ztimeout!(create_peer_client_pair(
-        "tcp/127.0.0.1:19102",
-        &[
-            Some(nonwild_ke!("ext/ns2").to_owned()),
-            Some(nonwild_ke!("ext/ns2").to_owned())
-        ]
-    ));
+    let (s1, s2) = ztimeout!(create_peer_client_pair(&[
+        Some(nonwild_ke!("ext/ns2").to_owned()),
+        Some(nonwild_ke!("ext/ns2").to_owned())
+    ]));
     ztimeout!(zenoh_namespace_queryable_get_inner(
         s1,
         s2,
@@ -364,13 +322,10 @@ async fn zenoh_namespace_queryable_get_peer_client_nested() -> ZResult<()> {
         Locality::Any
     ));
 
-    let (s1, s2) = ztimeout!(create_peer_client_pair(
-        "tcp/127.0.0.1:19102",
-        &[
-            Some(nonwild_ke!("ext").to_owned()),
-            Some(nonwild_ke!("ext/ns3").to_owned())
-        ]
-    ));
+    let (s1, s2) = ztimeout!(create_peer_client_pair(&[
+        Some(nonwild_ke!("ext").to_owned()),
+        Some(nonwild_ke!("ext/ns3").to_owned())
+    ]));
     ztimeout!(zenoh_namespace_queryable_get_inner(
         s1,
         s2,
@@ -411,13 +366,10 @@ async fn zenoh_namespace_queryable_get_local_nested() -> ZResult<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn zenoh_namespace_queryable_get_routed_clients_nested() -> ZResult<()> {
     zenoh_util::init_log_from_env_or("error");
-    let (s1, s2, _router) = ztimeout!(create_routed_clients_pair(
-        "tcp/127.0.0.1:19104",
-        &[
-            Some(nonwild_ke!("ext/ns4").to_owned()),
-            Some(nonwild_ke!("ext").to_owned())
-        ]
-    ));
+    let (s1, s2, _router) = ztimeout!(create_routed_clients_pair(&[
+        Some(nonwild_ke!("ext/ns4").to_owned()),
+        Some(nonwild_ke!("ext").to_owned())
+    ]));
     ztimeout!(zenoh_namespace_queryable_get_inner(
         s1,
         s2,
@@ -426,13 +378,10 @@ async fn zenoh_namespace_queryable_get_routed_clients_nested() -> ZResult<()> {
         Locality::Any
     ));
 
-    let (s1, s2, _router) = ztimeout!(create_routed_clients_pair(
-        "tcp/127.0.0.1:19106",
-        &[
-            Some(nonwild_ke!("ext/ns5").to_owned()),
-            Some(nonwild_ke!("ext/ns5").to_owned())
-        ]
-    ));
+    let (s1, s2, _router) = ztimeout!(create_routed_clients_pair(&[
+        Some(nonwild_ke!("ext/ns5").to_owned()),
+        Some(nonwild_ke!("ext/ns5").to_owned())
+    ]));
     ztimeout!(zenoh_namespace_queryable_get_inner(
         s1,
         s2,
@@ -441,13 +390,10 @@ async fn zenoh_namespace_queryable_get_routed_clients_nested() -> ZResult<()> {
         Locality::Any
     ));
 
-    let (s1, s2, _router) = ztimeout!(create_routed_clients_pair(
-        "tcp/127.0.0.1:19108",
-        &[
-            Some(nonwild_ke!("ext").to_owned()),
-            Some(nonwild_ke!("ext/ns6").to_owned())
-        ]
-    ));
+    let (s1, s2, _router) = ztimeout!(create_routed_clients_pair(&[
+        Some(nonwild_ke!("ext").to_owned()),
+        Some(nonwild_ke!("ext/ns6").to_owned())
+    ]));
     ztimeout!(zenoh_namespace_queryable_get_inner(
         s1,
         s2,
@@ -461,10 +407,10 @@ async fn zenoh_namespace_queryable_get_routed_clients_nested() -> ZResult<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn zenoh_namespace_pub_sub_peer_client() -> ZResult<()> {
     zenoh_util::init_log_from_env_or("error");
-    let (s1, s2) = ztimeout!(create_peer_client_pair(
-        "tcp/127.0.0.1:19001",
-        &[Some(nonwild_ke!("ns1").to_owned()), None]
-    ));
+    let (s1, s2) = ztimeout!(create_peer_client_pair(&[
+        Some(nonwild_ke!("ns1").to_owned()),
+        None
+    ]));
     ztimeout!(zenoh_namespace_pub_sub_inner(
         s1,
         s2,
@@ -473,13 +419,10 @@ async fn zenoh_namespace_pub_sub_peer_client() -> ZResult<()> {
         Locality::Any
     ));
 
-    let (s1, s2) = ztimeout!(create_peer_client_pair(
-        "tcp/127.0.0.1:19001",
-        &[
-            Some(nonwild_ke!("ns2").to_owned()),
-            Some(nonwild_ke!("ns2").to_owned())
-        ]
-    ));
+    let (s1, s2) = ztimeout!(create_peer_client_pair(&[
+        Some(nonwild_ke!("ns2").to_owned()),
+        Some(nonwild_ke!("ns2").to_owned())
+    ]));
     ztimeout!(zenoh_namespace_pub_sub_inner(
         s1,
         s2,
@@ -488,10 +431,10 @@ async fn zenoh_namespace_pub_sub_peer_client() -> ZResult<()> {
         Locality::Any
     ));
 
-    let (s1, s2) = ztimeout!(create_peer_client_pair(
-        "tcp/127.0.0.1:19001",
-        &[None, Some(nonwild_ke!("ns3").to_owned())]
-    ));
+    let (s1, s2) = ztimeout!(create_peer_client_pair(&[
+        None,
+        Some(nonwild_ke!("ns3").to_owned())
+    ]));
     ztimeout!(zenoh_namespace_pub_sub_inner(
         s1,
         s2,
@@ -528,10 +471,10 @@ async fn zenoh_namespace_pub_sub_local() -> ZResult<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn zenoh_namespace_pub_sub_routed_clients() -> ZResult<()> {
     zenoh_util::init_log_from_env_or("error");
-    let (s1, s2, _router) = ztimeout!(create_routed_clients_pair(
-        "tcp/127.0.0.1:19003",
-        &[Some(nonwild_ke!("ns4").to_owned()), None]
-    ));
+    let (s1, s2, _router) = ztimeout!(create_routed_clients_pair(&[
+        Some(nonwild_ke!("ns4").to_owned()),
+        None
+    ]));
     ztimeout!(zenoh_namespace_pub_sub_inner(
         s1,
         s2,
@@ -540,13 +483,10 @@ async fn zenoh_namespace_pub_sub_routed_clients() -> ZResult<()> {
         Locality::Any
     ));
 
-    let (s1, s2, _router) = ztimeout!(create_routed_clients_pair(
-        "tcp/127.0.0.1:19005",
-        &[
-            Some(nonwild_ke!("ns5").to_owned()),
-            Some(nonwild_ke!("ns5").to_owned())
-        ]
-    ));
+    let (s1, s2, _router) = ztimeout!(create_routed_clients_pair(&[
+        Some(nonwild_ke!("ns5").to_owned()),
+        Some(nonwild_ke!("ns5").to_owned())
+    ]));
     ztimeout!(zenoh_namespace_pub_sub_inner(
         s1,
         s2,
@@ -555,10 +495,10 @@ async fn zenoh_namespace_pub_sub_routed_clients() -> ZResult<()> {
         Locality::Any
     ));
 
-    let (s1, s2, _router) = ztimeout!(create_routed_clients_pair(
-        "tcp/127.0.0.1:19007",
-        &[None, Some(nonwild_ke!("ns6").to_owned())]
-    ));
+    let (s1, s2, _router) = ztimeout!(create_routed_clients_pair(&[
+        None,
+        Some(nonwild_ke!("ns6").to_owned())
+    ]));
     ztimeout!(zenoh_namespace_pub_sub_inner(
         s1,
         s2,
@@ -572,10 +512,10 @@ async fn zenoh_namespace_pub_sub_routed_clients() -> ZResult<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn zenoh_namespace_queryable_get_peer_client() -> ZResult<()> {
     zenoh_util::init_log_from_env_or("error");
-    let (s1, s2) = ztimeout!(create_peer_client_pair(
-        "tcp/127.0.0.1:19002",
-        &[Some(nonwild_ke!("ns1").to_owned()), None]
-    ));
+    let (s1, s2) = ztimeout!(create_peer_client_pair(&[
+        Some(nonwild_ke!("ns1").to_owned()),
+        None
+    ]));
     ztimeout!(zenoh_namespace_queryable_get_inner(
         s1,
         s2,
@@ -584,13 +524,10 @@ async fn zenoh_namespace_queryable_get_peer_client() -> ZResult<()> {
         Locality::Any
     ));
 
-    let (s1, s2) = ztimeout!(create_peer_client_pair(
-        "tcp/127.0.0.1:19002",
-        &[
-            Some(nonwild_ke!("ns2").to_owned()),
-            Some(nonwild_ke!("ns2").to_owned())
-        ]
-    ));
+    let (s1, s2) = ztimeout!(create_peer_client_pair(&[
+        Some(nonwild_ke!("ns2").to_owned()),
+        Some(nonwild_ke!("ns2").to_owned())
+    ]));
     ztimeout!(zenoh_namespace_queryable_get_inner(
         s1,
         s2,
@@ -599,10 +536,10 @@ async fn zenoh_namespace_queryable_get_peer_client() -> ZResult<()> {
         Locality::Any
     ));
 
-    let (s1, s2) = ztimeout!(create_peer_client_pair(
-        "tcp/127.0.0.1:19002",
-        &[None, Some(nonwild_ke!("ns3").to_owned())]
-    ));
+    let (s1, s2) = ztimeout!(create_peer_client_pair(&[
+        None,
+        Some(nonwild_ke!("ns3").to_owned())
+    ]));
     ztimeout!(zenoh_namespace_queryable_get_inner(
         s1,
         s2,
@@ -639,10 +576,10 @@ async fn zenoh_namespace_queryable_get_local() -> ZResult<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn zenoh_namespace_queryable_get_routed_clients() -> ZResult<()> {
     zenoh_util::init_log_from_env_or("error");
-    let (s1, s2, _router) = ztimeout!(create_routed_clients_pair(
-        "tcp/127.0.0.1:19004",
-        &[Some(nonwild_ke!("ns4").to_owned()), None]
-    ));
+    let (s1, s2, _router) = ztimeout!(create_routed_clients_pair(&[
+        Some(nonwild_ke!("ns4").to_owned()),
+        None
+    ]));
     ztimeout!(zenoh_namespace_queryable_get_inner(
         s1,
         s2,
@@ -651,13 +588,10 @@ async fn zenoh_namespace_queryable_get_routed_clients() -> ZResult<()> {
         Locality::Any
     ));
 
-    let (s1, s2, _router) = ztimeout!(create_routed_clients_pair(
-        "tcp/127.0.0.1:19006",
-        &[
-            Some(nonwild_ke!("ns5").to_owned()),
-            Some(nonwild_ke!("ns5").to_owned())
-        ]
-    ));
+    let (s1, s2, _router) = ztimeout!(create_routed_clients_pair(&[
+        Some(nonwild_ke!("ns5").to_owned()),
+        Some(nonwild_ke!("ns5").to_owned())
+    ]));
     ztimeout!(zenoh_namespace_queryable_get_inner(
         s1,
         s2,
@@ -666,10 +600,10 @@ async fn zenoh_namespace_queryable_get_routed_clients() -> ZResult<()> {
         Locality::Any
     ));
 
-    let (s1, s2, _router) = ztimeout!(create_routed_clients_pair(
-        "tcp/127.0.0.1:19008",
-        &[None, Some(nonwild_ke!("ns6").to_owned())]
-    ));
+    let (s1, s2, _router) = ztimeout!(create_routed_clients_pair(&[
+        None,
+        Some(nonwild_ke!("ns6").to_owned())
+    ]));
     ztimeout!(zenoh_namespace_queryable_get_inner(
         s1,
         s2,

--- a/zenoh/tests/open_time.rs
+++ b/zenoh/tests/open_time.rs
@@ -12,7 +12,10 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
+#![cfg(feature = "unstable")]
 #![allow(unused)]
+mod common;
+
 use std::{
     future::IntoFuture,
     time::{Duration, Instant},
@@ -21,6 +24,8 @@ use std::{
 use zenoh_config::Config;
 use zenoh_link::EndPoint;
 use zenoh_protocol::core::WhatAmI;
+
+use crate::common::TestSessions;
 
 const TIMEOUT_EXPECTED: Duration = Duration::from_secs(5);
 const SLEEP: Duration = Duration::from_millis(100);
@@ -31,20 +36,45 @@ macro_rules! ztimeout_expected {
     };
 }
 
+fn endpoint_with_address(template: &EndPoint, address: &str) -> EndPoint {
+    EndPoint::new(
+        template.protocol().as_str(),
+        address,
+        template.metadata().as_str(),
+        template.config().as_str(),
+    )
+    .unwrap()
+}
+
+// Preserve the original connect host/config and only replace the port with the
+// actual bound listener port. This is important for transports like TLS/QUIC,
+// where connecting to the discovered listener locator directly may break host-
+// based expectations such as certificates issued for `localhost`.
+fn endpoint_with_listener_port(template: &EndPoint, listener_endpoint: &EndPoint) -> EndPoint {
+    let template_address = template.address().as_str();
+    let listener_address = listener_endpoint.address().as_str();
+
+    let Some((template_host, _)) = template_address.rsplit_once(':') else {
+        return template.clone();
+    };
+    let Some((_, listener_port)) = listener_address.rsplit_once(':') else {
+        return template.clone();
+    };
+
+    endpoint_with_address(template, &format!("{template_host}:{listener_port}"))
+}
+
 async fn time_open(
     listen_endpoint: &EndPoint,
     connect_endpoint: &EndPoint,
     connect_mode: WhatAmI,
     lowlatency: bool,
 ) {
+    let mut test_context = TestSessions::new();
+
     /* [ROUTER] */
-    let mut router_config = zenoh_config::Config::default();
+    let mut router_config = test_context.get_listener_config(&listen_endpoint.to_string(), 1);
     router_config.set_mode(Some(WhatAmI::Router)).unwrap();
-    router_config
-        .listen
-        .endpoints
-        .set(vec![listen_endpoint.clone()])
-        .unwrap();
     router_config
         .transport
         .unicast
@@ -58,23 +88,25 @@ async fn time_open(
         .unwrap();
 
     let start = Instant::now();
-    let router = ztimeout_expected!(zenoh::open(router_config).into_future()).unwrap();
+    let router = ztimeout_expected!(test_context.open_listener_with_cfg(router_config));
+    let listener_endpoint = TestSessions::get_locators_from_session(&router)
+        .await
+        .into_iter()
+        .find(|endpoint| endpoint.protocol().as_str() == listen_endpoint.protocol().as_str())
+        .unwrap();
+    let connect_endpoint = endpoint_with_listener_port(connect_endpoint, &listener_endpoint);
     println!(
         "open(mode:{}, listen_endpoint:{}, lowlatency:{}): {:#?}",
         WhatAmI::Router,
-        listen_endpoint.as_str().split('#').next().unwrap(),
+        listener_endpoint.as_str().split('#').next().unwrap(),
         lowlatency,
         start.elapsed()
     );
 
     /* [APP] */
-    let mut app_config = zenoh_config::Config::default();
+    let mut app_config =
+        test_context.get_connector_config_with_endpoint(vec![connect_endpoint.clone()]);
     app_config.set_mode(Some(connect_mode)).unwrap();
-    app_config
-        .connect
-        .endpoints
-        .set(vec![connect_endpoint.clone()])
-        .unwrap();
     app_config
         .transport
         .unicast
@@ -90,7 +122,7 @@ async fn time_open(
     /* [1] */
     // Open a transport from the app to the router
     let start = Instant::now();
-    let app = ztimeout_expected!(zenoh::open(app_config).into_future()).unwrap();
+    let app = ztimeout_expected!(test_context.open_connector_with_cfg(app_config));
     println!(
         "open(mode:{}, connect_endpoint:{}, lowlatency:{}): {:#?}",
         connect_mode,
@@ -118,7 +150,7 @@ async fn time_open(
     println!(
         "close(mode:{}, listen_endpoint:{}, lowlatency:{}): {:#?}",
         WhatAmI::Router,
-        listen_endpoint.as_str().split('#').next().unwrap(),
+        listener_endpoint.as_str().split('#').next().unwrap(),
         lowlatency,
         start.elapsed()
     );
@@ -140,7 +172,7 @@ async fn time_lowlatency_open(endpoint: &EndPoint, mode: WhatAmI) {
 #[ignore]
 async fn time_tcp_only_open() {
     zenoh::init_log_from_env_or("error");
-    let endpoint: EndPoint = format!("tcp/127.0.0.1:{}", 14000).parse().unwrap();
+    let endpoint: EndPoint = "tcp/127.0.0.1:0".parse().unwrap();
     time_universal_open(&endpoint, WhatAmI::Client).await;
 }
 
@@ -149,7 +181,7 @@ async fn time_tcp_only_open() {
 #[ignore]
 async fn time_tcp_only_with_lowlatency_open() {
     zenoh::init_log_from_env_or("error");
-    let endpoint: EndPoint = format!("tcp/127.0.0.1:{}", 14100).parse().unwrap();
+    let endpoint: EndPoint = "tcp/127.0.0.1:0".parse().unwrap();
     time_lowlatency_open(&endpoint, WhatAmI::Client).await;
 }
 
@@ -158,7 +190,7 @@ async fn time_tcp_only_with_lowlatency_open() {
 #[ignore]
 async fn time_udp_only_open() {
     zenoh::init_log_from_env_or("error");
-    let endpoint: EndPoint = format!("udp/127.0.0.1:{}", 14010).parse().unwrap();
+    let endpoint: EndPoint = "udp/127.0.0.1:0".parse().unwrap();
     time_universal_open(&endpoint, WhatAmI::Client).await;
 }
 
@@ -167,7 +199,7 @@ async fn time_udp_only_open() {
 #[ignore]
 async fn time_udp_only_with_lowlatency_open() {
     zenoh::init_log_from_env_or("error");
-    let endpoint: EndPoint = format!("udp/127.0.0.1:{}", 14110).parse().unwrap();
+    let endpoint: EndPoint = "udp/127.0.0.1:0".parse().unwrap();
     time_lowlatency_open(&endpoint, WhatAmI::Client).await;
 }
 
@@ -304,7 +336,7 @@ Ck0v2xSPAiVjg6w65rUQeW6uB5m0T2wyj+wm0At8vzhZPlgS1fKhcmT2dzOq3+oN
 R+IdLiXcyIkg0m9N8I17p0ljCSkbrgGMD3bbePRTfg==
 -----END CERTIFICATE-----";
 
-    let mut endpoint: EndPoint = format!("tls/localhost:{}", 14030).parse().unwrap();
+    let mut endpoint: EndPoint = "tls/localhost:0".parse().unwrap();
     endpoint
         .config_mut()
         .extend_from_iter(
@@ -403,7 +435,7 @@ R+IdLiXcyIkg0m9N8I17p0ljCSkbrgGMD3bbePRTfg==
 -----END CERTIFICATE-----";
 
     // Define the locator
-    let mut endpoint: EndPoint = format!("quic/localhost:{}", 14040).parse().unwrap();
+    let mut endpoint: EndPoint = "quic/localhost:0".parse().unwrap();
     endpoint
         .config_mut()
         .extend_from_iter(

--- a/zenoh/tests/routing.rs
+++ b/zenoh/tests/routing.rs
@@ -11,6 +11,8 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
+#![cfg(feature = "unstable")]
+mod common;
 
 use std::{
     sync::{
@@ -27,6 +29,8 @@ use zenoh_config::{Config, ModeDependentValue, WhatAmIMatcher};
 use zenoh_core::ztimeout;
 use zenoh_link::EndPoint;
 use zenoh_result::bail;
+
+use crate::common::{get_free_port, get_tcp_locator};
 
 const TIMEOUT: Duration = Duration::from_secs(10);
 const MSG_COUNT: usize = 50;
@@ -470,7 +474,7 @@ impl Recipe {
 async fn gossip() -> Result<()> {
     zenoh::init_log_from_env_or("error");
 
-    let locator = String::from("tcp/127.0.0.1:17446");
+    let locator = format!("tcp/127.0.0.1:{}", get_free_port());
     let ke = String::from("testKeyExprGossip");
     let msg_size = 8;
 
@@ -537,14 +541,11 @@ async fn gossip() -> Result<()> {
 async fn gossip_regression_1() -> Result<()> {
     zenoh::init_log_from_env_or("error");
 
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:17480";
-    const PEER_ENDPOINT: &str = "tcp/localhost:17481";
-
     let router = {
         let mut c = Config::default();
         c.listen
             .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec!["tcp/127.0.0.1:0".parse::<EndPoint>().unwrap()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Router));
@@ -552,6 +553,7 @@ async fn gossip_regression_1() -> Result<()> {
         tracing::info!("Router ZID: {}", s.zid());
         s
     };
+    let router_endpoint = get_tcp_locator(&router).await;
 
     tokio::time::sleep(Duration::from_secs(1)).await;
 
@@ -559,7 +561,7 @@ async fn gossip_regression_1() -> Result<()> {
         let mut c = Config::default();
         c.connect
             .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec![router_endpoint.clone()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         c.scouting
@@ -576,13 +578,10 @@ async fn gossip_regression_1() -> Result<()> {
 
     let peer2 = {
         let mut c = Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.connect.endpoints.set(vec![router_endpoint]).unwrap();
         c.listen
             .endpoints
-            .set(vec![PEER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec!["tcp/127.0.0.1:0".parse::<EndPoint>().unwrap()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         c.scouting
@@ -594,15 +593,13 @@ async fn gossip_regression_1() -> Result<()> {
         tracing::info!("Peer (2) ZID: {}", s.zid());
         s
     };
+    let peer_endpoint = get_tcp_locator(&peer2).await;
 
     tokio::time::sleep(Duration::from_secs(1)).await;
 
     let peer3 = {
         let mut c = Config::default();
-        c.connect
-            .endpoints
-            .set(vec![PEER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.connect.endpoints.set(vec![peer_endpoint]).unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         c.scouting
             .gossip
@@ -635,13 +632,11 @@ async fn gossip_regression_1() -> Result<()> {
 async fn gossip_regression_2() -> Result<()> {
     zenoh::init_log_from_env_or("error");
 
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:17482";
-
     let router = {
         let mut c = Config::default();
         c.listen
             .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec!["tcp/127.0.0.1:0".parse::<EndPoint>().unwrap()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Router));
@@ -649,6 +644,7 @@ async fn gossip_regression_2() -> Result<()> {
         tracing::info!("Router ZID: {}", s.zid());
         s
     };
+    let router_endpoint = get_tcp_locator(&router).await;
 
     tokio::time::sleep(Duration::from_secs(1)).await;
 
@@ -656,7 +652,7 @@ async fn gossip_regression_2() -> Result<()> {
         let mut c = Config::default();
         c.connect
             .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec![router_endpoint.clone()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         c.scouting
@@ -674,10 +670,7 @@ async fn gossip_regression_2() -> Result<()> {
 
     let peer2 = {
         let mut c = Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.connect.endpoints.set(vec![router_endpoint]).unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         c.scouting
             .gossip
@@ -712,14 +705,11 @@ async fn gossip_regression_2() -> Result<()> {
 async fn gossip_regression_3() -> Result<()> {
     zenoh::init_log_from_env_or("error");
 
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:17483";
-    const PEER_ENDPOINT: &str = "tcp/localhost:17484";
-
     let router = {
         let mut c = Config::default();
         c.listen
             .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec!["tcp/127.0.0.1:0".parse::<EndPoint>().unwrap()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         c.scouting.gossip.set_multihop(Some(true)).unwrap();
@@ -728,6 +718,7 @@ async fn gossip_regression_3() -> Result<()> {
         tracing::info!("Router ZID: {}", s.zid());
         s
     };
+    let router_endpoint = get_tcp_locator(&router).await;
 
     tokio::time::sleep(Duration::from_secs(1)).await;
 
@@ -735,7 +726,7 @@ async fn gossip_regression_3() -> Result<()> {
         let mut c = Config::default();
         c.connect
             .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec![router_endpoint.clone()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         c.scouting
@@ -754,13 +745,10 @@ async fn gossip_regression_3() -> Result<()> {
 
     let peer2 = {
         let mut c = Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.connect.endpoints.set(vec![router_endpoint]).unwrap();
         c.listen
             .endpoints
-            .set(vec![PEER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec!["tcp/127.0.0.1:0".parse::<EndPoint>().unwrap()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         c.scouting
@@ -773,15 +761,13 @@ async fn gossip_regression_3() -> Result<()> {
         tracing::info!("Peer (2) ZID: {}", s.zid());
         s
     };
+    let peer_endpoint = get_tcp_locator(&peer2).await;
 
     tokio::time::sleep(Duration::from_secs(1)).await;
 
     let peer3 = {
         let mut c = Config::default();
-        c.connect
-            .endpoints
-            .set(vec![PEER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.connect.endpoints.set(vec![peer_endpoint]).unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         c.scouting
             .gossip
@@ -825,7 +811,7 @@ async fn gossip_regression_3() -> Result<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn static_failover_brokering() -> Result<()> {
     zenoh::init_log_from_env_or("error");
-    let locator = String::from("tcp/127.0.0.1:17449");
+    let locator = format!("tcp/127.0.0.1:{}", get_free_port());
     let ke = String::from("testKeyExprStaticFailoverBrokering");
     let msg_size = 8;
 
@@ -899,8 +885,6 @@ async fn three_node_combination() -> Result<()> {
     ];
 
     let mut idx = 0;
-    // Ports going to be used: 17451 to 17498
-    let base_port = 17450;
 
     let recipe_list: Vec<_> = modes
         .map(|n1| modes.map(|n2| (n1, n2)))
@@ -911,7 +895,7 @@ async fn three_node_combination() -> Result<()> {
         .map(
             |(node1_mode, node2_mode, msg_size, (delay1, delay2, delay3))| {
                 idx += 1;
-                let locator = format!("tcp/127.0.0.1:{}", base_port + idx);
+                let locator = format!("tcp/127.0.0.1:{}", get_free_port());
 
                 let ke_pubsub = format!("three_node_combination_keyexpr_pubsub_{idx}");
                 let ke_getqueryable = format!("three_node_combination_keyexpr_getqueryable_{idx}");
@@ -1076,8 +1060,6 @@ async fn two_node_combination() -> Result<()> {
     ];
 
     let mut idx = 0;
-    // Ports going to be used: 17501 to 17509
-    let base_port = 17500;
     let recipe_list: Vec<_> = modes
         .into_iter()
         .flat_map(|(n1, n2, who)| MSG_SIZE.map(|s| (n1, n2, who, s)))
@@ -1089,7 +1071,7 @@ async fn two_node_combination() -> Result<()> {
             let ke_getliveliness = format!("two_node_combination_keyexpr_getliveliness_{idx}");
 
             let (node1_listen_connect, node2_listen_connect) = {
-                let locator = format!("tcp/127.0.0.1:{}", base_port + idx);
+                let locator = format!("tcp/127.0.0.1:{}", get_free_port());
                 let listen = vec![locator];
                 let connect = vec![];
 
@@ -1227,8 +1209,6 @@ async fn three_node_combination_multicast() -> Result<()> {
     ];
 
     let mut idx = 0;
-    // Ports going to be used: 18511 .. 18535
-    let base_port = 18510;
 
     let recipe_list: Vec<_> = modes
         .map(|n1| modes.map(|n2| (n1, n2)))
@@ -1239,8 +1219,9 @@ async fn three_node_combination_multicast() -> Result<()> {
         .map(
             |(node1_mode, node2_mode, msg_size, (delay1, delay2, delay3))| {
                 idx += 1;
-                let unicast_locator = format!("tcp/127.0.0.1:{}", base_port + idx);
-                let multicast_locator = format!("udp/224.0.0.1:{}", base_port + idx);
+                let port = get_free_port();
+                let unicast_locator = format!("tcp/127.0.0.1:{}", port);
+                let multicast_locator = format!("udp/224.0.0.1:{}", port);
 
                 let ke_pubsub = format!("three_node_combination_multicast_keyexpr_pubsub_{idx}");
 
@@ -1345,17 +1326,15 @@ async fn router_linkstate() -> Result<()> {
     ];
 
     let mut idx = 0;
-    // Ports going to be used: 17601 to 17648
-    let base_port = 17600;
 
     let recipe_list: Vec<_> = delay_in_secs
         .into_iter()
         .map(|d| (1024, d))
         .map(|(msg_size, (delay1, delay2, delay3))| {
             idx += 1;
-            let locator1 = format!("tcp/127.0.0.1:{}", base_port + (idx * 3));
-            let locator2 = format!("tcp/127.0.0.1:{}", base_port + (idx * 3) + 1);
-            let locator3 = format!("tcp/127.0.0.1:{}", base_port + (idx * 3) + 2);
+            let locator1 = format!("tcp/127.0.0.1:{}", get_free_port());
+            let locator2 = format!("tcp/127.0.0.1:{}", get_free_port());
+            let locator3 = format!("tcp/127.0.0.1:{}", get_free_port());
 
             let ke_pubsub = format!("router_linkstate_keyexpr_pubsub_{idx}");
             let ke_getqueryable = format!("router_linkstate_keyexpr_getqueryable_{idx}");
@@ -1533,13 +1512,11 @@ async fn router_linkstate() -> Result<()> {
 async fn scouting_delay_regression() -> Result<()> {
     zenoh::init_log_from_env_or("error");
 
-    const ROUTER_ENDPOINT: &str = "tcp/localhost:17490";
-
     let router = {
         let mut c = Config::default();
         c.listen
             .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec!["tcp/127.0.0.1:0".parse::<EndPoint>().unwrap()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Router));
@@ -1547,6 +1524,7 @@ async fn scouting_delay_regression() -> Result<()> {
         tracing::info!("Router ZID: {}", s.zid());
         s
     };
+    let router_endpoint = get_tcp_locator(&router).await;
 
     tokio::time::sleep(Duration::from_secs(1)).await;
 
@@ -1554,7 +1532,7 @@ async fn scouting_delay_regression() -> Result<()> {
         let mut c = Config::default();
         c.connect
             .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .set(vec![router_endpoint.clone()])
             .unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Peer));
@@ -1569,10 +1547,7 @@ async fn scouting_delay_regression() -> Result<()> {
     let start = std::time::Instant::now();
     let peer2 = {
         let mut c = Config::default();
-        c.connect
-            .endpoints
-            .set(vec![ROUTER_ENDPOINT.parse::<EndPoint>().unwrap()])
-            .unwrap();
+        c.connect.endpoints.set(vec![router_endpoint]).unwrap();
         c.scouting.multicast.set_enabled(Some(false)).unwrap();
         let _ = c.set_mode(Some(WhatAmI::Peer));
         ztimeout!(zenoh::open(c)).unwrap()


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->
Following https://github.com/eclipse-zenoh/zenoh/pull/2525 and https://github.com/eclipse-zenoh/zenoh/pull/2540, migrate other tests to adopt the common test framework.
So we can avoid the potential port collision by using port 0.
Refer to https://github.com/eclipse-zenoh/zenoh/issues/2526

### Why is this change needed?
If we run several tests at the same time, it might cause a port collision when we use fixed ports.

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->
https://github.com/eclipse-zenoh/zenoh/issues/2526

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `enhancement`

## ✨ Enhancement Requirements

Since this PR enhances existing functionality:

- [x] **Enhancement scope documented** - Clear description of what is being improved
- [x] **Minimum necessary code** - Implementation is as simple as possible, doesn't overcomplicate the system
- [x] **Backwards compatible** - Existing code/APIs still work unchanged
- [x] **No new APIs added** - Only improving existing functionality
- [x] **Tests updated** - Existing tests pass, new test cases added if needed
- [x] **Performance improvement measured** - If applicable, before/after metrics provided
- [x] **Documentation updated** - Existing docs updated to reflect improvements
- [x] **User impact documented** - How users benefit from this enhancement

**Remember:** Enhancements should not introduce new APIs or breaking changes.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->