### PR TITLE
fix(codec): reject impossible scouting locator counts

### DIFF
--- a/commons/zenoh-codec/src/core/locator.rs
+++ b/commons/zenoh-codec/src/core/locator.rs
@@ -69,11 +69,8 @@ where
     type Error = DidntRead;
 
     fn read(self, reader: &mut R) -> Result<Vec<Locator>, Self::Error> {
-        let len = self.read(&mut *reader)?;
-        if len > reader.remaining() {
-            return Err(DidntRead);
-        }
-        let mut vec: Vec<Locator> = Vec::with_capacity(len);
+        let len: usize = self.read(&mut *reader)?;
+        let mut vec = Vec::new();
         for _ in 0..len {
             vec.push(self.read(&mut *reader)?);
         }

--- a/commons/zenoh-codec/src/core/locator.rs
+++ b/commons/zenoh-codec/src/core/locator.rs
@@ -70,6 +70,9 @@ where
 
     fn read(self, reader: &mut R) -> Result<Vec<Locator>, Self::Error> {
         let len = self.read(&mut *reader)?;
+        if len > reader.remaining() {
+            return Err(DidntRead);
+        }
         let mut vec: Vec<Locator> = Vec::with_capacity(len);
         for _ in 0..len {
             vec.push(self.read(&mut *reader)?);

--- a/commons/zenoh-codec/tests/malformed_inputs.rs
+++ b/commons/zenoh-codec/tests/malformed_inputs.rs
@@ -26,8 +26,8 @@ fn fixed_zid() -> ZenohIdProto {
 fn hello_rejects_locator_count_larger_than_remaining_input() {
     // Start from a valid HELLO with one locator, then corrupt only the
     // locator-count prefix into an absurdly large varint. The decoder should
-    // reject that malformed locator list before allocating attacker-controlled
-    // Vec<Locator> capacity.
+    // fail cleanly once it runs out of bytes for the declared locator list,
+    // without preallocating from that attacker-controlled count.
     let hello = HelloProto {
         version: 1,
         whatami: WhatAmI::Client,

--- a/commons/zenoh-codec/tests/malformed_inputs.rs
+++ b/commons/zenoh-codec/tests/malformed_inputs.rs
@@ -1,0 +1,60 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+use zenoh_buffers::{reader::HasReader, writer::HasWriter};
+use zenoh_codec::{RCodec, WCodec, Zenoh080};
+use zenoh_protocol::{
+    core::{Locator, WhatAmI, ZenohIdProto},
+    scouting::{HelloProto, ScoutingMessage},
+};
+
+fn fixed_zid() -> ZenohIdProto {
+    ZenohIdProto::try_from([0x14, 0x20, 0x30, 0xff].as_slice()).expect("fixed zid must be valid")
+}
+
+#[test]
+fn hello_rejects_locator_count_larger_than_remaining_input() {
+    // Start from a valid HELLO with one locator, then corrupt only the
+    // locator-count prefix into an absurdly large varint. The decoder should
+    // reject that malformed locator list before allocating attacker-controlled
+    // Vec<Locator> capacity.
+    let hello = HelloProto {
+        version: 1,
+        whatami: WhatAmI::Client,
+        zid: fixed_zid(),
+        locators: vec![Locator::new("tcp", "127.0.0.1:7447", "").expect("locator must be valid")],
+    };
+
+    let codec = Zenoh080::new();
+    let mut bytes = vec![];
+    let mut writer = bytes.writer();
+    codec
+        .write(&mut writer, &ScoutingMessage::from(hello))
+        .unwrap();
+
+    // HELLO layout here is:
+    //   [0]    header
+    //   [1]    version
+    //   [2]    flags
+    //   [3..7] zid (4 bytes)
+    //   [7]    locator_count
+    //   [8]    locator_len
+    //   [9..]  locator_bytes
+    // Replace the valid one-byte locator_count with a huge varint and leave the
+    // remaining payload unchanged, so the declared count is impossible.
+    bytes.splice(7..8, [255, 255, 255, 255, 255, 255, 255, 255, 0]);
+
+    let mut reader = bytes.as_slice().reader();
+    let decoded: Result<ScoutingMessage, _> = codec.read(&mut reader);
+    assert!(decoded.is_err());
+}


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->
This PR hardens scouting HELLO decoding against malformed locator counts that could otherwise trigger a large allocation during decode.

### What does this PR do?
<!-- Describe the changes and their purpose -->
The locator-list decoder now avoids preallocating from the declared locator count and instead grows the vector only as locators are actually decoded, while preserving clean decode failure on truncated input.

### Why is this change needed?
<!-- Explain the motivation or problem being solved -->
HELLO messages are decoded from untrusted input, so the declared locator count must not directly determine memory allocation size. The decoder should allocate only in proportion to the locators that are actually present and successfully parsed, and it should fail cleanly when the input is truncated or malformed. This keeps the decode path robust against malformed locator lists.

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->
https://github.com/eclipse-zenoh/zenoh/issues/2592

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [x] **Reproduction test added** - Test that fails on main branch without the fix
- [x] **Test passes with fix** - The reproduction test passes with your changes
- [x] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->