### PR TITLE
Fix re-entrant routing-tables RwLock deadlock in admin-space handle

### DIFF
--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -750,19 +750,36 @@ where
     F: Fn(&Tables) -> HashMap<Arc<Resource>, Sources>,
 {
     let tables = &context.runtime.state.router.tables;
-    let rtables = zread!(tables.tables);
-    for res in f(&rtables) {
-        let key = prefix / keyexpr::new(res.0.expr()).unwrap();
-        if query.key_expr().intersects(&key) {
-            let payload =
-                ZBytes::from(serde_json::to_string(&res.1).unwrap_or_else(|_| "{}".to_string()));
-            if let Err(e) = query
-                .reply(key, payload)
-                .encoding(Encoding::APPLICATION_JSON)
-                .wait()
-            {
-                tracing::error!("Error sending AdminSpace reply: {:?}", e);
-            }
+    // BUGFIX(routing deadlock): collect replies while holding the routing-tables
+    // read lock, then DROP the guard before replying. `query.reply().wait()` routes
+    // the response via `route_send_response`, which re-acquires `zread!(tables.tables)`;
+    // holding the guard across the reply is a re-entrant read that deadlocks against
+    // a concurrent `register_expr` writer (std::sync::RwLock is writer-preferring).
+    let to_reply: Vec<_> = {
+        let rtables = zread!(tables.tables);
+        f(&rtables)
+            .into_iter()
+            .filter_map(|res| {
+                // BUGFIX(panic): stock 1.9.0 `.unwrap()`s here; a resource caught
+                // transiently under declare churn can have an expr that is not a
+                // valid keyexpr (e.g. empty) -> panic -> process abort. Skip it.
+                let key = prefix / keyexpr::new(res.0.expr()).ok()?;
+                query.key_expr().intersects(&key).then(|| {
+                    let payload = ZBytes::from(
+                        serde_json::to_string(&res.1).unwrap_or_else(|_| "{}".to_string()),
+                    );
+                    (key, payload)
+                })
+            })
+            .collect()
+    };
+    for (key, payload) in to_reply {
+        if let Err(e) = query
+            .reply(key, payload)
+            .encoding(Encoding::APPLICATION_JSON)
+            .wait()
+        {
+            tracing::error!("Error sending AdminSpace reply: {:?}", e);
         }
     }
 }
@@ -797,23 +814,29 @@ fn tokens_data(prefix: &keyexpr, context: &AdminContext, query: Query) {
 #[tracing::instrument(level = "trace", skip_all)]
 fn linkstate_data(prefix: &keyexpr, context: &AdminContext, query: Query) {
     let tables = &context.runtime.state.router.tables;
-    let rtables = zread!(tables.tables);
-
-    for (region, hat) in rtables
-        .hats
-        .iter()
-        .filter(|(_, hat)| hat.mode().is_peer() || hat.mode().is_router())
-    {
-        let reply_key = prefix / &KeyExpr::try_from(format!("{region}")).unwrap();
-
-        if query.key_expr().intersects(&reply_key) {
-            if let Err(e) = query
-                .reply(reply_key, hat.info())
-                .encoding(Encoding::TEXT_PLAIN)
-                .wait()
-            {
-                tracing::error!("Error sending AdminSpace reply: {:?}", e);
-            }
+    // BUGFIX(routing deadlock): collect under the lock, drop the guard, then reply.
+    let to_reply: Vec<_> = {
+        let rtables = zread!(tables.tables);
+        rtables
+            .hats
+            .iter()
+            .filter(|(_, hat)| hat.mode().is_peer() || hat.mode().is_router())
+            .filter_map(|(region, hat)| {
+                let reply_key = prefix / &KeyExpr::try_from(format!("{region}")).unwrap();
+                query
+                    .key_expr()
+                    .intersects(&reply_key)
+                    .then(|| (reply_key, hat.info()))
+            })
+            .collect()
+    };
+    for (reply_key, info) in to_reply {
+        if let Err(e) = query
+            .reply(reply_key, info)
+            .encoding(Encoding::TEXT_PLAIN)
+            .wait()
+        {
+            tracing::error!("Error sending AdminSpace reply: {:?}", e);
         }
     }
 }
@@ -830,29 +853,36 @@ fn route_successor(prefix: &keyexpr, context: &AdminContext, query: Query) {
         }
     };
     let tables = &context.runtime.state.router.tables;
-    let rtables = zread!(tables.tables);
+    // BUGFIX(routing deadlock): collect everything that needs the routing-tables
+    // read lock, drop the guard, then reply. `reply` -> `route_send_response`
+    // re-acquires `zread!(tables.tables)`; replying under the guard is a re-entrant
+    // read that deadlocks against a concurrent `register_expr` writer.
 
     // Try to shortcut full successor retrieval if suffix matches 'src/<zid>/dst/<zid>' pattern.
-
     let suffix = query.key_expr().as_str().strip_prefix(prefix.as_str());
-    if let Some((src, dst)) = suffix.and_then(|s| s.strip_prefix("/src/")?.split_once("/dst/")) {
-        if let (Ok(src_zid), Ok(dst_zid)) = (src.parse(), dst.parse()) {
-            for hat in rtables.hats.values().filter(|hat| hat.mode().is_router()) {
-                if let Some(successor) = hat.route_successor(src_zid, dst_zid) {
-                    reply(query.key_expr(), successor);
+    let (shortcut, successors) = {
+        let rtables = zread!(tables.tables);
+        let mut shortcut: Vec<ZenohIdProto> = Vec::new();
+        if let Some((src, dst)) = suffix.and_then(|s| s.strip_prefix("/src/")?.split_once("/dst/")) {
+            if let (Ok(src_zid), Ok(dst_zid)) = (src.parse(), dst.parse()) {
+                for hat in rtables.hats.values().filter(|hat| hat.mode().is_router()) {
+                    if let Some(successor) = hat.route_successor(src_zid, dst_zid) {
+                        shortcut.push(successor);
+                    }
                 }
             }
         }
+        let successors = rtables
+            .hats
+            .values()
+            .filter(|hat| hat.mode().is_router())
+            .flat_map(|hat| hat.route_successors())
+            .collect_vec();
+        (shortcut, successors)
+    };
+    for successor in shortcut {
+        reply(query.key_expr(), successor);
     }
-
-    // Reply with every successor suffix matching the keyexpr.
-    let successors = rtables
-        .hats
-        .values()
-        .filter(|hat| hat.mode().is_router())
-        .flat_map(|hat| hat.route_successors())
-        .collect_vec();
-    drop(rtables);
     for entry in successors {
         let ke = KeyExpr::new(format!(
             "{prefix}/src/{src}/dst/{dst}",


### PR DESCRIPTION
The admin-space handlers `resources_data`, `linkstate_data`, and `route_successor` hold `zread!(tables.tables)` across `query.reply(...).wait()`. `.wait()` routes the response synchronously via `Face::send_response` → `route_send_response`, which **re-acquires the same `zread!(tables.tables)`** on the same thread.

`std::sync::RwLock` is writer-preferring: once a `register_expr` writer (any peer `declare`) queues between the two reads, the re-entrant second read blocks behind it, the writer blocks behind the first read, and the entire routing layer wedges. The transport acceptor task is independent and keeps running, so the node still accepts connections and *looks* alive while routing is dead.

The pattern has existed since at least 1.7.0 and is present on `main`.

## Root cause

Three admin handlers in `zenoh/src/net/runtime/adminspace.rs` reply while holding the routing-tables read guard:

| Handler | Lock acquisition | Reply call under lock |
|---|---|---|
| `resources_data` | `let rtables = zread!(tables.tables);` | `query.reply(...).wait()` inside the loop |
| `linkstate_data` | `let rtables = zread!(tables.tables);` | `query.reply(...).wait()` inside the loop |
| `route_successor` | `let rtables = zread!(tables.tables);` | `reply(...)` (calls `query.reply().wait()`) under the guard before the explicit `drop(rtables)` |

`query.reply(...).wait()` ultimately calls
`zenoh/src/net/routing/dispatcher/queries.rs::route_send_response`:

```rust
pub fn route_send_response(..., tables_ref: &Arc<TablesLock>, ...) {
    let tables = zread!(tables_ref.tables);   // <-- same RwLock, second read
    ...
}
```

Concurrently, `zenoh/src/net/routing/dispatcher/resource.rs::register_expr` takes `zwrite!(tables.tables)` on every `declare`. Sequence that wedges:

1. Thread A enters `resources_data` and takes read no 1.
2. Thread B issues `register_expr` and queues a write.
3. Thread A calls `query.reply(...).wait()` which re-enters `route_send_response` and tries to take read no 2.
4. Writer-preferring `RwLock` blocks read no 2 behind the queued write.
5. The write blocks behind read no 1, which Thread A still holds.
6. Permanent deadlock; all subsequent routing piles up.

<details>

<summary>A live 8-thread `gdb thread apply all bt` showing all four states:</summary>

```
gdb -p <host-pid-of-zenohd> -batch -ex 'thread apply all bt'
Zenoh release/1.9.0 @ 81c6c933b6e41d72a05f04c4442ef57717ddc72b — zenohd, aarch64 Linux
Captured 2026-05-22 while the routing loop was deadlocked (frozen since 11:11:48).

Note: gdb run from the container HOST (the container itself blocks ptrace by default).
"Target and debugger are in different PID namespaces" warning is expected and harmless.

================================================================================
DEADLOCKED ROUTING THREADS — all contended on the same RwLock (router tables.tables)
================================================================================

Thread 8 (LWP 262662 "rx-30")  —  RE-ENTRANT READER (holds read #1, blocked on read #2)
#1  std::sys::sync::rwlock::futex::RwLock::read_contended ()        <-- blocked acquiring READ
#2  zenoh::net::routing::dispatcher::queries::route_send_response ()   queries.rs:538  zread!(tables.tables)
#3  <...Face as ...Primitives>::send_response ()
#4  zenoh::api::queryable::Query::_reply_sample ()
#5  <...ReplyBuilder<...> as zenoh_core::Wait>::wait ()
#6  zenoh::net::runtime::adminspace::resources_data ()               adminspace.rs:740 holds zread!(tables.tables)
#7  core::ops::function::Fn::call ()
#8  <...AdminSpace as ...Primitives>::send_request ()
#9  <...AdminSpace as ...EPrimitives>::send_request ()
#10 <...Face as ...Primitives>::send_request ()
#11 <...DeMux as ...TransportPeerEventHandler>::handle_message ()
#12 ...universal::rx::...::trigger_callback ()
#13 ...universal::rx::...::read_messages ()
   --> incoming request -> admin-space resources_data takes zread!(tables) [HELD]
       -> query.reply().wait() -> route_send_response takes zread!(tables) AGAIN [BLOCKED]

Thread 7 (LWP 262613 "rx-28")  —  WRITER (the trigger)
#1  std::sys::sync::rwlock::futex::RwLock::write_contended ()        <-- blocked acquiring WRITE
#2  zenoh::net::routing::dispatcher::resource::register_expr ()      resource.rs zwrite!(tables.tables)
#3  <...Face as ...Primitives>::send_declare ()
#4  <...DeMux as ...TransportPeerEventHandler>::handle_message ()
#5  ...universal::rx::...::trigger_callback ()
#6  ...universal::rx::...::read_messages ()
   --> incoming declare -> register_expr wants zwrite!(tables); queued behind readers,
       and (writer-priority) blocks all further readers including Thread 8's read #2.

Thread 5 (LWP 262549 "rx-26")  —  reader piled up behind the queued writer
#1  std::sys::sync::rwlock::futex::RwLock::read_contended ()
#2  zenoh::net::routing::dispatcher::queries::route_send_response ()
#3  <...Face as ...Primitives>::send_response ()
#4  <...DeMux as ...TransportPeerEventHandler>::handle_message ()
   (... rx_task / tokio worker ...)

Thread 6 (LWP 262550 "net-14")  —  reader piled up behind the queued writer
#1  std::sys::sync::rwlock::futex::RwLock::read_contended ()
#2  zenoh::net::routing::dispatcher::queries::route_send_response ()
#3  <...QueryCleanup as zenoh_util::timer::Timed>::run::{{closure}} ()
   (... tokio worker ...)

================================================================================
IDLE THREADS — unaffected (this is why the node still "looks up")
================================================================================

Thread 1 (LWP 255715 "zenohd")  — main thread, parked
#1  std::thread::functions::park ()
#2  zenohd::main ()

Thread 2 (LWP 255717 "app-0")   — tokio worker, idle in epoll_pwait
Thread 3 (LWP 255721 "acc-0")   — transport ACCEPTOR, idle in epoll_pwait
                                  (independent of routing — keeps accepting
                                   QUIC/TLS connections while routing is dead)
Thread 4 (LWP 255722 "tx-0")    — tokio worker, idle in epoll_pwait

================================================================================
DEADLOCK CYCLE
================================================================================

  Thread 8  holds  read #1   (adminspace.rs:740)
            wants  read #2   (queries.rs:538)   --> blocked: writer is queued
  Thread 7  wants  write     (resource.rs register_expr) --> blocked: read #1 still held
  Threads 5,6  want read     --> blocked behind the queued writer

  std::sync::RwLock is writer-preferring: once Thread 7's write is queued, no new
  reader may proceed. Thread 8's re-entrant read #2 is a "new reader" -> blocked
  -> read #1 never released -> Thread 7 never writes -> total routing deadlock.
```

</details>


## Secondary bug fixed in the same change

`resources_data` had `keyexpr::new(res.0.expr()).unwrap()`. Under declare churn a resource can be caught transiently with an expr that is not a valid keyexpr (e.g. empty), causing a panic. `zenohd`'s release profile is `panic = "abort"`, so this took the entire process down once the primary deadlock was patched away. Changed to `.ok()?` (skip the resource).

## Suggested fix

Collect the data that needs the lock, **drop the guard**, then reply:

```rust
let to_reply: Vec<_> = {
    let rtables = zread!(tables.tables);
    f(&rtables)
        .into_iter()
        .filter_map(|res| {
            let key = prefix / keyexpr::new(res.0.expr()).ok()?;
            query.key_expr().intersects(&key).then(|| {
                let payload = ZBytes::from(
                    serde_json::to_string(&res.1).unwrap_or_else(|_| "{}".to_string()),
                );
                (key, payload)
            })
        })
        .collect()
};
for (key, payload) in to_reply {
    if let Err(e) = query.reply(key, payload).encoding(Encoding::APPLICATION_JSON).wait() {
        tracing::error!("Error sending AdminSpace reply: {:?}", e);
    }
}
```

Applied identically in `linkstate_data` and `route_successor` (the latter also folds both the shortcut and full-successor paths into one collect-then-drop block — stock already had a `drop(rtables)` before the full-successor reply, but the shortcut `reply()` calls above it were still under the guard).

154-line patch, no behavior change beyond the lock-hold window. Replies still go out in the same order; the only externally visible difference is that responses are computed before they are streamed, which for these handlers (small admin queries) is negligible.

## Reproduction

<details>
<summary>Python repro code</summary>

```python3
"""Local plaintext churn repro for the Zenoh routing-tables re-entrant deadlock.

  - admin-query churn:  `get @/**`  -> resources_data holds zread!(tables.tables)
                                       across query.reply().wait() -> route_send_response re-reads.
  - declare churn:      declare/undeclare subscribers -> register_expr zwrite!(tables.tables).

Usage:  churn.py <label>   (label is just printed, e.g. "patched" / "unpatched")
A health probe (`get @/*/router`) detects a wedge: 3 consecutive failures = deadlocked.
"""
import sys, time, threading
import zenoh

ENDPOINT = 'tcp/127.0.0.1:7447'
LABEL = sys.argv[1] if len(sys.argv) > 1 else 'run'
ADMIN_CHURN_THREADS   = 12
DECLARE_CHURN_THREADS = 12
RUN_SECONDS = 300
PROBE_EVERY = 8

stop = threading.Event()
stats = {'admin_gets': 0, 'declares': 0, 'errors': 0}
slock = threading.Lock()

def mk(mode):
    cfg = zenoh.Config()
    cfg.insert_json5('mode', '"%s"' % mode)
    cfg.insert_json5('connect/endpoints', '["%s"]' % ENDPOINT)
    cfg.insert_json5('scouting/multicast/enabled', 'false')
    return zenoh.open(cfg)

def admin_churn():
    s = None
    while not stop.is_set():
        try:
            if s is None:
                s = mk('client')
            for _ in s.get('@/**'):
                pass
            with slock: stats['admin_gets'] += 1
        except Exception:
            with slock: stats['errors'] += 1
            try: s and s.close()
            except Exception: pass
            s = None
            time.sleep(0.2)
    try: s and s.close()
    except Exception: pass

def declare_churn():
    # Reuse one session per thread (re-open only on error). Declaring/undeclaring
    # subscribers drives register_expr -> zwrite!(tables.tables) without the
    # client-side resource leak of churning whole sessions.
    s = None
    while not stop.is_set():
        try:
            if s is None:
                s = mk('peer')
            subs = [s.declare_subscriber('churn/%d/%d' % (id(s) % 9999, i),
                                         lambda sample: None)
                    for i in range(15)]
            with slock: stats['declares'] += len(subs)
            time.sleep(0.02)
            for x in subs:
                try: x.undeclare()
                except Exception: pass
        except Exception:
            with slock: stats['errors'] += 1
            try: s and s.close()
            except Exception: pass
            s = None
            time.sleep(0.2)
    try: s and s.close()
    except Exception: pass

def probe():
    t0 = time.time()
    s = None
    try:
        s = mk('client')
        n = sum(1 for _ in s.get('@/*/router', timeout=5.0))
        return (n > 0, 'routers=%d in %.1fs' % (n, time.time() - t0))
    except Exception as e:
        return (False, '%s: %s' % (type(e).__name__, str(e)[:80]))
    finally:
        try: s and s.close()
        except Exception: pass

def main():
    print('[%s] endpoint=%s admin=%d declare=%d cap=%ds'
          % (LABEL, ENDPOINT, ADMIN_CHURN_THREADS, DECLARE_CHURN_THREADS, RUN_SECONDS), flush=True)
    ok, detail = probe()
    print('[%s] baseline probe: %s (%s)' % (LABEL, 'OK' if ok else 'FAIL', detail), flush=True)
    if not ok:
        print('[%s] relay not healthy at start - aborting' % LABEL, flush=True)
        return 2

    threads = ([threading.Thread(target=admin_churn,   daemon=True) for _ in range(ADMIN_CHURN_THREADS)] +
               [threading.Thread(target=declare_churn, daemon=True) for _ in range(DECLARE_CHURN_THREADS)])
    for t in threads: t.start()

    start = time.time(); bad = 0; reproduced = False
    while time.time() - start < RUN_SECONDS:
        time.sleep(PROBE_EVERY)
        el = int(time.time() - start)
        ok, detail = probe()
        with slock:
            ag, dc, er = stats['admin_gets'], stats['declares'], stats['errors']
        print('[%s t+%4ds] probe %-4s (%s) | admin_gets=%d declares=%d errs=%d'
              % (LABEL, el, 'OK' if ok else 'BAD', detail, ag, dc, er), flush=True)
        if not ok:
            bad += 1
            if bad >= 3:
                print('[%s] *** DEADLOCK REPRODUCED at t+%ds ***' % (LABEL, el), flush=True)
                reproduced = True
                break
        else:
            bad = 0
    if not reproduced:
        print('[%s] survived full %ds under churn — no deadlock' % (LABEL, RUN_SECONDS), flush=True)
    stop.set(); time.sleep(1)
    return 1 if reproduced else 0

if __name__ == '__main__':
    sys.exit(main())

```
</details>

- 12 threads looping `get @/**` (admin-query side → `resources_data`)
- 12 threads declaring / undeclaring 15 subscribers in a loop (declare side → `register_expr`)
- Health probe `get @/*/router` every 8s; three consecutive failures = wedged.

Run against a stock `zenohd` with **no config file, no extra features**, only `-l tcp/127.0.0.1:7447` so the harness can reach it. Effective config is zenohd's built-in default: `mode=router`, gossip on, multicast on, no gateway, no region routing, default features (no `transport_quic`, no `shared-memory`, no `stats`, no `unstable`).

```text
[stock-1.9.0-defaultcfg] baseline probe: OK (routers=1 in 0.0s)
[stock-1.9.0-defaultcfg t+   8s] probe BAD | admin_gets=52  declares=108795 errs=0
[stock-1.9.0-defaultcfg t+  26s] probe BAD | admin_gets=76  declares=218040 errs=0
[stock-1.9.0-defaultcfg t+  44s] probe BAD | admin_gets=100 declares=329385 errs=0
[stock-1.9.0-defaultcfg] *** DEADLOCK REPRODUCED at t+44s ***
```

Two independent runs (with and without the bundled repro config that disables multicast) wedged at exactly t+44s, after ~110k declares — race is very tight and very reliable.

## Operational impact

Until this lands, any peer that can open a session and declare resources can wedge a `zenohd` router in seconds — remote DoS without any authentication-bypass needed (just a trusted peer that churns subscriptions fast enough; the original incident was triggered by accidental gossip churn, not an attack).

## Files changed

- `zenoh/src/net/runtime/adminspace.rs` — three handlers fixed, ~154 lines.

## Related

- Upstream issue: #2581 (same `Tables` `RwLock` deadlock observed via `route_data` rather than `route_send_response` — same lock, same trigger, this PR adds the concrete re-entrant mechanism + fix).

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [ ] **Root cause documented** - Explain what caused the bug in the PR description
- [ ] **Reproduction test added** - Test that fails on main branch without the fix
- [ ] **Test passes with fix** - The reproduction test passes with your changes
- [ ] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [ ] **Fix is minimal** - Changes are focused only on fixing the bug
- [ ] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->