### PR TITLE
zenoh-ext: deduplicate FetchingSubscriber liveliness samples on startup

### DIFF
--- a/zenoh-ext/src/querying_subscriber.rs
+++ b/zenoh-ext/src/querying_subscriber.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use std::{
-    collections::{btree_map, BTreeMap, VecDeque},
+    collections::{btree_map, BTreeMap, HashSet, VecDeque},
     convert::TryInto,
     future::{IntoFuture, Ready},
     mem::swap,
@@ -406,6 +406,14 @@ where
 struct MergeQueue {
     untimestamped: VecDeque<Sample>,
     timestamped: BTreeMap<Timestamp, Sample>,
+    // Track (key_expr, SampleKind) pairs already present in `untimestamped`.
+    // When a live-path sample arrives with a synthetic timestamp for the same
+    // (key_expr, kind), it is a duplicate of a fetch-path sample and is dropped.
+    // This prevents FetchingSubscriber from delivering the same logical event
+    // twice when both the fetch query and the live subscription carry it —
+    // which is the common case for liveliness tokens that exist before the
+    // subscriber is created.  See: https://github.com/eclipse-zenoh/zenoh/issues/2523
+    untimestamped_keys: HashSet<(String, u8)>,
 }
 
 impl MergeQueue {
@@ -413,6 +421,7 @@ impl MergeQueue {
         MergeQueue {
             untimestamped: VecDeque::new(),
             timestamped: BTreeMap::new(),
+            untimestamped_keys: HashSet::new(),
         }
     }
 
@@ -422,8 +431,16 @@ impl MergeQueue {
 
     fn push(&mut self, sample: Sample) {
         if let Some(ts) = sample.timestamp() {
+            // Drop this timestamped (live-path) sample if the same (key_expr, kind)
+            // was already received without a timestamp via the fetch path.
+            let merge_key = (sample.key_expr().as_str().to_owned(), sample.kind() as u8);
+            if self.untimestamped_keys.contains(&merge_key) {
+                return;
+            }
             self.timestamped.entry(*ts).or_insert(sample);
         } else {
+            let merge_key = (sample.key_expr().as_str().to_owned(), sample.kind() as u8);
+            self.untimestamped_keys.insert(merge_key);
             self.untimestamped.push_back(sample);
         }
     }
@@ -433,6 +450,7 @@ impl MergeQueue {
         let mut queue = BTreeMap::new();
         swap(&mut self.untimestamped, &mut vec);
         swap(&mut self.timestamped, &mut queue);
+        self.untimestamped_keys.clear();
         MergeQueueValues {
             untimestamped: vec,
             timestamped: queue.into_values(),

--- a/zenoh-ext/tests/liveliness.rs
+++ b/zenoh-ext/tests/liveliness.rs
@@ -397,3 +397,107 @@ async fn test_liveliness_fetching_subscriber_brokered() {
     client2.close().await.unwrap();
     client3.close().await.unwrap();
 }
+
+/// Regression test for https://github.com/eclipse-zenoh/zenoh/issues/2523
+///
+/// A liveliness token that exists *before* a `FetchingSubscriber` is created
+/// must be delivered exactly once.  Prior to the fix, the token arrived via
+/// both the `liveliness().get()` fetch path (no timestamp → `untimestamped`
+/// queue) and the concurrent live subscription (synthetic timestamp →
+/// `timestamped` queue), causing the caller to receive two identical Put
+/// samples with no way to distinguish them.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[allow(deprecated)]
+async fn test_liveliness_fetching_subscriber_no_duplicates() {
+    use std::{collections::HashMap, time::Duration};
+
+    use zenoh::internal::ztimeout;
+    use zenoh_ext::SubscriberBuilderExt;
+
+    const TIMEOUT: Duration = Duration::from_secs(60);
+    const SLEEP: Duration = Duration::from_millis(500);
+    const RECV_TIMEOUT: Duration = Duration::from_millis(500);
+    const PEER1_ENDPOINT: &str = "udp/localhost:47453";
+    const LIVELINESS_KEYEXPR_1: &str = "test/liveliness/dedup/1";
+    const LIVELINESS_KEYEXPR_ALL: &str = "test/liveliness/dedup/**";
+
+    zenoh_util::init_log_from_env_or("error");
+
+    let peer1 = {
+        let mut c = zenoh::Config::default();
+        c.listen
+            .endpoints
+            .set(vec![PEER1_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .unwrap();
+        c.scouting.multicast.set_enabled(Some(false)).unwrap();
+        let _ = c.set_mode(Some(WhatAmI::Peer));
+        let s = ztimeout!(zenoh::open(c)).unwrap();
+        tracing::info!("Peer (1) ZID: {}", s.zid());
+        s
+    };
+
+    let peer2 = {
+        let mut c = zenoh::Config::default();
+        c.connect
+            .endpoints
+            .set(vec![PEER1_ENDPOINT.parse::<EndPoint>().unwrap()])
+            .unwrap();
+        c.scouting.multicast.set_enabled(Some(false)).unwrap();
+        let _ = c.set_mode(Some(WhatAmI::Peer));
+        let s = ztimeout!(zenoh::open(c)).unwrap();
+        tracing::info!("Peer (2) ZID: {}", s.zid());
+        s
+    };
+
+    // Declare a liveliness token BEFORE the FetchingSubscriber is created.
+    // This token will be returned by the liveliness().get() fetch AND delivered
+    // again by the live subscription, which is the race that causes duplicates.
+    let _token = ztimeout!(peer2
+        .liveliness()
+        .declare_token(LIVELINESS_KEYEXPR_1))
+    .unwrap();
+    tokio::time::sleep(SLEEP).await;
+
+    // Create a FetchingSubscriber: issues a liveliness().get() for historical
+    // tokens and subscribes to future liveliness events simultaneously.
+    let sub = ztimeout!(peer1
+        .liveliness()
+        .declare_subscriber(LIVELINESS_KEYEXPR_ALL)
+        .fetching(|cb| {
+            peer1
+                .liveliness()
+                .get(LIVELINESS_KEYEXPR_ALL)
+                .callback(cb)
+                .wait()
+        }))
+    .unwrap();
+
+    // Wait for the fetch + merge window to flush.
+    tokio::time::sleep(SLEEP).await;
+
+    // Collect all samples received within a short timeout window.
+    let mut counts: HashMap<(String, SampleKind), usize> = HashMap::new();
+    loop {
+        match tokio::time::timeout(RECV_TIMEOUT, sub.recv_async()).await {
+            Ok(Ok(sample)) => {
+                *counts
+                    .entry((sample.key_expr().to_string(), sample.kind()))
+                    .or_insert(0) += 1;
+            }
+            _ => break,
+        }
+    }
+
+    // The token must have been delivered exactly once — no duplicates.
+    let key = (LIVELINESS_KEYEXPR_1.to_string(), SampleKind::Put);
+    assert_eq!(
+        counts.get(&key).copied().unwrap_or(0),
+        1,
+        "Expected exactly 1 Put for {LIVELINESS_KEYEXPR_1}, got: {counts:?}",
+    );
+    assert_eq!(counts.len(), 1, "Unexpected extra samples: {counts:?}");
+
+    sub.undeclare().await.unwrap();
+    peer1.close().await.unwrap();
+    peer2.close().await.unwrap();
+}


### PR DESCRIPTION
Fixes #2523.

## Summary

- Add `untimestamped_keys: HashSet<(String, u8)>` to `MergeQueue` in `zenoh-ext/src/querying_subscriber.rs` to track `(key_expr, SampleKind)` pairs buffered via the fetch path.
- When the live subscription delivers the same key+kind with a synthetic timestamp during the fetch window, drop the duplicate before it enters the `timestamped` BTreeMap.
- Add regression test `test_liveliness_fetching_subscriber_no_duplicates` to `zenoh-ext/tests/liveliness.rs`.

## Root Cause (Existing Behavior Audit)

`MergeQueue` uses two internal stores:

| Path | Storage | Dedup |
|------|---------|-------|
| Fetch reply — no timestamp | `untimestamped: VecDeque<Sample>` | **none** |
| Live sub during fetch — synthetic `SystemTime::now()` timestamp | `timestamped: BTreeMap<Timestamp, Sample>` | by exact timestamp |

A liveliness token that exists before the subscriber is created produces a fetch reply with **no timestamp** (→ `untimestamped`). The same token is also delivered by the live subscription with a freshly-minted synthetic timestamp (→ `timestamped`). `drain()` delivers both, so the caller receives two identical `SampleKind::Put` events for the same key expression with no way to distinguish them.

See `sub_callback` in `FetchingSubscriber::new` (lines 852–875): live samples always receive a synthetic timestamp during the fetch window, so they always go to `timestamped`, never to `untimestamped`. The cross-queue duplicate can only arise when a fetch reply has no timestamp.

## Fix

```rust
// MergeQueue::push — before this fix
fn push(&mut self, sample: Sample) {
    if let Some(ts) = sample.timestamp() {
        self.timestamped.entry(*ts).or_insert(sample);  // no cross-queue dedup
    } else {
        self.untimestamped.push_back(sample);            // no dedup at all
    }
}
```

```rust
// MergeQueue::push — after
fn push(&mut self, sample: Sample) {
    if let Some(ts) = sample.timestamp() {
        let merge_key = (sample.key_expr().as_str().to_owned(), sample.kind() as u8);
        if self.untimestamped_keys.contains(&merge_key) {
            return;  // already buffered via fetch path; drop duplicate
        }
        self.timestamped.entry(*ts).or_insert(sample);
    } else {
        let merge_key = (sample.key_expr().as_str().to_owned(), sample.kind() as u8);
        self.untimestamped_keys.insert(merge_key);
        self.untimestamped.push_back(sample);
    }
}
```

`untimestamped_keys` is cleared in `drain()` so re-fetches work correctly and post-fetch live deliveries are unaffected (they go directly to the callback when `pending_fetches == 0`, bypassing `MergeQueue` entirely).

## Scope Classification

**(a) Bug fix** — change is contained to `MergeQueue::{push, drain}` within `zenoh-ext`; no API changes.

## Prior Art

1. **PR #441** — introduced `FetchingSubscriber` + liveliness integration (2023-04-04); the merge path that contains this bug was introduced here without dedup logic.
2. **Issue #1274 / #1438** — liveliness duplication bugs at the router and subscriber layers (closed 2024-09-19); establish the precedent of fixing liveliness duplication at the delivery layer rather than the source.
3. **Issue #1617** — duplicate liveliness tokens with the same key (closed 2024-11-29); confirms `FetchingSubscriber` dedup must be scoped to the merge window only (not indefinitely), which this fix respects via `untimestamped_keys.clear()` on `drain()`.

## Test Evidence (OPS-RULE-011)

`test_liveliness_fetching_subscriber_no_duplicates` in `zenoh-ext/tests/liveliness.rs`:
1. Peer 2 declares a liveliness token before the subscriber is created.
2. Peer 1 creates a `FetchingSubscriber` with `liveliness().get()` as the fetch source.
3. After the fetch window flushes, all received samples are collected with a 500 ms timeout.
4. Asserts the token was delivered **exactly once** (`counts[(key, Put)] == 1`).

Test uses UDP peer mode on `localhost:47453`; no router required.

---

*AI-assisted — authored with Claude, reviewed by Komada.*

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [ ] **Root cause documented** - Explain what caused the bug in the PR description
- [ ] **Reproduction test added** - Test that fails on main branch without the fix
- [ ] **Test passes with fix** - The reproduction test passes with your changes
- [ ] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [ ] **Fix is minimal** - Changes are focused only on fixing the bug
- [ ] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->