### PR TITLE
chore(debug): implement Debug for public types

### DIFF
--- a/commons/zenoh-buffers/src/slice.rs
+++ b/commons/zenoh-buffers/src/slice.rs
@@ -106,6 +106,7 @@ impl Writer for &mut [u8] {
     }
 }
 
+#[derive(Debug)]
 pub struct SliceMark<'s> {
     ptr: *const u8,
     len: usize,

--- a/commons/zenoh-buffers/src/zbuf.rs
+++ b/commons/zenoh-buffers/src/zbuf.rs
@@ -428,6 +428,7 @@ impl io::Seek for ZBufReader<'_> {
 }
 
 // ZSlice iterator
+#[derive(Debug)]
 pub struct ZBufSliceIterator<'a, 'b> {
     reader: &'a mut ZBufReader<'b>,
     remaining: usize,

--- a/commons/zenoh-buffers/src/zslice.rs
+++ b/commons/zenoh-buffers/src/zslice.rs
@@ -81,7 +81,7 @@ impl<const N: usize> ZSliceBuffer for [u8; N] {
 /*               ZSLICE              */
 /*************************************/
 #[cfg(feature = "shared-memory")]
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(u8)]
 pub enum ZSliceKind {
     Raw = 0,

--- a/commons/zenoh-codec/src/lib.rs
+++ b/commons/zenoh-codec/src/lib.rs
@@ -138,7 +138,7 @@ impl<T> Zenoh080Bounded<T> {
 }
 
 #[cfg(feature = "shared-memory")]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Zenoh080Sliced<T> {
     is_sliced: bool,
     codec: Zenoh080Bounded<T>,

--- a/commons/zenoh-codec/src/lib.rs
+++ b/commons/zenoh-codec/src/lib.rs
@@ -45,7 +45,7 @@ pub trait LCodec<Message> {
     fn w_len(self, message: Message) -> usize;
 }
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct Zenoh080;
 
 impl Default for Zenoh080 {
@@ -60,7 +60,7 @@ impl Zenoh080 {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct Zenoh080Header {
     pub header: u8,
     pub codec: Zenoh080,
@@ -75,7 +75,7 @@ impl Zenoh080Header {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct Zenoh080Condition {
     pub condition: bool,
     pub codec: Zenoh080,
@@ -90,7 +90,7 @@ impl Zenoh080Condition {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct Zenoh080Length {
     pub length: usize,
     pub codec: Zenoh080,
@@ -105,7 +105,7 @@ impl Zenoh080Length {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct Zenoh080Reliability {
     pub reliability: Reliability,
     pub codec: Zenoh080,
@@ -120,7 +120,7 @@ impl Zenoh080Reliability {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct Zenoh080Bounded<T> {
     _t: PhantomData<T>,
 }

--- a/commons/zenoh-codec/src/network/mod.rs
+++ b/commons/zenoh-codec/src/network/mod.rs
@@ -140,6 +140,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub struct NetworkMessageIter<R> {
     codec: Zenoh080Reliability,
     reader: R,

--- a/commons/zenoh-collections/src/int_hash_map.rs
+++ b/commons/zenoh-collections/src/int_hash_map.rs
@@ -193,6 +193,7 @@ impl<K, V> Default for IntHashMap<K, V> {
     }
 }
 
+#[derive(Debug)]
 pub enum Entry<'a, K, V> {
     Vec {
         key: K,
@@ -216,6 +217,7 @@ impl<'a, K, V> Entry<'a, K, V> {
     }
 }
 
+#[derive(Debug)]
 pub enum Iter<'a, K, V> {
     Vec(slice::Iter<'a, Option<(K, V)>>),
     Map(hash_map::Iter<'a, K, V>),
@@ -233,6 +235,7 @@ impl<'a, K, V> Iterator for Iter<'a, K, V> {
     }
 }
 
+#[derive(Debug)]
 pub enum IterMut<'a, K, V> {
     Vec(slice::IterMut<'a, Option<(K, V)>>),
     Map(hash_map::IterMut<'a, K, V>),
@@ -250,6 +253,7 @@ impl<'a, K, V> Iterator for IterMut<'a, K, V> {
     }
 }
 
+#[derive(Debug)]
 pub enum Values<'a, K, V> {
     Vec(slice::Iter<'a, Option<(K, V)>>),
     Map(hash_map::Values<'a, K, V>),
@@ -266,6 +270,7 @@ impl<'a, K, V> Iterator for Values<'a, K, V> {
     }
 }
 
+#[derive(Debug)]
 pub enum ValuesMut<'a, K, V> {
     Vec(slice::IterMut<'a, Option<(K, V)>>),
     Map(hash_map::ValuesMut<'a, K, V>),

--- a/commons/zenoh-collections/src/ring_buffer.rs
+++ b/commons/zenoh-collections/src/ring_buffer.rs
@@ -13,6 +13,7 @@
 //
 use std::collections::VecDeque;
 
+#[derive(Debug)]
 pub struct RingBuffer<T> {
     capacity: usize,
     len: usize,

--- a/commons/zenoh-collections/src/single_or_box_hashset.rs
+++ b/commons/zenoh-collections/src/single_or_box_hashset.rs
@@ -259,6 +259,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub enum Iter<'a, T> {
     Empty,
     Single(&'a T),
@@ -316,6 +317,7 @@ impl<T> Drop for Drain<'_, T> {
     }
 }
 
+#[derive(Debug)]
 pub enum IntoIter<T> {
     Empty,
     Single(T),

--- a/commons/zenoh-collections/src/single_or_vec.rs
+++ b/commons/zenoh-collections/src/single_or_vec.rs
@@ -186,12 +186,14 @@ impl<T> SingleOrVec<T> {
     }
 }
 
+#[derive(Debug)]
 enum DrainInner<'a, T> {
     Vec(alloc::vec::Drain<'a, T>),
     Single(&'a mut SingleOrVecInner<T>),
     Done,
 }
 
+#[derive(Debug)]
 pub struct Drain<'a, T> {
     inner: DrainInner<'a, T>,
 }
@@ -278,6 +280,7 @@ impl<T> iter::Extend<T> for SingleOrVec<T> {
     }
 }
 
+#[derive(Debug)]
 pub struct IntoIter<T> {
     pub drain: alloc::vec::IntoIter<T>,
     pub last: Option<T>,

--- a/commons/zenoh-collections/src/stack_buffer.rs
+++ b/commons/zenoh-collections/src/stack_buffer.rs
@@ -13,6 +13,7 @@
 //
 use std::collections::VecDeque;
 
+#[derive(Debug)]
 pub struct StackBuffer<T> {
     buffer: VecDeque<T>,
 }

--- a/commons/zenoh-config/src/connection_retry.rs
+++ b/commons/zenoh-config/src/connection_retry.rs
@@ -69,6 +69,7 @@ impl ConnectionRetryConf {
     }
 }
 
+#[derive(Debug)]
 pub struct ConnectionRetryPeriod {
     conf: ConnectionRetryConf,
     delay: i64,

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -1884,6 +1884,12 @@ pub trait IConfig: Send + Sync {
 
 pub struct GenericConfig(Arc<dyn IConfig>);
 
+impl std::fmt::Debug for GenericConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("GenericConfig").field(&"..").finish()
+    }
+}
+
 impl Deref for GenericConfig {
     type Target = Arc<dyn IConfig>;
 

--- a/commons/zenoh-core/src/lib.rs
+++ b/commons/zenoh-core/src/lib.rs
@@ -85,6 +85,16 @@ where
     To: Sized + Send,
     C: FnOnce() -> To + Send;
 
+impl<C, To> std::fmt::Debug for ResolveClosure<C, To>
+where
+    To: Sized + Send,
+    C: FnOnce() -> To + Send,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("ResolveClosure").field(&"..").finish()
+    }
+}
+
 impl<C, To> ResolveClosure<C, To>
 where
     To: Sized + Send,
@@ -132,6 +142,16 @@ pub struct ResolveFuture<F, To>(F)
 where
     To: Sized + Send,
     F: Future<Output = To> + Send;
+
+impl<F, To> std::fmt::Debug for ResolveFuture<F, To>
+where
+    To: Sized + Send,
+    F: Future<Output = To> + Send,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("ResolveFuture").field(&"..").finish()
+    }
+}
 
 impl<F, To> ResolveFuture<F, To>
 where

--- a/commons/zenoh-crypto/src/cipher.rs
+++ b/commons/zenoh-crypto/src/cipher.rs
@@ -20,6 +20,7 @@ use zenoh_result::{bail, ZResult};
 
 use super::PseudoRng;
 
+#[derive(Debug)]
 pub struct BlockCipher {
     inner: Aes128,
 }

--- a/commons/zenoh-keyexpr/benches/keyexpr_tree.rs
+++ b/commons/zenoh-keyexpr/benches/keyexpr_tree.rs
@@ -149,6 +149,7 @@ fn main() {
     }
 }
 
+#[derive(Debug)]
 pub struct Benchmarker {
     benches: HashMap<String, Bench>,
 }
@@ -170,14 +171,18 @@ impl Benchmarker {
         self.benches.entry(name.into()).or_default().run_once(f);
     }
 }
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct Bench {
     runs: Vec<std::time::Duration>,
 }
+
+#[derive(Debug)]
 pub struct Stats {
     mean: std::time::Duration,
     variance: f64,
 }
+
+#[derive(Debug)]
 pub struct FullStats {
     base: Stats,
     min: f64,

--- a/commons/zenoh-keyexpr/src/key_expr/format/mod.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/format/mod.rs
@@ -133,7 +133,7 @@ pub mod macro_support {
     ///
     /// This is a support structure for [`const_new`], which is only meant to be used through the `zenoh::keformat` macro.
     #[doc(hidden)]
-    #[derive(Clone, Copy)]
+    #[derive(Debug, Clone, Copy)]
     pub struct SegmentBuilder {
         pub segment_start: usize,
         pub prefix_end: usize,
@@ -553,6 +553,7 @@ impl<'s, Storage: IKeFormatStorage<'s>> KeFormatter<'s, Storage> {
 }
 
 /// A [`KeFormat`] that owns its format-string.
+#[derive(Debug)]
 pub struct OwnedKeFormat<Storage: IKeFormatStorage<'static> + 'static = Vec<Segment<'static>>> {
     _owner: Box<str>,
     format: KeFormat<'static, Storage>,

--- a/commons/zenoh-keyexpr/src/key_expr/format/parsing.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/format/parsing.rs
@@ -22,6 +22,15 @@ pub struct Parsed<'s, Storage: IKeFormatStorage<'s>> {
     results: Storage::ValuesStorage<Option<&'s keyexpr>>,
 }
 
+impl<'s, Storage: IKeFormatStorage<'s>> core::fmt::Debug for Parsed<'s, Storage> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Parsed")
+            .field("format", &self.format)
+            .field("results_len", &self.results.as_ref().len())
+            .finish()
+    }
+}
+
 impl<'s, Storage: IKeFormatStorage<'s>> Parsed<'s, Storage> {
     /// Access the `id` element.
     ///
@@ -66,6 +75,16 @@ pub struct Iter<'s, Storage: IKeFormatStorage<'s>> {
     parsed: &'s Parsed<'s, Storage>,
     start: usize,
     end: usize,
+}
+
+impl<'s, Storage: IKeFormatStorage<'s>> core::fmt::Debug for Iter<'s, Storage> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Iter")
+            .field("parsed", &"..")
+            .field("start", &self.start)
+            .field("end", &self.end)
+            .finish()
+    }
 }
 impl<'s, Storage: IKeFormatStorage<'s>> Iterator for Iter<'s, Storage> {
     type Item = (&'s str, Option<&'s keyexpr>);

--- a/commons/zenoh-keyexpr/src/key_expr/format/support.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/format/support.rs
@@ -117,6 +117,7 @@ impl Segment<'_> {
     }
 }
 
+#[derive(Debug)]
 pub enum IterativeConstructor<Complete, Partial, Error> {
     Complete(Complete),
     Partial(Partial),

--- a/commons/zenoh-keyexpr/src/key_expr/fuzzer.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/fuzzer.rs
@@ -49,6 +49,7 @@ fn make(ke: &mut Vec<u8>, rng: &mut impl rand::Rng) {
     }
 }
 
+#[derive(Debug)]
 pub struct KeyExprFuzzer<Rng: rand::Rng>(pub Rng);
 impl<Rng: rand::Rng> Iterator for KeyExprFuzzer<Rng> {
     type Item = OwnedKeyExpr;

--- a/commons/zenoh-keyexpr/src/key_expr/include.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/include.rs
@@ -31,6 +31,7 @@ impl<T: for<'a> Includer<&'a [u8], &'a [u8]>> Includer<&keyexpr, &keyexpr> for T
     }
 }
 
+#[derive(Debug)]
 pub struct LTRIncluder;
 impl Includer<&[u8], &[u8]> for LTRIncluder {
     fn includes(&self, mut left: &[u8], mut right: &[u8]) -> bool {

--- a/commons/zenoh-keyexpr/src/key_expr/intersect/classical.rs
+++ b/commons/zenoh-keyexpr/src/key_expr/intersect/classical.rs
@@ -121,6 +121,7 @@ pub fn intersect<const STAR_DSL: bool>(s1: &[u8], s2: &[u8]) -> bool {
 
 use super::{restriction::NoSubWilds, Intersector, MayHaveVerbatim};
 
+#[derive(Debug)]
 pub struct ClassicIntersector;
 impl Intersector<NoSubWilds<&[u8]>, NoSubWilds<&[u8]>> for ClassicIntersector {
     fn intersect(&self, left: NoSubWilds<&[u8]>, right: NoSubWilds<&[u8]>) -> bool {

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/arc_tree.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/arc_tree.rs
@@ -630,6 +630,7 @@ pub struct KeArcTreeNode<
 impl<Weight, Parent, Wildness, Children, Token> core::fmt::Debug
     for KeArcTreeNode<Weight, Parent, Wildness, Children, Token>
 where
+    Weight: Debug,
     Parent: IArcProvider,
     Wildness: IWildness,
     Children: IChildrenProvider<
@@ -642,7 +643,7 @@ where
             .field("has_parent", &self.parent.is_some())
             .field("chunk", &self.chunk)
             .field("children", &"..")
-            .field("has_weight", &self.weight.is_some())
+            .field("weight", &self.weight)
             .finish()
     }
 }

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/arc_tree.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/arc_tree.rs
@@ -38,6 +38,23 @@ pub struct KeArcTreeInner<
     wildness: Wildness,
 }
 
+impl<Weight, Wildness, Children, Token> core::fmt::Debug
+    for KeArcTreeInner<Weight, Wildness, Children, Token>
+where
+    Wildness: IWildness,
+    Children: IChildrenProvider<
+        Arc<TokenCell<KeArcTreeNode<Weight, Weak<()>, Wildness, Children, Token>, Token>>,
+    >,
+    Token: TokenTrait,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("KeArcTreeInner")
+            .field("children", &"..")
+            .field("is_wild", &self.wildness.get())
+            .finish()
+    }
+}
+
 token_cell::token!(pub DefaultToken);
 fn ketree_borrow<'a, T, Token: TokenTrait>(
     cell: &'a TokenCell<T, Token>,
@@ -69,6 +86,20 @@ pub struct KeArcTree<
     > = DefaultChildrenProvider,
 > {
     inner: TokenCell<KeArcTreeInner<Weight, Wildness, Children, Token>, Token>,
+}
+
+impl<Weight, Token, Wildness, Children> core::fmt::Debug
+    for KeArcTree<Weight, Token, Wildness, Children>
+where
+    Token: TokenTrait,
+    Wildness: IWildness,
+    Children: IChildrenProvider<
+        Arc<TokenCell<KeArcTreeNode<Weight, Weak<()>, Wildness, Children, Token>, Token>>,
+    >,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("KeArcTree").field(&"..").finish()
+    }
 }
 
 impl<
@@ -458,6 +489,11 @@ pub(crate) mod sealed {
     use token_cell::prelude::{TokenCell, TokenTrait};
 
     pub struct Tokenized<A, B>(pub A, pub(crate) B);
+    impl<A, B> core::fmt::Debug for Tokenized<A, B> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            f.debug_tuple("Tokenized").field(&"..").finish()
+        }
+    }
     impl<T, Token: TokenTrait> Deref for Tokenized<&TokenCell<T, Token>, &Token> {
         type Target = T;
         fn deref(&self) -> &Self::Target {
@@ -506,6 +542,12 @@ pub(crate) mod sealed {
     pub struct TokenPacker<I, T> {
         pub(crate) iter: I,
         pub(crate) token: T,
+    }
+
+    impl<I, T> core::fmt::Debug for TokenPacker<I, T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            f.debug_struct("TokenPacker").finish_non_exhaustive()
+        }
     }
 
     impl<'a, I: Iterator, T> Iterator for TokenPacker<I, &'a T> {
@@ -583,6 +625,26 @@ pub struct KeArcTreeNode<
     chunk: OwnedKeyExpr,
     children: Children::Assoc,
     weight: Option<Weight>,
+}
+
+impl<Weight, Parent, Wildness, Children, Token> core::fmt::Debug
+    for KeArcTreeNode<Weight, Parent, Wildness, Children, Token>
+where
+    Parent: IArcProvider,
+    Wildness: IWildness,
+    Children: IChildrenProvider<
+        Arc<TokenCell<KeArcTreeNode<Weight, Weak<()>, Wildness, Children, Token>, Token>>,
+    >,
+    Token: TokenTrait,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("KeArcTreeNode")
+            .field("has_parent", &self.parent.is_some())
+            .field("chunk", &self.chunk)
+            .field("children", &"..")
+            .field("has_weight", &self.weight.is_some())
+            .finish()
+    }
 }
 
 impl<

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/box_tree.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/box_tree.rs
@@ -36,6 +36,19 @@ pub struct KeBoxTree<
     wildness: Wildness,
 }
 
+impl<Weight, Wildness, Children> core::fmt::Debug for KeBoxTree<Weight, Wildness, Children>
+where
+    Wildness: IWildness,
+    Children: IChildrenProvider<Box<KeyExprTreeNode<Weight, Wildness, Children>>>,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("KeBoxTree")
+            .field("children", &"..")
+            .field("is_wild", &self.wildness.get())
+            .finish()
+    }
+}
+
 impl<Weight> KeBoxTree<Weight, bool, DefaultChildrenProvider>
 where
     DefaultChildrenProvider:
@@ -267,6 +280,21 @@ pub struct KeyExprTreeNode<Weight, Wildness: IWildness, Children: IChildrenProvi
     chunk: OwnedKeyExpr,
     children: Children::Assoc,
     weight: Option<Weight>,
