### PR TITLE
Rename `ext_south` to `ext_remote_bound` for consistency

### DIFF
--- a/commons/zenoh-codec/src/transport/open.rs
+++ b/commons/zenoh-codec/src/transport/open.rs
@@ -48,7 +48,7 @@ where
             ext_mlink,
             ext_lowlatency,
             ext_compression,
-            ext_south,
+            ext_remote_bound,
         } = x;
 
         // Header
@@ -61,7 +61,7 @@ where
             + (ext_mlink.is_some() as u8)
             + (ext_lowlatency.is_some() as u8)
             + (ext_compression.is_some() as u8)
-            + (ext_south.is_some() as u8);
+            + (ext_remote_bound.is_some() as u8);
 
         #[cfg(feature = "shared-memory")]
         {
@@ -108,7 +108,7 @@ where
             n_exts -= 1;
             self.write(&mut *writer, (compression, n_exts != 0))?;
         }
-        if let Some(south) = ext_south.as_ref() {
+        if let Some(south) = ext_remote_bound.as_ref() {
             n_exts -= 1;
             self.write(&mut *writer, (south, n_exts != 0))?;
         }
@@ -159,7 +159,7 @@ where
         let mut ext_mlink = None;
         let mut ext_lowlatency = None;
         let mut ext_compression = None;
-        let mut ext_south = None;
+        let mut ext_remote_bound = None;
 
         let mut has_ext = imsg::has_flag(self.header, flag::Z);
         while has_ext {
@@ -199,7 +199,7 @@ where
                 }
                 ext::RemoteBound::ID => {
                     let (q, ext): (ext::RemoteBound, bool) = eodec.read(&mut *reader)?;
-                    ext_south = Some(q);
+                    ext_remote_bound = Some(q);
                     has_ext = ext;
                 }
                 _ => {
@@ -219,7 +219,7 @@ where
             ext_mlink,
             ext_lowlatency,
             ext_compression,
-            ext_south,
+            ext_remote_bound,
         })
     }
 }
@@ -242,7 +242,7 @@ where
             ext_mlink,
             ext_lowlatency,
             ext_compression,
-            ext_south,
+            ext_remote_bound,
         } = x;
 
         // Header
@@ -257,7 +257,7 @@ where
             + (ext_mlink.is_some() as u8)
             + (ext_lowlatency.is_some() as u8)
             + (ext_compression.is_some() as u8)
-            + (ext_south.is_some() as u8);
+            + (ext_remote_bound.is_some() as u8);
 
         #[cfg(feature = "shared-memory")]
         {
@@ -303,7 +303,7 @@ where
             n_exts -= 1;
             self.write(&mut *writer, (compression, n_exts != 0))?;
         }
-        if let Some(south) = ext_south.as_ref() {
+        if let Some(south) = ext_remote_bound.as_ref() {
             n_exts -= 1;
             self.write(&mut *writer, (south, n_exts != 0))?;
         }
@@ -353,7 +353,7 @@ where
         let mut ext_mlink = None;
         let mut ext_lowlatency = None;
         let mut ext_compression = None;
-        let mut ext_south = None;
+        let mut ext_remote_bound = None;
 
         let mut has_ext = imsg::has_flag(self.header, flag::Z);
         while has_ext {
@@ -393,7 +393,7 @@ where
                 }
                 ext::RemoteBound::ID => {
                     let (q, ext): (ext::RemoteBound, bool) = eodec.read(&mut *reader)?;
-                    ext_south = Some(q);
+                    ext_remote_bound = Some(q);
                     has_ext = ext;
                 }
                 _ => {
@@ -412,7 +412,7 @@ where
             ext_mlink,
             ext_lowlatency,
             ext_compression,
-            ext_south,
+            ext_remote_bound,
         })
     }
 }

--- a/commons/zenoh-protocol/src/transport/open.rs
+++ b/commons/zenoh-protocol/src/transport/open.rs
@@ -94,7 +94,7 @@ pub struct OpenSyn {
     pub ext_mlink: Option<ext::MultiLinkSyn>,
     pub ext_lowlatency: Option<ext::LowLatency>,
     pub ext_compression: Option<ext::Compression>,
-    pub ext_south: Option<ext::RemoteBound>,
+    pub ext_remote_bound: Option<ext::RemoteBound>,
 }
 
 // Extensions
@@ -160,7 +160,7 @@ impl OpenSyn {
         let ext_mlink = rng.gen_bool(0.5).then_some(ZExtZBuf::rand());
         let ext_lowlatency = rng.gen_bool(0.5).then_some(ZExtUnit::rand());
         let ext_compression = rng.gen_bool(0.5).then_some(ZExtUnit::rand());
-        let ext_south = rng.gen_bool(0.5).then_some(ZExtZ64::rand());
+        let ext_remote_bound = rng.gen_bool(0.5).then_some(ZExtZ64::rand());
 
         Self {
             lease,
@@ -173,7 +173,7 @@ impl OpenSyn {
             ext_mlink,
             ext_lowlatency,
             ext_compression,
-            ext_south,
+            ext_remote_bound,
         }
     }
 }
