### PR TITLE
ci: add note about pull_request_target usage

### DIFF
--- a/.github/workflows/pr-label-checklists-generate.yml
+++ b/.github/workflows/pr-label-checklists-generate.yml
@@ -1,5 +1,7 @@
-name: PR Label Checklists
+name: PR Label Checklists Generate
 
+# This workflow runs in the context of the base repository, so be mindful of the permissions granted here and the actions used in the workflow:
+# For more information see https://docs.github.com/en/enterprise-cloud@latest/actions/reference/security/secure-use#mitigating-the-risks-of-untrusted-code-checkout
 on:
   pull_request_target:
     types: [opened, reopened, labeled, unlabeled, synchronize]

--- a/.github/workflows/pr-label-checklists-verify.yml
+++ b/.github/workflows/pr-label-checklists-verify.yml
@@ -1,5 +1,7 @@
-name: PR Label Checklists
+name: PR Label Checklists Verify
 
+# This workflow runs in the context of the base repository, so be mindful of the permissions granted here and the actions used in the workflow:
+# For more information see https://docs.github.com/en/enterprise-cloud@latest/actions/reference/security/secure-use#mitigating-the-risks-of-untrusted-code-checkout
 on:
   pull_request_target:
     types: [edited]


### PR DESCRIPTION
## Description
pull_request_target may be used as an attack vector to exfiltrate credentials available to the base repository. Also fixes the name of the workflows so they are properly displayed in the github web ui

### What does this PR do?
Add a note to the pr-label-checklists-*.yml workflows since they use `pull_request_target` to avoid including third-party actions or an untrusted checkout.

### Why is this change needed?
Clear documentation about the risk of pull_request_target

