### PR TITLE
fix(util): avoid panic when parsing a bare "s" duration

### DIFF
--- a/commons/zenoh-util/src/time_range.rs
+++ b/commons/zenoh-util/src/time_range.rs
@@ -427,9 +427,13 @@ fn parse_duration(s: &str) -> Result<f64, ZError> {
     let mut it = s.bytes().enumerate().rev();
     match it.next().unwrap() {
         (i, b'u') => s[..i].parse::<f64>().map(|u| U_TO_SECS * u),
-        (_, b's') => match it.next().unwrap() {
-            (i, b'm') => s[..i].parse::<f64>().map(|ms| MS_TO_SECS * ms),
-            (i, _) => s[..i + 1].parse::<f64>(),
+        (_, b's') => match it.next() {
+            Some((i, b'm')) => s[..i].parse::<f64>().map(|ms| MS_TO_SECS * ms),
+            Some((i, _)) => s[..i + 1].parse::<f64>(),
+            // A bare "s" with no preceding value: behave like the other unit-only
+            // inputs ("u", "m", ...) and return an error instead of panicking on the
+            // exhausted iterator.
+            None => "".parse::<f64>(),
         },
         (i, b'm') => s[..i].parse::<f64>().map(|m| M_TO_SECS * m),
         (i, b'h') => s[..i].parse::<f64>().map(|h| H_TO_SECS * h),
@@ -683,5 +687,22 @@ mod tests {
         assert!(parse_duration("abcd").is_err());
         assert!(parse_duration("4mm").is_err());
         assert!(parse_duration("1h4m").is_err());
+
+        // Unit-only inputs (no numeric part) must all return an error, not panic.
+        // Regression: a bare "s" used to double-`next().unwrap()` an exhausted
+        // iterator and panic while disambiguating "s" from "ms".
+        for unit in ["u", "ms", "s", "m", "h", "d", "w"] {
+            assert!(
+                parse_duration(unit).is_err(),
+                "parse_duration({unit:?}) should be an error, not a panic"
+            );
+        }
+
+        // The same malformed duration reached through the public time DSL must
+        // surface as a parse error rather than a panic.
+        assert!("now(s)".parse::<TimeExpr>().is_err());
+        assert!("now(-s)".parse::<TimeExpr>().is_err());
+        assert!("[now(s)..]".parse::<TimeRange>().is_err());
+        assert!("[1970-01-01T00:00:00Z;s]".parse::<TimeRange>().is_err());
     }
 }

--- a/commons/zenoh-util/src/time_range.rs
+++ b/commons/zenoh-util/src/time_range.rs
@@ -431,8 +431,7 @@ fn parse_duration(s: &str) -> Result<f64, ZError> {
             Some((i, b'm')) => s[..i].parse::<f64>().map(|ms| MS_TO_SECS * ms),
             Some((i, _)) => s[..i + 1].parse::<f64>(),
             // A bare "s" with no preceding value: behave like the other unit-only
-            // inputs ("u", "m", ...) and return an error instead of panicking on the
-            // exhausted iterator.
+            // inputs ("u", "m", ...) and return an error.
             None => "".parse::<f64>(),
         },
         (i, b'm') => s[..i].parse::<f64>().map(|m| M_TO_SECS * m),


### PR DESCRIPTION
## Description

### What does this PR do?

`parse_duration` (in `zenoh-util`'s time DSL) panics on the input `"s"`.

It reads the duration's trailing byte to detect the unit, and for `s` it reads a **second** byte to disambiguate `s` (seconds) from `ms` (milliseconds):

```rust
let mut it = s.bytes().enumerate().rev();
match it.next().unwrap() {                    // guarded by the leading is_empty() check
    ...
    (_, b's') => match it.next().unwrap() {   // <-- second next(): NOT guarded
        (i, b'm') => ... // "ms"
        (i, _)    => ... // "s"
    },
    ...
}
```

The leading `is_empty()` guard only covers the *first* `next()`. The input `"s"` (a unit with no numeric part) exhausts the iterator, so the second `unwrap()` panics with `called Option::unwrap() on a None value`. Every other unit-only input (`"u"`, `"m"`, `"h"`, `"d"`, `"w"`) only calls `next()` once and already returns an `Err`; `"s"` is the only unit that double-consumes.

This change handles the exhausted-iterator case like the other unit-only inputs and returns a parse error instead of panicking. It also extends `test_parse_duration` with all unit-only inputs and end-to-end `TimeExpr`/`TimeRange` cases.

Minimal repro on `main`:

```rust
use zenoh_util::time_range::{TimeExpr, TimeRange};

let _ = "now(s)".parse::<TimeExpr>();      // panics
let _ = "[now(s)..]".parse::<TimeRange>(); // panics
```

### Why is this change needed?

`parse_duration` is reachable from the public time DSL (`TimeExpr` / `TimeRange`), which backs the standardized `_time` selector parameter (`ZenohParameters::time_range()`). That value comes from the querier's selector, so a malformed `_time` (e.g. `_time=[now(s)..]`) is **untrusted input that can panic the parsing side** — both when sending a `get()` (`ConsolidationMode::Auto` reads `time_range()`) and on a queryable/storage that inspects `_time`.

The intent is clearly to fail gracefully: `time_range()` returns `Option<ZResult<TimeRange>>`, i.e. malformed input is supposed to yield an `Err`, not a panic. This follows the same "reject malformed input instead of panicking" direction as recent parsing fixes.

### Related Issues

N/A — found via review of the time-DSL parsing path.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [x] **Reproduction test added** - Test that fails on main branch without the fix
- [x] **Test passes with fix** - The reproduction test passes with your changes
- [x] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->