### PR TITLE
feat(enhancement): resolve the problem of udp asymmetric routing

### DIFF
--- a/io/zenoh-links/zenoh-link-udp/src/pktinfo/mod.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/pktinfo/mod.rs
@@ -62,4 +62,73 @@ impl PktInfoUdpSocket {
         }
         Ok((res.0, res.1, src_addr))
     }
+
+    pub(crate) async fn send_to(
+        &self,
+        buffer: &[u8],
+        dst_addr: &SocketAddr,
+        src_addr: &SocketAddr,
+    ) -> io::Result<usize> {
+        #[cfg(target_family = "unix")]
+        {
+            send_with_src(&self.socket, buffer, dst_addr, src_addr).await
+        }
+        #[cfg(not(target_family = "unix"))]
+        {
+            // Fallback for non-unix platforms
+            let _ = src_addr;
+            self.socket.send_to(buffer, dst_addr).await
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        net::{IpAddr, Ipv4Addr, SocketAddr},
+        sync::Arc,
+    };
+
+    use tokio::net::UdpSocket;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_pktinfo_source_ip_consistency() {
+        let server_socket = UdpSocket::bind("0.0.0.0:0").await.unwrap();
+        let server_addr = server_socket.local_addr().unwrap();
+        let server_pktinfo = PktInfoUdpSocket::new(Arc::new(server_socket)).unwrap();
+
+        let client_socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let client_target_addr =
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), server_addr.port());
+
+        // The connect() call makes the OS kernel strict about the source IP of incoming packets.
+        client_socket.connect(client_target_addr).await.unwrap();
+
+        client_socket.send(b"request").await.unwrap();
+
+        let mut buf = [0u8; 1024];
+        let (size, client_addr, captured_local_ip) =
+            server_pktinfo.receive(&mut buf).await.unwrap();
+        assert_eq!(&buf[..size], b"request");
+        assert_eq!(
+            captured_local_ip.ip(),
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))
+        );
+
+        // Server replies using send_to with IP_PKTINFO
+        server_pktinfo
+            .send_to(b"response", &client_addr, &captured_local_ip)
+            .await
+            .unwrap();
+
+        let mut resp_buf = [0u8; 1024];
+        let n = tokio::time::timeout(std::time::Duration::from_secs(1), client_socket.recv(&mut resp_buf))
+            .await
+            .expect("Timeout: Client did not receive the response. This usually means the source IP drifted and the packet was dropped by the OS kernel.")
+            .unwrap();
+
+        assert_eq!(&resp_buf[..n], b"response");
+    }
 }

--- a/io/zenoh-links/zenoh-link-udp/src/pktinfo/pktinfo_unix.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/pktinfo/pktinfo_unix.rs
@@ -13,7 +13,7 @@
 //
 
 /// mostly taken from https://github.com/pixsper/socket-pktinfo/blob/main/src/unix.rs
