### PR TITLE
Source info doc

### DIFF
--- a/zenoh-ext/src/advanced_publisher.rs
+++ b/zenoh-ext/src/advanced_publisher.rs
@@ -25,9 +25,7 @@ use zenoh::{
     internal::{
         bail,
         runtime::ZRuntime,
-        traits::{
-            EncodingBuilderTrait, QoSBuilderTrait, TimestampBuilderTrait,
-        },
+        traits::{EncodingBuilderTrait, QoSBuilderTrait, TimestampBuilderTrait},
         TerminatableTask,
     },
     key_expr::{keyexpr, KeyExpr},

--- a/zenoh-ext/src/advanced_publisher.rs
+++ b/zenoh-ext/src/advanced_publisher.rs
@@ -26,7 +26,7 @@ use zenoh::{
         bail,
         runtime::ZRuntime,
         traits::{
-            EncodingBuilderTrait, QoSBuilderTrait, SampleBuilderTrait, TimestampBuilderTrait,
+            EncodingBuilderTrait, QoSBuilderTrait, TimestampBuilderTrait,
         },
         TerminatableTask,
     },
@@ -697,23 +697,13 @@ impl EncodingBuilderTrait for AdvancedPublicationBuilder<'_, PublicationBuilderP
     }
 }
 
-#[zenoh_macros::internal_trait]
 #[zenoh_macros::unstable]
-impl<P> SampleBuilderTrait for AdvancedPublicationBuilder<'_, P> {
-    #[zenoh_macros::unstable]
-    /// Sets an optional [`SourceInfo`](zenoh::sample::SourceInfo) to be sent along with the publication.
-    fn source_info<TS: Into<Option<SourceInfo>>>(self, source_info: TS) -> Self {
-        Self {
-            builder: self.builder.source_info(source_info),
-            ..self
-        }
-    }
-    #[zenoh_macros::unstable]
+impl<P> AdvancedPublicationBuilder<'_, P> {
     /// Sets an optional attachment to be sent along with the publication.
     ///
     /// The argument is converted via [`OptionZBytes`], which supports both `T: Into<ZBytes>`
     /// and `Option<T>` where `T: Into<ZBytes>`.
