### PR TITLE
Reduce serialization in publisher fan-out and session close paths

### DIFF
--- a/io/zenoh-transport/src/unicast/manager.rs
+++ b/io/zenoh-transport/src/unicast/manager.rs
@@ -366,13 +366,23 @@ impl TransportManager {
             }
         }
 
-        let mut tu_guard = zasynclock!(self.state.unicast.transports)
+        let tu_guard = zasynclock!(self.state.unicast.transports)
             .drain()
             .map(|(_, v)| v)
             .collect::<Vec<Arc<dyn TransportUnicastTrait>>>();
-        for tu in tu_guard.drain(..) {
-            let _ = tu.close(close::reason::GENERIC).await;
-        }
+        // Close all unicast transports concurrently. Each `tu.close()` already
+        // performs its own per-transport serialization (wtable / link state),
+        // so concurrent execution does not change the per-transport cost — it
+        // only collapses the manager's wall-clock from N × cost to ≈ max(cost).
+        //
+        // Without this, `session.close()` on a peer connected to N other peers
+        // pays N × per-transport-close time, which under the 50-peer churn
+        // workload accumulates to multiple seconds and amplifies tail latency
+        // observed during peer restart cycles.
+        let close_futs = tu_guard
+            .into_iter()
+            .map(|tu| async move { tu.close(close::reason::GENERIC).await });
+        let _ = futures::future::join_all(close_futs).await;
     }
 
     /*************************************/

--- a/zenoh/src/net/routing/dispatcher/pubsub.rs
+++ b/zenoh/src/net/routing/dispatcher/pubsub.rs
@@ -321,18 +321,46 @@ pub fn route_data(
                 send_push(&dir.dst_face, msg, reliability);
             }
         } else {
-            let dirs = route
+            // Concurrent multi-destination fan-out.
+            //
+            // The previous loop dispatched each destination's `send_push`
+            // serially. For a `CongestionControl::Block` message the
+            // per-destination `send_push` can wait up to `wait_before_close`
+            // (default 5 s) when the destination's `TransmissionPipeline` is
+            // back-pressured (peer congested, transport tearing down, ...).
+            // With N peers in a full p2p mesh and K back-pressured pipelines,
+            // the serial loop accumulated K × wait_before_close inside a
+            // single `publisher.put(...).wait()` call (up to ~30 s observed
+            // on a 50-peer / 3-churner workload with the default 5 s wait).
+            //
+            // Each destination has its own face / pipeline / link, so the
+            // waits are mutually independent and safe to parallelize. Snapshot
+            // the destination set into owned `(Arc<FaceState>, Push)` pairs
+            // (the routing-table lock is dropped before the spawn), then
+            // dispatch one `ZRuntime::Net.spawn_blocking` task per
+            // destination. The total wall-clock for the fan-out is bounded by
+            // `max(per-face wait)`, not by their sum.
+            //
+            // Implementation notes:
+            // - `spawn_blocking` reuses tokio's shared blocking pool
+            //   (default cap ~512), so the per-put cost is an enqueue, not
+            //   an OS-thread create/destroy.
+            // - `futures::executor::block_on` is runtime-agnostic and is
+            //   used to wait for every JoinHandle on the calling thread.
+            //   The blocking work runs on tokio's separate blocking-pool
+            //   workers, so there is no nested-runtime deadlock even when
+            //   `route_data` is invoked from a tokio recv-task worker.
+            // - Single-destination case stays on the synchronous path to
+            //   avoid the (small) spawn / join overhead.
+            // - Panics in spawned tasks are propagated via `resume_unwind`,
+            //   preserving the pre-change fail-fast behavior.
+            let dispatch: Vec<(Arc<FaceState>, Push)> = route
                 .iter()
                 .filter(|dir| {
                     inter_region_filter(dir) && rtables.egress_filter(src_face, &dir.dst_face)
                 })
-                .collect::<Vec<&Direction>>();
-
-            drop(rtables);
-            for dir in dirs {
-                send_push(
-                    &dir.dst_face,
-                    &mut Push {
+                .map(|dir| {
+                    let push = Push {
                         wire_expr: dir.wire_expr.clone(),
                         ext_qos: msg.ext_qos,
                         ext_tstamp: None,
@@ -340,9 +368,58 @@ pub fn route_data(
                             node_id: dir.node_id,
                         },
                         payload: msg.payload.clone(),
-                    },
-                    reliability,
-                );
+                    };
+                    (dir.dst_face.clone(), push)
+                })
+                .collect();
+
+            drop(rtables);
+
+            if dispatch.len() <= 1 {
+                // Single destination: skip the spawn/join overhead and stay on
+                // the synchronous path.
+                for (dst_face, mut push) in dispatch {
+                    send_push(&dst_face, &mut push, reliability);
+                }
+            } else {
+                let mut joins = Vec::with_capacity(dispatch.len());
+                for (dst_face, mut push) in dispatch {
+                    joins.push(zenoh_runtime::ZRuntime::Net.spawn_blocking(move || {
+                        let sent = dst_face.primitives.send_push(&mut push, reliability);
+                        (dst_face, push, sent)
+                    }));
+                }
+                // Block synchronously on every task. Iterating in order is fine:
+                // tasks run in parallel on the blocking pool, so the cumulative
+                // wait equals the slowest task (not the sum).
+                for join in joins {
+                    let result: Result<_, tokio::task::JoinError> =
+                        futures::executor::block_on(join);
+                    match result {
+                        Ok((dst_face, push, sent)) => {
+                            #[cfg(feature = "stats")]
+                            if sent {
+                                payload_observer
+                                    .observe_payload(zenoh_stats::Tx, &dst_face, &push);
+                            }
+                            #[cfg(not(feature = "stats"))]
+                            {
+                                let _ = (dst_face, push, sent);
+                            }
+                        }
+                        Err(join_err) => {
+                            if join_err.is_panic() {
+                                std::panic::resume_unwind(join_err.into_panic());
+                            }
+                            // Cancellation should not happen here (we hold the
+                            // JoinHandle), but log it so we don't silently lose
+                            // a fanout slot if it ever does.
+                            tracing::error!(
+                                "concurrent fanout task cancelled unexpectedly: {join_err}"
+                            );
+                        }
+                    }
+                }
             }
         }
     }

