### PR TITLE
Fix duplicate peer usrpwd transport reconciliation

### DIFF
--- a/io/zenoh-transport/src/lib.rs
+++ b/io/zenoh-transport/src/lib.rs
@@ -119,6 +119,7 @@ pub trait TransportPeerEventHandler: Send + Sync {
     fn handle_message(&self, msg: NetworkMessageMut) -> ZResult<()>;
     fn new_link(&self, src: Link);
     fn del_link(&self, link: Link);
+    fn metadata_changed(&self) {}
     fn closed(&self);
     fn as_any(&self) -> &dyn Any;
 }

--- a/io/zenoh-transport/src/unicast/authentication.rs
+++ b/io/zenoh-transport/src/unicast/authentication.rs
@@ -13,9 +13,50 @@
 //
 use zenoh_link::LinkAuthId;
 use zenoh_protocol::core::ZenohIdProto;
+#[cfg(feature = "auth_usrpwd")]
+use zenoh_result::{zerror, ZResult};
 
 #[cfg(feature = "auth_usrpwd")]
 use super::establishment::ext::auth::UsrPwdId;
+
+#[cfg(feature = "auth_usrpwd")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum TransportUsrPwdPrincipal {
+    Unknown,
+    Known(Vec<u8>),
+}
+
+#[cfg(feature = "auth_usrpwd")]
+impl TransportUsrPwdPrincipal {
+    pub(crate) fn from_auth_id(auth_id: UsrPwdId) -> Self {
+        if let Some(username) = auth_id.0 {
+            Self::Known(username)
+        } else {
+            Self::Unknown
+        }
+    }
+}
+
+#[cfg(feature = "auth_usrpwd")]
+pub(crate) fn plan_usrpwd_principal_update(
+    existing: &TransportUsrPwdPrincipal,
+    incoming: &TransportUsrPwdPrincipal,
+) -> ZResult<bool> {
+    match (existing, incoming) {
+        (TransportUsrPwdPrincipal::Unknown, TransportUsrPwdPrincipal::Unknown)
+        | (TransportUsrPwdPrincipal::Known(_), TransportUsrPwdPrincipal::Unknown) => Ok(false),
+        (TransportUsrPwdPrincipal::Unknown, TransportUsrPwdPrincipal::Known(_)) => Ok(true),
+        (TransportUsrPwdPrincipal::Known(a), TransportUsrPwdPrincipal::Known(b)) if a == b => {
+            Ok(false)
+        }
+        _ => Err(zerror!(
+            "Invalid authenticated principal: {:?}. Expected: {:?}.",
+            incoming,
+            existing
+        )
+        .into()),
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TransportAuthId {
@@ -34,8 +75,8 @@ impl TransportAuthId {
     }
 
     #[cfg(feature = "auth_usrpwd")]
-    pub(crate) fn set_username(&mut self, user_pwd_id: &UsrPwdId) {
-        self.username = if let Some(username) = &user_pwd_id.0 {
+    pub(crate) fn set_username(&mut self, principal: &TransportUsrPwdPrincipal) {
+        self.username = if let TransportUsrPwdPrincipal::Known(username) = principal {
             // Convert username from Vec<u8> to String
             match std::str::from_utf8(username) {
                 Ok(name) => Some(name.to_owned()),

--- a/io/zenoh-transport/src/unicast/establishment/accept.rs
+++ b/io/zenoh-transport/src/unicast/establishment/accept.rs
@@ -38,6 +38,8 @@ use super::ext::auth::UsrPwdId;
 use super::ext::shm::AuthSegment;
 #[cfg(feature = "shared-memory")]
 use crate::shm::TransportShmConfig;
+#[cfg(feature = "auth_usrpwd")]
+use crate::unicast::authentication::TransportUsrPwdPrincipal;
 use crate::{
     common::batch::BatchConfig,
     unicast::{
@@ -877,11 +879,12 @@ pub(crate) async fn accept_link(link: LinkUnicast, manager: &TransportManager) -
             false => None,
         },
         is_lowlatency: state.transport.ext_lowlatency.is_lowlatency(),
-        #[cfg(feature = "auth_usrpwd")]
-        auth_id: osyn_out.other_auth_id,
         patch: state.transport.ext_patch.get(),
         region_name: state.transport.ext_region_name.other_region_name(),
     };
+
+    #[cfg(feature = "auth_usrpwd")]
+    let usrpwd_principal = TransportUsrPwdPrincipal::from_auth_id(osyn_out.other_auth_id);
 
     let a_config = TransportLinkUnicastConfig {
         direction,
@@ -929,6 +932,8 @@ pub(crate) async fn accept_link(link: LinkUnicast, manager: &TransportManager) -
     let _transport = manager
         .init_transport_unicast(
             config,
+            #[cfg(feature = "auth_usrpwd")]
+            usrpwd_principal,
             a_link,
             osyn_out.other_initial_sn,
             osyn_out.other_lease,

--- a/io/zenoh-transport/src/unicast/establishment/open.rs
+++ b/io/zenoh-transport/src/unicast/establishment/open.rs
@@ -33,7 +33,7 @@ use super::ext::shm::AuthSegment;
 #[cfg(feature = "shared-memory")]
 use crate::shm::TransportShmConfig;
 #[cfg(feature = "auth_usrpwd")]
-use crate::unicast::establishment::ext::auth::UsrPwdId;
+use crate::unicast::authentication::TransportUsrPwdPrincipal;
 use crate::{
     common::batch::BatchConfig,
     unicast::{
@@ -758,11 +758,12 @@ pub(crate) async fn open_link(
             false => None,
         },
         is_lowlatency: state.transport.ext_lowlatency.is_lowlatency(),
-        #[cfg(feature = "auth_usrpwd")]
-        auth_id: UsrPwdId(None),
         patch: state.transport.ext_patch.get(),
         region_name: state.transport.ext_region_name.other_region_name(),
     };
+
+    #[cfg(feature = "auth_usrpwd")]
+    let usrpwd_principal = TransportUsrPwdPrincipal::from_auth_id(super::ext::auth::UsrPwdId(None));
 
     let o_config = TransportLinkUnicastConfig {
         direction,
@@ -810,6 +811,8 @@ pub(crate) async fn open_link(
     let transport = manager
         .init_transport_unicast(
             config,
+            #[cfg(feature = "auth_usrpwd")]
+            usrpwd_principal,
             o_link,
             oack_out.other_initial_sn,
             oack_out.other_lease,

--- a/io/zenoh-transport/src/unicast/lowlatency/transport.rs
+++ b/io/zenoh-transport/src/unicast/lowlatency/transport.rs
@@ -34,6 +34,8 @@ use zenoh_result::{zerror, ZResult};
 
 #[cfg(feature = "shared-memory")]
 use crate::shm_context::UnicastTransportShmContext;
+#[cfg(feature = "auth_usrpwd")]
+use crate::unicast::authentication::{plan_usrpwd_principal_update, TransportUsrPwdPrincipal};
 use crate::{
     unicast::{
         authentication::TransportAuthId,
@@ -64,6 +66,8 @@ pub(crate) struct TransportUnicastLowlatency {
     pub(super) stats: zenoh_stats::TransportStats,
     #[cfg(feature = "stats")]
     pub(super) link_stats: Arc<OnceLock<zenoh_stats::LinkStats>>,
+    #[cfg(feature = "auth_usrpwd")]
+    pub(super) usrpwd_principal: Arc<SyncRwLock<TransportUsrPwdPrincipal>>,
 
     // The handles for TX/RX tasks
     pub(crate) token: CancellationToken,
@@ -77,6 +81,7 @@ impl TransportUnicastLowlatency {
     pub fn make(
         manager: TransportManager,
         config: TransportConfigUnicast,
+        #[cfg(feature = "auth_usrpwd")] usrpwd_principal: TransportUsrPwdPrincipal,
         #[cfg(feature = "shared-memory")] shm_context: Option<UnicastTransportShmContext>,
         #[cfg(feature = "stats")] stats: zenoh_stats::TransportStats,
     ) -> Arc<dyn TransportUnicastTrait> {
@@ -90,6 +95,8 @@ impl TransportUnicastLowlatency {
             stats,
             #[cfg(feature = "stats")]
             link_stats: Arc::new(OnceLock::new()),
+            #[cfg(feature = "auth_usrpwd")]
+            usrpwd_principal: Arc::new(SyncRwLock::new(usrpwd_principal)),
             token: CancellationToken::new(),
             tracker: TaskTracker::new(),
             #[cfg(feature = "shared-memory")]
@@ -197,6 +204,11 @@ impl TransportUnicastTrait for TransportUnicastLowlatency {
         self.config.zid
     }
 
+    #[cfg(feature = "auth_usrpwd")]
+    fn set_usrpwd_principal(&self, principal: TransportUsrPwdPrincipal) {
+        *zwrite!(self.usrpwd_principal) = principal;
+    }
+
     fn get_auth_ids(&self) -> TransportAuthId {
         // Convert LinkUnicast auth id to AuthId
         let mut transport_auth_id = TransportAuthId::new(self.get_zid());
@@ -208,7 +220,7 @@ impl TransportUnicastTrait for TransportUnicastLowlatency {
         }
         // Convert usrpwd auth id to AuthId
         #[cfg(feature = "auth_usrpwd")]
-        transport_auth_id.set_username(&self.config.auth_id);
+        transport_auth_id.set_username(&zread!(self.usrpwd_principal));
         transport_auth_id
     }
 
@@ -260,6 +272,7 @@ impl TransportUnicastTrait for TransportUnicastLowlatency {
     async fn add_link(
         &self,
         link: LinkUnicastWithOpenAck,
+        #[cfg(feature = "auth_usrpwd")] usrpwd_principal: &TransportUsrPwdPrincipal,
         other_initial_sn: TransportSn,
         other_lease: Duration,
     ) -> AddLinkResult {
@@ -277,6 +290,20 @@ impl TransportUnicastTrait for TransportUnicastLowlatency {
                 return Err((e, l, asl, close::reason::GENERIC));
             }
         };
+
+        #[cfg(feature = "auth_usrpwd")]
+        let principal_update = {
+            let current = zread!(self.usrpwd_principal);
+            match plan_usrpwd_principal_update(&current, usrpwd_principal) {
+                Ok(update) => update,
+                Err(e) => {
+                    let (l, asl) = link.fail();
+                    return Err((e, l, asl, close::reason::INVALID));
+                }
+            }
+        };
+        #[cfg(not(feature = "auth_usrpwd"))]
+        let principal_update = false;
 
         let mut guard = zasyncwrite!(self.link);
         if guard.is_some() {
@@ -321,7 +348,7 @@ impl TransportUnicastTrait for TransportUnicastLowlatency {
             self.internal_start_rx(other_lease);
         });
 
-        Ok((start_tx, start_rx, ack, status_guard))
+        Ok((start_tx, start_rx, ack, status_guard, principal_update))
     }
 
     /*************************************/

--- a/io/zenoh-transport/src/unicast/manager.rs
+++ b/io/zenoh-transport/src/unicast/manager.rs
@@ -34,6 +34,8 @@ use zenoh_protocol::{
 use zenoh_result::{bail, zerror, ZResult};
 
 use super::{link::LinkUnicastWithOpenAck, transport_unicast_inner::InitTransportResult};
+#[cfg(feature = "auth_usrpwd")]
+use crate::unicast::authentication::TransportUsrPwdPrincipal;
 #[cfg(feature = "transport_auth")]
 use crate::unicast::establishment::ext::auth::Auth;
 #[cfg(feature = "transport_multilink")]
@@ -439,6 +441,7 @@ impl TransportManager {
     async fn init_existing_transport_unicast(
         &self,
         config: TransportConfigUnicast,
+        #[cfg(feature = "auth_usrpwd")] usrpwd_principal: TransportUsrPwdPrincipal,
         link: LinkUnicastWithOpenAck,
         other_initial_sn: TransportSn,
         other_lease: Duration,
@@ -447,7 +450,7 @@ impl TransportManager {
         let existing_config = transport.get_config();
         // Verify that fundamental parameters are correct.
         // Ignore the non fundamental parameters like initial SN.
-        if *existing_config != config {
+        if !existing_config.is_compatible_with(&config) {
             let e = zerror!(
                 "Transport with peer {} already exist. Invalid config: {:?}. Expected: {:?}.",
                 config.zid,
@@ -465,8 +468,14 @@ impl TransportManager {
         }
 
         // Add the link to the transport
-        let (start_tx, start_rx, ack, add_link_guard) = transport
-            .add_link(link, other_initial_sn, other_lease)
+        let (start_tx, start_rx, ack, add_link_guard, principal_update) = transport
+            .add_link(
+                link,
+                #[cfg(feature = "auth_usrpwd")]
+                &usrpwd_principal,
+                other_initial_sn,
+                other_lease,
+            )
             .await
             .map_err(InitTransportError::Link)?;
 
@@ -475,6 +484,16 @@ impl TransportManager {
         ack.send_open_ack().await.map_err(|e| {
             InitTransportError::Transport((e, transport.clone(), close::reason::GENERIC))
         })?;
+
+        #[cfg(feature = "auth_usrpwd")]
+        if principal_update {
+            transport.set_usrpwd_principal(usrpwd_principal);
+            Self::notify_metadata_changed_unicast(&transport)
+                .await
+                .map_err(|e| {
+                    InitTransportError::Transport((e, transport.clone(), close::reason::GENERIC))
+                })?;
+        }
 
         start_tx();
 
@@ -499,6 +518,19 @@ impl TransportManager {
         if let Some(callback) = transport.get_callback() {
             tokio::task::spawn_blocking(move || {
                 callback.new_link(link);
+            })
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn notify_metadata_changed_unicast(
+        transport: &Arc<dyn TransportUnicastTrait>,
+    ) -> ZResult<()> {
+        if let Some(callback) = transport.get_callback() {
+            tokio::task::spawn_blocking(move || {
+                callback.metadata_changed();
             })
             .await?;
         }
@@ -538,6 +570,7 @@ impl TransportManager {
     pub(super) async fn init_new_transport_unicast(
         &self,
         config: TransportConfigUnicast,
+        #[cfg(feature = "auth_usrpwd")] usrpwd_principal: TransportUsrPwdPrincipal,
         link: LinkUnicastWithOpenAck,
         other_initial_sn: TransportSn,
         other_lease: Duration,
@@ -627,6 +660,8 @@ impl TransportManager {
             TransportUnicastLowlatency::make(
                 self.clone(),
                 config.clone(),
+                #[cfg(feature = "auth_usrpwd")]
+                usrpwd_principal.clone(),
                 #[cfg(feature = "shared-memory")]
                 shm_context,
                 #[cfg(feature = "stats")]
@@ -638,6 +673,8 @@ impl TransportManager {
                 TransportUnicastUniversal::make(
                     self.clone(),
                     config.clone(),
+                    #[cfg(feature = "auth_usrpwd")]
+                    usrpwd_principal.clone(),
                     #[cfg(feature = "shared-memory")]
                     shm_context,
                     #[cfg(feature = "stats")]
@@ -648,8 +685,16 @@ impl TransportManager {
         };
 
         // Add the link to the transport
-        let (start_tx, start_rx, ack, add_link_guard) =
-            match t.add_link(link, other_initial_sn, other_lease).await {
+        let (start_tx, start_rx, ack, add_link_guard, _) = match t
+            .add_link(
+                link,
+                #[cfg(feature = "auth_usrpwd")]
+                &usrpwd_principal,
+                other_initial_sn,
+                other_lease,
+            )
+            .await
+        {
                 Ok(val) => val,
                 Err(e) => {
                     let _ = t.close(e.3).await;
@@ -731,6 +776,7 @@ impl TransportManager {
     pub(super) async fn init_transport_unicast(
         &self,
         config: TransportConfigUnicast,
+        #[cfg(feature = "auth_usrpwd")] usrpwd_principal: TransportUsrPwdPrincipal,
         link: LinkUnicastWithOpenAck,
         other_initial_sn: TransportSn,
         other_lease: Duration,
@@ -744,6 +790,8 @@ impl TransportManager {
                     drop(guard);
                     self.init_existing_transport_unicast(
                         config,
+                        #[cfg(feature = "auth_usrpwd")]
+                        usrpwd_principal,
                         link,
                         other_initial_sn,
                         other_lease,
@@ -754,6 +802,8 @@ impl TransportManager {
                 None => {
                     self.init_new_transport_unicast(
                         config,
+                        #[cfg(feature = "auth_usrpwd")]
+                        usrpwd_principal,
                         link,
                         other_initial_sn,
                         other_lease,

--- a/io/zenoh-transport/src/unicast/mod.rs
+++ b/io/zenoh-transport/src/unicast/mod.rs
@@ -43,8 +43,6 @@ use super::{TransportPeer, TransportPeerEventHandler};
 #[cfg(feature = "shared-memory")]
 use crate::shm::TransportShmConfig;
 use crate::unicast::authentication::TransportAuthId;
-#[cfg(feature = "auth_usrpwd")]
-use crate::unicast::establishment::ext::auth::UsrPwdId;
 
 /*************************************/
 /*        TRANSPORT UNICAST          */
@@ -63,9 +61,26 @@ pub(crate) struct TransportConfigUnicast {
     #[cfg(feature = "shared-memory")]
     pub(crate) shm: Option<TransportShmConfig>,
     pub(crate) is_lowlatency: bool,
-    #[cfg(feature = "auth_usrpwd")]
-    pub(crate) auth_id: UsrPwdId,
     pub(crate) patch: PatchType,
+}
+
+impl TransportConfigUnicast {
+    pub(crate) fn is_compatible_with(&self, other: &Self) -> bool {
+        self.zid == other.zid
+            && self.whatami == other.whatami
+            && self.region_name == other.region_name
+            && self.bound == other.bound
+            && self.sn_resolution == other.sn_resolution
+            && self.is_qos == other.is_qos
+            && zcondfeat!(
+                "transport_multilink",
+                self.multilink == other.multilink,
+                true
+            )
+            && zcondfeat!("shared-memory", self.shm == other.shm, true)
+            && self.is_lowlatency == other.is_lowlatency
+            && self.patch == other.patch
+    }
 }
 
 /// [`TransportUnicast`] is the transport handler returned

--- a/io/zenoh-transport/src/unicast/test_helpers.rs
+++ b/io/zenoh-transport/src/unicast/test_helpers.rs
@@ -70,6 +70,14 @@ impl TransportUnicastTrait for MockTransportUnicastInner {
         vec![]
     }
 
+    #[cfg(feature = "auth_usrpwd")]
+    fn set_usrpwd_principal(
+        &self,
+        _principal: crate::unicast::authentication::TransportUsrPwdPrincipal,
+    ) {
+        unimplemented!("MockTransportUnicastInner::set_usrpwd_principal")
+    }
+
     fn get_auth_ids(&self) -> TransportAuthId {
         unimplemented!("MockTransportUnicastInner::get_auth_ids")
     }
@@ -103,6 +111,8 @@ impl TransportUnicastTrait for MockTransportUnicastInner {
     async fn add_link(
         &self,
         _link: LinkUnicastWithOpenAck,
+        #[cfg(feature = "auth_usrpwd")]
+        _usrpwd_principal: &crate::unicast::authentication::TransportUsrPwdPrincipal,
         _other_initial_sn: TransportSn,
         _other_lease: Duration,
     ) -> AddLinkResult {

--- a/io/zenoh-transport/src/unicast/transport_unicast_inner.rs
+++ b/io/zenoh-transport/src/unicast/transport_unicast_inner.rs
@@ -48,6 +48,7 @@ pub(crate) type AddLinkResult<'a> = Result<
         Box<dyn FnOnce() + Send + Sync + 'a>,
         MaybeOpenAck,
         AsyncMutexGuard<'a, TransportStatus>,
+        bool,
     ),
     LinkError,
 >;
@@ -74,6 +75,8 @@ pub(crate) trait TransportUnicastTrait: Send + Sync {
     fn get_whatami(&self) -> WhatAmI;
     fn get_callback(&self) -> Option<Arc<dyn TransportPeerEventHandler>>;
     fn get_links(&self) -> Vec<Link>;
+    #[cfg(feature = "auth_usrpwd")]
+    fn set_usrpwd_principal(&self, principal: super::authentication::TransportUsrPwdPrincipal);
     fn get_auth_ids(&self) -> super::authentication::TransportAuthId;
     #[cfg(feature = "shared-memory")]
     fn is_shm(&self) -> bool;
@@ -90,6 +93,8 @@ pub(crate) trait TransportUnicastTrait: Send + Sync {
     async fn add_link(
         &self,
         link: LinkUnicastWithOpenAck,
+        #[cfg(feature = "auth_usrpwd")]
+        usrpwd_principal: &super::authentication::TransportUsrPwdPrincipal,
         other_initial_sn: TransportSn,
         other_lease: Duration,
     ) -> AddLinkResult;

--- a/io/zenoh-transport/src/unicast/universal/transport.rs
+++ b/io/zenoh-transport/src/unicast/universal/transport.rs
@@ -31,6 +31,8 @@ use zenoh_result::{bail, zerror, ZResult};
 
 #[cfg(feature = "shared-memory")]
 use crate::shm_context::UnicastTransportShmContext;
+#[cfg(feature = "auth_usrpwd")]
+use crate::unicast::authentication::{plan_usrpwd_principal_update, TransportUsrPwdPrincipal};
 use crate::{
     common::priority::{TransportPriorityRx, TransportPriorityTx},
     unicast::{
@@ -67,12 +69,15 @@ pub(crate) struct TransportUnicastUniversal {
     // Transport statistics
     #[cfg(feature = "stats")]
     pub(super) stats: zenoh_stats::TransportStats,
+    #[cfg(feature = "auth_usrpwd")]
+    pub(super) usrpwd_principal: Arc<RwLock<TransportUsrPwdPrincipal>>,
 }
 
 impl TransportUnicastUniversal {
     pub fn make(
         manager: TransportManager,
         config: TransportConfigUnicast,
+        #[cfg(feature = "auth_usrpwd")] usrpwd_principal: TransportUsrPwdPrincipal,
         #[cfg(feature = "shared-memory")] shm_context: Option<UnicastTransportShmContext>,
         #[cfg(feature = "stats")] stats: zenoh_stats::TransportStats,
     ) -> ZResult<Arc<dyn TransportUnicastTrait>> {
@@ -109,6 +114,8 @@ impl TransportUnicastUniversal {
             status: Arc::new(AsyncMutex::new(TransportStatus::Uninitialized)),
             #[cfg(feature = "stats")]
             stats,
+            #[cfg(feature = "auth_usrpwd")]
+            usrpwd_principal: Arc::new(RwLock::new(usrpwd_principal)),
             #[cfg(feature = "shared-memory")]
             shm_context,
         });
@@ -230,6 +237,7 @@ impl TransportUnicastTrait for TransportUnicastUniversal {
     async fn add_link(
         &self,
         link: LinkUnicastWithOpenAck,
+        #[cfg(feature = "auth_usrpwd")] usrpwd_principal: &TransportUsrPwdPrincipal,
         other_initial_sn: TransportSn,
         other_lease: Duration,
     ) -> AddLinkResult {
@@ -246,6 +254,20 @@ impl TransportUnicastTrait for TransportUnicastUniversal {
                 return Err((e, l, asl, close::reason::GENERIC));
             }
         };
+
+        #[cfg(feature = "auth_usrpwd")]
+        let principal_update = {
+            let current = zread!(self.usrpwd_principal);
+            match plan_usrpwd_principal_update(&current, usrpwd_principal) {
+                Ok(update) => update,
+                Err(e) => {
+                    let (l, asl) = link.fail();
+                    return Err((e, l, asl, close::reason::INVALID));
+                }
+            }
+        };
+        #[cfg(not(feature = "auth_usrpwd"))]
+        let principal_update = false;
 
         let mut guard = zwrite!(self.links);
 
@@ -312,7 +334,7 @@ impl TransportUnicastTrait for TransportUnicastUniversal {
             }
         });
 
-        Ok((start_tx, start_rx, ack, status_guard))
+        Ok((start_tx, start_rx, ack, status_guard, principal_update))
     }
 
     /*************************************/
@@ -353,6 +375,11 @@ impl TransportUnicastTrait for TransportUnicastUniversal {
 
     fn get_callback(&self) -> Option<Arc<dyn TransportPeerEventHandler>> {
         zread!(self.callback).clone()
+    }
+
+    #[cfg(feature = "auth_usrpwd")]
+    fn set_usrpwd_principal(&self, principal: TransportUsrPwdPrincipal) {
+        *zwrite!(self.usrpwd_principal) = principal;
     }
 
     fn get_config(&self) -> &TransportConfigUnicast {
@@ -410,7 +437,7 @@ impl TransportUnicastTrait for TransportUnicastUniversal {
 
         // Convert usrpwd auth id to AuthId
         #[cfg(feature = "auth_usrpwd")]
-        transport_auth_id.set_username(&self.config.auth_id);
+        transport_auth_id.set_username(&zread!(self.usrpwd_principal));
         transport_auth_id
     }
 

--- a/io/zenoh-transport/tests/unicast_authenticator.rs
+++ b/io/zenoh-transport/tests/unicast_authenticator.rs
@@ -574,6 +574,149 @@ async fn auth_usrpwd(endpoint: &EndPoint, lowlatency_transport: bool) {
     tokio::time::sleep(SLEEP).await;
 }
 
+#[cfg(feature = "auth_usrpwd")]
+async fn auth_usrpwd_peer_duplicate_transport(endpoint01: &EndPoint, endpoint02: &EndPoint) {
+    use zenoh_transport::{
+        unicast::{
+            establishment::ext::auth::AuthUsrPwd,
+            test_helpers::make_basic_transport_manager_builder,
+        },
+        TransportManager,
+    };
+
+    let peer01_id = ZenohIdProto::try_from([11]).unwrap();
+    let peer02_id = ZenohIdProto::try_from([12]).unwrap();
+    let username = "user01".to_string();
+    let password = "password01".to_string();
+
+    let mut usrpwd01 = AuthUsrPwd::new(Some((
+        username.clone().into_bytes(),
+        password.clone().into_bytes(),
+    )));
+    ztimeout!(usrpwd01.add_user(username.clone().into_bytes(), password.clone().into_bytes()))
+        .unwrap();
+    let mut auth01 = Auth::empty();
+    auth01.set_usrpwd(Some(usrpwd01));
+
+    let mut usrpwd02 = AuthUsrPwd::new(Some((
+        username.clone().into_bytes(),
+        password.clone().into_bytes(),
+    )));
+    ztimeout!(usrpwd02.add_user(username.clone().into_bytes(), password.clone().into_bytes()))
+        .unwrap();
+    let mut auth02 = Auth::empty();
+    auth02.set_usrpwd(Some(usrpwd02));
+
+    let peer01_manager = TransportManager::builder()
+        .whatami(WhatAmI::Peer)
+        .zid(peer01_id)
+        .unicast(
+            make_basic_transport_manager_builder(false)
+                .authenticator(auth01)
+                .max_links(1),
+        )
+        .build_test(Arc::new(SHClientAuthenticator))
+        .unwrap();
+
+    let peer02_manager = TransportManager::builder()
+        .whatami(WhatAmI::Peer)
+        .zid(peer02_id)
+        .unicast(
+            make_basic_transport_manager_builder(false)
+                .authenticator(auth02)
+                .max_links(1),
+        )
+        .build_test(Arc::new(SHClientAuthenticator))
+        .unwrap();
+
+    let res = ztimeout!(peer01_manager.add_listener(endpoint01.clone()));
+    println!("Transport Authenticator UserPassword Peer Duplicate [1a]: {res:?}");
+    assert!(res.is_ok());
+    let res = ztimeout!(peer02_manager.add_listener(endpoint02.clone()));
+    println!("Transport Authenticator UserPassword Peer Duplicate [1b]: {res:?}");
+    assert!(res.is_ok());
+
+    let res = ztimeout!(peer01_manager.open_transport_unicast(endpoint02.clone()));
+    println!("Transport Authenticator UserPassword Peer Duplicate [2a]: {res:?}");
+    assert!(res.is_ok());
+
+    let peer01_transport = ztimeout!(async {
+        loop {
+            if let Some(transport) = peer01_manager.get_transport_unicast(&peer02_id).await {
+                break transport;
+            }
+            tokio::time::sleep(SLEEP).await;
+        }
+    });
+    let peer02_transport = ztimeout!(async {
+        loop {
+            if let Some(transport) = peer02_manager.get_transport_unicast(&peer01_id).await {
+                break transport;
+            }
+            tokio::time::sleep(SLEEP).await;
+        }
+    });
+
+    assert_eq!(peer01_transport.get_auth_ids().unwrap().username(), None);
+    assert_eq!(
+        peer02_transport
+            .get_auth_ids()
+            .unwrap()
+            .username()
+            .map(String::as_str),
+        Some(username.as_str())
+    );
+
+    let res = ztimeout!(peer02_manager.open_transport_unicast(endpoint01.clone()));
+    println!("Transport Authenticator UserPassword Peer Duplicate [2b]: {res:?}");
+    assert!(res.is_ok());
+
+    ztimeout!(async {
+        loop {
+            let current_username = peer01_manager
+                .get_transport_unicast(&peer02_id)
+                .await
+                .unwrap()
+                .get_auth_ids()
+                .unwrap()
+                .username()
+                .cloned();
+            if current_username.as_deref() == Some(username.as_str()) {
+                break;
+            }
+            tokio::time::sleep(SLEEP).await;
+        }
+    });
+
+    assert_eq!(
+        peer01_manager
+            .get_transport_unicast(&peer02_id)
+            .await
+            .unwrap()
+            .get_auth_ids()
+            .unwrap()
+            .username()
+            .map(String::as_str),
+        Some(username.as_str())
+    );
+    assert_eq!(
+        peer02_manager
+            .get_transport_unicast(&peer01_id)
+            .await
+            .unwrap()
+            .get_auth_ids()
+            .unwrap()
+            .username()
+            .map(String::as_str),
+        Some(username.as_str())
+    );
+
+    ztimeout!(peer01_manager.close());
+    ztimeout!(peer02_manager.close());
+
+    tokio::time::sleep(SLEEP).await;
+}
+
 async fn run(endpoint: &EndPoint, lowlatency_transport: bool) {
     #[cfg(feature = "auth_pubkey")]
     auth_pubkey(endpoint, lowlatency_transport).await;
@@ -769,6 +912,15 @@ R+IdLiXcyIkg0m9N8I17p0ljCSkbrgGMD3bbePRTfg==
         .unwrap();
 
     run_with_universal_transport(&endpoint).await;
+}
+
+#[cfg(feature = "transport_tcp")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn authenticator_tcp_usrpwd_peer_duplicate_transport() {
+    zenoh_util::init_log_from_env_or("error");
+    let endpoint01: EndPoint = format!("tcp/127.0.0.1:{}", 8040).parse().unwrap();
+    let endpoint02: EndPoint = format!("tcp/127.0.0.1:{}", 8041).parse().unwrap();
+    auth_usrpwd_peer_duplicate_transport(&endpoint01, &endpoint02).await;
 }
 
 #[cfg(feature = "transport_quic")]

--- a/zenoh/src/net/primitives/demux.rs
+++ b/zenoh/src/net/primitives/demux.rs
@@ -11,7 +11,11 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use std::{any::Any, cell::OnceCell, sync::Arc};
+use std::{
+    any::Any,
+    cell::OnceCell,
+    sync::{atomic::Ordering, Arc},
+};
 
 use arc_swap::ArcSwapOption;
 use zenoh_link::Link;
@@ -227,6 +231,18 @@ impl TransportPeerEventHandler for DeMux {
     fn new_link(&self, _link: Link) {}
 
     fn del_link(&self, _link: Link) {}
+
+    fn metadata_changed(&self) {
+        let tables = self.face.tables.tables.read().unwrap();
+        let version = tables
+            .data
+            .next_interceptor_version
+            .fetch_add(1, Ordering::SeqCst)
+            + 1;
+        self.face
+            .state
+            .set_interceptors_from_factories(&tables.data.interceptors, version);
+    }
 
     fn closed(&self) {
         self.face.send_close();

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -1041,6 +1041,14 @@ impl TransportPeerEventHandler for RuntimeSession {
         Runtime::closed_link(self, link.dst.to_endpoint());
     }
 
+    fn metadata_changed(&self) {
+        let _span = self.runtime.state.span.enter();
+        self.main_handler.metadata_changed();
+        for handler in &self.slave_handlers {
+            handler.metadata_changed();
+        }
+    }
+
     fn closed(&self) {
         let _span = self.runtime.state.span.enter();
         self.main_handler.closed();

--- a/zenoh/tests/authentication.rs
+++ b/zenoh/tests/authentication.rs
@@ -33,7 +33,7 @@ mod test {
     use zenoh_config::{Config, EndPoint, ModeDependentValue};
     use zenoh_core::{zlock, ztimeout};
 
-    use crate::common::TestSessions;
+    use crate::common::{get_free_port, TestSessions};
 
     const TIMEOUT: Duration = Duration::from_secs(60);
     const SLEEP: Duration = Duration::from_secs(1);
@@ -52,6 +52,15 @@ mod test {
         test_pub_sub_allow_then_deny_usrpswd().await;
         test_get_qbl_allow_then_deny_usrpswd().await;
         test_get_qbl_deny_then_allow_usrpswd().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_authentication_usrpwd_duplicate_peer_acl_refresh() {
+        zenoh_util::init_log_from_env_or("error");
+        create_new_files(TESTFILES_PATH.to_path_buf())
+            .await
+            .unwrap();
+        test_peer_pub_sub_auth_usrpswd_duplicate_transport_acl_refresh().await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -807,6 +816,150 @@ client2name:client2passwd";
         println!("Closing client sessions");
         ztimeout!(s01.close()).unwrap();
         ztimeout!(s02.close()).unwrap();
+    }
+
+    fn get_peer_config_usrpswd(
+        listen_endpoint: &str,
+        connect_endpoints: &[&str],
+        user: &str,
+        password: &str,
+        zid: &str,
+    ) -> Config {
+        let mut config = zenoh_config::Config::default();
+        config.set_mode(Some(WhatAmI::Peer)).unwrap();
+        config
+            .set_id(Some(ZenohId::from_str(zid).unwrap()))
+            .unwrap();
+        config
+            .listen
+            .endpoints
+            .set(vec![listen_endpoint.parse().unwrap()])
+            .unwrap();
+        if !connect_endpoints.is_empty() {
+            config
+                .connect
+                .set_endpoints(ModeDependentValue::Unique(
+                    connect_endpoints
+                        .iter()
+                        .map(|endpoint| endpoint.parse().unwrap())
+                        .collect(),
+                ))
+                .unwrap();
+        }
+        config.scouting.multicast.set_enabled(Some(false)).unwrap();
+        config.scouting.gossip.set_enabled(Some(false)).unwrap();
+        config.transport.unicast.set_max_links(2).unwrap();
+        config
+            .insert_json5(
+                "transport",
+                &format!(
+                    r#"{{
+                        "auth": {{
+                            "usrpwd": {{
+                                "user": "{user}",
+                                "password": "{password}",
+                            }},
+                        }},
+                    }}"#
+                ),
+            )
+            .unwrap();
+        config
+            .transport
+            .auth
+            .usrpwd
+            .set_dictionary_file(Some(format!(
+                "{}/credentials.txt",
+                TESTFILES_PATH.to_string_lossy()
+            )))
+            .unwrap();
+        config
+    }
+
+    async fn test_peer_pub_sub_auth_usrpswd_duplicate_transport_acl_refresh() {
+        let key_expr_denied = "acl_auth_test/peer/duplicate_refresh/denied";
+        let mut test_context = TestSessions::new();
+
+        let peer01_zid = "abc001";
+        let peer02_zid = "abc002";
+        let peer01_endpoint = format!("tcp/127.0.0.1:{}", get_free_port());
+        let peer02a_endpoint = format!("tcp/127.0.0.1:{}", get_free_port());
+        let peer02b_endpoint = format!("tcp/127.0.0.1:{}", get_free_port());
+
+        let mut config_peer01 = get_peer_config_usrpswd(
+            &peer01_endpoint,
+            &[&peer02a_endpoint],
+            "client1name",
+            "client1passwd",
+            peer01_zid,
+        );
+        config_peer01
+            .insert_json5(
+                "access_control",
+                r#"{
+                    "enabled": true,
+                    "default_permission": "allow",
+                    "rules": [
+                        {
+                            "id": "deny_client2_put",
+                            "permission": "deny",
+                            "flows": ["ingress"],
+                            "messages": ["put"],
+                            "key_exprs": ["acl_auth_test/peer/duplicate_refresh/denied"],
+                        }
+                    ],
+                    "subjects": [
+                        {
+                            "id": "client2_subject",
+                            "usernames": ["client2name"],
+                        }
+                    ],
+                    "policies": [
+                        {
+                            "rules": ["deny_client2_put"],
+                            "subjects": ["client2_subject"],
+                        }
+                    ]
+                }"#,
+            )
+            .unwrap();
+        let config_peer02a = get_peer_config_usrpswd(
+            &peer02a_endpoint,
+            &[],
+            "client2name",
+            "client2passwd",
+            peer02_zid,
+        );
+        let config_peer02b = get_peer_config_usrpswd(
+            &peer02b_endpoint,
+            &[&peer01_endpoint],
+            "client2name",
+            "client2passwd",
+            peer02_zid,
+        );
+
+        let peer02a = test_context.open_listener_with_cfg(config_peer02a).await;
+        let peer01 = test_context.open_listener_with_cfg(config_peer01).await;
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let denied_subscriber = peer01.declare_subscriber(key_expr_denied).await.unwrap();
+        tokio::time::sleep(SLEEP).await;
+
+        peer02a.put(key_expr_denied, "BEFORE").await.unwrap();
+        tokio::time::sleep(SLEEP).await;
+        let sample = denied_subscriber.recv_async().await.unwrap();
+        let payload = sample.payload().try_to_string().unwrap();
+        assert!(payload.eq("BEFORE"));
+
+        let _peer02b = test_context.open_listener_with_cfg(config_peer02b).await;
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        peer02a.put(key_expr_denied, "AFTER").await.unwrap();
+        tokio::time::sleep(SLEEP).await;
+        assert!(denied_subscriber.try_recv().unwrap().is_none());
+
+        denied_subscriber.undeclare().await.unwrap();
+        test_context.close().await;
     }
 
     async fn test_pub_sub_deny_then_allow_tls(lowlatency: bool) {


### PR DESCRIPTION
## Description

### What does this PR do?
This PR fixes duplicate peer transport reconciliation when `transport.auth.usrpwd` is enabled.

The transport layer no longer treats the authenticated principal as part of transport compatibility, and instead stores the usrpwd principal as transport-local metadata. When a duplicate transport is merged, the principal can now be upgraded from `Unknown` to `Known(username)` after a successful `OpenAck`.

The PR also refreshes interceptors after such principal upgrades so that username-based access control sees the updated authenticated principal.

In addition, it adds:
- a transport-level regression test for duplicate peer transport reconciliation with usrpwd
- an integration test covering ACL refresh after a duplicate transport upgrades the principal

### Why is this change needed?
In a peer-to-peer duplicate connect scenario, inbound and outbound paths do not carry symmetric usrpwd identity information:
- the accept path can learn the remote username
- the open path does not know the remote username and starts as unknown

Before this change, that difference leaked into transport compatibility and caused duplicate peer connections to be rejected with repeated `OpenSyn -> Close(INVALID)` errors.

Even if duplicate reconciliation succeeds, the authenticated principal still needs to be propagated to runtime interceptors, otherwise username-based ACL decisions may continue to observe stale metadata.

### Related Issues
- Closes #2577
- Repro branch: https://github.com/BOURBONCASK/zenoh/tree/repro/usrpwd-duplicate-transport

### Validation
- `cargo test -p zenoh-transport --test unicast_authenticator --features transport_tcp,auth_usrpwd authenticator_tcp_usrpwd_peer_duplicate_transport -- --exact --nocapture`
- `cargo test -p zenoh --test authentication --features unstable test::test_authentication_usrpwd_duplicate_peer_acl_refresh -- --exact --nocapture`
- `cargo test -p zenoh --test authentication --features unstable test::test_authentication_usrpwd -- --exact --nocapture`
- `cargo test -p zenoh --test authentication --features unstable test::test_authentication_subject_combinations -- --exact --nocapture`
- `cargo check -p zenoh --features internal`

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

**No specific label requirements detected.**

Current labels: _No labels_

Add one of these labels to this PR to see relevant checklist items: `api-sync`, `breaking-change`, `bug`, `ci`, `dependencies`, `documentation`, `enhancement`, `new feature`, `internal`

*This section updates automatically when labels change.*

<!-- 🏷️ Label-Based Checklist END -->