### PR TITLE
test(rest): use zenoh-test peer setup in plugin tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5460,6 +5460,7 @@ dependencies = [
  "tracing",
  "zenoh",
  "zenoh-plugin-trait",
+ "zenoh-test",
 ]
 
 [[package]]

--- a/plugins/zenoh-plugin-rest/Cargo.toml
+++ b/plugins/zenoh-plugin-rest/Cargo.toml
@@ -63,6 +63,7 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 clap = { workspace = true }
+zenoh-test = { workspace = true }
 
 [[example]]
 name = "z_serve_sse"

--- a/plugins/zenoh-plugin-rest/src/lib.rs
+++ b/plugins/zenoh-plugin-rest/src/lib.rs
@@ -572,36 +572,21 @@ mod tests {
     use futures::{FutureExt, StreamExt};
     use tokio::time::timeout;
     use tower::ServiceExt;
-    use zenoh::{bytes::Encoding, sample::SampleKind, Config, Session, Wait};
+    use zenoh::{bytes::Encoding, sample::SampleKind, Session, Wait};
+    use zenoh_test::TestSessions;
 
     use crate::app;
 
-    const TEST_PORTS: [u16; 3] = [42000, 42001, 42002];
-
-    async fn setup(port: u16) -> (Session, Session) {
-        let mut config1 = Config::default();
-        config1.scouting.multicast.set_enabled(Some(false)).unwrap();
-        config1
-            .listen
-            .endpoints
-            .set(vec![format!("tcp/127.0.0.1:{}", port).parse().unwrap()])
-            .unwrap();
-
-        let mut config2 = Config::default();
-        config2.scouting.multicast.set_enabled(Some(false)).unwrap();
-        config2
-            .connect
-            .endpoints
-            .set(vec![format!("tcp/127.0.0.1:{}", port).parse().unwrap()])
-            .unwrap();
-        let (s1, s2) = tokio::try_join!(zenoh::open(config1), zenoh::open(config2)).unwrap();
+    async fn setup() -> (TestSessions, Session, Session) {
+        let mut test_sessions = TestSessions::new();
+        let (s1, s2) = test_sessions.open_pairs().await;
         tokio::time::sleep(Duration::from_secs(1)).await;
-        (s1, s2)
+        (test_sessions, s1, s2)
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn publish() {
-        let (pub_session, sub_session) = setup(TEST_PORTS[0]).await;
+        let (mut test_sessions, pub_session, sub_session) = setup().await;
         let subscriber = sub_session.declare_subscriber("test/**").await.unwrap();
         tokio::time::sleep(Duration::from_secs(1)).await;
         for method in [Method::PUT, Method::PATCH] {
@@ -639,11 +624,13 @@ mod tests {
         let sample = subscriber.try_recv().unwrap().unwrap();
         assert_eq!(sample.kind(), SampleKind::Delete);
         assert_eq!(sample.key_expr().as_str(), "test/publish");
+
+        test_sessions.close().await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn subscribe() {
-        let (pub_session, sub_session) = setup(TEST_PORTS[1]).await;
+        let (mut test_sessions, pub_session, sub_session) = setup().await;
         let response = app(sub_session.clone())
             .oneshot(
                 Request::builder()
@@ -685,11 +672,13 @@ mod tests {
                 }),
             );
         }
+
+        test_sessions.close().await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn query() {
-        let (get_session, queryable_session) = setup(TEST_PORTS[2]).await;
+        let (mut test_sessions, get_session, queryable_session) = setup().await;
         let _queryable = queryable_session
             .declare_queryable("test/**")
             .callback(|q| {
@@ -746,5 +735,7 @@ mod tests {
                 .unwrap();
             check(body);
         }
+
+        test_sessions.close().await;
     }
 }


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->
This PR updates the REST plugin tests to use the shared `zenoh-test` peer-to-peer setup helper instead of manually wiring two sessions over fixed TCP ports.

### What does this PR do?
<!-- Describe the changes and their purpose -->
Introduce zenoh-test to run the test in the REST plugin.


### Why is this change needed?
<!-- Explain the motivation or problem being solved -->
The previous REST plugin tests depended on a small set of hardcoded TCP ports, which makes them vulnerable to port collisions in parallel CI runs. Using the shared `zenoh-test` peer-to-peer helper lets the OS assign an available listener port and keeps the setup aligned with the rest of the test infrastructure.

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->
Failed here: https://github.com/eclipse-zenoh/zenoh/actions/runs/26084838129/job/76695199928

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->