### PR TITLE
Avoid blocking peer connector termination in routing paths

### DIFF
--- a/zenoh/src/net/protocol/gossip.rs
+++ b/zenoh/src/net/protocol/gossip.rs
@@ -409,11 +409,13 @@ impl Gossip {
             }
         }
         if (!self.wait_declares) || src_whatami != WhatAmI::Peer {
-            zenoh_runtime::ZRuntime::Net.block_in_place(
-                strong_runtime
+            let runtime = strong_runtime.clone();
+            strong_runtime.spawn(async move {
+                runtime
                     .start_conditions()
-                    .terminate_peer_connector_zid(src),
-            );
+                    .terminate_peer_connector_zid(src)
+                    .await;
+            });
         }
     }
 

--- a/zenoh/src/net/routing/hat/peer/interests.rs
+++ b/zenoh/src/net/routing/hat/peer/interests.rs
@@ -280,17 +280,22 @@ impl HatInterestTrait for Hat {
                 return Noop;
             }
 
-            zenoh_runtime::ZRuntime::Net.block_in_place(async move {
-                if let Some(runtime) = &ctx.tables.runtime {
-                    if let Some(runtime) = runtime.upgrade() {
-                        tracing::debug!("Terminating peer connector");
-                        runtime
-                            .start_conditions()
-                            .terminate_peer_connector_zid(ctx.src_face.zid)
-                            .await
-                    }
-                }
-            });
+            if let Some(runtime) = ctx
+                .tables
+                .runtime
+                .as_ref()
+                .and_then(|runtime| runtime.upgrade())
+            {
+                let task_runtime = runtime.clone();
+                let zid = ctx.src_face.zid;
+                runtime.spawn(async move {
+                    tracing::debug!("Terminating peer connector");
+                    task_runtime
+                        .start_conditions()
+                        .terminate_peer_connector_zid(zid)
+                        .await
+                });
+            }
 
             Noop
         } else {


### PR DESCRIPTION
Fixes #2581.

This PR avoids synchronously blocking routing/control paths while marking peer connector start conditions as terminated.

In the reproducer from #2581, a peer-to-peer churn workload can eventually stall publisher `put()` calls. The captured backtraces seem to show routing/control paths blocked around peer connector termination while other threads are waiting on routing table/control locks. In particular, `route_declare_final()` and `Gossip::link_states()` could call:

```rust
ZRuntime::Net.block_in_place(...terminate_peer_connector_zid(...))
```

from paths that may still be handling routing state updates.

`terminate_peer_connector_zid()` only updates `Runtime::start_conditions()` and notifies startup waiters. From what I can tell, it does not need to complete synchronously while the routing path is still active. This PR changes those calls to spawn the termination update on the runtime instead of blocking in place.

This keeps the routing path from waiting on the async `StartConditions` mutex while routing/control locks may be held.

Validation:

- `cargo check -p zenoh`
- Reproducer from #2581:
  - Before this fix: publisher `put()` calls could stall, with `slowest_put` reaching the 5s stall threshold after roughly one hour. This matches the issue report, where a longer run eventually entered a sustained stall after about 4 hours.
  - With this fix: the same stress workload ran for about 10 hours without stalling. The observed `slowest_put` stayed around 400ms, well below the 5s stall threshold.

Discussion:

This is intended as a small and focused fix. It preserves the existing behavior of terminating the peer connector start condition, but performs that update asynchronously instead of blocking the routing path.

A possibly cleaner but more invasive alternative would be to restructure the routing/gossip paths so they collect side effects such as "terminate this peer connector zid" while holding routing state, then execute those side effects only after the routing table/control locks have been released. That would preserve synchronous completion without blocking inside the locked section, but it would require broader changes across the routing trait/call structure.

I'm opening this minimal version first because it directly addresses the observed lock-chain risk with a small diff. I'd be very happy to adjust the approach if you guys prefer the more explicit "defer side effects until after locks are dropped" design.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

**No specific label requirements detected.**

Current labels: _No labels_

Add one of these labels to this PR to see relevant checklist items: `api-sync`, `breaking-change`, `bug`, `ci`, `dependencies`, `documentation`, `enhancement`, `new feature`, `internal`

*This section updates automatically when labels change.*

<!-- 🏷️ Label-Based Checklist END -->