### PR TITLE
[Reconnect] Trigger reconnect on all error-paths

### DIFF
--- a/zenoh/src/net/runtime/orchestrator.rs
+++ b/zenoh/src/net/runtime/orchestrator.rs
@@ -795,20 +795,27 @@ impl Runtime {
                     self.get_global_connect_timeout(),
                     self.get_connect_retry_config(&peer)
                 );
-                match self.manager().open_transport_unicast(peer.clone()).await {
-                    Ok(transport) => {
+                let result = self
+                    .manager()
+                    .open_transport_unicast(peer.clone())
+                    .await
+                    .and_then(|transport| -> ZResult<_> {
+                        let zid = transport.get_zid()?;
+                        let cb = transport
+                            .get_callback()?
+                            .ok_or_else(|| zerror!("Transport closed immediately"))?;
+                        let session = cb
+                            .as_any()
+                            .downcast_ref::<super::RuntimeSession>()
+                            .ok_or_else(|| zerror!("Unexpected callback type"))?;
+                        zwrite!(session.endpoints).insert(peer.clone());
+                        Ok(zid)
+                    });
+
+                match result {
+                    Ok(zid) => {
                         tracing::debug!("Successfully connected to configured peer {}", peer);
-                        if let Ok(Some(orch_transport)) = transport.get_callback() {
-                            if let Some(orch_transport) = orch_transport
-                                .as_any()
-                                .downcast_ref::<super::RuntimeSession>()
-                            {
-                                zwrite!(orch_transport.endpoints).insert(peer);
-                            }
-                        }
-                        if let Ok(zid) = transport.get_zid() {
-                            connected_peers.push(zid);
-                        }
+                        connected_peers.push(zid);
                         if stop_after_first_connection {
                             break;
                         }

--- a/zenoh/src/net/runtime/orchestrator.rs
+++ b/zenoh/src/net/runtime/orchestrator.rs
@@ -422,23 +422,26 @@ impl Runtime {
     }
 
     async fn peer_connector(&self, peer: EndPoint) -> ZResult<()> {
-        match self.manager().open_transport_unicast(peer.clone()).await {
-            Ok(transport) => {
-                if let Ok(Some(orch_transport)) = transport.get_callback() {
-                    if let Some(orch_transport) = orch_transport
-                        .as_any()
-                        .downcast_ref::<super::RuntimeSession>()
-                    {
-                        zwrite!(orch_transport.endpoints).insert(peer);
-                    }
-                }
+        let result = self
+            .manager()
+            .open_transport_unicast(peer.clone())
+            .await
+            .and_then(|transport| -> ZResult<_> {
+                let cb = transport
+                    .get_callback()?
+                    .ok_or_else(|| zerror!("Transport closed immediately"))?;
+                let session = cb
+                    .as_any()
+                    .downcast_ref::<super::RuntimeSession>()
+                    .ok_or_else(|| zerror!("Unexpected callback type"))?;
+                zwrite!(session.endpoints).insert(peer.clone());
                 Ok(())
-            }
-            Err(e) => {
-                tracing::warn!("Unable to connect to {}! {}", peer, e);
-                Err(e)
-            }
+            });
+
+        if let Err(e) = &result {
+            tracing::warn!("Unable to connect to {}! {}", peer, e);
         }
+        result
     }
 
     fn get_listen_retry_config(&self, endpoint: &EndPoint) -> zenoh_config::ConnectionRetryConf {


### PR DESCRIPTION
## Description
Trigger a reconnect on all error-paths in the runtime orchestrator. The existing implementation is not handling the case when `if let Ok(Some(orch_transport)) = transport.get_callback()` or `if let Some(orch_transport) = orch_transport` return false, which leads to rare events when nodes do not reconnect. Even if the previous check was successful, by the time these checks are performed the transport could have already been closed.

### What does this PR do?
Fixes an existing bug, see https://github.com/ciprianf/zenoh/pull/1 on how to reproduce the issue on main. Root cause identified by Claude.

### Why is this change needed?
We have a deployment setup where two routers are bridging a WiFi connection. Router A has a connect endpoint to router B (which has no specific connect). The WiFi connection is flaky and sometimes drops & reconnects. We noticed that in some cases after the WiFi reconnects the subscriber nodes do not get data. 

https://github.com/ciprianf/zenoh/pull/2 tests that the fix solves indeed the issue. By re-running the repro steps, the issue no longer surfaces.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [x] **Reproduction test added** - Test that fails on main branch without the fix
- [x] **Test passes with fix** - The reproduction test passes with your changes
- [x] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->