+}
+
+impl<Weight, Wildness, Children> core::fmt::Debug for KeyExprTreeNode<Weight, Wildness, Children>
+where
+    Wildness: IWildness,
+    Children: IChildrenProvider<Box<Self>>,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("KeyExprTreeNode")
+            .field("has_parent", &self.parent.is_some())
+            .field("chunk", &self.chunk)
+            .field("children", &"..")
+            .field("has_weight", &self.weight.is_some())
+            .finish()
+    }
 }
 
 unsafe impl<Weight: Send, Wildness: IWildness + Send, Children: IChildrenProvider<Box<Self>> + Send>

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/impls/hashmap_impl.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/impls/hashmap_impl.rs
@@ -32,6 +32,7 @@ use hashbrown::{
 use crate::keyexpr_tree::*;
 
 #[cfg_attr(not(feature = "std"), allow(deprecated))]
+#[derive(Debug)]
 pub struct HashMapProvider<Hash: Hasher + Default + 'static = DefaultHasher>(
     core::marker::PhantomData<Hash>,
 );

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/impls/keyed_set_impl.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/impls/keyed_set_impl.rs
@@ -25,6 +25,7 @@ use keyed_set::{KeyExtractor, KeyedSet};
 use crate::keyexpr_tree::*;
 
 #[cfg_attr(not(feature = "std"), allow(deprecated))]
+#[derive(Debug)]
 pub struct KeyedSetProvider<Hash: Hasher + Default + 'static = DefaultHasher>(
     core::marker::PhantomData<Hash>,
 );

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/impls/mod.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/impls/mod.rs
@@ -23,6 +23,7 @@ mod vec_set_impl;
 
 /// The advised way of storing children in KeTrees, based on benchmarks.
 pub type DefaultChildrenProvider = KeyedSetProvider;
+#[derive(Debug)]
 pub struct FilterMap<I, F> {
     iter: I,
     filter: F,
@@ -49,6 +50,7 @@ impl<I: Iterator, F: IFilter<<I as Iterator>::Item>> Iterator for FilterMap<I, F
         None
     }
 }
+#[derive(Debug)]
 pub struct Intersection<'a>(pub &'a keyexpr);
 impl<K: core::ops::Deref<Target = keyexpr>, V> IFilter<(&K, V)> for Intersection<'_> {
     type O = V;
@@ -71,6 +73,7 @@ impl<'a, T: super::HasChunk> IFilter<&'a mut T> for Intersection<'_> {
     }
 }
 
+#[derive(Debug)]
 pub struct Inclusion<'a>(pub &'a keyexpr);
 impl<K: core::ops::Deref<Target = keyexpr>, V> IFilter<(&K, V)> for Inclusion<'_> {
     type O = V;

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/impls/vec_set_impl.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/impls/vec_set_impl.rs
@@ -18,6 +18,7 @@ use zenoh_result::unlikely;
 
 use crate::keyexpr_tree::*;
 
+#[derive(Debug)]
 pub struct VecSetProvider;
 impl<T: 'static> IChildrenProvider<T> for VecSetProvider {
     type Assoc = Vec<T>;
@@ -35,6 +36,7 @@ impl<'a, 'b, T: HasChunk> IEntry<'a, 'b, T> for Entry<'a, 'b, T> {
     }
 }
 
+#[derive(Debug)]
 pub enum Entry<'a, 'b, T> {
     Vacant(&'a mut Vec<T>, &'b keyexpr),
     Occupied(&'a mut T),

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/iters/includer.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/iters/includer.rs
@@ -36,6 +36,20 @@ where
 }
 
 impl<'a, Children: IChildrenProvider<Node>, Node: UIKeyExprTreeNode<Weight>, Weight>
+    core::fmt::Debug for Includer<'a, Children, Node, Weight>
+where
+    Children::Assoc: IChildren<Node> + 'a,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Includer")
+            .field("key", &self.key)
+            .field("ke_indices_len", &self.ke_indices.len())
+            .field("depth", &self.iterators.len())
+            .finish()
+    }
+}
+
+impl<'a, Children: IChildrenProvider<Node>, Node: UIKeyExprTreeNode<Weight>, Weight>
     Includer<'a, Children, Node, Weight>
 where
     Children::Assoc: IChildren<Node> + 'a,
@@ -200,6 +214,20 @@ pub struct IncluderMut<
     key: &'a keyexpr,
     ke_indices: Vec<usize>,
     iterators: Vec<StackFrameMut<'a, Children, Node, Weight>>,
+}
+
+impl<'a, Children: IChildrenProvider<Node>, Node: UIKeyExprTreeNode<Weight>, Weight>
+    core::fmt::Debug for IncluderMut<'a, Children, Node, Weight>
+where
+    Children::Assoc: IChildren<Node> + 'a,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("IncluderMut")
+            .field("key", &self.key)
+            .field("ke_indices_len", &self.ke_indices.len())
+            .field("depth", &self.iterators.len())
+            .finish()
+    }
 }
 
 impl<'a, Children: IChildrenProvider<Node>, Node: UIKeyExprTreeNode<Weight>, Weight>

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/iters/inclusion.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/iters/inclusion.rs
@@ -38,6 +38,20 @@ where
 }
 
 impl<'a, Children: IChildrenProvider<Node>, Node: UIKeyExprTreeNode<Weight>, Weight>
+    core::fmt::Debug for Inclusion<'a, Children, Node, Weight>
+where
+    Children::Assoc: IChildren<Node> + 'a,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Inclusion")
+            .field("key", &self.key)
+            .field("ke_indices_len", &self.ke_indices.len())
+            .field("depth", &self.iterators.len())
+            .finish()
+    }
+}
+
+impl<'a, Children: IChildrenProvider<Node>, Node: UIKeyExprTreeNode<Weight>, Weight>
     Inclusion<'a, Children, Node, Weight>
 where
     Children::Assoc: IChildren<Node> + 'a,
@@ -203,6 +217,20 @@ pub struct InclusionMut<
     key: &'a keyexpr,
     ke_indices: Vec<usize>,
     iterators: Vec<StackFrameMut<'a, Children, Node, Weight>>,
+}
+
+impl<'a, Children: IChildrenProvider<Node>, Node: UIKeyExprTreeNode<Weight>, Weight>
+    core::fmt::Debug for InclusionMut<'a, Children, Node, Weight>
+where
+    Children::Assoc: IChildren<Node> + 'a,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("InclusionMut")
+            .field("key", &self.key)
+            .field("ke_indices_len", &self.ke_indices.len())
+            .field("depth", &self.iterators.len())
+            .finish()
+    }
 }
 
 impl<'a, Children: IChildrenProvider<Node>, Node: UIKeyExprTreeNode<Weight>, Weight>

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/iters/intersection.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/iters/intersection.rs
@@ -42,6 +42,20 @@ pub struct Intersection<
 }
 
 impl<'a, Children: IChildrenProvider<Node>, Node: UIKeyExprTreeNode<Weight>, Weight>
+    core::fmt::Debug for Intersection<'a, Children, Node, Weight>
+where
+    Children::Assoc: IChildren<Node> + 'a,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Intersection")
+            .field("key", &self.key)
+            .field("ke_indices_len", &self.ke_indices.len())
+            .field("depth", &self.iterators.len())
+            .finish()
+    }
+}
+
+impl<'a, Children: IChildrenProvider<Node>, Node: UIKeyExprTreeNode<Weight>, Weight>
     Intersection<'a, Children, Node, Weight>
 where
     Children::Assoc: IChildren<Node> + 'a,
@@ -244,6 +258,20 @@ pub struct IntersectionMut<
     key: &'a keyexpr,
     ke_indices: Vec<usize>,
     iterators: Vec<StackFrameMut<'a, Children, Node, Weight>>,
+}
+
+impl<'a, Children: IChildrenProvider<Node>, Node: IKeyExprTreeNode<Weight>, Weight> core::fmt::Debug
+    for IntersectionMut<'a, Children, Node, Weight>
+where
+    Children::Assoc: IChildren<Node> + 'a,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("IntersectionMut")
+            .field("key", &self.key)
+            .field("ke_indices_len", &self.ke_indices.len())
+            .field("depth", &self.iterators.len())
+            .finish()
+    }
 }
 
 impl<'a, Children: IChildrenProvider<Node>, Node: IKeyExprTreeNode<Weight>, Weight>

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/iters/tree_iter.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/iters/tree_iter.rs
@@ -26,6 +26,19 @@ where
 }
 
 impl<'a, Children: IChildrenProvider<Node>, Node: UIKeyExprTreeNode<Weight>, Weight>
+    core::fmt::Debug for TreeIter<'a, Children, Node, Weight>
+where
+    Children::Assoc: IChildren<Node> + 'a,
+    <Children::Assoc as IChildren<Node>>::Node: 'a,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("TreeIter")
+            .field("depth", &self.iterators.len())
+            .finish()
+    }
+}
+
+impl<'a, Children: IChildrenProvider<Node>, Node: UIKeyExprTreeNode<Weight>, Weight>
     TreeIter<'a, Children, Node, Weight>
 where
     Children::Assoc: IChildren<Node> + 'a,
@@ -82,6 +95,19 @@ pub struct TreeIterMut<
     _marker: core::marker::PhantomData<Weight>,
 }
 
+impl<'a, Children: IChildrenProvider<Node>, Node: IKeyExprTreeNode<Weight>, Weight> core::fmt::Debug
+    for TreeIterMut<'a, Children, Node, Weight>
+where
+    Children::Assoc: IChildren<Node> + 'a,
+    <Children::Assoc as IChildren<Node>>::Node: 'a,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("TreeIterMut")
+            .field("depth", &self.iterators.len())
+            .finish()
+    }
+}
+
 impl<'a, Children: IChildrenProvider<Node>, Node: IKeyExprTreeNode<Weight>, Weight>
     TreeIterMut<'a, Children, Node, Weight>
 where
@@ -127,6 +153,12 @@ where
 }
 
 pub struct DepthInstrumented<T>(T);
+
+impl<T> core::fmt::Debug for DepthInstrumented<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("DepthInstrumented").field(&"..").finish()
+    }
+}
 impl<
         'a,
         Children: IChildrenProvider<Node>,

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/support.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/support.rs
@@ -73,30 +73,6 @@ where
         }
     }
 }
-pub struct Coerced<Iter: Iterator, Item> {
-    iter: Iter,
-    _item: core::marker::PhantomData<Item>,
-}
-
-impl<Iter: Iterator, Item> Coerced<Iter, Item> {
-    pub fn new(iter: Iter) -> Self {
-        Self {
-            iter,
-            _item: Default::default(),
-        }
-    }
-}
-impl<Iter: Iterator, Item> Iterator for Coerced<Iter, Item>
-where
-    Iter::Item: Coerce<Item>,
-{
-    type Item = Item;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next().map(Coerce::coerce)
-    }
-}
-
 trait Coerce<Into> {
     fn coerce(self) -> Into;
 }

--- a/commons/zenoh-keyexpr/src/keyexpr_tree/support.rs
+++ b/commons/zenoh-keyexpr/src/keyexpr_tree/support.rs
@@ -61,6 +61,15 @@ pub enum IterOrOption<Iter: Iterator, Item> {
     Opt(Option<Item>),
     Iter(Iter),
 }
+
+impl<Iter: Iterator, Item> core::fmt::Debug for IterOrOption<Iter, Item> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Opt(_) => f.debug_tuple("Opt").field(&"..").finish(),
+            Self::Iter(_) => f.debug_tuple("Iter").field(&"..").finish(),
+        }
+    }
+}
 impl<Iter: Iterator, Item> Iterator for IterOrOption<Iter, Item>
 where
     Iter::Item: Coerce<Item>,

--- a/commons/zenoh-protocol/src/common/extension.rs
+++ b/commons/zenoh-protocol/src/common/extension.rs
@@ -105,6 +105,7 @@ pub mod iext {
     }
 }
 
+#[derive(Debug)]
 pub struct DidntConvert;
 
 #[repr(transparent)]

--- a/commons/zenoh-protocol/src/core/resolution.rs
+++ b/commons/zenoh-protocol/src/core/resolution.rs
@@ -174,6 +174,7 @@ impl serde::Serialize for Bits {
     }
 }
 
+#[derive(Debug)]
 pub struct BitsVisitor;
 impl<'de> serde::de::Visitor<'de> for BitsVisitor {
     type Value = Bits;

--- a/commons/zenoh-protocol/src/core/whatami.rs
+++ b/commons/zenoh-protocol/src/core/whatami.rs
@@ -315,6 +315,7 @@ impl serde::Serialize for WhatAmI {
     }
 }
 
+#[derive(Debug)]
 pub struct WhatAmIVisitor;
 
 impl<'de> serde::de::Visitor<'de> for WhatAmIVisitor {
@@ -376,6 +377,7 @@ impl serde::Serialize for WhatAmIMatcher {
     }
 }
 