@@ -197,7 +197,7 @@ pub struct OpenAck {
     pub ext_mlink: Option<ext::MultiLinkAck>,
     pub ext_lowlatency: Option<ext::LowLatency>,
     pub ext_compression: Option<ext::Compression>,
-    pub ext_south: Option<ext::RemoteBound>,
+    pub ext_remote_bound: Option<ext::RemoteBound>,
 }
 
 impl OpenAck {
@@ -224,7 +224,7 @@ impl OpenAck {
         let ext_mlink = rng.gen_bool(0.5).then_some(ZExtUnit::rand());
         let ext_lowlatency = rng.gen_bool(0.5).then_some(ZExtUnit::rand());
         let ext_compression = rng.gen_bool(0.5).then_some(ZExtUnit::rand());
-        let ext_south = rng.gen_bool(0.5).then_some(ZExtZ64::rand());
+        let ext_remote_bound = rng.gen_bool(0.5).then_some(ZExtZ64::rand());
 
         Self {
             lease,
@@ -236,7 +236,7 @@ impl OpenAck {
             ext_mlink,
             ext_lowlatency,
             ext_compression,
-            ext_south,
+            ext_remote_bound,
         }
     }
 }

--- a/io/zenoh-transport/src/unicast/establishment/accept.rs
+++ b/io/zenoh-transport/src/unicast/establishment/accept.rs
@@ -149,7 +149,7 @@ struct AcceptLink<'a> {
     #[cfg(feature = "transport_compression")]
     ext_compression: ext::compression::CompressionFsm<'a>,
     ext_patch: ext::patch::PatchFsm<'a>,
-    ext_south: Option<RemoteBoundCallback>,
+    ext_remote_bound: Option<RemoteBoundCallback>,
     ext_region_name: ext::region_name::RegionNameFsm,
 }
 
@@ -596,7 +596,7 @@ impl<'a, 'b: 'a> AcceptFsm for &'a mut AcceptLink<'b> {
         let output = RecvOpenSynOut {
             other_zid: cookie.zid,
             other_whatami: cookie.whatami,
-            other_bound: match open_syn.ext_south {
+            other_bound: match open_syn.ext_remote_bound {
                 Some(ext) => Some(
                     Bound::try_from(ext.value as u8)
                         .map_err(|e| (e.into(), Some(close::reason::GENERIC)))?,
@@ -681,7 +681,7 @@ impl<'a, 'b: 'a> AcceptFsm for &'a mut AcceptLink<'b> {
             .map_err(|e| (e, Some(close::reason::GENERIC)))?;
 
         // Extension South
-        let ext_south = if let Some(callback) = self.ext_south.as_ref() {
+        let ext_remote_bound = if let Some(callback) = self.ext_remote_bound.as_ref() {
             let p = TransportPeer {
                 zid: input.other_zid,
                 whatami: input.other_whatami,
@@ -716,7 +716,7 @@ impl<'a, 'b: 'a> AcceptFsm for &'a mut AcceptLink<'b> {
             ext_mlink,
             ext_lowlatency,
             ext_compression,
-            ext_south,
+            ext_remote_bound,
         };
 
         // Do not send the OpenAck right now since we might still incur in MAX_LINKS error
@@ -767,7 +767,7 @@ pub(crate) async fn accept_link(link: LinkUnicast, manager: &TransportManager) -
         #[cfg(feature = "transport_compression")]
         ext_compression: ext::compression::CompressionFsm::new(),
         ext_patch: ext::patch::PatchFsm::new(),
-        ext_south: manager.config.bound_callback.clone(),
+        ext_remote_bound: manager.config.bound_callback.clone(),
         ext_region_name: ext::region_name::RegionNameFsm::new(manager.config.region_name.clone()),
     };
 

--- a/io/zenoh-transport/src/unicast/establishment/open.rs
+++ b/io/zenoh-transport/src/unicast/establishment/open.rs
@@ -131,7 +131,7 @@ struct OpenLink<'a> {
     ext_patch: ext::patch::PatchFsm<'a>,
     ext_region_name: ext::region_name::RegionNameFsm,
     // TODO(regions): move this into `ext::region::RegionFsm` (?)
-    ext_south: Option<RemoteBoundCallback>,
+    ext_remote_bound: Option<RemoteBoundCallback>,
 }
 
 #[async_trait]
@@ -466,7 +466,7 @@ impl<'a, 'b: 'a> OpenFsm for &'a mut OpenLink<'b> {
             .map_err(|e| (e, Some(close::reason::GENERIC)))?;
 
         // Extension South
-        let ext_south = if let Some(callback) = self.ext_south.as_ref() {
+        let ext_remote_bound = if let Some(callback) = self.ext_remote_bound.as_ref() {
             let p = TransportPeer {
                 zid: input.other_zid,
                 whatami: input.other_whatami,
@@ -502,7 +502,7 @@ impl<'a, 'b: 'a> OpenFsm for &'a mut OpenLink<'b> {
             ext_mlink,
             ext_lowlatency,
             ext_compression,
-            ext_south,
+            ext_remote_bound,
         }
         .into();
 
@@ -603,7 +603,7 @@ impl<'a, 'b: 'a> OpenFsm for &'a mut OpenLink<'b> {
             .map_err(|e| (e, Some(close::reason::GENERIC)))?;
 
         let output = RecvOpenAckOut {
-            other_bound: match open_ack.ext_south {
+            other_bound: match open_ack.ext_remote_bound {
                 Some(ext) => Some(
                     Bound::try_from(ext.value as u8)
                         .map_err(|e| (e.into(), Some(close::reason::GENERIC)))?,
@@ -652,7 +652,7 @@ pub(crate) async fn open_link(
         #[cfg(feature = "transport_compression")]
         ext_compression: ext::compression::CompressionFsm::new(),
         ext_patch: ext::patch::PatchFsm::new(),
-        ext_south: manager.config.bound_callback.clone(),
+        ext_remote_bound: manager.config.bound_callback.clone(),
         ext_region_name: ext::region_name::RegionNameFsm::new(manager.config.region_name.clone()),
     };
 


### PR DESCRIPTION
## Description

The extension type itself is already named `RemoteBound`. This name is important as it is used in zenoh-dissector.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->