### PR TITLE
fix(buffers): reject oversized zslice reads

### DIFF
--- a/commons/zenoh-buffers/src/slice.rs
+++ b/commons/zenoh-buffers/src/slice.rs
@@ -181,6 +181,9 @@ impl Reader for &[u8] {
     }
 
     fn read_zslice(&mut self, len: usize) -> Result<ZSlice, DidntRead> {
+        if self.len() < len {
+            return Err(DidntRead);
+        }
         // SAFETY: the buffer is initialized by the `read_exact()` function. Should the `read_exact()`
         // function fail, the `read_zslice()` will fail as well and return None. It is hence guaranteed
         // that any `ZSlice` returned by `read_zslice()` points to a fully initialized buffer.

--- a/commons/zenoh-buffers/src/zbuf.rs
+++ b/commons/zenoh-buffers/src/zbuf.rs
@@ -263,6 +263,9 @@ impl Reader for ZBufReader<'_> {
     }
 
     fn read_zslice(&mut self, len: usize) -> Result<ZSlice, DidntRead> {
+        if self.remaining() < len {
+            return Err(DidntRead);
+        }
         let slice = self.inner.slices.get(self.cursor.slice).ok_or(DidntRead)?;
         match (slice.len() - self.cursor.byte).cmp(&len) {
             cmp::Ordering::Less => {

--- a/commons/zenoh-buffers/tests/readwrite.rs
+++ b/commons/zenoh-buffers/tests/readwrite.rs
@@ -219,6 +219,29 @@ fn buffer_zslice() {
 }
 
 #[test]
+fn read_zslice_oversized_length_fails_without_consuming() {
+    // This test targets the reader-layer contract directly.
+    // In real packet decoding, a length is first decoded from the wire and then
+    // passed into `read_zslice(len)`. Here we inject the oversized `len`
+    // directly to verify the readers reject it before trying to allocate.
+    let bytes = [1_u8];
+
+    let mut slice_reader = bytes.as_slice().reader();
+    assert!(slice_reader.read_zslice(2).is_err());
+    assert_eq!(slice_reader.remaining(), 1);
+
+    let mut zslice_reader = ZSlice::from(bytes.to_vec());
+    assert!(zslice_reader.read_zslice(2).is_err());
+    assert_eq!(zslice_reader.remaining(), 1);
+
+    let mut zbuf = ZBuf::empty();
+    zbuf.push_zslice(bytes.to_vec().into());
+    let mut zbuf_reader = zbuf.reader();
+    assert!(zbuf_reader.read_zslice(2).is_err());
+    assert_eq!(zbuf_reader.remaining(), 1);
+}
+
+#[test]
 fn buffer_siphon() {
     let capacity = 1 + u8::MAX as usize;
 


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->
This PR hardens zenoh-buffers against oversized ZSlice read lengths by rejecting impossible reads before any allocation happens.

### What does this PR do?
<!-- Describe the changes and their purpose -->
The change adds early bounds checks in buffer readers so read_zslice(len) fails immediately when len exceeds the remaining input, and adds a regression test covering the reader-layer contract.

### Why is this change needed?
<!-- Explain the motivation or problem being solved -->
A fuzzed OPEN SYN packet exposed that ZSlice decoding could attempt a large allocation from an attacker-controlled length before discovering the input was truncated. Rejecting oversized lengths up front makes the reader behavior safer and avoids unnecessary allocation on invalid input.

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->
https://github.com/eclipse-zenoh/zenoh/issues/2592

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [x] **Reproduction test added** - Test that fails on main branch without the fix
- [x] **Test passes with fix** - The reproduction test passes with your changes
- [x] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->