### PR TITLE
implement transport from fields constructor

### DIFF
--- a/zenoh/src/api/info.rs
+++ b/zenoh/src/api/info.rs
@@ -560,26 +560,6 @@ mod tests {
     use zenoh_protocol::core::WhatAmI;
 
     #[test]
-    fn test_new_from_fields_stores_fields() {
-        let zid = ZenohId::default();
-        let whatami = WhatAmI::Peer;
-        let t = Transport::new_from_fields(
-            zid.clone(),
-            whatami,
-            /*is_qos=*/ true,
-            /*is_multicast=*/ false,
-            #[cfg(feature = "shared-memory")]
-            /*is_shm=*/ true,
-        );
-        assert_eq!(t.zid, zid);
-        assert_eq!(t.whatami, whatami);
-        assert!(t.is_qos);
-        assert!(!t.is_multicast);
-        #[cfg(feature = "shared-memory")]
-        assert!(t.is_shm);
-    }
-
-    #[test]
     fn test_new_from_fields_equals_new_from_peer() {
         let peer = TransportPeer {
             zid: ZenohId::default().into(),

--- a/zenoh/src/api/info.rs
+++ b/zenoh/src/api/info.rs
@@ -553,3 +553,54 @@ impl CallbackParameter for LinkEvent {
         msg
     }
 }
+
+#[cfg(all(test, feature = "internal"))]
+mod tests {
+    use super::*;
+    use zenoh_protocol::core::WhatAmI;
+
+    #[test]
+    fn test_new_from_fields_stores_fields() {
+        let zid = ZenohId::default();
+        let whatami = WhatAmI::Peer;
+        let t = Transport::new_from_fields(
+            zid.clone(),
+            whatami,
+            /*is_qos=*/ true,
+            /*is_multicast=*/ false,
+            #[cfg(feature = "shared-memory")]
+            /*is_shm=*/ true,
+        );
+        assert_eq!(t.zid, zid);
+        assert_eq!(t.whatami, whatami);
+        assert!(t.is_qos);
+        assert!(!t.is_multicast);
+        #[cfg(feature = "shared-memory")]
+        assert!(t.is_shm);
+    }
+
+    #[test]
+    fn test_new_from_fields_equals_new_from_peer() {
+        let peer = TransportPeer {
+            zid: zenoh_protocol::core::ZenohId::default().into(),
+            whatami: WhatAmI::Router,
+            is_qos: true,
+            #[cfg(feature = "shared-memory")]
+            is_shm: false,
+            links: vec![],
+            region_name: None,
+        };
+
+        let via_new = Transport::new(&peer, /*is_multicast=*/ false);
+        let via_fields = Transport::new_from_fields(
+            peer.zid.clone().into(),
+            peer.whatami,
+            peer.is_qos,
+            /*is_multicast=*/ false,
+            #[cfg(feature = "shared-memory")]
+            peer.is_shm,
+        );
+
+        assert_eq!(via_new, via_fields);
+    }
+}

--- a/zenoh/src/api/info.rs
+++ b/zenoh/src/api/info.rs
@@ -556,8 +556,9 @@ impl CallbackParameter for LinkEvent {
 
 #[cfg(all(test, feature = "internal"))]
 mod tests {
-    use super::*;
     use zenoh_protocol::core::WhatAmI;
+
+    use super::*;
 
     #[test]
     fn test_new_from_fields_equals_new_from_peer() {

--- a/zenoh/src/api/info.rs
+++ b/zenoh/src/api/info.rs
@@ -574,7 +574,7 @@ mod tests {
 
         let via_new = Transport::new(&peer, /*is_multicast=*/ false);
         let via_fields = Transport::new_from_fields(
-            peer.zid.clone().into(),
+            peer.zid.into(),
             peer.whatami,
             peer.is_qos,
             /*is_multicast=*/ false,

--- a/zenoh/src/api/info.rs
+++ b/zenoh/src/api/info.rs
@@ -254,6 +254,25 @@ impl Transport {
             is_shm: false,
         }
     }
+
+    /// Constructs a Transport from individual fields.
+    #[zenoh_macros::internal]
+    pub fn new_from_fields(
+        zid: ZenohId,
+        whatami: WhatAmI,
+        is_qos: bool,
+        is_multicast: bool,
+        #[cfg(feature = "shared-memory")] is_shm: bool,
+    ) -> Self {
+        Transport {
+            zid,
+            whatami,
+            is_qos,
+            is_multicast,
+            #[cfg(feature = "shared-memory")]
+            is_shm,
+        }
+    }
 }
 
 #[cfg(feature = "unstable")]

--- a/zenoh/src/api/info.rs
+++ b/zenoh/src/api/info.rs
@@ -582,7 +582,7 @@ mod tests {
     #[test]
     fn test_new_from_fields_equals_new_from_peer() {
         let peer = TransportPeer {
-            zid: zenoh_protocol::core::ZenohId::default().into(),
+            zid: ZenohId::default().into(),
             whatami: WhatAmI::Router,
             is_qos: true,
             #[cfg(feature = "shared-memory")]


### PR DESCRIPTION
## Description

### What does this PR do?

Create internal (under internal feature) constructor for Transport object which constructs it from the fields values

### Why is this change needed?

For some language bindings (zenoh-go) it's more effective to make the "Transport" type language-native. We need a way to build rust Transport object back from fields for applying it to links filtering.

### Related Issues
https://github.com/eclipse-zenoh/zenoh/issues/2554
