### PR TITLE
Add timestamp instrumentation for latency measurement

### DIFF
--- a/commons/zenoh-codec/src/network/mod.rs
+++ b/commons/zenoh-codec/src/network/mod.rs
@@ -17,6 +17,7 @@ mod oam;
 mod push;
 mod request;
 mod response;
+mod timestamp_stack;
 
 use zenoh_buffers::{
     reader::{BacktrackableReader, DidntRead, Reader},

--- a/commons/zenoh-codec/src/network/push.rs
+++ b/commons/zenoh-codec/src/network/push.rs
@@ -41,6 +41,7 @@ where
             ext_qos,
             ext_tstamp,
             ext_nodeid,
+            ext_ts_stack,
             payload,
         } = x;
 
@@ -48,7 +49,8 @@ where
         let mut header = id::PUSH;
         let mut n_exts = ((ext_qos != &ext::QoSType::DEFAULT) as u8)
             + (ext_tstamp.is_some() as u8)
-            + ((ext_nodeid != &ext::NodeIdType::DEFAULT) as u8);
+            + ((ext_nodeid != &ext::NodeIdType::DEFAULT) as u8)
+            + (ext_ts_stack.is_some() as u8);
         if n_exts != 0 {
             header |= flag::Z;
         }
@@ -75,6 +77,10 @@ where
         if ext_nodeid != &ext::NodeIdType::DEFAULT {
             n_exts -= 1;
             self.write(&mut *writer, (*ext_nodeid, n_exts != 0))?;
+        }
+        if let Some(ts_stack) = ext_ts_stack.as_ref() {
+            n_exts -= 1;
+            self.write(&mut *writer, (ts_stack, n_exts != 0))?;
         }
         // Payload
         self.write(&mut *writer, payload)?;
@@ -121,6 +127,7 @@ where
         let mut ext_qos = ext::QoSType::DEFAULT;
         let mut ext_tstamp = None;
         let mut ext_nodeid = ext::NodeIdType::DEFAULT;
+        let mut ext_ts_stack = None;
 
         let mut has_ext = imsg::has_flag(self.header, flag::Z);
         while has_ext {
@@ -142,6 +149,11 @@ where
                     ext_nodeid = nid;
                     has_ext = ext;
                 }
+                ext::TsStack::ID => {
+                    let (ts, ext): (ext::TsStackType, bool) = eodec.read(&mut *reader)?;
+                    ext_ts_stack = Some(ts);
+                    has_ext = ext;
+                }
                 _ => {
                     has_ext = extension::skip(reader, "Push", ext)?;
                 }
@@ -157,6 +169,7 @@ where
             ext_qos,
             ext_tstamp,
             ext_nodeid,
+            ext_ts_stack,
         })
     }
 }

--- a/commons/zenoh-codec/src/network/request.rs
+++ b/commons/zenoh-codec/src/network/request.rs
@@ -84,6 +84,7 @@ where
             ext_target,
             ext_budget,
             ext_timeout,
+            ext_ts_stack,
             payload,
         } = x;
 
@@ -94,7 +95,8 @@ where
             + ((ext_target != &ext::QueryTarget::DEFAULT) as u8)
             + (ext_budget.is_some() as u8)
             + (ext_timeout.is_some() as u8)
-            + ((ext_nodeid != &ext::NodeIdType::DEFAULT) as u8);
+            + ((ext_nodeid != &ext::NodeIdType::DEFAULT) as u8)
+            + (ext_ts_stack.is_some() as u8);
         if n_exts != 0 {
             header |= flag::Z;
         }
@@ -136,6 +138,10 @@ where
         if ext_nodeid != &ext::NodeIdType::DEFAULT {
             n_exts -= 1;
             self.write(&mut *writer, (*ext_nodeid, n_exts != 0))?;
+        }
+        if let Some(ts_stack) = ext_ts_stack.as_ref() {
+            n_exts -= 1;
+            self.write(&mut *writer, (ts_stack, n_exts != 0))?;
         }
 
         // Payload
@@ -187,6 +193,7 @@ where
         let mut ext_target = ext::QueryTarget::DEFAULT;
         let mut ext_limit = None;
         let mut ext_timeout = None;
+        let mut ext_ts_stack = None;
 
         let mut has_ext = imsg::has_flag(self.header, flag::Z);
         while has_ext {
@@ -223,6 +230,11 @@ where
                     ext_timeout = Some(ext::TimeoutType::from_millis(to.value));
                     has_ext = ext;
                 }
+                ext::TsStack::ID => {
+                    let (ts, ext): (ext::TsStackType, bool) = eodec.read(&mut *reader)?;
+                    ext_ts_stack = Some(ts);
+                    has_ext = ext;
+                }
                 _ => {
                     has_ext = extension::skip(reader, "Request", ext)?;
                 }
@@ -242,6 +254,7 @@ where
             ext_target,
             ext_budget: ext_limit,
             ext_timeout,
+            ext_ts_stack,
         })
     }
 }

--- a/commons/zenoh-codec/src/network/response.rs
+++ b/commons/zenoh-codec/src/network/response.rs
@@ -45,13 +45,15 @@ where
             ext_qos,
             ext_tstamp,
             ext_respid,
+            ext_ts_stack,
         } = x;
 
         // Header
         let mut header = id::RESPONSE;
         let mut n_exts = ((ext_qos != &ext::QoSType::DEFAULT) as u8)
             + (ext_tstamp.is_some() as u8)
-            + (ext_respid.is_some() as u8);
+            + (ext_respid.is_some() as u8)
+            + (ext_ts_stack.is_some() as u8);
         if n_exts != 0 {
             header |= flag::Z;
         }
@@ -79,6 +81,10 @@ where
         if let Some(ri) = ext_respid.as_ref() {
             n_exts -= 1;
             self.write(&mut *writer, (ri, n_exts != 0))?;
+        }
+        if let Some(ts_stack) = ext_ts_stack.as_ref() {
+            n_exts -= 1;
+            self.write(&mut *writer, (ts_stack, n_exts != 0))?;
         }
 
         // Payload
@@ -127,6 +133,7 @@ where
         let mut ext_qos = ext::QoSType::DEFAULT;
         let mut ext_tstamp = None;
         let mut ext_respid = None;
+        let mut ext_ts_stack = None;
 
         let mut has_ext = imsg::has_flag(self.header, flag::Z);
         while has_ext {
@@ -148,6 +155,11 @@ where
                     ext_respid = Some(t);
                     has_ext = ext;
                 }
+                ext::TsStack::ID => {
+                    let (ts, ext): (ext::TsStackType, bool) = eodec.read(&mut *reader)?;
+                    ext_ts_stack = Some(ts);
+                    has_ext = ext;
+                }
                 _ => {
                     has_ext = extension::skip(reader, "Response", ext)?;
                 }
@@ -164,6 +176,7 @@ where
             ext_qos,
             ext_tstamp,
             ext_respid,
+            ext_ts_stack,
         })
     }
 }

--- a/commons/zenoh-codec/src/network/timestamp_stack.rs
+++ b/commons/zenoh-codec/src/network/timestamp_stack.rs
@@ -92,6 +92,10 @@ where
 
     fn read(self, reader: &mut R) -> Result<TimestampStack, Self::Error> {
         let conf_flags: u8 = self.read(&mut *reader)?;
+        if conf_flags == 0 {
+            // empty conf_flags is invalid
+            return Err(DidntRead);
+        }
         let count: usize = self.read(&mut *reader)?;
         if count > zenoh_protocol::network::timestamp_stack::MAX_STACK_SIZE {
             return Err(DidntRead);

--- a/commons/zenoh-codec/src/network/timestamp_stack.rs
+++ b/commons/zenoh-codec/src/network/timestamp_stack.rs
@@ -93,7 +93,9 @@ where
     fn read(self, reader: &mut R) -> Result<TimestampStack, Self::Error> {
         let conf_flags: u8 = self.read(&mut *reader)?;
         let count: usize = self.read(&mut *reader)?;
-        //FIXME: this can panic due to call with unsanitized count input
+        if count > zenoh_protocol::network::timestamp_stack::MAX_STACK_SIZE {
+            return Err(DidntRead);
+        }
         let mut stack: Vec<Interception> = Vec::with_capacity(count);
         for _ in 0..count {
             stack.push(self.read(&mut *reader)?);

--- a/commons/zenoh-codec/src/network/timestamp_stack.rs
+++ b/commons/zenoh-codec/src/network/timestamp_stack.rs
@@ -1,0 +1,150 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+use alloc::vec::Vec;
+
+use zenoh_buffers::{
+    reader::{DidntRead, Reader},
+    writer::{DidntWrite, Writer},
+};
+use zenoh_protocol::{
+    common::ZExtZBufHeader,
+    network::timestamp_stack::{Interception, TimestampStack, TsStackType},
+};
+
+use crate::{LCodec, RCodec, WCodec, Zenoh080, Zenoh080Header};
+
+// Interception
+impl LCodec<&Interception> for Zenoh080 {
+    fn w_len(self, x: &Interception) -> usize {
+        1 + self.w_len(&x.timestamp[..])
+    }
+}
+
+impl<W> WCodec<&Interception, &mut W> for Zenoh080
+where
+    W: Writer,
+{
+    type Output = Result<(), DidntWrite>;
+
+    fn write(self, writer: &mut W, x: &Interception) -> Self::Output {
+        self.write(&mut *writer, x.flags)?;
+        self.write(&mut *writer, &x.timestamp[..])
+    }
+}
+
+impl<R> RCodec<Interception, &mut R> for Zenoh080
+where
+    R: Reader,
+{
+    type Error = DidntRead;
+
+    fn read(self, reader: &mut R) -> Result<Interception, Self::Error> {
+        let flags: u8 = self.read(&mut *reader)?;
+        let timestamp: Vec<u8> = self.read(&mut *reader)?;
+        Ok(Interception { flags, timestamp })
+    }
+}
+
+// TimestampStack
+impl LCodec<&TimestampStack> for Zenoh080 {
+    fn w_len(self, x: &TimestampStack) -> usize {
+        let mut len = 1; // conf_flags
+        len += self.w_len(x.stack.len());
+        for i in &x.stack {
+            len += self.w_len(i);
+        }
+        len
+    }
+}
+
+impl<W> WCodec<&TimestampStack, &mut W> for Zenoh080
+where
+    W: Writer,
+{
+    type Output = Result<(), DidntWrite>;
+
+    fn write(self, writer: &mut W, x: &TimestampStack) -> Self::Output {
+        self.write(&mut *writer, x.conf_flags)?;
+        self.write(&mut *writer, x.stack.len())?;
+        for i in &x.stack {
+            self.write(&mut *writer, i)?;
+        }
+        Ok(())
+    }
+}
+
+impl<R> RCodec<TimestampStack, &mut R> for Zenoh080
+where
+    R: Reader,
+{
+    type Error = DidntRead;
+
+    fn read(self, reader: &mut R) -> Result<TimestampStack, Self::Error> {
+        let conf_flags: u8 = self.read(&mut *reader)?;
+        let count: usize = self.read(&mut *reader)?;
+        //FIXME: this can panic due to call with unsanitized count input
+        let mut stack: Vec<Interception> = Vec::with_capacity(count);
+        for _ in 0..count {
+            stack.push(self.read(&mut *reader)?);
+        }
+        Ok(TimestampStack { conf_flags, stack })
+    }
+}
+
+// TsStackType extension wrapper
+impl<const ID: u8> LCodec<&TsStackType<{ ID }>> for Zenoh080 {
+    fn w_len(self, x: &TsStackType<{ ID }>) -> usize {
+        self.w_len(&x.ts_stack)
+    }
+}
+
+impl<W, const ID: u8> WCodec<(&TsStackType<{ ID }>, bool), &mut W> for Zenoh080
+where
+    W: Writer,
+{
+    type Output = Result<(), DidntWrite>;
+
+    fn write(self, writer: &mut W, x: (&TsStackType<{ ID }>, bool)) -> Self::Output {
+        let (x, more) = x;
+        let header: ZExtZBufHeader<{ ID }> = ZExtZBufHeader::new(self.w_len(x));
+        self.write(&mut *writer, (&header, more))?;
+        self.write(&mut *writer, &x.ts_stack)
+    }
+}
+
+impl<R, const ID: u8> RCodec<(TsStackType<{ ID }>, bool), &mut R> for Zenoh080
+where
+    R: Reader,
+{
+    type Error = DidntRead;
+
+    fn read(self, reader: &mut R) -> Result<(TsStackType<{ ID }>, bool), Self::Error> {
+        let header: u8 = self.read(&mut *reader)?;
+        let codec = Zenoh080Header::new(header);
+        codec.read(reader)
+    }
+}
+
+impl<R, const ID: u8> RCodec<(TsStackType<{ ID }>, bool), &mut R> for Zenoh080Header
+where
+    R: Reader,
+{
+    type Error = DidntRead;
+
+    fn read(self, reader: &mut R) -> Result<(TsStackType<{ ID }>, bool), Self::Error> {
+        let (_, more): (ZExtZBufHeader<{ ID }>, bool) = self.read(&mut *reader)?;
+        let ts_stack: TimestampStack = self.codec.read(&mut *reader)?;
+        Ok((TsStackType { ts_stack }, more))
+    }
+}

--- a/commons/zenoh-protocol/src/network/mod.rs
+++ b/commons/zenoh-protocol/src/network/mod.rs
@@ -17,6 +17,7 @@ pub mod oam;
 pub mod push;
 pub mod request;
 pub mod response;
+pub mod timestamp_stack;
 
 use core::fmt;
 

--- a/commons/zenoh-protocol/src/network/push.rs
+++ b/commons/zenoh-protocol/src/network/push.rs
@@ -48,6 +48,7 @@ pub struct Push {
     pub ext_qos: ext::QoSType,
     pub ext_tstamp: Option<ext::TimestampType>,
     pub ext_nodeid: ext::NodeIdType,
+    pub ext_ts_stack: Option<ext::TsStackType>,
     pub payload: PushBody,
 }
 
@@ -62,6 +63,9 @@ pub mod ext {
 
     pub type NodeId = zextz64!(0x3, true);
     pub type NodeIdType = crate::network::ext::NodeIdType<{ NodeId::ID }>;
+
+    pub type TsStack = zextzbuf!(0x7, false);
+    pub type TsStackType = crate::network::timestamp_stack::TsStackType<{ TsStack::ID }>;
 }
 
 impl Push {
@@ -85,6 +89,7 @@ impl Push {
         let ext_qos = ext::QoSType::rand();
         let ext_tstamp = rng.gen_bool(0.5).then(ext::TimestampType::rand);
         let ext_nodeid = ext::NodeIdType::rand();
+        let ext_ts_stack = rng.gen_bool(0.5).then(ext::TsStackType::rand);
 
         Self {
             wire_expr,
@@ -92,6 +97,7 @@ impl Push {
             ext_tstamp,
             ext_qos,
             ext_nodeid,
+            ext_ts_stack,
         }
     }
 }
@@ -103,6 +109,7 @@ impl From<PushBody> for Push {
             ext_qos: ext::QoSType::DEFAULT,
             ext_tstamp: None,
             ext_nodeid: ext::NodeIdType::DEFAULT,
+            ext_ts_stack: None,
             payload: value,
         }
     }

--- a/commons/zenoh-protocol/src/network/request.rs
+++ b/commons/zenoh-protocol/src/network/request.rs
@@ -63,6 +63,7 @@ pub struct Request {
     pub ext_target: ext::QueryTarget,
     pub ext_budget: Option<ext::BudgetType>,
     pub ext_timeout: Option<ext::TimeoutType>,
+    pub ext_ts_stack: Option<ext::TsStackType>,
     pub payload: RequestBody,
 }
 
@@ -129,6 +130,9 @@ pub mod ext {
     // The timeout of the request
     pub type Timeout = zextz64!(0x6, false);
     pub type TimeoutType = Duration;
+
+    pub type TsStack = zextzbuf!(0x7, false);
+    pub type TsStackType = crate::network::timestamp_stack::TsStackType<{ TsStack::ID }>;
 }
 
 impl Request {
@@ -166,6 +170,7 @@ impl Request {
         } else {
             None
         };
+        let ext_ts_stack = rng.gen_bool(0.5).then(ext::TsStackType::rand);
 
         Self {
             wire_expr,
@@ -177,6 +182,7 @@ impl Request {
             ext_target,
             ext_budget,
             ext_timeout,
+            ext_ts_stack,
         }
     }
 }

--- a/commons/zenoh-protocol/src/network/response.rs
+++ b/commons/zenoh-protocol/src/network/response.rs
@@ -56,6 +56,7 @@ pub struct Response {
     pub ext_qos: ext::QoSType,
     pub ext_tstamp: Option<ext::TimestampType>,
     pub ext_respid: Option<ext::ResponderIdType>,
+    pub ext_ts_stack: Option<ext::TsStackType>,
 }
 
 pub mod ext {
@@ -68,6 +69,9 @@ pub mod ext {
 
     pub type ResponderId = zextzbuf!(0x3, false);
     pub type ResponderIdType = crate::network::ext::EntityGlobalIdType<{ ResponderId::ID }>;
+
+    pub type TsStack = zextzbuf!(0x7, false);
+    pub type TsStackType = crate::network::timestamp_stack::TsStackType<{ TsStack::ID }>;
 }
 
 impl Response {
@@ -95,6 +99,7 @@ impl Response {
         let ext_qos = ext::QoSType::rand();
         let ext_tstamp = rng.gen_bool(0.5).then(ext::TimestampType::rand);
         let ext_respid = rng.gen_bool(0.5).then(ext::ResponderIdType::rand);
+        let ext_ts_stack = rng.gen_bool(0.5).then(ext::TsStackType::rand);
 
         Self {
             rid,
@@ -103,6 +108,7 @@ impl Response {
             ext_qos,
             ext_tstamp,
             ext_respid,
+            ext_ts_stack,
         }
     }
 }

--- a/commons/zenoh-protocol/src/network/timestamp_stack.rs
+++ b/commons/zenoh-protocol/src/network/timestamp_stack.rs
@@ -32,8 +32,20 @@ impl<const ID: u8> TsStackType<{ ID }> {
         let conf_flags: u8 = rng.gen();
         let n: usize = rng.gen_range(0..=3);
         let mut stack = Vec::with_capacity(n);
+        let points = [
+            interception_point::SEND,
+            interception_point::ROUTE,
+            interception_point::RECEIVE,
+        ];
         for _ in 0..n {
-            let flags: u8 = rng.gen();
+            let point = points[rng.gen_range(0..points.len())];
+            let is_custom = rng.gen_bool(0.5);
+            let flags = point
+                | if is_custom {
+                    interception_point::IS_CUSTOM_TS
+                } else {
+                    0
+                };
             let ts_len: usize = rng.gen_range(0..=16);
             let timestamp: Vec<u8> = (0..ts_len).map(|_| rng.gen()).collect();
             stack.push(Interception { flags, timestamp });
@@ -50,10 +62,14 @@ pub mod interception_point {
     pub const SEND: u8 = 0b0000_0001;
     pub const ROUTE: u8 = 0b0000_0010;
     pub const RECEIVE: u8 = 0b0000_0100;
+
+    /// Bit 7 of the `Interception.flags` field: set when the timestamp was produced by a
+    /// user-defined callback (custom format), cleared when it is a standard UHLC timestamp.
+    pub const IS_CUSTOM_TS: u8 = 0b1000_0000;
 }
 
-/// A single interception record containing the interception point identifier
-/// and raw timestamp bytes.
+/// A single interception record containing the interception point identifier,
+/// timestamp format flag, and raw timestamp bytes.
 ///
 /// Wire format:
 ///
@@ -64,6 +80,12 @@ pub mod interception_point {
 /// % timestamp     % -- <u8;z16>
 /// +---------------+
 /// ```
+///
+/// `flags` bit layout:
+/// - Bit 7 (`IS_CUSTOM_TS`): set when the timestamp was produced by a user-defined callback,
+///   cleared when it is a standard UHLC timestamp.
+/// - Bits 0-2: interception point ID (`SEND`, `ROUTE`, `RECEIVE`).
+/// - Bits 3-6: reserved (must be 0).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Interception {
     /// Bitfield: interception point id + timestamp format.

--- a/commons/zenoh-protocol/src/network/timestamp_stack.rs
+++ b/commons/zenoh-protocol/src/network/timestamp_stack.rs
@@ -13,6 +13,8 @@
 //
 use alloc::vec::Vec;
 
+pub const MAX_STACK_SIZE: usize = 255;
+
 /// Zenoh extension wrapper for the timestamp stack.
 ///
 /// The `const ID: u8` parameter encodes the extension's wire ID, ensuring

--- a/commons/zenoh-protocol/src/network/timestamp_stack.rs
+++ b/commons/zenoh-protocol/src/network/timestamp_stack.rs
@@ -73,21 +73,20 @@ pub mod interception_point {
 /// A single interception record containing the interception point identifier,
 /// timestamp format flag, and raw timestamp bytes.
 ///
-/// Wire format:
-///
 /// ```text
+/// Flags:
+/// - U:     User-defined               If U==1 then the timestamp format is user-defined;
+///                                     otherwise it is a standard UHLC timestamp.
+/// - X:     Reserved                   Must be 0.
+/// - point: Interception point         0b001=SEND, 0b010=ROUTE, 0b100=RECEIVE.
+///
+///  7 6 5 4 3 2 1 0
+/// +-+-+-+-+-+-+-+-+
+/// |U|X|X|X|X|point|
 /// +---------------+
-/// | flags    | u8 |
-/// +---------------+
-/// % timestamp     % -- <u8;z16>
+/// ~   timestamp   ~
 /// +---------------+
 /// ```
-///
-/// `flags` bit layout:
-/// - Bit 7 (`IS_CUSTOM_TS`): set when the timestamp was produced by a user-defined callback,
-///   cleared when it is a standard UHLC timestamp.
-/// - Bits 0-2: interception point ID (`SEND`, `ROUTE`, `RECEIVE`).
-/// - Bits 3-6: reserved (must be 0).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Interception {
     /// Bitfield: interception point id + timestamp format.
@@ -98,15 +97,19 @@ pub struct Interception {
 
 /// A stack of interception timestamps carried as a message extension.
 ///
-/// Wire format (inside ZExtZBuf body):
-///
 /// ```text
+/// Flags:
+/// - S: Send            If S==1 then the send interception point is activated.
+/// - R: Route           If R==1 then the route interception point is activated.
+/// - E: Receive         If E==1 then the receive interception point is activated.
+/// - X: Reserved
+///  7 6 5 4 3 2 1 0
+/// +-+-+-+-+-+-+-+-+
+/// |X|X|X|X|X|E|R|S|
 /// +---------------+
-/// | conf_flags|u8 |
+/// ~  count: zint   ~
 /// +---------------+
-/// % count: zint   %
-/// +---------------+
-/// ~ [Interception]~
+/// ~ [Interception] ~
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/commons/zenoh-protocol/src/network/timestamp_stack.rs
+++ b/commons/zenoh-protocol/src/network/timestamp_stack.rs
@@ -1,0 +1,94 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+use alloc::vec::Vec;
+
+/// Zenoh extension wrapper for the timestamp stack.
+///
+/// The `const ID: u8` parameter encodes the extension's wire ID, ensuring
+/// type-safety across different message contexts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TsStackType<const ID: u8> {
+    pub ts_stack: TimestampStack,
+}
+
+impl<const ID: u8> TsStackType<{ ID }> {
+    #[cfg(feature = "test")]
+    #[doc(hidden)]
+    pub fn rand() -> Self {
+        use rand::Rng;
+        let mut rng = rand::thread_rng();
+
+        let conf_flags: u8 = rng.gen();
+        let n: usize = rng.gen_range(0..=3);
+        let mut stack = Vec::with_capacity(n);
+        for _ in 0..n {
+            let flags: u8 = rng.gen();
+            let ts_len: usize = rng.gen_range(0..=16);
+            let timestamp: Vec<u8> = (0..ts_len).map(|_| rng.gen()).collect();
+            stack.push(Interception { flags, timestamp });
+        }
+
+        Self {
+            ts_stack: TimestampStack { conf_flags, stack },
+        }
+    }
+}
+
+/// Bitmask flags indicating which interception points are activated in a timestamp stack.
+pub mod interception_point {
+    pub const SEND: u8 = 0b0000_0001;
+    pub const ROUTE: u8 = 0b0000_0010;
+    pub const RECEIVE: u8 = 0b0000_0100;
+}
+
+/// A single interception record containing the interception point identifier
+/// and raw timestamp bytes.
+///
+/// Wire format:
+///
+/// ```text
+/// +---------------+
+/// | flags    | u8 |
+/// +---------------+
+/// % timestamp     % -- <u8;z16>
+/// +---------------+
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Interception {
+    /// Bitfield: interception point id + timestamp format.
+    pub flags: u8,
+    /// Raw timestamp bytes (format defined by `flags`).
+    pub timestamp: Vec<u8>,
+}
+
+/// A stack of interception timestamps carried as a message extension.
+///
+/// Wire format (inside ZExtZBuf body):
+///
+/// ```text
+/// +---------------+
+/// | conf_flags|u8 |
+/// +---------------+
+/// % count: zint   %
+/// +---------------+
+/// ~ [Interception]~
+/// +---------------+
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TimestampStack {
+    /// Bitmask of which interception points are activated.
+    pub conf_flags: u8,
+    /// Ordered list of interceptions collected along the message path.
+    pub stack: Vec<Interception>,
+}

--- a/commons/zenoh-protocol/src/network/timestamp_stack.rs
+++ b/commons/zenoh-protocol/src/network/timestamp_stack.rs
@@ -31,7 +31,7 @@ impl<const ID: u8> TsStackType<{ ID }> {
         use rand::Rng;
         let mut rng = rand::thread_rng();
 
-        let conf_flags: u8 = rng.gen();
+        let conf_flags: u8 = rng.gen_range(1..=7);
         let n: usize = rng.gen_range(0..=3);
         let mut stack = Vec::with_capacity(n);
         let points = [

--- a/zenoh-ext/src/advanced_publisher.rs
+++ b/zenoh-ext/src/advanced_publisher.rs
@@ -26,7 +26,10 @@ use zenoh::{
     internal::{
         bail,
         runtime::ZRuntime,
-        traits::{EncodingBuilderTrait, QoSBuilderTrait, TimestampBuilderTrait},
+        traits::{
+            EncodingBuilderTrait, QoSBuilderTrait, TimestampBuilderTrait,
+            TimestampInstrumentationBuilderTrait,
+        },
         TerminatableTask,
     },
     key_expr::{keyexpr, KeyExpr},
@@ -770,6 +773,23 @@ impl<P> TimestampBuilderTrait for AdvancedPublicationBuilder<'_, P> {
     fn timestamp<TS: Into<Option<uhlc::Timestamp>>>(self, timestamp: TS) -> Self {
         Self {
             builder: self.builder.timestamp(timestamp),
+            ..self
+        }
+    }
+}
+
+#[zenoh_macros::internal_trait]
+#[zenoh_macros::unstable]
+impl<P> TimestampInstrumentationBuilderTrait for AdvancedPublicationBuilder<'_, P> {
+    #[zenoh_macros::unstable]
+    fn timestamp_instrumentation<
+        TS: Into<Option<zenoh::timestamp_stack::TimestampInstrumentation>>,
+    >(
+        self,
+        instrumentation: TS,
+    ) -> Self {
+        Self {
+            builder: self.builder.timestamp_instrumentation(instrumentation),
             ..self
         }
     }

--- a/zenoh/src/api/admin.rs
+++ b/zenoh/src/api/admin.rs
@@ -226,6 +226,8 @@ pub(crate) fn init(session: WeakSession) {
                 #[cfg(feature = "unstable")]
                 None,
                 None,
+                #[cfg(feature = "unstable")]
+                None,
             ) {
                 if e.downcast_ref::<SessionClosedError>().is_none() {
                     tracing::error!("Unable to publish transport event: {}", e);
@@ -281,6 +283,8 @@ pub(crate) fn init(session: WeakSession) {
                     None,
                     #[cfg(feature = "unstable")]
                     None,
+                    None,
+                    #[cfg(feature = "unstable")]
                     None,
                 ) {
                     if e.downcast_ref::<SessionClosedError>().is_none() {

--- a/zenoh/src/api/builders/publisher.rs
+++ b/zenoh/src/api/builders/publisher.rs
@@ -17,6 +17,8 @@ use zenoh_core::{Resolvable, Result as ZResult, Wait};
 use zenoh_protocol::core::CongestionControl;
 #[cfg(feature = "unstable")]
 use zenoh_protocol::core::Reliability;
+#[cfg(feature = "unstable")]
+use zenoh_protocol::network::timestamp_stack::TimestampStack;
 
 #[cfg(feature = "unstable")]
 use crate::api::sample::SourceInfo;
@@ -103,6 +105,8 @@ pub struct PublicationBuilder<P, T> {
     #[cfg(feature = "unstable")]
     pub(crate) source_info: Option<SourceInfo>,
     pub(crate) attachment: Option<ZBytes>,
+    #[cfg(feature = "unstable")]
+    pub(crate) timestamp_stack: Option<TimestampStack>,
 }
 
 #[zenoh_macros::internal_trait]
@@ -208,6 +212,13 @@ impl<P, T> SampleBuilderTrait for PublicationBuilder<P, T> {
             ..self
         }
     }
+    #[zenoh_macros::unstable]
+    fn timestamp_stack<S: Into<Option<TimestampStack>>>(self, stack: S) -> Self {
+        Self {
+            timestamp_stack: stack.into(),
+            ..self
+        }
+    }
 }
 
 #[zenoh_macros::internal_trait]
@@ -244,6 +255,8 @@ impl Wait for PublicationBuilder<PublisherBuilder<'_, '_>, PublicationBuilderPut
             #[cfg(feature = "unstable")]
             self.source_info,
             self.attachment,
+            #[cfg(feature = "unstable")]
+            self.timestamp_stack,
         )
     }
 }
@@ -267,6 +280,8 @@ impl Wait for PublicationBuilder<PublisherBuilder<'_, '_>, PublicationBuilderDel
             #[cfg(feature = "unstable")]
             self.source_info,
             self.attachment,
+            #[cfg(feature = "unstable")]
+            self.timestamp_stack,
         )
     }
 }
@@ -506,6 +521,8 @@ impl Wait for PublicationBuilder<&Publisher<'_>, PublicationBuilderPut> {
             #[cfg(feature = "unstable")]
             self.source_info,
             self.attachment,
+            #[cfg(feature = "unstable")]
+            self.timestamp_stack,
         )
     }
 }
@@ -527,6 +544,8 @@ impl Wait for PublicationBuilder<&Publisher<'_>, PublicationBuilderDelete> {
             #[cfg(feature = "unstable")]
             self.source_info,
             self.attachment,
+            #[cfg(feature = "unstable")]
+            self.timestamp_stack,
         )
     }
 }

--- a/zenoh/src/api/builders/publisher.rs
+++ b/zenoh/src/api/builders/publisher.rs
@@ -26,6 +26,7 @@ use crate::{
     api::{
         builders::sample::{
             EncodingBuilderTrait, QoSBuilderTrait, SampleBuilderTrait, TimestampBuilderTrait,
+            TimestampInstrumentationBuilderTrait,
         },
         bytes::{OptionZBytes, ZBytes},
         cancellation::SyncGroup,
@@ -212,10 +213,17 @@ impl<P, T> SampleBuilderTrait for PublicationBuilder<P, T> {
             ..self
         }
     }
+}
+
+#[zenoh_macros::internal_trait]
+impl<P, T> TimestampInstrumentationBuilderTrait for PublicationBuilder<P, T> {
     #[zenoh_macros::unstable]
-    fn timestamp_instrumentation(self, instrumentation: Option<TimestampInstrumentation>) -> Self {
+    fn timestamp_instrumentation<TS: Into<Option<TimestampInstrumentation>>>(
+        self,
+        instrumentation: TS,
+    ) -> Self {
         Self {
-            timestamp_instrumentation: instrumentation,
+            timestamp_instrumentation: instrumentation.into(),
             ..self
         }
     }

--- a/zenoh/src/api/builders/publisher.rs
+++ b/zenoh/src/api/builders/publisher.rs
@@ -17,11 +17,11 @@ use zenoh_core::{Resolvable, Result as ZResult, Wait};
 use zenoh_protocol::core::CongestionControl;
 #[cfg(feature = "unstable")]
 use zenoh_protocol::core::Reliability;
-#[cfg(feature = "unstable")]
-use zenoh_protocol::network::timestamp_stack::TimestampStack;
 
 #[cfg(feature = "unstable")]
 use crate::api::sample::SourceInfo;
+#[cfg(feature = "unstable")]
+use crate::api::timestamp_stack::TimestampInstrumentation;
 use crate::{
     api::{
         builders::sample::{
@@ -106,7 +106,7 @@ pub struct PublicationBuilder<P, T> {
     pub(crate) source_info: Option<SourceInfo>,
     pub(crate) attachment: Option<ZBytes>,
     #[cfg(feature = "unstable")]
-    pub(crate) timestamp_stack: Option<TimestampStack>,
+    pub(crate) timestamp_instrumentation: Option<TimestampInstrumentation>,
 }
 
 #[zenoh_macros::internal_trait]
@@ -213,9 +213,9 @@ impl<P, T> SampleBuilderTrait for PublicationBuilder<P, T> {
         }
     }
     #[zenoh_macros::unstable]
-    fn timestamp_stack<S: Into<Option<TimestampStack>>>(self, stack: S) -> Self {
+    fn timestamp_instrumentation(self, instrumentation: Option<TimestampInstrumentation>) -> Self {
         Self {
-            timestamp_stack: stack.into(),
+            timestamp_instrumentation: instrumentation,
             ..self
         }
     }
@@ -256,7 +256,7 @@ impl Wait for PublicationBuilder<PublisherBuilder<'_, '_>, PublicationBuilderPut
             self.source_info,
             self.attachment,
             #[cfg(feature = "unstable")]
-            self.timestamp_stack,
+            self.timestamp_instrumentation,
         )
     }
 }
@@ -281,7 +281,7 @@ impl Wait for PublicationBuilder<PublisherBuilder<'_, '_>, PublicationBuilderDel
             self.source_info,
             self.attachment,
             #[cfg(feature = "unstable")]
-            self.timestamp_stack,
+            self.timestamp_instrumentation,
         )
     }
 }
@@ -522,7 +522,7 @@ impl Wait for PublicationBuilder<&Publisher<'_>, PublicationBuilderPut> {
             self.source_info,
             self.attachment,
             #[cfg(feature = "unstable")]
-            self.timestamp_stack,
+            self.timestamp_instrumentation,
         )
     }
 }
@@ -545,7 +545,7 @@ impl Wait for PublicationBuilder<&Publisher<'_>, PublicationBuilderDelete> {
             self.source_info,
             self.attachment,
             #[cfg(feature = "unstable")]
-            self.timestamp_stack,
+            self.timestamp_instrumentation,
         )
     }
 }

--- a/zenoh/src/api/builders/querier.rs
+++ b/zenoh/src/api/builders/querier.rs
@@ -32,7 +32,9 @@ use crate::api::sample::SourceInfo;
 use crate::api::timestamp_stack::TimestampInstrumentation;
 use crate::{
     api::{
-        builders::sample::{EncodingBuilderTrait, SampleBuilderTrait},
+        builders::sample::{
+            EncodingBuilderTrait, SampleBuilderTrait, TimestampInstrumentationBuilderTrait,
+        },
         bytes::ZBytes,
         cancellation::SyncGroup,
         encoding::Encoding,
@@ -314,11 +316,17 @@ impl<Handler> SampleBuilderTrait for QuerierGetBuilder<'_, '_, Handler> {
             ..self
         }
     }
+}
 
+#[zenoh_macros::internal_trait]
+impl<Handler> TimestampInstrumentationBuilderTrait for QuerierGetBuilder<'_, '_, Handler> {
     #[zenoh_macros::unstable]
-    fn timestamp_instrumentation(self, instrumentation: Option<TimestampInstrumentation>) -> Self {
+    fn timestamp_instrumentation<TS: Into<Option<TimestampInstrumentation>>>(
+        self,
+        instrumentation: TS,
+    ) -> Self {
         Self {
-            timestamp_instrumentation: instrumentation,
+            timestamp_instrumentation: instrumentation.into(),
             ..self
         }
     }

--- a/zenoh/src/api/builders/querier.rs
+++ b/zenoh/src/api/builders/querier.rs
@@ -17,6 +17,8 @@ use std::{
 };
 
 use zenoh_core::{Resolvable, Wait};
+#[cfg(feature = "unstable")]
+use zenoh_protocol::network::timestamp_stack::TimestampStack;
 use zenoh_protocol::{
     core::{CongestionControl, Parameters},
     network::request::ext::QueryTarget,
@@ -244,6 +246,8 @@ pub struct QuerierGetBuilder<'a, 'b, Handler> {
     #[cfg(feature = "unstable")]
     pub(crate) source_info: Option<SourceInfo>,
     #[cfg(feature = "unstable")]
+    pub(crate) timestamp_stack: Option<TimestampStack>,
+    #[cfg(feature = "unstable")]
     pub(crate) cancellation_token: Option<crate::api::cancellation::CancellationToken>,
 }
 
@@ -307,6 +311,14 @@ impl<Handler> SampleBuilderTrait for QuerierGetBuilder<'_, '_, Handler> {
         let attachment: OptionZBytes = attachment.into();
         Self {
             attachment: attachment.into(),
+            ..self
+        }
+    }
+
+    #[zenoh_macros::unstable]
+    fn timestamp_stack<S: Into<Option<TimestampStack>>>(self, stack: S) -> Self {
+        Self {
+            timestamp_stack: stack.into(),
             ..self
         }
     }
@@ -424,6 +436,8 @@ impl<'a, 'b> QuerierGetBuilder<'a, 'b, DefaultHandler> {
             attachment,
             #[cfg(feature = "unstable")]
             source_info,
+            #[cfg(feature = "unstable")]
+            timestamp_stack,
             handler: _,
             #[cfg(feature = "unstable")]
             cancellation_token,
@@ -435,6 +449,8 @@ impl<'a, 'b> QuerierGetBuilder<'a, 'b, DefaultHandler> {
             attachment,
             #[cfg(feature = "unstable")]
             source_info,
+            #[cfg(feature = "unstable")]
+            timestamp_stack,
             handler,
             #[cfg(feature = "unstable")]
             cancellation_token,
@@ -503,6 +519,8 @@ where
             self.cancellation_token,
             Some(self.querier.id),
             self.querier.callback_sync_group.notifier(),
+            #[cfg(feature = "unstable")]
+            self.timestamp_stack,
         )?;
         Ok(receiver)
     }

--- a/zenoh/src/api/builders/querier.rs
+++ b/zenoh/src/api/builders/querier.rs
@@ -17,8 +17,6 @@ use std::{
 };
 
 use zenoh_core::{Resolvable, Wait};
-#[cfg(feature = "unstable")]
-use zenoh_protocol::network::timestamp_stack::TimestampStack;
 use zenoh_protocol::{
     core::{CongestionControl, Parameters},
     network::request::ext::QueryTarget,
@@ -30,6 +28,8 @@ use super::sample::QoSBuilderTrait;
 use crate::api::cancellation::CancellationTokenBuilderTrait;
 #[cfg(feature = "unstable")]
 use crate::api::sample::SourceInfo;
+#[cfg(feature = "unstable")]
+use crate::api::timestamp_stack::TimestampInstrumentation;
 use crate::{
     api::{
         builders::sample::{EncodingBuilderTrait, SampleBuilderTrait},
@@ -246,7 +246,7 @@ pub struct QuerierGetBuilder<'a, 'b, Handler> {
     #[cfg(feature = "unstable")]
     pub(crate) source_info: Option<SourceInfo>,
     #[cfg(feature = "unstable")]
-    pub(crate) timestamp_stack: Option<TimestampStack>,
+    pub(crate) timestamp_instrumentation: Option<TimestampInstrumentation>,
     #[cfg(feature = "unstable")]
     pub(crate) cancellation_token: Option<crate::api::cancellation::CancellationToken>,
 }
@@ -316,9 +316,9 @@ impl<Handler> SampleBuilderTrait for QuerierGetBuilder<'_, '_, Handler> {
     }
 
     #[zenoh_macros::unstable]
-    fn timestamp_stack<S: Into<Option<TimestampStack>>>(self, stack: S) -> Self {
+    fn timestamp_instrumentation(self, instrumentation: Option<TimestampInstrumentation>) -> Self {
         Self {
-            timestamp_stack: stack.into(),
+            timestamp_instrumentation: instrumentation,
             ..self
         }
     }
@@ -437,7 +437,7 @@ impl<'a, 'b> QuerierGetBuilder<'a, 'b, DefaultHandler> {
             #[cfg(feature = "unstable")]
             source_info,
             #[cfg(feature = "unstable")]
-            timestamp_stack,
+            timestamp_instrumentation,
             handler: _,
             #[cfg(feature = "unstable")]
             cancellation_token,
@@ -450,7 +450,7 @@ impl<'a, 'b> QuerierGetBuilder<'a, 'b, DefaultHandler> {
             #[cfg(feature = "unstable")]
             source_info,
             #[cfg(feature = "unstable")]
-            timestamp_stack,
+            timestamp_instrumentation,
             handler,
             #[cfg(feature = "unstable")]
             cancellation_token,
@@ -520,7 +520,7 @@ where
             Some(self.querier.id),
             self.querier.callback_sync_group.notifier(),
             #[cfg(feature = "unstable")]
-            self.timestamp_stack,
+            self.timestamp_instrumentation,
         )?;
         Ok(receiver)
     }

--- a/zenoh/src/api/builders/query.rs
+++ b/zenoh/src/api/builders/query.rs
@@ -28,7 +28,10 @@ use crate::api::sample::SourceInfo;
 use crate::api::timestamp_stack::TimestampInstrumentation;
 use crate::{
     api::{
-        builders::sample::{EncodingBuilderTrait, QoSBuilderTrait, SampleBuilderTrait},
+        builders::sample::{
+            EncodingBuilderTrait, QoSBuilderTrait, SampleBuilderTrait,
+            TimestampInstrumentationBuilderTrait,
+        },
         bytes::ZBytes,
         encoding::Encoding,
         handlers::{locked, Callback, DefaultHandler, IntoHandler},
@@ -106,11 +109,17 @@ impl<Handler> SampleBuilderTrait for SessionGetBuilder<'_, '_, Handler> {
             ..self
         }
     }
+}
 
+#[zenoh_macros::internal_trait]
+impl<Handler> TimestampInstrumentationBuilderTrait for SessionGetBuilder<'_, '_, Handler> {
     #[zenoh_macros::unstable]
-    fn timestamp_instrumentation(self, instrumentation: Option<TimestampInstrumentation>) -> Self {
+    fn timestamp_instrumentation<TS: Into<Option<TimestampInstrumentation>>>(
+        self,
+        instrumentation: TS,
+    ) -> Self {
         Self {
-            timestamp_instrumentation: instrumentation,
+            timestamp_instrumentation: instrumentation.into(),
             ..self
         }
     }

--- a/zenoh/src/api/builders/query.rs
+++ b/zenoh/src/api/builders/query.rs
@@ -17,6 +17,8 @@ use std::{
 };
 
 use zenoh_core::{Resolvable, Wait};
+#[cfg(feature = "unstable")]
+use zenoh_protocol::network::timestamp_stack::TimestampStack;
 use zenoh_protocol::{core::CongestionControl, network::request::ext::QueryTarget};
 use zenoh_result::ZResult;
 
@@ -79,6 +81,8 @@ pub struct SessionGetBuilder<'a, 'b, Handler> {
     #[cfg(feature = "unstable")]
     pub(crate) source_info: Option<SourceInfo>,
     #[cfg(feature = "unstable")]
+    pub(crate) timestamp_stack: Option<TimestampStack>,
+    #[cfg(feature = "unstable")]
     pub(crate) cancellation_token: Option<crate::api::cancellation::CancellationToken>,
 }
 
@@ -99,6 +103,14 @@ impl<Handler> SampleBuilderTrait for SessionGetBuilder<'_, '_, Handler> {
         let attachment: OptionZBytes = attachment.into();
         Self {
             attachment: attachment.into(),
+            ..self
+        }
+    }
+
+    #[zenoh_macros::unstable]
+    fn timestamp_stack<S: Into<Option<TimestampStack>>>(self, stack: S) -> Self {
+        Self {
+            timestamp_stack: stack.into(),
             ..self
         }
     }
@@ -264,6 +276,8 @@ impl<'a, 'b> SessionGetBuilder<'a, 'b, DefaultHandler> {
             attachment,
             #[cfg(feature = "unstable")]
             source_info,
+            #[cfg(feature = "unstable")]
+            timestamp_stack,
             handler: _,
             #[cfg(feature = "unstable")]
             cancellation_token,
@@ -280,6 +294,8 @@ impl<'a, 'b> SessionGetBuilder<'a, 'b, DefaultHandler> {
             attachment,
             #[cfg(feature = "unstable")]
             source_info,
+            #[cfg(feature = "unstable")]
+            timestamp_stack,
             handler,
             #[cfg(feature = "unstable")]
             cancellation_token,
@@ -405,6 +421,8 @@ where
             self.cancellation_token,
             None,
             None,
+            #[cfg(feature = "unstable")]
+            self.timestamp_stack,
         )?;
         Ok(receiver)
     }

--- a/zenoh/src/api/builders/query.rs
+++ b/zenoh/src/api/builders/query.rs
@@ -17,8 +17,6 @@ use std::{
 };
 
 use zenoh_core::{Resolvable, Wait};
-#[cfg(feature = "unstable")]
-use zenoh_protocol::network::timestamp_stack::TimestampStack;
 use zenoh_protocol::{core::CongestionControl, network::request::ext::QueryTarget};
 use zenoh_result::ZResult;
 
@@ -26,6 +24,8 @@ use zenoh_result::ZResult;
 use crate::api::cancellation::CancellationTokenBuilderTrait;
 #[cfg(feature = "unstable")]
 use crate::api::sample::SourceInfo;
+#[cfg(feature = "unstable")]
+use crate::api::timestamp_stack::TimestampInstrumentation;
 use crate::{
     api::{
         builders::sample::{EncodingBuilderTrait, QoSBuilderTrait, SampleBuilderTrait},
@@ -81,7 +81,7 @@ pub struct SessionGetBuilder<'a, 'b, Handler> {
     #[cfg(feature = "unstable")]
     pub(crate) source_info: Option<SourceInfo>,
     #[cfg(feature = "unstable")]
-    pub(crate) timestamp_stack: Option<TimestampStack>,
+    pub(crate) timestamp_instrumentation: Option<TimestampInstrumentation>,
     #[cfg(feature = "unstable")]
     pub(crate) cancellation_token: Option<crate::api::cancellation::CancellationToken>,
 }
@@ -108,9 +108,9 @@ impl<Handler> SampleBuilderTrait for SessionGetBuilder<'_, '_, Handler> {
     }
 
     #[zenoh_macros::unstable]
-    fn timestamp_stack<S: Into<Option<TimestampStack>>>(self, stack: S) -> Self {
+    fn timestamp_instrumentation(self, instrumentation: Option<TimestampInstrumentation>) -> Self {
         Self {
-            timestamp_stack: stack.into(),
+            timestamp_instrumentation: instrumentation,
             ..self
         }
     }
@@ -277,7 +277,7 @@ impl<'a, 'b> SessionGetBuilder<'a, 'b, DefaultHandler> {
             #[cfg(feature = "unstable")]
             source_info,
             #[cfg(feature = "unstable")]
-            timestamp_stack,
+            timestamp_instrumentation,
             handler: _,
             #[cfg(feature = "unstable")]
             cancellation_token,
@@ -295,7 +295,7 @@ impl<'a, 'b> SessionGetBuilder<'a, 'b, DefaultHandler> {
             #[cfg(feature = "unstable")]
             source_info,
             #[cfg(feature = "unstable")]
-            timestamp_stack,
+            timestamp_instrumentation,
             handler,
             #[cfg(feature = "unstable")]
             cancellation_token,
@@ -422,7 +422,7 @@ where
             None,
             None,
             #[cfg(feature = "unstable")]
-            self.timestamp_stack,
+            self.timestamp_instrumentation,
         )?;
         Ok(receiver)
     }

--- a/zenoh/src/api/builders/reply.rs
+++ b/zenoh/src/api/builders/reply.rs
@@ -15,8 +15,6 @@ use std::future::{IntoFuture, Ready};
 
 use uhlc::Timestamp;
 use zenoh_core::{Resolvable, Wait};
-#[cfg(feature = "unstable")]
-use zenoh_protocol::network::timestamp_stack::TimestampStack;
 use zenoh_protocol::{
     core::{CongestionControl, WireExpr},
     network::{response, Mapping, Response},
@@ -26,6 +24,8 @@ use zenoh_result::ZResult;
 
 #[zenoh_macros::unstable]
 use crate::api::sample::SourceInfo;
+#[cfg(feature = "unstable")]
+use crate::api::timestamp_stack::TimestampInstrumentation;
 use crate::api::{
     builders::sample::{
         EncodingBuilderTrait, QoSBuilderTrait, SampleBuilder, SampleBuilderTrait,
@@ -64,7 +64,7 @@ pub struct ReplyBuilder<'a, 'b, T> {
     source_info: Option<SourceInfo>,
     attachment: Option<ZBytes>,
     #[cfg(feature = "unstable")]
-    timestamp_stack: Option<TimestampStack>,
+    timestamp_instrumentation: Option<TimestampInstrumentation>,
 }
 
 impl<'a, 'b> ReplyBuilder<'a, 'b, ReplyBuilderPut> {
@@ -91,7 +91,7 @@ impl<'a, 'b> ReplyBuilder<'a, 'b, ReplyBuilderPut> {
             source_info: None,
             attachment: None,
             #[cfg(feature = "unstable")]
-            timestamp_stack: None,
+            timestamp_instrumentation: None,
         }
     }
 }
@@ -112,7 +112,7 @@ impl<'a, 'b> ReplyBuilder<'a, 'b, ReplyBuilderDelete> {
             source_info: None,
             attachment: None,
             #[cfg(feature = "unstable")]
-            timestamp_stack: None,
+            timestamp_instrumentation: None,
         }
     }
 }
@@ -150,9 +150,9 @@ impl<T> SampleBuilderTrait for ReplyBuilder<'_, '_, T> {
     }
 
     #[zenoh_macros::unstable]
-    fn timestamp_stack<S: Into<Option<TimestampStack>>>(self, stack: S) -> Self {
+    fn timestamp_instrumentation(self, instrumentation: Option<TimestampInstrumentation>) -> Self {
         Self {
-            timestamp_stack: stack.into(),
+            timestamp_instrumentation: instrumentation,
             ..self
         }
     }
@@ -208,7 +208,7 @@ impl Wait for ReplyBuilder<'_, '_, ReplyBuilderPut> {
         #[cfg(feature = "unstable")]
         let sample = sample.source_info(self.source_info);
         #[cfg(feature = "unstable")]
-        let sample = sample.timestamp_stack(self.timestamp_stack);
+        let sample = sample.timestamp_instrumentation(self.timestamp_instrumentation);
         let sample = sample.attachment(self.attachment);
         self.query._reply_sample(sample.into())
     }
@@ -223,7 +223,7 @@ impl Wait for ReplyBuilder<'_, '_, ReplyBuilderDelete> {
         #[cfg(feature = "unstable")]
         let sample = sample.source_info(self.source_info);
         #[cfg(feature = "unstable")]
-        let sample = sample.timestamp_stack(self.timestamp_stack);
+        let sample = sample.timestamp_instrumentation(self.timestamp_instrumentation);
         let sample = sample.attachment(self.attachment);
         self.query._reply_sample(sample.into())
     }
@@ -256,7 +256,7 @@ pub struct ReplyErrBuilder<'a> {
     payload: ZBytes,
     encoding: Encoding,
     #[cfg(feature = "unstable")]
-    timestamp_stack: Option<TimestampStack>,
+    timestamp_instrumentation: Option<TimestampInstrumentation>,
 }
 
 impl<'a> ReplyErrBuilder<'a> {
@@ -269,7 +269,7 @@ impl<'a> ReplyErrBuilder<'a> {
             payload: payload.into(),
             encoding: Encoding::default(),
             #[cfg(feature = "unstable")]
-            timestamp_stack: None,
+            timestamp_instrumentation: None,
         }
     }
 }
@@ -287,10 +287,13 @@ impl EncodingBuilderTrait for ReplyErrBuilder<'_> {
 
 #[cfg(feature = "unstable")]
 impl ReplyErrBuilder<'_> {
-    /// Activates timestamp stack instrumentation with the given `stack`.
+    /// Activates timestamp stack instrumentation with the given config.
     #[zenoh_macros::unstable]
-    pub fn timestamp_stack(mut self, stack: TimestampStack) -> Self {
-        self.timestamp_stack = Some(stack);
+    pub fn timestamp_instrumentation(
+        mut self,
+        instrumentation: Option<TimestampInstrumentation>,
+    ) -> Self {
+        self.timestamp_instrumentation = instrumentation;
         self
     }
 }
@@ -325,16 +328,24 @@ impl Wait for ReplyErrBuilder<'_> {
             ext_ts_stack: None,
         };
         #[cfg(feature = "unstable")]
-        if let Some(ts_stack) = self.timestamp_stack {
+        if let Some(instrumentation) = self.timestamp_instrumentation {
             use std::ops::Deref;
+
+            use zenoh_protocol::network::timestamp_stack::{
+                interception_point, TimestampStack, TsStackType,
+            };
             let rt = self.query.inner.runtime.clone().and_then(|r| r.upgrade());
             let irt = rt.as_deref().map(|r| r.deref());
-            let mut ext_ts_stack =
-                Some(zenoh_protocol::network::timestamp_stack::TsStackType { ts_stack });
+            let mut ext_ts_stack = Some(TsStackType {
+                ts_stack: TimestampStack {
+                    conf_flags: instrumentation.conf_flags(),
+                    stack: vec![],
+                },
+            });
             crate::api::timestamp_stack::push_ts_interception(
                 &mut ext_ts_stack,
                 irt,
-                zenoh_protocol::network::timestamp_stack::interception_point::SEND,
+                interception_point::SEND,
             );
             response.ext_ts_stack = ext_ts_stack;
         }

--- a/zenoh/src/api/builders/reply.rs
+++ b/zenoh/src/api/builders/reply.rs
@@ -15,6 +15,8 @@ use std::future::{IntoFuture, Ready};
 
 use uhlc::Timestamp;
 use zenoh_core::{Resolvable, Wait};
+#[cfg(feature = "unstable")]
+use zenoh_protocol::network::timestamp_stack::TimestampStack;
 use zenoh_protocol::{
     core::{CongestionControl, WireExpr},
     network::{response, Mapping, Response},
@@ -61,6 +63,8 @@ pub struct ReplyBuilder<'a, 'b, T> {
     #[cfg(feature = "unstable")]
     source_info: Option<SourceInfo>,
     attachment: Option<ZBytes>,
+    #[cfg(feature = "unstable")]
+    timestamp_stack: Option<TimestampStack>,
 }
 
 impl<'a, 'b> ReplyBuilder<'a, 'b, ReplyBuilderPut> {
@@ -86,6 +90,8 @@ impl<'a, 'b> ReplyBuilder<'a, 'b, ReplyBuilderPut> {
             #[cfg(feature = "unstable")]
             source_info: None,
             attachment: None,
+            #[cfg(feature = "unstable")]
+            timestamp_stack: None,
         }
     }
 }
@@ -105,6 +111,8 @@ impl<'a, 'b> ReplyBuilder<'a, 'b, ReplyBuilderDelete> {
             #[cfg(feature = "unstable")]
             source_info: None,
             attachment: None,
+            #[cfg(feature = "unstable")]
+            timestamp_stack: None,
         }
     }
 }
@@ -137,6 +145,14 @@ impl<T> SampleBuilderTrait for ReplyBuilder<'_, '_, T> {
     fn source_info<TS: Into<Option<SourceInfo>>>(self, source_info: TS) -> Self {
         Self {
             source_info: source_info.into(),
+            ..self
+        }
+    }
+
+    #[zenoh_macros::unstable]
+    fn timestamp_stack<S: Into<Option<TimestampStack>>>(self, stack: S) -> Self {
+        Self {
+            timestamp_stack: stack.into(),
             ..self
         }
     }
@@ -191,6 +207,8 @@ impl Wait for ReplyBuilder<'_, '_, ReplyBuilderPut> {
             .qos(self.qos.into());
         #[cfg(feature = "unstable")]
         let sample = sample.source_info(self.source_info);
+        #[cfg(feature = "unstable")]
+        let sample = sample.timestamp_stack(self.timestamp_stack);
         let sample = sample.attachment(self.attachment);
         self.query._reply_sample(sample.into())
     }
@@ -204,6 +222,8 @@ impl Wait for ReplyBuilder<'_, '_, ReplyBuilderDelete> {
             .qos(self.qos.into());
         #[cfg(feature = "unstable")]
         let sample = sample.source_info(self.source_info);
+        #[cfg(feature = "unstable")]
+        let sample = sample.timestamp_stack(self.timestamp_stack);
         let sample = sample.attachment(self.attachment);
         self.query._reply_sample(sample.into())
     }
@@ -235,6 +255,8 @@ pub struct ReplyErrBuilder<'a> {
     query: &'a Query,
     payload: ZBytes,
     encoding: Encoding,
+    #[cfg(feature = "unstable")]
+    timestamp_stack: Option<TimestampStack>,
 }
 
 impl<'a> ReplyErrBuilder<'a> {
@@ -246,6 +268,8 @@ impl<'a> ReplyErrBuilder<'a> {
             query,
             payload: payload.into(),
             encoding: Encoding::default(),
+            #[cfg(feature = "unstable")]
+            timestamp_stack: None,
         }
     }
 }
@@ -261,13 +285,23 @@ impl EncodingBuilderTrait for ReplyErrBuilder<'_> {
     }
 }
 
+#[cfg(feature = "unstable")]
+impl ReplyErrBuilder<'_> {
+    /// Activates timestamp stack instrumentation with the given `stack`.
+    #[zenoh_macros::unstable]
+    pub fn timestamp_stack(mut self, stack: TimestampStack) -> Self {
+        self.timestamp_stack = Some(stack);
+        self
+    }
+}
+
 impl Resolvable for ReplyErrBuilder<'_> {
     type To = ZResult<()>;
 }
 
 impl Wait for ReplyErrBuilder<'_> {
     fn wait(self) -> <Self as Resolvable>::To {
-        self.query.inner.primitives.send_response(&mut Response {
+        let mut response = Response {
             rid: self.query.inner.qid,
             wire_expr: WireExpr {
                 scope: 0,
@@ -289,7 +323,23 @@ impl Wait for ReplyErrBuilder<'_> {
                 eid: self.query.eid,
             }),
             ext_ts_stack: None,
-        });
+        };
+        #[cfg(feature = "unstable")]
+        if let Some(ts_stack) = self.timestamp_stack {
+            let mut ext_ts_stack =
+                Some(zenoh_protocol::network::timestamp_stack::TsStackType { ts_stack });
+            if let Some(ref cb) = self.query.inner.ts_stack_callback {
+                crate::api::timestamp_stack::push_ts_interception(
+                    &mut ext_ts_stack,
+                    self.query.inner.zid.into(),
+                    self.query.inner.whatami,
+                    |ctx| cb(ctx),
+                    zenoh_protocol::network::timestamp_stack::interception_point::SEND,
+                );
+                response.ext_ts_stack = ext_ts_stack;
+            }
+        }
+        self.query.inner.primitives.send_response(&mut response);
         Ok(())
     }
 }

--- a/zenoh/src/api/builders/reply.rs
+++ b/zenoh/src/api/builders/reply.rs
@@ -288,6 +288,7 @@ impl Wait for ReplyErrBuilder<'_> {
                 zid: self.query.inner.zid,
                 eid: self.query.eid,
             }),
+            ext_ts_stack: None,
         });
         Ok(())
     }

--- a/zenoh/src/api/builders/reply.rs
+++ b/zenoh/src/api/builders/reply.rs
@@ -326,18 +326,17 @@ impl Wait for ReplyErrBuilder<'_> {
         };
         #[cfg(feature = "unstable")]
         if let Some(ts_stack) = self.timestamp_stack {
+            use std::ops::Deref;
+            let rt = self.query.inner.runtime.clone().and_then(|r| r.upgrade());
+            let irt = rt.as_deref().map(|r| r.deref());
             let mut ext_ts_stack =
                 Some(zenoh_protocol::network::timestamp_stack::TsStackType { ts_stack });
-            if let Some(ref cb) = self.query.inner.ts_stack_callback {
-                crate::api::timestamp_stack::push_ts_interception(
-                    &mut ext_ts_stack,
-                    self.query.inner.zid.into(),
-                    self.query.inner.whatami,
-                    |ctx| cb(ctx),
-                    zenoh_protocol::network::timestamp_stack::interception_point::SEND,
-                );
-                response.ext_ts_stack = ext_ts_stack;
-            }
+            crate::api::timestamp_stack::push_ts_interception(
+                &mut ext_ts_stack,
+                irt,
+                zenoh_protocol::network::timestamp_stack::interception_point::SEND,
+            );
+            response.ext_ts_stack = ext_ts_stack;
         }
         self.query.inner.primitives.send_response(&mut response);
         Ok(())

--- a/zenoh/src/api/builders/reply.rs
+++ b/zenoh/src/api/builders/reply.rs
@@ -292,10 +292,7 @@ impl Wait for ReplyErrBuilder<'_> {
         };
         #[cfg(feature = "unstable")]
         {
-            use std::ops::Deref;
-
-            let rt = self.query.inner.runtime.clone().and_then(|r| r.upgrade());
-            let irt = rt.as_deref().map(|r| r.deref());
+            let weak_rt = self.query.inner.runtime.clone();
             response.ext_ts_stack = self
                 .query
                 .inner
@@ -308,9 +305,10 @@ impl Wait for ReplyErrBuilder<'_> {
                     let mut ext_ts_stack = Some(TsStackType {
                         ts_stack: (ts_stack).into(),
                     });
+                    let upgrade = weak_rt.clone();
                     crate::api::timestamp_stack::push_ts_interception(
                         &mut ext_ts_stack,
-                        irt,
+                        move || upgrade.and_then(|r| r.upgrade()).map(|dr| dr.get_inner()),
                         interception_point::SEND,
                     );
                     ext_ts_stack

--- a/zenoh/src/api/builders/reply.rs
+++ b/zenoh/src/api/builders/reply.rs
@@ -301,7 +301,7 @@ impl Wait for ReplyErrBuilder<'_> {
                 .inner
                 .query_ts_stack
                 .as_ref()
-                .map(|ts_stack| {
+                .and_then(|ts_stack| {
                     use zenoh_protocol::network::timestamp_stack::{
                         interception_point, TsStackType,
                     };
@@ -314,8 +314,7 @@ impl Wait for ReplyErrBuilder<'_> {
                         interception_point::SEND,
                     );
                     ext_ts_stack
-                })
-                .flatten();
+                });
         }
         self.query.inner.primitives.send_response(&mut response);
         Ok(())

--- a/zenoh/src/api/builders/reply.rs
+++ b/zenoh/src/api/builders/reply.rs
@@ -24,8 +24,6 @@ use zenoh_result::ZResult;
 
 #[zenoh_macros::unstable]
 use crate::api::sample::SourceInfo;
-#[cfg(feature = "unstable")]
-use crate::api::timestamp_stack::TimestampInstrumentation;
 use crate::api::{
     builders::sample::{
         EncodingBuilderTrait, QoSBuilderTrait, SampleBuilder, SampleBuilderTrait,
@@ -63,8 +61,6 @@ pub struct ReplyBuilder<'a, 'b, T> {
     #[cfg(feature = "unstable")]
     source_info: Option<SourceInfo>,
     attachment: Option<ZBytes>,
-    #[cfg(feature = "unstable")]
-    timestamp_instrumentation: Option<TimestampInstrumentation>,
 }
 
 impl<'a, 'b> ReplyBuilder<'a, 'b, ReplyBuilderPut> {
@@ -90,8 +86,6 @@ impl<'a, 'b> ReplyBuilder<'a, 'b, ReplyBuilderPut> {
             #[cfg(feature = "unstable")]
             source_info: None,
             attachment: None,
-            #[cfg(feature = "unstable")]
-            timestamp_instrumentation: None,
         }
     }
 }
@@ -111,8 +105,6 @@ impl<'a, 'b> ReplyBuilder<'a, 'b, ReplyBuilderDelete> {
             #[cfg(feature = "unstable")]
             source_info: None,
             attachment: None,
-            #[cfg(feature = "unstable")]
-            timestamp_instrumentation: None,
         }
     }
 }
@@ -145,14 +137,6 @@ impl<T> SampleBuilderTrait for ReplyBuilder<'_, '_, T> {
     fn source_info<TS: Into<Option<SourceInfo>>>(self, source_info: TS) -> Self {
         Self {
             source_info: source_info.into(),
-            ..self
-        }
-    }
-
-    #[zenoh_macros::unstable]
-    fn timestamp_instrumentation(self, instrumentation: Option<TimestampInstrumentation>) -> Self {
-        Self {
-            timestamp_instrumentation: instrumentation,
             ..self
         }
     }
@@ -207,8 +191,6 @@ impl Wait for ReplyBuilder<'_, '_, ReplyBuilderPut> {
             .qos(self.qos.into());
         #[cfg(feature = "unstable")]
         let sample = sample.source_info(self.source_info);
-        #[cfg(feature = "unstable")]
-        let sample = sample.timestamp_instrumentation(self.timestamp_instrumentation);
         let sample = sample.attachment(self.attachment);
         self.query._reply_sample(sample.into())
     }
@@ -222,8 +204,6 @@ impl Wait for ReplyBuilder<'_, '_, ReplyBuilderDelete> {
             .qos(self.qos.into());
         #[cfg(feature = "unstable")]
         let sample = sample.source_info(self.source_info);
-        #[cfg(feature = "unstable")]
-        let sample = sample.timestamp_instrumentation(self.timestamp_instrumentation);
         let sample = sample.attachment(self.attachment);
         self.query._reply_sample(sample.into())
     }
@@ -255,8 +235,6 @@ pub struct ReplyErrBuilder<'a> {
     query: &'a Query,
     payload: ZBytes,
     encoding: Encoding,
-    #[cfg(feature = "unstable")]
-    timestamp_instrumentation: Option<TimestampInstrumentation>,
 }
 
 impl<'a> ReplyErrBuilder<'a> {
@@ -268,8 +246,6 @@ impl<'a> ReplyErrBuilder<'a> {
             query,
             payload: payload.into(),
             encoding: Encoding::default(),
-            #[cfg(feature = "unstable")]
-            timestamp_instrumentation: None,
         }
     }
 }
@@ -282,19 +258,6 @@ impl EncodingBuilderTrait for ReplyErrBuilder<'_> {
             encoding: encoding.into(),
             ..self
         }
-    }
-}
-
-#[cfg(feature = "unstable")]
-impl ReplyErrBuilder<'_> {
-    /// Activates timestamp stack instrumentation with the given config.
-    #[zenoh_macros::unstable]
-    pub fn timestamp_instrumentation(
-        mut self,
-        instrumentation: Option<TimestampInstrumentation>,
-    ) -> Self {
-        self.timestamp_instrumentation = instrumentation;
-        self
     }
 }
 
@@ -328,26 +291,31 @@ impl Wait for ReplyErrBuilder<'_> {
             ext_ts_stack: None,
         };
         #[cfg(feature = "unstable")]
-        if let Some(instrumentation) = self.timestamp_instrumentation {
+        {
             use std::ops::Deref;
 
-            use zenoh_protocol::network::timestamp_stack::{
-                interception_point, TimestampStack, TsStackType,
-            };
             let rt = self.query.inner.runtime.clone().and_then(|r| r.upgrade());
             let irt = rt.as_deref().map(|r| r.deref());
-            let mut ext_ts_stack = Some(TsStackType {
-                ts_stack: TimestampStack {
-                    conf_flags: instrumentation.conf_flags(),
-                    stack: vec![],
-                },
-            });
-            crate::api::timestamp_stack::push_ts_interception(
-                &mut ext_ts_stack,
-                irt,
-                interception_point::SEND,
-            );
-            response.ext_ts_stack = ext_ts_stack;
+            response.ext_ts_stack = self
+                .query
+                .inner
+                .query_ts_stack
+                .as_ref()
+                .map(|ts_stack| {
+                    use zenoh_protocol::network::timestamp_stack::{
+                        interception_point, TsStackType,
+                    };
+                    let mut ext_ts_stack = Some(TsStackType {
+                        ts_stack: (ts_stack).into(),
+                    });
+                    crate::api::timestamp_stack::push_ts_interception(
+                        &mut ext_ts_stack,
+                        irt,
+                        interception_point::SEND,
+                    );
+                    ext_ts_stack
+                })
+                .flatten();
         }
         self.query.inner.primitives.send_response(&mut response);
         Ok(())

--- a/zenoh/src/api/builders/sample.rs
+++ b/zenoh/src/api/builders/sample.rs
@@ -18,9 +18,9 @@ use zenoh_core::zresult;
 use zenoh_protocol::core::CongestionControl;
 #[cfg(feature = "unstable")]
 use zenoh_protocol::core::Reliability;
-#[cfg(feature = "unstable")]
-use zenoh_protocol::network::timestamp_stack::TimestampStack;
 
+#[cfg(feature = "unstable")]
+use crate::api::timestamp_stack::TimestampInstrumentation;
 use crate::api::{
     bytes::{OptionZBytes, ZBytes},
     encoding::Encoding,
@@ -58,12 +58,12 @@ pub trait SampleBuilderTrait {
     /// The method accepts any `T` where `T: Into<ZBytes>` or `Option<T>` where `T: Into<ZBytes>`.
     /// See [`OptionZBytes`](crate::api::bytes::OptionZBytes) for the exact accepted forms.
     fn attachment<T: Into<OptionZBytes>>(self, attachment: T) -> Self;
-    /// Sets the timestamp stack to be sent along with the publication.
+    /// Sets the timestamp stack instrumentation to be sent along with the publication.
     ///
     /// The timestamp stack carries interception records (Send, Route, Receive)
     /// collected along the message's path through the network.
     #[zenoh_macros::unstable]
-    fn timestamp_stack<T: Into<Option<TimestampStack>>>(self, stack: T) -> Self;
+    fn timestamp_instrumentation(self, instrumentation: Option<TimestampInstrumentation>) -> Self;
 }
 
 pub trait EncodingBuilderTrait {
@@ -238,10 +238,11 @@ impl<T> SampleBuilderTrait for SampleBuilder<T> {
     }
 
     #[zenoh_macros::unstable]
-    fn timestamp_stack<S: Into<Option<TimestampStack>>>(self, stack: S) -> Self {
+    fn timestamp_instrumentation(self, instrumentation: Option<TimestampInstrumentation>) -> Self {
         Self {
             sample: Sample {
-                timestamp_stack: stack.into(),
+                timestamp_stack: instrumentation
+                    .map(|instr| crate::api::timestamp_stack::TimestampStack::new(instr)),
                 ..self.sample
             },
             _t: PhantomData::<T>,

--- a/zenoh/src/api/builders/sample.rs
+++ b/zenoh/src/api/builders/sample.rs
@@ -255,7 +255,7 @@ impl<T> TimestampInstrumentationBuilderTrait for SampleBuilder<T> {
             sample: Sample {
                 timestamp_stack: instrumentation
                     .into()
-                    .map(|instr| crate::api::timestamp_stack::TimestampStack::new(instr)),
+                    .map(crate::api::timestamp_stack::TimestampStack::new),
                 ..self.sample
             },
             _t: PhantomData::<T>,

--- a/zenoh/src/api/builders/sample.rs
+++ b/zenoh/src/api/builders/sample.rs
@@ -18,6 +18,8 @@ use zenoh_core::zresult;
 use zenoh_protocol::core::CongestionControl;
 #[cfg(feature = "unstable")]
 use zenoh_protocol::core::Reliability;
+#[cfg(feature = "unstable")]
+use zenoh_protocol::network::timestamp_stack::TimestampStack;
 
 use crate::api::{
     bytes::{OptionZBytes, ZBytes},
@@ -56,6 +58,12 @@ pub trait SampleBuilderTrait {
     /// The method accepts any `T` where `T: Into<ZBytes>` or `Option<T>` where `T: Into<ZBytes>`.
     /// See [`OptionZBytes`](crate::api::bytes::OptionZBytes) for the exact accepted forms.
     fn attachment<T: Into<OptionZBytes>>(self, attachment: T) -> Self;
+    /// Sets the timestamp stack to be sent along with the publication.
+    ///
+    /// The timestamp stack carries interception records (Send, Route, Receive)
+    /// collected along the message's path through the network.
+    #[zenoh_macros::unstable]
+    fn timestamp_stack<T: Into<Option<TimestampStack>>>(self, stack: T) -> Self;
 }
 
 pub trait EncodingBuilderTrait {
@@ -111,6 +119,8 @@ impl SampleBuilder<SampleBuilderPut> {
                 #[cfg(feature = "unstable")]
                 source_info: None,
                 attachment: None,
+                #[cfg(feature = "unstable")]
+                timestamp_stack: None,
             },
             _t: PhantomData::<SampleBuilderPut>,
         }
@@ -143,6 +153,8 @@ impl SampleBuilder<SampleBuilderDelete> {
                 #[cfg(feature = "unstable")]
                 source_info: None,
                 attachment: None,
+                #[cfg(feature = "unstable")]
+                timestamp_stack: None,
             },
             _t: PhantomData::<SampleBuilderDelete>,
         }
@@ -219,6 +231,17 @@ impl<T> SampleBuilderTrait for SampleBuilder<T> {
         Self {
             sample: Sample {
                 attachment: attachment.into(),
+                ..self.sample
+            },
+            _t: PhantomData::<T>,
+        }
+    }
+
+    #[zenoh_macros::unstable]
+    fn timestamp_stack<S: Into<Option<TimestampStack>>>(self, stack: S) -> Self {
+        Self {
+            sample: Sample {
+                timestamp_stack: stack.into(),
                 ..self.sample
             },
             _t: PhantomData::<T>,
@@ -334,6 +357,8 @@ impl From<&PublicationBuilder<&Publisher<'_>, PublicationBuilderPut>> for Sample
             #[cfg(feature = "unstable")]
             source_info: builder.source_info.clone(),
             attachment: builder.attachment.clone(),
+            #[cfg(feature = "unstable")]
+            timestamp_stack: None,
         }
     }
 }
@@ -357,6 +382,8 @@ impl From<&PublicationBuilder<&Publisher<'_>, PublicationBuilderDelete>> for Sam
             #[cfg(feature = "unstable")]
             source_info: builder.source_info.clone(),
             attachment: builder.attachment.clone(),
+            #[cfg(feature = "unstable")]
+            timestamp_stack: None,
         }
     }
 }

--- a/zenoh/src/api/builders/sample.rs
+++ b/zenoh/src/api/builders/sample.rs
@@ -58,12 +58,18 @@ pub trait SampleBuilderTrait {
     /// The method accepts any `T` where `T: Into<ZBytes>` or `Option<T>` where `T: Into<ZBytes>`.
     /// See [`OptionZBytes`](crate::api::bytes::OptionZBytes) for the exact accepted forms.
     fn attachment<T: Into<OptionZBytes>>(self, attachment: T) -> Self;
+}
+
+pub trait TimestampInstrumentationBuilderTrait {
     /// Sets the timestamp stack instrumentation to be sent along with the publication.
     ///
     /// The timestamp stack carries interception records (Send, Route, Receive)
     /// collected along the message's path through the network.
     #[zenoh_macros::unstable]
-    fn timestamp_instrumentation(self, instrumentation: Option<TimestampInstrumentation>) -> Self;
+    fn timestamp_instrumentation<TS: Into<Option<TimestampInstrumentation>>>(
+        self,
+        instrumentation: TS,
+    ) -> Self;
 }
 
 pub trait EncodingBuilderTrait {
@@ -236,12 +242,19 @@ impl<T> SampleBuilderTrait for SampleBuilder<T> {
             _t: PhantomData::<T>,
         }
     }
+}
 
+#[zenoh_macros::internal_trait]
+impl<T> TimestampInstrumentationBuilderTrait for SampleBuilder<T> {
     #[zenoh_macros::unstable]
-    fn timestamp_instrumentation(self, instrumentation: Option<TimestampInstrumentation>) -> Self {
+    fn timestamp_instrumentation<TS: Into<Option<TimestampInstrumentation>>>(
+        self,
+        instrumentation: TS,
+    ) -> Self {
         Self {
             sample: Sample {
                 timestamp_stack: instrumentation
+                    .into()
                     .map(|instr| crate::api::timestamp_stack::TimestampStack::new(instr)),
                 ..self.sample
             },

--- a/zenoh/src/api/builders/session.rs
+++ b/zenoh/src/api/builders/session.rs
@@ -27,6 +27,8 @@ use zenoh_result::ZResult;
 use zenoh_shm::api::client_storage::ShmClientStorage;
 
 use crate::api::session::Session;
+#[cfg(feature = "unstable")]
+use crate::api::timestamp_stack::GetTimestampCallback;
 #[cfg(feature = "internal")]
 use crate::net::runtime::DynamicRuntime;
 
@@ -49,6 +51,8 @@ where
     config: TryIntoConfig,
     #[cfg(feature = "shared-memory")]
     shm_clients: Option<Arc<ShmClientStorage>>,
+    #[cfg(feature = "unstable")]
+    timestamp_callback: Option<GetTimestampCallback>,
 }
 
 impl<TryIntoConfig> fmt::Debug for OpenBuilder<TryIntoConfig>
@@ -61,6 +65,11 @@ where
         debug.field("config", &"..");
         #[cfg(feature = "shared-memory")]
         debug.field("shm_clients", &self.shm_clients.as_ref().map(|_| ".."));
+        #[cfg(feature = "unstable")]
+        debug.field(
+            "timestamp_callback",
+            &self.timestamp_callback.as_ref().map(|_| ".."),
+        );
         debug.finish()
     }
 }
@@ -75,6 +84,8 @@ where
             config,
             #[cfg(feature = "shared-memory")]
             shm_clients: None,
+            #[cfg(feature = "unstable")]
+            timestamp_callback: None,
         }
     }
 }
@@ -87,6 +98,25 @@ where
 {
     pub fn with_shm_clients(mut self, shm_clients: Arc<ShmClientStorage>) -> Self {
         self.shm_clients = Some(shm_clients);
+        self
+    }
+}
+
+#[cfg(feature = "unstable")]
+impl<TryIntoConfig> OpenBuilder<TryIntoConfig>
+where
+    TryIntoConfig: std::convert::TryInto<crate::config::Config> + Send + 'static,
+    <TryIntoConfig as std::convert::TryInto<crate::config::Config>>::Error: std::fmt::Debug,
+{
+    /// Set a custom timestamp callback for timestamp stack instrumentation.
+    ///
+    /// The callback will be called at each interception point (Send, Route, Receive)
+    /// when the timestamp stack feature is activated.
+    ///
+    /// If no callback is provided, the default UHLC timestamp generation will be used.
+    #[zenoh_macros::unstable]
+    pub fn with_timestamp_callback(mut self, cb: GetTimestampCallback) -> Self {
+        self.timestamp_callback = Some(cb);
         self
     }
 }
@@ -113,6 +143,8 @@ where
             config,
             #[cfg(feature = "shared-memory")]
             self.shm_clients,
+            #[cfg(feature = "unstable")]
+            self.timestamp_callback,
         )
         .wait()
     }

--- a/zenoh/src/api/builders/session.rs
+++ b/zenoh/src/api/builders/session.rs
@@ -27,10 +27,10 @@ use zenoh_result::ZResult;
 use zenoh_shm::api::client_storage::ShmClientStorage;
 
 use crate::api::session::Session;
-#[cfg(feature = "unstable")]
-use crate::api::timestamp_stack::GetTimestampCallback;
 #[cfg(feature = "internal")]
 use crate::net::runtime::DynamicRuntime;
+#[cfg(feature = "unstable")]
+use crate::{api::timestamp_stack::GetTimestampCallback, timestamp_stack::TimestampContext};
 
 /// A builder returned by [`crate::open`] used to open a zenoh [`Session`].
 ///
@@ -115,8 +115,11 @@ where
     ///
     /// If no callback is provided, the default UHLC timestamp generation will be used.
     #[zenoh_macros::unstable]
-    pub fn with_timestamp_callback(mut self, cb: impl Into<GetTimestampCallback>) -> Self {
-        self.timestamp_callback = Some(cb.into());
+    pub fn with_timestamp_callback<F: Fn(TimestampContext) -> Vec<u8> + Send + Sync + 'static>(
+        mut self,
+        cb: F,
+    ) -> Self {
+        self.timestamp_callback = Some(Box::new(cb));
         self
     }
 }

--- a/zenoh/src/api/builders/session.rs
+++ b/zenoh/src/api/builders/session.rs
@@ -115,8 +115,8 @@ where
     ///
     /// If no callback is provided, the default UHLC timestamp generation will be used.
     #[zenoh_macros::unstable]
-    pub fn with_timestamp_callback(mut self, cb: GetTimestampCallback) -> Self {
-        self.timestamp_callback = Some(cb);
+    pub fn with_timestamp_callback(mut self, cb: impl Into<GetTimestampCallback>) -> Self {
+        self.timestamp_callback = Some(cb.into());
         self
     }
 }

--- a/zenoh/src/api/mod.rs
+++ b/zenoh/src/api/mod.rs
@@ -39,3 +39,5 @@ pub(crate) mod scouting;
 pub(crate) mod selector;
 pub(crate) mod session;
 pub(crate) mod subscriber;
+#[cfg(feature = "unstable")]
+pub(crate) mod timestamp_stack;

--- a/zenoh/src/api/publisher.rs
+++ b/zenoh/src/api/publisher.rs
@@ -270,7 +270,7 @@ impl<'a> Publisher<'a> {
             source_info: None,
             attachment: None,
             #[cfg(feature = "unstable")]
-            timestamp_stack: None,
+            timestamp_instrumentation: None,
         }
     }
 
@@ -299,7 +299,7 @@ impl<'a> Publisher<'a> {
             source_info: None,
             attachment: None,
             #[cfg(feature = "unstable")]
-            timestamp_stack: None,
+            timestamp_instrumentation: None,
         }
     }
 

--- a/zenoh/src/api/publisher.rs
+++ b/zenoh/src/api/publisher.rs
@@ -269,6 +269,8 @@ impl<'a> Publisher<'a> {
             #[cfg(feature = "unstable")]
             source_info: None,
             attachment: None,
+            #[cfg(feature = "unstable")]
+            timestamp_stack: None,
         }
     }
 
@@ -296,6 +298,8 @@ impl<'a> Publisher<'a> {
             #[cfg(feature = "unstable")]
             source_info: None,
             attachment: None,
+            #[cfg(feature = "unstable")]
+            timestamp_stack: None,
         }
     }
 
@@ -506,6 +510,8 @@ impl Sink<Sample> for Publisher<'_> {
             #[cfg(feature = "unstable")]
             None,
             attachment,
+            #[cfg(feature = "unstable")]
+            None,
         )
     }
 

--- a/zenoh/src/api/querier.rs
+++ b/zenoh/src/api/querier.rs
@@ -176,7 +176,7 @@ impl<'a> Querier<'a> {
             #[cfg(feature = "unstable")]
             cancellation_token: None,
             #[cfg(feature = "unstable")]
-            timestamp_stack: None,
+            timestamp_instrumentation: None,
         }
     }
 

--- a/zenoh/src/api/querier.rs
+++ b/zenoh/src/api/querier.rs
@@ -175,6 +175,8 @@ impl<'a> Querier<'a> {
             handler: DefaultHandler::default(),
             #[cfg(feature = "unstable")]
             cancellation_token: None,
+            #[cfg(feature = "unstable")]
+            timestamp_stack: None,
         }
     }
 

--- a/zenoh/src/api/query.rs
+++ b/zenoh/src/api/query.rs
@@ -101,6 +101,8 @@ impl Default for QueryConsolidation {
 pub struct ReplyError {
     pub(crate) payload: ZBytes,
     pub(crate) encoding: Encoding,
+    #[cfg(feature = "unstable")]
+    pub(crate) timestamp_stack: Option<zenoh_protocol::network::timestamp_stack::TimestampStack>,
 }
 
 impl ReplyError {
@@ -108,6 +110,8 @@ impl ReplyError {
         Self {
             payload: payload.into(),
             encoding,
+            #[cfg(feature = "unstable")]
+            timestamp_stack: None,
         }
     }
 
@@ -135,7 +139,21 @@ impl ReplyError {
         ReplyError {
             payload: ZBytes::new(),
             encoding: Encoding::default(),
+            #[cfg(feature = "unstable")]
+            timestamp_stack: None,
         }
+    }
+
+    /// Gets the timestamp stack of this ReplyError.
+    ///
+    /// The timestamp stack carries interception records (Send, Route, Receive)
+    /// collected along the message's path through the network.
+    #[zenoh_macros::unstable]
+    #[inline]
+    pub fn timestamp_stack(
+        &self,
+    ) -> Option<&zenoh_protocol::network::timestamp_stack::TimestampStack> {
+        self.timestamp_stack.as_ref()
     }
 }
 

--- a/zenoh/src/api/query.rs
+++ b/zenoh/src/api/query.rs
@@ -102,7 +102,7 @@ pub struct ReplyError {
     pub(crate) payload: ZBytes,
     pub(crate) encoding: Encoding,
     #[cfg(feature = "unstable")]
-    pub(crate) timestamp_stack: Option<zenoh_protocol::network::timestamp_stack::TimestampStack>,
+    pub(crate) timestamp_stack: Option<crate::api::timestamp_stack::TimestampStack>,
 }
 
 impl ReplyError {
@@ -150,9 +150,7 @@ impl ReplyError {
     /// collected along the message's path through the network.
     #[zenoh_macros::unstable]
     #[inline]
-    pub fn timestamp_stack(
-        &self,
-    ) -> Option<&zenoh_protocol::network::timestamp_stack::TimestampStack> {
+    pub fn timestamp_stack(&self) -> Option<&crate::api::timestamp_stack::TimestampStack> {
         self.timestamp_stack.as_ref()
     }
 }

--- a/zenoh/src/api/queryable.rs
+++ b/zenoh/src/api/queryable.rs
@@ -598,6 +598,8 @@ impl Query {
                 zid: self.inner.zid,
                 eid: self.eid,
             }),
+            //TODO: inherit from query
+            ext_ts_stack: None,
         });
         Ok(())
     }

--- a/zenoh/src/api/queryable.rs
+++ b/zenoh/src/api/queryable.rs
@@ -123,7 +123,7 @@ pub(crate) struct QueryInner {
     #[cfg(feature = "unstable")]
     pub(crate) runtime: Option<WeakDynamicRuntime>,
     #[cfg(feature = "unstable")]
-    pub(crate) query_ts_stack: Option<zenoh_protocol::network::timestamp_stack::TimestampStack>,
+    pub(crate) query_ts_stack: Option<crate::api::timestamp_stack::TimestampStack>,
 }
 
 impl QueryInner {
@@ -360,9 +360,7 @@ impl Query {
     /// collected along the message's path through the network.
     #[zenoh_macros::unstable]
     #[inline]
-    pub fn timestamp_stack(
-        &self,
-    ) -> Option<&zenoh_protocol::network::timestamp_stack::TimestampStack> {
+    pub fn timestamp_stack(&self) -> Option<&crate::api::timestamp_stack::TimestampStack> {
         self.inner.query_ts_stack.as_ref()
     }
 
@@ -628,13 +626,17 @@ impl Query {
             let irt = rt.as_deref().map(|r| r.deref());
             response.ext_ts_stack = sample
                 .timestamp_stack
-                .map(|ts_stack| {
-                    let mut ext_ts_stack =
-                        Some(zenoh_protocol::network::timestamp_stack::TsStackType { ts_stack });
+                .map(|ts_stack_view| {
+                    use zenoh_protocol::network::timestamp_stack::{
+                        interception_point, TsStackType,
+                    };
+                    let mut ext_ts_stack = Some(TsStackType {
+                        ts_stack: (&ts_stack_view).into(),
+                    });
                     crate::api::timestamp_stack::push_ts_interception(
                         &mut ext_ts_stack,
                         irt,
-                        zenoh_protocol::network::timestamp_stack::interception_point::SEND,
+                        interception_point::SEND,
                     );
                     ext_ts_stack
                 })

--- a/zenoh/src/api/queryable.rs
+++ b/zenoh/src/api/queryable.rs
@@ -624,23 +624,18 @@ impl Query {
         {
             let rt = self.inner.runtime.clone().and_then(|r| r.upgrade());
             let irt = rt.as_deref().map(|r| r.deref());
-            response.ext_ts_stack = sample
-                .timestamp_stack
-                .map(|ts_stack_view| {
-                    use zenoh_protocol::network::timestamp_stack::{
-                        interception_point, TsStackType,
-                    };
-                    let mut ext_ts_stack = Some(TsStackType {
-                        ts_stack: (&ts_stack_view).into(),
-                    });
-                    crate::api::timestamp_stack::push_ts_interception(
-                        &mut ext_ts_stack,
-                        irt,
-                        interception_point::SEND,
-                    );
-                    ext_ts_stack
-                })
-                .flatten();
+            response.ext_ts_stack = self.inner.query_ts_stack.as_ref().and_then(|ts_stack| {
+                use zenoh_protocol::network::timestamp_stack::{interception_point, TsStackType};
+                let mut ext_ts_stack = Some(TsStackType {
+                    ts_stack: ts_stack.into(),
+                });
+                crate::api::timestamp_stack::push_ts_interception(
+                    &mut ext_ts_stack,
+                    irt,
+                    interception_point::SEND,
+                );
+                ext_ts_stack
+            })
         }
         self.inner.primitives.send_response(&mut response);
         Ok(())

--- a/zenoh/src/api/queryable.rs
+++ b/zenoh/src/api/queryable.rs
@@ -20,6 +20,8 @@ use std::{
 
 use tracing::error;
 use zenoh_core::{Resolvable, Wait};
+#[cfg(feature = "unstable")]
+use zenoh_protocol::core::WhatAmI;
 use zenoh_protocol::{
     core::{EntityId, Parameters, WireExpr, ZenohIdProto},
     network::{response, Mapping, RequestId, Response, ResponseFinal},
@@ -31,6 +33,8 @@ use {zenoh_config::wrappers::EntityGlobalId, zenoh_protocol::core::EntityGlobalI
 
 #[zenoh_macros::unstable]
 use crate::api::sample::SourceInfo;
+#[zenoh_macros::unstable]
+use crate::api::timestamp_stack::GetTimestampCallback;
 #[zenoh_macros::internal]
 use crate::net::primitives::DummyPrimitives;
 use crate::{
@@ -118,6 +122,13 @@ pub(crate) struct QueryInner {
     #[cfg(feature = "unstable")]
     pub(crate) source_info: Option<SourceInfo>,
     pub(crate) primitives: ReplyPrimitives,
+    // TODO: fix this mess
+    #[cfg(feature = "unstable")]
+    pub(crate) whatami: WhatAmI,
+    #[cfg(feature = "unstable")]
+    pub(crate) ts_stack_callback: Option<GetTimestampCallback>,
+    #[cfg(feature = "unstable")]
+    pub(crate) query_ts_stack: Option<zenoh_protocol::network::timestamp_stack::TimestampStack>,
 }
 
 impl QueryInner {
@@ -132,6 +143,12 @@ impl QueryInner {
             #[cfg(feature = "unstable")]
             source_info: None,
             primitives: ReplyPrimitives::new_remote(None, Arc::new(DummyPrimitives)),
+            #[cfg(feature = "unstable")]
+            whatami: WhatAmI::Router, // ?!
+            #[cfg(feature = "unstable")]
+            ts_stack_callback: None,
+            #[cfg(feature = "unstable")]
+            query_ts_stack: None,
         }
     }
 }
@@ -342,6 +359,18 @@ impl Query {
     #[inline]
     pub fn source_info(&self) -> Option<&SourceInfo> {
         self.inner.source_info.as_ref()
+    }
+
+    /// Gets the timestamp stack attached to this query.
+    ///
+    /// The timestamp stack carries interception records (Send, Route, Receive)
+    /// collected along the message's path through the network.
+    #[zenoh_macros::unstable]
+    #[inline]
+    pub fn timestamp_stack(
+        &self,
+    ) -> Option<&zenoh_protocol::network::timestamp_stack::TimestampStack> {
+        self.inner.query_ts_stack.as_ref()
     }
 
     /// Sends a reply in the form of [`Sample`] to this Query.
@@ -567,7 +596,7 @@ impl Query {
         let ext_sinfo = None;
         #[cfg(feature = "unstable")]
         let ext_sinfo = sample.source_info.map(Into::into);
-        self.inner.primitives.send_response(&mut Response {
+        let mut response = Response {
             rid: self.inner.qid,
             wire_expr: self.inner.primitives.keyexpr_to_wire(&sample.key_expr),
             payload: ResponseBody::Reply(zenoh::Reply {
@@ -598,9 +627,29 @@ impl Query {
                 zid: self.inner.zid,
                 eid: self.eid,
             }),
-            //TODO: inherit from query
             ext_ts_stack: None,
-        });
+        };
+        #[cfg(feature = "unstable")]
+        {
+            response.ext_ts_stack = sample
+                .timestamp_stack
+                .map(|ts_stack| {
+                    let mut ext_ts_stack =
+                        Some(zenoh_protocol::network::timestamp_stack::TsStackType { ts_stack });
+                    if let Some(ref cb) = self.inner.ts_stack_callback {
+                        crate::api::timestamp_stack::push_ts_interception(
+                            &mut ext_ts_stack,
+                            self.inner.zid.into(),
+                            self.inner.whatami,
+                            |ctx| cb(ctx),
+                            zenoh_protocol::network::timestamp_stack::interception_point::SEND,
+                        );
+                    }
+                    ext_ts_stack
+                })
+                .flatten();
+        }
+        self.inner.primitives.send_response(&mut response);
         Ok(())
     }
 }

--- a/zenoh/src/api/queryable.rs
+++ b/zenoh/src/api/queryable.rs
@@ -622,20 +622,20 @@ impl Query {
         };
         #[cfg(feature = "unstable")]
         {
-            let rt = self.inner.runtime.clone().and_then(|r| r.upgrade());
-            let irt = rt.as_deref().map(|r| r.deref());
+            let weak_rt = self.inner.runtime.clone();
             response.ext_ts_stack = self.inner.query_ts_stack.as_ref().and_then(|ts_stack| {
                 use zenoh_protocol::network::timestamp_stack::{interception_point, TsStackType};
                 let mut ext_ts_stack = Some(TsStackType {
                     ts_stack: ts_stack.into(),
                 });
+                let upgrade = weak_rt.clone();
                 crate::api::timestamp_stack::push_ts_interception(
                     &mut ext_ts_stack,
-                    irt,
+                    move || upgrade.and_then(|r| r.upgrade()).map(|dr| dr.get_inner()),
                     interception_point::SEND,
                 );
                 ext_ts_stack
-            })
+            });
         }
         self.inner.primitives.send_response(&mut response);
         Ok(())

--- a/zenoh/src/api/queryable.rs
+++ b/zenoh/src/api/queryable.rs
@@ -20,8 +20,6 @@ use std::{
 
 use tracing::error;
 use zenoh_core::{Resolvable, Wait};
-#[cfg(feature = "unstable")]
-use zenoh_protocol::core::WhatAmI;
 use zenoh_protocol::{
     core::{EntityId, Parameters, WireExpr, ZenohIdProto},
     network::{response, Mapping, RequestId, Response, ResponseFinal},
@@ -33,10 +31,10 @@ use {zenoh_config::wrappers::EntityGlobalId, zenoh_protocol::core::EntityGlobalI
 
 #[zenoh_macros::unstable]
 use crate::api::sample::SourceInfo;
-#[zenoh_macros::unstable]
-use crate::api::timestamp_stack::GetTimestampCallback;
 #[zenoh_macros::internal]
 use crate::net::primitives::DummyPrimitives;
+#[cfg(feature = "unstable")]
+use crate::net::runtime::WeakDynamicRuntime;
 use crate::{
     api::{
         builders::reply::{ReplyBuilder, ReplyBuilderDelete, ReplyBuilderPut, ReplyErrBuilder},
@@ -122,11 +120,8 @@ pub(crate) struct QueryInner {
     #[cfg(feature = "unstable")]
     pub(crate) source_info: Option<SourceInfo>,
     pub(crate) primitives: ReplyPrimitives,
-    // TODO: fix this mess
     #[cfg(feature = "unstable")]
-    pub(crate) whatami: WhatAmI,
-    #[cfg(feature = "unstable")]
-    pub(crate) ts_stack_callback: Option<GetTimestampCallback>,
+    pub(crate) runtime: Option<WeakDynamicRuntime>,
     #[cfg(feature = "unstable")]
     pub(crate) query_ts_stack: Option<zenoh_protocol::network::timestamp_stack::TimestampStack>,
 }
@@ -144,9 +139,7 @@ impl QueryInner {
             source_info: None,
             primitives: ReplyPrimitives::new_remote(None, Arc::new(DummyPrimitives)),
             #[cfg(feature = "unstable")]
-            whatami: WhatAmI::Router, // ?!
-            #[cfg(feature = "unstable")]
-            ts_stack_callback: None,
+            runtime: None,
             #[cfg(feature = "unstable")]
             query_ts_stack: None,
         }
@@ -631,20 +624,18 @@ impl Query {
         };
         #[cfg(feature = "unstable")]
         {
+            let rt = self.inner.runtime.clone().and_then(|r| r.upgrade());
+            let irt = rt.as_deref().map(|r| r.deref());
             response.ext_ts_stack = sample
                 .timestamp_stack
                 .map(|ts_stack| {
                     let mut ext_ts_stack =
                         Some(zenoh_protocol::network::timestamp_stack::TsStackType { ts_stack });
-                    if let Some(ref cb) = self.inner.ts_stack_callback {
-                        crate::api::timestamp_stack::push_ts_interception(
-                            &mut ext_ts_stack,
-                            self.inner.zid.into(),
-                            self.inner.whatami,
-                            |ctx| cb(ctx),
-                            zenoh_protocol::network::timestamp_stack::interception_point::SEND,
-                        );
-                    }
+                    crate::api::timestamp_stack::push_ts_interception(
+                        &mut ext_ts_stack,
+                        irt,
+                        zenoh_protocol::network::timestamp_stack::interception_point::SEND,
+                    );
                     ext_ts_stack
                 })
                 .flatten();

--- a/zenoh/src/api/sample.rs
+++ b/zenoh/src/api/sample.rs
@@ -373,8 +373,7 @@ impl Sample {
     ) -> Self {
         #[cfg(feature = "unstable")]
         let timestamp_stack = timestamp_stack
-            .map(|ts| crate::api::timestamp_stack::TimestampStack::try_from(&ts).ok())
-            .flatten();
+            .and_then(|ts| crate::api::timestamp_stack::TimestampStack::try_from(&ts).ok());
         match body {
             PushBody::Put(put) => Self {
                 key_expr,

--- a/zenoh/src/api/sample.rs
+++ b/zenoh/src/api/sample.rs
@@ -369,6 +369,9 @@ impl Sample {
         qos: push::ext::QoSType,
         body: &mut PushBody,
         #[cfg(feature = "unstable")] reliability: Reliability,
+        #[cfg(feature = "unstable")] timestamp_stack: Option<
+            zenoh_protocol::network::timestamp_stack::TimestampStack,
+        >,
     ) -> Self {
         match body {
             PushBody::Put(put) => Self {
@@ -384,7 +387,7 @@ impl Sample {
                 source_info: put.ext_sinfo.map(Into::into),
                 attachment: mem::take(&mut put.ext_attachment).map(Into::into),
                 #[cfg(feature = "unstable")]
-                timestamp_stack: None,
+                timestamp_stack,
             },
             PushBody::Del(del) => Self {
                 key_expr,
@@ -399,7 +402,7 @@ impl Sample {
                 source_info: del.ext_sinfo.map(Into::into),
                 attachment: mem::take(&mut del.ext_attachment).map(Into::into),
                 #[cfg(feature = "unstable")]
-                timestamp_stack: None,
+                timestamp_stack,
             },
         }
     }
@@ -412,6 +415,7 @@ impl CallbackParameter for Sample {
         push::ext::QoSType,
         &'a mut PushBody,
         Reliability,
+        Option<zenoh_protocol::network::timestamp_stack::TimestampStack>,
     );
     #[cfg(not(feature = "unstable"))]
     type Message<'a> = (KeyExpr<'static>, push::ext::QoSType, &'a mut PushBody);
@@ -423,6 +427,8 @@ impl CallbackParameter for Sample {
             msg.2,
             #[cfg(feature = "unstable")]
             msg.3,
+            #[cfg(feature = "unstable")]
+            msg.4,
         )
     }
 }

--- a/zenoh/src/api/sample.rs
+++ b/zenoh/src/api/sample.rs
@@ -250,7 +250,6 @@ pub struct Sample {
     #[cfg(feature = "unstable")]
     pub(crate) source_info: Option<SourceInfo>,
     pub(crate) attachment: Option<ZBytes>,
-    // TODO: expose higher-level type instead of using zenoh_protocol
     #[cfg(feature = "unstable")]
     pub(crate) timestamp_stack: Option<crate::api::timestamp_stack::TimestampStack>,
 }

--- a/zenoh/src/api/sample.rs
+++ b/zenoh/src/api/sample.rs
@@ -252,7 +252,7 @@ pub struct Sample {
     pub(crate) attachment: Option<ZBytes>,
     // TODO: expose higher-level type instead of using zenoh_protocol
     #[cfg(feature = "unstable")]
-    pub(crate) timestamp_stack: Option<zenoh_protocol::network::timestamp_stack::TimestampStack>,
+    pub(crate) timestamp_stack: Option<crate::api::timestamp_stack::TimestampStack>,
 }
 
 impl Sample {
@@ -326,9 +326,7 @@ impl Sample {
     /// collected along the message's path through the network.
     #[zenoh_macros::unstable]
     #[inline]
-    pub fn timestamp_stack(
-        &self,
-    ) -> Option<&zenoh_protocol::network::timestamp_stack::TimestampStack> {
+    pub fn timestamp_stack(&self) -> Option<&crate::api::timestamp_stack::TimestampStack> {
         self.timestamp_stack.as_ref()
     }
 
@@ -373,6 +371,10 @@ impl Sample {
             zenoh_protocol::network::timestamp_stack::TimestampStack,
         >,
     ) -> Self {
+        #[cfg(feature = "unstable")]
+        let timestamp_stack = timestamp_stack
+            .map(|ts| crate::api::timestamp_stack::TimestampStack::try_from(&ts).ok())
+            .flatten();
         match body {
             PushBody::Put(put) => Self {
                 key_expr,

--- a/zenoh/src/api/sample.rs
+++ b/zenoh/src/api/sample.rs
@@ -250,6 +250,9 @@ pub struct Sample {
     #[cfg(feature = "unstable")]
     pub(crate) source_info: Option<SourceInfo>,
     pub(crate) attachment: Option<ZBytes>,
+    // TODO: expose higher-level type instead of using zenoh_protocol
+    #[cfg(feature = "unstable")]
+    pub(crate) timestamp_stack: Option<zenoh_protocol::network::timestamp_stack::TimestampStack>,
 }
 
 impl Sample {
@@ -317,6 +320,18 @@ impl Sample {
         self.source_info.as_ref()
     }
 
+    /// Gets the optional timestamp stack attached to this sample.
+    ///
+    /// The timestamp stack carries interception records (Send, Route, Receive)
+    /// collected along the message's path through the network.
+    #[zenoh_macros::unstable]
+    #[inline]
+    pub fn timestamp_stack(
+        &self,
+    ) -> Option<&zenoh_protocol::network::timestamp_stack::TimestampStack> {
+        self.timestamp_stack.as_ref()
+    }
+
     /// Gets the optional sample attachment as bytes.
     #[inline]
     pub fn attachment(&self) -> Option<&ZBytes> {
@@ -344,6 +359,8 @@ impl Sample {
             #[cfg(feature = "unstable")]
             source_info: None,
             attachment: None,
+            #[cfg(feature = "unstable")]
+            timestamp_stack: None,
         }
     }
 
@@ -366,6 +383,8 @@ impl Sample {
                 #[cfg(feature = "unstable")]
                 source_info: put.ext_sinfo.map(Into::into),
                 attachment: mem::take(&mut put.ext_attachment).map(Into::into),
+                #[cfg(feature = "unstable")]
+                timestamp_stack: None,
             },
             PushBody::Del(del) => Self {
                 key_expr,
@@ -379,6 +398,8 @@ impl Sample {
                 #[cfg(feature = "unstable")]
                 source_info: del.ext_sinfo.map(Into::into),
                 attachment: mem::take(&mut del.ext_attachment).map(Into::into),
+                #[cfg(feature = "unstable")]
+                timestamp_stack: None,
             },
         }
     }

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -74,11 +74,6 @@ use super::{
     builders::close::{CloseBuilder, Closeable, Closee},
     connectivity,
 };
-#[cfg(feature = "unstable")]
-use crate::api::{
-    cancellation::CancellationToken, sample::SourceInfo, selector::ZenohParameters,
-    timestamp_stack::GetTimestampCallback,
-};
 #[cfg(feature = "internal")]
 use crate::net::runtime::Runtime;
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
@@ -123,6 +118,14 @@ use crate::{
     },
     query::ReplyError,
     Config,
+};
+#[cfg(feature = "unstable")]
+use crate::{
+    api::{
+        cancellation::CancellationToken, sample::SourceInfo, selector::ZenohParameters,
+        timestamp_stack::GetTimestampCallback,
+    },
+    net::runtime::DynamicRuntime,
 };
 
 zconfigurable! {
@@ -2536,9 +2539,7 @@ impl Session {
                 Some(zenoh_protocol::network::timestamp_stack::TsStackType { ts_stack });
             crate::api::timestamp_stack::push_ts_interception(
                 &mut ext_ts_stack,
-                self.0.runtime.zid(),
-                self.0.runtime.whatami(),
-                |ctx| self.0.runtime.get_ts_stack_timestamp(ctx),
+                Some(&*self.0.runtime.as_ref()),
                 zenoh_protocol::network::timestamp_stack::interception_point::SEND,
             );
             push.ext_ts_stack = ext_ts_stack;
@@ -2743,9 +2744,7 @@ impl Session {
                     Some(zenoh_protocol::network::timestamp_stack::TsStackType { ts_stack });
                 crate::api::timestamp_stack::push_ts_interception(
                     &mut ext_ts_stack,
-                    self.0.runtime.zid(),
-                    self.0.runtime.whatami(),
-                    |ctx| self.0.runtime.get_ts_stack_timestamp(ctx),
+                    Some(&*self.0.runtime.as_ref()),
                     zenoh_protocol::network::timestamp_stack::interception_point::SEND,
                 );
                 ext_ts_stack
@@ -2955,17 +2954,7 @@ impl Session {
                 ReplyPrimitives::new_remote(Some(self.downgrade()), primitives.into_primitives())
             },
             #[cfg(feature = "unstable")]
-            whatami: self.0.runtime.whatami(),
-            #[cfg(feature = "unstable")]
-            ts_stack_callback: {
-                let runtime = self.0.runtime.clone();
-                // FIXME: check if this keeps strong reference on Runtime
-                Some(std::sync::Arc::new(
-                    move |ctx: crate::api::timestamp_stack::TsStackContext| {
-                        runtime.get_ts_stack_timestamp(ctx)
-                    },
-                ))
-            },
+            runtime: Some(DynamicRuntime::downgrade(&self.0.runtime.deref())),
             #[cfg(feature = "unstable")]
             query_ts_stack: timestamp_stack,
         });
@@ -3286,9 +3275,7 @@ impl Primitives for WeakSession {
         #[cfg(feature = "unstable")]
         crate::api::timestamp_stack::push_ts_interception(
             &mut msg.ext_ts_stack,
-            self.0.runtime.zid(),
-            self.0.runtime.whatami(),
-            |ctx| self.0.runtime.get_ts_stack_timestamp(ctx),
+            Some(&*self.0.runtime.as_ref()),
             zenoh_protocol::network::timestamp_stack::interception_point::RECEIVE,
         );
         callbacks.call(
@@ -3306,9 +3293,7 @@ impl Primitives for WeakSession {
         #[cfg(feature = "unstable")]
         crate::api::timestamp_stack::push_ts_interception(
             &mut msg.ext_ts_stack,
-            self.0.runtime.zid(),
-            self.0.runtime.whatami(),
-            |ctx| self.0.runtime.get_ts_stack_timestamp(ctx),
+            Some(&*self.0.runtime.as_ref()),
             zenoh_protocol::network::timestamp_stack::interception_point::RECEIVE,
         );
         match &mut msg.payload {
@@ -3350,9 +3335,7 @@ impl Primitives for WeakSession {
         #[cfg(feature = "unstable")]
         crate::api::timestamp_stack::push_ts_interception(
             &mut msg.ext_ts_stack,
-            self.0.runtime.zid(),
-            self.0.runtime.whatami(),
-            |ctx| self.0.runtime.get_ts_stack_timestamp(ctx),
+            Some(&*self.0.runtime.as_ref()),
             zenoh_protocol::network::timestamp_stack::interception_point::RECEIVE,
         );
         match &mut msg.payload {

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -73,7 +73,10 @@ use super::{
     connectivity,
 };
 #[cfg(feature = "unstable")]
-use crate::api::{cancellation::CancellationToken, sample::SourceInfo, selector::ZenohParameters};
+use crate::api::{
+    cancellation::CancellationToken, sample::SourceInfo, selector::ZenohParameters,
+    timestamp_stack::GetTimestampCallback,
+};
 #[cfg(feature = "internal")]
 use crate::net::runtime::Runtime;
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
@@ -1431,6 +1434,7 @@ impl Session {
     pub(super) fn new(
         config: Config,
         #[cfg(feature = "shared-memory")] shm_clients: Option<Arc<ShmClientStorage>>,
+        #[cfg(feature = "unstable")] timestamp_callback: Option<GetTimestampCallback>,
     ) -> impl Resolve<ZResult<Session>> {
         ResolveFuture::new(async move {
             tracing::debug!("Config: {:?}", &config);
@@ -1441,6 +1445,10 @@ impl Session {
             #[cfg(feature = "shared-memory")]
             {
                 runtime = runtime.shm_clients(shm_clients);
+            }
+            #[cfg(feature = "unstable")]
+            {
+                runtime = runtime.timestamp_callback(timestamp_callback);
             }
             let mut runtime = runtime.build().await?;
 

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -2493,7 +2493,7 @@ impl Session {
             #[cfg(feature = "unstable")]
             reliability,
             // NOTE: execute_subscriber_callbacks is currently only called for Liveliness subscribers,
-            // so there is not need to pass ext_ts_stack in its parameters.
+            // so there is no need to pass ext_ts_stack in its parameters.
             #[cfg(feature = "unstable")]
             None,
         );

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -3222,6 +3222,14 @@ impl Primitives for WeakSession {
         let callbacks =
             state.subscriber_callbacks(false, SubscriberKind::Subscriber, &msg.wire_expr, false);
         drop(state);
+        #[cfg(feature = "unstable")]
+        crate::api::timestamp_stack::push_ts_interception(
+            &mut msg.ext_ts_stack,
+            self.0.runtime.zid(),
+            self.0.runtime.whatami(),
+            |ctx| self.0.runtime.get_ts_stack_timestamp(ctx),
+            zenoh_protocol::network::timestamp_stack::interception_point::RECEIVE,
+        );
         callbacks.call(
             consume,
             msg.ext_qos,
@@ -3233,6 +3241,15 @@ impl Primitives for WeakSession {
 
     fn send_request(&self, msg: &mut Request) {
         trace!("recv Request {:?}", msg);
+        // TODO: move closer to the queryable callback
+        #[cfg(feature = "unstable")]
+        crate::api::timestamp_stack::push_ts_interception(
+            &mut msg.ext_ts_stack,
+            self.0.runtime.zid(),
+            self.0.runtime.whatami(),
+            |ctx| self.0.runtime.get_ts_stack_timestamp(ctx),
+            zenoh_protocol::network::timestamp_stack::interception_point::RECEIVE,
+        );
         match &mut msg.payload {
             RequestBody::Query(m) => {
                 let state = zread!(self.0.state);
@@ -3266,6 +3283,14 @@ impl Primitives for WeakSession {
 
     fn send_response(&self, msg: &mut Response) {
         trace!("recv Response {:?}", msg);
+        #[cfg(feature = "unstable")]
+        crate::api::timestamp_stack::push_ts_interception(
+            &mut msg.ext_ts_stack,
+            self.0.runtime.zid(),
+            self.0.runtime.whatami(),
+            |ctx| self.0.runtime.get_ts_stack_timestamp(ctx),
+            zenoh_protocol::network::timestamp_stack::interception_point::RECEIVE,
+        );
         match &mut msg.payload {
             ResponseBody::Err(e) => {
                 let mut state = zwrite!(self.0.state);

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -2567,11 +2567,14 @@ impl Session {
                     stack: vec![],
                 },
             });
-            crate::api::timestamp_stack::push_ts_interception(
-                &mut ext_ts_stack,
-                Some(self.0.runtime.as_ref()),
-                interception_point::SEND,
-            );
+            {
+                let rt = self.0.runtime.get_inner();
+                crate::api::timestamp_stack::push_ts_interception(
+                    &mut ext_ts_stack,
+                    || Some(rt),
+                    interception_point::SEND,
+                );
+            }
             push.ext_ts_stack = ext_ts_stack;
         }
         let has_local_callbacks = !callbacks.is_empty();
@@ -2608,9 +2611,10 @@ impl Session {
 
             #[cfg(feature = "unstable")]
             {
+                let rt = self.0.runtime.get_inner();
                 crate::api::timestamp_stack::push_ts_interception(
                     &mut push.ext_ts_stack,
-                    Some(self.0.runtime.as_ref()),
+                    || Some(rt),
                     zenoh_protocol::network::timestamp_stack::interception_point::RECEIVE,
                 );
             }
@@ -2796,11 +2800,14 @@ impl Session {
                     stack: vec![],
                 },
             });
-            crate::api::timestamp_stack::push_ts_interception(
-                &mut ext_ts_stack,
-                Some(self.0.runtime.as_ref()),
-                interception_point::SEND,
-            );
+            {
+                let rt = self.0.runtime.get_inner();
+                crate::api::timestamp_stack::push_ts_interception(
+                    &mut ext_ts_stack,
+                    || Some(rt),
+                    interception_point::SEND,
+                );
+            }
             ext_ts_stack
         });
         if destination != Locality::SessionLocal {
@@ -2837,9 +2844,10 @@ impl Session {
         if destination != Locality::Remote {
             #[cfg(feature = "unstable")]
             {
+                let rt = self.0.runtime.get_inner();
                 crate::api::timestamp_stack::push_ts_interception(
                     &mut ext_ts_stack,
-                    Some(self.0.runtime.as_ref()),
+                    || Some(rt),
                     zenoh_protocol::network::timestamp_stack::interception_point::RECEIVE,
                 );
             }
@@ -3340,11 +3348,14 @@ impl Primitives for WeakSession {
             state.subscriber_callbacks(false, SubscriberKind::Subscriber, &msg.wire_expr, false);
         drop(state);
         #[cfg(feature = "unstable")]
-        crate::api::timestamp_stack::push_ts_interception(
-            &mut msg.ext_ts_stack,
-            Some(self.0.runtime.as_ref()),
-            zenoh_protocol::network::timestamp_stack::interception_point::RECEIVE,
-        );
+        {
+            let rt = self.0.runtime.get_inner();
+            crate::api::timestamp_stack::push_ts_interception(
+                &mut msg.ext_ts_stack,
+                || Some(rt),
+                zenoh_protocol::network::timestamp_stack::interception_point::RECEIVE,
+            );
+        }
         callbacks.call(
             consume,
             msg.ext_qos,
@@ -3359,11 +3370,14 @@ impl Primitives for WeakSession {
     fn send_request(&self, msg: &mut Request) {
         trace!("recv Request {:?}", msg);
         #[cfg(feature = "unstable")]
-        crate::api::timestamp_stack::push_ts_interception(
-            &mut msg.ext_ts_stack,
-            Some(self.0.runtime.as_ref()),
-            zenoh_protocol::network::timestamp_stack::interception_point::RECEIVE,
-        );
+        {
+            let rt = self.0.runtime.get_inner();
+            crate::api::timestamp_stack::push_ts_interception(
+                &mut msg.ext_ts_stack,
+                || Some(rt),
+                zenoh_protocol::network::timestamp_stack::interception_point::RECEIVE,
+            );
+        }
         match &mut msg.payload {
             RequestBody::Query(m) => {
                 let state = zread!(self.0.state);
@@ -3400,11 +3414,14 @@ impl Primitives for WeakSession {
     fn send_response(&self, msg: &mut Response) {
         trace!("recv Response {:?}", msg);
         #[cfg(feature = "unstable")]
-        crate::api::timestamp_stack::push_ts_interception(
-            &mut msg.ext_ts_stack,
-            Some(self.0.runtime.as_ref()),
-            zenoh_protocol::network::timestamp_stack::interception_point::RECEIVE,
-        );
+        {
+            let rt = self.0.runtime.get_inner();
+            crate::api::timestamp_stack::push_ts_interception(
+                &mut msg.ext_ts_stack,
+                || Some(rt),
+                zenoh_protocol::network::timestamp_stack::interception_point::RECEIVE,
+            );
+        }
         match &mut msg.payload {
             ResponseBody::Err(e) => {
                 let mut state = zwrite!(self.0.state);

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -2556,7 +2556,7 @@ impl Session {
             });
             crate::api::timestamp_stack::push_ts_interception(
                 &mut ext_ts_stack,
-                Some(&*self.0.runtime.as_ref()),
+                Some(self.0.runtime.as_ref()),
                 interception_point::SEND,
             );
             push.ext_ts_stack = ext_ts_stack;
@@ -2597,7 +2597,7 @@ impl Session {
             {
                 crate::api::timestamp_stack::push_ts_interception(
                     &mut push.ext_ts_stack,
-                    Some(&*self.0.runtime.as_ref()),
+                    Some(self.0.runtime.as_ref()),
                     zenoh_protocol::network::timestamp_stack::interception_point::RECEIVE,
                 );
             }
@@ -2773,25 +2773,23 @@ impl Session {
         #[cfg(not(feature = "unstable"))]
         let ext_ts_stack = None;
         #[cfg(feature = "unstable")]
-        let mut ext_ts_stack = timestamp_instrumentation
-            .map(|instrumentation| {
-                use zenoh_protocol::network::timestamp_stack::{
-                    interception_point, TimestampStack, TsStackType,
-                };
-                let mut ext_ts_stack = Some(TsStackType {
-                    ts_stack: TimestampStack {
-                        conf_flags: instrumentation.conf_flags(),
-                        stack: vec![],
-                    },
-                });
-                crate::api::timestamp_stack::push_ts_interception(
-                    &mut ext_ts_stack,
-                    Some(&*self.0.runtime.as_ref()),
-                    interception_point::SEND,
-                );
-                ext_ts_stack
-            })
-            .flatten();
+        let mut ext_ts_stack = timestamp_instrumentation.and_then(|instrumentation| {
+            use zenoh_protocol::network::timestamp_stack::{
+                interception_point, TimestampStack, TsStackType,
+            };
+            let mut ext_ts_stack = Some(TsStackType {
+                ts_stack: TimestampStack {
+                    conf_flags: instrumentation.conf_flags(),
+                    stack: vec![],
+                },
+            });
+            crate::api::timestamp_stack::push_ts_interception(
+                &mut ext_ts_stack,
+                Some(self.0.runtime.as_ref()),
+                interception_point::SEND,
+            );
+            ext_ts_stack
+        });
         if destination != Locality::SessionLocal {
             let wexpr = key_expr.to_wire(self).to_owned();
             let ext_attachment = attachment.clone().map(Into::into);
@@ -2830,7 +2828,7 @@ impl Session {
             {
                 crate::api::timestamp_stack::push_ts_interception(
                     &mut ext_ts_stack,
-                    Some(&*self.0.runtime.as_ref()),
+                    Some(self.0.runtime.as_ref()),
                     zenoh_protocol::network::timestamp_stack::interception_point::RECEIVE,
                 );
             }
@@ -2996,8 +2994,7 @@ impl Session {
         #[cfg(feature = "unstable")]
         let query_ts_stack = timestamp_stack
             .as_ref()
-            .map(|ts| crate::api::timestamp_stack::TimestampStack::try_from(ts).ok())
-            .flatten();
+            .and_then(|ts| crate::api::timestamp_stack::TimestampStack::try_from(ts).ok());
 
         let query_inner = Arc::new(QueryInner {
             key_expr: key_expr.clone().into_owned(),
@@ -3334,7 +3331,7 @@ impl Primitives for WeakSession {
         #[cfg(feature = "unstable")]
         crate::api::timestamp_stack::push_ts_interception(
             &mut msg.ext_ts_stack,
-            Some(&*self.0.runtime.as_ref()),
+            Some(self.0.runtime.as_ref()),
             zenoh_protocol::network::timestamp_stack::interception_point::RECEIVE,
         );
         callbacks.call(
@@ -3353,7 +3350,7 @@ impl Primitives for WeakSession {
         #[cfg(feature = "unstable")]
         crate::api::timestamp_stack::push_ts_interception(
             &mut msg.ext_ts_stack,
-            Some(&*self.0.runtime.as_ref()),
+            Some(self.0.runtime.as_ref()),
             zenoh_protocol::network::timestamp_stack::interception_point::RECEIVE,
         );
         match &mut msg.payload {
@@ -3395,7 +3392,7 @@ impl Primitives for WeakSession {
         #[cfg(feature = "unstable")]
         crate::api::timestamp_stack::push_ts_interception(
             &mut msg.ext_ts_stack,
-            Some(&*self.0.runtime.as_ref()),
+            Some(self.0.runtime.as_ref()),
             zenoh_protocol::network::timestamp_stack::interception_point::RECEIVE,
         );
         match &mut msg.payload {
@@ -3417,7 +3414,7 @@ impl Primitives for WeakSession {
                                 timestamp_stack: msg
                                     .ext_ts_stack
                                     .as_ref()
-                                    .map(|ts| crate::api::timestamp_stack::TimestampStack::try_from(&ts.ts_stack).ok()).flatten(),
+                                    .and_then(|ts| crate::api::timestamp_stack::TimestampStack::try_from(&ts.ts_stack).ok()),
                             }),
                             #[cfg(feature = "unstable")]
                             replier_id: mem::take(&mut msg.ext_respid).map(|rid| {

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -40,8 +40,6 @@ use zenoh_config::{
 use zenoh_config::{wrappers::EntityGlobalId, GenericConfig};
 use zenoh_core::{zconfigurable, zread, Resolve, ResolveClosure, ResolveFuture, Wait};
 use zenoh_keyexpr::keyexpr_tree::{IKeyExprTree, IKeyExprTreeNode, KeBoxTree};
-#[cfg(feature = "unstable")]
-use zenoh_protocol::network::timestamp_stack::TimestampStack;
 use zenoh_protocol::{
     core::{
         key_expr::{keyexpr, OwnedKeyExpr},
@@ -74,6 +72,8 @@ use super::{
     builders::close::{CloseBuilder, Closeable, Closee},
     connectivity,
 };
+#[cfg(feature = "unstable")]
+use crate::api::timestamp_stack::TimestampInstrumentation;
 #[cfg(feature = "unstable")]
 use crate::api::{
     cancellation::CancellationToken, sample::SourceInfo, selector::ZenohParameters,
@@ -1352,7 +1352,7 @@ impl Session {
             #[cfg(feature = "unstable")]
             source_info: None,
             #[cfg(feature = "unstable")]
-            timestamp_stack: None,
+            timestamp_instrumentation: None,
         }
     }
 
@@ -1389,7 +1389,7 @@ impl Session {
             #[cfg(feature = "unstable")]
             source_info: None,
             #[cfg(feature = "unstable")]
-            timestamp_stack: None,
+            timestamp_instrumentation: None,
         }
     }
     /// Query data from the matching queryables in the system. This is a shortcut for declaring
@@ -1441,7 +1441,7 @@ impl Session {
             #[cfg(feature = "unstable")]
             cancellation_token: None,
             #[cfg(feature = "unstable")]
-            timestamp_stack: None,
+            timestamp_instrumentation: None,
         }
     }
 }
@@ -2501,7 +2501,7 @@ impl Session {
         timestamp: Option<uhlc::Timestamp>,
         #[cfg(feature = "unstable")] source_info: Option<SourceInfo>,
         attachment: Option<ZBytes>,
-        #[cfg(feature = "unstable")] timestamp_stack: Option<TimestampStack>,
+        #[cfg(feature = "unstable")] timestamp_instrumentation: Option<TimestampInstrumentation>,
     ) -> ZResult<()> {
         trace!("write({:?}, [...])", key_expr);
         let state = zread!(self.0.state);
@@ -2544,13 +2544,20 @@ impl Session {
             })
         };
         #[cfg(feature = "unstable")]
-        if let Some(ts_stack) = timestamp_stack {
-            let mut ext_ts_stack =
-                Some(zenoh_protocol::network::timestamp_stack::TsStackType { ts_stack });
+        if let Some(instrumentation) = timestamp_instrumentation {
+            use zenoh_protocol::network::timestamp_stack::{
+                interception_point, TimestampStack, TsStackType,
+            };
+            let mut ext_ts_stack = Some(TsStackType {
+                ts_stack: TimestampStack {
+                    conf_flags: instrumentation.conf_flags(),
+                    stack: vec![],
+                },
+            });
             crate::api::timestamp_stack::push_ts_interception(
                 &mut ext_ts_stack,
                 Some(&*self.0.runtime.as_ref()),
-                zenoh_protocol::network::timestamp_stack::interception_point::SEND,
+                interception_point::SEND,
             );
             push.ext_ts_stack = ext_ts_stack;
         }
@@ -2675,7 +2682,7 @@ impl Session {
         #[cfg(feature = "unstable")] cancellation_token: Option<CancellationToken>,
         querier_id: Option<EntityId>,
         querier_notifier: Option<SyncGroupNotifier>,
-        #[cfg(feature = "unstable")] timestamp_stack: Option<TimestampStack>,
+        #[cfg(feature = "unstable")] timestamp_instrumentation: Option<TimestampInstrumentation>,
     ) -> ZResult<()> {
         tracing::trace!(
             "get({}, {:?}, {:?})",
@@ -2758,14 +2765,21 @@ impl Session {
         #[cfg(not(feature = "unstable"))]
         let ext_ts_stack = None;
         #[cfg(feature = "unstable")]
-        let ext_ts_stack = timestamp_stack
-            .map(|ts_stack| {
-                let mut ext_ts_stack =
-                    Some(zenoh_protocol::network::timestamp_stack::TsStackType { ts_stack });
+        let ext_ts_stack = timestamp_instrumentation
+            .map(|instrumentation| {
+                use zenoh_protocol::network::timestamp_stack::{
+                    interception_point, TimestampStack, TsStackType,
+                };
+                let mut ext_ts_stack = Some(TsStackType {
+                    ts_stack: TimestampStack {
+                        conf_flags: instrumentation.conf_flags(),
+                        stack: vec![],
+                    },
+                });
                 crate::api::timestamp_stack::push_ts_interception(
                     &mut ext_ts_stack,
                     Some(&*self.0.runtime.as_ref()),
-                    zenoh_protocol::network::timestamp_stack::interception_point::SEND,
+                    interception_point::SEND,
                 );
                 ext_ts_stack
             })
@@ -2939,7 +2953,9 @@ impl Session {
         #[cfg(feature = "unstable")] source_info: Option<SourceInfo>,
         body: Option<QueryBodyType>,
         attachment: Option<ZBytes>,
-        #[cfg(feature = "unstable")] timestamp_stack: Option<TimestampStack>,
+        #[cfg(feature = "unstable")] timestamp_stack: Option<
+            zenoh_protocol::network::timestamp_stack::TimestampStack,
+        >,
     ) {
         let Ok(primitives) = state.primitives() else {
             return;
@@ -2960,6 +2976,12 @@ impl Session {
 
         let zid = self.zid();
 
+        #[cfg(feature = "unstable")]
+        let query_ts_stack = timestamp_stack
+            .as_ref()
+            .map(|ts| crate::api::timestamp_stack::TimestampStack::try_from(ts).ok())
+            .flatten();
+
         let query_inner = Arc::new(QueryInner {
             key_expr: key_expr.clone().into_owned(),
             parameters: parameters.to_owned().into(),
@@ -2976,7 +2998,7 @@ impl Session {
             #[cfg(feature = "unstable")]
             runtime: Some(self.0.runtime.downgrade()),
             #[cfg(feature = "unstable")]
-            query_ts_stack: timestamp_stack,
+            query_ts_stack,
         });
         if !queryables.is_empty() {
             let mut query = Query {
@@ -3378,7 +3400,7 @@ impl Primitives for WeakSession {
                                 timestamp_stack: msg
                                     .ext_ts_stack
                                     .as_ref()
-                                    .map(|ts| ts.ts_stack.clone()),
+                                    .map(|ts| crate::api::timestamp_stack::TimestampStack::try_from(&ts.ts_stack).ok()).flatten(),
                             }),
                             #[cfg(feature = "unstable")]
                             replier_id: mem::take(&mut msg.ext_respid).map(|rid| {

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -74,6 +74,11 @@ use super::{
     builders::close::{CloseBuilder, Closeable, Closee},
     connectivity,
 };
+#[cfg(feature = "unstable")]
+use crate::api::{
+    cancellation::CancellationToken, sample::SourceInfo, selector::ZenohParameters,
+    timestamp_stack::GetTimestampCallback,
+};
 #[cfg(feature = "internal")]
 use crate::net::runtime::Runtime;
 #[cfg(all(feature = "shared-memory", feature = "unstable"))]
@@ -118,14 +123,6 @@ use crate::{
     },
     query::ReplyError,
     Config,
-};
-#[cfg(feature = "unstable")]
-use crate::{
-    api::{
-        cancellation::CancellationToken, sample::SourceInfo, selector::ZenohParameters,
-        timestamp_stack::GetTimestampCallback,
-    },
-    net::runtime::DynamicRuntime,
 };
 
 zconfigurable! {
@@ -560,11 +557,20 @@ impl SubscriberCallbacks {
         qos: push::ext::QoSType,
         msg: &mut PushBody,
         #[cfg(feature = "unstable")] reliability: Reliability,
+        #[cfg(feature = "unstable")] timestamp_stack: Option<
+            zenoh_protocol::network::timestamp_stack::TimestampStack,
+        >,
     ) {
         let zenoh_collections::single_or_vec::IntoIter { drain, last } = self.0.into_iter();
         for (cb, key_expr) in drain {
             #[cfg(feature = "unstable")]
-            cb.call_with_message((key_expr, qos, &mut msg.clone(), reliability));
+            cb.call_with_message((
+                key_expr,
+                qos,
+                &mut msg.clone(),
+                reliability,
+                timestamp_stack.clone(),
+            ));
             #[cfg(not(feature = "unstable"))]
             cb.call_with_message((key_expr, qos, &mut msg.clone()));
         }
@@ -576,7 +582,7 @@ impl SubscriberCallbacks {
                 msg = &mut msg_clone;
             }
             #[cfg(feature = "unstable")]
-            cb.call_with_message((key_expr, qos, msg, reliability));
+            cb.call_with_message((key_expr, qos, msg, reliability, timestamp_stack));
             #[cfg(not(feature = "unstable"))]
             cb.call_with_message((key_expr, qos, msg));
         }
@@ -2473,6 +2479,10 @@ impl Session {
             msg,
             #[cfg(feature = "unstable")]
             reliability,
+            // NOTE: execute_subscriber_callbacks is currently only caled for Liveliness subscribers,
+            // so there is not need to pass ext_ts_stack in its parameters.
+            #[cfg(feature = "unstable")]
+            None,
         );
     }
 
@@ -2561,6 +2571,9 @@ impl Session {
                 callbacks: SubscriberCallbacks,
                 push: &mut Push,
                 #[cfg(feature = "unstable")] reliability: Reliability,
+                #[cfg(feature = "unstable")] timestamp_stack: Option<
+                    zenoh_protocol::network::timestamp_stack::TimestampStack,
+                >,
             ) {
                 callbacks.call(
                     true,
@@ -2568,13 +2581,20 @@ impl Session {
                     &mut push.payload,
                     #[cfg(feature = "unstable")]
                     reliability,
+                    #[cfg(feature = "unstable")]
+                    timestamp_stack,
                 );
             }
+
+            #[cfg(feature = "unstable")]
+            let timestamp_stack = push.ext_ts_stack.as_ref().map(|ts| ts.ts_stack.clone());
             call_local(
                 callbacks,
                 &mut push,
                 #[cfg(feature = "unstable")]
                 reliability,
+                #[cfg(feature = "unstable")]
+                timestamp_stack,
             );
         }
         // ext_unknown is not touched by routing/callbacks, so it must be empty
@@ -2954,7 +2974,7 @@ impl Session {
                 ReplyPrimitives::new_remote(Some(self.downgrade()), primitives.into_primitives())
             },
             #[cfg(feature = "unstable")]
-            runtime: Some(DynamicRuntime::downgrade(&self.0.runtime.deref())),
+            runtime: Some(self.0.runtime.downgrade()),
             #[cfg(feature = "unstable")]
             query_ts_stack: timestamp_stack,
         });
@@ -3284,12 +3304,13 @@ impl Primitives for WeakSession {
             &mut msg.payload,
             #[cfg(feature = "unstable")]
             _reliability,
+            #[cfg(feature = "unstable")]
+            msg.ext_ts_stack.as_ref().map(|ts| ts.ts_stack.clone()),
         );
     }
 
     fn send_request(&self, msg: &mut Request) {
         trace!("recv Request {:?}", msg);
-        // TODO: move closer to the queryable callback
         #[cfg(feature = "unstable")]
         crate::api::timestamp_stack::push_ts_interception(
             &mut msg.ext_ts_stack,
@@ -3352,6 +3373,12 @@ impl Primitives for WeakSession {
                             result: Err(ReplyError {
                                 payload: mem::take(&mut e.payload).into(),
                                 encoding: mem::take(&mut e.encoding).into(),
+                                #[cfg(feature = "unstable")]
+                                // TODO: avoid this clone if possible. should we just mem::take ?
+                                timestamp_stack: msg
+                                    .ext_ts_stack
+                                    .as_ref()
+                                    .map(|ts| ts.ts_stack.clone()),
                             }),
                             #[cfg(feature = "unstable")]
                             replier_id: mem::take(&mut msg.ext_respid).map(|rid| {
@@ -3401,6 +3428,9 @@ impl Primitives for WeakSession {
                                 &mut m.payload,
                                 #[cfg(feature = "unstable")]
                                 Reliability::Reliable,
+                                #[cfg(feature = "unstable")]
+                                // TODO: avoid this clone if possible. should we just mem::take ?
+                                msg.ext_ts_stack.as_ref().map(|ts| ts.ts_stack.clone()),
                             )),
                             #[cfg(feature = "unstable")]
                             replier_id: mem::take(&mut msg.ext_respid).map(|rid| {

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -2818,12 +2818,10 @@ impl Session {
                     ext_attachment,
                     ext_unknown: vec![],
                 }),
-                // TODO: avoid this clone if possible
                 ext_ts_stack: ext_ts_stack.clone(),
             });
         }
         if destination != Locality::Remote {
-            // TODO: maybe RECEIVE points can be pushed inside handle_query?
             #[cfg(feature = "unstable")]
             {
                 crate::api::timestamp_stack::push_ts_interception(
@@ -3375,8 +3373,7 @@ impl Primitives for WeakSession {
                             mem::take(&mut m.ext_body),
                             mem::take(&mut m.ext_attachment).map(Into::into),
                             #[cfg(feature = "unstable")]
-                            // TODO: avoid this clone if possible. should we just mem::take ?
-                            msg.ext_ts_stack.as_ref().map(|ts| ts.ts_stack.clone()),
+                            mem::take(&mut msg.ext_ts_stack).map(|ts| ts.ts_stack),
                         );
                     }
                     Err(err) => {
@@ -3410,11 +3407,12 @@ impl Primitives for WeakSession {
                                 payload: mem::take(&mut e.payload).into(),
                                 encoding: mem::take(&mut e.encoding).into(),
                                 #[cfg(feature = "unstable")]
-                                // TODO: avoid this clone if possible. should we just mem::take ?
-                                timestamp_stack: msg
-                                    .ext_ts_stack
-                                    .as_ref()
-                                    .and_then(|ts| crate::api::timestamp_stack::TimestampStack::try_from(&ts.ts_stack).ok()),
+                                timestamp_stack: msg.ext_ts_stack.as_ref().and_then(|ts| {
+                                    crate::api::timestamp_stack::TimestampStack::try_from(
+                                        &ts.ts_stack,
+                                    )
+                                    .ok()
+                                }),
                             }),
                             #[cfg(feature = "unstable")]
                             replier_id: mem::take(&mut msg.ext_respid).map(|rid| {
@@ -3465,8 +3463,7 @@ impl Primitives for WeakSession {
                                 #[cfg(feature = "unstable")]
                                 Reliability::Reliable,
                                 #[cfg(feature = "unstable")]
-                                // TODO: avoid this clone if possible. should we just mem::take ?
-                                msg.ext_ts_stack.as_ref().map(|ts| ts.ts_stack.clone()),
+                                mem::take(&mut msg.ext_ts_stack).map(|ts| ts.ts_stack),
                             )),
                             #[cfg(feature = "unstable")]
                             replier_id: mem::take(&mut msg.ext_respid).map(|rid| {

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -2594,6 +2594,14 @@ impl Session {
             }
 
             #[cfg(feature = "unstable")]
+            {
+                crate::api::timestamp_stack::push_ts_interception(
+                    &mut push.ext_ts_stack,
+                    Some(&*self.0.runtime.as_ref()),
+                    zenoh_protocol::network::timestamp_stack::interception_point::RECEIVE,
+                );
+            }
+            #[cfg(feature = "unstable")]
             let timestamp_stack = push.ext_ts_stack.as_ref().map(|ts| ts.ts_stack.clone());
             call_local(
                 callbacks,
@@ -2765,7 +2773,7 @@ impl Session {
         #[cfg(not(feature = "unstable"))]
         let ext_ts_stack = None;
         #[cfg(feature = "unstable")]
-        let ext_ts_stack = timestamp_instrumentation
+        let mut ext_ts_stack = timestamp_instrumentation
             .map(|instrumentation| {
                 use zenoh_protocol::network::timestamp_stack::{
                     interception_point, TimestampStack, TsStackType,
@@ -2817,6 +2825,15 @@ impl Session {
             });
         }
         if destination != Locality::Remote {
+            // TODO: maybe RECEIVE points can be pushed inside handle_query?
+            #[cfg(feature = "unstable")]
+            {
+                crate::api::timestamp_stack::push_ts_interception(
+                    &mut ext_ts_stack,
+                    Some(&*self.0.runtime.as_ref()),
+                    zenoh_protocol::network::timestamp_stack::interception_point::RECEIVE,
+                );
+            }
             self.handle_query(
                 zread!(self.0.state),
                 true,

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -40,6 +40,8 @@ use zenoh_config::{
 use zenoh_config::{wrappers::EntityGlobalId, GenericConfig};
 use zenoh_core::{zconfigurable, zread, Resolve, ResolveClosure, ResolveFuture, Wait};
 use zenoh_keyexpr::keyexpr_tree::{IKeyExprTree, IKeyExprTreeNode, KeBoxTree};
+#[cfg(feature = "unstable")]
+use zenoh_protocol::network::timestamp_stack::TimestampStack;
 use zenoh_protocol::{
     core::{
         key_expr::{keyexpr, OwnedKeyExpr},
@@ -1340,6 +1342,8 @@ impl Session {
             attachment: None,
             #[cfg(feature = "unstable")]
             source_info: None,
+            #[cfg(feature = "unstable")]
+            timestamp_stack: None,
         }
     }
 
@@ -1375,6 +1379,8 @@ impl Session {
             attachment: None,
             #[cfg(feature = "unstable")]
             source_info: None,
+            #[cfg(feature = "unstable")]
+            timestamp_stack: None,
         }
     }
     /// Query data from the matching queryables in the system. This is a shortcut for declaring
@@ -1425,6 +1431,8 @@ impl Session {
             source_info: None,
             #[cfg(feature = "unstable")]
             cancellation_token: None,
+            #[cfg(feature = "unstable")]
+            timestamp_stack: None,
         }
     }
 }
@@ -2062,6 +2070,8 @@ impl Session {
                             #[cfg(feature = "unstable")]
                             source_info: None,
                             attachment: None,
+                            #[cfg(feature = "unstable")]
+                            timestamp_stack: None,
                         });
                     }
                 });
@@ -2478,6 +2488,7 @@ impl Session {
         timestamp: Option<uhlc::Timestamp>,
         #[cfg(feature = "unstable")] source_info: Option<SourceInfo>,
         attachment: Option<ZBytes>,
+        #[cfg(feature = "unstable")] timestamp_stack: Option<TimestampStack>,
     ) -> ZResult<()> {
         trace!("write({:?}, [...])", key_expr);
         let state = zread!(self.0.state);
@@ -2519,6 +2530,19 @@ impl Session {
                 }),
             })
         };
+        #[cfg(feature = "unstable")]
+        if let Some(ts_stack) = timestamp_stack {
+            let mut ext_ts_stack =
+                Some(zenoh_protocol::network::timestamp_stack::TsStackType { ts_stack });
+            crate::api::timestamp_stack::push_ts_interception(
+                &mut ext_ts_stack,
+                self.0.runtime.zid(),
+                self.0.runtime.whatami(),
+                |ctx| self.0.runtime.get_ts_stack_timestamp(ctx),
+                zenoh_protocol::network::timestamp_stack::interception_point::SEND,
+            );
+            push.ext_ts_stack = ext_ts_stack;
+        }
         let has_local_callbacks = !callbacks.is_empty();
         if destination != Locality::SessionLocal {
             primitives.send_push_consume(
@@ -2630,6 +2654,7 @@ impl Session {
         #[cfg(feature = "unstable")] cancellation_token: Option<CancellationToken>,
         querier_id: Option<EntityId>,
         querier_notifier: Option<SyncGroupNotifier>,
+        #[cfg(feature = "unstable")] timestamp_stack: Option<TimestampStack>,
     ) -> ZResult<()> {
         tracing::trace!(
             "get({}, {:?}, {:?})",
@@ -2709,6 +2734,23 @@ impl Session {
         );
         drop(state);
 
+        #[cfg(not(feature = "unstable"))]
+        let ext_ts_stack = None;
+        #[cfg(feature = "unstable")]
+        let ext_ts_stack = timestamp_stack
+            .map(|ts_stack| {
+                let mut ext_ts_stack =
+                    Some(zenoh_protocol::network::timestamp_stack::TsStackType { ts_stack });
+                crate::api::timestamp_stack::push_ts_interception(
+                    &mut ext_ts_stack,
+                    self.0.runtime.zid(),
+                    self.0.runtime.whatami(),
+                    |ctx| self.0.runtime.get_ts_stack_timestamp(ctx),
+                    zenoh_protocol::network::timestamp_stack::interception_point::SEND,
+                );
+                ext_ts_stack
+            })
+            .flatten();
         if destination != Locality::SessionLocal {
             let wexpr = key_expr.to_wire(self).to_owned();
             let ext_attachment = attachment.clone().map(Into::into);
@@ -2737,7 +2779,8 @@ impl Session {
                     ext_attachment,
                     ext_unknown: vec![],
                 }),
-                ext_ts_stack: None,
+                // TODO: avoid this clone if possible
+                ext_ts_stack: ext_ts_stack.clone(),
             });
         }
         if destination != Locality::Remote {
@@ -2759,6 +2802,8 @@ impl Session {
                     payload: v.0.clone().into(),
                 }),
                 attachment,
+                #[cfg(feature = "unstable")]
+                ext_ts_stack.map(|ext| ext.ts_stack),
             );
         }
         Ok(())
@@ -2861,7 +2906,6 @@ impl Session {
         }
     }
 
-    // TODO: add timestamp_stack
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn handle_query(
         &self,
@@ -2876,6 +2920,7 @@ impl Session {
         #[cfg(feature = "unstable")] source_info: Option<SourceInfo>,
         body: Option<QueryBodyType>,
         attachment: Option<ZBytes>,
+        #[cfg(feature = "unstable")] timestamp_stack: Option<TimestampStack>,
     ) {
         let Ok(primitives) = state.primitives() else {
             return;
@@ -2909,6 +2954,20 @@ impl Session {
             } else {
                 ReplyPrimitives::new_remote(Some(self.downgrade()), primitives.into_primitives())
             },
+            #[cfg(feature = "unstable")]
+            whatami: self.0.runtime.whatami(),
+            #[cfg(feature = "unstable")]
+            ts_stack_callback: {
+                let runtime = self.0.runtime.clone();
+                // FIXME: check if this keeps strong reference on Runtime
+                Some(std::sync::Arc::new(
+                    move |ctx: crate::api::timestamp_stack::TsStackContext| {
+                        runtime.get_ts_stack_timestamp(ctx)
+                    },
+                ))
+            },
+            #[cfg(feature = "unstable")]
+            query_ts_stack: timestamp_stack,
         });
         if !queryables.is_empty() {
             let mut query = Query {
@@ -3118,6 +3177,8 @@ impl Primitives for WeakSession {
                                         #[cfg(feature = "unstable")]
                                         source_info: None,
                                         attachment: None,
+                                        #[cfg(feature = "unstable")]
+                                        timestamp_stack: None,
                                     }),
                                     #[cfg(feature = "unstable")]
                                     replier_id: None,
@@ -3271,6 +3332,9 @@ impl Primitives for WeakSession {
                             m.ext_sinfo.map(Into::into),
                             mem::take(&mut m.ext_body),
                             mem::take(&mut m.ext_attachment).map(Into::into),
+                            #[cfg(feature = "unstable")]
+                            // TODO: avoid this clone if possible. should we just mem::take ?
+                            msg.ext_ts_stack.as_ref().map(|ts| ts.ts_stack.clone()),
                         );
                     }
                     Err(err) => {

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -2729,6 +2729,7 @@ impl Session {
                     ext_attachment,
                     ext_unknown: vec![],
                 }),
+                ext_ts_stack: None,
             });
         }
         if destination != Locality::Remote {
@@ -2852,6 +2853,7 @@ impl Session {
         }
     }
 
+    // TODO: add timestamp_stack
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn handle_query(
         &self,

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -2479,7 +2479,7 @@ impl Session {
             msg,
             #[cfg(feature = "unstable")]
             reliability,
-            // NOTE: execute_subscriber_callbacks is currently only caled for Liveliness subscribers,
+            // NOTE: execute_subscriber_callbacks is currently only called for Liveliness subscribers,
             // so there is not need to pass ext_ts_stack in its parameters.
             #[cfg(feature = "unstable")]
             None,

--- a/zenoh/src/api/timestamp_stack.rs
+++ b/zenoh/src/api/timestamp_stack.rs
@@ -245,6 +245,8 @@ impl TimestampInstrumentation {
 /// ```
 /// use zenoh::timestamp_stack::InstrumentationTimestamp;
 ///
+/// // InstrumentationTimestamp is usually constructed automatically.
+/// let ts = InstrumentationTimestamp::Custom(b"my_format".to_vec());
 /// // Pattern match to handle both variants:
 /// match &ts {
 ///     InstrumentationTimestamp::UHLC(uhlc_ts) => println!("UHLC: {:?}", uhlc_ts),
@@ -470,7 +472,7 @@ impl TryFrom<&zenoh_protocol::network::timestamp_stack::TimestampStack> for Time
                 Ok(p) => p,
                 Err(_) => {
                     // FIXME: find a way to hold unknown inteception points
-                    //        (required for Reply to inherit the full stack of its query)
+                    //        (required for forward-compatibility)
                     tracing::warn!("
                         Skipping instrumentation measurement with unknown or malformed instrumentation flags '{:b}'",
                         record.flags

--- a/zenoh/src/api/timestamp_stack.rs
+++ b/zenoh/src/api/timestamp_stack.rs
@@ -437,6 +437,10 @@ pub(crate) fn push_ts_interception<const ID: u8, T: IRuntime + ?Sized, R, F>(
                 .expect("internal calls should provide valid interception point IDs"),
         };
         let (timestamp, is_custom) = runtime.get_ts_stack_timestamp(context);
+        if timestamp.is_empty() {
+            // Skip writing empty Vec
+            return;
+        }
         ts_stack.ts_stack.stack.push(Interception {
             flags: point
                 | if is_custom {

--- a/zenoh/src/api/timestamp_stack.rs
+++ b/zenoh/src/api/timestamp_stack.rs
@@ -1,0 +1,43 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+use std::sync::Arc;
+
+use zenoh_protocol::core::WhatAmI;
+
+use crate::session::ZenohId;
+
+/// Context passed to the user-defined timestamp callback.
+///
+/// This struct provides the callback with information about the current Zenoh node
+/// and the interception point at which the timestamp is being generated.
+///
+/// The struct is `#[non_exhaustive]` to allow adding new fields in the future.
+#[non_exhaustive]
+#[zenoh_macros::unstable]
+pub struct TsStackContext {
+    /// The Zenoh ID of the current node.
+    pub zid: ZenohId,
+    /// The mode of the current node (router, peer, or client).
+    pub whatami: WhatAmI,
+    // TODO: should be a non-exhaustive enum
+    /// The interception point identifier (e.g., `zenoh_protocol::network::timestamp_stack::interception_point::SEND`).
+    pub interception_point: u8,
+}
+
+/// Type alias for the user-defined timestamp callback.
+///
+/// The callback receives a [`TsStackContext`] and returns the raw timestamp bytes
+/// to be pushed onto the timestamp stack.
+#[zenoh_macros::unstable]
+pub type GetTimestampCallback = Arc<dyn Fn(TsStackContext) -> Vec<u8> + Send + Sync>;

--- a/zenoh/src/api/timestamp_stack.rs
+++ b/zenoh/src/api/timestamp_stack.rs
@@ -20,8 +20,7 @@ use crate::{net::runtime::IRuntime, session::ZenohId};
 
 /// Context passed to the user-defined timestamp callback.
 ///
-/// This struct provides the callback with information about the current Zenoh node
-/// and the interception point at which the timestamp is being generated.
+/// This struct provides the callback with information about the current Zenoh node.
 ///
 /// The struct is `#[non_exhaustive]` to allow adding new fields in the future.
 #[non_exhaustive]
@@ -226,7 +225,8 @@ impl TimestampInstrumentation {
 
 /// A timestamp measurement, either UHLC or the result of a custom user-defined callback.
 ///
-/// The semantics depend on whether a [custom timestamp callback](GetTimestampCallback)
+/// The semantics depend on whether a [custom timestamp
+/// callback](crate::api::builders::session::OpenBuilder::with_timestamp_callback)
 /// was registered on the session that performed the measurement:
 ///
 /// - **UHLC**: the default — a Zenoh UHLC hybrid logical clock timestamp.
@@ -252,8 +252,8 @@ pub enum InstrumentationTimestamp {
     ///
     /// [UHLC]: https://github.com/eclipse-zenoh/uhlc-rs
     UHLC(uhlc::Timestamp),
-    /// A timestamp in a format defined by the user's
-    /// [custom timestamp callback](GetTimestampCallback).
+    /// A timestamp in a format defined by the user's [custom timestamp
+    /// callback](crate::api::builders::session::OpenBuilder::with_timestamp_callback).
     Custom(Vec<u8>),
 }
 

--- a/zenoh/src/api/timestamp_stack.rs
+++ b/zenoh/src/api/timestamp_stack.rs
@@ -273,6 +273,8 @@ impl TryFrom<&zenoh_protocol::network::timestamp_stack::TimestampStack> for Time
             let point: InterceptionPoint = match record.flags.try_into() {
                 Ok(p) => p,
                 Err(_) => {
+                    // FIXME: find a way to hold unknown inteception points
+                    //        (required for Reply to inherit the full stack of its query)
                     tracing::warn!("
                         Skipping instrumentation measurement with unknown or malformed instrumentation flags '{:b}'",
                         record.flags

--- a/zenoh/src/api/timestamp_stack.rs
+++ b/zenoh/src/api/timestamp_stack.rs
@@ -162,13 +162,22 @@ impl TimestampInstrumentation {
     }
 }
 
+/// A timestamp measurement, either UHLC or the result of a custom user-defined callback.
+#[zenoh_macros::unstable]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InstrumentationTimestamp {
+    /// Zenoh UHLC timestamp
+    UHLC(uhlc::Timestamp),
+    /// User-defined timestamp format
+    Custom(Vec<u8>),
+}
+
 /// A single interception record in a timestamp stack.
 #[zenoh_macros::unstable]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TimestampStackRecord {
     point: InterceptionPoint,
-    is_custom_ts: bool,
-    timestamp: Vec<u8>,
+    timestamp: InstrumentationTimestamp,
 }
 
 impl TimestampStackRecord {
@@ -180,16 +189,16 @@ impl TimestampStackRecord {
 
     /// Whether the timestamp was produced by a user-defined callback.
     ///
-    /// Returns `true` when the timestamp bytes were produced by a user-defined callback,
+    /// Returns `true` when the timestamp was produced by a user-defined callback,
     /// and `false` when the timestamp is a standard UHLC timestamp.
     #[zenoh_macros::unstable]
     pub fn is_custom(&self) -> bool {
-        self.is_custom_ts
+        matches!(self.timestamp, InstrumentationTimestamp::Custom(_))
     }
 
     /// Raw timestamp bytes (format defined by the wire protocol).
     #[zenoh_macros::unstable]
-    pub fn timestamp(&self) -> &[u8] {
+    pub fn timestamp(&self) -> &InstrumentationTimestamp {
         &self.timestamp
     }
 }
@@ -283,11 +292,25 @@ impl TryFrom<&zenoh_protocol::network::timestamp_stack::TimestampStack> for Time
                 }
             };
             let is_custom = (record.flags & interception_point::IS_CUSTOM_TS) != 0;
-            instance.records.push(TimestampStackRecord {
-                point,
-                is_custom_ts: is_custom,
-                timestamp: record.timestamp.clone(),
-            });
+            let timestamp = match is_custom {
+                true => InstrumentationTimestamp::Custom(record.timestamp.clone()),
+                false => {
+                    use zenoh_buffers::reader::HasReader;
+                    use zenoh_codec::{RCodec, Zenoh080};
+
+                    let mut reader = (&record.timestamp).reader();
+                    let Ok(ts): Result<uhlc::Timestamp, _> = Zenoh080.read(&mut reader) else {
+                        tracing::warn!(
+                            "Skipping instrumentation measurement with malformed uhlc timestamp"
+                        );
+                        continue;
+                    };
+                    InstrumentationTimestamp::UHLC(ts)
+                }
+            };
+            instance
+                .records
+                .push(TimestampStackRecord { point, timestamp });
         }
         Ok(instance)
     }
@@ -303,12 +326,23 @@ impl From<&TimestampStack> for zenoh_protocol::network::timestamp_stack::Timesta
                 .iter()
                 .map(|r| Interception {
                     flags: u8::from(r.point)
-                        | if r.is_custom_ts {
+                        | if matches!(r.timestamp, InstrumentationTimestamp::Custom(_)) {
                             interception_point::IS_CUSTOM_TS
                         } else {
                             0
                         },
-                    timestamp: r.timestamp.clone(),
+                    timestamp: match &r.timestamp {
+                        InstrumentationTimestamp::UHLC(ts) => {
+                            use zenoh_codec::{WCodec, Zenoh080};
+
+                            let mut buf = Vec::new();
+                            Zenoh080
+                                .write(&mut buf, ts)
+                                .expect("serializing valid UHLC timestamp should not fail");
+                            buf
+                        }
+                        InstrumentationTimestamp::Custom(ts) => ts.clone(),
+                    },
                 })
                 .collect(),
         }

--- a/zenoh/src/api/timestamp_stack.rs
+++ b/zenoh/src/api/timestamp_stack.rs
@@ -13,9 +13,12 @@
 //
 use std::sync::Arc;
 
-use zenoh_protocol::{core::WhatAmI, network::timestamp_stack::TsStackType};
+use zenoh_protocol::{
+    core::WhatAmI,
+    network::timestamp_stack::{Interception, TsStackType},
+};
 
-use crate::session::ZenohId;
+use crate::{net::runtime::IRuntime, session::ZenohId};
 
 /// Context passed to the user-defined timestamp callback.
 ///
@@ -45,31 +48,26 @@ pub type GetTimestampCallback = Arc<dyn Fn(TsStackContext) -> Vec<u8> + Send + S
 /// Push a timestamp interception record onto the stack if the corresponding
 /// `conf_flags` bit is set for this interception point.
 ///
-/// This is a no-op if `ext_ts_stack` is `None` or if the flag is not present.
+/// This is a no-op if `ext_ts_stack` is `None`, if the flag is not present, or if `runtime` is `None`.
 #[cfg(feature = "unstable")]
-pub(crate) fn push_ts_interception<const ID: u8, F>(
+pub(crate) fn push_ts_interception<const ID: u8, T: IRuntime + ?Sized>(
     ext_ts_stack: &mut Option<TsStackType<ID>>,
-    zid: ZenohId,
-    whatami: WhatAmI,
-    get_timestamp: F,
+    runtime: Option<&T>,
     point: u8,
-) where
-    F: FnOnce(TsStackContext) -> Vec<u8>,
-{
-    use zenoh_protocol::network::timestamp_stack::Interception;
-
-    if let Some(ts_stack) = ext_ts_stack {
-        if ts_stack.ts_stack.conf_flags & point != 0 {
-            let context = TsStackContext {
-                zid,
-                whatami,
-                interception_point: point,
-            };
-            let timestamp = get_timestamp(context);
-            ts_stack.ts_stack.stack.push(Interception {
-                flags: point,
-                timestamp,
-            });
-        }
+) {
+    let (Some(runtime), Some(ts_stack)) = (runtime, ext_ts_stack) else {
+        return;
+    };
+    if ts_stack.ts_stack.conf_flags & point != 0 {
+        let context = TsStackContext {
+            zid: runtime.zid(),
+            whatami: runtime.whatami(),
+            interception_point: point,
+        };
+        let timestamp = runtime.get_ts_stack_timestamp(context);
+        ts_stack.ts_stack.stack.push(Interception {
+            flags: point,
+            timestamp,
+        });
     }
 }

--- a/zenoh/src/api/timestamp_stack.rs
+++ b/zenoh/src/api/timestamp_stack.rs
@@ -443,6 +443,10 @@ pub(crate) fn push_ts_interception<const ID: u8, T: IRuntime + ?Sized, R, F>(
             // Skip writing empty Vec
             return;
         }
+        if ts_stack.ts_stack.stack.len() >= zenoh_protocol::network::timestamp_stack::MAX_STACK_SIZE {
+            // Avoid producing an invalid frame that will be rejected by the codec decoder.
+            return;
+        }
         ts_stack.ts_stack.stack.push(Interception {
             flags: point
                 | if is_custom {
@@ -467,14 +471,14 @@ impl TryFrom<&zenoh_protocol::network::timestamp_stack::TimestampStack> for Time
             records: Vec::new(),
         };
         for record in &ts.stack {
-            // Skip unknonw/malformed measurement configs
+            // Skip unknown/malformed measurement configs
             let point: InterceptionPoint = match record.flags.try_into() {
                 Ok(p) => p,
                 Err(_) => {
-                    // FIXME: find a way to hold unknown inteception points
+                    // FIXME: find a way to hold unknown interception points
                     //        (required for forward-compatibility)
-                    tracing::warn!("
-                        Skipping instrumentation measurement with unknown or malformed instrumentation flags '{:b}'",
+                    tracing::warn!(
+                        "Skipping instrumentation measurement with unknown or malformed instrumentation flags '{:b}'",
                         record.flags
                     );
                     continue;

--- a/zenoh/src/api/timestamp_stack.rs
+++ b/zenoh/src/api/timestamp_stack.rs
@@ -58,7 +58,7 @@ impl TryFrom<u8> for InterceptionPoint {
     type Error = zenoh_result::Error;
 
     fn try_from(value: u8) -> zenoh_result::ZResult<Self> {
-        match value {
+        match value & !interception_point::IS_CUSTOM_TS {
             interception_point::SEND => Ok(Self::Send),
             interception_point::RECEIVE => Ok(Self::Receive),
             interception_point::ROUTE => Ok(Self::Route),
@@ -167,6 +167,7 @@ impl TimestampInstrumentation {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TimestampStackRecord {
     point: InterceptionPoint,
+    is_custom_ts: bool,
     timestamp: Vec<u8>,
 }
 
@@ -175,6 +176,15 @@ impl TimestampStackRecord {
     #[zenoh_macros::unstable]
     pub fn point(&self) -> InterceptionPoint {
         self.point
+    }
+
+    /// Whether the timestamp was produced by a user-defined callback.
+    ///
+    /// Returns `true` when the timestamp bytes were produced by a user-defined callback,
+    /// and `false` when the timestamp is a standard UHLC timestamp.
+    #[zenoh_macros::unstable]
+    pub fn is_custom(&self) -> bool {
+        self.is_custom_ts
     }
 
     /// Raw timestamp bytes (format defined by the wire protocol).
@@ -234,9 +244,14 @@ pub(crate) fn push_ts_interception<const ID: u8, T: IRuntime + ?Sized>(
                 .try_into()
                 .expect("internal calls should provide valid interception point IDs"),
         };
-        let timestamp = runtime.get_ts_stack_timestamp(context);
+        let (timestamp, is_custom) = runtime.get_ts_stack_timestamp(context);
         ts_stack.ts_stack.stack.push(Interception {
-            flags: point,
+            flags: point
+                | if is_custom {
+                    interception_point::IS_CUSTOM_TS
+                } else {
+                    0
+                },
             timestamp,
         });
     }
@@ -265,8 +280,10 @@ impl TryFrom<&zenoh_protocol::network::timestamp_stack::TimestampStack> for Time
                     continue;
                 }
             };
+            let is_custom = (record.flags & interception_point::IS_CUSTOM_TS) != 0;
             instance.records.push(TimestampStackRecord {
                 point,
+                is_custom_ts: is_custom,
                 timestamp: record.timestamp.clone(),
             });
         }
@@ -283,7 +300,12 @@ impl From<&TimestampStack> for zenoh_protocol::network::timestamp_stack::Timesta
                 .records
                 .iter()
                 .map(|r| Interception {
-                    flags: r.point.into(),
+                    flags: u8::from(r.point)
+                        | if r.is_custom_ts {
+                            interception_point::IS_CUSTOM_TS
+                        } else {
+                            0
+                        },
                     timestamp: r.timestamp.clone(),
                 })
                 .collect(),

--- a/zenoh/src/api/timestamp_stack.rs
+++ b/zenoh/src/api/timestamp_stack.rs
@@ -33,7 +33,6 @@ pub struct TsStackContext {
     pub zid: ZenohId,
     /// The mode of the current node (router, peer, or client).
     pub whatami: WhatAmI,
-    // TODO: should be a non-exhaustive enum
     /// The interception point identifier (e.g., `zenoh_protocol::network::timestamp_stack::interception_point::SEND`).
     pub interception_point: InterceptionPoint,
 }

--- a/zenoh/src/api/timestamp_stack.rs
+++ b/zenoh/src/api/timestamp_stack.rs
@@ -13,7 +13,7 @@
 //
 use std::sync::Arc;
 
-use zenoh_protocol::core::WhatAmI;
+use zenoh_protocol::{core::WhatAmI, network::timestamp_stack::TsStackType};
 
 use crate::session::ZenohId;
 
@@ -41,3 +41,35 @@ pub struct TsStackContext {
 /// to be pushed onto the timestamp stack.
 #[zenoh_macros::unstable]
 pub type GetTimestampCallback = Arc<dyn Fn(TsStackContext) -> Vec<u8> + Send + Sync>;
+
+/// Push a timestamp interception record onto the stack if the corresponding
+/// `conf_flags` bit is set for this interception point.
+///
+/// This is a no-op if `ext_ts_stack` is `None` or if the flag is not present.
+#[cfg(feature = "unstable")]
+pub(crate) fn push_ts_interception<const ID: u8, F>(
+    ext_ts_stack: &mut Option<TsStackType<ID>>,
+    zid: ZenohId,
+    whatami: WhatAmI,
+    get_timestamp: F,
+    point: u8,
+) where
+    F: FnOnce(TsStackContext) -> Vec<u8>,
+{
+    use zenoh_protocol::network::timestamp_stack::Interception;
+
+    if let Some(ts_stack) = ext_ts_stack {
+        if ts_stack.ts_stack.conf_flags & point != 0 {
+            let context = TsStackContext {
+                zid,
+                whatami,
+                interception_point: point,
+            };
+            let timestamp = get_timestamp(context);
+            ts_stack.ts_stack.stack.push(Interception {
+                flags: point,
+                timestamp,
+            });
+        }
+    }
+}

--- a/zenoh/src/api/timestamp_stack.rs
+++ b/zenoh/src/api/timestamp_stack.rs
@@ -45,11 +45,37 @@ pub struct TsStackContext {
 pub type GetTimestampCallback = Arc<dyn Fn(TsStackContext) -> Vec<u8> + Send + Sync>;
 
 /// Identifies which interception point a timestamp record was captured at.
+///
+/// The three points represent the lifecycle of a message traveling through
+/// the Zenoh topology:
+///
+/// - [`Send`](InterceptionPoint::Send): triggered when the message leaves
+///   the publishing/replying application.
+/// - [`Route`](InterceptionPoint::Route): triggered at each intermediate
+///   node (router or peer) that forwards the message.
+/// - [`Receive`](InterceptionPoint::Receive): triggered when the message
+///   is delivered to the subscribing/querying application.
+///
+/// # Example
+///
+/// ```
+/// use std::convert::TryFrom;
+/// use zenoh::timestamp_stack::InterceptionPoint;
+///
+/// assert!(InterceptionPoint::try_from(1u8).is_ok());
+/// assert!(InterceptionPoint::try_from(0xFFu8).is_err());
+/// ```
 #[zenoh_macros::unstable]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InterceptionPoint {
+    /// Timestamp recorded when the message leaves the publishing or replying
+    /// node — the application layer's "send" side.
     Send,
+    /// Timestamp recorded when the message passes through a routing node
+    /// (router or peer forwarding layer).
     Route,
+    /// Timestamp recorded when the message arrives at a subscribing or
+    /// queryable node — the application layer's "receive" side.
     Receive,
 }
 
@@ -76,7 +102,32 @@ impl From<InterceptionPoint> for u8 {
     }
 }
 
-/// Builder for [`TimestampInstrumentation`] instances
+/// Builder for [`TimestampInstrumentation`] instances.
+///
+/// Collects which interception points should be instrumented and produces
+/// an immutable [`TimestampInstrumentation`] via [`build`](Self::build).
+///
+/// At least one interception point must be enabled; calling [`build`](Self::build)
+/// with none enabled returns an error.
+///
+/// # Example
+///
+/// ```
+/// use zenoh::timestamp_stack::{
+///     InterceptionPoint, TimestampInstrumentationBuilder,
+/// };
+///
+/// let instr = TimestampInstrumentationBuilder::new()
+///     .set_send(true)
+///     .set_route(true)
+///     .set_receive(true)
+///     .build()
+///     .unwrap();
+///
+/// assert!(instr.is_instrumented(InterceptionPoint::Send));
+/// assert!(instr.is_instrumented(InterceptionPoint::Route));
+/// assert!(instr.is_instrumented(InterceptionPoint::Receive));
+/// ```
 #[zenoh_macros::unstable]
 #[derive(Debug, Default, Clone, Copy)]
 pub struct TimestampInstrumentationBuilder {
@@ -85,11 +136,20 @@ pub struct TimestampInstrumentationBuilder {
 
 #[zenoh_macros::unstable]
 impl TimestampInstrumentationBuilder {
+    /// Creates a new builder with no interception points enabled.
+    ///
+    /// At least one point must be enabled via [`set_send`](Self::set_send),
+    /// [`set_route`](Self::set_route), or [`set_receive`](Self::set_receive)
+    /// before calling [`build`](Self::build).
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Record timestamps at the SEND point.
+    /// Enable or disable timestamp recording at the [`Send`](InterceptionPoint::Send)
+    /// interception point.
+    ///
+    /// The SEND point is triggered when a message is about to leave the
+    /// publishing or replying node.
     pub fn set_send(self, enabled: bool) -> Self {
         Self {
             conf_flags: if enabled {
@@ -100,7 +160,11 @@ impl TimestampInstrumentationBuilder {
         }
     }
 
-    /// Record timestamps at the ROUTE point.
+    /// Enable or disable timestamp recording at the [`Route`](InterceptionPoint::Route)
+    /// interception point.
+    ///
+    /// The ROUTE point is triggered on every intermediate node (router or peer)
+    /// that forwards the message through its routing layer.
     pub fn set_route(self, enabled: bool) -> Self {
         Self {
             conf_flags: if enabled {
@@ -111,7 +175,11 @@ impl TimestampInstrumentationBuilder {
         }
     }
 
-    /// Record timestamps at the RECEIVE point.
+    /// Enable or disable timestamp recording at the [`Receive`](InterceptionPoint::Receive)
+    /// interception point.
+    ///
+    /// The RECEIVE point is triggered when a message is delivered to a
+    /// subscribing or queryable application.
     pub fn set_receive(self, enabled: bool) -> Self {
         Self {
             conf_flags: if enabled {
@@ -122,6 +190,9 @@ impl TimestampInstrumentationBuilder {
         }
     }
 
+    /// Consumes the builder and produces a [`TimestampInstrumentation`].
+    ///
+    /// Returns an error if no interception points were enabled.
     pub fn build(self) -> zenoh_result::ZResult<TimestampInstrumentation> {
         if self.conf_flags == 0 {
             bail!("Invalid instrumentation config: at least one point must be active");
@@ -162,16 +233,60 @@ impl TimestampInstrumentation {
 }
 
 /// A timestamp measurement, either UHLC or the result of a custom user-defined callback.
+///
+/// The semantics depend on whether a [custom timestamp callback](GetTimestampCallback)
+/// was registered on the session that performed the measurement:
+///
+/// - **UHLC**: the default — a Zenoh UHLC hybrid logical clock timestamp.
+/// - **Custom**: arbitrary bytes produced by the user-defined callback.
+///
+/// # Example
+///
+/// ```
+/// use zenoh::timestamp_stack::InstrumentationTimestamp;
+///
+/// // Pattern match to handle both variants:
+/// match &ts {
+///     InstrumentationTimestamp::UHLC(uhlc_ts) => println!("UHLC: {:?}", uhlc_ts),
+///     InstrumentationTimestamp::Custom(bytes) => println!("Custom({} bytes)", bytes.len()),
+/// }
+/// ```
 #[zenoh_macros::unstable]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InstrumentationTimestamp {
-    /// Zenoh UHLC timestamp
+    /// A Zenoh [UHLC] hybrid logical clock timestamp.
+    ///
+    /// [UHLC]: https://github.com/eclipse-zenoh/uhlc-rs
     UHLC(uhlc::Timestamp),
-    /// User-defined timestamp format
+    /// A timestamp in a format defined by the user's
+    /// [custom timestamp callback](GetTimestampCallback).
     Custom(Vec<u8>),
 }
 
 /// A single interception record in a timestamp stack.
+///
+/// Each record captures the [`InterceptionPoint`] where the measurement was
+/// taken and the [`InstrumentationTimestamp`] that was recorded. Records are
+/// obtained by iterating over [`TimestampStack::records`].
+///
+/// # Example
+///
+/// ```
+/// use zenoh::timestamp_stack::{
+///     InstrumentationTimestamp, InterceptionPoint,
+/// };
+///
+/// // Records are typically obtained from a received TimestampStack.
+/// // This shows how to inspect a hypothetical record:
+/// fn inspect(record: &zenoh::timestamp_stack::TimestampStackRecord) {
+///     println!("Point: {:?}", record.point());
+///     if record.is_custom() {
+///         println!("Custom timestamp: {:?}", record.timestamp());
+///     } else {
+///         println!("UHLC timestamp: {:?}", record.timestamp());
+///     }
+/// }
+/// ```
 #[zenoh_macros::unstable]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TimestampStackRecord {
@@ -203,6 +318,64 @@ impl TimestampStackRecord {
 }
 
 /// The timestamp stack carried by a received message.
+///
+/// When timestamp instrumentation is enabled on a publication or query, the
+/// resulting message carries a [`TimestampStack`] that accumulates records at
+/// each interception point it passes through. The stack can be accessed from
+/// a [`Sample`] via [`Sample::timestamp_stack`] or from a [`Query`] via
+/// [`Query::timestamp_stack`].
+///
+/// Use [`instrumentation`](Self::instrumentation) to inspect which points were
+/// configured, and [`records`](Self::records) to iterate over the ordered list
+/// of timestamps collected along the message path.
+///
+/// # Example
+///
+/// ```no_run
+/// # #[tokio::main]
+/// # async fn main() {
+/// use zenoh::timestamp_stack::{
+///     InstrumentationTimestamp, InterceptionPoint, TimestampInstrumentationBuilder,
+/// };
+///
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
+/// let subscriber = session.declare_subscriber("key/expr").await.unwrap();
+/// let publisher = session.declare_publisher("key/expr").await.unwrap();
+///
+/// let instr = TimestampInstrumentationBuilder::new()
+///     .set_send(true)
+///     .set_receive(true)
+///     .build()
+///     .unwrap();
+///
+/// publisher
+///     .put("payload")
+///     .timestamp_instrumentation(instr)
+///     .await
+///     .unwrap();
+///
+/// let sample = subscriber.recv_async().await.unwrap();
+/// if let Some(stack) = sample.timestamp_stack() {
+///     // Check which points were configured
+///     let config = stack.instrumentation();
+///     assert!(config.is_instrumented(InterceptionPoint::Send));
+///
+///     // Iterate records in traversal order
+///     for record in stack.records() {
+///         match record.point() {
+///             InterceptionPoint::Send => println!("sent at {:?}", record.timestamp()),
+///             InterceptionPoint::Receive => println!("received at {:?}", record.timestamp()),
+///             _ => {}
+///         }
+///     }
+/// }
+/// # }
+/// ```
+///
+/// [`Sample`]: crate::sample::Sample
+/// [`Sample::timestamp_stack`]: crate::sample::Sample::timestamp_stack
+/// [`Query`]: crate::query::Query
+/// [`Query::timestamp_stack`]: crate::query::Query::timestamp_stack
 #[zenoh_macros::unstable]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TimestampStack {

--- a/zenoh/src/api/timestamp_stack.rs
+++ b/zenoh/src/api/timestamp_stack.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 use zenoh_protocol::{
     core::WhatAmI,
-    network::timestamp_stack::{Interception, TsStackType},
+    network::timestamp_stack::{interception_point, Interception, TsStackType},
 };
 
 use crate::{net::runtime::IRuntime, session::ZenohId};
@@ -35,7 +35,7 @@ pub struct TsStackContext {
     pub whatami: WhatAmI,
     // TODO: should be a non-exhaustive enum
     /// The interception point identifier (e.g., `zenoh_protocol::network::timestamp_stack::interception_point::SEND`).
-    pub interception_point: u8,
+    pub interception_point: InterceptionPoint,
 }
 
 /// Type alias for the user-defined timestamp callback.
@@ -44,6 +44,174 @@ pub struct TsStackContext {
 /// to be pushed onto the timestamp stack.
 #[zenoh_macros::unstable]
 pub type GetTimestampCallback = Arc<dyn Fn(TsStackContext) -> Vec<u8> + Send + Sync>;
+
+/// Identifies which interception point a timestamp record was captured at.
+#[zenoh_macros::unstable]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InterceptionPoint {
+    Send,
+    Route,
+    Receive,
+}
+
+impl TryFrom<u8> for InterceptionPoint {
+    type Error = zenoh_result::Error;
+
+    fn try_from(value: u8) -> zenoh_result::ZResult<Self> {
+        match value {
+            interception_point::SEND => Ok(Self::Send),
+            interception_point::RECEIVE => Ok(Self::Receive),
+            interception_point::ROUTE => Ok(Self::Route),
+            _ => bail!("Unknown interception point ID '{value}'"),
+        }
+    }
+}
+
+impl From<InterceptionPoint> for u8 {
+    fn from(value: InterceptionPoint) -> Self {
+        match value {
+            InterceptionPoint::Send => interception_point::SEND,
+            InterceptionPoint::Route => interception_point::ROUTE,
+            InterceptionPoint::Receive => interception_point::RECEIVE,
+        }
+    }
+}
+
+/// Builder for [`TimestampInstrumentation`] instances
+#[zenoh_macros::unstable]
+#[derive(Debug, Default, Clone, Copy)]
+pub struct TimestampInstrumentationBuilder {
+    conf_flags: u8,
+}
+
+#[zenoh_macros::unstable]
+impl TimestampInstrumentationBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record timestamps at the SEND point.
+    pub fn set_send(self, enabled: bool) -> Self {
+        Self {
+            conf_flags: if enabled {
+                self.conf_flags | interception_point::SEND
+            } else {
+                self.conf_flags & !interception_point::SEND
+            },
+        }
+    }
+
+    /// Record timestamps at the ROUTE point.
+    pub fn set_route(self, enabled: bool) -> Self {
+        Self {
+            conf_flags: if enabled {
+                self.conf_flags | interception_point::ROUTE
+            } else {
+                self.conf_flags & !interception_point::ROUTE
+            },
+        }
+    }
+
+    /// Record timestamps at the RECEIVE point.
+    pub fn set_receive(self, enabled: bool) -> Self {
+        Self {
+            conf_flags: if enabled {
+                self.conf_flags | interception_point::RECEIVE
+            } else {
+                self.conf_flags & !interception_point::RECEIVE
+            },
+        }
+    }
+
+    pub fn build(self) -> zenoh_result::ZResult<TimestampInstrumentation> {
+        if self.conf_flags == 0 {
+            bail!("Invalid instrumentation config: at least one point must be active");
+        }
+        Ok(TimestampInstrumentation {
+            conf_flags: self.conf_flags,
+        })
+    }
+}
+
+/// A config for timestramp instrumentation. Build via [`TimestampInstrumentationBuilder`].
+#[zenoh_macros::unstable]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct TimestampInstrumentation {
+    conf_flags: u8,
+}
+
+#[zenoh_macros::unstable]
+impl TimestampInstrumentation {
+    /// Returns true if the [`InterceptionPoint`] is activated
+    #[zenoh_macros::unstable]
+    pub fn is_instrumented(&self, point: InterceptionPoint) -> bool {
+        self.conf_flags & u8::from(point) != 0
+    }
+
+    /// Returns the raw conf_flags bitmask.
+    pub(crate) fn conf_flags(&self) -> u8 {
+        self.conf_flags
+    }
+
+    /// Initialize from raw flags
+    pub(crate) fn try_from_flags(conf_flags: u8) -> zenoh_result::ZResult<Self> {
+        if conf_flags == 0 {
+            bail!("invalid instrumentation flags: at least one point must be active");
+        }
+        Ok(Self { conf_flags })
+    }
+}
+
+/// A single interception record in a timestamp stack.
+#[zenoh_macros::unstable]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TimestampStackRecord {
+    point: InterceptionPoint,
+    timestamp: Vec<u8>,
+}
+
+impl TimestampStackRecord {
+    /// Which interception point this record was captured at.
+    #[zenoh_macros::unstable]
+    pub fn point(&self) -> InterceptionPoint {
+        self.point
+    }
+
+    /// Raw timestamp bytes (format defined by the wire protocol).
+    #[zenoh_macros::unstable]
+    pub fn timestamp(&self) -> &[u8] {
+        &self.timestamp
+    }
+}
+
+/// The timestamp stack carried by a received message.
+#[zenoh_macros::unstable]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TimestampStack {
+    instrumentation: TimestampInstrumentation,
+    records: Vec<TimestampStackRecord>,
+}
+
+#[zenoh_macros::unstable]
+impl TimestampStack {
+    /// Which interception points were configured for this message.
+    pub fn instrumentation(&self) -> TimestampInstrumentation {
+        self.instrumentation
+    }
+
+    /// The ordered list of interception records.
+    pub fn records(&self) -> &[TimestampStackRecord] {
+        &self.records
+    }
+
+    /// Create a new empty `TimestampStackView` with the given instrumentation config.
+    pub(crate) fn new(instrumentation: TimestampInstrumentation) -> Self {
+        Self {
+            instrumentation,
+            records: Vec::new(),
+        }
+    }
+}
 
 /// Push a timestamp interception record onto the stack if the corresponding
 /// `conf_flags` bit is set for this interception point.
@@ -62,12 +230,63 @@ pub(crate) fn push_ts_interception<const ID: u8, T: IRuntime + ?Sized>(
         let context = TsStackContext {
             zid: runtime.zid(),
             whatami: runtime.whatami(),
-            interception_point: point,
+            interception_point: point
+                .try_into()
+                .expect("internal calls should provide valid interception point IDs"),
         };
         let timestamp = runtime.get_ts_stack_timestamp(context);
         ts_stack.ts_stack.stack.push(Interception {
             flags: point,
             timestamp,
         });
+    }
+}
+
+#[cfg(feature = "unstable")]
+impl TryFrom<&zenoh_protocol::network::timestamp_stack::TimestampStack> for TimestampStack {
+    type Error = zenoh_result::Error;
+
+    fn try_from(
+        ts: &zenoh_protocol::network::timestamp_stack::TimestampStack,
+    ) -> zenoh_result::ZResult<Self> {
+        let mut instance = Self {
+            instrumentation: TimestampInstrumentation::try_from_flags(ts.conf_flags)?,
+            records: Vec::new(),
+        };
+        for record in &ts.stack {
+            // Skip unknonw/malformed measurement configs
+            let point: InterceptionPoint = match record.flags.try_into() {
+                Ok(p) => p,
+                Err(_) => {
+                    tracing::warn!("
+                        Skipping instrumentation measurement with unknown or malformed instrumentation flags '{:b}'",
+                        record.flags
+                    );
+                    continue;
+                }
+            };
+            instance.records.push(TimestampStackRecord {
+                point,
+                timestamp: record.timestamp.clone(),
+            });
+        }
+        Ok(instance)
+    }
+}
+
+#[cfg(feature = "unstable")]
+impl From<&TimestampStack> for zenoh_protocol::network::timestamp_stack::TimestampStack {
+    fn from(value: &TimestampStack) -> Self {
+        zenoh_protocol::network::timestamp_stack::TimestampStack {
+            conf_flags: value.instrumentation.conf_flags,
+            stack: value
+                .records
+                .iter()
+                .map(|r| Interception {
+                    flags: r.point.into(),
+                    timestamp: r.timestamp.clone(),
+                })
+                .collect(),
+        }
     }
 }

--- a/zenoh/src/api/timestamp_stack.rs
+++ b/zenoh/src/api/timestamp_stack.rs
@@ -132,7 +132,7 @@ impl TimestampInstrumentationBuilder {
     }
 }
 
-/// A config for timestramp instrumentation. Build via [`TimestampInstrumentationBuilder`].
+/// A config for timestamp instrumentation. Build via [`TimestampInstrumentationBuilder`].
 #[zenoh_macros::unstable]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct TimestampInstrumentation {

--- a/zenoh/src/api/timestamp_stack.rs
+++ b/zenoh/src/api/timestamp_stack.rs
@@ -234,17 +234,28 @@ impl TimestampStack {
 /// Push a timestamp interception record onto the stack if the corresponding
 /// `conf_flags` bit is set for this interception point.
 ///
-/// This is a no-op if `ext_ts_stack` is `None`, if the flag is not present, or if `runtime` is `None`.
+/// This is a no-op if `ext_ts_stack` is `None`, if the flag is not present,
+/// or if `get_runtime` returns `None`.
+///
+/// The `get_runtime` closure is only invoked when `ext_ts_stack` is `Some`
+/// and the relevant `conf_flags` bit is set, avoiding unnecessary work
+/// (e.g. upgrading a weak runtime reference) in the common no-op case.
 #[cfg(feature = "unstable")]
-pub(crate) fn push_ts_interception<const ID: u8, T: IRuntime + ?Sized>(
+pub(crate) fn push_ts_interception<const ID: u8, T: IRuntime + ?Sized, R, F>(
     ext_ts_stack: &mut Option<TsStackType<ID>>,
-    runtime: Option<&T>,
+    get_runtime: F,
     point: u8,
-) {
-    let (Some(runtime), Some(ts_stack)) = (runtime, ext_ts_stack) else {
+) where
+    R: std::ops::Deref<Target = T>,
+    F: FnOnce() -> Option<R>,
+{
+    let Some(ts_stack) = ext_ts_stack else {
         return;
     };
     if ts_stack.ts_stack.conf_flags & point != 0 {
+        let Some(runtime) = get_runtime() else {
+            return;
+        };
         let context = TsStackContext {
             zid: runtime.zid(),
             whatami: runtime.whatami(),

--- a/zenoh/src/api/timestamp_stack.rs
+++ b/zenoh/src/api/timestamp_stack.rs
@@ -11,8 +11,6 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-use std::sync::Arc;
-
 use zenoh_protocol::{
     core::WhatAmI,
     network::timestamp_stack::{interception_point, Interception, TsStackType},
@@ -28,21 +26,15 @@ use crate::{net::runtime::IRuntime, session::ZenohId};
 /// The struct is `#[non_exhaustive]` to allow adding new fields in the future.
 #[non_exhaustive]
 #[zenoh_macros::unstable]
-pub struct TsStackContext {
+pub struct TimestampContext {
     /// The Zenoh ID of the current node.
     pub zid: ZenohId,
     /// The mode of the current node (router, peer, or client).
     pub whatami: WhatAmI,
-    /// The interception point identifier (e.g., `zenoh_protocol::network::timestamp_stack::interception_point::SEND`).
-    pub interception_point: InterceptionPoint,
 }
 
-/// Type alias for the user-defined timestamp callback.
-///
-/// The callback receives a [`TsStackContext`] and returns the raw timestamp bytes
-/// to be pushed onto the timestamp stack.
 #[zenoh_macros::unstable]
-pub type GetTimestampCallback = Arc<dyn Fn(TsStackContext) -> Vec<u8> + Send + Sync>;
+pub(crate) type GetTimestampCallback = Box<dyn Fn(TimestampContext) -> Vec<u8> + Send + Sync>;
 
 /// Identifies which interception point a timestamp record was captured at.
 ///
@@ -431,19 +423,17 @@ pub(crate) fn push_ts_interception<const ID: u8, T: IRuntime + ?Sized, R, F>(
         let Some(runtime) = get_runtime() else {
             return;
         };
-        let context = TsStackContext {
+        let context = TimestampContext {
             zid: runtime.zid(),
             whatami: runtime.whatami(),
-            interception_point: point
-                .try_into()
-                .expect("internal calls should provide valid interception point IDs"),
         };
         let (timestamp, is_custom) = runtime.get_ts_stack_timestamp(context);
         if timestamp.is_empty() {
             // Skip writing empty Vec
             return;
         }
-        if ts_stack.ts_stack.stack.len() >= zenoh_protocol::network::timestamp_stack::MAX_STACK_SIZE {
+        if ts_stack.ts_stack.stack.len() >= zenoh_protocol::network::timestamp_stack::MAX_STACK_SIZE
+        {
             // Avoid producing an invalid frame that will be rejected by the codec decoder.
             return;
         }

--- a/zenoh/src/api/timestamp_stack.rs
+++ b/zenoh/src/api/timestamp_stack.rs
@@ -389,7 +389,7 @@ impl TimestampStack {
         &self.records
     }
 
-    /// Create a new empty `TimestampStackView` with the given instrumentation config.
+    /// Create a new empty [`TimestampStack`](Self) with the given instrumentation config.
     pub(crate) fn new(instrumentation: TimestampInstrumentation) -> Self {
         Self {
             instrumentation,

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -1144,8 +1144,7 @@ pub mod shm {
 /// # Timestamp Sources
 ///
 /// By default, each interception point records a Zenoh [UHLC] timestamp.
-/// Alternatively, you can register a [custom callback](crate::timestamp_stack::GetTimestampCallback) on
-/// the session via
+/// Alternatively, you can register a custom callback on the session via
 /// [`OpenBuilder::with_timestamp_callback`](crate::api::builders::session::OpenBuilder::with_timestamp_callback)
 /// to produce arbitrary timestamp formats.
 ///

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -1188,9 +1188,8 @@ pub mod shm {
 #[zenoh_macros::unstable]
 pub mod timestamp_stack {
     pub use crate::api::timestamp_stack::{
-        GetTimestampCallback, InstrumentationTimestamp, InterceptionPoint,
-        TimestampInstrumentation, TimestampInstrumentationBuilder, TimestampStack,
-        TimestampStackRecord, TsStackContext,
+        InstrumentationTimestamp, InterceptionPoint, TimestampContext, TimestampInstrumentation,
+        TimestampInstrumentationBuilder, TimestampStack, TimestampStackRecord,
     };
 }
 

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -1127,12 +1127,10 @@ pub mod shm {
 #[zenoh_macros::unstable]
 #[cfg(feature = "unstable")]
 pub mod timestamp_stack {
-    // TODO: review public API
-    pub use zenoh_protocol::network::timestamp_stack::{
-        interception_point, Interception, TimestampStack,
+    pub use crate::api::timestamp_stack::{
+        GetTimestampCallback, InterceptionPoint, TimestampInstrumentation,
+        TimestampInstrumentationBuilder, TimestampStack, TimestampStackRecord, TsStackContext,
     };
-
-    pub use crate::api::timestamp_stack::{GetTimestampCallback, TsStackContext};
 }
 
 /// Functionality for interrupting queries.

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -1122,9 +1122,70 @@ pub mod shm {
     pub use crate::net::runtime::ShmProviderState;
 }
 
-/// Timestamp stack types.
+/// Timestamp instrumentation for Zenoh messages.
+///
+/// Timestamp instrumentation allows you to track the temporal path of a message
+/// as it travels through the Zenoh topology. By enabling one or more
+/// *interception points*, timestamps are recorded at each matching node and
+/// accumulated into a **timestamp stack** carried alongside the message.
+///
+/// # Interception Points
+///
+/// | Point | Where recorded | Meaning |
+/// |-------|---------------|---------|
+/// | [`Send`](crate::timestamp_stack::InterceptionPoint::Send) | Data source | Message leaves the application |
+/// | [`Route`](crate::timestamp_stack::InterceptionPoint::Route) | Routing layer of any instance | Message transits the routing layer |
+/// | [`Receive`](crate::timestamp_stack::InterceptionPoint::Receive) | Data receiver | Message arrives at the application |
+///
+/// Records are appended in traversal order. For example, in a routed
+/// client→router→client topology with all three points enabled, a subscriber
+/// will receive a stack ordered: `Send → Route → Route → Route → Receive`.
+///
+/// # Timestamp Sources
+///
+/// By default, each interception point records a Zenoh [UHLC] timestamp.
+/// Alternatively, you can register a [custom callback](crate::timestamp_stack::GetTimestampCallback) on
+/// the session via
+/// [`OpenBuilder::with_timestamp_callback`](crate::api::builders::session::OpenBuilder::with_timestamp_callback)
+/// to produce arbitrary timestamp formats.
+///
+/// # Usage
+///
+/// ```no_run
+/// # #[tokio::main]
+/// # async fn main() {
+/// use zenoh::timestamp_stack::{
+///     InstrumentationTimestamp, InterceptionPoint, TimestampInstrumentationBuilder,
+/// };
+///
+/// // Build an instrumentation config: record at send and receive.
+/// let instr = TimestampInstrumentationBuilder::new()
+///     .set_send(true)
+///     .set_receive(true)
+///     .build()
+///     .unwrap();
+///
+/// let session = zenoh::open(zenoh::Config::default()).await.unwrap();
+/// let publisher = session.declare_publisher("key/expr").await.unwrap();
+/// let subscriber = session.declare_subscriber("key/expr").await.unwrap();
+///
+/// publisher
+///     .put("payload")
+///     .timestamp_instrumentation(instr)
+///     .await
+///     .unwrap();
+///
+/// let sample = subscriber.recv_async().await.unwrap();
+/// if let Some(stack) = sample.timestamp_stack() {
+///     for record in stack.records() {
+///         println!("{:?} at {:?}", record.point(), record.timestamp());
+///     }
+/// }
+/// # }
+/// ```
+///
+/// [UHLC]: https://github.com/eclipse-zenoh/uhlc-rs
 #[zenoh_macros::unstable]
-#[cfg(feature = "unstable")]
 pub mod timestamp_stack {
     pub use crate::api::timestamp_stack::{
         GetTimestampCallback, InstrumentationTimestamp, InterceptionPoint,

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -1035,6 +1035,7 @@ pub mod internal {
     pub mod traits {
         pub use crate::api::builders::sample::{
             EncodingBuilderTrait, QoSBuilderTrait, SampleBuilderTrait, TimestampBuilderTrait,
+            TimestampInstrumentationBuilderTrait,
         };
     }
     pub use zenoh_core::{

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -1123,6 +1123,11 @@ pub mod shm {
     pub use crate::net::runtime::ShmProviderState;
 }
 
+/// Timestamp stack types.
+#[zenoh_macros::unstable]
+#[cfg(feature = "unstable")]
+pub use crate::api::timestamp_stack::{GetTimestampCallback, TsStackContext};
+
 /// Functionality for interrupting queries.
 #[zenoh_macros::unstable]
 pub mod cancellation {

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -1129,8 +1129,9 @@ pub mod shm {
 #[cfg(feature = "unstable")]
 pub mod timestamp_stack {
     pub use crate::api::timestamp_stack::{
-        GetTimestampCallback, InterceptionPoint, TimestampInstrumentation,
-        TimestampInstrumentationBuilder, TimestampStack, TimestampStackRecord, TsStackContext,
+        GetTimestampCallback, InstrumentationTimestamp, InterceptionPoint,
+        TimestampInstrumentation, TimestampInstrumentationBuilder, TimestampStack,
+        TimestampStackRecord, TsStackContext,
     };
 }
 

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -1126,7 +1126,14 @@ pub mod shm {
 /// Timestamp stack types.
 #[zenoh_macros::unstable]
 #[cfg(feature = "unstable")]
-pub use crate::api::timestamp_stack::{GetTimestampCallback, TsStackContext};
+pub mod timestamp_stack {
+    // TODO: review public API
+    pub use zenoh_protocol::network::timestamp_stack::{
+        interception_point, Interception, TimestampStack,
+    };
+
+    pub use crate::api::timestamp_stack::{GetTimestampCallback, TsStackContext};
+}
 
 /// Functionality for interrupting queries.
 #[zenoh_macros::unstable]

--- a/zenoh/src/net/routing/dispatcher/pubsub.rs
+++ b/zenoh/src/net/routing/dispatcher/pubsub.rs
@@ -306,6 +306,10 @@ pub fn route_data(
             let dir = route.iter().next().unwrap();
 
             if inter_region_filter(dir) && rtables.egress_filter(src_face, &dir.dst_face) {
+                // Get the runtime to handle ext_ts_stack
+                #[cfg(feature = "unstable")]
+                let runtime = rtables.data.runtime.as_ref().and_then(|w| w.upgrade());
+
                 drop(rtables);
                 let mut msg_clone;
                 let mut msg = &mut *msg;
@@ -318,6 +322,16 @@ pub fn route_data(
                 msg.ext_nodeid = ext::NodeIdType {
                     node_id: dir.node_id,
                 };
+                #[cfg(feature = "unstable")]
+                if let Some(ref rt) = runtime {
+                    crate::api::timestamp_stack::push_ts_interception(
+                        &mut msg.ext_ts_stack,
+                        rt.zid(),
+                        rt.whatami(),
+                        |ctx| rt.get_ts_stack_timestamp(ctx),
+                        zenoh_protocol::network::timestamp_stack::interception_point::ROUTE,
+                    );
+                }
                 send_push(&dir.dst_face, msg, reliability);
             }
         } else {
@@ -328,8 +342,26 @@ pub fn route_data(
                 })
                 .collect::<Vec<&Direction>>();
 
+            // Get the runtime to handle ext_ts_stack
+            // FIXME: this may be holding the Arc for too long, preventing the runtime from closing?
+            #[cfg(feature = "unstable")]
+            let runtime = rtables.data.runtime.as_ref().and_then(|w| w.upgrade());
+
             drop(rtables);
+
+            #[cfg(feature = "unstable")]
+            if let Some(ref rt) = runtime {
+                crate::api::timestamp_stack::push_ts_interception(
+                    &mut msg.ext_ts_stack,
+                    rt.zid(),
+                    rt.whatami(),
+                    |ctx| rt.get_ts_stack_timestamp(ctx),
+                    zenoh_protocol::network::timestamp_stack::interception_point::ROUTE,
+                );
+            }
             for dir in dirs {
+                // TODO: might be more accurate to push the new timestamp to ext_ts_stack here to
+                // account for `send_push` running sequentially for each message
                 send_push(
                     &dir.dst_face,
                     &mut Push {

--- a/zenoh/src/net/routing/dispatcher/pubsub.rs
+++ b/zenoh/src/net/routing/dispatcher/pubsub.rs
@@ -347,32 +347,27 @@ pub fn route_data(
 
             drop(rtables);
 
-            #[cfg(feature = "unstable")]
-            {
-                let weak = weak_runtime;
-                crate::api::timestamp_stack::push_ts_interception(
-                    &mut msg.ext_ts_stack,
-                    move || weak.and_then(|w| w.upgrade()).map(|rt| rt.state),
-                    zenoh_protocol::network::timestamp_stack::interception_point::ROUTE,
-                );
-            }
             for dir in dirs {
-                // TODO: might be more accurate to push the new timestamp to ext_ts_stack here to
-                // account for `send_push` running sequentially for each message
-                send_push(
-                    &dir.dst_face,
-                    &mut Push {
-                        wire_expr: dir.wire_expr.clone(),
-                        ext_qos: msg.ext_qos,
-                        ext_tstamp: None,
-                        ext_nodeid: ext::NodeIdType {
-                            node_id: dir.node_id,
-                        },
-                        ext_ts_stack: msg.ext_ts_stack.clone(),
-                        payload: msg.payload.clone(),
+                let mut push = Push {
+                    wire_expr: dir.wire_expr.clone(),
+                    ext_qos: msg.ext_qos,
+                    ext_tstamp: None,
+                    ext_nodeid: ext::NodeIdType {
+                        node_id: dir.node_id,
                     },
-                    reliability,
-                );
+                    ext_ts_stack: msg.ext_ts_stack.clone(),
+                    payload: msg.payload.clone(),
+                };
+                #[cfg(feature = "unstable")]
+                {
+                    let weak = weak_runtime.as_ref();
+                    crate::api::timestamp_stack::push_ts_interception(
+                        &mut push.ext_ts_stack,
+                        || weak.and_then(|w| w.upgrade()).map(|rt| rt.state),
+                        zenoh_protocol::network::timestamp_stack::interception_point::ROUTE,
+                    );
+                }
+                send_push(&dir.dst_face, &mut push, reliability);
             }
         }
     }

--- a/zenoh/src/net/routing/dispatcher/pubsub.rs
+++ b/zenoh/src/net/routing/dispatcher/pubsub.rs
@@ -339,6 +339,7 @@ pub fn route_data(
                         ext_nodeid: ext::NodeIdType {
                             node_id: dir.node_id,
                         },
+                        ext_ts_stack: msg.ext_ts_stack.clone(),
                         payload: msg.payload.clone(),
                     },
                     reliability,

--- a/zenoh/src/net/routing/dispatcher/pubsub.rs
+++ b/zenoh/src/net/routing/dispatcher/pubsub.rs
@@ -308,7 +308,7 @@ pub fn route_data(
             if inter_region_filter(dir) && rtables.egress_filter(src_face, &dir.dst_face) {
                 // Get the runtime to handle ext_ts_stack
                 #[cfg(feature = "unstable")]
-                let runtime = rtables.data.runtime.as_ref().and_then(|w| w.upgrade());
+                let weak_runtime = rtables.data.runtime.clone();
 
                 drop(rtables);
                 let mut msg_clone;
@@ -323,12 +323,12 @@ pub fn route_data(
                     node_id: dir.node_id,
                 };
                 #[cfg(feature = "unstable")]
-                if let Some(ref rt) = runtime {
+                {
+                    let rt = weak_runtime.and_then(|r| r.upgrade());
+                    let rt_state = rt.as_ref().map(|r| r.state.as_ref());
                     crate::api::timestamp_stack::push_ts_interception(
                         &mut msg.ext_ts_stack,
-                        rt.zid(),
-                        rt.whatami(),
-                        |ctx| rt.get_ts_stack_timestamp(ctx),
+                        rt_state,
                         zenoh_protocol::network::timestamp_stack::interception_point::ROUTE,
                     );
                 }
@@ -343,19 +343,18 @@ pub fn route_data(
                 .collect::<Vec<&Direction>>();
 
             // Get the runtime to handle ext_ts_stack
-            // FIXME: this may be holding the Arc for too long, preventing the runtime from closing?
             #[cfg(feature = "unstable")]
-            let runtime = rtables.data.runtime.as_ref().and_then(|w| w.upgrade());
+            let weak_runtime = rtables.data.runtime.clone();
 
             drop(rtables);
 
             #[cfg(feature = "unstable")]
-            if let Some(ref rt) = runtime {
+            {
+                let rt = weak_runtime.and_then(|r| r.upgrade());
+                let rt_state = rt.as_ref().map(|r| r.state.as_ref());
                 crate::api::timestamp_stack::push_ts_interception(
                     &mut msg.ext_ts_stack,
-                    rt.zid(),
-                    rt.whatami(),
-                    |ctx| rt.get_ts_stack_timestamp(ctx),
+                    rt_state,
                     zenoh_protocol::network::timestamp_stack::interception_point::ROUTE,
                 );
             }

--- a/zenoh/src/net/routing/dispatcher/pubsub.rs
+++ b/zenoh/src/net/routing/dispatcher/pubsub.rs
@@ -324,11 +324,10 @@ pub fn route_data(
                 };
                 #[cfg(feature = "unstable")]
                 {
-                    let rt = weak_runtime.and_then(|r| r.upgrade());
-                    let rt_state = rt.as_ref().map(|r| r.state.as_ref());
+                    let weak = weak_runtime.clone();
                     crate::api::timestamp_stack::push_ts_interception(
                         &mut msg.ext_ts_stack,
-                        rt_state,
+                        move || weak.and_then(|w| w.upgrade()).map(|rt| rt.state),
                         zenoh_protocol::network::timestamp_stack::interception_point::ROUTE,
                     );
                 }
@@ -350,11 +349,10 @@ pub fn route_data(
 
             #[cfg(feature = "unstable")]
             {
-                let rt = weak_runtime.and_then(|r| r.upgrade());
-                let rt_state = rt.as_ref().map(|r| r.state.as_ref());
+                let weak = weak_runtime;
                 crate::api::timestamp_stack::push_ts_interception(
                     &mut msg.ext_ts_stack,
-                    rt_state,
+                    move || weak.and_then(|w| w.upgrade()).map(|rt| rt.state),
                     zenoh_protocol::network::timestamp_stack::interception_point::ROUTE,
                 );
             }

--- a/zenoh/src/net/routing/dispatcher/queries.rs
+++ b/zenoh/src/net/routing/dispatcher/queries.rs
@@ -318,6 +318,7 @@ impl Face {
                             ext_target: msg.ext_target,
                             ext_budget: msg.ext_budget,
                             ext_timeout: msg.ext_timeout,
+                            ext_ts_stack: msg.ext_ts_stack.clone(),
                             payload: msg.payload.clone(),
                         };
 
@@ -480,6 +481,8 @@ impl Timed for QueryCleanup {
                     ext_qos: self.qos,
                     ext_tstamp: None,
                     ext_respid,
+                    // TODO: Maybe this should be set?
+                    ext_ts_stack: None,
                 },
             );
             let queries_lock = zwrite!(self.tables.queries_lock);

--- a/zenoh/src/net/routing/dispatcher/queries.rs
+++ b/zenoh/src/net/routing/dispatcher/queries.rs
@@ -326,11 +326,10 @@ impl Face {
 
                         #[cfg(feature = "unstable")]
                         {
-                            let rt = weak_runtime.clone().and_then(|r| r.upgrade());
-                            let rt_state = rt.as_ref().map(|r| r.state.as_ref());
+                            let weak = weak_runtime.clone();
                             crate::api::timestamp_stack::push_ts_interception(
                                 &mut msg.ext_ts_stack,
-                                rt_state,
+                                move || weak.and_then(|w| w.upgrade()).map(|rt| rt.state),
                                 zenoh_protocol::network::timestamp_stack::interception_point::ROUTE,
                             );
                         }
@@ -604,11 +603,10 @@ pub(crate) fn route_send_response(
                     msg.ext_qos = query.src_qos;
                     #[cfg(feature = "unstable")]
                     {
-                        let rt = weak_runtime.and_then(|r| r.upgrade());
-                        let rt_state = rt.as_ref().map(|r| r.state.as_ref());
+                        let weak = weak_runtime.clone();
                         crate::api::timestamp_stack::push_ts_interception(
                             &mut msg.ext_ts_stack,
-                            rt_state,
+                            move || weak.and_then(|w| w.upgrade()).map(|rt| rt.state),
                             zenoh_protocol::network::timestamp_stack::interception_point::ROUTE,
                         );
                     }

--- a/zenoh/src/net/routing/dispatcher/queries.rs
+++ b/zenoh/src/net/routing/dispatcher/queries.rs
@@ -49,7 +49,6 @@ use crate::net::routing::{
     gateway::{get_or_set_route, node_id_as_source, QueryDirection, QueryTargetQabl, RouteBuilder},
     hat::{DispatcherContext, SendDeclare, UnregisterEntityResult},
 };
-
 #[derive(Clone)]
 pub(crate) struct Query {
     src_face: Arc<FaceState>,
@@ -268,6 +267,9 @@ impl Face {
                     .ext_timeout
                     .unwrap_or(rtables.data.queries_default_timeout);
 
+                #[cfg(feature = "unstable")]
+                let runtime = rtables.data.runtime.as_ref().and_then(|w| w.upgrade());
+
                 drop(queries_lock);
                 drop(rtables);
 
@@ -321,6 +323,17 @@ impl Face {
                             ext_ts_stack: msg.ext_ts_stack.clone(),
                             payload: msg.payload.clone(),
                         };
+
+                        #[cfg(feature = "unstable")]
+                        if let Some(ref rt) = runtime {
+                            crate::api::timestamp_stack::push_ts_interception(
+                                &mut msg.ext_ts_stack,
+                                rt.zid(),
+                                rt.whatami(),
+                                |ctx| rt.get_ts_stack_timestamp(ctx),
+                                zenoh_protocol::network::timestamp_stack::interception_point::ROUTE,
+                            );
+                        }
 
                         if dir.dst_face.primitives.send_request(msg) {
                             #[cfg(feature = "stats")]
@@ -539,6 +552,8 @@ pub(crate) fn route_send_response(
     msg: &mut Response,
 ) {
     let tables = zread!(tables_ref.tables);
+    #[cfg(feature = "unstable")]
+    let runtime = tables.data.runtime.as_ref().and_then(|w| w.upgrade());
     match tables
         .data
         .get_mapping(face, &msg.wire_expr.scope, msg.wire_expr.mapping)
@@ -588,6 +603,16 @@ pub(crate) fn route_send_response(
 
                     msg.rid = query.src_qid;
                     msg.ext_qos = query.src_qos;
+                    #[cfg(feature = "unstable")]
+                    if let Some(ref rt) = runtime {
+                        crate::api::timestamp_stack::push_ts_interception(
+                            &mut msg.ext_ts_stack,
+                            rt.zid(),
+                            rt.whatami(),
+                            |ctx| rt.get_ts_stack_timestamp(ctx),
+                            zenoh_protocol::network::timestamp_stack::interception_point::ROUTE,
+                        );
+                    }
                     if query.src_face.primitives.send_response(msg) {
                         #[cfg(feature = "stats")]
                         payload_observer.observe_payload(zenoh_stats::Tx, &query.src_face, msg);

--- a/zenoh/src/net/routing/dispatcher/queries.rs
+++ b/zenoh/src/net/routing/dispatcher/queries.rs
@@ -268,7 +268,7 @@ impl Face {
                     .unwrap_or(rtables.data.queries_default_timeout);
 
                 #[cfg(feature = "unstable")]
-                let runtime = rtables.data.runtime.as_ref().and_then(|w| w.upgrade());
+                let weak_runtime = rtables.data.runtime.clone();
 
                 drop(queries_lock);
                 drop(rtables);
@@ -325,16 +325,15 @@ impl Face {
                         };
 
                         #[cfg(feature = "unstable")]
-                        if let Some(ref rt) = runtime {
+                        {
+                            let rt = weak_runtime.clone().and_then(|r| r.upgrade());
+                            let rt_state = rt.as_ref().map(|r| r.state.as_ref());
                             crate::api::timestamp_stack::push_ts_interception(
                                 &mut msg.ext_ts_stack,
-                                rt.zid(),
-                                rt.whatami(),
-                                |ctx| rt.get_ts_stack_timestamp(ctx),
+                                rt_state,
                                 zenoh_protocol::network::timestamp_stack::interception_point::ROUTE,
                             );
                         }
-
                         if dir.dst_face.primitives.send_request(msg) {
                             #[cfg(feature = "stats")]
                             payload_observer.observe_payload(zenoh_stats::Tx, &dir.dst_face, msg);
@@ -553,7 +552,7 @@ pub(crate) fn route_send_response(
 ) {
     let tables = zread!(tables_ref.tables);
     #[cfg(feature = "unstable")]
-    let runtime = tables.data.runtime.as_ref().and_then(|w| w.upgrade());
+    let weak_runtime = tables.data.runtime.clone();
     match tables
         .data
         .get_mapping(face, &msg.wire_expr.scope, msg.wire_expr.mapping)
@@ -604,12 +603,12 @@ pub(crate) fn route_send_response(
                     msg.rid = query.src_qid;
                     msg.ext_qos = query.src_qos;
                     #[cfg(feature = "unstable")]
-                    if let Some(ref rt) = runtime {
+                    {
+                        let rt = weak_runtime.and_then(|r| r.upgrade());
+                        let rt_state = rt.as_ref().map(|r| r.state.as_ref());
                         crate::api::timestamp_stack::push_ts_interception(
                             &mut msg.ext_ts_stack,
-                            rt.zid(),
-                            rt.whatami(),
-                            |ctx| rt.get_ts_stack_timestamp(ctx),
+                            rt_state,
                             zenoh_protocol::network::timestamp_stack::interception_point::ROUTE,
                         );
                     }

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -502,6 +502,19 @@ impl Primitives for AdminSpace {
                         #[cfg(feature = "unstable")]
                         source_info: query.ext_sinfo.map(Into::into),
                         primitives: ReplyPrimitives::new_remote(None, primitives),
+                        #[cfg(feature = "unstable")]
+                        whatami: self.context.runtime.whatami(),
+                        #[cfg(feature = "unstable")]
+                        ts_stack_callback: {
+                            let runtime = self.context.runtime.clone();
+                            Some(std::sync::Arc::new(
+                                move |ctx: crate::api::timestamp_stack::TsStackContext| {
+                                    runtime.get_ts_stack_timestamp(ctx)
+                                },
+                            ))
+                        },
+                        #[cfg(feature = "unstable")]
+                        query_ts_stack: None,
                     }),
                     eid: self.queryable_id,
                     value: mem::take(&mut query.ext_body)

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -382,11 +382,14 @@ impl Primitives for AdminSpace {
     fn send_push_consume(&self, msg: &mut Push, _reliability: Reliability, _consume: bool) {
         trace!("recv Push {:?}", msg);
         #[cfg(feature = "unstable")]
-        crate::api::timestamp_stack::push_ts_interception(
-            &mut msg.ext_ts_stack,
-            Some(self.context.runtime.state.as_ref()),
-            zenoh_protocol::network::timestamp_stack::interception_point::RECEIVE,
-        );
+        {
+            let state = self.context.runtime.state.clone();
+            crate::api::timestamp_stack::push_ts_interception(
+                &mut msg.ext_ts_stack,
+                || Some(state),
+                zenoh_protocol::network::timestamp_stack::interception_point::RECEIVE,
+            );
+        }
         {
             let conf = &self.context.runtime.state.config.lock();
             if !conf.adminspace.permissions().write {
@@ -446,11 +449,14 @@ impl Primitives for AdminSpace {
     fn send_request(&self, msg: &mut Request) {
         trace!("recv Request {:?}", msg);
         #[cfg(feature = "unstable")]
-        crate::api::timestamp_stack::push_ts_interception(
-            &mut msg.ext_ts_stack,
-            Some(self.context.runtime.state.as_ref()),
-            zenoh_protocol::network::timestamp_stack::interception_point::RECEIVE,
-        );
+        {
+            let state = self.context.runtime.state.clone();
+            crate::api::timestamp_stack::push_ts_interception(
+                &mut msg.ext_ts_stack,
+                || Some(state),
+                zenoh_protocol::network::timestamp_stack::interception_point::RECEIVE,
+            );
+        }
         match &mut msg.payload {
             RequestBody::Query(query) => {
                 let _span =

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -386,9 +386,7 @@ impl Primitives for AdminSpace {
         #[cfg(feature = "unstable")]
         crate::api::timestamp_stack::push_ts_interception(
             &mut msg.ext_ts_stack,
-            self.context.runtime.zid(),
-            self.context.runtime.whatami(),
-            |ctx| self.context.runtime.get_ts_stack_timestamp(ctx),
+            Some(self.context.runtime.state.as_ref()),
             zenoh_protocol::network::timestamp_stack::interception_point::RECEIVE,
         );
         {
@@ -452,9 +450,7 @@ impl Primitives for AdminSpace {
         #[cfg(feature = "unstable")]
         crate::api::timestamp_stack::push_ts_interception(
             &mut msg.ext_ts_stack,
-            self.context.runtime.zid(),
-            self.context.runtime.whatami(),
-            |ctx| self.context.runtime.get_ts_stack_timestamp(ctx),
+            Some(self.context.runtime.state.as_ref()),
             zenoh_protocol::network::timestamp_stack::interception_point::RECEIVE,
         );
         match &mut msg.payload {
@@ -503,16 +499,9 @@ impl Primitives for AdminSpace {
                         source_info: query.ext_sinfo.map(Into::into),
                         primitives: ReplyPrimitives::new_remote(None, primitives),
                         #[cfg(feature = "unstable")]
-                        whatami: self.context.runtime.whatami(),
-                        #[cfg(feature = "unstable")]
-                        ts_stack_callback: {
-                            let runtime = self.context.runtime.clone();
-                            Some(std::sync::Arc::new(
-                                move |ctx: crate::api::timestamp_stack::TsStackContext| {
-                                    runtime.get_ts_stack_timestamp(ctx)
-                                },
-                            ))
-                        },
+                        runtime: Some(crate::internal::runtime::DynamicRuntime::downgrade(
+                            &self.context.runtime.clone().into(),
+                        )),
                         #[cfg(feature = "unstable")]
                         query_ts_stack: None,
                     }),

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -47,8 +47,6 @@ use zenoh_transport::{multicast::TransportMulticast, unicast::TransportUnicast, 
 use super::{routing::dispatcher::face::Face, Runtime};
 #[cfg(all(feature = "plugins", feature = "runtime_plugins"))]
 use crate::api::plugins::PluginsManager;
-#[cfg(all(feature = "plugins", feature = "runtime_plugins"))]
-use crate::internal::runtime::DynamicRuntime;
 use crate::{
     api::{
         bytes::ZBytes,
@@ -59,7 +57,7 @@ use crate::{
     net::{
         primitives::Primitives,
         routing::{dispatcher::tables::Tables, gateway::Resource, hat::Sources},
-        runtime::region,
+        runtime::{region, DynamicRuntime},
     },
     LONG_VERSION,
 };
@@ -499,9 +497,9 @@ impl Primitives for AdminSpace {
                         source_info: query.ext_sinfo.map(Into::into),
                         primitives: ReplyPrimitives::new_remote(None, primitives),
                         #[cfg(feature = "unstable")]
-                        runtime: Some(crate::internal::runtime::DynamicRuntime::downgrade(
-                            &self.context.runtime.clone().into(),
-                        )),
+                        runtime: Some(
+                            DynamicRuntime::from(self.context.runtime.clone()).downgrade(),
+                        ),
                         #[cfg(feature = "unstable")]
                         query_ts_stack: None,
                     }),

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -383,6 +383,14 @@ impl Primitives for AdminSpace {
 
     fn send_push_consume(&self, msg: &mut Push, _reliability: Reliability, _consume: bool) {
         trace!("recv Push {:?}", msg);
+        #[cfg(feature = "unstable")]
+        crate::api::timestamp_stack::push_ts_interception(
+            &mut msg.ext_ts_stack,
+            self.context.runtime.zid(),
+            self.context.runtime.whatami(),
+            |ctx| self.context.runtime.get_ts_stack_timestamp(ctx),
+            zenoh_protocol::network::timestamp_stack::interception_point::RECEIVE,
+        );
         {
             let conf = &self.context.runtime.state.config.lock();
             if !conf.adminspace.permissions().write {
@@ -441,6 +449,14 @@ impl Primitives for AdminSpace {
 
     fn send_request(&self, msg: &mut Request) {
         trace!("recv Request {:?}", msg);
+        #[cfg(feature = "unstable")]
+        crate::api::timestamp_stack::push_ts_interception(
+            &mut msg.ext_ts_stack,
+            self.context.runtime.zid(),
+            self.context.runtime.whatami(),
+            |ctx| self.context.runtime.get_ts_stack_timestamp(ctx),
+            zenoh_protocol::network::timestamp_stack::interception_point::RECEIVE,
+        );
         match &mut msg.payload {
             RequestBody::Query(query) => {
                 let _span =

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -83,6 +83,8 @@ use super::{
 use crate::api::loader::{load_plugins, start_plugins};
 #[cfg(feature = "plugins")]
 use crate::api::plugins::PluginsManager;
+#[cfg(feature = "unstable")]
+use crate::api::timestamp_stack::{GetTimestampCallback, TsStackContext};
 #[cfg(feature = "internal")]
 use crate::session::CloseBuilder;
 use crate::{
@@ -130,6 +132,8 @@ pub(crate) struct RuntimeState {
     transport_handlers: std::sync::RwLock<Vec<Arc<dyn TransportEventHandler>>>,
     locators: std::sync::RwLock<Vec<Locator>>,
     hlc: Option<Arc<HLC>>,
+    #[cfg(feature = "unstable")]
+    timestamp_callback: Option<GetTimestampCallback>,
     task_controller: TaskController,
     #[cfg(feature = "plugins")]
     plugins_manager: Mutex<PluginsManager>,
@@ -149,6 +153,8 @@ pub trait IRuntime: Send + Sync {
     fn next_id(&self) -> u32;
     fn is_closed(&self) -> bool;
     fn new_timestamp(&self) -> Option<uhlc::Timestamp>;
+    #[cfg(feature = "unstable")]
+    fn get_ts_stack_timestamp(&self, context: TsStackContext) -> Vec<u8>;
     fn get_locators(&self) -> Vec<Locator>;
     fn get_zids(&self, whatami: WhatAmI) -> Box<dyn Iterator<Item = ZenohId> + Send + Sync>;
     fn new_handler(&self, handler: Arc<dyn TransportEventHandler>);
@@ -215,6 +221,30 @@ impl IRuntime for RuntimeState {
 
     fn new_timestamp(&self) -> Option<uhlc::Timestamp> {
         self.hlc.as_ref().map(|hlc| hlc.new_timestamp())
+    }
+
+    #[cfg(feature = "unstable")]
+    fn get_ts_stack_timestamp(&self, context: TsStackContext) -> Vec<u8> {
+        if let Some(cb) = &self.timestamp_callback {
+            return cb(context);
+        }
+
+        let ts = match &self.hlc {
+            Some(hlc) => hlc.new_timestamp(),
+            None => {
+                // TODO: instead of using system time, HLC should be initialized in this case
+                use std::time::{SystemTime, UNIX_EPOCH};
+                let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().into();
+                uhlc::Timestamp::new(now, self.zid.into())
+            }
+        };
+
+        use zenoh_codec::{WCodec, Zenoh080};
+        let mut buf = Vec::new();
+        Zenoh080
+            .write(&mut buf, &ts)
+            .expect("Failed to serialize timestamp");
+        buf
     }
 
     fn get_locators(&self) -> Vec<Locator> {
@@ -562,6 +592,8 @@ pub struct RuntimeBuilder {
     plugins_manager: Option<PluginsManager>,
     #[cfg(feature = "shared-memory")]
     shm_clients: Option<Arc<ShmClientStorage>>,
+    #[cfg(feature = "unstable")]
+    timestamp_callback: Option<GetTimestampCallback>,
     #[cfg(test)]
     subregions: Option<Vec<Region>>,
     #[cfg(test)]
@@ -598,6 +630,8 @@ impl RuntimeBuilder {
             plugins_manager: None,
             #[cfg(feature = "shared-memory")]
             shm_clients: None,
+            #[cfg(feature = "unstable")]
+            timestamp_callback: None,
             #[cfg(test)]
             subregions: None,
             #[cfg(test)]
@@ -614,6 +648,12 @@ impl RuntimeBuilder {
     #[cfg(feature = "shared-memory")]
     pub fn shm_clients(mut self, shm_clients: Option<Arc<ShmClientStorage>>) -> Self {
         self.shm_clients = shm_clients;
+        self
+    }
+
+    #[cfg(feature = "unstable")]
+    pub fn timestamp_callback(mut self, cb: Option<GetTimestampCallback>) -> Self {
+        self.timestamp_callback = cb;
         self
     }
 
@@ -638,6 +678,8 @@ impl RuntimeBuilder {
             mut plugins_manager,
             #[cfg(feature = "shared-memory")]
             shm_clients,
+            #[cfg(feature = "unstable")]
+            timestamp_callback,
             #[cfg(test)]
             subregions,
             #[cfg(test)]
@@ -726,6 +768,8 @@ impl RuntimeBuilder {
                 transport_handlers: std::sync::RwLock::new(vec![]),
                 locators: std::sync::RwLock::new(vec![]),
                 hlc,
+                #[cfg(feature = "unstable")]
+                timestamp_callback,
                 task_controller: TaskController::default(),
                 #[cfg(feature = "plugins")]
                 plugins_manager: Mutex::new(plugins_manager),
@@ -831,6 +875,11 @@ impl Runtime {
     #[allow(dead_code)]
     pub fn new_timestamp(&self) -> Option<uhlc::Timestamp> {
         self.state.new_timestamp()
+    }
+
+    #[cfg(feature = "unstable")]
+    pub fn get_ts_stack_timestamp(&self, context: TsStackContext) -> Vec<u8> {
+        self.state.get_ts_stack_timestamp(context)
     }
 
     pub fn get_locators(&self) -> Vec<Locator> {

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -22,6 +22,8 @@ pub mod orchestrator;
 mod region;
 
 #[cfg(feature = "unstable")]
+use std::sync::OnceLock;
+#[cfg(feature = "unstable")]
 #[cfg(feature = "plugins")]
 use std::sync::{Mutex, MutexGuard};
 use std::{
@@ -132,6 +134,11 @@ pub(crate) struct RuntimeState {
     transport_handlers: std::sync::RwLock<Vec<Arc<dyn TransportEventHandler>>>,
     locators: std::sync::RwLock<Vec<Locator>>,
     hlc: Option<Arc<HLC>>,
+    // TODO: lazy_hlc is added for timestamp instrumentation feature, in order to avoid breaking
+    // existing logic that relies on state of hlc Option to check if timestamping is enabled or
+    // not. Once ts_instrumetnation is stabilized, hlc should be changed to use OnceLock instead.
+    #[cfg(feature = "unstable")]
+    lazy_hlc: OnceLock<Arc<HLC>>,
     #[cfg(feature = "unstable")]
     timestamp_callback: Option<GetTimestampCallback>,
     task_controller: TaskController,
@@ -231,15 +238,13 @@ impl IRuntime for RuntimeState {
             return (cb(context), true);
         }
 
-        let ts = match &self.hlc {
-            Some(hlc) => hlc.new_timestamp(),
-            None => {
-                // TODO: instead of using system time, HLC should be initialized in this case
-                use std::time::{SystemTime, UNIX_EPOCH};
-                let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().into();
-                uhlc::Timestamp::new(now, self.zid.into())
-            }
-        };
+        let hlc = self.hlc.as_ref().unwrap_or_else(|| {
+            self.lazy_hlc.get_or_init(|| {
+                Arc::new(HLCBuilder::new().with_id(uhlc::ID::from(self.zid)).build())
+            })
+        });
+
+        let ts = hlc.new_timestamp();
 
         use zenoh_codec::{WCodec, Zenoh080};
         let mut buf = Vec::new();
@@ -771,6 +776,8 @@ impl RuntimeBuilder {
                 transport_handlers: std::sync::RwLock::new(vec![]),
                 locators: std::sync::RwLock::new(vec![]),
                 hlc,
+                #[cfg(feature = "unstable")]
+                lazy_hlc: OnceLock::new(),
                 #[cfg(feature = "unstable")]
                 timestamp_callback,
                 task_controller: TaskController::default(),

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -568,6 +568,7 @@ impl RuntimeState {
     }
 }
 
+#[derive(Clone)]
 pub struct WeakRuntime {
     state: Weak<RuntimeState>,
 }
@@ -805,7 +806,7 @@ impl RuntimeBuilder {
 
 #[derive(Clone)]
 pub struct Runtime {
-    state: Arc<RuntimeState>,
+    pub(crate) state: Arc<RuntimeState>,
 }
 
 impl fmt::Debug for Runtime {
@@ -820,6 +821,12 @@ impl fmt::Debug for Runtime {
 
 #[derive(Clone)]
 pub struct DynamicRuntime(Arc<dyn IRuntime>);
+
+impl DynamicRuntime {
+    pub(crate) fn downgrade(&self) -> WeakDynamicRuntime {
+        WeakDynamicRuntime(Arc::downgrade(&self.0))
+    }
+}
 
 impl fmt::Debug for DynamicRuntime {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -845,6 +852,15 @@ impl StructVersion for DynamicRuntime {
 }
 
 impl PluginStartArgs for DynamicRuntime {}
+
+#[derive(Clone)]
+pub struct WeakDynamicRuntime(pub(crate) Weak<dyn IRuntime>);
+
+impl WeakDynamicRuntime {
+    pub(crate) fn upgrade(&self) -> Option<DynamicRuntime> {
+        self.0.upgrade().map(|r| DynamicRuntime(r))
+    }
+}
 
 impl Runtime {
     #[inline(always)]

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -289,9 +289,9 @@ impl IRuntime for RuntimeState {
 
         use zenoh_codec::{WCodec, Zenoh080};
         let mut buf = Vec::new();
-        Zenoh080
-            .write(&mut buf, &ts)
-            .expect("Failed to serialize timestamp");
+        if Zenoh080.write(&mut buf, &ts).is_err() {
+            return (Vec::new(), false);
+        }
         (buf, false)
     }
 

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -90,7 +90,7 @@ use crate::api::loader::{load_plugins, start_plugins};
 #[cfg(feature = "plugins")]
 use crate::api::plugins::PluginsManager;
 #[cfg(feature = "unstable")]
-use crate::api::timestamp_stack::{GetTimestampCallback, TsStackContext};
+use crate::api::timestamp_stack::{GetTimestampCallback, TimestampContext};
 #[cfg(feature = "internal")]
 use crate::session::CloseBuilder;
 use crate::{
@@ -204,7 +204,7 @@ pub trait IRuntime: Send + Sync {
     /// Returns a timestamp for timestamp instrumentation. The boolean indicates whether the timestamp
     /// is the result of a custom user-callback or a Zenoh UHLC timestamp.
     #[cfg(feature = "unstable")]
-    fn get_ts_stack_timestamp(&self, context: TsStackContext) -> (Vec<u8>, bool);
+    fn get_ts_stack_timestamp(&self, context: TimestampContext) -> (Vec<u8>, bool);
     fn get_locators(&self) -> Vec<Locator>;
     fn get_zids(&self, whatami: WhatAmI) -> Box<dyn Iterator<Item = ZenohId> + Send + Sync>;
     fn new_handler(&self, handler: Arc<dyn TransportEventHandler>);
@@ -274,7 +274,7 @@ impl IRuntime for RuntimeState {
     }
 
     #[cfg(feature = "unstable")]
-    fn get_ts_stack_timestamp(&self, context: TsStackContext) -> (Vec<u8>, bool) {
+    fn get_ts_stack_timestamp(&self, context: TimestampContext) -> (Vec<u8>, bool) {
         if let Some(cb) = &self.timestamp_callback {
             return (cb(context), true);
         }

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -153,8 +153,10 @@ pub trait IRuntime: Send + Sync {
     fn next_id(&self) -> u32;
     fn is_closed(&self) -> bool;
     fn new_timestamp(&self) -> Option<uhlc::Timestamp>;
+    /// Returns a timestamp for timestamp instrumentation. The boolean indicates if the timsetamp
+    /// is the result of a custom user-callback or Zenoh UHLC
     #[cfg(feature = "unstable")]
-    fn get_ts_stack_timestamp(&self, context: TsStackContext) -> Vec<u8>;
+    fn get_ts_stack_timestamp(&self, context: TsStackContext) -> (Vec<u8>, bool);
     fn get_locators(&self) -> Vec<Locator>;
     fn get_zids(&self, whatami: WhatAmI) -> Box<dyn Iterator<Item = ZenohId> + Send + Sync>;
     fn new_handler(&self, handler: Arc<dyn TransportEventHandler>);
@@ -224,9 +226,9 @@ impl IRuntime for RuntimeState {
     }
 
     #[cfg(feature = "unstable")]
-    fn get_ts_stack_timestamp(&self, context: TsStackContext) -> Vec<u8> {
+    fn get_ts_stack_timestamp(&self, context: TsStackContext) -> (Vec<u8>, bool) {
         if let Some(cb) = &self.timestamp_callback {
-            return cb(context);
+            return (cb(context), true);
         }
 
         let ts = match &self.hlc {
@@ -244,7 +246,7 @@ impl IRuntime for RuntimeState {
         Zenoh080
             .write(&mut buf, &ts)
             .expect("Failed to serialize timestamp");
-        buf
+        (buf, false)
     }
 
     fn get_locators(&self) -> Vec<Locator> {

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -177,7 +177,7 @@ pub(crate) struct RuntimeState {
     hlc: Option<Arc<HLC>>,
     // TODO: lazy_hlc is added for timestamp instrumentation feature, in order to avoid breaking
     // existing logic that relies on state of hlc Option to check if timestamping is enabled or
-    // not. Once ts_instrumetnation is stabilized, hlc should be changed to use OnceLock instead.
+    // not. Once ts_instrumentation is stabilized, hlc should be changed to use OnceLock instead.
     #[cfg(feature = "unstable")]
     lazy_hlc: OnceLock<Arc<HLC>>,
     #[cfg(feature = "unstable")]
@@ -201,8 +201,8 @@ pub trait IRuntime: Send + Sync {
     fn next_id(&self) -> u32;
     fn is_closed(&self) -> bool;
     fn new_timestamp(&self) -> Option<uhlc::Timestamp>;
-    /// Returns a timestamp for timestamp instrumentation. The boolean indicates if the timsetamp
-    /// is the result of a custom user-callback or Zenoh UHLC
+    /// Returns a timestamp for timestamp instrumentation. The boolean indicates whether the timestamp
+    /// is the result of a custom user-callback or a Zenoh UHLC timestamp.
     #[cfg(feature = "unstable")]
     fn get_ts_stack_timestamp(&self, context: TsStackContext) -> (Vec<u8>, bool);
     fn get_locators(&self) -> Vec<Locator>;

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -893,11 +893,6 @@ impl Runtime {
         self.state.new_timestamp()
     }
 
-    #[cfg(feature = "unstable")]
-    pub fn get_ts_stack_timestamp(&self, context: TsStackContext) -> Vec<u8> {
-        self.state.get_ts_stack_timestamp(context)
-    }
-
     pub fn get_locators(&self) -> Vec<Locator> {
         self.state.get_locators()
     }

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -867,7 +867,7 @@ pub struct WeakDynamicRuntime(pub(crate) Weak<dyn IRuntime>);
 
 impl WeakDynamicRuntime {
     pub(crate) fn upgrade(&self) -> Option<DynamicRuntime> {
-        self.0.upgrade().map(|r| DynamicRuntime(r))
+        self.0.upgrade().map(DynamicRuntime)
     }
 }
 

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -876,6 +876,10 @@ impl DynamicRuntime {
     pub(crate) fn downgrade(&self) -> WeakDynamicRuntime {
         WeakDynamicRuntime(Arc::downgrade(&self.0))
     }
+
+    pub(crate) fn get_inner(&self) -> Arc<dyn IRuntime> {
+        self.0.clone()
+    }
 }
 
 impl fmt::Debug for DynamicRuntime {

--- a/zenoh/src/net/tests/regions/mod.rs
+++ b/zenoh/src/net/tests/regions/mod.rs
@@ -504,6 +504,7 @@ impl MockFace {
                 ext_qos: ext::QoSType::DEFAULT,
                 ext_tstamp: None,
                 ext_nodeid: NodeIdType::DEFAULT,
+                ext_ts_stack: None,
                 payload: PushBody::Put(Put {
                     payload: payload.into(),
                     ..Default::default()
@@ -524,6 +525,7 @@ impl MockFace {
             ext_target: QueryTarget::DEFAULT,
             ext_budget: None,
             ext_timeout: None,
+            ext_ts_stack: None,
             payload: RequestBody::Query(Query::default()),
         });
     }
@@ -537,6 +539,7 @@ impl MockFace {
                 ext_qos: ext::QoSType::DEFAULT,
                 ext_tstamp: None,
                 ext_nodeid: NodeIdType::DEFAULT,
+                ext_ts_stack: None,
                 payload: PushBody::Del(Del::default()),
             },
             Reliability::BestEffort,

--- a/zenoh/src/net/tests/tables.rs
+++ b/zenoh/src/net/tests/tables.rs
@@ -683,6 +683,7 @@ fn test_response_wireexpr() {
         ext_target: QueryTarget::All,
         ext_budget: None,
         ext_timeout: None,
+        ext_ts_stack: None,
     });
 
     route_send_response(
@@ -703,6 +704,7 @@ fn test_response_wireexpr() {
             ext_qos: zenoh_protocol::network::response::ext::QoSType::default(),
             ext_tstamp: None,
             ext_respid: None,
+            ext_ts_stack: None,
         },
     );
     assert_eq!(
@@ -749,6 +751,7 @@ fn test_response_wireexpr() {
             ext_qos: zenoh_protocol::network::response::ext::QoSType::default(),
             ext_tstamp: None,
             ext_respid: None,
+            ext_ts_stack: None,
         },
     );
     assert_eq!(

--- a/zenoh/src/tests/query_reply.rs
+++ b/zenoh/src/tests/query_reply.rs
@@ -77,11 +77,8 @@ async fn test_reply_preserves_optimized_ke() {
         #[cfg(feature = "unstable")]
         source_info: None,
         primitives: ReplyPrimitives::new_remote(Some(session.downgrade()), primitives.clone()),
-        // TODO: fix this mess
         #[cfg(feature = "unstable")]
-        whatami: zenoh_protocol::core::WhatAmI::Peer,
-        #[cfg(feature = "unstable")]
-        ts_stack_callback: None,
+        runtime: None,
         #[cfg(feature = "unstable")]
         query_ts_stack: None,
     };

--- a/zenoh/src/tests/query_reply.rs
+++ b/zenoh/src/tests/query_reply.rs
@@ -77,6 +77,13 @@ async fn test_reply_preserves_optimized_ke() {
         #[cfg(feature = "unstable")]
         source_info: None,
         primitives: ReplyPrimitives::new_remote(Some(session.downgrade()), primitives.clone()),
+        // TODO: fix this mess
+        #[cfg(feature = "unstable")]
+        whatami: zenoh_protocol::core::WhatAmI::Peer,
+        #[cfg(feature = "unstable")]
+        ts_stack_callback: None,
+        #[cfg(feature = "unstable")]
+        query_ts_stack: None,
     };
     let query = Query {
         inner: Arc::new(query_inner),

--- a/zenoh/tests/timestamp_instrumentation.rs
+++ b/zenoh/tests/timestamp_instrumentation.rs
@@ -1511,24 +1511,24 @@ async fn custom_callback_context() {
     tokio::time::sleep(SLEEP).await;
     ztimeout!(publisher.put("payload").timestamp_instrumentation(instr)).unwrap();
     let _sample = ztimeout!(subscriber.recv_async()).unwrap();
+    {
+        let contexts = capture.contexts.lock().unwrap();
+        assert_eq!(
+            contexts.len(),
+            2,
+            "Expected 2 context captures (SEND + RECEIVE)"
+        );
 
-    let contexts = capture.contexts.lock().unwrap();
-    assert_eq!(
-        contexts.len(),
-        2,
-        "Expected 2 context captures (SEND + RECEIVE)"
-    );
+        // SEND context
+        assert_eq!(contexts[0].0, expected_zid);
+        assert_eq!(contexts[0].1, WhatAmI::Peer);
+        assert_eq!(contexts[0].2, InterceptionPoint::Send);
 
-    // SEND context
-    assert_eq!(contexts[0].0, expected_zid);
-    assert_eq!(contexts[0].1, WhatAmI::Peer);
-    assert_eq!(contexts[0].2, InterceptionPoint::Send);
-
-    // RECEIVE context
-    assert_eq!(contexts[1].0, expected_zid);
-    assert_eq!(contexts[1].1, WhatAmI::Peer);
-    assert_eq!(contexts[1].2, InterceptionPoint::Receive);
-
+        // RECEIVE context
+        assert_eq!(contexts[1].0, expected_zid);
+        assert_eq!(contexts[1].1, WhatAmI::Peer);
+        assert_eq!(contexts[1].2, InterceptionPoint::Receive);
+    }
     session.close().await.unwrap();
 }
 

--- a/zenoh/tests/timestamp_instrumentation.rs
+++ b/zenoh/tests/timestamp_instrumentation.rs
@@ -20,8 +20,8 @@ use zenoh::{
     config::WhatAmI,
     query::ConsolidationMode,
     timestamp_stack::{
-        GetTimestampCallback, InstrumentationTimestamp, InterceptionPoint,
-        TimestampInstrumentation, TimestampInstrumentationBuilder,
+        InstrumentationTimestamp, InterceptionPoint, TimestampContext, TimestampInstrumentation,
+        TimestampInstrumentationBuilder,
     },
 };
 use zenoh_core::ztimeout;
@@ -1380,7 +1380,7 @@ async fn custom_callback_pub_sub() {
     zenoh_util::init_log_from_env_or("error");
     let ke = "test/ts_instr/custom_callback/pub_sub";
     let custom_bytes = b"custom_ts_123".to_vec();
-    let cb: GetTimestampCallback = Arc::new(move |_ctx| custom_bytes.clone());
+    let cb = move |_ctx| custom_bytes.clone();
 
     let instr = make_instrumentation(true, false, false);
 
@@ -1415,8 +1415,8 @@ async fn custom_callback_query_reply() {
     let custom_bytes_query = b"custom_query_ts".to_vec();
     let custom_bytes_reply = b"custom_reply_ts".to_vec();
 
-    let cb_query: GetTimestampCallback = Arc::new(move |_ctx| custom_bytes_query.clone());
-    let cb_reply: GetTimestampCallback = Arc::new(move |_ctx| custom_bytes_reply.clone());
+    let cb_query = move |_ctx| custom_bytes_query.clone();
+    let cb_reply = move |_ctx| custom_bytes_reply.clone();
 
     let instr = make_instrumentation(true, false, true);
 
@@ -1497,21 +1497,21 @@ async fn custom_callback_context() {
     use std::sync::Mutex;
     #[derive(Clone)]
     struct ContextCapture {
-        contexts: Arc<Mutex<Vec<(zenoh::session::ZenohId, WhatAmI, InterceptionPoint)>>>,
+        contexts: Arc<Mutex<Vec<(zenoh::session::ZenohId, WhatAmI)>>>,
     }
     let capture = ContextCapture {
         contexts: Arc::new(Mutex::new(Vec::new())),
     };
     let capture_clone = capture.clone();
 
-    let cb: GetTimestampCallback = Arc::new(move |ctx| {
+    let cb = move |ctx: TimestampContext| {
         capture_clone
             .contexts
             .lock()
             .unwrap()
-            .push((ctx.zid, ctx.whatami, ctx.interception_point));
+            .push((ctx.zid, ctx.whatami));
         b"ctx_ts".to_vec()
-    });
+    };
 
     let instr = make_instrumentation(true, false, true);
 
@@ -1536,12 +1536,10 @@ async fn custom_callback_context() {
         // SEND context
         assert_eq!(contexts[0].0, expected_zid);
         assert_eq!(contexts[0].1, WhatAmI::Peer);
-        assert_eq!(contexts[0].2, InterceptionPoint::Send);
 
         // RECEIVE context
         assert_eq!(contexts[1].0, expected_zid);
         assert_eq!(contexts[1].1, WhatAmI::Peer);
-        assert_eq!(contexts[1].2, InterceptionPoint::Receive);
     }
     session.close().await.unwrap();
 }

--- a/zenoh/tests/timestamp_instrumentation.rs
+++ b/zenoh/tests/timestamp_instrumentation.rs
@@ -20,8 +20,8 @@ use zenoh::{
     config::WhatAmI,
     query::ConsolidationMode,
     timestamp_stack::{
-        GetTimestampCallback, InterceptionPoint, TimestampInstrumentation,
-        TimestampInstrumentationBuilder,
+        GetTimestampCallback, InstrumentationTimestamp, InterceptionPoint,
+        TimestampInstrumentation, TimestampInstrumentationBuilder,
     },
 };
 use zenoh_core::ztimeout;
@@ -81,10 +81,22 @@ fn assert_record(
 ) {
     assert_eq!(record.point(), expected_point);
     assert_eq!(record.is_custom(), expected_custom);
-    assert!(
-        !record.timestamp().is_empty(),
-        "timestamp bytes should not be empty"
-    );
+    match record.timestamp() {
+        InstrumentationTimestamp::Custom(ts_bytes) => {
+            assert!(!ts_bytes.is_empty(), "timestamp bytes should not be empty")
+        }
+        InstrumentationTimestamp::UHLC(_timestamp) => return,
+    }
+}
+
+fn assert_custom_ts_record(
+    record: &zenoh::timestamp_stack::InstrumentationTimestamp,
+    content: &[u8],
+) {
+    match record {
+        InstrumentationTimestamp::UHLC(_) => panic!("expected custom timestamp, found UHLC"),
+        InstrumentationTimestamp::Custom(ts) => assert_eq!(ts, content),
+    }
 }
 
 // ─── Builder & Unit Tests ───────────────────────────────────────────────
@@ -192,8 +204,8 @@ async fn records_non_empty_timestamp_bytes() {
         .expect("timestamp_stack should be Some");
     for record in ts_stack.records() {
         assert!(
-            !record.timestamp().is_empty(),
-            "UHLC timestamp bytes should not be empty"
+            matches!(record.timestamp(), InstrumentationTimestamp::UHLC(_)),
+            "UHLC timestamp should be valid"
         );
     }
 
@@ -1391,7 +1403,7 @@ async fn custom_callback_pub_sub() {
         record.is_custom(),
         "is_custom should be true when using custom callback"
     );
-    assert_eq!(record.timestamp(), b"custom_ts_123");
+    assert_custom_ts_record(record.timestamp(), b"custom_ts_123");
 
     session.close().await.unwrap();
 }
@@ -1442,10 +1454,10 @@ async fn custom_callback_query_reply() {
     assert_eq!(ts_stack.records().len(), 2);
     // Query side uses session1's callback for SEND, session2's callback for RECEIVE
     assert!(ts_stack.records()[0].is_custom());
-    assert_eq!(ts_stack.records()[0].timestamp(), b"custom_query_ts");
+    assert_custom_ts_record(ts_stack.records()[0].timestamp(), b"custom_query_ts");
     assert!(ts_stack.records()[1].is_custom());
     // RECEIVE is pushed on session2's side, so it uses session2's callback
-    assert_eq!(ts_stack.records()[1].timestamp(), b"custom_reply_ts");
+    assert_custom_ts_record(ts_stack.records()[1].timestamp(), b"custom_reply_ts");
 
     ztimeout!(query.reply(ke, "data")).unwrap();
     std::mem::drop(query);
@@ -1460,16 +1472,16 @@ async fn custom_callback_query_reply() {
     assert_eq!(ts_stack.records().len(), 4);
     // Query side is the same
     assert!(ts_stack.records()[0].is_custom());
-    assert_eq!(ts_stack.records()[0].timestamp(), b"custom_query_ts");
+    assert_custom_ts_record(ts_stack.records()[0].timestamp(), b"custom_query_ts");
     assert!(ts_stack.records()[1].is_custom());
-    assert_eq!(ts_stack.records()[1].timestamp(), b"custom_reply_ts");
+    assert_custom_ts_record(ts_stack.records()[1].timestamp(), b"custom_reply_ts");
 
     // Reply side uses session2's callback for SEND, session1's callback for RECEIVE
     assert!(ts_stack.records()[2].is_custom());
-    assert_eq!(ts_stack.records()[2].timestamp(), b"custom_reply_ts");
+    assert_custom_ts_record(ts_stack.records()[2].timestamp(), b"custom_reply_ts");
     assert!(ts_stack.records()[3].is_custom());
     // RECEIVE is pushed on session1's side, so it uses session1's callback
-    assert_eq!(ts_stack.records()[3].timestamp(), b"custom_query_ts");
+    assert_custom_ts_record(ts_stack.records()[3].timestamp(), b"custom_query_ts");
 
     session1.close().await.unwrap();
     session2.close().await.unwrap();

--- a/zenoh/tests/timestamp_instrumentation.rs
+++ b/zenoh/tests/timestamp_instrumentation.rs
@@ -184,10 +184,7 @@ async fn records_non_empty_timestamp_bytes() {
     let subscriber = ztimeout!(session.declare_subscriber(ke)).unwrap();
 
     tokio::time::sleep(SLEEP).await;
-    ztimeout!(publisher
-        .put("payload")
-        .timestamp_instrumentation(Some(instr)))
-    .unwrap();
+    ztimeout!(publisher.put("payload").timestamp_instrumentation(instr)).unwrap();
     let sample = ztimeout!(subscriber.recv_async()).unwrap();
 
     let ts_stack = sample
@@ -216,10 +213,7 @@ async fn records_order_matters() {
     let subscriber = ztimeout!(client2.declare_subscriber(ke)).unwrap();
 
     tokio::time::sleep(SLEEP).await;
-    ztimeout!(publisher
-        .put("payload")
-        .timestamp_instrumentation(Some(instr)))
-    .unwrap();
+    ztimeout!(publisher.put("payload").timestamp_instrumentation(instr)).unwrap();
     let sample = ztimeout!(subscriber.recv_async()).unwrap();
 
     let ts_stack = sample
@@ -249,10 +243,7 @@ async fn instrumentation_config_preserved() {
     let subscriber = ztimeout!(client2.declare_subscriber(ke)).unwrap();
 
     tokio::time::sleep(SLEEP).await;
-    ztimeout!(publisher
-        .put("payload")
-        .timestamp_instrumentation(Some(instr)))
-    .unwrap();
+    ztimeout!(publisher.put("payload").timestamp_instrumentation(instr)).unwrap();
     let sample = ztimeout!(subscriber.recv_async()).unwrap();
 
     let ts_stack = sample
@@ -279,10 +270,7 @@ async fn pubsub_same_session_send_only() {
     let subscriber = ztimeout!(session.declare_subscriber(ke)).unwrap();
 
     tokio::time::sleep(SLEEP).await;
-    ztimeout!(publisher
-        .put("payload")
-        .timestamp_instrumentation(Some(instr)))
-    .unwrap();
+    ztimeout!(publisher.put("payload").timestamp_instrumentation(instr)).unwrap();
     let sample = ztimeout!(subscriber.recv_async()).unwrap();
 
     let ts_stack = sample
@@ -305,10 +293,7 @@ async fn pubsub_same_session_receive_only() {
     let subscriber = ztimeout!(session.declare_subscriber(ke)).unwrap();
 
     tokio::time::sleep(SLEEP).await;
-    ztimeout!(publisher
-        .put("payload")
-        .timestamp_instrumentation(Some(instr)))
-    .unwrap();
+    ztimeout!(publisher.put("payload").timestamp_instrumentation(instr)).unwrap();
     let sample = ztimeout!(subscriber.recv_async()).unwrap();
 
     let ts_stack = sample
@@ -331,10 +316,7 @@ async fn pubsub_same_session_send_receive() {
     let subscriber = ztimeout!(session.declare_subscriber(ke)).unwrap();
 
     tokio::time::sleep(SLEEP).await;
-    ztimeout!(publisher
-        .put("payload")
-        .timestamp_instrumentation(Some(instr)))
-    .unwrap();
+    ztimeout!(publisher.put("payload").timestamp_instrumentation(instr)).unwrap();
     let sample = ztimeout!(subscriber.recv_async()).unwrap();
 
     let ts_stack = sample
@@ -387,10 +369,7 @@ async fn pubsub_local_and_remote_no_duplicate_receive() {
     let remote_sub = ztimeout!(peer2.declare_subscriber(ke)).unwrap();
 
     tokio::time::sleep(SLEEP).await;
-    ztimeout!(publisher
-        .put("payload")
-        .timestamp_instrumentation(Some(instr)))
-    .unwrap();
+    ztimeout!(publisher.put("payload").timestamp_instrumentation(instr)).unwrap();
 
     // Local subscriber should get exactly 1 RECEIVE (not duplicated)
     let local_sample = ztimeout!(local_sub.recv_async()).unwrap();
@@ -453,10 +432,7 @@ async fn pubsub_local_only_destination() {
     let remote_sub = ztimeout!(peer2.declare_subscriber(ke)).unwrap();
 
     tokio::time::sleep(SLEEP).await;
-    ztimeout!(publisher
-        .put("payload")
-        .timestamp_instrumentation(Some(instr)))
-    .unwrap();
+    ztimeout!(publisher.put("payload").timestamp_instrumentation(instr)).unwrap();
 
     // Local subscriber should get exactly 1 RECEIVE
     let local_sample = ztimeout!(local_sub.recv_async()).unwrap();
@@ -505,10 +481,7 @@ async fn pubsub_remote_only_destination() {
     let remote_sub = ztimeout!(peer2.declare_subscriber(ke)).unwrap();
 
     tokio::time::sleep(SLEEP).await;
-    ztimeout!(publisher
-        .put("payload")
-        .timestamp_instrumentation(Some(instr)))
-    .unwrap();
+    ztimeout!(publisher.put("payload").timestamp_instrumentation(instr)).unwrap();
 
     // Remote subscriber should get exactly 1 RECEIVE
     let remote_sample = ztimeout!(remote_sub.recv_async()).unwrap();
@@ -556,10 +529,7 @@ async fn pubsub_p2p_send_only() {
     let subscriber = ztimeout!(peer2.declare_subscriber(ke)).unwrap();
 
     tokio::time::sleep(SLEEP).await;
-    ztimeout!(publisher
-        .put("payload")
-        .timestamp_instrumentation(Some(instr)))
-    .unwrap();
+    ztimeout!(publisher.put("payload").timestamp_instrumentation(instr)).unwrap();
     let sample = ztimeout!(subscriber.recv_async()).unwrap();
 
     let ts_stack = sample
@@ -584,10 +554,7 @@ async fn pubsub_p2p_receive_only() {
     let subscriber = ztimeout!(peer2.declare_subscriber(ke)).unwrap();
 
     tokio::time::sleep(SLEEP).await;
-    ztimeout!(publisher
-        .put("payload")
-        .timestamp_instrumentation(Some(instr)))
-    .unwrap();
+    ztimeout!(publisher.put("payload").timestamp_instrumentation(instr)).unwrap();
     let sample = ztimeout!(subscriber.recv_async()).unwrap();
 
     let ts_stack = sample
@@ -612,10 +579,7 @@ async fn pubsub_p2p_send_receive() {
     let subscriber = ztimeout!(peer2.declare_subscriber(ke)).unwrap();
 
     tokio::time::sleep(SLEEP).await;
-    ztimeout!(publisher
-        .put("payload")
-        .timestamp_instrumentation(Some(instr)))
-    .unwrap();
+    ztimeout!(publisher.put("payload").timestamp_instrumentation(instr)).unwrap();
     let sample = ztimeout!(subscriber.recv_async()).unwrap();
 
     let ts_stack = sample
@@ -641,10 +605,7 @@ async fn pubsub_p2p_route_only() {
     let subscriber = ztimeout!(peer2.declare_subscriber(ke)).unwrap();
 
     tokio::time::sleep(SLEEP).await;
-    ztimeout!(publisher
-        .put("payload")
-        .timestamp_instrumentation(Some(instr)))
-    .unwrap();
+    ztimeout!(publisher.put("payload").timestamp_instrumentation(instr)).unwrap();
     let sample = ztimeout!(subscriber.recv_async()).unwrap();
 
     // In peer-peer, message goes through routing layer on both peers → 2 ROUTE records
@@ -699,10 +660,7 @@ async fn pubsub_routed_send_only() {
     let subscriber = ztimeout!(client2.declare_subscriber(ke)).unwrap();
 
     tokio::time::sleep(SLEEP).await;
-    ztimeout!(publisher
-        .put("payload")
-        .timestamp_instrumentation(Some(instr)))
-    .unwrap();
+    ztimeout!(publisher.put("payload").timestamp_instrumentation(instr)).unwrap();
     let sample = ztimeout!(subscriber.recv_async()).unwrap();
 
     let ts_stack = sample
@@ -727,10 +685,7 @@ async fn pubsub_routed_route_only() {
     let subscriber = ztimeout!(client2.declare_subscriber(ke)).unwrap();
 
     tokio::time::sleep(SLEEP).await;
-    ztimeout!(publisher
-        .put("payload")
-        .timestamp_instrumentation(Some(instr)))
-    .unwrap();
+    ztimeout!(publisher.put("payload").timestamp_instrumentation(instr)).unwrap();
     let sample = ztimeout!(subscriber.recv_async()).unwrap();
 
     let ts_stack = sample
@@ -757,10 +712,7 @@ async fn pubsub_routed_receive_only() {
     let subscriber = ztimeout!(client2.declare_subscriber(ke)).unwrap();
 
     tokio::time::sleep(SLEEP).await;
-    ztimeout!(publisher
-        .put("payload")
-        .timestamp_instrumentation(Some(instr)))
-    .unwrap();
+    ztimeout!(publisher.put("payload").timestamp_instrumentation(instr)).unwrap();
     let sample = ztimeout!(subscriber.recv_async()).unwrap();
 
     let ts_stack = sample
@@ -785,10 +737,7 @@ async fn pubsub_routed_send_route() {
     let subscriber = ztimeout!(client2.declare_subscriber(ke)).unwrap();
 
     tokio::time::sleep(SLEEP).await;
-    ztimeout!(publisher
-        .put("payload")
-        .timestamp_instrumentation(Some(instr)))
-    .unwrap();
+    ztimeout!(publisher.put("payload").timestamp_instrumentation(instr)).unwrap();
     let sample = ztimeout!(subscriber.recv_async()).unwrap();
 
     let ts_stack = sample
@@ -816,10 +765,7 @@ async fn pubsub_routed_send_receive() {
     let subscriber = ztimeout!(client2.declare_subscriber(ke)).unwrap();
 
     tokio::time::sleep(SLEEP).await;
-    ztimeout!(publisher
-        .put("payload")
-        .timestamp_instrumentation(Some(instr)))
-    .unwrap();
+    ztimeout!(publisher.put("payload").timestamp_instrumentation(instr)).unwrap();
     let sample = ztimeout!(subscriber.recv_async()).unwrap();
 
     let ts_stack = sample
@@ -845,10 +791,7 @@ async fn pubsub_routed_route_receive() {
     let subscriber = ztimeout!(client2.declare_subscriber(ke)).unwrap();
 
     tokio::time::sleep(SLEEP).await;
-    ztimeout!(publisher
-        .put("payload")
-        .timestamp_instrumentation(Some(instr)))
-    .unwrap();
+    ztimeout!(publisher.put("payload").timestamp_instrumentation(instr)).unwrap();
     let sample = ztimeout!(subscriber.recv_async()).unwrap();
 
     let ts_stack = sample
@@ -876,10 +819,7 @@ async fn pubsub_routed_send_route_receive() {
     let subscriber = ztimeout!(client2.declare_subscriber(ke)).unwrap();
 
     tokio::time::sleep(SLEEP).await;
-    ztimeout!(publisher
-        .put("payload")
-        .timestamp_instrumentation(Some(instr)))
-    .unwrap();
+    ztimeout!(publisher.put("payload").timestamp_instrumentation(instr)).unwrap();
     let sample = ztimeout!(subscriber.recv_async()).unwrap();
 
     let ts_stack = sample
@@ -933,7 +873,7 @@ async fn delete_p2p_send_receive() {
     let subscriber = ztimeout!(peer2.declare_subscriber(ke)).unwrap();
 
     tokio::time::sleep(SLEEP).await;
-    ztimeout!(publisher.delete().timestamp_instrumentation(Some(instr))).unwrap();
+    ztimeout!(publisher.delete().timestamp_instrumentation(instr)).unwrap();
     let sample = ztimeout!(subscriber.recv_async()).unwrap();
 
     assert_eq!(sample.kind(), zenoh::sample::SampleKind::Delete);
@@ -960,7 +900,7 @@ async fn delete_routed_send_route_receive() {
     let subscriber = ztimeout!(client2.declare_subscriber(ke)).unwrap();
 
     tokio::time::sleep(SLEEP).await;
-    ztimeout!(publisher.delete().timestamp_instrumentation(Some(instr))).unwrap();
+    ztimeout!(publisher.delete().timestamp_instrumentation(instr)).unwrap();
     let sample = ztimeout!(subscriber.recv_async()).unwrap();
 
     assert_eq!(sample.kind(), zenoh::sample::SampleKind::Delete);
@@ -993,7 +933,7 @@ async fn queryreply_local_and_remote_no_duplicate_receive() {
     tokio::time::sleep(SLEEP).await;
 
     // Local querier on peer1 (queries peer2)
-    let local_replies = ztimeout!(peer1.get(ke).timestamp_instrumentation(Some(instr))).unwrap();
+    let local_replies = ztimeout!(peer1.get(ke).timestamp_instrumentation(instr)).unwrap();
 
     // Receive query on peer2
     let query = ztimeout!(queryable.recv_async()).unwrap();
@@ -1012,11 +952,8 @@ async fn queryreply_local_and_remote_no_duplicate_receive() {
         false,
     );
 
-    // Reply with instrumentation
-    ztimeout!(query
-        .reply(ke, "data")
-        .timestamp_instrumentation(Some(instr)))
-    .unwrap();
+    // Reply
+    ztimeout!(query.reply(ke, "data")).unwrap();
     std::mem::drop(query);
 
     // Receive reply on peer1
@@ -1028,8 +965,8 @@ async fn queryreply_local_and_remote_no_duplicate_receive() {
         .expect("timestamp_stack should be Some");
     assert_eq!(
         reply_ts_stack.records().len(),
-        2,
-        "reply sample should have exactly SEND + RECEIVE"
+        4,
+        "reply sample should have exactly SEND + RECEIVE + SEND + RECEIVE"
     );
     assert_record(&reply_ts_stack.records()[0], InterceptionPoint::Send, false);
     assert_record(
@@ -1037,7 +974,12 @@ async fn queryreply_local_and_remote_no_duplicate_receive() {
         InterceptionPoint::Receive,
         false,
     );
-
+    assert_record(&reply_ts_stack.records()[2], InterceptionPoint::Send, false);
+    assert_record(
+        &reply_ts_stack.records()[3],
+        InterceptionPoint::Receive,
+        false,
+    );
     test_context.close().await;
 }
 
@@ -1060,7 +1002,7 @@ async fn queryreply_local_and_remote_queryable_no_duplicate_receive() {
         .get(ke)
         // Disable consolidation to receive both replies
         .consolidation(ConsolidationMode::None)
-        .timestamp_instrumentation(Some(instr)))
+        .timestamp_instrumentation(instr))
     .unwrap();
 
     // Both queryables should receive the query
@@ -1114,6 +1056,22 @@ async fn queryreply_local_and_remote_queryable_no_duplicate_receive() {
     let reply2 = ztimeout!(replies.recv_async()).unwrap();
     assert!(reply1.result().is_ok());
     assert!(reply2.result().is_ok());
+    for r in [reply1, reply2] {
+        let ts_stack = r
+            .result()
+            .unwrap()
+            .timestamp_stack()
+            .expect("timestamp_stack should be Some");
+        assert_eq!(
+            ts_stack.records().len(),
+            4,
+            "reply ts_stack should have exactly SEND + RECEIVE + SEND + RECEIVE"
+        );
+        assert_record(&ts_stack.records()[0], InterceptionPoint::Send, false);
+        assert_record(&ts_stack.records()[1], InterceptionPoint::Receive, false);
+        assert_record(&ts_stack.records()[2], InterceptionPoint::Send, false);
+        assert_record(&ts_stack.records()[3], InterceptionPoint::Receive, false);
+    }
 
     test_context.close().await;
 }
@@ -1132,7 +1090,7 @@ async fn queryreply_p2p_query_send_only() {
     let queryable = ztimeout!(peer2.declare_queryable(ke)).unwrap();
     tokio::time::sleep(SLEEP).await;
 
-    let replies = ztimeout!(peer1.get(ke).timestamp_instrumentation(Some(instr))).unwrap();
+    let replies = ztimeout!(peer1.get(ke).timestamp_instrumentation(instr)).unwrap();
 
     let query = ztimeout!(queryable.recv_async()).unwrap();
     let ts_stack = query
@@ -1146,6 +1104,18 @@ async fn queryreply_p2p_query_send_only() {
 
     let reply = ztimeout!(replies.recv_async()).unwrap();
     assert!(reply.result().is_ok());
+    let ts_stack = reply
+        .result()
+        .unwrap()
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(
+        ts_stack.records().len(),
+        2,
+        "reply ts_stack should have exactly SEND + SEND"
+    );
+    assert_record(&ts_stack.records()[0], InterceptionPoint::Send, false);
+    assert_record(&ts_stack.records()[1], InterceptionPoint::Send, false);
 
     test_context.close().await;
 }
@@ -1162,7 +1132,7 @@ async fn queryreply_p2p_query_send_receive() {
     let queryable = ztimeout!(peer2.declare_queryable(ke)).unwrap();
     tokio::time::sleep(SLEEP).await;
 
-    let replies = ztimeout!(peer1.get(ke).timestamp_instrumentation(Some(instr))).unwrap();
+    let replies = ztimeout!(peer1.get(ke).timestamp_instrumentation(instr)).unwrap();
 
     let query = ztimeout!(queryable.recv_async()).unwrap();
     let ts_stack = query
@@ -1177,6 +1147,21 @@ async fn queryreply_p2p_query_send_receive() {
 
     let reply = ztimeout!(replies.recv_async()).unwrap();
     assert!(reply.result().is_ok());
+
+    let ts_stack = reply
+        .result()
+        .unwrap()
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(
+        ts_stack.records().len(),
+        4,
+        "reply ts_stack should have exactly SEND + RECEIVE + SEND + RECEIVE"
+    );
+    assert_record(&ts_stack.records()[0], InterceptionPoint::Send, false);
+    assert_record(&ts_stack.records()[1], InterceptionPoint::Receive, false);
+    assert_record(&ts_stack.records()[2], InterceptionPoint::Send, false);
+    assert_record(&ts_stack.records()[3], InterceptionPoint::Receive, false);
 
     test_context.close().await;
 }
@@ -1210,41 +1195,6 @@ async fn queryreply_p2p_query_no_instrumentation() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn queryreply_p2p_reply_send_receive() {
-    zenoh_util::init_log_from_env_or("error");
-    let ke = "test/ts_instr/reply/peer/send_receive";
-    let instr = make_instrumentation(true, false, true);
-
-    let mut test_context = TestSessions::new();
-    let (peer1, peer2) = ztimeout!(open_peer_sessions(&mut test_context));
-
-    let queryable = ztimeout!(peer2.declare_queryable(ke)).unwrap();
-    tokio::time::sleep(SLEEP).await;
-
-    let replies = ztimeout!(peer1.get(ke)).unwrap();
-
-    let query = ztimeout!(queryable.recv_async()).unwrap();
-    ztimeout!(query
-        .reply(ke, "data")
-        .timestamp_instrumentation(Some(instr)))
-    .unwrap();
-    std::mem::drop(query);
-
-    let reply = ztimeout!(replies.recv_async()).unwrap();
-    assert!(reply.result().is_ok());
-    let sample = reply.result().unwrap();
-
-    let ts_stack = sample
-        .timestamp_stack()
-        .expect("timestamp_stack should be Some");
-    assert_eq!(ts_stack.records().len(), 2);
-    assert_record(&ts_stack.records()[0], InterceptionPoint::Send, false);
-    assert_record(&ts_stack.records()[1], InterceptionPoint::Receive, false);
-
-    test_context.close().await;
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn queryreply_p2p_reply_no_instrumentation() {
     zenoh_util::init_log_from_env_or("error");
     let ke = "test/ts_instr/reply/peer/no_instr";
@@ -1267,7 +1217,7 @@ async fn queryreply_p2p_reply_no_instrumentation() {
 
     assert!(
         sample.timestamp_stack().is_none(),
-        "timestamp_stack should be None when no instrumentation on reply"
+        "timestamp_stack should be None when no instrumentation on query"
     );
 
     test_context.close().await;
@@ -1287,7 +1237,7 @@ async fn queryreply_routed_query_send_route_receive() {
     let queryable = ztimeout!(client2.declare_queryable(ke)).unwrap();
     tokio::time::sleep(SLEEP).await;
 
-    let replies = ztimeout!(client1.get(ke).timestamp_instrumentation(Some(instr))).unwrap();
+    let replies = ztimeout!(client1.get(ke).timestamp_instrumentation(instr)).unwrap();
 
     let query = ztimeout!(queryable.recv_async()).unwrap();
     let ts_stack = query
@@ -1305,45 +1255,24 @@ async fn queryreply_routed_query_send_route_receive() {
 
     let reply = ztimeout!(replies.recv_async()).unwrap();
     assert!(reply.result().is_ok());
-
-    test_context.close().await;
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn queryreply_routed_reply_send_route_receive() {
-    zenoh_util::init_log_from_env_or("error");
-    let ke = "test/ts_instr/reply/routed/send_route_receive";
-    let instr = make_instrumentation(true, true, true);
-
-    let mut test_context = TestSessions::new();
-    let (client1, client2, _router) = ztimeout!(open_routed_sessions(&mut test_context));
-
-    let queryable = ztimeout!(client2.declare_queryable(ke)).unwrap();
-    tokio::time::sleep(SLEEP).await;
-
-    let replies = ztimeout!(client1.get(ke)).unwrap();
-
-    let query = ztimeout!(queryable.recv_async()).unwrap();
-    ztimeout!(query
-        .reply(ke, "data")
-        .timestamp_instrumentation(Some(instr)))
-    .unwrap();
-    std::mem::drop(query);
-
-    let reply = ztimeout!(replies.recv_async()).unwrap();
-    assert!(reply.result().is_ok());
-    let sample = reply.result().unwrap();
-
-    let ts_stack = sample
+    let ts_stack = reply
+        .result()
+        .unwrap()
         .timestamp_stack()
         .expect("timestamp_stack should be Some");
-    assert_eq!(ts_stack.records().len(), 5);
+    assert_eq!(ts_stack.records().len(), 10);
+
     assert_record(&ts_stack.records()[0], InterceptionPoint::Send, false);
     for i in 1..4 {
         assert_record(&ts_stack.records()[i], InterceptionPoint::Route, false);
     }
     assert_record(&ts_stack.records()[4], InterceptionPoint::Receive, false);
 
+    assert_record(&ts_stack.records()[5], InterceptionPoint::Send, false);
+    for i in 6..9 {
+        assert_record(&ts_stack.records()[i], InterceptionPoint::Route, false);
+    }
+    assert_record(&ts_stack.records()[9], InterceptionPoint::Receive, false);
     test_context.close().await;
 }
 
@@ -1359,7 +1288,7 @@ async fn queryreply_routed_query_route_only() {
     let queryable = ztimeout!(client2.declare_queryable(ke)).unwrap();
     tokio::time::sleep(SLEEP).await;
 
-    let replies = ztimeout!(client1.get(ke).timestamp_instrumentation(Some(instr))).unwrap();
+    let replies = ztimeout!(client1.get(ke).timestamp_instrumentation(instr)).unwrap();
 
     let query = ztimeout!(queryable.recv_async()).unwrap();
     let ts_stack = query
@@ -1375,6 +1304,16 @@ async fn queryreply_routed_query_route_only() {
 
     let reply = ztimeout!(replies.recv_async()).unwrap();
     assert!(reply.result().is_ok());
+    let ts_stack = reply
+        .result()
+        .unwrap()
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(ts_stack.records().len(), 6);
+
+    for r in ts_stack.records() {
+        assert_record(r, InterceptionPoint::Route, false);
+    }
 
     test_context.close().await;
 }
@@ -1393,13 +1332,17 @@ async fn queryreply_reply_err_send_receive() {
     let queryable = ztimeout!(peer2.declare_queryable(ke)).unwrap();
     tokio::time::sleep(SLEEP).await;
 
-    let replies = ztimeout!(peer1.get(ke)).unwrap();
+    let replies = ztimeout!(peer1.get(ke).timestamp_instrumentation(instr)).unwrap();
 
     let query = ztimeout!(queryable.recv_async()).unwrap();
-    ztimeout!(query
-        .reply_err("error payload")
-        .timestamp_instrumentation(Some(instr)))
-    .unwrap();
+    let ts_stack = query
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(ts_stack.records().len(), 2);
+    assert_record(&ts_stack.records()[0], InterceptionPoint::Send, false);
+    assert_record(&ts_stack.records()[1], InterceptionPoint::Receive, false);
+
+    ztimeout!(query.reply_err("error payload")).unwrap();
     std::mem::drop(query);
 
     let reply = ztimeout!(replies.recv_async()).unwrap();
@@ -1409,9 +1352,11 @@ async fn queryreply_reply_err_send_receive() {
     let ts_stack = reply_err
         .timestamp_stack()
         .expect("timestamp_stack should be Some");
-    assert_eq!(ts_stack.records().len(), 2);
+    assert_eq!(ts_stack.records().len(), 4);
     assert_record(&ts_stack.records()[0], InterceptionPoint::Send, false);
     assert_record(&ts_stack.records()[1], InterceptionPoint::Receive, false);
+    assert_record(&ts_stack.records()[2], InterceptionPoint::Send, false);
+    assert_record(&ts_stack.records()[3], InterceptionPoint::Receive, false);
 
     test_context.close().await;
 }
@@ -1433,10 +1378,7 @@ async fn custom_callback_pub_sub() {
     let subscriber = ztimeout!(session.declare_subscriber(ke)).unwrap();
 
     tokio::time::sleep(SLEEP).await;
-    ztimeout!(publisher
-        .put("payload")
-        .timestamp_instrumentation(Some(instr)))
-    .unwrap();
+    ztimeout!(publisher.put("payload").timestamp_instrumentation(instr)).unwrap();
     let sample = ztimeout!(subscriber.recv_async()).unwrap();
 
     let ts_stack = sample
@@ -1466,8 +1408,15 @@ async fn custom_callback_query_reply() {
 
     let instr = make_instrumentation(true, false, true);
 
-    let session1 =
-        ztimeout!(zenoh::open(zenoh::Config::default()).with_timestamp_callback(cb_query)).unwrap();
+    let mut config = zenoh::Config::default();
+    config
+        .listen
+        .set_endpoints(zenoh_config::ModeDependentValue::Unique(
+            ["tcp/127.0.0.1:0".parse().unwrap()].to_vec(),
+        ))
+        .unwrap();
+    config.scouting.multicast.set_enabled(Some(false)).unwrap();
+    let session1 = ztimeout!(zenoh::open(config).with_timestamp_callback(cb_query)).unwrap();
 
     let locators = session1.info().locators().await;
     let mut config2 = zenoh::Config::default();
@@ -1484,7 +1433,7 @@ async fn custom_callback_query_reply() {
     let queryable = ztimeout!(session2.declare_queryable(ke)).unwrap();
     tokio::time::sleep(SLEEP).await;
 
-    let replies = ztimeout!(session1.get(ke).timestamp_instrumentation(Some(instr))).unwrap();
+    let replies = ztimeout!(session1.get(ke).timestamp_instrumentation(instr)).unwrap();
 
     let query = ztimeout!(queryable.recv_async()).unwrap();
     let ts_stack = query
@@ -1498,10 +1447,7 @@ async fn custom_callback_query_reply() {
     // RECEIVE is pushed on session2's side, so it uses session2's callback
     assert_eq!(ts_stack.records()[1].timestamp(), b"custom_reply_ts");
 
-    ztimeout!(query
-        .reply(ke, "data")
-        .timestamp_instrumentation(Some(instr)))
-    .unwrap();
+    ztimeout!(query.reply(ke, "data")).unwrap();
     std::mem::drop(query);
 
     let reply = ztimeout!(replies.recv_async()).unwrap();
@@ -1511,13 +1457,19 @@ async fn custom_callback_query_reply() {
     let ts_stack = sample
         .timestamp_stack()
         .expect("timestamp_stack should be Some");
-    assert_eq!(ts_stack.records().len(), 2);
-    // Reply side uses session2's callback for SEND, session1's callback for RECEIVE
+    assert_eq!(ts_stack.records().len(), 4);
+    // Query side is the same
     assert!(ts_stack.records()[0].is_custom());
-    assert_eq!(ts_stack.records()[0].timestamp(), b"custom_reply_ts");
+    assert_eq!(ts_stack.records()[0].timestamp(), b"custom_query_ts");
     assert!(ts_stack.records()[1].is_custom());
+    assert_eq!(ts_stack.records()[1].timestamp(), b"custom_reply_ts");
+
+    // Reply side uses session2's callback for SEND, session1's callback for RECEIVE
+    assert!(ts_stack.records()[2].is_custom());
+    assert_eq!(ts_stack.records()[2].timestamp(), b"custom_reply_ts");
+    assert!(ts_stack.records()[3].is_custom());
     // RECEIVE is pushed on session1's side, so it uses session1's callback
-    assert_eq!(ts_stack.records()[1].timestamp(), b"custom_query_ts");
+    assert_eq!(ts_stack.records()[3].timestamp(), b"custom_query_ts");
 
     session1.close().await.unwrap();
     session2.close().await.unwrap();
@@ -1557,10 +1509,7 @@ async fn custom_callback_context() {
     let subscriber = ztimeout!(session.declare_subscriber(ke)).unwrap();
 
     tokio::time::sleep(SLEEP).await;
-    ztimeout!(publisher
-        .put("payload")
-        .timestamp_instrumentation(Some(instr)))
-    .unwrap();
+    ztimeout!(publisher.put("payload").timestamp_instrumentation(instr)).unwrap();
     let _sample = ztimeout!(subscriber.recv_async()).unwrap();
 
     let contexts = capture.contexts.lock().unwrap();
@@ -1598,7 +1547,7 @@ async fn querier_get_send_receive() {
     tokio::time::sleep(SLEEP).await;
 
     let querier = ztimeout!(peer1.declare_querier(ke)).unwrap();
-    let replies = ztimeout!(querier.get().timestamp_instrumentation(Some(instr))).unwrap();
+    let replies = ztimeout!(querier.get().timestamp_instrumentation(instr)).unwrap();
 
     let query = ztimeout!(queryable.recv_async()).unwrap();
     let ts_stack = query
@@ -1630,7 +1579,7 @@ async fn querier_get_routed_send_route_receive() {
     tokio::time::sleep(SLEEP).await;
 
     let querier = ztimeout!(client1.declare_querier(ke)).unwrap();
-    let replies = ztimeout!(querier.get().timestamp_instrumentation(Some(instr))).unwrap();
+    let replies = ztimeout!(querier.get().timestamp_instrumentation(instr)).unwrap();
 
     let query = ztimeout!(queryable.recv_async()).unwrap();
     let ts_stack = query

--- a/zenoh/tests/timestamp_instrumentation.rs
+++ b/zenoh/tests/timestamp_instrumentation.rs
@@ -1,0 +1,1653 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+#![cfg(feature = "unstable")]
+
+use std::{sync::Arc, time::Duration};
+
+use zenoh::{
+    config::WhatAmI,
+    query::ConsolidationMode,
+    timestamp_stack::{
+        GetTimestampCallback, InterceptionPoint, TimestampInstrumentation,
+        TimestampInstrumentationBuilder,
+    },
+};
+use zenoh_core::ztimeout;
+use zenoh_test::TestSessions;
+
+const TIMEOUT: Duration = Duration::from_secs(60);
+const SLEEP: Duration = Duration::from_secs(1);
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+fn make_instrumentation(send: bool, route: bool, receive: bool) -> TimestampInstrumentation {
+    TimestampInstrumentationBuilder::new()
+        .set_send(send)
+        .set_route(route)
+        .set_receive(receive)
+        .build()
+        .unwrap()
+}
+
+async fn open_peer_sessions(test_context: &mut TestSessions) -> (zenoh::Session, zenoh::Session) {
+    let mut config_peer1 = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config_peer1.set_mode(Some(WhatAmI::Peer)).unwrap();
+    let peer1 = test_context.open_listener_with_cfg(config_peer1).await;
+
+    let mut config_peer2 = test_context.get_connector_config();
+    config_peer2.set_mode(Some(WhatAmI::Peer)).unwrap();
+    let peer2 = test_context.open_connector_with_cfg(config_peer2).await;
+
+    tokio::time::sleep(SLEEP).await;
+    (peer1, peer2)
+}
+
+async fn open_routed_sessions(
+    test_context: &mut TestSessions,
+) -> (zenoh::Session, zenoh::Session, zenoh::Session) {
+    let mut config_router = test_context.get_listener_config("tcp/127.0.0.1:0", 1);
+    config_router.set_mode(Some(WhatAmI::Router)).unwrap();
+    let router = test_context.open_listener_with_cfg(config_router).await;
+    tokio::time::sleep(SLEEP).await;
+
+    let mut config_client1 = test_context.get_connector_config();
+    config_client1.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client1 = test_context.open_connector_with_cfg(config_client1).await;
+
+    let mut config_client2 = test_context.get_connector_config();
+    config_client2.set_mode(Some(WhatAmI::Client)).unwrap();
+    let client2 = test_context.open_connector_with_cfg(config_client2).await;
+
+    tokio::time::sleep(SLEEP).await;
+    (client1, client2, router)
+}
+
+fn assert_record(
+    record: &zenoh::timestamp_stack::TimestampStackRecord,
+    expected_point: InterceptionPoint,
+    expected_custom: bool,
+) {
+    assert_eq!(record.point(), expected_point);
+    assert_eq!(record.is_custom(), expected_custom);
+    assert!(
+        !record.timestamp().is_empty(),
+        "timestamp bytes should not be empty"
+    );
+}
+
+// ─── Builder & Unit Tests ───────────────────────────────────────────────
+
+#[test]
+fn builder_no_points_active() {
+    let result = TimestampInstrumentationBuilder::new().build();
+    assert!(result.is_err());
+}
+
+#[test]
+fn builder_send_only() {
+    let instr = TimestampInstrumentationBuilder::new()
+        .set_send(true)
+        .build()
+        .unwrap();
+    assert!(instr.is_instrumented(InterceptionPoint::Send));
+    assert!(!instr.is_instrumented(InterceptionPoint::Route));
+    assert!(!instr.is_instrumented(InterceptionPoint::Receive));
+}
+
+#[test]
+fn builder_route_only() {
+    let instr = TimestampInstrumentationBuilder::new()
+        .set_route(true)
+        .build()
+        .unwrap();
+    assert!(!instr.is_instrumented(InterceptionPoint::Send));
+    assert!(instr.is_instrumented(InterceptionPoint::Route));
+    assert!(!instr.is_instrumented(InterceptionPoint::Receive));
+}
+
+#[test]
+fn builder_receive_only() {
+    let instr = TimestampInstrumentationBuilder::new()
+        .set_receive(true)
+        .build()
+        .unwrap();
+    assert!(!instr.is_instrumented(InterceptionPoint::Send));
+    assert!(!instr.is_instrumented(InterceptionPoint::Route));
+    assert!(instr.is_instrumented(InterceptionPoint::Receive));
+}
+
+#[test]
+fn builder_all_points() {
+    let instr = TimestampInstrumentationBuilder::new()
+        .set_send(true)
+        .set_route(true)
+        .set_receive(true)
+        .build()
+        .unwrap();
+    assert!(instr.is_instrumented(InterceptionPoint::Send));
+    assert!(instr.is_instrumented(InterceptionPoint::Route));
+    assert!(instr.is_instrumented(InterceptionPoint::Receive));
+}
+
+#[test]
+fn builder_set_unset() {
+    let instr = TimestampInstrumentationBuilder::new()
+        .set_send(true)
+        .set_send(false)
+        .set_route(true)
+        .build()
+        .unwrap();
+    assert!(!instr.is_instrumented(InterceptionPoint::Send));
+    assert!(instr.is_instrumented(InterceptionPoint::Route));
+    assert!(!instr.is_instrumented(InterceptionPoint::Receive));
+}
+
+#[test]
+fn interception_point_try_from_valid() {
+    use zenoh_protocol::network::timestamp_stack::interception_point;
+    let send: InterceptionPoint = interception_point::SEND.try_into().unwrap();
+    assert_eq!(send, InterceptionPoint::Send);
+    let route: InterceptionPoint = interception_point::ROUTE.try_into().unwrap();
+    assert_eq!(route, InterceptionPoint::Route);
+    let receive: InterceptionPoint = interception_point::RECEIVE.try_into().unwrap();
+    assert_eq!(receive, InterceptionPoint::Receive);
+}
+
+#[test]
+fn interception_point_try_from_invalid() {
+    let result: Result<InterceptionPoint, _> = 0xFFu8.try_into();
+    assert!(result.is_err());
+}
+
+// ─── Records Content Verification ───────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn records_non_empty_timestamp_bytes() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/records/non_empty_ts";
+    let instr = make_instrumentation(true, false, false);
+
+    let session = ztimeout!(zenoh::open(zenoh::Config::default())).unwrap();
+    let publisher = ztimeout!(session.declare_publisher(ke)).unwrap();
+    let subscriber = ztimeout!(session.declare_subscriber(ke)).unwrap();
+
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(publisher
+        .put("payload")
+        .timestamp_instrumentation(Some(instr)))
+    .unwrap();
+    let sample = ztimeout!(subscriber.recv_async()).unwrap();
+
+    let ts_stack = sample
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    for record in ts_stack.records() {
+        assert!(
+            !record.timestamp().is_empty(),
+            "UHLC timestamp bytes should not be empty"
+        );
+    }
+
+    session.close().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn records_order_matters() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/records/order";
+    let instr = make_instrumentation(true, true, true);
+
+    let mut test_context = TestSessions::new();
+    let (client1, client2, _router) = ztimeout!(open_routed_sessions(&mut test_context));
+
+    let publisher = ztimeout!(client1.declare_publisher(ke)).unwrap();
+    let subscriber = ztimeout!(client2.declare_subscriber(ke)).unwrap();
+
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(publisher
+        .put("payload")
+        .timestamp_instrumentation(Some(instr)))
+    .unwrap();
+    let sample = ztimeout!(subscriber.recv_async()).unwrap();
+
+    let ts_stack = sample
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(ts_stack.records().len(), 5);
+    // Verify exact order: Send → Route → Route → Route → Receive
+    assert_eq!(ts_stack.records()[0].point(), InterceptionPoint::Send);
+    for i in 1..4 {
+        assert_eq!(ts_stack.records()[i].point(), InterceptionPoint::Route);
+    }
+    assert_eq!(ts_stack.records()[4].point(), InterceptionPoint::Receive);
+
+    test_context.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn instrumentation_config_preserved() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/records/config_preserved";
+    let instr = make_instrumentation(true, true, true);
+
+    let mut test_context = TestSessions::new();
+    let (client1, client2, _router) = ztimeout!(open_routed_sessions(&mut test_context));
+
+    let publisher = ztimeout!(client1.declare_publisher(ke)).unwrap();
+    let subscriber = ztimeout!(client2.declare_subscriber(ke)).unwrap();
+
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(publisher
+        .put("payload")
+        .timestamp_instrumentation(Some(instr)))
+    .unwrap();
+    let sample = ztimeout!(subscriber.recv_async()).unwrap();
+
+    let ts_stack = sample
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    let preserved_instr = ts_stack.instrumentation();
+    assert!(preserved_instr.is_instrumented(InterceptionPoint::Send));
+    assert!(preserved_instr.is_instrumented(InterceptionPoint::Route));
+    assert!(preserved_instr.is_instrumented(InterceptionPoint::Receive));
+
+    test_context.close().await;
+}
+
+// ─── Pub/Sub — Same Session ─────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pubsub_same_session_send_only() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/same_session/send_only";
+    let instr = make_instrumentation(true, false, false);
+
+    let session = ztimeout!(zenoh::open(zenoh::Config::default())).unwrap();
+    let publisher = ztimeout!(session.declare_publisher(ke)).unwrap();
+    let subscriber = ztimeout!(session.declare_subscriber(ke)).unwrap();
+
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(publisher
+        .put("payload")
+        .timestamp_instrumentation(Some(instr)))
+    .unwrap();
+    let sample = ztimeout!(subscriber.recv_async()).unwrap();
+
+    let ts_stack = sample
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(ts_stack.records().len(), 1);
+    assert_record(&ts_stack.records()[0], InterceptionPoint::Send, false);
+
+    session.close().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pubsub_same_session_receive_only() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/same_session/receive_only";
+    let instr = make_instrumentation(false, false, true);
+
+    let session = ztimeout!(zenoh::open(zenoh::Config::default())).unwrap();
+    let publisher = ztimeout!(session.declare_publisher(ke)).unwrap();
+    let subscriber = ztimeout!(session.declare_subscriber(ke)).unwrap();
+
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(publisher
+        .put("payload")
+        .timestamp_instrumentation(Some(instr)))
+    .unwrap();
+    let sample = ztimeout!(subscriber.recv_async()).unwrap();
+
+    let ts_stack = sample
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(ts_stack.records().len(), 1);
+    assert_record(&ts_stack.records()[0], InterceptionPoint::Receive, false);
+
+    session.close().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pubsub_same_session_send_receive() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/same_session/send_receive";
+    let instr = make_instrumentation(true, false, true);
+
+    let session = ztimeout!(zenoh::open(zenoh::Config::default())).unwrap();
+    let publisher = ztimeout!(session.declare_publisher(ke)).unwrap();
+    let subscriber = ztimeout!(session.declare_subscriber(ke)).unwrap();
+
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(publisher
+        .put("payload")
+        .timestamp_instrumentation(Some(instr)))
+    .unwrap();
+    let sample = ztimeout!(subscriber.recv_async()).unwrap();
+
+    let ts_stack = sample
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(ts_stack.records().len(), 2);
+    assert_record(&ts_stack.records()[0], InterceptionPoint::Send, false);
+    assert_record(&ts_stack.records()[1], InterceptionPoint::Receive, false);
+
+    session.close().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pubsub_same_session_no_instrumentation() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/same_session/no_instr";
+
+    let session = ztimeout!(zenoh::open(zenoh::Config::default())).unwrap();
+    let publisher = ztimeout!(session.declare_publisher(ke)).unwrap();
+    let subscriber = ztimeout!(session.declare_subscriber(ke)).unwrap();
+
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(publisher.put("payload")).unwrap();
+    let sample = ztimeout!(subscriber.recv_async()).unwrap();
+
+    assert!(
+        sample.timestamp_stack().is_none(),
+        "timestamp_stack should be None when no instrumentation"
+    );
+
+    session.close().await.unwrap();
+}
+
+// ─── Pub/Sub — Local + Remote Delivery (destination=Any) ────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pubsub_local_and_remote_no_duplicate_receive() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/pubsub/local_and_remote";
+    let instr = make_instrumentation(true, false, true);
+
+    let mut test_context = TestSessions::new();
+    let (peer1, peer2) = ztimeout!(open_peer_sessions(&mut test_context));
+
+    // Publisher on peer1 with destination=Any (default)
+    let publisher = ztimeout!(peer1.declare_publisher(ke)).unwrap();
+    // Local subscriber on peer1
+    let local_sub = ztimeout!(peer1.declare_subscriber(ke)).unwrap();
+    // Remote subscriber on peer2
+    let remote_sub = ztimeout!(peer2.declare_subscriber(ke)).unwrap();
+
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(publisher
+        .put("payload")
+        .timestamp_instrumentation(Some(instr)))
+    .unwrap();
+
+    // Local subscriber should get exactly 1 RECEIVE (not duplicated)
+    let local_sample = ztimeout!(local_sub.recv_async()).unwrap();
+    let local_ts_stack = local_sample
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(
+        local_ts_stack.records().len(),
+        2,
+        "local subscriber should have exactly SEND + RECEIVE (no duplicate RECEIVE)"
+    );
+    assert_record(&local_ts_stack.records()[0], InterceptionPoint::Send, false);
+    assert_record(
+        &local_ts_stack.records()[1],
+        InterceptionPoint::Receive,
+        false,
+    );
+
+    // Remote subscriber should get exactly 1 RECEIVE
+    let remote_sample = ztimeout!(remote_sub.recv_async()).unwrap();
+    let remote_ts_stack = remote_sample
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(
+        remote_ts_stack.records().len(),
+        2,
+        "remote subscriber should have exactly SEND + RECEIVE"
+    );
+    assert_record(
+        &remote_ts_stack.records()[0],
+        InterceptionPoint::Send,
+        false,
+    );
+    assert_record(
+        &remote_ts_stack.records()[1],
+        InterceptionPoint::Receive,
+        false,
+    );
+
+    test_context.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pubsub_local_only_destination() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/pubsub/local_only_destination";
+    let instr = make_instrumentation(true, false, true);
+
+    let mut test_context = TestSessions::new();
+    let (peer1, peer2) = ztimeout!(open_peer_sessions(&mut test_context));
+
+    // Publisher on peer1 with destination=SessionLocal
+    let publisher = ztimeout!(peer1
+        .declare_publisher(ke)
+        .allowed_destination(zenoh::sample::Locality::SessionLocal))
+    .unwrap();
+    // Local subscriber on peer1
+    let local_sub = ztimeout!(peer1.declare_subscriber(ke)).unwrap();
+    // Remote subscriber on peer2 (should NOT receive)
+    let remote_sub = ztimeout!(peer2.declare_subscriber(ke)).unwrap();
+
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(publisher
+        .put("payload")
+        .timestamp_instrumentation(Some(instr)))
+    .unwrap();
+
+    // Local subscriber should get exactly 1 RECEIVE
+    let local_sample = ztimeout!(local_sub.recv_async()).unwrap();
+    let local_ts_stack = local_sample
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(
+        local_ts_stack.records().len(),
+        2,
+        "local subscriber should have exactly SEND + RECEIVE"
+    );
+    assert_record(&local_ts_stack.records()[0], InterceptionPoint::Send, false);
+    assert_record(
+        &local_ts_stack.records()[1],
+        InterceptionPoint::Receive,
+        false,
+    );
+
+    // Remote subscriber should NOT receive anything
+    let remote_result = tokio::time::timeout(Duration::from_secs(2), remote_sub.recv_async()).await;
+    assert!(
+        remote_result.is_err(),
+        "remote subscriber should not receive when destination=SessionLocal"
+    );
+
+    test_context.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pubsub_remote_only_destination() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/pubsub/remote_only_destination";
+    let instr = make_instrumentation(true, false, true);
+
+    let mut test_context = TestSessions::new();
+    let (peer1, peer2) = ztimeout!(open_peer_sessions(&mut test_context));
+
+    // Publisher on peer1 with destination=Remote
+    let publisher = ztimeout!(peer1
+        .declare_publisher(ke)
+        .allowed_destination(zenoh::sample::Locality::Remote))
+    .unwrap();
+    // Local subscriber on peer1 (should NOT receive)
+    let local_sub = ztimeout!(peer1.declare_subscriber(ke)).unwrap();
+    // Remote subscriber on peer2
+    let remote_sub = ztimeout!(peer2.declare_subscriber(ke)).unwrap();
+
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(publisher
+        .put("payload")
+        .timestamp_instrumentation(Some(instr)))
+    .unwrap();
+
+    // Remote subscriber should get exactly 1 RECEIVE
+    let remote_sample = ztimeout!(remote_sub.recv_async()).unwrap();
+    let remote_ts_stack = remote_sample
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(
+        remote_ts_stack.records().len(),
+        2,
+        "remote subscriber should have exactly SEND + RECEIVE"
+    );
+    assert_record(
+        &remote_ts_stack.records()[0],
+        InterceptionPoint::Send,
+        false,
+    );
+    assert_record(
+        &remote_ts_stack.records()[1],
+        InterceptionPoint::Receive,
+        false,
+    );
+
+    // Local subscriber should NOT receive anything
+    let local_result = tokio::time::timeout(Duration::from_secs(2), local_sub.recv_async()).await;
+    assert!(
+        local_result.is_err(),
+        "local subscriber should not receive when destination=Remote"
+    );
+
+    test_context.close().await;
+}
+
+// ─── Pub/Sub — Peer-Peer ─────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pubsub_p2p_send_only() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/peer_peer/send_only";
+    let instr = make_instrumentation(true, false, false);
+
+    let mut test_context = TestSessions::new();
+    let (peer1, peer2) = ztimeout!(open_peer_sessions(&mut test_context));
+
+    let publisher = ztimeout!(peer1.declare_publisher(ke)).unwrap();
+    let subscriber = ztimeout!(peer2.declare_subscriber(ke)).unwrap();
+
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(publisher
+        .put("payload")
+        .timestamp_instrumentation(Some(instr)))
+    .unwrap();
+    let sample = ztimeout!(subscriber.recv_async()).unwrap();
+
+    let ts_stack = sample
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(ts_stack.records().len(), 1);
+    assert_record(&ts_stack.records()[0], InterceptionPoint::Send, false);
+
+    test_context.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pubsub_p2p_receive_only() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/peer_peer/receive_only";
+    let instr = make_instrumentation(false, false, true);
+
+    let mut test_context = TestSessions::new();
+    let (peer1, peer2) = ztimeout!(open_peer_sessions(&mut test_context));
+
+    let publisher = ztimeout!(peer1.declare_publisher(ke)).unwrap();
+    let subscriber = ztimeout!(peer2.declare_subscriber(ke)).unwrap();
+
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(publisher
+        .put("payload")
+        .timestamp_instrumentation(Some(instr)))
+    .unwrap();
+    let sample = ztimeout!(subscriber.recv_async()).unwrap();
+
+    let ts_stack = sample
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(ts_stack.records().len(), 1);
+    assert_record(&ts_stack.records()[0], InterceptionPoint::Receive, false);
+
+    test_context.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pubsub_p2p_send_receive() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/peer_peer/send_receive";
+    let instr = make_instrumentation(true, false, true);
+
+    let mut test_context = TestSessions::new();
+    let (peer1, peer2) = ztimeout!(open_peer_sessions(&mut test_context));
+
+    let publisher = ztimeout!(peer1.declare_publisher(ke)).unwrap();
+    let subscriber = ztimeout!(peer2.declare_subscriber(ke)).unwrap();
+
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(publisher
+        .put("payload")
+        .timestamp_instrumentation(Some(instr)))
+    .unwrap();
+    let sample = ztimeout!(subscriber.recv_async()).unwrap();
+
+    let ts_stack = sample
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(ts_stack.records().len(), 2);
+    assert_record(&ts_stack.records()[0], InterceptionPoint::Send, false);
+    assert_record(&ts_stack.records()[1], InterceptionPoint::Receive, false);
+
+    test_context.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pubsub_p2p_route_only() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/peer_peer/route_only";
+    let instr = make_instrumentation(false, true, false);
+
+    let mut test_context = TestSessions::new();
+    let (peer1, peer2) = ztimeout!(open_peer_sessions(&mut test_context));
+
+    let publisher = ztimeout!(peer1.declare_publisher(ke)).unwrap();
+    let subscriber = ztimeout!(peer2.declare_subscriber(ke)).unwrap();
+
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(publisher
+        .put("payload")
+        .timestamp_instrumentation(Some(instr)))
+    .unwrap();
+    let sample = ztimeout!(subscriber.recv_async()).unwrap();
+
+    // In peer-peer, message goes through routing layer on both peers → 2 ROUTE records
+    let ts_stack = sample
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert!(ts_stack
+        .instrumentation()
+        .is_instrumented(InterceptionPoint::Route));
+    assert_eq!(ts_stack.records().len(), 2);
+    assert_record(&ts_stack.records()[0], InterceptionPoint::Route, false);
+    assert_record(&ts_stack.records()[1], InterceptionPoint::Route, false);
+
+    test_context.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pubsub_p2p_no_instrumentation() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/peer_peer/no_instr";
+
+    let mut test_context = TestSessions::new();
+    let (peer1, peer2) = ztimeout!(open_peer_sessions(&mut test_context));
+
+    let publisher = ztimeout!(peer1.declare_publisher(ke)).unwrap();
+    let subscriber = ztimeout!(peer2.declare_subscriber(ke)).unwrap();
+
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(publisher.put("payload")).unwrap();
+    let sample = ztimeout!(subscriber.recv_async()).unwrap();
+
+    assert!(
+        sample.timestamp_stack().is_none(),
+        "timestamp_stack should be None when no instrumentation"
+    );
+
+    test_context.close().await;
+}
+
+// ─── Pub/Sub — Routed Client-Router-Client ──────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pubsub_routed_send_only() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/routed/send_only";
+    let instr = make_instrumentation(true, false, false);
+
+    let mut test_context = TestSessions::new();
+    let (client1, client2, _router) = ztimeout!(open_routed_sessions(&mut test_context));
+
+    let publisher = ztimeout!(client1.declare_publisher(ke)).unwrap();
+    let subscriber = ztimeout!(client2.declare_subscriber(ke)).unwrap();
+
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(publisher
+        .put("payload")
+        .timestamp_instrumentation(Some(instr)))
+    .unwrap();
+    let sample = ztimeout!(subscriber.recv_async()).unwrap();
+
+    let ts_stack = sample
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(ts_stack.records().len(), 1);
+    assert_record(&ts_stack.records()[0], InterceptionPoint::Send, false);
+
+    test_context.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pubsub_routed_route_only() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/routed/route_only";
+    let instr = make_instrumentation(false, true, false);
+
+    let mut test_context = TestSessions::new();
+    let (client1, client2, _router) = ztimeout!(open_routed_sessions(&mut test_context));
+
+    let publisher = ztimeout!(client1.declare_publisher(ke)).unwrap();
+    let subscriber = ztimeout!(client2.declare_subscriber(ke)).unwrap();
+
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(publisher
+        .put("payload")
+        .timestamp_instrumentation(Some(instr)))
+    .unwrap();
+    let sample = ztimeout!(subscriber.recv_async()).unwrap();
+
+    let ts_stack = sample
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(ts_stack.records().len(), 3);
+    for r in ts_stack.records() {
+        assert_record(r, InterceptionPoint::Route, false);
+    }
+
+    test_context.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pubsub_routed_receive_only() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/routed/receive_only";
+    let instr = make_instrumentation(false, false, true);
+
+    let mut test_context = TestSessions::new();
+    let (client1, client2, _router) = ztimeout!(open_routed_sessions(&mut test_context));
+
+    let publisher = ztimeout!(client1.declare_publisher(ke)).unwrap();
+    let subscriber = ztimeout!(client2.declare_subscriber(ke)).unwrap();
+
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(publisher
+        .put("payload")
+        .timestamp_instrumentation(Some(instr)))
+    .unwrap();
+    let sample = ztimeout!(subscriber.recv_async()).unwrap();
+
+    let ts_stack = sample
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(ts_stack.records().len(), 1);
+    assert_record(&ts_stack.records()[0], InterceptionPoint::Receive, false);
+
+    test_context.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pubsub_routed_send_route() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/routed/send_route";
+    let instr = make_instrumentation(true, true, false);
+
+    let mut test_context = TestSessions::new();
+    let (client1, client2, _router) = ztimeout!(open_routed_sessions(&mut test_context));
+
+    let publisher = ztimeout!(client1.declare_publisher(ke)).unwrap();
+    let subscriber = ztimeout!(client2.declare_subscriber(ke)).unwrap();
+
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(publisher
+        .put("payload")
+        .timestamp_instrumentation(Some(instr)))
+    .unwrap();
+    let sample = ztimeout!(subscriber.recv_async()).unwrap();
+
+    let ts_stack = sample
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(ts_stack.records().len(), 4);
+    assert_record(&ts_stack.records()[0], InterceptionPoint::Send, false);
+    for i in 1..4 {
+        assert_record(&ts_stack.records()[i], InterceptionPoint::Route, false);
+    }
+
+    test_context.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pubsub_routed_send_receive() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/routed/send_receive";
+    let instr = make_instrumentation(true, false, true);
+
+    let mut test_context = TestSessions::new();
+    let (client1, client2, _router) = ztimeout!(open_routed_sessions(&mut test_context));
+
+    let publisher = ztimeout!(client1.declare_publisher(ke)).unwrap();
+    let subscriber = ztimeout!(client2.declare_subscriber(ke)).unwrap();
+
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(publisher
+        .put("payload")
+        .timestamp_instrumentation(Some(instr)))
+    .unwrap();
+    let sample = ztimeout!(subscriber.recv_async()).unwrap();
+
+    let ts_stack = sample
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(ts_stack.records().len(), 2);
+    assert_record(&ts_stack.records()[0], InterceptionPoint::Send, false);
+    assert_record(&ts_stack.records()[1], InterceptionPoint::Receive, false);
+
+    test_context.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pubsub_routed_route_receive() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/routed/route_receive";
+    let instr = make_instrumentation(false, true, true);
+
+    let mut test_context = TestSessions::new();
+    let (client1, client2, _router) = ztimeout!(open_routed_sessions(&mut test_context));
+
+    let publisher = ztimeout!(client1.declare_publisher(ke)).unwrap();
+    let subscriber = ztimeout!(client2.declare_subscriber(ke)).unwrap();
+
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(publisher
+        .put("payload")
+        .timestamp_instrumentation(Some(instr)))
+    .unwrap();
+    let sample = ztimeout!(subscriber.recv_async()).unwrap();
+
+    let ts_stack = sample
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(ts_stack.records().len(), 4);
+    for i in 0..3 {
+        assert_record(&ts_stack.records()[i], InterceptionPoint::Route, false);
+    }
+    assert_record(&ts_stack.records()[3], InterceptionPoint::Receive, false);
+
+    test_context.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pubsub_routed_send_route_receive() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/routed/send_route_receive";
+    let instr = make_instrumentation(true, true, true);
+
+    let mut test_context = TestSessions::new();
+    let (client1, client2, _router) = ztimeout!(open_routed_sessions(&mut test_context));
+
+    let publisher = ztimeout!(client1.declare_publisher(ke)).unwrap();
+    let subscriber = ztimeout!(client2.declare_subscriber(ke)).unwrap();
+
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(publisher
+        .put("payload")
+        .timestamp_instrumentation(Some(instr)))
+    .unwrap();
+    let sample = ztimeout!(subscriber.recv_async()).unwrap();
+
+    let ts_stack = sample
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(ts_stack.records().len(), 5);
+    assert_record(&ts_stack.records()[0], InterceptionPoint::Send, false);
+    for i in 1..4 {
+        assert_record(&ts_stack.records()[i], InterceptionPoint::Route, false);
+    }
+    assert_record(&ts_stack.records()[4], InterceptionPoint::Receive, false);
+
+    test_context.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pubsub_routed_no_instrumentation() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/routed/no_instr";
+
+    let mut test_context = TestSessions::new();
+    let (client1, client2, _router) = ztimeout!(open_routed_sessions(&mut test_context));
+
+    let publisher = ztimeout!(client1.declare_publisher(ke)).unwrap();
+    let subscriber = ztimeout!(client2.declare_subscriber(ke)).unwrap();
+
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(publisher.put("payload")).unwrap();
+    let sample = ztimeout!(subscriber.recv_async()).unwrap();
+
+    assert!(
+        sample.timestamp_stack().is_none(),
+        "timestamp_stack should be None when no instrumentation"
+    );
+
+    test_context.close().await;
+}
+
+// ─── Delete Operations ──────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn delete_p2p_send_receive() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/delete/peer_peer";
+    let instr = make_instrumentation(true, false, true);
+
+    let mut test_context = TestSessions::new();
+    let (peer1, peer2) = ztimeout!(open_peer_sessions(&mut test_context));
+
+    let publisher = ztimeout!(peer1.declare_publisher(ke)).unwrap();
+    let subscriber = ztimeout!(peer2.declare_subscriber(ke)).unwrap();
+
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(publisher.delete().timestamp_instrumentation(Some(instr))).unwrap();
+    let sample = ztimeout!(subscriber.recv_async()).unwrap();
+
+    assert_eq!(sample.kind(), zenoh::sample::SampleKind::Delete);
+    let ts_stack = sample
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(ts_stack.records().len(), 2);
+    assert_record(&ts_stack.records()[0], InterceptionPoint::Send, false);
+    assert_record(&ts_stack.records()[1], InterceptionPoint::Receive, false);
+
+    test_context.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn delete_routed_send_route_receive() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/delete/routed";
+    let instr = make_instrumentation(true, true, true);
+
+    let mut test_context = TestSessions::new();
+    let (client1, client2, _router) = ztimeout!(open_routed_sessions(&mut test_context));
+
+    let publisher = ztimeout!(client1.declare_publisher(ke)).unwrap();
+    let subscriber = ztimeout!(client2.declare_subscriber(ke)).unwrap();
+
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(publisher.delete().timestamp_instrumentation(Some(instr))).unwrap();
+    let sample = ztimeout!(subscriber.recv_async()).unwrap();
+
+    assert_eq!(sample.kind(), zenoh::sample::SampleKind::Delete);
+    let ts_stack = sample
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(ts_stack.records().len(), 5);
+    assert_record(&ts_stack.records()[0], InterceptionPoint::Send, false);
+    for i in 1..4 {
+        assert_record(&ts_stack.records()[i], InterceptionPoint::Route, false);
+    }
+    assert_record(&ts_stack.records()[4], InterceptionPoint::Receive, false);
+
+    test_context.close().await;
+}
+
+// ─── Query/Reply — Local + Remote Delivery ──────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn queryreply_local_and_remote_no_duplicate_receive() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/queryreply/local_and_remote";
+    let instr = make_instrumentation(true, false, true);
+
+    let mut test_context = TestSessions::new();
+    let (peer1, peer2) = ztimeout!(open_peer_sessions(&mut test_context));
+
+    // Queryable on peer2
+    let queryable = ztimeout!(peer2.declare_queryable(ke)).unwrap();
+    tokio::time::sleep(SLEEP).await;
+
+    // Local querier on peer1 (queries peer2)
+    let local_replies = ztimeout!(peer1.get(ke).timestamp_instrumentation(Some(instr))).unwrap();
+
+    // Receive query on peer2
+    let query = ztimeout!(queryable.recv_async()).unwrap();
+    let query_ts_stack = query
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(
+        query_ts_stack.records().len(),
+        2,
+        "query should have exactly SEND + RECEIVE"
+    );
+    assert_record(&query_ts_stack.records()[0], InterceptionPoint::Send, false);
+    assert_record(
+        &query_ts_stack.records()[1],
+        InterceptionPoint::Receive,
+        false,
+    );
+
+    // Reply with instrumentation
+    ztimeout!(query
+        .reply(ke, "data")
+        .timestamp_instrumentation(Some(instr)))
+    .unwrap();
+    std::mem::drop(query);
+
+    // Receive reply on peer1
+    let reply = ztimeout!(local_replies.recv_async()).unwrap();
+    assert!(reply.result().is_ok());
+    let reply_sample = reply.result().unwrap();
+    let reply_ts_stack = reply_sample
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(
+        reply_ts_stack.records().len(),
+        2,
+        "reply sample should have exactly SEND + RECEIVE"
+    );
+    assert_record(&reply_ts_stack.records()[0], InterceptionPoint::Send, false);
+    assert_record(
+        &reply_ts_stack.records()[1],
+        InterceptionPoint::Receive,
+        false,
+    );
+
+    test_context.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn queryreply_local_and_remote_queryable_no_duplicate_receive() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/queryreply/local_and_remote_queryable";
+    let instr = make_instrumentation(true, false, true);
+
+    let mut test_context = TestSessions::new();
+    let (peer1, peer2) = ztimeout!(open_peer_sessions(&mut test_context));
+
+    // Two queryables: one local on peer1, one remote on peer2
+    let local_queryable = ztimeout!(peer1.declare_queryable(ke)).unwrap();
+    let remote_queryable = ztimeout!(peer2.declare_queryable(ke)).unwrap();
+    tokio::time::sleep(SLEEP).await;
+
+    // Querier on peer1 with destination=Any (default)
+    let replies = ztimeout!(peer1
+        .get(ke)
+        // Disable consolidation to receive both replies
+        .consolidation(ConsolidationMode::None)
+        .timestamp_instrumentation(Some(instr)))
+    .unwrap();
+
+    // Both queryables should receive the query
+    let local_query = ztimeout!(local_queryable.recv_async()).unwrap();
+    let remote_query = ztimeout!(remote_queryable.recv_async()).unwrap();
+
+    // Local query should have exactly 1 RECEIVE (not duplicated)
+    let local_query_ts = local_query
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(
+        local_query_ts.records().len(),
+        2,
+        "local queryable should receive query with exactly SEND + RECEIVE (no duplicate RECEIVE)"
+    );
+    assert_record(&local_query_ts.records()[0], InterceptionPoint::Send, false);
+    assert_record(
+        &local_query_ts.records()[1],
+        InterceptionPoint::Receive,
+        false,
+    );
+
+    // Remote query should have exactly 1 RECEIVE
+    let remote_query_ts = remote_query
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(
+        remote_query_ts.records().len(),
+        2,
+        "remote queryable should receive query with exactly SEND + RECEIVE"
+    );
+    assert_record(
+        &remote_query_ts.records()[0],
+        InterceptionPoint::Send,
+        false,
+    );
+    assert_record(
+        &remote_query_ts.records()[1],
+        InterceptionPoint::Receive,
+        false,
+    );
+
+    // Both reply
+    ztimeout!(remote_query.reply(ke, "remote_data")).unwrap();
+    ztimeout!(local_query.reply(ke, "local_data")).unwrap();
+    std::mem::drop(remote_query);
+    std::mem::drop(local_query);
+
+    // Receive the replies
+    let reply1 = ztimeout!(replies.recv_async()).unwrap();
+    let reply2 = ztimeout!(replies.recv_async()).unwrap();
+    assert!(reply1.result().is_ok());
+    assert!(reply2.result().is_ok());
+
+    test_context.close().await;
+}
+
+// ─── Query/Reply — Peer-Peer ────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn queryreply_p2p_query_send_only() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/query/peer/send_only";
+    let instr = make_instrumentation(true, false, false);
+
+    let mut test_context = TestSessions::new();
+    let (peer1, peer2) = ztimeout!(open_peer_sessions(&mut test_context));
+
+    let queryable = ztimeout!(peer2.declare_queryable(ke)).unwrap();
+    tokio::time::sleep(SLEEP).await;
+
+    let replies = ztimeout!(peer1.get(ke).timestamp_instrumentation(Some(instr))).unwrap();
+
+    let query = ztimeout!(queryable.recv_async()).unwrap();
+    let ts_stack = query
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(ts_stack.records().len(), 1);
+    assert_record(&ts_stack.records()[0], InterceptionPoint::Send, false);
+
+    ztimeout!(query.reply(ke, "data")).unwrap();
+    std::mem::drop(query);
+
+    let reply = ztimeout!(replies.recv_async()).unwrap();
+    assert!(reply.result().is_ok());
+
+    test_context.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn queryreply_p2p_query_send_receive() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/query/peer/send_receive";
+    let instr = make_instrumentation(true, false, true);
+
+    let mut test_context = TestSessions::new();
+    let (peer1, peer2) = ztimeout!(open_peer_sessions(&mut test_context));
+
+    let queryable = ztimeout!(peer2.declare_queryable(ke)).unwrap();
+    tokio::time::sleep(SLEEP).await;
+
+    let replies = ztimeout!(peer1.get(ke).timestamp_instrumentation(Some(instr))).unwrap();
+
+    let query = ztimeout!(queryable.recv_async()).unwrap();
+    let ts_stack = query
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(ts_stack.records().len(), 2);
+    assert_record(&ts_stack.records()[0], InterceptionPoint::Send, false);
+    assert_record(&ts_stack.records()[1], InterceptionPoint::Receive, false);
+
+    ztimeout!(query.reply(ke, "data")).unwrap();
+    std::mem::drop(query);
+
+    let reply = ztimeout!(replies.recv_async()).unwrap();
+    assert!(reply.result().is_ok());
+
+    test_context.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn queryreply_p2p_query_no_instrumentation() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/query/peer/no_instr";
+
+    let mut test_context = TestSessions::new();
+    let (peer1, peer2) = ztimeout!(open_peer_sessions(&mut test_context));
+
+    let queryable = ztimeout!(peer2.declare_queryable(ke)).unwrap();
+    tokio::time::sleep(SLEEP).await;
+
+    let replies = ztimeout!(peer1.get(ke)).unwrap();
+
+    let query = ztimeout!(queryable.recv_async()).unwrap();
+    assert!(
+        query.timestamp_stack().is_none(),
+        "timestamp_stack should be None when no instrumentation"
+    );
+
+    ztimeout!(query.reply(ke, "data")).unwrap();
+    std::mem::drop(query);
+
+    let reply = ztimeout!(replies.recv_async()).unwrap();
+    assert!(reply.result().is_ok());
+
+    test_context.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn queryreply_p2p_reply_send_receive() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/reply/peer/send_receive";
+    let instr = make_instrumentation(true, false, true);
+
+    let mut test_context = TestSessions::new();
+    let (peer1, peer2) = ztimeout!(open_peer_sessions(&mut test_context));
+
+    let queryable = ztimeout!(peer2.declare_queryable(ke)).unwrap();
+    tokio::time::sleep(SLEEP).await;
+
+    let replies = ztimeout!(peer1.get(ke)).unwrap();
+
+    let query = ztimeout!(queryable.recv_async()).unwrap();
+    ztimeout!(query
+        .reply(ke, "data")
+        .timestamp_instrumentation(Some(instr)))
+    .unwrap();
+    std::mem::drop(query);
+
+    let reply = ztimeout!(replies.recv_async()).unwrap();
+    assert!(reply.result().is_ok());
+    let sample = reply.result().unwrap();
+
+    let ts_stack = sample
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(ts_stack.records().len(), 2);
+    assert_record(&ts_stack.records()[0], InterceptionPoint::Send, false);
+    assert_record(&ts_stack.records()[1], InterceptionPoint::Receive, false);
+
+    test_context.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn queryreply_p2p_reply_no_instrumentation() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/reply/peer/no_instr";
+
+    let mut test_context = TestSessions::new();
+    let (peer1, peer2) = ztimeout!(open_peer_sessions(&mut test_context));
+
+    let queryable = ztimeout!(peer2.declare_queryable(ke)).unwrap();
+    tokio::time::sleep(SLEEP).await;
+
+    let replies = ztimeout!(peer1.get(ke)).unwrap();
+
+    let query = ztimeout!(queryable.recv_async()).unwrap();
+    ztimeout!(query.reply(ke, "data")).unwrap();
+    std::mem::drop(query);
+
+    let reply = ztimeout!(replies.recv_async()).unwrap();
+    assert!(reply.result().is_ok());
+    let sample = reply.result().unwrap();
+
+    assert!(
+        sample.timestamp_stack().is_none(),
+        "timestamp_stack should be None when no instrumentation on reply"
+    );
+
+    test_context.close().await;
+}
+
+// ─── Query/Reply — Routed ───────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn queryreply_routed_query_send_route_receive() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/query/routed/send_route_receive";
+    let instr = make_instrumentation(true, true, true);
+
+    let mut test_context = TestSessions::new();
+    let (client1, client2, _router) = ztimeout!(open_routed_sessions(&mut test_context));
+
+    let queryable = ztimeout!(client2.declare_queryable(ke)).unwrap();
+    tokio::time::sleep(SLEEP).await;
+
+    let replies = ztimeout!(client1.get(ke).timestamp_instrumentation(Some(instr))).unwrap();
+
+    let query = ztimeout!(queryable.recv_async()).unwrap();
+    let ts_stack = query
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(ts_stack.records().len(), 5);
+    assert_record(&ts_stack.records()[0], InterceptionPoint::Send, false);
+    for i in 1..4 {
+        assert_record(&ts_stack.records()[i], InterceptionPoint::Route, false);
+    }
+    assert_record(&ts_stack.records()[4], InterceptionPoint::Receive, false);
+
+    ztimeout!(query.reply(ke, "data")).unwrap();
+    std::mem::drop(query);
+
+    let reply = ztimeout!(replies.recv_async()).unwrap();
+    assert!(reply.result().is_ok());
+
+    test_context.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn queryreply_routed_reply_send_route_receive() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/reply/routed/send_route_receive";
+    let instr = make_instrumentation(true, true, true);
+
+    let mut test_context = TestSessions::new();
+    let (client1, client2, _router) = ztimeout!(open_routed_sessions(&mut test_context));
+
+    let queryable = ztimeout!(client2.declare_queryable(ke)).unwrap();
+    tokio::time::sleep(SLEEP).await;
+
+    let replies = ztimeout!(client1.get(ke)).unwrap();
+
+    let query = ztimeout!(queryable.recv_async()).unwrap();
+    ztimeout!(query
+        .reply(ke, "data")
+        .timestamp_instrumentation(Some(instr)))
+    .unwrap();
+    std::mem::drop(query);
+
+    let reply = ztimeout!(replies.recv_async()).unwrap();
+    assert!(reply.result().is_ok());
+    let sample = reply.result().unwrap();
+
+    let ts_stack = sample
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(ts_stack.records().len(), 5);
+    assert_record(&ts_stack.records()[0], InterceptionPoint::Send, false);
+    for i in 1..4 {
+        assert_record(&ts_stack.records()[i], InterceptionPoint::Route, false);
+    }
+    assert_record(&ts_stack.records()[4], InterceptionPoint::Receive, false);
+
+    test_context.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn queryreply_routed_query_route_only() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/query/routed/route_only";
+    let instr = make_instrumentation(false, true, false);
+
+    let mut test_context = TestSessions::new();
+    let (client1, client2, _router) = ztimeout!(open_routed_sessions(&mut test_context));
+
+    let queryable = ztimeout!(client2.declare_queryable(ke)).unwrap();
+    tokio::time::sleep(SLEEP).await;
+
+    let replies = ztimeout!(client1.get(ke).timestamp_instrumentation(Some(instr))).unwrap();
+
+    let query = ztimeout!(queryable.recv_async()).unwrap();
+    let ts_stack = query
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(ts_stack.records().len(), 3);
+    for r in ts_stack.records() {
+        assert_record(r, InterceptionPoint::Route, false);
+    }
+
+    ztimeout!(query.reply(ke, "data")).unwrap();
+    std::mem::drop(query);
+
+    let reply = ztimeout!(replies.recv_async()).unwrap();
+    assert!(reply.result().is_ok());
+
+    test_context.close().await;
+}
+
+// ─── Reply Error ────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn queryreply_reply_err_send_receive() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/reply_err/send_receive";
+    let instr = make_instrumentation(true, false, true);
+
+    let mut test_context = TestSessions::new();
+    let (peer1, peer2) = ztimeout!(open_peer_sessions(&mut test_context));
+
+    let queryable = ztimeout!(peer2.declare_queryable(ke)).unwrap();
+    tokio::time::sleep(SLEEP).await;
+
+    let replies = ztimeout!(peer1.get(ke)).unwrap();
+
+    let query = ztimeout!(queryable.recv_async()).unwrap();
+    ztimeout!(query
+        .reply_err("error payload")
+        .timestamp_instrumentation(Some(instr)))
+    .unwrap();
+    std::mem::drop(query);
+
+    let reply = ztimeout!(replies.recv_async()).unwrap();
+    assert!(reply.result().is_err());
+    let reply_err = reply.result().unwrap_err();
+
+    let ts_stack = reply_err
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(ts_stack.records().len(), 2);
+    assert_record(&ts_stack.records()[0], InterceptionPoint::Send, false);
+    assert_record(&ts_stack.records()[1], InterceptionPoint::Receive, false);
+
+    test_context.close().await;
+}
+
+// ─── Custom Timestamp Callback ──────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn custom_callback_pub_sub() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/custom_callback/pub_sub";
+    let custom_bytes = b"custom_ts_123".to_vec();
+    let cb: GetTimestampCallback = Arc::new(move |_ctx| custom_bytes.clone());
+
+    let instr = make_instrumentation(true, false, false);
+
+    let session =
+        ztimeout!(zenoh::open(zenoh::Config::default()).with_timestamp_callback(cb)).unwrap();
+    let publisher = ztimeout!(session.declare_publisher(ke)).unwrap();
+    let subscriber = ztimeout!(session.declare_subscriber(ke)).unwrap();
+
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(publisher
+        .put("payload")
+        .timestamp_instrumentation(Some(instr)))
+    .unwrap();
+    let sample = ztimeout!(subscriber.recv_async()).unwrap();
+
+    let ts_stack = sample
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(ts_stack.records().len(), 1);
+    let record = &ts_stack.records()[0];
+    assert_eq!(record.point(), InterceptionPoint::Send);
+    assert!(
+        record.is_custom(),
+        "is_custom should be true when using custom callback"
+    );
+    assert_eq!(record.timestamp(), b"custom_ts_123");
+
+    session.close().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn custom_callback_query_reply() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/custom_callback/query_reply";
+    let custom_bytes_query = b"custom_query_ts".to_vec();
+    let custom_bytes_reply = b"custom_reply_ts".to_vec();
+
+    let cb_query: GetTimestampCallback = Arc::new(move |_ctx| custom_bytes_query.clone());
+    let cb_reply: GetTimestampCallback = Arc::new(move |_ctx| custom_bytes_reply.clone());
+
+    let instr = make_instrumentation(true, false, true);
+
+    let session1 =
+        ztimeout!(zenoh::open(zenoh::Config::default()).with_timestamp_callback(cb_query)).unwrap();
+
+    let locators = session1.info().locators().await;
+    let mut config2 = zenoh::Config::default();
+    config2.scouting.multicast.set_enabled(Some(false)).unwrap();
+    let endpoints: Vec<zenoh_link::EndPoint> =
+        locators.into_iter().map(|l| l.to_endpoint()).collect();
+    config2
+        .connect
+        .set_endpoints(zenoh_config::ModeDependentValue::Unique(endpoints))
+        .unwrap();
+    config2.set_mode(Some(WhatAmI::Peer)).unwrap();
+    let session2 = ztimeout!(zenoh::open(config2).with_timestamp_callback(cb_reply)).unwrap();
+
+    let queryable = ztimeout!(session2.declare_queryable(ke)).unwrap();
+    tokio::time::sleep(SLEEP).await;
+
+    let replies = ztimeout!(session1.get(ke).timestamp_instrumentation(Some(instr))).unwrap();
+
+    let query = ztimeout!(queryable.recv_async()).unwrap();
+    let ts_stack = query
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(ts_stack.records().len(), 2);
+    // Query side uses session1's callback for SEND, session2's callback for RECEIVE
+    assert!(ts_stack.records()[0].is_custom());
+    assert_eq!(ts_stack.records()[0].timestamp(), b"custom_query_ts");
+    assert!(ts_stack.records()[1].is_custom());
+    // RECEIVE is pushed on session2's side, so it uses session2's callback
+    assert_eq!(ts_stack.records()[1].timestamp(), b"custom_reply_ts");
+
+    ztimeout!(query
+        .reply(ke, "data")
+        .timestamp_instrumentation(Some(instr)))
+    .unwrap();
+    std::mem::drop(query);
+
+    let reply = ztimeout!(replies.recv_async()).unwrap();
+    assert!(reply.result().is_ok());
+    let sample = reply.result().unwrap();
+
+    let ts_stack = sample
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(ts_stack.records().len(), 2);
+    // Reply side uses session2's callback for SEND, session1's callback for RECEIVE
+    assert!(ts_stack.records()[0].is_custom());
+    assert_eq!(ts_stack.records()[0].timestamp(), b"custom_reply_ts");
+    assert!(ts_stack.records()[1].is_custom());
+    // RECEIVE is pushed on session1's side, so it uses session1's callback
+    assert_eq!(ts_stack.records()[1].timestamp(), b"custom_query_ts");
+
+    session1.close().await.unwrap();
+    session2.close().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn custom_callback_context() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/custom_callback/context";
+
+    use std::sync::Mutex;
+    #[derive(Clone)]
+    struct ContextCapture {
+        contexts: Arc<Mutex<Vec<(zenoh::session::ZenohId, WhatAmI, InterceptionPoint)>>>,
+    }
+    let capture = ContextCapture {
+        contexts: Arc::new(Mutex::new(Vec::new())),
+    };
+    let capture_clone = capture.clone();
+
+    let cb: GetTimestampCallback = Arc::new(move |ctx| {
+        capture_clone
+            .contexts
+            .lock()
+            .unwrap()
+            .push((ctx.zid, ctx.whatami, ctx.interception_point));
+        b"ctx_ts".to_vec()
+    });
+
+    let instr = make_instrumentation(true, false, true);
+
+    let session =
+        ztimeout!(zenoh::open(zenoh::Config::default()).with_timestamp_callback(cb)).unwrap();
+    let expected_zid = session.zid();
+
+    let publisher = ztimeout!(session.declare_publisher(ke)).unwrap();
+    let subscriber = ztimeout!(session.declare_subscriber(ke)).unwrap();
+
+    tokio::time::sleep(SLEEP).await;
+    ztimeout!(publisher
+        .put("payload")
+        .timestamp_instrumentation(Some(instr)))
+    .unwrap();
+    let _sample = ztimeout!(subscriber.recv_async()).unwrap();
+
+    let contexts = capture.contexts.lock().unwrap();
+    assert_eq!(
+        contexts.len(),
+        2,
+        "Expected 2 context captures (SEND + RECEIVE)"
+    );
+
+    // SEND context
+    assert_eq!(contexts[0].0, expected_zid);
+    assert_eq!(contexts[0].1, WhatAmI::Peer);
+    assert_eq!(contexts[0].2, InterceptionPoint::Send);
+
+    // RECEIVE context
+    assert_eq!(contexts[1].0, expected_zid);
+    assert_eq!(contexts[1].1, WhatAmI::Peer);
+    assert_eq!(contexts[1].2, InterceptionPoint::Receive);
+
+    session.close().await.unwrap();
+}
+
+// ─── Querier API ────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn querier_get_send_receive() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/querier/send_receive";
+    let instr = make_instrumentation(true, false, true);
+
+    let mut test_context = TestSessions::new();
+    let (peer1, peer2) = ztimeout!(open_peer_sessions(&mut test_context));
+
+    let queryable = ztimeout!(peer2.declare_queryable(ke)).unwrap();
+    tokio::time::sleep(SLEEP).await;
+
+    let querier = ztimeout!(peer1.declare_querier(ke)).unwrap();
+    let replies = ztimeout!(querier.get().timestamp_instrumentation(Some(instr))).unwrap();
+
+    let query = ztimeout!(queryable.recv_async()).unwrap();
+    let ts_stack = query
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(ts_stack.records().len(), 2);
+    assert_record(&ts_stack.records()[0], InterceptionPoint::Send, false);
+    assert_record(&ts_stack.records()[1], InterceptionPoint::Receive, false);
+
+    ztimeout!(query.reply(ke, "data")).unwrap();
+    std::mem::drop(query);
+
+    let reply = ztimeout!(replies.recv_async()).unwrap();
+    assert!(reply.result().is_ok());
+
+    test_context.close().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn querier_get_routed_send_route_receive() {
+    zenoh_util::init_log_from_env_or("error");
+    let ke = "test/ts_instr/querier/routed/send_route_receive";
+    let instr = make_instrumentation(true, true, true);
+
+    let mut test_context = TestSessions::new();
+    let (client1, client2, _router) = ztimeout!(open_routed_sessions(&mut test_context));
+
+    let queryable = ztimeout!(client2.declare_queryable(ke)).unwrap();
+    tokio::time::sleep(SLEEP).await;
+
+    let querier = ztimeout!(client1.declare_querier(ke)).unwrap();
+    let replies = ztimeout!(querier.get().timestamp_instrumentation(Some(instr))).unwrap();
+
+    let query = ztimeout!(queryable.recv_async()).unwrap();
+    let ts_stack = query
+        .timestamp_stack()
+        .expect("timestamp_stack should be Some");
+    assert_eq!(ts_stack.records().len(), 5);
+    assert_record(&ts_stack.records()[0], InterceptionPoint::Send, false);
+    for i in 1..4 {
+        assert_record(&ts_stack.records()[i], InterceptionPoint::Route, false);
+    }
+    assert_record(&ts_stack.records()[4], InterceptionPoint::Receive, false);
+
+    ztimeout!(query.reply(ke, "data")).unwrap();
+    std::mem::drop(query);
+
+    let reply = ztimeout!(replies.recv_async()).unwrap();
+    assert!(reply.result().is_ok());
+
+    test_context.close().await;
+}

--- a/zenoh/tests/timestamp_instrumentation.rs
+++ b/zenoh/tests/timestamp_instrumentation.rs
@@ -85,7 +85,7 @@ fn assert_record(
         InstrumentationTimestamp::Custom(ts_bytes) => {
             assert!(!ts_bytes.is_empty(), "timestamp bytes should not be empty")
         }
-        InstrumentationTimestamp::UHLC(_timestamp) => return,
+        InstrumentationTimestamp::UHLC(_timestamp) => (),
     }
 }
 


### PR DESCRIPTION
## Description
This PR adds the ability to record timestamps on messages along the Zenoh network path, notably to measure latency and identify bottlenecks in Zenoh routing.

### What does this PR do?
Adds `TimestampStack` extension to application messages (Push, Query, Response) and expose API to configure instrumentation and access collected timestamps.

Sister PR for Python bindings: https://github.com/eclipse-zenoh/zenoh-python/pull/739
<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `new feature`

## 🆕 New Feature Requirements

Since this PR adds a new feature:

- [x] **Feature scope documented** - Clear description of what the feature does and why it's needed
- [x] **Minimum necessary code** - Implementation is as simple as possible, doesn't overcomplicate the system
- [x] **New APIs well-designed** - Public APIs are intuitive, consistent with existing APIs
- [x] **Comprehensive tests** - All functionality is tested (happy path + edge cases + error cases)
- [x] **Examples provided** - Usage examples in code comments or separate example files
- [x] **Documentation added** - New docs explaining the feature, its use cases, and API
- [x] **Feature flag considered** - Can the feature be enabled/disabled for gradual rollout?
- [x] **Performance impact assessed** - Memory, CPU, storage implications measured
- [x] **Integration tested** - Feature works with existing features

**Consider:** Can this feature be split into smaller, incremental PRs?

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->