+#[derive(Debug)]
 pub struct WhatAmIMatcherVisitor;
 impl<'de> serde::de::Visitor<'de> for WhatAmIMatcherVisitor {
     type Value = WhatAmIMatcher;

--- a/commons/zenoh-runtime/src/lib.rs
+++ b/commons/zenoh-runtime/src/lib.rs
@@ -178,6 +178,7 @@ lazy_static! {
 }
 
 // A runtime guard used to explicitly drop the static variables that Rust doesn't drop by default
+#[derive(Debug)]
 pub struct ZRuntimePoolGuard;
 
 impl Drop for ZRuntimePoolGuard {

--- a/commons/zenoh-runtime/src/lib.rs
+++ b/commons/zenoh-runtime/src/lib.rs
@@ -21,7 +21,7 @@ use core::panic;
 use std::{
     borrow::Borrow,
     collections::HashMap,
-    env,
+    env, fmt,
     future::Future,
     ops::Deref,
     sync::{
@@ -193,6 +193,19 @@ impl Drop for ZRuntimePoolGuard {
 }
 
 pub struct ZRuntimePool(HashMap<ZRuntime, OnceLock<Runtime>>);
+
+impl fmt::Debug for ZRuntimePool {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let initialized = self
+            .0
+            .iter()
+            .filter_map(|(runtime, cell)| cell.get().map(|_| runtime))
+            .collect::<Vec<_>>();
+        f.debug_struct("ZRuntimePool")
+            .field("initialized", &initialized)
+            .finish_non_exhaustive()
+    }
+}
 
 impl ZRuntimePool {
     fn new() -> Self {

--- a/commons/zenoh-shm/src/api/buffer/typed.rs
+++ b/commons/zenoh-shm/src/api/buffer/typed.rs
@@ -28,6 +28,7 @@ use crate::api::buffer::{
 };
 
 /// Wrapper for SHM buffer types that is used for safe typed access to SHM data
+#[derive(Debug)]
 pub struct Typed<T, Buf> {
     buf: Buf,
     _phantom: PhantomData<T>,

--- a/commons/zenoh-shm/src/api/client_storage/mod.rs
+++ b/commons/zenoh-shm/src/api/client_storage/mod.rs
@@ -42,6 +42,7 @@ pub static mut GLOBAL_CLIENT_STORAGE: Arc<ShmClientStorage> = Arc::new(
 
 /// Builder to create new client storages
 #[zenoh_macros::unstable_doc]
+#[derive(Debug)]
 pub struct ShmClientSetBuilder;
 
 impl ShmClientSetBuilder {

--- a/commons/zenoh-shm/src/api/client_storage/mod.rs
+++ b/commons/zenoh-shm/src/api/client_storage/mod.rs
@@ -78,6 +78,14 @@ pub struct ShmClientStorageBuilder {
     clients: BTreeMap<ProtocolID, Arc<dyn ShmClient>>,
 }
 
+impl std::fmt::Debug for ShmClientStorageBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ShmClientStorageBuilder")
+            .field("clients_len", &self.clients.len())
+            .finish()
+    }
+}
+
 impl ShmClientStorageBuilder {
     fn new(clients: BTreeMap<ProtocolID, Arc<dyn ShmClient>>) -> Self {
         Self { clients }

--- a/commons/zenoh-shm/src/api/protocol_implementations/posix/posix_shm_provider_backend_binary_heap.rs
+++ b/commons/zenoh-shm/src/api/protocol_implementations/posix/posix_shm_provider_backend_binary_heap.rs
@@ -70,6 +70,14 @@ pub struct PosixShmProviderBackendBinaryHeapBuilder<Layout> {
     layout: Layout,
 }
 
+impl<Layout> std::fmt::Debug for PosixShmProviderBackendBinaryHeapBuilder<Layout> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PosixShmProviderBackendBinaryHeapBuilder")
+            .field("layout", &"..")
+            .finish()
+    }
+}
+
 #[zenoh_macros::unstable_doc]
 impl<Layout> Resolvable for PosixShmProviderBackendBinaryHeapBuilder<Layout> {
     type To = ZResult<PosixShmProviderBackendBinaryHeap>;
@@ -95,6 +103,20 @@ pub struct PosixShmProviderBackendBinaryHeap {
     segment: Arc<PosixShmSegment>,
     free_list: Mutex<BinaryHeap<Chunk>>,
     alignment: AllocAlignment,
+}
+
+impl std::fmt::Debug for PosixShmProviderBackendBinaryHeap {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PosixShmProviderBackendBinaryHeap")
+            .field(
+                "available",
+                &self.available.load(std::sync::atomic::Ordering::Acquire),
+            )
+            .field("segment", &"..")
+            .field("free_list", &"..")
+            .field("alignment", &self.alignment)
+            .finish()
+    }
 }
 
 impl PosixShmProviderBackendBinaryHeap {

--- a/commons/zenoh-shm/src/api/protocol_implementations/posix/posix_shm_provider_backend_buddy.rs
+++ b/commons/zenoh-shm/src/api/protocol_implementations/posix/posix_shm_provider_backend_buddy.rs
@@ -40,6 +40,14 @@ pub struct PosixShmProviderBackendBuddyBuilder<Layout> {
     layout: Layout,
 }
 
+impl<Layout> std::fmt::Debug for PosixShmProviderBackendBuddyBuilder<Layout> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PosixShmProviderBackendBuddyBuilder")
+            .field("layout", &"..")
+            .finish()
+    }
+}
+
 #[zenoh_macros::unstable_doc]
 impl<Layout> Resolvable for PosixShmProviderBackendBuddyBuilder<Layout> {
     type To = ZResult<PosixShmProviderBackendBuddy>;
@@ -64,6 +72,16 @@ pub struct PosixShmProviderBackendBuddy {
     segment: Arc<PosixShmSegment>,
     heap: Mutex<Heap<BUDDY_ORDER>>,
     alignment: AllocAlignment,
+}
+
+impl std::fmt::Debug for PosixShmProviderBackendBuddy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PosixShmProviderBackendBuddy")
+            .field("segment", &"..")
+            .field("heap", &"..")
+            .field("alignment", &self.alignment)
+            .finish()
+    }
 }
 
 // see `buddy_system_allocator` doc for details

--- a/commons/zenoh-shm/src/api/protocol_implementations/posix/posix_shm_provider_backend_talc.rs
+++ b/commons/zenoh-shm/src/api/protocol_implementations/posix/posix_shm_provider_backend_talc.rs
@@ -41,6 +41,14 @@ pub struct PosixShmProviderBackendTalcBuilder<Layout> {
     layout: Layout,
 }
 
+impl<Layout> std::fmt::Debug for PosixShmProviderBackendTalcBuilder<Layout> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PosixShmProviderBackendTalcBuilder")
+            .field("layout", &"..")
+            .finish()
+    }
+}
+
 #[zenoh_macros::unstable_doc]
 impl<Layout> Resolvable for PosixShmProviderBackendTalcBuilder<Layout> {
     type To = ZResult<PosixShmProviderBackendTalc>;
@@ -66,6 +74,16 @@ pub struct PosixShmProviderBackendTalc {
     segment: Arc<PosixShmSegment>,
     talc: Mutex<Talc<ErrOnOom>>,
     alignment: AllocAlignment,
+}
+
+impl std::fmt::Debug for PosixShmProviderBackendTalc {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PosixShmProviderBackendTalc")
+            .field("segment", &"..")
+            .field("talc", &"..")
+            .field("alignment", &self.alignment)
+            .finish()
+    }
 }
 
 impl PosixShmProviderBackendTalc {

--- a/commons/zenoh-shm/src/api/provider/chunk.rs
+++ b/commons/zenoh-shm/src/api/provider/chunk.rs
@@ -40,6 +40,7 @@ impl ChunkDescriptor {
 
 /// A recently-allocated chunk.
 #[zenoh_macros::unstable_doc]
+#[derive(Debug)]
 pub struct AllocatedChunk {
     pub descriptor: ChunkDescriptor,
     pub data: PtrInSegment,

--- a/commons/zenoh-shm/src/api/provider/memory_layout.rs
+++ b/commons/zenoh-shm/src/api/provider/memory_layout.rs
@@ -166,6 +166,7 @@ impl TryFrom<(usize, AllocAlignment)> for MemoryLayout {
 ///
 /// Statically-known layouts are always correct, zero-sized & zero-cost.
 #[zenoh_macros::unstable_doc]
+#[derive(Debug)]
 pub struct TypedLayout<T> {
     _phantom: PhantomData<T>,
 }

--- a/commons/zenoh-shm/src/api/provider/shm_provider.rs
+++ b/commons/zenoh-shm/src/api/provider/shm_provider.rs
@@ -197,6 +197,7 @@ impl<T: Copy> PolicyValue<T> for T {
     }
 }
 /// A const `bool`.
+#[derive(Debug)]
 pub struct ConstBool<const VALUE: bool>;
 impl<const VALUE: bool> ConstPolicy for ConstBool<VALUE> {
     const NEW: Self = Self;
@@ -207,6 +208,7 @@ impl<const VALUE: bool> PolicyValue<bool> for ConstBool<VALUE> {
     }
 }
 /// A const `usize`.
+#[derive(Debug)]
 pub struct ConstUsize<const VALUE: usize>;
 impl<const VALUE: usize> ConstPolicy for ConstUsize<VALUE> {
     const NEW: Self = Self;
@@ -219,7 +221,7 @@ impl<const VALUE: usize> PolicyValue<usize> for ConstUsize<VALUE> {
 
 /// Just try to allocate
 #[zenoh_macros::unstable_doc]
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct JustAlloc;
 impl<Backend> AllocPolicy<Backend> for JustAlloc
 where
@@ -668,6 +670,7 @@ impl<
 }
 
 #[zenoh_macros::unstable_doc]
+#[derive(Debug)]
 pub struct ShmProviderBuilder;
 impl ShmProviderBuilder {
     /// Set the backend

--- a/commons/zenoh-shm/src/api/provider/shm_provider.rs
+++ b/commons/zenoh-shm/src/api/provider/shm_provider.rs
@@ -243,7 +243,7 @@ impl ConstPolicy for JustAlloc {
 ///
 /// If `Safe` is set to false, the policy may lead to reallocate memory currently in-use.
 #[zenoh_macros::unstable_doc]
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct GarbageCollect<InnerPolicy = JustAlloc, AltPolicy = JustAlloc, Safe = ConstBool<true>> {
     inner_policy: InnerPolicy,
     alt_policy: AltPolicy,
@@ -304,7 +304,7 @@ impl<InnerPolicy: ConstPolicy, AltPolicy: ConstPolicy, Safe: ConstPolicy> ConstP
 /// Try to defragment if allocation failed and allocate again
 /// if the largest defragmented chuk is not smaller than the one required
 #[zenoh_macros::unstable_doc]
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct Defragment<InnerPolicy = JustAlloc, AltPolicy = JustAlloc> {
     inner_policy: InnerPolicy,
     alt_policy: AltPolicy,
@@ -354,7 +354,7 @@ impl<InnerPolicy: ConstPolicy, AltPolicy: ConstPolicy> ConstPolicy
 ///
 /// This policy is unsafe as it may lead to reallocate memory currently in-use.
 #[zenoh_macros::unstable_doc]
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct Deallocate<Limit, InnerPolicy = JustAlloc, AltPolicy = InnerPolicy> {
     limit: Limit,
     inner_policy: InnerPolicy,
@@ -408,7 +408,7 @@ impl<Limit: ConstPolicy, InnerPolicy: ConstPolicy, AltPolicy: ConstPolicy> Const
 /// This policy will block until the allocation succeeds.
 /// Both sync and async modes available.
 #[zenoh_macros::unstable_doc]
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct BlockOn<InnerPolicy = JustAlloc> {
     inner_policy: InnerPolicy,
 }
@@ -473,6 +473,16 @@ pub struct AllocBuilder<'a, Backend, Layout, Policy = JustAlloc> {
     provider: &'a ShmProvider<Backend>,
     layout: Layout,
     policy: Policy,
+}
+
+impl<Backend, Layout, Policy> std::fmt::Debug for AllocBuilder<'_, Backend, Layout, Policy> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AllocBuilder")
+            .field("provider", &"..")
+            .field("layout", &"..")
+            .field("policy", &"..")
+            .finish()
+    }
 }
 
 // Generic impl
@@ -582,6 +592,17 @@ impl<
 pub struct PrecomputedAllocBuilder<'b, 'a: 'b, Backend, Layout, Policy = JustAlloc> {
     layout: &'b PrecomputedLayout<'a, Backend, Layout>,
     policy: Policy,
+}
+
+impl<Backend, Layout, Policy> std::fmt::Debug
+    for PrecomputedAllocBuilder<'_, '_, Backend, Layout, Policy>
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PrecomputedAllocBuilder")
+            .field("layout", &"..")
+            .field("policy", &"..")
+            .finish()
+    }
 }
 
 // Generic impl
@@ -695,6 +716,17 @@ where
 {
     backend: Backend,
 }
+
+impl<Backend> std::fmt::Debug for ShmProviderBuilderBackend<Backend>
+where
+    Backend: ShmProviderBackend,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ShmProviderBuilderBackend")
+            .field("backend", &"..")
+            .finish()
+    }
+}
 #[zenoh_macros::unstable_doc]
 impl<Backend> Resolvable for ShmProviderBuilderBackend<Backend>
 where
@@ -717,6 +749,14 @@ where
 #[zenoh_macros::unstable_doc]
 pub struct ShmProviderBuilderWithDefaultBackend<Layout> {
     layout: Layout,
+}
+
+impl<Layout> std::fmt::Debug for ShmProviderBuilderWithDefaultBackend<Layout> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ShmProviderBuilderWithDefaultBackend")
+            .field("layout", &"..")
+            .finish()
+    }
 }
 
 #[zenoh_macros::unstable_doc]

--- a/commons/zenoh-shm/src/metadata/descriptor.rs
+++ b/commons/zenoh-shm/src/metadata/descriptor.rs
@@ -46,6 +46,14 @@ pub struct OwnedWatchdog {
     watchdog_mask: u64,
 }
 
+impl std::fmt::Debug for OwnedWatchdog {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OwnedWatchdog")
+            .field("watchdog_mask", &self.watchdog_mask)
+            .finish_non_exhaustive()
+    }
+}
+
 // The ordering strategy is important. See storage implementation for details
 impl Ord for OwnedWatchdog {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {

--- a/commons/zenoh-shm/src/metadata/descriptor.rs
+++ b/commons/zenoh-shm/src/metadata/descriptor.rs
@@ -49,6 +49,13 @@ pub struct OwnedWatchdog {
 impl std::fmt::Debug for OwnedWatchdog {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("OwnedWatchdog")
+            .field("watchdog_atomic", &self.watchdog_atomic.as_ptr())
+            .field(
+                "watchdog_value",
+                &self
+                    .watchdog_atomic
+                    .load(std::sync::atomic::Ordering::Relaxed),
+            )
             .field("watchdog_mask", &self.watchdog_mask)
             .finish_non_exhaustive()
     }

--- a/commons/zenoh-shm/src/metadata/storage.rs
+++ b/commons/zenoh-shm/src/metadata/storage.rs
@@ -34,6 +34,14 @@ pub struct MetadataStorage {
     available: Mutex<VecDeque<OwnedMetadataDescriptor>>,
 }
 
+impl std::fmt::Debug for MetadataStorage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MetadataStorage")
+            .field("available", &"..")
+            .finish()
+    }
+}
+
 impl MetadataStorage {
     fn new() -> ZResult<Self> {
         // See ordering implementation for OwnedMetadataDescriptor

--- a/commons/zenoh-shm/src/metadata/subscription.rs
+++ b/commons/zenoh-shm/src/metadata/subscription.rs
@@ -32,6 +32,14 @@ pub struct Subscription {
     linked_table: RwLock<BTreeMap<MetadataSegmentID, Arc<MetadataSegment>>>,
 }
 
+impl std::fmt::Debug for Subscription {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Subscription")
+            .field("linked_table", &"..")
+            .finish()
+    }
+}
+
 impl Subscription {
     fn new() -> Self {
         Self {

--- a/commons/zenoh-shm/src/metadata/subscription.rs
+++ b/commons/zenoh-shm/src/metadata/subscription.rs
@@ -34,9 +34,16 @@ pub struct Subscription {
 
 impl std::fmt::Debug for Subscription {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Subscription")
-            .field("linked_table", &"..")
-            .finish()
+        let mut debug = f.debug_struct("Subscription");
+        match self.linked_table.try_read() {
+            Ok(linked_table) => {
+                debug.field("linked_table_len", &linked_table.len());
+            }
+            Err(_) => {
+                debug.field("linked_table_len", &"<locked>");
+            }
+        }
+        debug.finish()
     }
 }
 

--- a/commons/zenoh-shm/src/shm/mod.rs
+++ b/commons/zenoh-shm/src/shm/mod.rs
@@ -52,6 +52,12 @@ pub struct Segment<ID: SegmentID> {
     inner: platform::SegmentImpl<ID>,
 }
 
+impl<ID: SegmentID> std::fmt::Debug for Segment<ID> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Segment").field(&self.inner).finish()
+    }
+}
+
 impl<ID: SegmentID> Segment<ID> {
     pub fn create(id: ID, len: NonZeroUsize) -> ShmCreateResult<Self> {
         let inner = platform::SegmentImpl::create(id, len)?;

--- a/commons/zenoh-shm/src/shm/unix.rs
+++ b/commons/zenoh-shm/src/shm/unix.rs
@@ -42,6 +42,17 @@ pub struct SegmentImpl<ID: SegmentID> {
     id: ID,
 }
 
+impl<ID: SegmentID> std::fmt::Debug for SegmentImpl<ID> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SegmentImpl")
+            .field("lock_fd", &self.lock_fd)
+            .field("len", &self.len)
+            .field("data_ptr", &self.data_ptr)
+            .field("id", &self.id.into())
+            .finish()
+    }
+}
+
 // PUBLIC
 impl<ID: SegmentID> SegmentImpl<ID> {
     pub fn create(id: ID, len: NonZeroUsize) -> ShmCreateResult<Self> {

--- a/commons/zenoh-shm/src/shm/windows.rs
+++ b/commons/zenoh-shm/src/shm/windows.rs
@@ -29,6 +29,17 @@ pub struct SegmentImpl<ID: SegmentID> {
     id: ID,
 }
 
+impl<ID: SegmentID> std::fmt::Debug for SegmentImpl<ID> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SegmentImpl")
+            .field("fd", &"..")
+            .field("len", &self.len)
+            .field("data_ptr", &"..")
+            .field("id", &self.id.into())
+            .finish()
+    }
+}
+
 // PUBLIC
 impl<ID: SegmentID> SegmentImpl<ID> {
     pub fn create(id: ID, len: NonZeroUsize) -> ShmCreateResult<Self> {

--- a/commons/zenoh-shm/src/watchdog/confirmator.rs
+++ b/commons/zenoh-shm/src/watchdog/confirmator.rs
@@ -155,6 +155,16 @@ pub struct WatchdogConfirmator {
     task: PeriodicTask,
 }
 
+impl std::fmt::Debug for WatchdogConfirmator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WatchdogConfirmator")
+            .field("confirmed", &"..")
+            .field("segment_transactions", &"..")
+            .field("task", &self.task)
+            .finish()
+    }
+}
+
 impl WatchdogConfirmator {
     fn new(interval: Duration) -> Self {
         let segment_transactions = Arc::<SegQueue<Arc<ConfirmedSegment>>>::default();

--- a/commons/zenoh-shm/src/watchdog/periodic_task.rs
+++ b/commons/zenoh-shm/src/watchdog/periodic_task.rs
@@ -27,7 +27,7 @@ use thread_priority::{
     ThreadSchedulePolicy::Realtime,
 };
 
-#[derive(PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum TaskWakeReason {
     Timeout,
     Kick,

--- a/commons/zenoh-shm/src/watchdog/validator.rs
+++ b/commons/zenoh-shm/src/watchdog/validator.rs
@@ -41,6 +41,16 @@ pub struct WatchdogValidator {
     task: PeriodicTask,
 }
 
+impl std::fmt::Debug for WatchdogValidator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WatchdogValidator")
+            .field("cap", &self.cap)
+            .field("sender", &self.sender)
+            .field("task", &self.task)
+            .finish()
+    }
+}
+
 impl WatchdogValidator {
     pub fn new(interval: Duration) -> Self {
         // Our channel here may change it's size (that size that is not capacity) from 0 to

--- a/commons/zenoh-shm/tests/common/mod.rs
+++ b/commons/zenoh-shm/tests/common/mod.rs
@@ -75,6 +75,15 @@ pub struct CpuLoad {
     flag: Arc<AtomicBool>,
 }
 
+impl Debug for CpuLoad {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CpuLoad")
+            .field("has_handle", &self.handle.is_some())
+            .field("flag", &self.flag)
+            .finish()
+    }
+}
+
 impl Drop for CpuLoad {
     fn drop(&mut self) {
         self.flag.store(false, std::sync::atomic::Ordering::SeqCst);

--- a/commons/zenoh-stats/src/keys.rs
+++ b/commons/zenoh-stats/src/keys.rs
@@ -30,6 +30,14 @@ pub struct StatsKeyCache {
     mutex: Mutex<()>,
 }
 
+impl fmt::Debug for StatsKeyCache {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StatsKeyCache")
+            .field("generation", &self.generation.load(Ordering::Acquire))
+            .finish_non_exhaustive()
+    }
+}
+
 unsafe impl Send for StatsKeyCache {}
 unsafe impl Sync for StatsKeyCache {}
 
@@ -37,6 +45,15 @@ unsafe impl Sync for StatsKeyCache {}
 pub struct StatsKeysTree {
     generation: u64,
     tree: Option<KeBoxTree<usize>>,
+}
+
+impl fmt::Debug for StatsKeysTree {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StatsKeysTree")
+            .field("generation", &self.generation)
+            .field("has_tree", &self.tree.is_some())
+            .finish()
+    }
 }
 
 impl StatsKeysTree {

--- a/commons/zenoh-sync/src/cache.rs
+++ b/commons/zenoh-sync/src/cache.rs
@@ -19,6 +19,7 @@ use std::sync::{
 
 use arc_swap::{ArcSwap, Guard};
 
+#[derive(Debug)]
 pub struct CacheValue<T: Sized> {
     version: usize,
     value: T,
@@ -35,6 +36,14 @@ impl<T> CacheValue<T> {
 pub struct Cache<T> {
     value: ArcSwap<CacheValue<T>>,
     is_updating: AtomicBool,
+}
+
+impl<T> std::fmt::Debug for Cache<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Cache")
+            .field("is_updating", &self.is_updating.load(Ordering::SeqCst))
+            .finish_non_exhaustive()
+    }
 }
 
 pub type CacheValueType<T> = Guard<Arc<CacheValue<T>>>;

--- a/commons/zenoh-sync/src/condition.rs
+++ b/commons/zenoh-sync/src/condition.rs
@@ -23,7 +23,7 @@ pub type ConditionWaiter = Pin<Box<EventListener>>;
 /// not be race condition on [notify_one](Condition::notify_one) or
 /// [notify_all](Condition::notify_all).
 ///
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct Condition {
     event: Event,
 }

--- a/commons/zenoh-sync/src/event.rs
+++ b/commons/zenoh-sync/src/event.rs
@@ -170,6 +170,12 @@ pub fn new() -> (Notifier, Waiter) {
 #[repr(transparent)]
 pub struct Notifier(Arc<EventInner>);
 
+impl std::fmt::Debug for Notifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Notifier").field(&"..").finish()
+    }
+}
+
 impl Notifier {
     /// Notifies one pending listener
     #[inline]
@@ -207,6 +213,12 @@ impl Drop for Notifier {
 
 #[repr(transparent)]
 pub struct Waiter(Arc<EventInner>);
+
+impl std::fmt::Debug for Waiter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Waiter").field(&"..").finish()
+    }
+}
 
 impl Waiter {
     /// Waits for the condition to be notified

--- a/commons/zenoh-sync/src/fifo_queue.rs
+++ b/commons/zenoh-sync/src/fifo_queue.rs
@@ -17,6 +17,7 @@ use zenoh_core::zasynclock;
 
 use crate::Condition;
 
+#[derive(Debug)]
 pub struct FifoQueue<T> {
     not_empty: Condition,
     not_full: Condition,

--- a/commons/zenoh-sync/src/lib.rs
+++ b/commons/zenoh-sync/src/lib.rs
@@ -57,6 +57,12 @@ pub fn get_mut_unchecked<T>(arc: &mut std::sync::Arc<T>) -> &mut T {
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct PinBoxFuture<T>(Pin<Box<dyn Future<Output = T> + Send>>);
 
+impl<T> std::fmt::Debug for PinBoxFuture<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("PinBoxFuture").field(&"..").finish()
+    }
+}
+
 impl<T> Future for PinBoxFuture<T> {
     type Output = T;
 

--- a/commons/zenoh-sync/src/lifo_queue.rs
+++ b/commons/zenoh-sync/src/lifo_queue.rs
@@ -16,6 +16,7 @@ use std::sync::{Condvar, Mutex};
 use zenoh_collections::StackBuffer;
 use zenoh_core::zlock;
 
+#[derive(Debug)]
 pub struct LifoQueue<T> {
     not_empty: Condvar,
     not_full: Condvar,

--- a/commons/zenoh-sync/src/mvar.rs
+++ b/commons/zenoh-sync/src/mvar.rs
@@ -18,6 +18,7 @@ use zenoh_core::zasynclock;
 
 use crate::Condition;
 
+#[derive(Debug)]
 pub struct Mvar<T> {
     inner: Mutex<Option<T>>,
     cond_put: Condition,

--- a/commons/zenoh-sync/src/object_pool.rs
+++ b/commons/zenoh-sync/src/object_pool.rs
@@ -24,6 +24,7 @@ use super::LifoQueue;
 
 /// Provides a pool of pre-allocated objects that are automaticlaly reinserted into
 /// the pool when dropped.
+#[derive(Debug)]
 pub struct RecyclingObjectPool<T, F>
 where
     F: Fn() -> T,

--- a/commons/zenoh-task/src/lib.rs
+++ b/commons/zenoh-task/src/lib.rs
@@ -32,6 +32,14 @@ pub struct TaskController {
     token: CancellationToken,
 }
 
+impl std::fmt::Debug for TaskController {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TaskController")
+            .field("is_cancelled", &self.token.is_cancelled())
+            .finish_non_exhaustive()
+    }
+}
+
 impl Default for TaskController {
     fn default() -> Self {
         TaskController {
@@ -141,6 +149,15 @@ impl TaskController {
 pub struct TerminatableTask {
     handle: Option<JoinHandle<()>>,
     token: CancellationToken,
+}
+
+impl std::fmt::Debug for TerminatableTask {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TerminatableTask")
+            .field("has_handle", &self.handle.is_some())
+            .field("is_cancelled", &self.token.is_cancelled())
+            .finish()
+    }
 }
 
 impl Drop for TerminatableTask {

--- a/commons/zenoh-util/src/lib_search_dirs.rs
+++ b/commons/zenoh-util/src/lib_search_dirs.rs
@@ -63,6 +63,7 @@ impl Display for InvalidLibSearchDir {
 
 impl Error for InvalidLibSearchDir {}
 
+#[derive(Debug)]
 pub struct IntoIter {
     iter: std::vec::IntoIter<LibSearchDir>,
 }

--- a/commons/zenoh-util/src/log.rs
+++ b/commons/zenoh-util/src/log.rs
@@ -67,6 +67,7 @@ fn init_env_filter(env_filter: EnvFilter) {
     let _ = tracing::subscriber::set_global_default(subscriber);
 }
 
+#[derive(Debug)]
 pub struct LogRecord {
     pub target: String,
     pub level: tracing::Level,

--- a/commons/zenoh-util/src/timer.rs
+++ b/commons/zenoh-util/src/timer.rs
@@ -40,6 +40,14 @@ type TimedFuture = Arc<dyn Timed + Send + Sync>;
 #[derive(Clone)]
 pub struct TimedHandle(Weak<AtomicBool>);
 
+impl std::fmt::Debug for TimedHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TimedHandle")
+            .field("is_live", &self.0.strong_count().gt(&0))
+            .finish()
+    }
+}
+
 impl TimedHandle {
     pub fn defuse(self) {
         if let Some(arc) = self.0.upgrade() {
@@ -54,6 +62,17 @@ pub struct TimedEvent {
     period: Option<Duration>,
     future: TimedFuture,
     fused: Arc<AtomicBool>,
+}
+
+impl std::fmt::Debug for TimedEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TimedEvent")
+            .field("when", &self.when)
+            .field("period", &self.period)
+            .field("future", &"..")
+            .field("fused", &self.fused.load(AtomicOrdering::Acquire))
+            .finish()
+    }
 }
 
 impl TimedEvent {
@@ -191,6 +210,16 @@ pub struct Timer {
     events: Arc<Mutex<BinaryHeap<TimedEvent>>>,
     sl_sender: Option<Sender<()>>,
     ev_sender: Option<Sender<(bool, TimedEvent)>>,
+}
+
+impl std::fmt::Debug for Timer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Timer")
+            .field("events", &"..")
+            .field("has_sleep_sender", &self.sl_sender.is_some())
+            .field("has_event_sender", &self.ev_sender.is_some())
+            .finish()
+    }
 }
 
 impl Timer {

--- a/io/zenoh-link-commons/src/listener.rs
+++ b/io/zenoh-link-commons/src/listener.rs
@@ -13,6 +13,7 @@
 //
 use std::{
     collections::HashMap,
+    fmt,
     net::{IpAddr, SocketAddr},
     sync::{Arc, RwLock},
 };
@@ -30,6 +31,16 @@ pub struct ListenerUnicastIP {
     endpoint: EndPoint,
     token: CancellationToken,
     handle: JoinHandle<ZResult<()>>,
+}
+
+impl fmt::Debug for ListenerUnicastIP {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ListenerUnicastIP")
+            .field("endpoint", &self.endpoint)
+            .field("token", &self.token)
+            .field("handle", &"..")
+            .finish()
+    }
 }
 
 impl ListenerUnicastIP {
@@ -54,6 +65,15 @@ pub struct ListenersUnicastIP {
     // TODO(yuyuan): should we change this to AsyncRwLock?
     listeners: Arc<RwLock<HashMap<SocketAddr, ListenerUnicastIP>>>,
     pub token: CancellationToken,
+}
+
+impl fmt::Debug for ListenersUnicastIP {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ListenersUnicastIP")
+            .field("listeners", &self.listeners)
+            .field("token", &self.token)
+            .finish()
+    }
 }
 
 impl ListenersUnicastIP {

--- a/io/zenoh-link-commons/src/listener.rs
+++ b/io/zenoh-link-commons/src/listener.rs
@@ -69,10 +69,16 @@ pub struct ListenersUnicastIP {
 
 impl fmt::Debug for ListenersUnicastIP {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ListenersUnicastIP")
-            .field("listeners", &self.listeners)
-            .field("token", &self.token)
-            .finish()
+        let mut debug = f.debug_struct("ListenersUnicastIP");
+        match self.listeners.try_read() {
+            Ok(listeners) => {
+                debug.field("listeners_len", &listeners.len());
+            }
+            Err(_) => {
+                debug.field("listeners_len", &"<locked>");
+            }
+        }
+        debug.field("token", &self.token).finish()
     }
 }
 

--- a/io/zenoh-link-commons/src/quic/unicast.rs
+++ b/io/zenoh-link-commons/src/quic/unicast.rs
@@ -758,6 +758,7 @@ impl<F: AcceptorCallback> QuicAcceptor<F> {
 }
 
 /// Material for building a link after accepting a new connection on a QUIC listener
+#[derive(Debug)]
 pub struct QuicLinkMaterial {
     pub quic_conn: QuicConnection,
     pub src_addr: SocketAddr,
@@ -765,22 +766,6 @@ pub struct QuicLinkMaterial {
     pub streams: Option<QuicStreams>,
     pub is_mixed_rel: bool,
     pub tls_close_link_on_expiration: bool,
-}
-
-impl fmt::Debug for QuicLinkMaterial {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("QuicLinkMaterial")
-            .field("quic_conn", &self.quic_conn)
-            .field("src_addr", &self.src_addr)
-            .field("dst_addr", &self.dst_addr)
-            .field("streams", &self.streams)
-            .field("is_mixed_rel", &self.is_mixed_rel)
-            .field(
-                "tls_close_link_on_expiration",
-                &self.tls_close_link_on_expiration,
-            )
-            .finish()
-    }
 }
 
 pub struct QuicStreams {

--- a/io/zenoh-link-commons/src/quic/unicast.rs
+++ b/io/zenoh-link-commons/src/quic/unicast.rs
@@ -15,6 +15,7 @@
 use std::{
     cell::UnsafeCell,
     collections::HashMap,
+    fmt,
     future::{Future, IntoFuture},
     net::SocketAddr,
     ops::Deref,
@@ -50,6 +51,15 @@ use crate::{
 pub struct QuicConnection {
     conn: quinn::Connection,
     closed: Arc<AtomicBool>,
+}
+
+impl fmt::Debug for QuicConnection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("QuicConnection")
+            .field("conn", &self.conn)
+            .field("closed", &self.closed)
+            .finish()
+    }
 }
 
 impl QuicConnection {
@@ -259,6 +269,17 @@ pub struct QuicServerBuilder<'a, F: AcceptorCallback> {
     is_secure: bool,
 }
 
+impl<F: AcceptorCallback> fmt::Debug for QuicServerBuilder<'_, F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("QuicServerBuilder")
+            .field("endpoint", &self.endpoint)
+            .field("acceptor_params", &self.acceptor_params)
+            .field("is_streamed", &self.is_streamed)
+            .field("is_secure", &self.is_secure)
+            .finish()
+    }
+}
+
 impl<'a, F: AcceptorCallback> QuicServerBuilder<'a, F> {
     pub fn new(endpoint: &'a EndPoint, acceptor_params: QuicAcceptorParams<F>) -> Self {
         Self {
@@ -300,6 +321,16 @@ pub struct QuicServer<F: AcceptorCallback> {
     pub quic_acceptor: QuicAcceptor<F>,
     pub locator: Locator,
     pub local_addr: SocketAddr,
+}
+
+impl<F: AcceptorCallback> fmt::Debug for QuicServer<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("QuicServer")
+            .field("quic_acceptor", &self.quic_acceptor)
+            .field("locator", &self.locator)
+            .field("local_addr", &self.local_addr)
+            .finish()
+    }
 }
 
 impl<F: AcceptorCallback> QuicServer<F> {
@@ -398,6 +429,16 @@ pub struct QuicClientBuilder<'a> {
     is_secure: bool,
 }
 
+impl fmt::Debug for QuicClientBuilder<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("QuicClientBuilder")
+            .field("endpoint", &self.endpoint)
+            .field("is_streamed", &self.is_streamed)
+            .field("is_secure", &self.is_secure)
+            .finish()
+    }
+}
+
 impl<'a> QuicClientBuilder<'a> {
     pub fn new(endpoint: &'a EndPoint) -> Self {
         Self {
@@ -439,6 +480,22 @@ pub struct QuicClient {
     pub dst_addr: SocketAddr,
     pub is_mixed_rel: bool,
     pub tls_close_link_on_expiration: bool,
+}
+
+impl fmt::Debug for QuicClient {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("QuicClient")
+            .field("quic_conn", &self.quic_conn)
+            .field("streams", &self.streams)
+            .field("src_addr", &self.src_addr)
+            .field("dst_addr", &self.dst_addr)
+            .field("is_mixed_rel", &self.is_mixed_rel)
+            .field(
+                "tls_close_link_on_expiration",
+                &self.tls_close_link_on_expiration,
+            )
+            .finish()
+    }
 }
 
 impl QuicClient {
@@ -567,11 +624,36 @@ pub struct QuicAcceptorParams<F: AcceptorCallback> {
     pub make_link: F,
 }
 
+impl<F: AcceptorCallback> fmt::Debug for QuicAcceptorParams<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("QuicAcceptorParams")
+            .field("token", &self.token)
+            .field("manager", &self.manager)
+            .field("throttle_time", &self.throttle_time)
+            .field("make_link", &"..")
+            .finish()
+    }
+}
+
 pub struct QuicAcceptor<F: AcceptorCallback> {
     quic_endpoint: quinn::Endpoint,
     tls_close_link_on_expiration: bool,
     is_streamed: bool,
     inner: QuicAcceptorParams<F>,
+}
+
+impl<F: AcceptorCallback> fmt::Debug for QuicAcceptor<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("QuicAcceptor")
+            .field("quic_endpoint", &self.quic_endpoint)
+            .field(
+                "tls_close_link_on_expiration",
+                &self.tls_close_link_on_expiration,
+            )
+            .field("is_streamed", &self.is_streamed)
+            .field("inner", &self.inner)
+            .finish()
+    }
 }
 
 impl<F: AcceptorCallback> QuicAcceptor<F> {
@@ -685,6 +767,22 @@ pub struct QuicLinkMaterial {
     pub tls_close_link_on_expiration: bool,
 }
 
+impl fmt::Debug for QuicLinkMaterial {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("QuicLinkMaterial")
+            .field("quic_conn", &self.quic_conn)
+            .field("src_addr", &self.src_addr)
+            .field("dst_addr", &self.dst_addr)
+            .field("streams", &self.streams)
+            .field("is_mixed_rel", &self.is_mixed_rel)
+            .field(
+                "tls_close_link_on_expiration",
+                &self.tls_close_link_on_expiration,
+            )
+            .finish()
+    }
+}
+
 pub struct QuicStreams {
     send: [UnsafeCell<Option<quinn::SendStream>>; Priority::NUM],
     recv: [UnsafeCell<Option<RecvStream>>; Priority::NUM],
@@ -692,6 +790,26 @@ pub struct QuicStreams {
 }
 
 unsafe impl Sync for QuicStreams {}
+
+impl fmt::Debug for QuicStreams {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let active_send_streams = self
+            .send
+            .iter()
+            .filter(|stream| unsafe { &*stream.get() }.is_some())
+            .count();
+        let active_recv_streams = self
+            .recv
+            .iter()
+            .filter(|stream| unsafe { &*stream.get() }.is_some())
+            .count();
+        f.debug_struct("QuicStreams")
+            .field("active_send_streams", &active_send_streams)
+            .field("active_recv_streams", &active_recv_streams)
+            .field("is_multistream", &self.is_multistream)
+            .finish()
+    }
+}
 
 impl QuicStreams {
     async fn open(connection: &quinn::Connection) -> ZResult<Self> {

--- a/io/zenoh-link-commons/src/quic/utils.rs
+++ b/io/zenoh-link-commons/src/quic/utils.rs
@@ -183,6 +183,18 @@ pub struct TlsServerConfig {
     pub tls_close_link_on_expiration: bool,
 }
 
+impl Debug for TlsServerConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TlsServerConfig")
+            .field("server_config", &"..")
+            .field(
+                "tls_close_link_on_expiration",
+                &self.tls_close_link_on_expiration,
+            )
+            .finish()
+    }
+}
+
 impl TlsServerConfig {
     pub async fn new(config: &Config<'_>, secure: bool) -> ZResult<Self> {
         let tls_close_link_on_expiration: bool = match config.get(TLS_CLOSE_LINK_ON_EXPIRATION) {
@@ -315,6 +327,18 @@ impl TlsServerConfig {
 pub struct TlsClientConfig {
     pub client_config: ClientConfig,
     pub tls_close_link_on_expiration: bool,
+}
+
+impl Debug for TlsClientConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TlsClientConfig")
+            .field("client_config", &"..")
+            .field(
+                "tls_close_link_on_expiration",
+                &self.tls_close_link_on_expiration,
+            )
+            .finish()
+    }
 }
 
 impl TlsClientConfig {

--- a/io/zenoh-link-commons/src/tcp.rs
+++ b/io/zenoh-link-commons/src/tcp.rs
@@ -18,6 +18,7 @@ use zenoh_result::{zerror, ZResult};
 
 use crate::set_dscp;
 
+#[derive(Debug)]
 pub struct TcpSocketConfig<'a> {
     tx_buffer_size: Option<u32>,
     rx_buffer_size: Option<u32>,

--- a/io/zenoh-link-commons/src/unicast.rs
+++ b/io/zenoh-link-commons/src/unicast.rs
@@ -54,6 +54,25 @@ pub enum NewLink {
     },
 }
 
+impl fmt::Debug for NewLink {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Single(link) => f
+                .debug_tuple("Single")
+                .field(&LinkUnicast::from(link.clone()))
+                .finish(),
+            Self::MixedReliability {
+                reliable,
+                best_effort,
+            } => f
+                .debug_struct("MixedReliability")
+                .field("reliable", &LinkUnicast::from(reliable.clone()))
+                .field("best_effort", &LinkUnicast::from(best_effort.clone()))
+                .finish(),
+        }
+    }
+}
+
 #[async_trait]
 pub trait LinkUnicastTrait: Send + Sync {
     fn get_mtu(&self) -> BatchSize;

--- a/io/zenoh-link/src/lib.rs
+++ b/io/zenoh-link/src/lib.rs
@@ -17,7 +17,7 @@
 //! This crate is intended for Zenoh's internal use.
 //!
 //! [Click here for Zenoh's documentation](https://docs.rs/zenoh/latest/zenoh)
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt};
 
 use zenoh_config::Config;
 pub use zenoh_link_commons::*;
@@ -242,6 +242,13 @@ pub struct LocatorInspector {
     #[cfg(all(feature = "transport_vsock", target_os = "linux"))]
     vsock_inspector: VsockLocatorInspector,
 }
+
+impl fmt::Debug for LocatorInspector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LocatorInspector").finish_non_exhaustive()
+    }
+}
+
 impl LocatorInspector {
     pub fn is_reliable(&self, locator: &Locator) -> ZResult<bool> {
         #[allow(unused_imports)]
@@ -313,6 +320,12 @@ pub struct LinkConfigurator {
     tls_inspector: TlsConfigurator,
     #[cfg(feature = "transport_unixpipe")]
     unixpipe_inspector: UnixPipeConfigurator,
+}
+
+impl fmt::Debug for LinkConfigurator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LinkConfigurator").finish_non_exhaustive()
+    }
 }
 
 impl LinkConfigurator {

--- a/io/zenoh-link/src/lib.rs
+++ b/io/zenoh-link/src/lib.rs
@@ -368,6 +368,7 @@ impl LinkConfigurator {
 /*             UNICAST               */
 /*************************************/
 
+#[derive(Debug)]
 pub struct LinkManagerBuilderUnicast;
 
 impl LinkManagerBuilderUnicast {
@@ -412,6 +413,7 @@ impl LinkManagerBuilderUnicast {
 /*            MULTICAST              */
 /*************************************/
 
+#[derive(Debug)]
 pub struct LinkManagerBuilderMulticast;
 
 impl LinkManagerBuilderMulticast {

--- a/io/zenoh-links/zenoh-link-quic/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/unicast.rs
@@ -217,18 +217,10 @@ impl fmt::Debug for LinkUnicastQuic {
     }
 }
 
+#[derive(Debug)]
 pub struct LinkManagerUnicastQuic {
     manager: NewLinkChannelSender,
     listeners: ListenersUnicastIP,
-}
-
-impl fmt::Debug for LinkManagerUnicastQuic {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("LinkManagerUnicastQuic")
-            .field("manager", &self.manager)
-            .field("listeners", &self.listeners)
-            .finish()
-    }
 }
 
 impl LinkManagerUnicastQuic {

--- a/io/zenoh-links/zenoh-link-quic/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/unicast.rs
@@ -222,6 +222,15 @@ pub struct LinkManagerUnicastQuic {
     listeners: ListenersUnicastIP,
 }
 
+impl fmt::Debug for LinkManagerUnicastQuic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LinkManagerUnicastQuic")
+            .field("manager", &self.manager)
+            .field("listeners", &self.listeners)
+            .finish()
+    }
+}
+
 impl LinkManagerUnicastQuic {
     pub fn new(manager: NewLinkChannelSender) -> Self {
         Self {

--- a/io/zenoh-links/zenoh-link-quic_datagram/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-quic_datagram/src/unicast.rs
@@ -217,6 +217,15 @@ pub struct LinkManagerUnicastQuicDatagram {
     listeners: ListenersUnicastIP,
 }
 
+impl fmt::Debug for LinkManagerUnicastQuicDatagram {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LinkManagerUnicastQuicDatagram")
+            .field("manager", &self.manager)
+            .field("listeners", &self.listeners)
+            .finish()
+    }
+}
+
 impl LinkManagerUnicastQuicDatagram {
     pub fn new(manager: NewLinkChannelSender) -> Self {
         Self {

--- a/io/zenoh-links/zenoh-link-quic_datagram/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-quic_datagram/src/unicast.rs
@@ -212,18 +212,10 @@ impl fmt::Debug for LinkUnicastQuicDatagram {
     }
 }
 
+#[derive(Debug)]
 pub struct LinkManagerUnicastQuicDatagram {
     manager: NewLinkChannelSender,
     listeners: ListenersUnicastIP,
-}
-
-impl fmt::Debug for LinkManagerUnicastQuicDatagram {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("LinkManagerUnicastQuicDatagram")
-            .field("manager", &self.manager)
-            .field("listeners", &self.listeners)
-            .finish()
-    }
 }
 
 impl LinkManagerUnicastQuicDatagram {

--- a/io/zenoh-links/zenoh-link-serial/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-serial/src/lib.rs
@@ -56,7 +56,7 @@ zconfigurable! {
     static ref SERIAL_ACCEPT_THROTTLE_TIME: u64 = 100_000;
 }
 
-#[derive(Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct SerialLocatorInspector;
 #[async_trait]
 impl LocatorInspector for SerialLocatorInspector {

--- a/io/zenoh-links/zenoh-link-serial/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-serial/src/unicast.rs
@@ -269,6 +269,15 @@ pub struct LinkManagerUnicastSerial {
     listeners: Arc<AsyncRwLock<HashMap<String, ListenerUnicastSerial>>>,
 }
 
+impl fmt::Debug for LinkManagerUnicastSerial {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LinkManagerUnicastSerial")
+            .field("manager", &self.manager)
+            .field("listeners", &"..")
+            .finish()
+    }
+}
+
 impl LinkManagerUnicastSerial {
     pub fn new(manager: NewLinkChannelSender) -> Self {
         Self {

--- a/io/zenoh-links/zenoh-link-tcp/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/lib.rs
@@ -45,7 +45,7 @@ pub const TCP_LOCATOR_PREFIX: &str = "tcp";
 
 const IS_RELIABLE: bool = true;
 
-#[derive(Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct TcpLocatorInspector;
 #[async_trait]
 impl LocatorInspector for TcpLocatorInspector {

--- a/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
@@ -233,6 +233,15 @@ pub struct LinkManagerUnicastTcp {
     listeners: ListenersUnicastIP,
 }
 
+impl fmt::Debug for LinkManagerUnicastTcp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LinkManagerUnicastTcp")
+            .field("manager", &self.manager)
+            .field("listeners", &self.listeners)
+            .finish()
+    }
+}
+
 impl LinkManagerUnicastTcp {
     pub fn new(manager: NewLinkChannelSender) -> Self {
         Self {

--- a/io/zenoh-links/zenoh-link-tls/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/lib.rs
@@ -44,7 +44,7 @@ pub const TLS_LOCATOR_PREFIX: &str = "tls";
 
 const IS_RELIABLE: bool = true;
 
-#[derive(Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct TlsLocatorInspector;
 #[async_trait]
 impl LocatorInspector for TlsLocatorInspector {

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -306,6 +306,15 @@ pub struct LinkManagerUnicastTls {
     listeners: ListenersUnicastIP,
 }
 
+impl fmt::Debug for LinkManagerUnicastTls {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LinkManagerUnicastTls")
+            .field("manager", &self.manager)
+            .field("listeners", &self.listeners)
+            .finish()
+    }
+}
+
 impl LinkManagerUnicastTls {
     pub fn new(manager: NewLinkChannelSender) -> Self {
         Self {

--- a/io/zenoh-links/zenoh-link-udp/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/lib.rs
@@ -77,7 +77,7 @@ zconfigurable! {
     static ref UDP_ACCEPT_THROTTLE_TIME: u64 = 100_000;
 }
 
-#[derive(Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct UdpLocatorInspector;
 #[async_trait]
 impl LocatorInspector for UdpLocatorInspector {

--- a/io/zenoh-links/zenoh-link-udp/src/multicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/multicast.rs
@@ -181,7 +181,7 @@ impl fmt::Debug for LinkMulticastUdp {
 /*************************************/
 /*             MANAGER               */
 /*************************************/
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct LinkManagerMulticastUdp;
 
 impl LinkManagerMulticastUdp {

--- a/io/zenoh-links/zenoh-link-udp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/unicast.rs
@@ -293,6 +293,15 @@ pub struct LinkManagerUnicastUdp {
     pub(crate) listeners: ListenersUnicastIP,
 }
 
+impl fmt::Debug for LinkManagerUnicastUdp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LinkManagerUnicastUdp")
+            .field("manager", &self.manager)
+            .field("listeners", &self.listeners)
+            .finish()
+    }
+}
+
 impl LinkManagerUnicastUdp {
     pub fn new(manager: NewLinkChannelSender) -> Self {
         Self {

--- a/io/zenoh-links/zenoh-link-unixpipe/src/unix/mod.rs
+++ b/io/zenoh-links/zenoh-link-unixpipe/src/unix/mod.rs
@@ -33,7 +33,7 @@ pub const UNIXPIPE_LOCATOR_PREFIX: &str = "unixpipe";
 
 const IS_RELIABLE: bool = true;
 
-#[derive(Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct UnixPipeLocatorInspector;
 #[async_trait]
 impl LocatorInspector for UnixPipeLocatorInspector {

--- a/io/zenoh-links/zenoh-link-unixpipe/src/unix/unicast.rs
+++ b/io/zenoh-links/zenoh-link-unixpipe/src/unix/unicast.rs
@@ -553,6 +553,15 @@ pub struct LinkManagerUnicastPipe {
     listeners: tokio::sync::RwLock<HashMap<EndPoint, UnicastPipeListener>>,
 }
 
+impl fmt::Debug for LinkManagerUnicastPipe {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LinkManagerUnicastPipe")
+            .field("manager", &self.manager)
+            .field("listeners", &"..")
+            .finish()
+    }
+}
+
 impl LinkManagerUnicastPipe {
     pub fn new(manager: NewLinkChannelSender) -> Self {
         Self {

--- a/io/zenoh-links/zenoh-link-unixsock_stream/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-unixsock_stream/src/lib.rs
@@ -55,7 +55,7 @@ zconfigurable! {
     static ref UNIXSOCKSTREAM_ACCEPT_THROTTLE_TIME: u64 = 100_000;
 }
 
-#[derive(Default, Clone, Copy)]
+#[derive(Default, Clone, Copy, Debug)]
 pub struct UnixSockStreamLocatorInspector;
 #[async_trait]
 impl LocatorInspector for UnixSockStreamLocatorInspector {

--- a/io/zenoh-links/zenoh-link-unixsock_stream/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-unixsock_stream/src/unicast.rs
@@ -209,6 +209,15 @@ pub struct LinkManagerUnicastUnixSocketStream {
     listeners: Arc<AsyncRwLock<HashMap<String, ListenerUnixSocketStream>>>,
 }
 
+impl fmt::Debug for LinkManagerUnicastUnixSocketStream {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LinkManagerUnicastUnixSocketStream")
+            .field("manager", &self.manager)
+            .field("listeners", &"..")
+            .finish()
+    }
+}
+
 impl LinkManagerUnicastUnixSocketStream {
     pub fn new(manager: NewLinkChannelSender) -> Self {
         Self {

--- a/io/zenoh-links/zenoh-link-vsock/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-vsock/src/lib.rs
@@ -39,7 +39,7 @@ pub const VSOCK_LOCATOR_PREFIX: &str = "vsock";
 
 const IS_RELIABLE: bool = true;
 
-#[derive(Default, Clone, Copy)]
+#[derive(Default, Clone, Copy, Debug)]
 pub struct VsockLocatorInspector;
 #[async_trait]
 impl LocatorInspector for VsockLocatorInspector {

--- a/io/zenoh-links/zenoh-link-vsock/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-vsock/src/unicast.rs
@@ -237,6 +237,15 @@ pub struct LinkManagerUnicastVsock {
     listeners: Arc<AsyncRwLock<HashMap<VsockAddr, ListenerUnicastVsock>>>,
 }
 
+impl fmt::Debug for LinkManagerUnicastVsock {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LinkManagerUnicastVsock")
+            .field("manager", &self.manager)
+            .field("listeners", &"..")
+            .finish()
+    }
+}
+
 impl LinkManagerUnicastVsock {
     pub fn new(manager: NewLinkChannelSender) -> Self {
         Self {

--- a/io/zenoh-links/zenoh-link-ws/src/lib.rs
+++ b/io/zenoh-links/zenoh-link-ws/src/lib.rs
@@ -43,7 +43,7 @@ pub const WS_LOCATOR_PREFIX: &str = "ws";
 
 const IS_RELIABLE: bool = true;
 
-#[derive(Default, Clone, Copy)]
+#[derive(Default, Clone, Copy, Debug)]
 pub struct WsLocatorInspector;
 #[async_trait]
 impl LocatorInspector for WsLocatorInspector {

--- a/io/zenoh-links/zenoh-link-ws/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-ws/src/unicast.rs
@@ -292,6 +292,15 @@ pub struct LinkManagerUnicastWs {
     listeners: Arc<AsyncRwLock<HashMap<SocketAddr, ListenerUnicastWs>>>,
 }
 
+impl fmt::Debug for LinkManagerUnicastWs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LinkManagerUnicastWs")
+            .field("manager", &self.manager)
+            .field("listeners", &"..")
+            .finish()
+    }
+}
+
 impl LinkManagerUnicastWs {
     pub fn new(manager: NewLinkChannelSender) -> Self {
         Self {

--- a/io/zenoh-transport/src/lib.rs
+++ b/io/zenoh-transport/src/lib.rs
@@ -56,7 +56,7 @@ pub trait TransportEventHandler: Send + Sync {
     ) -> ZResult<Arc<dyn TransportMulticastEventHandler>>;
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct DummyTransportEventHandler;
 
 impl TransportEventHandler for DummyTransportEventHandler {
@@ -86,7 +86,7 @@ pub trait TransportMulticastEventHandler: Send + Sync {
 }
 
 // Define an empty TransportCallback for the listener transport
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct DummyTransportMulticastEventHandler;
 
 impl TransportMulticastEventHandler for DummyTransportMulticastEventHandler {
@@ -124,7 +124,7 @@ pub trait TransportPeerEventHandler: Send + Sync {
 }
 
 // Define an empty TransportCallback for the listener transport
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct DummyTransportPeerEventHandler;
 
 impl TransportPeerEventHandler for DummyTransportPeerEventHandler {

--- a/io/zenoh-transport/src/manager.rs
+++ b/io/zenoh-transport/src/manager.rs
@@ -11,7 +11,7 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, fmt, sync::Arc, time::Duration};
 
 use rand::{RngCore, SeedableRng};
 use tokio::sync::Mutex as AsyncMutex;
@@ -133,6 +133,41 @@ pub struct TransportManagerConfig {
     pub region_name: Option<RegionName>,
 }
 
+impl fmt::Debug for TransportManagerConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TransportManagerConfig")
+            .field("version", &self.version)
+            .field("zid", &self.zid)
+            .field("whatami", &self.whatami)
+            .field("resolution", &self.resolution)
+            .field("batch_size", &self.batch_size)
+            .field("batching", &self.batching)
+            .field("wait_before_drop", &self.wait_before_drop)
+            .field(
+                "max_wait_before_drop_fragments",
+                &self.max_wait_before_drop_fragments,
+            )
+            .field("wait_before_close", &self.wait_before_close)
+            .field("queue_size", &self.queue_size)
+            .field("queue_backoff", &self.queue_backoff)
+            .field("queue_alloc", &self.queue_alloc)
+            .field("defrag_buff_size", &self.defrag_buff_size)
+            .field("link_rx_buffer_size", &self.link_rx_buffer_size)
+            .field("unicast", &self.unicast)
+            .field("multicast", &self.multicast)
+            .field("link_configs", &self.link_configs)
+            .field("handler", &"..")
+            .field("tx_threads", &self.tx_threads)
+            .field("supported_links", &self.supported_links)
+            .field(
+                "bound_callback",
+                &self.bound_callback.as_ref().map(|_| ".."),
+            )
+            .field("region_name", &self.region_name)
+            .finish()
+    }
+}
+
 pub struct TransportManagerState {
     pub unicast: TransportManagerStateUnicast,
     pub multicast: TransportManagerStateMulticast,
@@ -140,9 +175,29 @@ pub struct TransportManagerState {
     pub shm_context: Option<ShmContext>,
 }
 
+impl fmt::Debug for TransportManagerState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug = f.debug_struct("TransportManagerState");
+        debug.field("unicast", &self.unicast);
+        debug.field("multicast", &self.multicast);
+        #[cfg(feature = "shared-memory")]
+        debug.field("shm_context", &self.shm_context.as_ref().map(|_| ".."));
+        debug.finish()
+    }
+}
+
 pub struct TransportManagerParams {
     config: TransportManagerConfig,
     state: TransportManagerState,
+}
+
+impl fmt::Debug for TransportManagerParams {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TransportManagerParams")
+            .field("config", &self.config)
+            .field("state", &self.state)
+            .finish()
+    }
 }
 
 pub struct TransportManagerBuilder {
@@ -171,6 +226,45 @@ pub struct TransportManagerBuilder {
     shm: zenoh_config::ShmConf,
     #[cfg(feature = "shared-memory")]
     shm_reader: Option<ShmReader>,
+}
+
+impl fmt::Debug for TransportManagerBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug = f.debug_struct("TransportManagerBuilder");
+        debug
+            .field("version", &self.version)
+            .field("zid", &self.zid)
+            .field("whatami", &self.whatami)
+            .field("resolution", &self.resolution)
+            .field("batch_size", &self.batch_size)
+            .field("batching_enabled", &self.batching_enabled)
+            .field("batching_time_limit", &self.batching_time_limit)
+            .field("wait_before_drop", &self.wait_before_drop)
+            .field(
+                "max_wait_before_drop_fragments",
+                &self.max_wait_before_drop_fragments,
+            )
+            .field("wait_before_close", &self.wait_before_close)
+            .field("queue_size", &self.queue_size)
+            .field("queue_alloc", &self.queue_alloc)
+            .field("defrag_buff_size", &self.defrag_buff_size)
+            .field("link_rx_buffer_size", &self.link_rx_buffer_size)
+            .field("unicast", &self.unicast)
+            .field("multicast", &self.multicast)
+            .field("link_configs", &self.link_configs)
+            .field("tx_threads", &self.tx_threads)
+            .field("supported_links", &self.supported_links)
+            .field("region_name", &self.region_name)
+            .field(
+                "bound_callback",
+                &self.bound_callback.as_ref().map(|_| ".."),
+            );
+        #[cfg(feature = "shared-memory")]
+        debug.field("shm", &self.shm);
+        #[cfg(feature = "shared-memory")]
+        debug.field("shm_reader", &self.shm_reader.as_ref().map(|_| ".."));
+        debug.finish()
+    }
 }
 
 impl TransportManagerBuilder {
@@ -479,6 +573,24 @@ pub struct TransportManager {
     #[cfg(feature = "stats")]
     pub(crate) stats: zenoh_stats::StatsRegistry,
     pub(crate) task_controller: TaskController,
+}
+
+impl fmt::Debug for TransportManager {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug = f.debug_struct("TransportManager");
+        debug
+            .field("config", &self.config)
+            .field("state", &self.state)
+            .field("prng", &"..")
+            .field("cipher", &"..")
+            .field("locator_inspector", &self.locator_inspector)
+            .field("new_unicast_link_sender", &self.new_unicast_link_sender);
+        #[cfg(feature = "stats")]
+        debug.field("stats", &self.stats);
+        debug
+            .field("task_controller", &self.task_controller)
+            .finish()
+    }
 }
 
 impl TransportManager {

--- a/io/zenoh-transport/src/multicast/manager.rs
+++ b/io/zenoh-transport/src/multicast/manager.rs
@@ -11,7 +11,7 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, fmt, sync::Arc, time::Duration};
 
 use tokio::sync::Mutex;
 #[cfg(feature = "transport_compression")]
@@ -30,6 +30,7 @@ use crate::{
     TransportManager,
 };
 
+#[derive(Debug)]
 pub struct TransportManagerConfigMulticast {
     pub lease: Duration,
     pub keep_alive: usize,
@@ -50,6 +51,21 @@ pub struct TransportManagerBuilderMulticast {
     is_compression: bool,
 }
 
+impl fmt::Debug for TransportManagerBuilderMulticast {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug = f.debug_struct("TransportManagerBuilderMulticast");
+        debug
+            .field("lease", &self.lease)
+            .field("keep_alive", &self.keep_alive)
+            .field("join_interval", &self.join_interval)
+            .field("max_sessions", &self.max_sessions)
+            .field("is_qos", &self.is_qos);
+        #[cfg(feature = "transport_compression")]
+        debug.field("is_compression", &self.is_compression);
+        debug.finish()
+    }
+}
+
 pub struct TransportManagerStateMulticast {
     // Established listeners
     pub(crate) link_managers: Arc<Mutex<HashMap<LinkKind, LinkManagerMulticast>>>,
@@ -57,9 +73,27 @@ pub struct TransportManagerStateMulticast {
     pub(crate) transports: Arc<Mutex<HashMap<Locator, Arc<TransportMulticastInner>>>>,
 }
 
+impl fmt::Debug for TransportManagerStateMulticast {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TransportManagerStateMulticast")
+            .field("link_managers", &"..")
+            .field("transports", &"..")
+            .finish()
+    }
+}
+
 pub struct TransportManagerParamsMulticast {
     pub config: TransportManagerConfigMulticast,
     pub state: TransportManagerStateMulticast,
+}
+
+impl fmt::Debug for TransportManagerParamsMulticast {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TransportManagerParamsMulticast")
+            .field("config", &self.config)
+            .field("state", &self.state)
+            .finish()
+    }
 }
 
 impl TransportManagerBuilderMulticast {

--- a/io/zenoh-transport/src/shm.rs
+++ b/io/zenoh-transport/src/shm.rs
@@ -46,10 +46,12 @@ use zenoh_shm::{
 
 use crate::unicast::establishment::ext::shm::AuthSegment;
 
+#[derive(Debug)]
 struct ProviderInitCfg {
     shm_size: NonZeroUsize,
 }
 
+#[derive(Debug)]
 pub enum ProviderInitState {
     Initializing,
     Ready(Arc<ShmProvider<PosixShmProviderBackend>>),
@@ -63,9 +65,29 @@ enum ProviderInitStateInner {
     Error,
 }
 
+impl std::fmt::Debug for ProviderInitStateInner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Enabled(cfg) => f.debug_tuple("Enabled").field(cfg).finish(),
+            Self::Initializing(_) => f.debug_tuple("Initializing").field(&"..").finish(),
+            Self::Ready(provider) => f.debug_tuple("Ready").field(provider).finish(),
+            Self::Error => f.debug_tuple("Error").finish(),
+        }
+    }
+}
+
 pub struct LazyShmProvider {
     message_size_threshold: usize,
     state: Mutex<ProviderInitStateInner>,
+}
+
+impl std::fmt::Debug for LazyShmProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LazyShmProvider")
+            .field("message_size_threshold", &self.message_size_threshold)
+            .field("state", &self.state)
+            .finish()
+    }
 }
 
 impl LazyShmProvider {
@@ -176,7 +198,7 @@ impl TransportShmConfig {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct MulticastTransportShmConfig;
 
 impl PartnerShmConfig for MulticastTransportShmConfig {

--- a/io/zenoh-transport/src/shm_context.rs
+++ b/io/zenoh-transport/src/shm_context.rs
@@ -66,6 +66,16 @@ pub struct ShmContext {
     pub(super) auth: AuthUnicast,
 }
 
+impl std::fmt::Debug for ShmContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ShmContext")
+            .field("shm_reader", &self.shm_reader)
+            .field("shm_provider", &self.shm_provider)
+            .field("auth", &"..")
+            .finish()
+    }
+}
+
 impl ShmContext {
     pub fn new(
         cfg: zenoh_config::ShmConf,

--- a/io/zenoh-transport/src/unicast/manager.rs
+++ b/io/zenoh-transport/src/unicast/manager.rs
@@ -13,6 +13,7 @@
 //
 use std::{
     collections::HashMap,
+    fmt,
     sync::{
         atomic::{AtomicUsize, Ordering::SeqCst},
         Arc,
@@ -51,6 +52,7 @@ use crate::{
 /*************************************/
 /*         TRANSPORT CONFIG          */
 /*************************************/
+#[derive(Debug)]
 pub struct TransportManagerConfigUnicast {
     pub lease: Duration,
     pub keep_alive: usize,
@@ -112,9 +114,33 @@ pub struct TransportManagerStateUnicast {
     pub(super) authenticator: Arc<Auth>,
 }
 
+impl fmt::Debug for TransportManagerStateUnicast {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug = f.debug_struct("TransportManagerStateUnicast");
+        debug
+            .field("incoming", &self.incoming)
+            .field("link_managers", &"..")
+            .field("transports", &"..");
+        #[cfg(feature = "transport_multilink")]
+        debug.field("multilink", &"..");
+        #[cfg(feature = "transport_auth")]
+        debug.field("authenticator", &"..");
+        debug.finish()
+    }
+}
+
 pub struct TransportManagerParamsUnicast {
     pub config: TransportManagerConfigUnicast,
     pub state: TransportManagerStateUnicast,
+}
+
+impl fmt::Debug for TransportManagerParamsUnicast {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TransportManagerParamsUnicast")
+            .field("config", &self.config)
+            .field("state", &self.state)
+            .finish()
+    }
 }
 
 pub struct TransportManagerBuilderUnicast {
@@ -137,6 +163,28 @@ pub struct TransportManagerBuilderUnicast {
     pub(super) is_lowlatency: bool,
     #[cfg(feature = "transport_compression")]
     pub(super) is_compression: bool,
+}
+
+impl fmt::Debug for TransportManagerBuilderUnicast {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug = f.debug_struct("TransportManagerBuilderUnicast");
+        debug
+            .field("lease", &self.lease)
+            .field("keep_alive", &self.keep_alive)
+            .field("open_timeout", &self.open_timeout)
+            .field("accept_timeout", &self.accept_timeout)
+            .field("accept_pending", &self.accept_pending)
+            .field("max_sessions", &self.max_sessions)
+            .field("is_qos", &self.is_qos);
+        #[cfg(feature = "transport_multilink")]
+        debug.field("max_links", &self.max_links);
+        #[cfg(feature = "transport_auth")]
+        debug.field("authenticator", &"..");
+        debug.field("is_lowlatency", &self.is_lowlatency);
+        #[cfg(feature = "transport_compression")]
+        debug.field("is_compression", &self.is_compression);
+        debug.finish()
+    }
 }
 
 impl TransportManagerBuilderUnicast {

--- a/io/zenoh-transport/src/unicast/test_helpers.rs
+++ b/io/zenoh-transport/src/unicast/test_helpers.rs
@@ -11,7 +11,11 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use std::{fmt::DebugStruct, sync::Arc, time::Duration};
+use std::{
+    fmt::{self, DebugStruct},
+    sync::Arc,
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use tokio::sync::MutexGuard as AsyncMutexGuard;
@@ -44,6 +48,16 @@ pub struct MockTransportUnicastInner {
     zid: ZenohIdProto,
     whatami: WhatAmI,
     on_schedule: Arc<dyn Fn(NetworkMessage) + Send + Sync>,
+}
+
+impl fmt::Debug for MockTransportUnicastInner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MockTransportUnicastInner")
+            .field("zid", &self.zid)
+            .field("whatami", &self.whatami)
+            .field("on_schedule", &"..")
+            .finish()
+    }
 }
 
 #[async_trait]

--- a/io/zenoh-transport/tests/endpoints.rs
+++ b/io/zenoh-transport/tests/endpoints.rs
@@ -53,7 +53,7 @@ impl TransportEventHandler for SH {
 }
 
 // Transport Callback for the router
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct SC;
 
 impl TransportPeerEventHandler for SC {

--- a/io/zenoh-transport/tests/transport_whitelist.rs
+++ b/io/zenoh-transport/tests/transport_whitelist.rs
@@ -49,6 +49,7 @@ impl TransportEventHandler for SHRouter {
     }
 }
 
+#[derive(Debug)]
 pub struct SCRouter;
 
 impl TransportPeerEventHandler for SCRouter {

--- a/io/zenoh-transport/tests/unicast_fragmentation.rs
+++ b/io/zenoh-transport/tests/unicast_fragmentation.rs
@@ -90,6 +90,7 @@ impl TransportEventHandler for SHRouter {
 }
 
 // Transport Callback for the router
+#[derive(Debug)]
 pub struct SCRouter {
     count: Arc<AtomicUsize>,
 }
@@ -139,7 +140,7 @@ impl TransportEventHandler for SHClient {
 }
 
 // Transport Callback for the client
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct SCClient;
 
 impl TransportPeerEventHandler for SCClient {

--- a/io/zenoh-transport/tests/unicast_intermittent.rs
+++ b/io/zenoh-transport/tests/unicast_intermittent.rs
@@ -116,6 +116,7 @@ impl TransportEventHandler for SHClientStable {
 }
 
 // Transport Callback for the client
+#[derive(Debug)]
 pub struct SCClient {
     counter: Arc<AtomicUsize>,
 }

--- a/io/zenoh-transport/tests/unicast_priorities.rs
+++ b/io/zenoh-transport/tests/unicast_priorities.rs
@@ -101,6 +101,7 @@ impl TransportEventHandler for SHRouter {
 }
 
 // Transport Callback for the router
+#[derive(Debug)]
 pub struct SCRouter {
     priority: Arc<AtomicUsize>,
     count: Arc<AtomicUsize>,
@@ -163,6 +164,7 @@ impl TransportEventHandler for SHClient {
 }
 
 // Transport Callback for the client
+#[derive(Debug)]
 pub struct SCClient;
 
 impl Default for SCClient {

--- a/io/zenoh-transport/tests/unicast_transport.rs
+++ b/io/zenoh-transport/tests/unicast_transport.rs
@@ -302,6 +302,7 @@ impl TransportEventHandler for SHRouter {
 }
 
 // Transport Callback for the router
+#[derive(Debug)]
 pub struct SCRouter {
     count: Arc<AtomicUsize>,
 }
@@ -349,7 +350,7 @@ impl TransportEventHandler for SHClient {
 }
 
 // Transport Callback for the client
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct SCClient;
 
 impl TransportPeerEventHandler for SCClient {
@@ -1878,7 +1879,7 @@ impl TransportEventHandler for MultiRxHandler {
 }
 
 // Transport Callback for multistream and mixed-reliability tests
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct MultiRxCallback {
     msg_count: AtomicUsize,
     rx_task_ids: Mutex<HashSet<tokio::task::Id>>,

--- a/plugins/zenoh-backend-example/src/lib.rs
+++ b/plugins/zenoh-backend-example/src/lib.rs
@@ -45,8 +45,10 @@ impl Plugin for ExampleBackend {
     const PLUGIN_LONG_VERSION: &'static str = plugin_long_version!();
 }
 
+#[derive(Debug)]
 pub struct ExampleBackend {}
 
+#[derive(Debug)]
 pub struct ExampleStorage {
     map: RwLock<HashMap<Option<OwnedKeyExpr>, StoredData>>,
 }

--- a/plugins/zenoh-backend-traits/src/config.rs
+++ b/plugins/zenoh-backend-traits/src/config.rs
@@ -655,6 +655,7 @@ impl PartialEq for VolumeConfig {
         self.name == other.name && self.paths == other.paths && self.rest == other.rest
     }
 }
+#[derive(Debug)]
 pub enum PrivacyGetResult<T> {
     NotFound,
     Private(T),

--- a/plugins/zenoh-backend-traits/src/lib.rs
+++ b/plugins/zenoh-backend-traits/src/lib.rs
@@ -181,6 +181,7 @@ pub enum History {
     All,
 }
 
+#[derive(Debug)]
 pub enum StorageInsertionResult {
     Outdated,
     Inserted,

--- a/plugins/zenoh-plugin-example/src/lib.rs
+++ b/plugins/zenoh-plugin-example/src/lib.rs
@@ -66,6 +66,7 @@ fn spawn_runtime(task: impl Future<Output = ()> + Send + 'static) {
 }
 
 // The struct implementing the ZenohPlugin and ZenohPlugin traits
+#[derive(Debug)]
 pub struct ExamplePlugin {}
 
 // declaration of the plugin's VTable for zenohd to find the plugin's functions to be called

--- a/plugins/zenoh-plugin-rest/src/lib.rs
+++ b/plugins/zenoh-plugin-rest/src/lib.rs
@@ -273,6 +273,7 @@ fn response<'a, S: Into<&'a str> + std::fmt::Debug>(
 #[cfg(feature = "dynamic_plugin")]
 zenoh_plugin_trait::declare_plugin!(RestPlugin);
 
+#[derive(Debug)]
 pub struct RestPlugin {}
 
 impl ZenohPlugin for RestPlugin {}

--- a/plugins/zenoh-plugin-storage-manager/src/lib.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/lib.rs
@@ -69,6 +69,7 @@ lazy_static::lazy_static! {
 #[cfg(feature = "dynamic_plugin")]
 zenoh_plugin_trait::declare_plugin!(StoragesPlugin);
 
+#[derive(Debug)]
 pub struct StoragesPlugin {}
 impl ZenohPlugin for StoragesPlugin {}
 impl Plugin for StoragesPlugin {

--- a/plugins/zenoh-plugin-trait/src/manager.rs
+++ b/plugins/zenoh-plugin-trait/src/manager.rs
@@ -13,6 +13,8 @@
 mod dynamic_plugin;
 mod static_plugin;
 
+use std::fmt;
+
 use zenoh_keyexpr::keyexpr;
 use zenoh_result::ZResult;
 use zenoh_util::LibLoader;
@@ -105,6 +107,18 @@ pub struct PluginsManager<StartArgs: PluginStartArgs, Instance: PluginInstance> 
     default_lib_prefix: String,
     loader: Option<LibLoader>,
     plugins: Vec<PluginRecord<StartArgs, Instance>>,
+}
+
+impl<StartArgs: PluginStartArgs, Instance: PluginInstance> fmt::Debug
+    for PluginsManager<StartArgs, Instance>
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PluginsManager")
+            .field("default_lib_prefix", &self.default_lib_prefix)
+            .field("loader", &self.loader.as_ref().map(|_| ".."))
+            .field("plugins_len", &self.plugins.len())
+            .finish()
+    }
 }
 
 impl<StartArgs: PluginStartArgs + 'static, Instance: PluginInstance + 'static>

--- a/plugins/zenoh-plugin-trait/src/vtable.rs
+++ b/plugins/zenoh-plugin-trait/src/vtable.rs
@@ -21,6 +21,7 @@ pub const PLUGIN_LOADER_VERSION: PluginLoaderVersion = 2;
 type StartFn<StartArgs, Instance> = fn(&str, &StartArgs) -> ZResult<Instance>;
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct PluginVTable<StartArgs, Instance> {
     pub plugin_version: &'static str,
     pub plugin_long_version: &'static str,

--- a/zenoh-ext/src/advanced_publisher.rs
+++ b/zenoh-ext/src/advanced_publisher.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use std::{
+    fmt,
     future::{IntoFuture, Ready},
     sync::{
         atomic::{AtomicU32, Ordering},
@@ -48,7 +49,7 @@ use crate::{
 
 pub(crate) static KE_PUB: &keyexpr = ke!("pub");
 
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 #[zenoh_macros::unstable]
 pub(crate) enum Sequencing {
     None,
@@ -120,6 +121,28 @@ pub struct AdvancedPublisherBuilder<'a, 'b, 'c> {
     liveliness: bool,
     cache: bool,
     history: CacheConfig,
+}
+
+#[zenoh_macros::unstable]
+impl fmt::Debug for AdvancedPublisherBuilder<'_, '_, '_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AdvancedPublisherBuilder")
+            .field("session", &"..")
+            .field("pub_key_expr", &self.pub_key_expr)
+            .field("encoding", &self.encoding)
+            .field("destination", &self.destination)
+            .field("reliability", &self.reliability)
+            .field("congestion_control", &self.congestion_control)
+            .field("priority", &self.priority)
+            .field("is_express", &self.is_express)
+            .field("meta_key_expr", &self.meta_key_expr)
+            .field("sequencing", &self.sequencing)
+            .field("miss_config", &self.miss_config)
+            .field("liveliness", &self.liveliness)
+            .field("cache", &self.cache)
+            .field("history", &self.history)
+            .finish()
+    }
 }
 
 #[zenoh_macros::unstable]
@@ -322,6 +345,25 @@ pub struct AdvancedPublisher<'a> {
     cache: Option<AdvancedCache>,
     _token: Option<LivelinessToken>,
     _state_publisher: Option<TerminatableTask>,
+}
+
+#[zenoh_macros::unstable]
+impl fmt::Debug for AdvancedPublisher<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AdvancedPublisher")
+            .field("publisher", &self.publisher)
+            .field(
+                "seqnum",
+                &self
+                    .seqnum
+                    .as_ref()
+                    .map(|seqnum| seqnum.load(Ordering::Relaxed)),
+            )
+            .field("cache", &self.cache.as_ref().map(|_| ".."))
+            .field("token", &self._token.as_ref().map(|_| ".."))
+            .field("state_publisher", &self._state_publisher)
+            .finish()
+    }
 }
 
 #[zenoh_macros::unstable]
@@ -680,6 +722,16 @@ pub type AdvancedPublisherDeleteBuilder<'a> =
 pub struct AdvancedPublicationBuilder<'a, P> {
     pub(crate) builder: PublicationBuilder<&'a Publisher<'a>, P>,
     pub(crate) cache: Option<&'a AdvancedCache>,
+}
+
+#[zenoh_macros::unstable]
+impl<P> fmt::Debug for AdvancedPublicationBuilder<'_, P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AdvancedPublicationBuilder")
+            .field("builder", &"..")
+            .field("has_cache", &self.cache.is_some())
+            .finish()
+    }
 }
 
 #[zenoh_macros::internal_trait]

--- a/zenoh-ext/src/advanced_subscriber.rs
+++ b/zenoh-ext/src/advanced_subscriber.rs
@@ -11,7 +11,7 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use std::{collections::BTreeMap, future::IntoFuture, str::FromStr};
+use std::{collections::BTreeMap, fmt, future::IntoFuture, str::FromStr};
 
 use zenoh::{
     config::ZenohId,
@@ -146,6 +146,27 @@ pub struct AdvancedSubscriberBuilder<'a, 'b, 'c, Handler, const BACKGROUND: bool
     pub(crate) liveliness: bool,
     pub(crate) meta_key_expr: Option<ZResult<KeyExpr<'c>>>,
     pub(crate) handler: Handler,
+}
+
+#[zenoh_macros::unstable]
+impl<Handler, const BACKGROUND: bool> fmt::Debug
+    for AdvancedSubscriberBuilder<'_, '_, '_, Handler, BACKGROUND>
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AdvancedSubscriberBuilder")
+            .field("session", &"..")
+            .field("key_expr", &self.key_expr)
+            .field("origin", &self.origin)
+            .field("retransmission", &self.retransmission)
+            .field("query_target", &self.query_target)
+            .field("query_timeout", &self.query_timeout)
+            .field("history", &self.history)
+            .field("liveliness", &self.liveliness)
+            .field("meta_key_expr", &self.meta_key_expr)
+            .field("handler", &"..")
+            .field("background", &BACKGROUND)
+            .finish()
+    }
 }
 
 #[zenoh_macros::unstable]
@@ -527,6 +548,19 @@ pub struct AdvancedSubscriber<Receiver> {
     receiver: Receiver,
     liveliness_subscriber: Option<Subscriber<()>>,
     heartbeat_subscriber: Option<Subscriber<()>>,
+}
+
+#[zenoh_macros::unstable]
+impl<Receiver> fmt::Debug for AdvancedSubscriber<Receiver> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AdvancedSubscriber")
+            .field("statesref", &"..")
+            .field("subscriber", &self.subscriber)
+            .field("receiver", &"..")
+            .field("liveliness_subscriber", &self.liveliness_subscriber)
+            .field("heartbeat_subscriber", &self.heartbeat_subscriber)
+            .finish()
+    }
 }
 
 #[zenoh_macros::unstable]
@@ -1552,6 +1586,18 @@ pub struct SampleMissListener<Handler> {
 }
 
 #[zenoh_macros::unstable]
+impl<Handler> fmt::Debug for SampleMissListener<Handler> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SampleMissListener")
+            .field("id", &self.id)
+            .field("statesref", &"..")
+            .field("handler", &"..")
+            .field("undeclare_on_drop", &self.undeclare_on_drop)
+            .finish()
+    }
+}
+
+#[zenoh_macros::unstable]
 impl<Handler> SampleMissListener<Handler> {
     #[inline]
     pub fn undeclare(self) -> SampleMissHandlerUndeclaration<Handler>
@@ -1615,6 +1661,15 @@ pub struct SampleMissHandlerUndeclaration<Handler> {
     listener: SampleMissListener<Handler>,
 }
 
+#[zenoh_macros::unstable]
+impl<Handler> fmt::Debug for SampleMissHandlerUndeclaration<Handler> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("SampleMissHandlerUndeclaration")
+            .field(&self.listener)
+            .finish()
+    }
+}
+
 impl<Handler> SampleMissHandlerUndeclaration<Handler> {
     /// Block in undeclare operation until all currently running instances of sample miss listener callback (if any) return.
     pub fn wait_callbacks(self) -> Self {
@@ -1651,6 +1706,19 @@ impl<Handler> IntoFuture for SampleMissHandlerUndeclaration<Handler> {
 pub struct SampleMissListenerBuilder<'a, Handler, const BACKGROUND: bool = false> {
     statesref: &'a Arc<Mutex<State>>,
     handler: Handler,
+}
+
+#[zenoh_macros::unstable]
+impl<Handler, const BACKGROUND: bool> fmt::Debug
+    for SampleMissListenerBuilder<'_, Handler, BACKGROUND>
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SampleMissListenerBuilder")
+            .field("statesref", &"..")
+            .field("handler", &"..")
+            .field("background", &BACKGROUND)
+            .finish()
+    }
 }
 
 #[zenoh_macros::unstable]

--- a/zenoh-ext/src/group.rs
+++ b/zenoh-ext/src/group.rs
@@ -16,6 +16,7 @@
 use std::{
     collections::HashMap,
     convert::TryInto,
+    fmt,
     ops::Add,
     sync::Arc,
     time::{Duration, Instant},
@@ -173,6 +174,15 @@ struct GroupState {
 pub struct Group {
     state: Arc<GroupState>,
     task_controller: TaskController,
+}
+
+impl fmt::Debug for Group {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Group")
+            .field("state", &"..")
+            .field("task_controller", &self.task_controller)
+            .finish()
+    }
 }
 
 impl Drop for Group {

--- a/zenoh-ext/src/publication_cache.rs
+++ b/zenoh-ext/src/publication_cache.rs
@@ -14,6 +14,7 @@
 use std::{
     collections::{HashMap, VecDeque},
     convert::TryInto,
+    fmt,
     future::{IntoFuture, Ready},
     time::Duration,
 };
@@ -40,6 +41,23 @@ pub struct PublicationCacheBuilder<'a, 'b, 'c, const BACKGROUND: bool = false> {
     complete: Option<bool>,
     history: usize,
     resources_limit: Option<usize>,
+}
+
+#[zenoh_macros::unstable]
+#[allow(deprecated)]
+impl<const BACKGROUND: bool> fmt::Debug for PublicationCacheBuilder<'_, '_, '_, BACKGROUND> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PublicationCacheBuilder")
+            .field("session", &"..")
+            .field("pub_key_expr", &self.pub_key_expr)
+            .field("queryable_suffix", &self.queryable_suffix)
+            .field("queryable_origin", &self.queryable_origin)
+            .field("complete", &self.complete)
+            .field("history", &self.history)
+            .field("resources_limit", &self.resources_limit)
+            .field("background", &BACKGROUND)
+            .finish()
+    }
 }
 
 #[allow(deprecated)]
@@ -181,6 +199,18 @@ pub struct PublicationCache {
     local_sub: Subscriber<FifoChannelHandler<Sample>>,
     _queryable: Queryable<FifoChannelHandler<Query>>,
     task: TerminatableTask,
+}
+
+#[zenoh_macros::unstable]
+#[allow(deprecated)]
+impl fmt::Debug for PublicationCache {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PublicationCache")
+            .field("local_sub", &self.local_sub)
+            .field("queryable", &self._queryable)
+            .field("task", &self.task)
+            .finish()
+    }
 }
 
 #[zenoh_macros::unstable]

--- a/zenoh-ext/src/querying_subscriber.rs
+++ b/zenoh-ext/src/querying_subscriber.rs
@@ -34,6 +34,7 @@ use zenoh::{
 /// The space of keys to use in a [`FetchingSubscriber`].
 #[zenoh_macros::unstable]
 #[deprecated = "Use `AdvancedPublisher` and `AdvancedSubscriber` instead."]
+#[derive(Debug)]
 pub enum KeySpace {
     User,
     Liveliness,

--- a/zenoh-ext/src/querying_subscriber.rs
+++ b/zenoh-ext/src/querying_subscriber.rs
@@ -14,6 +14,7 @@
 use std::{
     collections::{btree_map, BTreeMap, VecDeque},
     convert::TryInto,
+    fmt,
     future::{IntoFuture, Ready},
     mem::swap,
     sync::{Arc, Mutex},
@@ -85,6 +86,28 @@ pub struct QueryingSubscriberBuilder<'a, 'b, KeySpace, Handler, const BACKGROUND
     pub(crate) query_accept_replies: ReplyKeyExpr,
     pub(crate) query_timeout: Duration,
     pub(crate) handler: Handler,
+}
+
+#[zenoh_macros::unstable]
+#[allow(deprecated)]
+impl<KeySpace, Handler, const BACKGROUND: bool> fmt::Debug
+    for QueryingSubscriberBuilder<'_, '_, KeySpace, Handler, BACKGROUND>
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("QueryingSubscriberBuilder")
+            .field("session", &"..")
+            .field("key_expr", &self.key_expr)
+            .field("key_space", &"..")
+            .field("origin", &self.origin)
+            .field("query_selector", &self.query_selector)
+            .field("query_target", &self.query_target)
+            .field("query_consolidation", &self.query_consolidation)
+            .field("query_accept_replies", &self.query_accept_replies)
+            .field("query_timeout", &self.query_timeout)
+            .field("handler", &"..")
+            .field("background", &BACKGROUND)
+            .finish()
+    }
 }
 
 #[zenoh_macros::unstable]
@@ -488,6 +511,32 @@ pub struct FetchingSubscriberBuilder<
 #[zenoh_macros::unstable]
 #[allow(deprecated)]
 impl<
+        KeySpace,
+        Handler,
+        Fetch: FnOnce(Box<dyn Fn(TryIntoSample) + Send + Sync>) -> ZResult<()>,
+        TryIntoSample,
+        const BACKGROUND: bool,
+    > fmt::Debug
+    for FetchingSubscriberBuilder<'_, '_, KeySpace, Handler, Fetch, TryIntoSample, BACKGROUND>
+where
+    TryIntoSample: ExtractSample,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FetchingSubscriberBuilder")
+            .field("session", &"..")
+            .field("key_expr", &self.key_expr)
+            .field("key_space", &"..")
+            .field("origin", &self.origin)
+            .field("fetch", &"..")
+            .field("handler", &"..")
+            .field("background", &BACKGROUND)
+            .finish()
+    }
+}
+
+#[zenoh_macros::unstable]
+#[allow(deprecated)]
+impl<
         'a,
         KeySpace,
         Handler,
@@ -803,6 +852,19 @@ pub struct FetchingSubscriber<Handler> {
     callback: Callback<Sample>,
     state: Arc<Mutex<InnerState>>,
     handler: Handler,
+}
+
+#[zenoh_macros::unstable]
+#[allow(deprecated)]
+impl<Handler> fmt::Debug for FetchingSubscriber<Handler> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FetchingSubscriber")
+            .field("subscriber", &self.subscriber)
+            .field("callback", &self.callback)
+            .field("state", &"..")
+            .field("handler", &"..")
+            .finish()
+    }
 }
 
 #[zenoh_macros::unstable]

--- a/zenoh-ext/src/serialization.rs
+++ b/zenoh-ext/src/serialization.rs
@@ -285,6 +285,15 @@ pub struct ZReadIter<'a, 'b, T: Deserialize> {
     _phantom: PhantomData<T>,
 }
 
+impl<T: Deserialize> fmt::Debug for ZReadIter<'_, '_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ZReadIter")
+            .field("deserializer", &"..")
+            .field("len", &self.len)
+            .finish()
+    }
+}
+
 impl<T: Deserialize> Iterator for ZReadIter<'_, '_, T> {
     type Item = Result<T, ZDeserializeError>;
     fn next(&mut self) -> Option<Self::Item> {

--- a/zenoh/src/api/builders/close.rs
+++ b/zenoh/src/api/builders/close.rs
@@ -13,6 +13,7 @@
 //
 
 use std::{
+    fmt,
     future::{Future, IntoFuture},
     pin::Pin,
     time::Duration,
@@ -35,6 +36,16 @@ pub struct CloseBuilder<TCloseable: Closeable> {
     closee: TCloseable::TClosee,
     timeout: Duration,
     close_args: <TCloseable::TClosee as Closee>::CloseArgs,
+}
+
+impl<TCloseable: Closeable> fmt::Debug for CloseBuilder<TCloseable> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CloseBuilder")
+            .field("closee", &"..")
+            .field("timeout", &self.timeout)
+            .field("close_args", &"..")
+            .finish()
+    }
 }
 
 // NOTE: `Closeable` is only pub(crate) because it is a zenoh-internal trait, so we don't
@@ -138,6 +149,15 @@ pub struct BackgroundCloseBuilder<TOutput: Send + 'static> {
 }
 
 #[cfg(all(feature = "unstable", feature = "internal"))]
+impl<TOutput: Send + 'static> fmt::Debug for BackgroundCloseBuilder<TOutput> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("BackgroundCloseBuilder")
+            .field(&"..")
+            .finish()
+    }
+}
+
+#[cfg(all(feature = "unstable", feature = "internal"))]
 #[doc(hidden)]
 impl<TOutput: Send + 'static> BackgroundCloseBuilder<TOutput> {
     fn new(inner: Pin<Box<dyn Future<Output = TOutput> + Send>>) -> Self {
@@ -182,6 +202,13 @@ impl<TOutput: Send + 'static> IntoFuture for BackgroundCloseBuilder<TOutput> {
 #[doc(hidden)]
 pub struct NolocalJoinHandle<TOutput: Send + 'static> {
     rx: Receiver<TOutput>,
+}
+
+#[cfg(all(feature = "unstable", feature = "internal"))]
+impl<TOutput: Send + 'static> fmt::Debug for NolocalJoinHandle<TOutput> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("NolocalJoinHandle").field(&"..").finish()
+    }
 }
 
 #[cfg(all(feature = "unstable", feature = "internal"))]

--- a/zenoh/src/api/builders/info.rs
+++ b/zenoh/src/api/builders/info.rs
@@ -12,7 +12,10 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-use std::future::{IntoFuture, Ready};
+use std::{
+    fmt,
+    future::{IntoFuture, Ready},
+};
 
 use zenoh_config::wrappers::ZenohId;
 use zenoh_core::{Resolvable, Wait};
@@ -34,6 +37,12 @@ use crate::net::runtime::DynamicRuntime;
 #[must_use = "Resolvables do nothing unless you resolve them using `.await` or `zenoh::Wait::wait`"]
 pub struct ZenohIdBuilder<'a> {
     runtime: &'a DynamicRuntime,
+}
+
+impl fmt::Debug for ZenohIdBuilder<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("ZenohIdBuilder").field(&"..").finish()
+    }
 }
 
 impl<'a> ZenohIdBuilder<'a> {
@@ -80,6 +89,12 @@ pub struct RoutersZenohIdBuilder<'a> {
     runtime: &'a DynamicRuntime,
 }
 
+impl fmt::Debug for RoutersZenohIdBuilder<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("RoutersZenohIdBuilder").field(&"..").finish()
+    }
+}
+
 impl<'a> RoutersZenohIdBuilder<'a> {
     pub(crate) fn new(runtime: &'a DynamicRuntime) -> Self {
         Self { runtime }
@@ -122,6 +137,12 @@ impl IntoFuture for RoutersZenohIdBuilder<'_> {
 #[must_use = "Resolvables do nothing unless you resolve them using `.await` or `zenoh::Wait::wait`"]
 pub struct PeersZenohIdBuilder<'a> {
     runtime: &'a DynamicRuntime,
+}
+
+impl fmt::Debug for PeersZenohIdBuilder<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("PeersZenohIdBuilder").field(&"..").finish()
+    }
 }
 
 impl<'a> PeersZenohIdBuilder<'a> {

--- a/zenoh/src/api/builders/info_links.rs
+++ b/zenoh/src/api/builders/info_links.rs
@@ -65,6 +65,16 @@ pub struct LinksBuilder<'a> {
 }
 
 #[zenoh_macros::unstable]
+impl std::fmt::Debug for LinksBuilder<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LinksBuilder")
+            .field("session", &"..")
+            .field("transport", &self.transport)
+            .finish()
+    }
+}
+
+#[zenoh_macros::unstable]
 impl<'a> LinksBuilder<'a> {
     pub(crate) fn new(session: &'a WeakSession) -> Self {
         Self {
@@ -165,11 +175,21 @@ impl std::fmt::Debug for LinkEventsListenerInner {
 /// # }
 /// ```
 #[zenoh_macros::unstable]
-#[derive(Debug)]
 pub struct LinkEventsListener<Handler> {
     pub(crate) inner: LinkEventsListenerInner,
     pub(crate) handler: Handler,
     pub(crate) callback_sync_group: SyncGroup,
+}
+
+#[zenoh_macros::unstable]
+impl<Handler> std::fmt::Debug for LinkEventsListener<Handler> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LinkEventsListener")
+            .field("inner", &self.inner)
+            .field("handler", &"..")
+            .field("callback_sync_group", &self.callback_sync_group)
+            .finish()
+    }
 }
 
 #[zenoh_macros::unstable]
@@ -273,6 +293,16 @@ pub struct LinkEventsListenerUndeclaration<Handler> {
 }
 
 #[zenoh_macros::unstable]
+impl<Handler> std::fmt::Debug for LinkEventsListenerUndeclaration<Handler> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LinkEventsListenerUndeclaration")
+            .field("listener", &self.listener)
+            .field("wait_callbacks", &self.wait_callbacks)
+            .finish()
+    }
+}
+
+#[zenoh_macros::unstable]
 impl<Handler> Resolvable for LinkEventsListenerUndeclaration<Handler> {
     type To = ZResult<()>;
 }
@@ -343,6 +373,21 @@ pub struct LinkEventsListenerBuilder<'a, Handler, const BACKGROUND: bool = false
     handler: Handler,
     history: bool,
     transport: Option<Transport>,
+}
+
+#[zenoh_macros::unstable]
+impl<Handler, const BACKGROUND: bool> std::fmt::Debug
+    for LinkEventsListenerBuilder<'_, Handler, BACKGROUND>
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LinkEventsListenerBuilder")
+            .field("session", &"..")
+            .field("handler", &"..")
+            .field("history", &self.history)
+            .field("transport", &self.transport)
+            .field("background", &BACKGROUND)
+            .finish()
+    }
 }
 
 #[zenoh_macros::unstable]

--- a/zenoh/src/api/builders/info_transport.rs
+++ b/zenoh/src/api/builders/info_transport.rs
@@ -57,6 +57,13 @@ pub struct TransportsBuilder<'a> {
 }
 
 #[zenoh_macros::unstable]
+impl std::fmt::Debug for TransportsBuilder<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("TransportsBuilder").field(&"..").finish()
+    }
+}
+
+#[zenoh_macros::unstable]
 impl<'a> TransportsBuilder<'a> {
     pub(crate) fn new(runtime: &'a DynamicRuntime) -> Self {
         Self { runtime }
@@ -136,6 +143,17 @@ pub struct TransportEventsListener<Handler> {
     pub(crate) inner: TransportEventsListenerInner,
     pub(crate) handler: Handler,
     pub(crate) callback_sync_group: SyncGroup,
+}
+
+#[zenoh_macros::unstable]
+impl<Handler> std::fmt::Debug for TransportEventsListener<Handler> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TransportEventsListener")
+            .field("inner", &self.inner)
+            .field("handler", &"..")
+            .field("callback_sync_group", &self.callback_sync_group)
+            .finish()
+    }
 }
 
 #[zenoh_macros::unstable]
@@ -239,6 +257,16 @@ pub struct TransportEventsListenerUndeclaration<Handler> {
 }
 
 #[zenoh_macros::unstable]
+impl<Handler> std::fmt::Debug for TransportEventsListenerUndeclaration<Handler> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TransportEventsListenerUndeclaration")
+            .field("listener", &self.listener)
+            .field("wait_callbacks", &self.wait_callbacks)
+            .finish()
+    }
+}
+
+#[zenoh_macros::unstable]
 impl<Handler> TransportEventsListenerUndeclaration<Handler> {
     #[zenoh_macros::internal_or_unstable]
     /// Block in undeclare operation until all currently running instances of transport events listener callback (if any) return.
@@ -304,6 +332,20 @@ pub struct TransportEventsListenerBuilder<'a, Handler, const BACKGROUND: bool = 
     session: &'a WeakSession,
     handler: Handler,
     history: bool,
+}
+
+#[zenoh_macros::unstable]
+impl<Handler, const BACKGROUND: bool> std::fmt::Debug
+    for TransportEventsListenerBuilder<'_, Handler, BACKGROUND>
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TransportEventsListenerBuilder")
+            .field("session", &"..")
+            .field("handler", &"..")
+            .field("history", &self.history)
+            .field("background", &BACKGROUND)
+            .finish()
+    }
 }
 
 #[zenoh_macros::unstable]

--- a/zenoh/src/api/builders/session.rs
+++ b/zenoh/src/api/builders/session.rs
@@ -12,9 +12,12 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-use std::future::{IntoFuture, Ready};
 #[cfg(feature = "shared-memory")]
 use std::sync::Arc;
+use std::{
+    fmt,
+    future::{IntoFuture, Ready},
+};
 
 use zenoh_core::{Resolvable, Wait};
 #[cfg(feature = "internal")]
@@ -46,6 +49,20 @@ where
     config: TryIntoConfig,
     #[cfg(feature = "shared-memory")]
     shm_clients: Option<Arc<ShmClientStorage>>,
+}
+
+impl<TryIntoConfig> fmt::Debug for OpenBuilder<TryIntoConfig>
+where
+    TryIntoConfig: std::convert::TryInto<crate::config::Config> + Send + 'static,
+    <TryIntoConfig as std::convert::TryInto<crate::config::Config>>::Error: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug = f.debug_struct("OpenBuilder");
+        debug.field("config", &"..");
+        #[cfg(feature = "shared-memory")]
+        debug.field("shm_clients", &self.shm_clients.as_ref().map(|_| ".."));
+        debug.finish()
+    }
 }
 
 impl<TryIntoConfig> OpenBuilder<TryIntoConfig>
