### PR TITLE
chore: remove version for zenoh-test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -253,7 +253,7 @@ zenoh-shm = { version = "=1.9.0", path = "commons/zenoh-shm" }
 zenoh-stats = { version = "=1.9.0", path = "commons/zenoh-stats" }
 zenoh-sync = { version = "=1.9.0", path = "commons/zenoh-sync" }
 zenoh-task = { version = "=1.9.0", path = "commons/zenoh-task" }
-zenoh-test = { version = "=1.9.0", path = "commons/zenoh-test" }
+zenoh-test = { path = "commons/zenoh-test" }
 zenoh-transport = { version = "=1.9.0", path = "io/zenoh-transport", default-features = false }
 zenoh-util = { version = "=1.9.0", path = "commons/zenoh-util" }
 zenoh_backend_traits = { version = "=1.9.0", path = "plugins/zenoh-backend-traits", default-features = false }


### PR DESCRIPTION
## Description
Fix release.yml workflow by setting zenoh-test as a path only dependency.

### What does this PR do?
Remove version key from zenoh-test workspace definition

- zenoh-test is non-publishable and dev-dependency only.
- when the version key is [defined](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#the-role-of-the-version-key) it takes precedence over the path dependency during publication.

### Why is this change needed?
This change avoids the error seen in https://github.com/eclipse-zenoh/zenoh/actions/runs/26425305854/job/77845882170

### Related Issues
https://github.com/eclipse-zenoh/zenoh/pull/2573
https://github.com/eclipse-zenoh/ci/pull/451

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->