### PR TITLE
chore: update zenoh-test to use workspace version

### DIFF
--- a/commons/zenoh-pinned-deps-1-75/Cargo.toml
+++ b/commons/zenoh-pinned-deps-1-75/Cargo.toml
@@ -47,6 +47,7 @@ pest_meta = "=2.8.0"
 potential_utf = "=0.1.0"
 prost = "=0.14.1"
 prost-derive = "=0.14.1"
+rcgen = "=0.14.7"
 rustc-hash = "=2.1.1"
 serde_spanned = "=1.0.1"
 serde_with = "=3.14.1"
@@ -92,6 +93,7 @@ ignored = [
   "potential_utf",
   "prost",
   "prost-derive",
+  "rcgen",
   "rustc-hash",
   "security-framework",
   "serde_spanned",

--- a/commons/zenoh-test/Cargo.toml
+++ b/commons/zenoh-test/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 name = "zenoh-test"
 publish = false
-version = "1.9.0"
+version = { workspace = true }
 
 [features]
 internal = ["zenoh-config/internal", "zenoh/internal"]

--- a/commons/zenoh-test/Cargo.toml
+++ b/commons/zenoh-test/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2021"
+edition = { workspace = true }
 name = "zenoh-test"
 publish = false
 version = { workspace = true }


### PR DESCRIPTION
## Description
zenoh-test crate introduced in https://github.com/eclipse-zenoh/zenoh/pull/2573 fails the release workflow https://github.com/eclipse-zenoh/zenoh/actions/runs/25643820800 due to the pinned version. It should use the workspace version instead.

### What does this PR do?
Changes zenoh-test Cargo.toml to use version from the workspace instead of pinning it to 1.9.0

### Why is this change needed?
Avoid failures in the release workflow

### Related Issues
https://github.com/eclipse-zenoh/zenoh/pull/2573

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->