### PR TITLE
chore: update release wokflow publication pattern

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
           live-run: ${{ inputs.live-run || false }}
           version: ${{ steps.create-release-branch.outputs.version }}
           branch: ${{ steps.create-release-branch.outputs.branch }}
-          bump-deps-pattern: zenoh.*
+          bump-deps-pattern: "zenoh(?!-test).*"
           bump-deps-version: ${{ steps.create-release-branch.outputs.version }}
           github-token: ${{ secrets.BOT_TOKEN_WORKFLOW }}
 
@@ -91,7 +91,7 @@ jobs:
       repo: ${{ github.repository }}
       live-run: ${{ inputs.live-run || false }}
       branch: ${{ needs.tag.outputs.branch }}
-      unpublished-deps-patterns: "zenoh.*"
+      unpublished-deps-patterns: "zenoh(?!-test).*"
     secrets: inherit
 
   debian:


### PR DESCRIPTION
## Description
remove zenoh-test from the packages that should be bumped and published

### What does this PR do?
Skip zenoh-test from being bumped and released during release.

### Why is this change needed?
Fix https://github.com/eclipse-zenoh/zenoh/actions/runs/26546768518

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->