@@ -133,6 +150,17 @@ pub struct InitBuilder {
     runtime: DynamicRuntime,
     aggregated_subscribers: Vec<OwnedKeyExpr>,
     aggregated_publishers: Vec<OwnedKeyExpr>,
+}
+
+#[zenoh_macros::internal]
+impl fmt::Debug for InitBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InitBuilder")
+            .field("runtime", &"..")
+            .field("aggregated_subscribers", &self.aggregated_subscribers)
+            .field("aggregated_publishers", &self.aggregated_publishers)
+            .finish()
+    }
 }
 
 #[zenoh_macros::internal]

--- a/zenoh/src/api/cancellation.rs
+++ b/zenoh/src/api/cancellation.rs
@@ -193,7 +193,7 @@ impl Default for CancellationToken {
 }
 
 #[cfg(feature = "unstable")]
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct CancelResult(CancellationToken);
 
 #[cfg(feature = "unstable")]

--- a/zenoh/src/api/config.rs
+++ b/zenoh/src/api/config.rs
@@ -201,6 +201,12 @@ pub struct Notifier<T> {
     inner: Arc<NotifierInner<T>>,
 }
 
+impl<T> fmt::Debug for Notifier<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Notifier").field(&"..").finish()
+    }
+}
+
 impl<T> Clone for Notifier<T> {
     fn clone(&self) -> Self {
         Self {

--- a/zenoh/src/api/handlers/callback.rs
+++ b/zenoh/src/api/handlers/callback.rs
@@ -14,7 +14,7 @@
 
 //! Callback handler trait.
 
-use std::sync::Arc;
+use std::{fmt, sync::Arc};
 
 use crate::api::handlers::IntoHandler;
 
@@ -72,6 +72,15 @@ impl<F> DropperTrait for Dropper<F> where F: FnOnce() + Send + Sync {}
 pub struct Callback<T> {
     callable: Arc<dyn CallbackImpl<T>>,
     drop: Option<Arc<dyn DropperTrait + Send + Sync>>,
+}
+
+impl<T> fmt::Debug for Callback<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Callback")
+            .field("callable", &"..")
+            .field("has_drop", &self.drop.is_some())
+            .finish()
+    }
 }
 
 impl<T> Clone for Callback<T> {
@@ -178,6 +187,18 @@ where
 {
     pub callback: Callback,
     pub drop: DropFn,
+}
+
+impl<Callback, DropFn> fmt::Debug for CallbackDrop<Callback, DropFn>
+where
+    DropFn: FnMut() + Send + Sync + 'static,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CallbackDrop")
+            .field("callback", &"..")
+            .field("drop", &"..")
+            .finish()
+    }
 }
 
 impl<Callback, DropFn> Drop for CallbackDrop<Callback, DropFn>

