### PR TITLE
Check for expected ZID when opening scouted links

### DIFF
--- a/io/zenoh-transport/src/unicast/establishment/open.rs
+++ b/io/zenoh-transport/src/unicast/establishment/open.rs
@@ -621,6 +621,7 @@ pub(crate) async fn open_link(
     endpoint: EndPoint,
     link: LinkUnicast,
     manager: &TransportManager,
+    expected_zid: Option<&ZenohIdProto>,
 ) -> ZResult<TransportUnicast> {
     let direction = TransportLinkUnicastDirection::Outbound;
     let is_streamed = link.is_streamed();
@@ -724,6 +725,19 @@ pub(crate) async fn open_link(
     );
 
     let iack_out = step!(fsm.recv_init_ack((&mut link_unicast, &mut state)).await);
+
+    // Check if the expected_zid matches the peer's ZID
+    if let Some(zid) = expected_zid {
+        if &iack_out.other_zid != zid {
+            let _ = link_unicast.close(Some(close::reason::INVALID)).await;
+            return Err(zerror!(
+                "Expected peer ZID {} but received {}",
+                zid,
+                iack_out.other_zid
+            )
+            .into());
+        }
+    }
 
     // Open handshake
     let osyn_in = SendOpenSynIn {

--- a/io/zenoh-transport/src/unicast/manager.rs
+++ b/io/zenoh-transport/src/unicast/manager.rs
@@ -780,9 +780,23 @@ impl TransportManager {
         }
     }
 
-    pub async fn open_transport_unicast(
+    pub async fn open_transport_unicast(&self, endpoint: EndPoint) -> ZResult<TransportUnicast> {
+        self.open_transport_unicast_inner(endpoint, None).await
+    }
+
+    pub async fn open_transport_unicast_with_zid(
+        &self,
+        endpoint: EndPoint,
+        expected_zid: &ZenohIdProto,
+    ) -> ZResult<TransportUnicast> {
+        self.open_transport_unicast_inner(endpoint, Some(expected_zid))
+            .await
+    }
+
+    async fn open_transport_unicast_inner(
         &self,
         mut endpoint: EndPoint,
+        expected_zid: Option<&ZenohIdProto>,
     ) -> ZResult<TransportUnicast> {
         if self
             .locator_inspector
@@ -817,7 +831,9 @@ impl TransportManager {
         // Open the link
         tokio::time::timeout(self.config.unicast.open_timeout, async {
             match manager.new_link(endpoint.clone()).await {
-                Ok(link) => super::establishment::open::open_link(endpoint, link, self).await,
+                Ok(link) => {
+                    super::establishment::open::open_link(endpoint, link, self, expected_zid).await
+                }
                 Err(e) => Err(e),
             }
         })

--- a/io/zenoh-transport/tests/unicast_transport.rs
+++ b/io/zenoh-transport/tests/unicast_transport.rs
@@ -2836,3 +2836,171 @@ async fn test_multilink_max_links(
         .await;
     (router_manager, client_manager, client_transport)
 }
+
+#[cfg(feature = "transport_tcp")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn transport_unicast_with_zid_matching() {
+    zenoh_util::init_log_from_env_or("error");
+
+    let endpoint: EndPoint = format!("tcp/127.0.0.1:{}", 16200).parse().unwrap();
+
+    let client_id = ZenohIdProto::try_from([1]).unwrap();
+    let router_id = ZenohIdProto::try_from([2]).unwrap();
+
+    let router_handler = Arc::new(SHRouter::default());
+    let unicast = make_transport_manager_builder(
+        #[cfg(feature = "transport_multilink")]
+        1,
+        false,
+    );
+    let router_manager = TransportManager::builder()
+        .zid(router_id)
+        .whatami(WhatAmI::Router)
+        .unicast(unicast)
+        .build_test(router_handler.clone())
+        .unwrap();
+
+    let _ = ztimeout!(router_manager.add_listener(endpoint.clone())).unwrap();
+
+    let unicast = make_transport_manager_builder(
+        #[cfg(feature = "transport_multilink")]
+        1,
+        false,
+    );
+    let client_manager = TransportManager::builder()
+        .whatami(WhatAmI::Client)
+        .zid(client_id)
+        .unicast(unicast)
+        .build_test(Arc::new(SHClient))
+        .unwrap();
+
+    // Open transport with expected ZID - should succeed
+    let transport =
+        ztimeout!(client_manager.open_transport_unicast_with_zid(endpoint.clone(), &router_id))
+            .unwrap();
+    assert_eq!(transport.get_zid().unwrap(), router_id);
+
+    ztimeout!(transport.close()).unwrap();
+    ztimeout!(async {
+        while !router_manager.get_transports_unicast().await.is_empty() {
+            tokio::time::sleep(SLEEP).await;
+        }
+    });
+    ztimeout!(router_manager.del_listener(&endpoint)).unwrap();
+    ztimeout!(router_manager.close());
+    ztimeout!(client_manager.close());
+}
+
+// Test that open_transport_unicast_with_zid fails when connecting to a peer with non-matching ZID
+#[cfg(feature = "transport_tcp")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn transport_unicast_with_zid_mismatch() {
+    zenoh_util::init_log_from_env_or("error");
+
+    let endpoint: EndPoint = format!("tcp/127.0.0.1:{}", 16201).parse().unwrap();
+
+    let client_id = ZenohIdProto::try_from([1]).unwrap();
+    let router_id = ZenohIdProto::try_from([2]).unwrap();
+    let wrong_zid = ZenohIdProto::try_from([99]).unwrap();
+
+    let router_handler = Arc::new(SHRouter::default());
+    let unicast = make_transport_manager_builder(
+        #[cfg(feature = "transport_multilink")]
+        1,
+        false,
+    );
+    let router_manager = TransportManager::builder()
+        .zid(router_id)
+        .whatami(WhatAmI::Router)
+        .unicast(unicast)
+        .build_test(router_handler.clone())
+        .unwrap();
+
+    let _ = ztimeout!(router_manager.add_listener(endpoint.clone())).unwrap();
+
+    let unicast = make_transport_manager_builder(
+        #[cfg(feature = "transport_multilink")]
+        1,
+        false,
+    );
+    let client_manager = TransportManager::builder()
+        .whatami(WhatAmI::Client)
+        .zid(client_id)
+        .unicast(unicast)
+        .build_test(Arc::new(SHClient))
+        .unwrap();
+
+    // Open transport with wrong expected ZID - should fail
+    let result =
+        ztimeout!(client_manager.open_transport_unicast_with_zid(endpoint.clone(), &wrong_zid));
+    assert!(
+        result.is_err(),
+        "Expected connection to fail with wrong ZID"
+    );
+
+    // Cleanup
+    ztimeout!(router_manager.del_listener(&endpoint)).unwrap();
+    ztimeout!(router_manager.close());
+    ztimeout!(client_manager.close());
+}
+
+// Test that multilink scenario works with open_transport_unicast_with_zid
+// When connecting to multiple endpoints of the same peer, the same ZID should be enforced
+#[cfg(all(feature = "transport_tcp", feature = "transport_multilink"))]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn transport_unicast_with_zid_multilink() {
+    zenoh_util::init_log_from_env_or("error");
+
+    let endpoints: Vec<EndPoint> = vec![
+        format!("tcp/127.0.0.1:{}", 16202).parse().unwrap(),
+        format!("tcp/127.0.0.1:{}", 16203).parse().unwrap(),
+    ];
+
+    let client_id = ZenohIdProto::try_from([1]).unwrap();
+    let router_id = ZenohIdProto::try_from([2]).unwrap();
+
+    let router_handler = Arc::new(SHRouter::default());
+    let unicast = make_transport_manager_builder(2, false);
+    let router_manager = TransportManager::builder()
+        .zid(router_id)
+        .whatami(WhatAmI::Router)
+        .unicast(unicast)
+        .build_test(router_handler.clone())
+        .unwrap();
+
+    for e in endpoints.iter() {
+        let _ = ztimeout!(router_manager.add_listener(e.clone())).unwrap();
+    }
+
+    let unicast = make_transport_manager_builder(2, false);
+    let client_manager = TransportManager::builder()
+        .whatami(WhatAmI::Client)
+        .zid(client_id)
+        .unicast(unicast)
+        .build_test(Arc::new(SHClient))
+        .unwrap();
+
+    // Open first transport with expected ZID - should succeed
+    let transport1 =
+        ztimeout!(client_manager.open_transport_unicast_with_zid(endpoints[0].clone(), &router_id))
+            .unwrap();
+    assert_eq!(transport1.get_zid().unwrap(), router_id);
+
+    // Open second transport with the same expected ZID - should succeed
+    let transport2 =
+        ztimeout!(client_manager.open_transport_unicast_with_zid(endpoints[1].clone(), &router_id))
+            .unwrap();
+    assert_eq!(transport2.get_zid().unwrap(), router_id);
+
+    ztimeout!(transport1.close()).unwrap();
+    ztimeout!(async {
+        while !router_manager.get_transports_unicast().await.is_empty() {
+            tokio::time::sleep(SLEEP).await;
+        }
+    });
+    for e in endpoints.iter() {
+        ztimeout!(router_manager.del_listener(e)).unwrap();
+    }
+    ztimeout!(router_manager.close());
+    ztimeout!(client_manager.close());
+}

--- a/io/zenoh-transport/tests/unicast_transport.rs
+++ b/io/zenoh-transport/tests/unicast_transport.rs
@@ -2993,8 +2993,6 @@ async fn test_multilink_max_links(
 async fn transport_unicast_with_zid_matching() {
     zenoh_util::init_log_from_env_or("error");
 
-    let endpoint: EndPoint = format!("tcp/127.0.0.1:{}", 16200).parse().unwrap();
-
     let client_id = ZenohIdProto::try_from([1]).unwrap();
     let router_id = ZenohIdProto::try_from([2]).unwrap();
 
@@ -3009,6 +3007,10 @@ async fn transport_unicast_with_zid_matching() {
         .whatami(WhatAmI::Router)
         .unicast(unicast)
         .build_test(router_handler.clone())
+        .unwrap();
+
+    let endpoint: EndPoint = format!("tcp/127.0.0.1:{}", get_free_tcp_port())
+        .parse()
         .unwrap();
 
     let _ = ztimeout!(router_manager.add_listener(endpoint.clone())).unwrap();
@@ -3048,8 +3050,6 @@ async fn transport_unicast_with_zid_matching() {
 async fn transport_unicast_with_zid_mismatch() {
     zenoh_util::init_log_from_env_or("error");
 
-    let endpoint: EndPoint = format!("tcp/127.0.0.1:{}", 16201).parse().unwrap();
-
     let client_id = ZenohIdProto::try_from([1]).unwrap();
     let router_id = ZenohIdProto::try_from([2]).unwrap();
     let wrong_zid = ZenohIdProto::try_from([99]).unwrap();
@@ -3065,6 +3065,10 @@ async fn transport_unicast_with_zid_mismatch() {
         .whatami(WhatAmI::Router)
         .unicast(unicast)
         .build_test(router_handler.clone())
+        .unwrap();
+
+    let endpoint: EndPoint = format!("tcp/127.0.0.1:{}", get_free_tcp_port())
+        .parse()
         .unwrap();
 
     let _ = ztimeout!(router_manager.add_listener(endpoint.clone())).unwrap();
@@ -3102,11 +3106,6 @@ async fn transport_unicast_with_zid_mismatch() {
 async fn transport_unicast_with_zid_multilink() {
     zenoh_util::init_log_from_env_or("error");
 
-    let endpoints: Vec<EndPoint> = vec![
-        format!("tcp/127.0.0.1:{}", 16202).parse().unwrap(),
-        format!("tcp/127.0.0.1:{}", 16203).parse().unwrap(),
-    ];
-
     let client_id = ZenohIdProto::try_from([1]).unwrap();
     let router_id = ZenohIdProto::try_from([2]).unwrap();
 
@@ -3118,6 +3117,15 @@ async fn transport_unicast_with_zid_multilink() {
         .unicast(unicast)
         .build_test(router_handler.clone())
         .unwrap();
+
+    let endpoints: Vec<EndPoint> = vec![
+        format!("tcp/127.0.0.1:{}", get_free_tcp_port())
+            .parse()
+            .unwrap(),
+        format!("tcp/127.0.0.1:{}", get_free_tcp_port())
+            .parse()
+            .unwrap(),
+    ];
 
     for e in endpoints.iter() {
         let _ = ztimeout!(router_manager.add_listener(e.clone())).unwrap();

--- a/zenoh/src/net/runtime/orchestrator.rs
+++ b/zenoh/src/net/runtime/orchestrator.rs
@@ -1016,7 +1016,7 @@ impl Runtime {
                         Err(e) => tracing::trace!("{} {} on {}: {}", ERR, zid, locator, e),
                     }
                 } else {
-                    match manager.open_transport_unicast(endpoint).await {
+                    match manager.open_transport_unicast_with_zid(endpoint, zid).await {
                         Ok(transport) => {
                             tracing::debug!(
                                 "Successfully connected to newly scouted peer: {:?}",


### PR DESCRIPTION
## Description
This PR makes scouted connections validate that the peer ZID matches what was advertised in scouting.
It can also be leveraged to improve multilink for `client` mode by making sure all endpoints belong to the same ZID (to be implemented as part of #2320) 

### Why is this change needed?
It fixes possible attacks described in #2151 

### Related Issues
Fixes #2151

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [x] **Reproduction test added** - Test that fails on main branch without the fix
- [x] **Test passes with fix** - The reproduction test passes with your changes
- [x] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->