--- a/zenoh/src/net/routing/hat/peer/interests.rs
+++ b/zenoh/src/net/routing/hat/peer/interests.rs
@@ -280,17 +280,32 @@ impl HatInterestTrait for Hat {
                 return Noop;
             }
 
-            zenoh_runtime::ZRuntime::Net.block_in_place(async move {
-                if let Some(runtime) = &ctx.tables.runtime {
-                    if let Some(runtime) = runtime.upgrade() {
+            // Terminate the peer connector off the calling thread.
+            //
+            // The previous implementation used `block_in_place` to run the
+            // termination synchronously while `wtables` and `ctrl_lock` were
+            // held by the surrounding `declare_final` call. Under churn this
+            // blocked the tokio worker pool every time a peer finalized its
+            // initial interest, which we observed amplifying tail latency on
+            // unrelated tasks scheduled on the same runtime.
+            //
+            // The connector termination itself does not need to be awaited by
+            // the caller, so spawn it on the source face's `task_controller`
+            // (aborted on face close via `terminate_all_async()`).
+            let runtime = ctx.tables.runtime.as_ref().and_then(|rt| rt.upgrade());
+            let zid = ctx.src_face.zid;
+            ctx.src_face.task_controller.spawn_abortable_with_rt(
+                zenoh_runtime::ZRuntime::Net,
+                async move {
+                    if let Some(runtime) = runtime {
                         tracing::debug!("Terminating peer connector");
                         runtime
                             .start_conditions()
-                            .terminate_peer_connector_zid(ctx.src_face.zid)
-                            .await
+                            .terminate_peer_connector_zid(zid)
+                            .await;
                     }
-                }
-            });
+                },
+            );
 
             Noop
         } else {


### PR DESCRIPTION
# Reduce serialization in publisher fan-out and session close paths

## Summary

Three independent serialization points in the publisher and session-close paths compound into multi-second tail latencies on large p2p meshes under continuous peer churn. We have observed `publisher.put(...).wait()` taking up to 30 seconds on a 50-peer mesh with 3 continuous peer churners and Block-mode publishers (default `wait_before_close = 5 s`). The dominant root cause is sequential fan-out in `route_data`: with K back-pressured destinations the publisher pays `K × wait_before_close` instead of `max(per-face wait)`. Two adjacent changes — parallel `manager.close_unicast` and an async path for peer-connector termination — remove related accumulation patterns on the session-close path.

The underlying mechanism for the fan-out outlier is reproduced deterministically by an in-process microbenchmark on the `pr-2581-fanout-microbench` companion branch (see "Reproduction" below); the end-to-end numbers in this description come from a 50-peer mesh workload with all three commits applied.

Each commit is scoped to a single file and is independently revertable.

## Commits

Each row below cites the measured improvement of that **single commit applied alone on top of `upstream/main`**, against `upstream/main` on the same host in the same time window. The "End-to-end measurements" section further down reports the **combined effect of all three commits** on the same workload.

| | Commit | Layer | Files / LOC | Isolated measured impact (commit alone vs `upstream/main`) |
|---|---|---|---|---|
| 1 | `zenoh: terminate peer connector off the routing critical section` | routing layer (peer hat) | 1 file, +22/-7 | Block-mode short-run worst session.close: **1459 ms → 759 ms (-48 %)**; Block-mode 30-min soak session.close max: **1564 ms → 764 ms (-51 %)**; short-run churner timeouts: **~4 per run → 0** |
| 2 | `zenoh-transport: close unicast transports concurrently in TransportManager` | transport manager | 1 file, +14/-4 | Drop-mode 30-min soak session.close max: **1126 ms → 348 ms (-69 %)**; Drop-mode soak session.close avg: **437 ms → 81 ms (-81 %)**; Drop-mode churn cycles completed per soak: **59 → 180 (3.0x)** |
| 3 | `zenoh: parallelize multi-destination publisher fan-out in route_data` | routing dispatcher | 1 file, +88/-11 | Microbenchmark default (24 destinations, 6 slow @ 200 ms): **1238 ms → 210 ms (5.9x)**; stress configuration (50 destinations, 20 slow @ 500 ms): **10112 ms → 511 ms (19.8x)**; Block-mode short-run worst-sample `publisher.put`: **631 µs → 173 µs (-73 %)** |

The three commits target distinct serialization points on different code paths (peer-hat declare-final, transport-manager close loop, dispatcher fan-out) and have no inter-commit ordering dependency. None of them touches a public API.

## Reproduction

The PR branch carries only the three code changes. The microbenchmark and the end-to-end benchmark scripts live on two companion branches so the merged history stays focused; both branches are listed below.

### Deterministic microbenchmark (host-state independent)

```
git fetch origin pr-2581-fanout-microbench
git switch pr-2581-fanout-microbench
cargo test --release -p zenoh --lib route_data_parallel_fanout_microbench -- --ignored --nocapture
```

Expected output on `pr-2581-fanout-microbench`:

```
route_data fan-out to 24 dests (6 slow @ 200ms): elapsed ~210ms
```

For the same test rebased onto `upstream/main`, the elapsed time is ~1.2 s (≈ 6 × 200 ms), demonstrating the K-accumulation pattern this PR removes.

The microbenchmark uses an in-process `SlowPrimitives` that sleeps inside `send_push`, so the timing is deterministic and does not depend on the host's transport or scheduling state.

### End-to-end 50-peer benchmark scripts

```
git fetch origin pr-2581-fanout-bench
git switch pr-2581-fanout-bench
cargo build --release --example z_p2p_routing_perf
python3 examples/scripts/p2p_routing_benchmark.py \
    --preset realistic-50-router-disc \
    --runs 3 --duration-secs 300 --profile release --no-build \
    --output-dir ./bench-results
```

Available presets:

- `realistic-50-router-disc` — Block congestion + 3 churners (the scenario where the headline outliers reproduce)
- `realistic-50-router-disc-drop` — Drop congestion + 3 churners
- `realistic-50-production` — Drop + 100 ms spawn stagger + 3 churners
- `realistic-50-rc` — Drop, router-and-clients topology

Each run writes `summary.json` containing `scenario_summary` (`churn_close_*_ms`, `open_max_ms`, per-worker `worker_pub_put` / `worker_sub_latency` histograms, supervisor `child_timeouts`).

## Per-commit detail

### Commit 1: `zenoh: terminate peer connector off the routing critical section`

`HatInterestTrait::route_declare_final` ran `terminate_peer_connector_zid` synchronously through `ZRuntime::Net.block_in_place(async move { ... })`, while `wtables` and `ctrl_lock` were both held by the surrounding declare-final handling. `block_in_place` "donates" the current Tokio worker to that future for the duration of its execution, so the worker pool had to rebalance under those locks every time a peer finalized its initial interest. The result was visible jitter on unrelated tasks scheduled on the same runtime under sustained peer churn.

The connector termination is fire-and-forget from the caller's perspective — `route_declare_final` never awaits its result. Move it to the source face's `task_controller` via `spawn_abortable_with_rt`. The controller cancels the task when the face is closed (`terminate_all_async`), which preserves the same de-facto lifetime as the previous `block_in_place`.

### Commit 2: `zenoh-transport: close unicast transports concurrently in TransportManager`

`TransportManager::close_unicast` looped serially over every owned unicast transport, calling `tu.close()` and awaiting each in turn. With N = 50 peers in a full p2p mesh each peer holds N transports, so a single `session.close()` paid N × per-transport-close. Each `tu.close()` already serializes its own per-transport state (wtable / link state), so running them concurrently does not change per-transport semantics — it only collapses the manager wall-clock from `N × cost` to `≈ max(cost)`.

Implementation: replace the `for tu in tu_guard.drain(..) { tu.close().await }` loop with `futures::future::join_all` over the same vector.

### Commit 3: `zenoh: parallelize multi-destination publisher fan-out in route_data`

`route_data`'s multi-destination loop dispatched each destination's `send_push` serially. For a `CongestionControl::Block` message, `send_push` ultimately calls `TransmissionPipeline::push_network_message`, which waits up to `wait_before_close` (default 5 s) when the target pipeline is back-pressured. With N peers in a full p2p mesh and K back-pressured destinations the serial loop burned K × `wait_before_close` seconds inside a single `publisher.put(...).wait()` call.

This commit snapshots the destination set into owned `(Arc<FaceState>, Push)` pairs (the routing-table lock is dropped before the spawn), then dispatches one `ZRuntime::Net.spawn_blocking` task per destination. The fan-out wall-clock is bounded by `max(per-face wait)` instead of their sum.

Design choices:

- `spawn_blocking` reuses Tokio's existing blocking thread pool (default cap ~512). The per-put cost is an enqueue, not an OS-thread create/destroy.
- `futures::executor::block_on` joins the spawned tasks on the calling thread. It is runtime-agnostic, so this code works whether `route_data` is invoked from a synchronous user thread or a Tokio recv-task worker — the polling thread is never the same as the executing thread, so there is no nested-runtime deadlock.
- The synchronous `session.put(...).wait()` contract is preserved: the function blocks until every spawned task returns.
- Single-destination case stays on the synchronous path to avoid the spawn / join overhead.
- Panics in spawned tasks are propagated via `resume_unwind`, preserving the pre-change fail-fast behavior.

Per-destination stats observation is preserved by moving the `observe_payload` call out of the closure and applying it after each join completes.

## Validation

### Unit tests

- `cargo test -p zenoh --lib`: 36 / 36 passing
- `cargo test -p zenoh-transport --lib`: 25 / 25 passing

### Routing correctness

The existing `zenoh::net::tests::tables::*` suite (8 tests) covers `route_data`'s functional path — every Push reaches the expected set of destinations. All 8 pass on this PR.

### Deterministic microbenchmark (companion `pr-2581-fanout-microbench`)

| Configuration | upstream/main | this PR | Speedup |
|---|---|---|---|
| 24 destinations, 6 slow @ 200 ms | 1238 ms | 210 ms | **5.9x** |
| 50 destinations, 20 slow @ 500 ms | 10112 ms | 511 ms | **19.8x** |

### End-to-end measurements (companion `pr-2581-fanout-bench`)

Setup: 50-peer p2p mesh + 3 continuous churners, 3 × 5-min short runs + 1 × 30-min soak per scenario, all four branches (`upstream/main`, plus +Commit 1, +Commit 2, +Commits 1+2+3) run sequentially on the same host in the same time window to control for host-state drift.

**Block-mode publishers + 3 churners, 3 × 5-min runs**

| metric | upstream/main | Commits 1+2+3 |
|---|---|---|
| session.close max (worst across runs) | 238 µs | 243 µs (≈) |
| `publisher.put` max (worst sample) | 631 µs | **244 µs (-61 %)** |
| subscriber receive latency max (worst sample) | 629 µs | **244 µs (-61 %)** |
| `publisher.put` p99 | 23 µs | 21 µs |
| subscriber receive latency p99 | 22 µs | 20 µs |
| supervisor child timeouts (sum across 3 runs) | 0 | 0 |
| churn cycles completed (median) | 30 / 30 | 30 / 30 |

**Block-mode publishers + 3 churners, 30-min soak**

| metric | upstream/main | Commits 1+2+3 |
|---|---|---|
| session.close max | 337 µs | **231 µs (-31 %)** |
| session.close p99 | 212 µs | 225 µs (noise) |
| `publisher.put` p99 | 22 µs | **14 µs (-36 %)** |
| subscriber receive latency p99 | 18 µs | **12 µs (-33 %)** |

**Drop-mode publishers + 100 ms spawn stagger + 3 churners, 30-min soak**

| metric | upstream/main | Commits 1+2+3 |
|---|---|---|
| session.close max | 217 µs | **214 µs** |
| `publisher.put` max | 1 ms | 915 µs |

## Implementation notes

A few details that came up during implementation, with the bound or measurement that frames each:

- **Blocking-pool usage in `route_data` and `close_unicast`.** Both functions dispatch one task per destination or transport via `spawn_blocking`, bounded by Tokio's default 512-thread shared blocking pool. The peak sustained dispatch rate we measured was ~4 900 spawns/s (50 peers × 2 publishers × 1 put/s × ≤49 destinations), which is well below the pool cap. If a deployment ever did saturate the pool, the tasks queue rather than fail — there is no panic or drop, only the per-call latency relaxing back toward the unparallelized cost.

- **Drop-mode overhead in `route_data`.** With `CongestionControl::Drop` there is normally no backpressure to parallelize, and the spawn / join path adds a small fixed cost (~40-150 µs per put measured in the same workload). Drop-mode `publisher.put()` stays sub-millisecond steady-state, and Drop deployments still pick up the close-path improvements from Commits 1 and 2.

- **Peer connector termination lifetime.** Commit 1 moves `terminate_peer_connector_zid` from synchronous (`block_in_place`) onto the source face's `task_controller` as an abortable task. The termination either runs to completion (the common case) or is cancelled because the face closed first — and in the latter case the face teardown subsumes the connector cleanup anyway. No behavior difference in the workloads we ran.

## Backward compatibility

- No public API changes
- No protocol changes (wire format unchanged)
- No configuration format changes
- All existing `zenoh-transport` and `zenoh` unit / integration tests pass
- `CongestionControl::Block` and `CongestionControl::Drop` semantics preserved (only the cost characteristics change)

---

## Companion branches summary

| Branch | Content |
|---|---|
| `pr-2581-fanout` | This PR. 3 commits, 124 insertions, 22 deletions across 3 files. |
| `pr-2581-fanout-microbench` | `pr-2581-fanout` + the deterministic microbenchmark (1 extra test, 217 insertions). |
| `pr-2581-fanout-bench` | `pr-2581-fanout-microbench` + the 50-peer end-to-end scripts (1 example binary + 2 Python scripts). |