--- a/zenoh/src/api/handlers/fifo.rs
+++ b/zenoh/src/api/handlers/fifo.rs
@@ -31,6 +31,7 @@ use crate::api::handlers::{callback::Callback, IntoHandler, API_DATA_RECEPTION_C
 /// E.g., a slow subscriber could block the underlying Zenoh thread because it is not emptying the
 /// [`FifoChannel`] fast enough. In this case, you may want to look into [`handlers::RingChannel`](crate::api::handlers::RingChannel) that
 /// will drop samples when full.
+#[derive(Debug)]
 pub struct FifoChannel {
     capacity: usize,
 }
@@ -195,6 +196,7 @@ impl<T> IntoIterator for FifoChannelHandler<T> {
 }
 
 /// An iterator over the msgs received from a channel.
+#[derive(Debug)]
 pub struct Iter<'a, T>(flume::Iter<'a, T>);
 
 impl<T> Iterator for Iter<'_, T> {
@@ -206,6 +208,7 @@ impl<T> Iterator for Iter<'_, T> {
 }
 
 /// A non-blocking iterator over the msgs received from a channel.
+#[derive(Debug)]
 pub struct TryIter<'a, T>(flume::TryIter<'a, T>);
 
 impl<T> Iterator for TryIter<'_, T> {
