### PR TITLE
fix(protocol): reject malformed endpoint parameter sections

### DIFF
--- a/commons/zenoh-protocol/src/core/endpoint.rs
+++ b/commons/zenoh-protocol/src/core/endpoint.rs
@@ -603,6 +603,8 @@ impl TryFrom<String> for EndPoint {
     fn try_from(s: String) -> Result<Self, Self::Error> {
         const ERR: &str =
             "Endpoints must be of the form <protocol>/<address>[?<metadata>][#<config>]";
+        const PARAM_ERR: &str =
+            "Endpoint metadata and config must contain at least one valid parameter with a non-empty key";
 
         let pidx = s
             .find(PROTO_SEPARATOR)
@@ -614,6 +616,9 @@ impl TryFrom<String> for EndPoint {
             (None, None) => Ok(EndPoint { inner: s }),
             // There is some metadata
             (Some(midx), None) if midx > pidx && !s[midx + 1..].is_empty() => {
+                if !parameters::is_well_formed(&s[midx + 1..]) {
+                    bail!("{}: {}", PARAM_ERR, s);
+                }
                 let mut inner = String::with_capacity(s.len());
                 inner.push_str(&s[..midx + 1]); // Includes metadata separator
                 parameters::from_iter_into(
@@ -624,6 +629,9 @@ impl TryFrom<String> for EndPoint {
             }
             // There is some config
             (None, Some(cidx)) if cidx > pidx && !s[cidx + 1..].is_empty() => {
+                if !parameters::is_well_formed(&s[cidx + 1..]) {
+                    bail!("{}: {}", PARAM_ERR, s);
+                }
                 let mut inner = String::with_capacity(s.len());
                 inner.push_str(&s[..cidx + 1]); // Includes config separator
                 parameters::from_iter_into(
@@ -639,6 +647,11 @@ impl TryFrom<String> for EndPoint {
                     && !s[midx + 1..cidx].is_empty()
                     && !s[cidx + 1..].is_empty() =>
             {
+                if !parameters::is_well_formed(&s[midx + 1..cidx])
+                    || !parameters::is_well_formed(&s[cidx + 1..])
+                {
+                    bail!("{}: {}", PARAM_ERR, s);
+                }
                 let mut inner = String::with_capacity(s.len());
                 inner.push_str(&s[..midx + 1]); // Includes metadata separator
 
@@ -726,6 +739,12 @@ fn endpoints() {
     assert!(EndPoint::from_str("udp#127.0.0.1:7447/").is_err());
     assert!(EndPoint::from_str("udp#127.0.0.1:7447/?").is_err());
     assert!(EndPoint::from_str("udp/127.0.0.1:7447?a=1#").is_err());
+    assert!(EndPoint::from_str("udp/127.0.0.1:7447?;;;").is_err());
+    assert!(EndPoint::from_str("udp/127.0.0.1:7447#;;;").is_err());
+    assert!(EndPoint::from_str("udp/127.0.0.1:7447?a=1#;;;").is_err());
+    assert!(EndPoint::from_str("udp/127.0.0.1:7447?=1").is_err());
+    assert!(EndPoint::from_str("udp/127.0.0.1:7447#=1").is_err());
+    assert!(EndPoint::from_str("udp/127.0.0.1:7447?a=1#=1").is_err());
 
     let endpoint = EndPoint::from_str("udp/127.0.0.1:7447").unwrap();
     assert_eq!(endpoint.as_str(), "udp/127.0.0.1:7447");

--- a/commons/zenoh-protocol/src/core/parameters.rs
+++ b/commons/zenoh-protocol/src/core/parameters.rs
@@ -111,6 +111,13 @@ pub fn values<'s>(s: &'s str, k: &str) -> impl DoubleEndedIterator<Item = &'s st
     }
 }
 
+/// Returns `true` if the parameter string contains at least one valid entry
+/// and none of its keys are empty.
+pub fn is_well_formed(s: &str) -> bool {
+    let mut iter = iter(s);
+    iter.clone().next().is_some() && iter.all(|(k, _)| !k.is_empty())
+}
+
 fn _insert<'s, I>(
     i: I,
     k: &'s str,


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->
This PR hardens `EndPoint ::from_str` so it rejects malformed metadata and config sections that cannot survive canonicalization.

### What does this PR do?
<!-- Describe the changes and their purpose -->
`EndPoint` parsing now requires `?metadata` and `#config` sections to contain at least one valid parameter entry, and all parsed parameter keys must be non-empty. This prevents malformed endpoint strings from being accepted and then normalized into a different or invalid canonical form.

### Why is this change needed?
<!-- Explain the motivation or problem being solved -->
`EndPoint ::from_str` should only accept parameter sections that remain valid after parsing and canonicalization. Malformed sections like `?;;;` or `#=1` were previously accepted even though canonicalization dropped or changed them, which made parse/stringify/parse inconsistent. Rejecting those inputs at parse time keeps endpoint parsing stable and predictable.

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->
https://github.com/eclipse-zenoh/zenoh/issues/2592

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [x] **Reproduction test added** - Test that fails on main branch without the fix
- [x] **Test passes with fix** - The reproduction test passes with your changes
- [x] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->