-use std::io::{Error, IoSliceMut};
+use std::io::{Error, IoSlice, IoSliceMut};
 use std::{
     io, mem,
     mem::MaybeUninit,
@@ -24,6 +24,9 @@ use std::{
 
 use socket2::SockAddr;
 use tokio::{io::Interest, net::UdpSocket};
+
+const CMSG_BUF_SIZE: usize =
+    unsafe { libc::CMSG_SPACE(mem::size_of::<libc::in6_pktinfo>() as libc::c_uint) as usize };
 
 /// # Safety
 /// The caller must ensure that:
@@ -90,12 +93,7 @@ fn recv_with_dst_inner(
 ) -> io::Result<(usize, SocketAddr, Option<SocketAddr>)> {
     let mut addr_src: MaybeUninit<libc::sockaddr_storage> = MaybeUninit::uninit();
     let mut msg_iov = IoSliceMut::new(buf);
-    let mut cmsg = {
-        let space = unsafe {
-            libc::CMSG_SPACE(mem::size_of::<libc::in_pktinfo>() as libc::c_uint) as usize
-        };
-        Vec::<u8>::with_capacity(space)
-    };
+    let mut cmsg = [0u8; CMSG_BUF_SIZE];
 
     let mut mhdr = unsafe {
         let mut mhdr = MaybeUninit::<libc::msghdr>::zeroed();
@@ -105,7 +103,7 @@ fn recv_with_dst_inner(
         (*p).msg_iov = &mut msg_iov as *mut IoSliceMut as *mut libc::iovec;
         (*p).msg_iovlen = 1;
         (*p).msg_control = cmsg.as_mut_ptr() as *mut libc::c_void;
-        (*p).msg_controllen = cmsg.capacity() as _;
+        (*p).msg_controllen = cmsg.len() as _;
         (*p).msg_flags = 0;
         mhdr.assume_init()
     };
@@ -126,7 +124,7 @@ fn recv_with_dst_inner(
 
     let mut header = if mhdr.msg_controllen > 0 {
         debug_assert!(!mhdr.msg_control.is_null());
-        debug_assert!(cmsg.capacity() >= mhdr.msg_controllen as usize);
+        debug_assert!(cmsg.len() >= mhdr.msg_controllen as _);
 
         Some(unsafe {
             libc::CMSG_FIRSTHDR(&mhdr as *const libc::msghdr)
@@ -182,4 +180,116 @@ pub(crate) async fn recv_with_dst(
             recv_with_dst_inner(fd, local_port, buffer)
         })
         .await
+}
+
+pub(crate) async fn send_with_src(
+    socket: &UdpSocket,
+    buffer: &[u8],
+    dst_addr: &SocketAddr,
+    src_addr: &SocketAddr,
+) -> io::Result<usize> {
+    let fd = socket.as_raw_fd();
+    socket
+        .async_io(Interest::WRITABLE, || {
+            send_with_src_inner(fd, buffer, dst_addr, src_addr)
+        })
+        .await
+}
+
+fn send_with_src_inner(
+    fd: RawFd,
+    buffer: &[u8],
+    dst_addr: &SocketAddr,
+    src_addr: &SocketAddr,
+) -> io::Result<usize> {
+    let mut msg_iov = IoSlice::new(buffer);
+
+    let mut addr_dst: MaybeUninit<libc::sockaddr_storage> = MaybeUninit::zeroed();
+    let addr_dst_len = match dst_addr {
+        SocketAddr::V4(a) => {
+            let sockaddr: *mut libc::sockaddr_in = addr_dst.as_mut_ptr() as *mut _;
+            unsafe {
+                (*sockaddr).sin_family = libc::AF_INET as libc::sa_family_t;
+                (*sockaddr).sin_port = a.port().to_be();
+                (*sockaddr).sin_addr.s_addr = u32::from_ne_bytes(a.ip().octets());
+            }
+            mem::size_of::<libc::sockaddr_in>() as libc::socklen_t
+        }
+        SocketAddr::V6(a) => {
+            let sockaddr: *mut libc::sockaddr_in6 = addr_dst.as_mut_ptr() as *mut _;
+            unsafe {
+                (*sockaddr).sin6_family = libc::AF_INET6 as libc::sa_family_t;
+                (*sockaddr).sin6_port = a.port().to_be();
+                (*sockaddr).sin6_addr.s6_addr = a.ip().octets();
+                (*sockaddr).sin6_flowinfo = a.flowinfo();
+                (*sockaddr).sin6_scope_id = a.scope_id();
+            }
+            mem::size_of::<libc::sockaddr_in6>() as libc::socklen_t
+        }
+    };
+
+    let mut cmsg = [0u8; CMSG_BUF_SIZE];
+
+    let mhdr = unsafe {
+        let mut mhdr = MaybeUninit::<libc::msghdr>::zeroed();
+        let p = mhdr.as_mut_ptr();
+        (*p).msg_name = addr_dst.as_mut_ptr() as *mut libc::c_void;
+        (*p).msg_namelen = addr_dst_len;
+        (*p).msg_iov = &mut msg_iov as *mut IoSlice as *mut libc::iovec;
+        (*p).msg_iovlen = 1;
+
+        if src_addr.ip().is_unspecified() {
+            (*p).msg_control = ptr::null_mut();
+            (*p).msg_controllen = 0;
+        } else {
+            (*p).msg_control = cmsg.as_mut_ptr() as *mut libc::c_void;
+            match src_addr {
+                SocketAddr::V4(a) => {
+                    let cmsg_space =
+                        libc::CMSG_SPACE(mem::size_of::<libc::in_pktinfo>() as libc::c_uint)
+                            as usize;
+                    (*p).msg_controllen = cmsg_space as _;
+
+                    let cmsg_hdr = libc::CMSG_FIRSTHDR(p);
+                    (*cmsg_hdr).cmsg_level = libc::IPPROTO_IP;
+                    (*cmsg_hdr).cmsg_type = libc::IP_PKTINFO;
+                    (*cmsg_hdr).cmsg_len =
+                        libc::CMSG_LEN(mem::size_of::<libc::in_pktinfo>() as libc::c_uint) as _;
+
+                    let pktinfo = libc::CMSG_DATA(cmsg_hdr) as *mut libc::in_pktinfo;
+                    ptr::write_bytes(pktinfo, 0, 1);
+                    // set ipi_ifindex to 0 for routing by source address
+                    (*pktinfo).ipi_ifindex = 0;
+                    // ipi_spec_dst is used as the local source address for the routing table lookup and for setting up IP source route options
+                    (*pktinfo).ipi_spec_dst.s_addr = u32::from_ne_bytes(a.ip().octets());
+                }
+                SocketAddr::V6(a) => {
+                    let cmsg_space =
+                        libc::CMSG_SPACE(mem::size_of::<libc::in6_pktinfo>() as libc::c_uint)
+                            as usize;
+                    (*p).msg_controllen = cmsg_space as _;
+
+                    let cmsg_hdr = libc::CMSG_FIRSTHDR(p);
+                    (*cmsg_hdr).cmsg_level = libc::IPPROTO_IPV6;
+                    (*cmsg_hdr).cmsg_type = libc::IPV6_PKTINFO;
+                    (*cmsg_hdr).cmsg_len =
+                        libc::CMSG_LEN(mem::size_of::<libc::in6_pktinfo>() as libc::c_uint) as _;
+
+                    let pktinfo = libc::CMSG_DATA(cmsg_hdr) as *mut libc::in6_pktinfo;
+                    ptr::write_bytes(pktinfo, 0, 1);
+                    (*pktinfo).ipi6_ifindex = 0;
+                    (*pktinfo).ipi6_addr.s6_addr = a.ip().octets();
+                }
+            }
+        }
+        (*p).msg_flags = 0;
+        mhdr.assume_init()
+    };
+
+    let res = unsafe { libc::sendmsg(fd, &mhdr, 0) };
+    if res < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(res as usize)
+    }
 }

--- a/io/zenoh-links/zenoh-link-udp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/unicast.rs
@@ -70,7 +70,7 @@ impl LinkUnicastUdpConnected {
 }
 
 struct LinkUnicastUdpUnconnected {
-    socket: Weak<UdpSocket>,
+    socket: Weak<pktinfo::PktInfoUdpSocket>,
     links: LinkHashMap,
     input: Mvar<LinkInput>,
     leftover: AsyncMutex<Option<LinkLeftOver>>,
@@ -105,10 +105,15 @@ impl LinkUnicastUdpUnconnected {
         Ok(len_min)
     }
 
-    async fn write(&self, buffer: &[u8], dst_addr: SocketAddr) -> ZResult<usize> {
+    async fn write(
+        &self,
+        buffer: &[u8],
+        src_addr: SocketAddr,
+        dst_addr: SocketAddr,
+    ) -> ZResult<usize> {
         match self.socket.upgrade() {
             Some(socket) => socket
-                .send_to(buffer, &dst_addr)
+                .send_to(buffer, &dst_addr, &src_addr)
                 .await
                 .map_err(|e| zerror!(e).into()),
             None => bail!("UDP listener has been dropped"),
@@ -175,7 +180,9 @@ impl LinkUnicastTrait for LinkUnicastUdp {
     async fn write(&self, buffer: &[u8], priority: Option<Priority>) -> ZResult<usize> {
         match &self.variant {
             LinkUnicastUdpVariant::Connected(link) => link.write(buffer).await,
-            LinkUnicastUdpVariant::Unconnected(link) => link.write(buffer, self.dst_addr).await,
+            LinkUnicastUdpVariant::Unconnected(link) => {
+                link.write(buffer, self.src_addr, self.dst_addr).await
+            }
             LinkUnicastUdpVariant::Reliable(link) => link.write(buffer, priority).await,
         }
     }
@@ -645,7 +652,7 @@ async fn accept_read_task(
                                     // A new peers has sent data to this socket
                                     tracing::debug!("Accepted UDP connection on {}: {}", src_addr, dst_addr);
                                     let unconnected = Arc::new(LinkUnicastUdpUnconnected {
-                                        socket: Arc::downgrade(&socket.socket),
+                                        socket: Arc::downgrade(&socket),
                                         links: links.clone(),
                                         input: Mvar::new(),
                                         leftover: AsyncMutex::new(None),


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->
 This PR adds the sender-side support for `IP_PKTINFO` (and `IPV6_PKTINFO`) in the `zenoh-link-udp` module on Unix platforms. 

### What does this PR do?
<!-- Describe the changes and their purpose -->

 1. Adds `send_with_src_inner` to `pktinfo_unix.rs`, utilizing `libc::sendmsg` to inject `IP_PKTINFO` (or `IPV6_PKTINFO`) into the ancillary data (`cmsg`) of outgoing UDP packets.
 2. Ensures the `cmsg` buffer is efficiently stack-allocated using a compile-time computed `CMSG_BUF_SIZE` to avoid heap allocations in the hot path.
 3. Exposes a new `send_to(buffer, dst_addr, src_addr)` API in `PktInfoUdpSocket` and gracefully falls back to the standard `send_to` on non-Unix platforms.
 4. Updates `LinkUnicastUdpUnconnected` in `unicast.rs` to leverage this new API, ensuring that unconnected UDP sockets (e.g., those listening on `0.0.0.0` or `[::]`) reply using the exact local IP address on which the incoming packet was received.

### Why is this change needed?
<!-- Explain the motivation or problem being solved -->
Prior to this PR, Zenoh's UDP link successfully utilized `IP_PKTINFO` via `recvmsg` to determine the specific local IP address a packet arrived on. However, when replying, Zenoh fell back to the standard `UdpSocket::send_to()`, ignoring the captured local IP. 

This created a severe issue known as **udp asymmetric routing** in multi-homed environments (e.g., a node with both `eth0` and `wlan0` listening on `0.0.0.0`). 
 When a client connected to the server's `wlan0` IP, the server would often reply via `eth0` due to OS routing table defaults, causing the reply packet to bear the `eth0` source IP. Because the client's socket was `connect()`ed to the `wlan0` IP, the client's OS kernel would strictly drop the mismatching reply packet.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [ ] **Reproduction test added** - Test that fails on main branch without the fix
- [ ] **Test passes with fix** - The reproduction test passes with your changes
- [ ] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->