@@ -235,6 +238,7 @@ impl<T> ExactSizeIterator for Drain<'_, T> {
 }
 
 /// An owned iterator over the msgs received from a channel.
+#[derive(Debug)]
 pub struct IntoIter<T>(flume::IntoIter<T>);
 
 impl<T> Iterator for IntoIter<T> {
@@ -264,6 +268,7 @@ impl<T> FifoChannelHandler<T> {
 ///
 /// Can be created via [`FifoChannelHandler::recv_async`] or [`FifoChannelHandler::into_recv_async`].
 #[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
+#[derive(Debug)]
 pub struct RecvFut<'a, T>(flume::r#async::RecvFut<'a, T>);
 
 impl<T> Future for RecvFut<'_, T> {
@@ -297,7 +302,7 @@ impl<T> FifoChannelHandler<T> {
 /// A stream which allows asynchronously receiving messages.
 ///
 /// Can be created via [`FifoChannelHandler::stream`] or [`FifoChannelHandler::into_stream`].
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct RecvStream<'a, T>(flume::r#async::RecvStream<'a, T>);
 
 impl<T> RecvStream<'_, T> {

--- a/zenoh/src/api/handlers/mod.rs
+++ b/zenoh/src/api/handlers/mod.rs
@@ -44,7 +44,7 @@ pub trait IntoHandler<T> {
 /// separate type was created to make it possible to change the default handler implementation
 /// without breaking API changes.
 #[repr(transparent)]
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct DefaultHandler(FifoChannel);
 
 impl<T: Send + 'static> IntoHandler<T> for DefaultHandler {

--- a/zenoh/src/api/handlers/ring.rs
+++ b/zenoh/src/api/handlers/ring.rs
@@ -30,6 +30,7 @@ use crate::api::{
 ///
 /// [`RingChannel`] implements FIFO semantics with a dropping strategy when full.
 /// The oldest elements will be dropped when newer ones arrive.
+#[derive(Debug)]
 pub struct RingChannel {
     capacity: usize,
 }
@@ -47,11 +48,13 @@ impl Default for RingChannel {
     }
 }
 
+#[derive(Debug)]
 struct RingChannelInner<T> {
     ring: std::sync::Mutex<RingBuffer<T>>,
     not_empty: flume::Receiver<()>,
 }
 
+#[derive(Debug)]
 pub struct RingChannelHandler<T> {
     ring: Weak<RingChannelInner<T>>,
 }

--- a/zenoh/src/api/info.rs
+++ b/zenoh/src/api/info.rs
@@ -54,6 +54,12 @@ pub struct SessionInfo {
     pub(crate) session: WeakSession,
 }
 
+impl std::fmt::Debug for SessionInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("SessionInfo").field(&"..").finish()
+    }
+}
+
 impl SessionInfo {
     /// Return the [`ZenohId`](crate::session::ZenohId) of the current zenoh [`Session`](crate::Session).
     ///

--- a/zenoh/src/api/key_expr.rs
+++ b/zenoh/src/api/key_expr.rs
@@ -13,6 +13,7 @@
 //
 use std::{
     convert::{TryFrom, TryInto},
+    fmt,
     future::{IntoFuture, Ready},
     str::FromStr,
     sync::Arc,
@@ -602,6 +603,15 @@ impl<'a> UndeclarableSealed<&'a Session> for KeyExpr<'a> {
 pub struct KeyExprUndeclaration<'a> {
     session: &'a Session,
     expr: KeyExpr<'a>,
+}
+
+impl fmt::Debug for KeyExprUndeclaration<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("KeyExprUndeclaration")
+            .field("session", &"..")
+            .field("expr", &self.expr)
+            .finish()
+    }
 }
 
 impl Resolvable for KeyExprUndeclaration<'_> {