-    fn attachment<TA: Into<OptionZBytes>>(self, attachment: TA) -> Self {
+    pub fn attachment<TA: Into<OptionZBytes>>(self, attachment: TA) -> Self {
         let attachment: OptionZBytes = attachment.into();
         Self {
             builder: self.builder.attachment(attachment),

--- a/zenoh/src/api/queryable.rs
+++ b/zenoh/src/api/queryable.rs
@@ -337,7 +337,7 @@ impl Query {
         self.attachment.as_mut()
     }
 
-    /// Gets info on the source of this Query.
+    /// Gets info on the source of this Query as an optional [`SourceInfo`].
     #[zenoh_macros::unstable]
     #[inline]
     pub fn source_info(&self) -> Option<&SourceInfo> {

--- a/zenoh/src/api/sample.rs
+++ b/zenoh/src/api/sample.rs
@@ -75,17 +75,17 @@ impl From<Locality> for PublisherLocalityConf {
 }
 
 /// Information on the source of a zenoh [`Sample`].
-/// 
+///
 /// [`SourceInfo`] is metadata attached to a [`Sample`] or [`Query`]. It contains
 /// the unique identifier of the zenoh entity that published the sample or issued the query,
 /// and a sequence number for the sample or query itself.
-/// 
+///
 /// It is the sender's responsibility to include [`SourceInfo`] when desired and to
 /// assign the entity identifier and sequence number. The entity
 /// identifier [`EntityGlobalId`] can be obtained by the `id()` method of
 /// each entity (e.g., [`Session::id()`](crate::session::Session::id()),
 /// [`Publisher::id()`](crate::pubsub::Publisher::id()), etc.).
-/// 
+///
 /// The base zenoh primitives only transmit [`SourceInfo`] without
 /// any additional processing or validation.
 /// The [`Advanced pub/sub`](https://docs.rs/zenoh-ext/latest/zenoh_ext/#advanced-pubsub)

--- a/zenoh/src/api/sample.rs
+++ b/zenoh/src/api/sample.rs
@@ -76,20 +76,20 @@ impl From<Locality> for PublisherLocalityConf {
 
 /// Information on the source of a zenoh [`Sample`].
 /// 
-/// The [`SourceInfo`] is the metadata attached to a [`Sample`] or [`Query`]. It contains
-/// the unique identifier of the zenoh entity that published the sample or issued the query, 
-/// and a sequence number of the sample or query itself.
+/// [`SourceInfo`] is metadata attached to a [`Sample`] or [`Query`]. It contains
+/// the unique identifier of the zenoh entity that published the sample or issued the query,
+/// and a sequence number for the sample or query itself.
 /// 
-/// It's a sender responsibility to set or not the [`SourceInfo`] and to
-/// assign the entity identifier and sequence number to it. The entity
+/// It is the sender's responsibility to include [`SourceInfo`] when desired and to
+/// assign the entity identifier and sequence number. The entity
 /// identifier [`EntityGlobalId`] can be obtained by the `id()` method of
-/// each entity (e.g., [`Session::id()`](crate::session::Session::id()), 
+/// each entity (e.g., [`Session::id()`](crate::session::Session::id()),
 /// [`Publisher::id()`](crate::pubsub::Publisher::id()), etc.).
 /// 
-/// The base zenoh primitives only transmits the [`SourceInfo`] without
-/// any additional processing or validation. 
+/// The base zenoh primitives only transmit [`SourceInfo`] without
+/// any additional processing or validation.
 /// The [`Advanced pub/sub`](https://docs.rs/zenoh-ext/latest/zenoh_ext/#advanced-pubsub)
-/// uses it for missing sample detection, reordering and duplicate detection.
+/// uses it for missing sample detection, reordering, and duplicate detection.
 #[zenoh_macros::unstable]
 #[derive(Debug, Clone)]
 pub struct SourceInfo {

--- a/zenoh/src/api/sample.rs
+++ b/zenoh/src/api/sample.rs
@@ -310,7 +310,7 @@ impl Sample {
         self.qos.express()
     }
 
-    /// Gets info on the source of this Sample.
+    /// Gets info on the source of this Sample as an optional [`SourceInfo`].
     #[zenoh_macros::unstable]
     #[inline]
     pub fn source_info(&self) -> Option<&SourceInfo> {

--- a/zenoh/src/api/sample.rs
+++ b/zenoh/src/api/sample.rs
@@ -76,7 +76,7 @@ impl From<Locality> for PublisherLocalityConf {
 
 /// Information on the source of a zenoh [`Sample`].
 ///
-/// [`SourceInfo`] is metadata attached to a [`Sample`] or [`Query`]. It contains
+/// [`SourceInfo`] is metadata attached to a [`Sample`] or [`crate::query::Query`]. It contains
 /// the unique identifier of the zenoh entity that published the sample or issued the query,
 /// and a sequence number for the sample or query itself.
 ///

--- a/zenoh/src/api/sample.rs
+++ b/zenoh/src/api/sample.rs
@@ -75,6 +75,21 @@ impl From<Locality> for PublisherLocalityConf {
 }
 
 /// Information on the source of a zenoh [`Sample`].
+/// 
+/// The [`SourceInfo`] is the metadata attached to a [`Sample`] or [`Query`]. It contains
+/// the unique identifier of the zenoh entity that published the sample or issued the query, 
+/// and a sequence number of the sample or query itself.
+/// 
+/// It's a sender responsibility to set or not the [`SourceInfo`] and to
+/// assign the entity identifier and sequence number to it. The entity
+/// identifier [`EntityGlobalId`] can be obtained by the `id()` method of
+/// each entity (e.g., [`Session::id()`](crate::session::Session::id()), 
+/// [`Publisher::id()`](crate::pubsub::Publisher::id()), etc.).
+/// 
+/// The base zenoh primitives only transmits the [`SourceInfo`] without
+/// any additional processing or validation. 
+/// The [`Advanced pub/sub`](https://docs.rs/zenoh-ext/latest/zenoh_ext/#advanced-pubsub)
+/// uses it for missing sample detection, reordering and duplicate detection.
 #[zenoh_macros::unstable]
 #[derive(Debug, Clone)]
 pub struct SourceInfo {


### PR DESCRIPTION
## Description

- `SourceInfo` documented
- removed setting `SourceInfo` from advanced subscriber

### Why is this change needed?
`SourceInfo` wasn't documented.
`AdvancedSubscriber` allowed to set `SourceInfo` and overrided it immediately because it uses this field for it's own purpose

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `documentation`, `breaking-change`, `api fix`

## 📚 Documentation Update Requirements

Since this PR updates documentation:

- [x] **Accuracy verified** - Technical details are correct
- [x] **Examples tested** - Code examples actually work
- [x] **Links valid** - All links work and point to correct versions
- [x] **Grammar/spelling** - Text is clear and well-written
- [x] **Formatting correct** - Markdown/formatting renders properly
- [x] **Up-to-date** - Reflects current codebase state

**Suggestion:** Have someone unfamiliar with the feature review for clarity.

## 💥 Breaking Change Requirements

Since this PR contains breaking changes:

- [x] **Breaking changes documented** - Clear list of what breaks
- [x] **Migration guide provided** - Step-by-step instructions for users
- [x] **Deprecation considered** - Could this be done with deprecation warnings first?
- [x] **Version bump planned** - Major or minor version bump needed
- [x] **Alternatives explored** - Why is breaking change necessary?
- [x] **Impact assessed** - How many users/use cases affected?

**Note:** Breaking changes should be discussed with maintainers before implementation.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->