### PR TITLE
Disable `full_linkstate` in `peer::Hat::Network`

### DIFF
--- a/zenoh/src/net/protocol/network.rs
+++ b/zenoh/src/net/protocol/network.rs
@@ -563,7 +563,7 @@ impl Network {
             .collect::<Vec<_>>()
     }
 
-    fn process_linkstates_peer_to_peer(&mut self, link_states: Vec<LocalLinkState>) -> Changes {
+    fn process_singlehop_gossip_linkstate(&mut self, link_states: Vec<LocalLinkState>) -> Changes {
         let mut changes = Changes::default();
 
         for ls in link_states.into_iter() {
@@ -589,7 +589,14 @@ impl Network {
                         continue;
                     }
                     node.sn = ls.sn;
-                    node.links.clone_from(&ls.links);
+                    // NOTE(regions): only Gossip may send malformed messages with empty
+                    // linkstate. These can be safely ignored since they don't occur in "full"
+                    // linkstate. Note that a Gossip node sends non-empty linkstate for itself
+                    // to its gateway. Also note that Network only considers two nodes to be
+                    // connected if both their linkstates imply the connection.
+                    if !ls.links.is_empty() {
+                        node.links.clone_from(&ls.links);
+                    }
                     changes.updated_nodes.push((idx, node.clone()));
                     if ls.locators.is_none() || node.locators == ls.locators {
                         continue;
@@ -705,7 +712,7 @@ impl Network {
         }
 
         if !self.full_linkstate && !self.gossip_multihop {
-            return self.process_linkstates_peer_to_peer(link_states);
+            return self.process_singlehop_gossip_linkstate(link_states);
         }
 
         let mut new_nodes = vec![];
@@ -718,14 +725,7 @@ impl Network {
                     let oldsn = node.sn;
                     if oldsn < ls.sn {
                         node.sn = ls.sn;
-                        // NOTE(regions): only Gossip may send malformed messages with empty
-                        // linkstate. These can be safely ignored since they don't occur in "full"
-                        // linkstate. Note that a Gossip node sends non-empty linkstate for itself
-                        // to its gateway. Also note that Network only considers two nodes to be
-                        // connected if both their linkstates imply the connection.
-                        if !ls.links.is_empty() {
-                            node.links.clone_from(&ls.links);
-                        }
+                        node.links.clone_from(&ls.links);
                         if ls.locators.is_some() {
                             node.locators = ls.locators;
                         }

--- a/zenoh/src/net/routing/hat/peer/mod.rs
+++ b/zenoh/src/net/routing/hat/peer/mod.rs
@@ -243,7 +243,7 @@ impl HatBaseTrait for Hat {
                         NAME.to_string(),
                         tables.zid,
                         runtime,
-                        true,
+                        false,
                         is_gossip_enabled,
                         is_gossip_multihop_enabled,
                         gossip_target,

--- a/zenoh/src/net/tests/regions/mod.rs
+++ b/zenoh/src/net/tests/regions/mod.rs
@@ -26,6 +26,7 @@ mod adminspace;
 mod declare;
 mod forwarding;
 mod interest;
+mod oam;
 
 use std::{
     any::Any,
@@ -37,6 +38,7 @@ use futures::executor::block_on;
 use tracing_subscriber::EnvFilter;
 use zenoh_config::{Config, ZenohId};
 use zenoh_protocol::{
+    common::ZExtBody,
     core::{Bound, ExprId, Region, Reliability, WhatAmI, WireExpr, ZenohIdProto},
     network::{
         declare::{
@@ -48,6 +50,7 @@ use zenoh_protocol::{
         },
         ext::{self, NodeIdType},
         interest::{InterestId, InterestMode, InterestOptions},
+        oam::id::OAM_LINKSTATE,
         request::ext::QueryTarget,
         Declare, DeclareBody, DeclareFinal, DeclareKeyExpr, Interest, NetworkBody, NetworkBodyMut,
         NetworkMessageMut, Oam, Push, Request, RequestId, Response, ResponseFinal,
@@ -59,7 +62,9 @@ use zenoh_transport::{
 };
 
 use crate::net::{
+    codec::Zenoh080Routing,
     primitives::{DeMux, EPrimitives, Primitives},
+    protocol::linkstate::{LinkState, LinkStateList},
     routing::{
         dispatcher::face::Face,
         gateway::{Gateway, GatewayBuilder},
@@ -328,6 +333,48 @@ impl RecordingPrimitives {
                     None
                 }
             })
+            .collect()
+    }
+
+    /// Decode and return all recorded OAM messages whose `id` is [`OAM_LINKSTATE`].
+    ///
+    /// Each matching OAM message carries a [`ZExtBody::ZBuf`] that is decoded as a
+    /// [`LinkStateList`] using [`Zenoh080Routing`].  Messages that fail to decode are
+    /// silently skipped.
+    pub(crate) fn linkstates(&self) -> Vec<LinkStateList> {
+        use zenoh_buffers::reader::HasReader;
+        use zenoh_codec::RCodec;
+
+        self.messages
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|m| {
+                if let Message::Oam(Oam {
+                    id: OAM_LINKSTATE,
+                    body: ZExtBody::ZBuf(buf),
+                    ..
+                }) = m
+                {
+                    let codec = Zenoh080Routing::new();
+                    let mut reader = buf.reader();
+                    codec.read(&mut reader).ok()
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Decode and return all individual [`LinkState`] entries from every recorded OAM linkstate
+    /// message, in arrival order.
+    ///
+    /// This is a flattened view of [`linkstates`](Self::linkstates): each [`LinkStateList`] is
+    /// expanded and all contained [`LinkState`] entries are concatenated into a single `Vec`.
+    pub(crate) fn flat_linkstates(&self) -> Vec<LinkState> {
+        self.linkstates()
+            .into_iter()
+            .flat_map(|list| list.link_states)
             .collect()
     }
 

--- a/zenoh/src/net/tests/regions/oam.rs
+++ b/zenoh/src/net/tests/regions/oam.rs
@@ -1,0 +1,142 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+//! Tests involving [`zenoh_protocol::network::oam`].
+
+use zenoh_protocol::core::{Bound, Region, WhatAmI};
+
+use super::{Connection, EstablishedConnection, FaceDef, HarnessBuilder};
+
+/// Checks the following properties:
+/// 1. Peer gateways, in single-hop gossip mode, propagate linkstate information downstream without
+///    link info.
+/// 2. Non-gateway peers, in single-hop mode, propagate linkstate information upstream with link
+///    info.
+#[test]
+fn test_peer_singlehop_gossip_linkstate_propagation() {
+    const S: Region = Region::default_south(WhatAmI::Peer);
+    let a = HarnessBuilder::new()
+        .zid("a".parse().unwrap())
+        .subregions([S])
+        .build();
+
+    let b0 = HarnessBuilder::new().zid("b0".parse().unwrap()).build();
+    let b1 = HarnessBuilder::new().zid("b1".parse().unwrap()).build();
+
+    let mut b0_b1 = Connection {
+        a: &b0,
+        a2b: FaceDef::default(),
+        b: &b1,
+        b2a: FaceDef::default(),
+    }
+    .establish();
+
+    let mut a_b0 = Connection {
+        a: &a,
+        a2b: FaceDef::default().region(S),
+        b: &b0,
+        b2a: FaceDef::default().remote_bound(Bound::South),
+    }
+    .establish();
+
+    let mut a_b1 = Connection {
+        a: &a,
+        a2b: FaceDef::default().region(S),
+        b: &b1,
+        b2a: FaceDef::default().remote_bound(Bound::South),
+    }
+    .establish();
+
+    EstablishedConnection::bi_fwd_many_unbounded([&mut b0_b1, &mut a_b0, &mut a_b1]);
+
+    assert!(
+        a_b0.a2b
+            .recorder()
+            .flat_linkstates()
+            .into_iter()
+            .filter(|ls| ls.psid != 0)
+            .all(|ls| ls.links.is_empty()),
+        "all linkstate updates propagated by a to b0 should have an empty `links` field"
+    );
+
+    assert!(
+        a_b1.a2b
+            .recorder()
+            .flat_linkstates()
+            .into_iter()
+            .filter(|ls| ls.psid != 0)
+            .all(|ls| ls.links.is_empty()),
+        "all linkstate updates propagated by a to b1 should have an empty `links` field"
+    );
+
+    assert!(
+        a_b0.b2a
+            .recorder()
+            .flat_linkstates()
+            .into_iter()
+            .any(|ls| ls.psid == 0 && !ls.links.is_empty()),
+        "there exists a self linkstate update sent from b0 to a with a non-empty `links` field"
+    );
+
+    assert!(
+        a_b1.b2a
+            .recorder()
+            .flat_linkstates()
+            .into_iter()
+            .any(|ls| ls.psid == 0 && !ls.links.is_empty()),
+        "there exists a self linkstate update sent from b1 to a with a non-empty `links` field"
+    );
+
+    assert!(
+        a_b0.b2a
+            .recorder()
+            .flat_linkstates()
+            .into_iter()
+            .filter(|ls| ls.psid != 0)
+            .all(|ls| ls.links.is_empty()),
+        "all linkstate updates propagated by b0 to a should have an empty `links` field"
+    );
+
+    assert!(
+        a_b1.b2a
+            .recorder()
+            .flat_linkstates()
+            .into_iter()
+            .filter(|ls| ls.psid != 0)
+            .all(|ls| ls.links.is_empty()),
+        "all linkstate updates propagated by b1 to a should have an empty `links` field"
+    );
+
+    assert!(
+        b0_b1
+            .a2b
+            .recorder()
+            .flat_linkstates()
+            .into_iter()
+            .filter(|ls| ls.psid != 0)
+            .all(|ls| ls.links.is_empty()),
+        "all linkstate updates propagated by b0 to b1 should have an empty `links` field"
+    );
+
+    assert!(
+        b0_b1
+            .b2a
+            .recorder()
+            .flat_linkstates()
+            .into_iter()
+            .filter(|ls| ls.psid != 0)
+            .all(|ls| ls.links.is_empty()),
+        "all linkstate updates propagated by b1 to b0 should have an empty `links` field"
+    );
+}


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->

This was a typo introduced in #2096 leading to a regression where gateways would use the "full" linkstate protocol (i.e not the gossip protocol) with south-bound peers, incurring high overhead. This was functionally sound and thus uncovered by any existing e2e/intergration test. This patch adds a new `oam` module dedicated to testing linkstate behavior of which the first test is regression test `test_peer_singlehop_gossip_linkstate_propagation`.