--- a/zenoh/src/api/liveliness.rs
+++ b/zenoh/src/api/liveliness.rs
@@ -14,6 +14,7 @@
 
 use std::{
     convert::TryInto,
+    fmt,
     future::{IntoFuture, Ready},
 };
 
@@ -89,6 +90,12 @@ use crate::api::{
 /// ```
 pub struct Liveliness<'a> {
     pub(crate) session: &'a Session,
+}
+
+impl fmt::Debug for Liveliness<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Liveliness").field(&"..").finish()
+    }
 }
 
 impl<'a> Liveliness<'a> {

--- a/zenoh/src/api/liveliness.rs
+++ b/zenoh/src/api/liveliness.rs
@@ -253,6 +253,7 @@ pub struct LivelinessToken {
 /// # }
 /// ```
 #[must_use = "Resolvables do nothing unless you resolve them using `.await` or `zenoh::Wait::wait`"]
+#[derive(Debug)]
 pub struct LivelinessTokenUndeclaration(LivelinessToken);
 
 impl Resolvable for LivelinessTokenUndeclaration {

--- a/zenoh/src/api/matching.rs
+++ b/zenoh/src/api/matching.rs
@@ -153,11 +153,20 @@ pub(crate) struct MatchingListenerInner {
 /// }
 /// # }
 /// ```
-#[derive(Debug)]
 pub struct MatchingListener<Handler> {
     pub(crate) inner: MatchingListenerInner,
     pub(crate) handler: Handler,
     pub(crate) callback_sync_group: SyncGroup,
+}
+
+impl<Handler> fmt::Debug for MatchingListener<Handler> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MatchingListener")
+            .field("inner", &self.inner)
+            .field("handler", &"..")
+            .field("callback_sync_group", &self.callback_sync_group)
+            .finish()
+    }
 }
 
 impl<Handler> MatchingListener<Handler> {
@@ -250,6 +259,15 @@ impl<Handler> std::ops::DerefMut for MatchingListener<Handler> {
 pub struct MatchingListenerUndeclaration<Handler> {
     listener: MatchingListener<Handler>,
     wait_callbacks: bool,
+}
+
+impl<Handler> fmt::Debug for MatchingListenerUndeclaration<Handler> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MatchingListenerUndeclaration")
+            .field("listener", &self.listener)
+            .field("wait_callbacks", &self.wait_callbacks)
+            .finish()
+    }
 }
 
 impl<Handler> MatchingListenerUndeclaration<Handler> {

--- a/zenoh/src/api/publisher.rs
+++ b/zenoh/src/api/publisher.rs
@@ -423,6 +423,15 @@ pub struct PublisherUndeclaration<'a> {
     wait_callbacks: bool,
 }
 
+impl fmt::Debug for PublisherUndeclaration<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PublisherUndeclaration")
+            .field("publisher", &self.publisher)
+            .field("wait_callbacks", &self.wait_callbacks)
+            .finish()
+    }
+}
+
 impl<'a> PublisherUndeclaration<'a> {
     #[zenoh_macros::internal_or_unstable]
     /// Block in undeclare operation until all currently running instances of matching listeners' callbacks (if any) return.

--- a/zenoh/src/api/querier.rs
+++ b/zenoh/src/api/querier.rs
@@ -304,6 +304,15 @@ pub struct QuerierUndeclaration<'a> {
     wait_callbacks: bool,
 }
 
+impl fmt::Debug for QuerierUndeclaration<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("QuerierUndeclaration")
+            .field("querier", &self.querier)
+            .field("wait_callbacks", &self.wait_callbacks)
+            .finish()
+    }
+}
+
 impl<'a> QuerierUndeclaration<'a> {
     #[zenoh_macros::internal_or_unstable]
     /// Block in undeclare operation until all currently running instances of reply and matching listeners' callbacks (if any) return.

--- a/zenoh/src/api/queryable.rs
+++ b/zenoh/src/api/queryable.rs
@@ -527,6 +527,16 @@ pub struct ReplySample<'a> {
 }
 
 #[zenoh_macros::internal]
+impl fmt::Debug for ReplySample<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReplySample")
+            .field("query", &self.query)
+            .field("sample", &self.sample)
+            .finish()
+    }
+}
+
+#[zenoh_macros::internal]
 impl Resolvable for ReplySample<'_> {
     type To = ZResult<()>;
 }
@@ -636,6 +646,15 @@ pub struct QueryableUndeclaration<Handler> {
     wait_callbacks: bool,
 }
 
+impl<Handler> fmt::Debug for QueryableUndeclaration<Handler> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("QueryableUndeclaration")
+            .field("queryable", &self.queryable)
+            .field("wait_callbacks", &self.wait_callbacks)
+            .finish()
+    }
+}
+
 impl<Handler> QueryableUndeclaration<Handler> {
     #[zenoh_macros::internal_or_unstable]
     /// Block in undeclare operation until all currently running instances of query callbacks (if any) return.
@@ -722,11 +741,20 @@ impl<Handler> IntoFuture for QueryableUndeclaration<Handler> {
 /// # }
 /// ```
 #[non_exhaustive]
-#[derive(Debug)]
 pub struct Queryable<Handler> {
     pub(crate) inner: QueryableInner,
     pub(crate) handler: Handler,
     pub(crate) callback_sync_group: SyncGroup,
+}
+
+impl<Handler> fmt::Debug for Queryable<Handler> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Queryable")
+            .field("inner", &self.inner)
+            .field("handler", &"..")
+            .field("callback_sync_group", &self.callback_sync_group)
+            .finish()
+    }
 }
 
 impl<Handler> Queryable<Handler> {

--- a/zenoh/src/api/subscriber.rs
+++ b/zenoh/src/api/subscriber.rs
@@ -79,6 +79,15 @@ pub struct SubscriberUndeclaration<Handler> {
     wait_callbacks: bool,
 }
 
+impl<Handler> fmt::Debug for SubscriberUndeclaration<Handler> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SubscriberUndeclaration")
+            .field("subscriber", &self.subscriber)
+            .field("wait_callbacks", &self.wait_callbacks)
+            .finish()
+    }
+}
+
 impl<Handler> SubscriberUndeclaration<Handler> {
     #[zenoh_macros::internal_or_unstable]
     /// Block in undeclare operation until all currently running instances of subscriber callbacks (if any) return.
@@ -150,11 +159,20 @@ impl<Handler> IntoFuture for SubscriberUndeclaration<Handler> {
 /// # }
 /// ```
 #[non_exhaustive]
-#[derive(Debug)]
 pub struct Subscriber<Handler> {
     pub(crate) inner: SubscriberInner,
     pub(crate) handler: Handler,
     pub(crate) callback_sync_group: SyncGroup,
+}
+
+impl<Handler> fmt::Debug for Subscriber<Handler> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Subscriber")
+            .field("inner", &self.inner)
+            .field("handler", &"..")
+            .field("callback_sync_group", &self.callback_sync_group)
+            .finish()
+    }
 }
 
 impl<Handler> Subscriber<Handler> {

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -114,6 +114,19 @@ impl ConfigValidator for AdminSpace {
     }
 }
 
+impl std::fmt::Debug for AdminSpace {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AdminSpace")
+            .field("zid", &self.zid)
+            .field("queryable_id", &self.queryable_id)
+            .field("primitives", &"..")
+            .field("mappings", &"..")
+            .field("handlers_len", &self.handlers.len())
+            .field("context", &"..")
+            .finish()
+    }
+}
+
 impl AdminSpace {
     #[cfg(all(feature = "plugins", feature = "runtime_plugins"))]
     fn start_plugin(

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -27,6 +27,7 @@ use std::sync::{Mutex, MutexGuard};
 use std::{
     any::Any,
     collections::HashSet,
+    fmt,
     ops::Deref,
     sync::{
         atomic::{AtomicU32, Ordering},
@@ -100,6 +101,7 @@ use crate::{
 /// State of current lazily-initialized [`ShmProvider`](ShmProvider) associated with [`Runtime`](Runtime)
 #[cfg(feature = "shared-memory")]
 #[zenoh_macros::unstable]
+#[derive(Debug)]
 pub enum ShmProviderState {
     Disabled,
     Initializing,
@@ -540,6 +542,14 @@ pub struct WeakRuntime {
     state: Weak<RuntimeState>,
 }
 
+impl fmt::Debug for WeakRuntime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WeakRuntime")
+            .field("is_live", &self.state.strong_count().gt(&0))
+            .finish()
+    }
+}
+
 impl WeakRuntime {
     pub fn upgrade(&self) -> Option<Runtime> {
         self.state.upgrade().map(|state| Runtime { state })
@@ -556,6 +566,28 @@ pub struct RuntimeBuilder {
     subregions: Option<Vec<Region>>,
     #[cfg(test)]
     disable_async_tree_computation: bool,
+}
+
+impl fmt::Debug for RuntimeBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug = f.debug_struct("RuntimeBuilder");
+        debug.field("config", &self.config);
+        #[cfg(feature = "plugins")]
+        debug.field(
+            "plugins_manager",
+            &self.plugins_manager.as_ref().map(|_| ".."),
+        );
+        #[cfg(feature = "shared-memory")]
+        debug.field("shm_clients", &self.shm_clients.as_ref().map(|_| ".."));
+        #[cfg(test)]
+        debug.field("subregions", &self.subregions);
+        #[cfg(test)]
+        debug.field(
+            "disable_async_tree_computation",
+            &self.disable_async_tree_computation,
+        );
+        debug.finish()
+    }
 }
 
 impl RuntimeBuilder {
@@ -732,8 +764,24 @@ pub struct Runtime {
     state: Arc<RuntimeState>,
 }
 
+impl fmt::Debug for Runtime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Runtime")
+            .field("zid", &self.state.zid)
+            .field("whatami", &self.state.whatami)
+            .field("namespace", &self.state.namespace)
+            .finish_non_exhaustive()
+    }
+}
+
 #[derive(Clone)]
 pub struct DynamicRuntime(Arc<dyn IRuntime>);
+
+impl fmt::Debug for DynamicRuntime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("DynamicRuntime").field(&"..").finish()
+    }
+}
 
 impl Deref for DynamicRuntime {
     type Target = Arc<dyn IRuntime>;

--- a/zenoh/src/net/runtime/orchestrator.rs
+++ b/zenoh/src/net/runtime/orchestrator.rs
@@ -50,6 +50,7 @@ const SCOUT_INITIAL_PERIOD: Duration = Duration::from_millis(1_000);
 const SCOUT_MAX_PERIOD: Duration = Duration::from_millis(8_000);
 const SCOUT_PERIOD_INCREASE_FACTOR: u32 = 2;
 
+#[derive(Debug)]
 pub enum Loop {
     Continue,
     Break,

--- a/zenoh/tests/regions/main.rs
+++ b/zenoh/tests/regions/main.rs
@@ -49,7 +49,7 @@ use zenoh_core::ztimeout;
 
 const TIMEOUT: Duration = Duration::from_secs(60);
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct Node {
     c: zenoh::Config,
 }
@@ -192,6 +192,7 @@ pub fn unbounded_sink() -> UnboundedSinkHandler {
     UnboundedSinkHandler
 }
 
+#[derive(Debug)]
 pub struct UnboundedSinkHandler;
 
 impl<T> IntoHandler<T> for UnboundedSinkHandler
@@ -214,6 +215,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub struct UnboundedSink<T>(Arc<RwLock<Vec<T>>>);
 
 impl<T> UnboundedSink<T> {


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->
This PR adds Debug implementations for public types across the workspace so the codebase is clean under `missing_debug_implementations`.

### What does this PR do?
<!-- Describe the changes and their purpose -->
* Added `#[derive(Debug)]` for simple public data/config/test helper types.
* Added manual Debug implementations for public types containing callbacks, handlers, runtime state, SHM internals, task handles, channels, or trait objects.
* Avoided unnecessary generic `T: Debug / Handler: Debug` bounds by summarizing opaque fields where appropriate.
* Removed an unnecessary public helper type as part of the initial cleanup.

Have already tested with 

```bash
RUSTFLAGS="-W missing_debug_implementations" cargo check
RUSTFLAGS="-W missing_debug_implementations" cargo check --all-features
RUSTFLAGS="-W missing_debug_implementations" cargo clippy --all-features --all-targets -- -D warnings
```

### Why is this change needed?
<!-- Explain the motivation or problem being solved -->
Adding Debug to public types improves the baseline ergonomics and diagnosability of the public API surface. Even when a type is not primarily meant to be formatted by end users, public types often appear in tests, logs, assertions, error reports, and downstream wrapper code. Having Debug available makes those workflows easier and keeps the API consistent across crates.

This is recommended by [the Rust document](https://doc.rust-lang.org/std/fmt/index.html#fmtdisplay-vs-fmtdebug)

> fmt::Debug implementations should be implemented for all public types.

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->
https://github.com/eclipse-zenoh/zenoh/issues/967

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->