### PR TITLE
Fix for the deadlock when dropping a Querier with a pending query whose completion callback re-enters the Session

### DIFF
--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -1681,39 +1681,55 @@ impl Session {
     }
 
     pub(crate) fn undeclare_querier_inner(&self, querier_id: Id) -> ZResult<()> {
-        let mut state = zwrite!(self.0.state);
-        let Ok(primitives) = state.primitives() else {
-            return Ok(());
-        };
-        if let Some(querier_state) = state.queriers.remove(&querier_id) {
+        // Everything that needs the state lock happens in this scope. The
+        // removed `QueryState`s (which own the user callbacks, including
+        // completion/drop callbacks) are returned out of the scope so they are
+        // dropped *after* the lock is released: a completion callback that
+        // re-enters the `Session` would otherwise deadlock re-acquiring the lock.
+        let (primitives, remote_id, removed_queries, send_final) = {
+            let mut state = zwrite!(self.0.state);
+            let Ok(primitives) = state.primitives() else {
+                return Ok(());
+            };
+            let Some(querier_state) = state.queriers.remove(&querier_id) else {
+                return Err(zerror!("Unable to find querier").into());
+            };
             trace!("undeclare_querier({:?})", querier_state);
-            // remove all pending queries from this querier
-            state
+            // Remove all pending queries from this querier.
+            let removed_query_ids: Vec<_> = state
                 .queries
-                .retain(|_, q| q.querier_id != Some(querier_id));
-            if querier_state.destination != Locality::SessionLocal {
-                // Note: there might be several queriers on the same KeyExpr.
-                // Before calling forget_queriers(key_expr), check if this was the last one.
-                if !state.queriers.values().any(|p| {
+                .iter()
+                .filter(|(_, q)| q.querier_id == Some(querier_id))
+                .map(|(id, _)| *id)
+                .collect();
+            let removed_queries: Vec<_> = removed_query_ids
+                .into_iter()
+                .filter_map(|id| state.queries.remove(&id))
+                .collect();
+            // Note: there might be several queriers on the same KeyExpr.
+            // Before calling forget_queriers(key_expr), check if this was the last one.
+            let send_final = querier_state.destination != Locality::SessionLocal
+                && !state.queriers.values().any(|p| {
                     p.destination != Locality::SessionLocal
                         && p.remote_id == querier_state.remote_id
-                }) {
-                    drop(state);
-                    primitives.send_interest(&mut Interest {
-                        id: querier_state.remote_id,
-                        mode: InterestMode::Final,
-                        options: InterestOptions::empty(),
-                        wire_expr: None,
-                        ext_qos: interest::ext::QoSType::DEFAULT,
-                        ext_tstamp: None,
-                        ext_nodeid: interest::ext::NodeIdType::DEFAULT,
-                    });
-                }
-            }
-            Ok(())
-        } else {
-            Err(zerror!("Unable to find querier").into())
+                });
+            (primitives, querier_state.remote_id, removed_queries, send_final)
+        };
+        // Lock released. Drop the removed queries (and their callbacks) and send
+        // the final interest without holding the state lock.
+        drop(removed_queries);
+        if send_final {
+            primitives.send_interest(&mut Interest {
+                id: remote_id,
+                mode: InterestMode::Final,
+                options: InterestOptions::empty(),
+                wire_expr: None,
+                ext_qos: interest::ext::QoSType::DEFAULT,
+                ext_tstamp: None,
+                ext_nodeid: interest::ext::NodeIdType::DEFAULT,
+            });
         }
+        Ok(())
     }
 
     fn register_callback_drop_notifier<T>(

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -1688,17 +1688,16 @@ impl Session {
         if let Some(querier_state) = state.queriers.remove(&querier_id) {
             trace!("undeclare_querier({:?})", querier_state);
             // Remove all pending queries from this querier. The removed queries own
-            // the user callbacks (including completion/drop callbacks); they are
-            // dropped at the end of this function, *after* the state lock has been
-            // released below, otherwise a completion callback that re-enters the
-            // `Session` would deadlock re-acquiring the lock.
+            // the user callbacks (including completion/drop callbacks); they must be
+            // dropped *after* the state lock is released below, otherwise a completion
+            // callback that re-enters the `Session` would deadlock re-acquiring the lock.
             let removed_query_ids: Vec<_> = state
                 .queries
                 .iter()
                 .filter(|(_, q)| q.querier_id == Some(querier_id))
                 .map(|(id, _)| *id)
                 .collect();
-            let _removed_queries = removed_query_ids
+            let removed_queries = removed_query_ids
                 .into_iter()
                 .filter_map(|id| state.queries.remove(&id))
                 .collect::<Vec<_>>();
@@ -1710,6 +1709,9 @@ impl Session {
                         && p.remote_id == querier_state.remote_id
                 });
             drop(state);
+            // Lock released: now it is safe to drop the removed queries (and their
+            // callbacks, which may re-enter the `Session`).
+            drop(removed_queries);
             if send_final {
                 primitives.send_interest(&mut Interest {
                     id: querier_state.remote_id,

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -1684,8 +1684,9 @@ impl Session {
         // The pending queries removed below own the user callbacks (including
         // completion/drop callbacks). They must be dropped *after* the state lock
         // is released, otherwise a completion callback that re-enters the
-        // `Session` would deadlock re-acquiring the lock. Declared before `state`
-        // so it is dropped last.
+        // `Session` would deadlock re-acquiring the lock.
+        // "_removed_queries" is specifically declared before `state` so it is dropped after
+        // the lock is released.
         let _removed_queries;
         let mut state = zwrite!(self.0.state);
         let Ok(primitives) = state.primitives() else {

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -1681,19 +1681,17 @@ impl Session {
     }
 
     pub(crate) fn undeclare_querier_inner(&self, querier_id: Id) -> ZResult<()> {
-        // Everything that needs the state lock happens in this scope. The
-        // removed `QueryState`s (which own the user callbacks, including
-        // completion/drop callbacks) are returned out of the scope so they are
-        // dropped *after* the lock is released: a completion callback that
-        // re-enters the `Session` would otherwise deadlock re-acquiring the lock.
-        let (primitives, remote_id, removed_queries, send_final) = {
-            let mut state = zwrite!(self.0.state);
-            let Ok(primitives) = state.primitives() else {
-                return Ok(());
-            };
-            let Some(querier_state) = state.queriers.remove(&querier_id) else {
-                return Err(zerror!("Unable to find querier").into());
-            };
+        // The pending queries removed below own the user callbacks (including
+        // completion/drop callbacks). They must be dropped *after* the state lock
+        // is released, otherwise a completion callback that re-enters the
+        // `Session` would deadlock re-acquiring the lock. Declared before `state`
+        // so it is dropped last.
+        let _removed_queries;
+        let mut state = zwrite!(self.0.state);
+        let Ok(primitives) = state.primitives() else {
+            return Ok(());
+        };
+        if let Some(querier_state) = state.queriers.remove(&querier_id) {
             trace!("undeclare_querier({:?})", querier_state);
             // Remove all pending queries from this querier.
             let removed_query_ids: Vec<_> = state
@@ -1702,39 +1700,33 @@ impl Session {
                 .filter(|(_, q)| q.querier_id == Some(querier_id))
                 .map(|(id, _)| *id)
                 .collect();
-            let removed_queries: Vec<_> = removed_query_ids
+            _removed_queries = removed_query_ids
                 .into_iter()
                 .filter_map(|id| state.queries.remove(&id))
-                .collect();
-            // Note: there might be several queriers on the same KeyExpr.
-            // Before calling forget_queriers(key_expr), check if this was the last one.
-            let send_final = querier_state.destination != Locality::SessionLocal
-                && !state.queriers.values().any(|p| {
+                .collect::<Vec<_>>();
+            if querier_state.destination != Locality::SessionLocal {
+                // Note: there might be several queriers on the same KeyExpr.
+                // Before calling forget_queriers(key_expr), check if this was the last one.
+                if !state.queriers.values().any(|p| {
                     p.destination != Locality::SessionLocal
                         && p.remote_id == querier_state.remote_id
-                });
-            (
-                primitives,
-                querier_state.remote_id,
-                removed_queries,
-                send_final,
-            )
-        };
-        // Lock released. Drop the removed queries (and their callbacks) and send
-        // the final interest without holding the state lock.
-        drop(removed_queries);
-        if send_final {
-            primitives.send_interest(&mut Interest {
-                id: remote_id,
-                mode: InterestMode::Final,
-                options: InterestOptions::empty(),
-                wire_expr: None,
-                ext_qos: interest::ext::QoSType::DEFAULT,
-                ext_tstamp: None,
-                ext_nodeid: interest::ext::NodeIdType::DEFAULT,
-            });
+                }) {
+                    drop(state);
+                    primitives.send_interest(&mut Interest {
+                        id: querier_state.remote_id,
+                        mode: InterestMode::Final,
+                        options: InterestOptions::empty(),
+                        wire_expr: None,
+                        ext_qos: interest::ext::QoSType::DEFAULT,
+                        ext_tstamp: None,
+                        ext_nodeid: interest::ext::NodeIdType::DEFAULT,
+                    });
+                }
+            }
+            Ok(())
+        } else {
+            Err(zerror!("Unable to find querier").into())
         }
-        Ok(())
     }
 
     fn register_callback_drop_notifier<T>(

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -1681,48 +1681,45 @@ impl Session {
     }
 
     pub(crate) fn undeclare_querier_inner(&self, querier_id: Id) -> ZResult<()> {
-        // The pending queries removed below own the user callbacks (including
-        // completion/drop callbacks). They must be dropped *after* the state lock
-        // is released, otherwise a completion callback that re-enters the
-        // `Session` would deadlock re-acquiring the lock.
-        // "_removed_queries" is specifically declared before `state` so it is dropped after
-        // the lock is released.
-        let _removed_queries;
         let mut state = zwrite!(self.0.state);
         let Ok(primitives) = state.primitives() else {
             return Ok(());
         };
         if let Some(querier_state) = state.queriers.remove(&querier_id) {
             trace!("undeclare_querier({:?})", querier_state);
-            // Remove all pending queries from this querier.
+            // Remove all pending queries from this querier. The removed queries own
+            // the user callbacks (including completion/drop callbacks); they are
+            // dropped at the end of this function, *after* the state lock has been
+            // released below, otherwise a completion callback that re-enters the
+            // `Session` would deadlock re-acquiring the lock.
             let removed_query_ids: Vec<_> = state
                 .queries
                 .iter()
                 .filter(|(_, q)| q.querier_id == Some(querier_id))
                 .map(|(id, _)| *id)
                 .collect();
-            _removed_queries = removed_query_ids
+            let _removed_queries = removed_query_ids
                 .into_iter()
                 .filter_map(|id| state.queries.remove(&id))
                 .collect::<Vec<_>>();
-            if querier_state.destination != Locality::SessionLocal {
-                // Note: there might be several queriers on the same KeyExpr.
-                // Before calling forget_queriers(key_expr), check if this was the last one.
-                if !state.queriers.values().any(|p| {
+            // Note: there might be several queriers on the same KeyExpr.
+            // Before calling forget_queriers(key_expr), check if this was the last one.
+            let send_final = querier_state.destination != Locality::SessionLocal
+                && !state.queriers.values().any(|p| {
                     p.destination != Locality::SessionLocal
                         && p.remote_id == querier_state.remote_id
-                }) {
-                    drop(state);
-                    primitives.send_interest(&mut Interest {
-                        id: querier_state.remote_id,
-                        mode: InterestMode::Final,
-                        options: InterestOptions::empty(),
-                        wire_expr: None,
-                        ext_qos: interest::ext::QoSType::DEFAULT,
-                        ext_tstamp: None,
-                        ext_nodeid: interest::ext::NodeIdType::DEFAULT,
-                    });
-                }
+                });
+            drop(state);
+            if send_final {
+                primitives.send_interest(&mut Interest {
+                    id: querier_state.remote_id,
+                    mode: InterestMode::Final,
+                    options: InterestOptions::empty(),
+                    wire_expr: None,
+                    ext_qos: interest::ext::QoSType::DEFAULT,
+                    ext_tstamp: None,
+                    ext_nodeid: interest::ext::NodeIdType::DEFAULT,
+                });
             }
             Ok(())
         } else {

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -1713,7 +1713,12 @@ impl Session {
                     p.destination != Locality::SessionLocal
                         && p.remote_id == querier_state.remote_id
                 });
-            (primitives, querier_state.remote_id, removed_queries, send_final)
+            (
+                primitives,
+                querier_state.remote_id,
+                removed_queries,
+                send_final,
+            )
         };
         // Lock released. Drop the removed queries (and their callbacks) and send
         // the final interest without holding the state lock.

--- a/zenoh/tests/session.rs
+++ b/zenoh/tests/session.rs
@@ -359,6 +359,54 @@ async fn test_undeclare_subscribers_same_keyexpr() {
     ztimeout!(sub2.undeclare()).unwrap();
 }
 
+/// Regression test: dropping a `Querier` while one of its queries is still
+/// pending must not deadlock, even if the query's completion (drop) callback
+/// re-enters the `Session`.
+///
+/// The querier destructor removes the pending query; the query's callback (and
+/// thus its completion callback) must be dropped *without* holding the session
+/// state lock, otherwise re-entering the `Session` from the completion callback
+/// deadlocks.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_querier_drop_pending_query_completion_callback_reentrancy() {
+    use std::sync::Mutex;
+
+    use zenoh::{handlers::CallbackDrop, query::Reply, Wait};
+
+    let key_expr = "test/querier/drop/pending/completion";
+    let session = zenoh::open(zenoh::Config::default()).await.unwrap();
+
+    // Queryable that keeps queries pending forever (never replies), so the
+    // query is still in flight when the querier is dropped.
+    let held: Arc<Mutex<Vec<zenoh::query::Query>>> = Arc::new(Mutex::new(Vec::new()));
+    let c_held = held.clone();
+    let _queryable = ztimeout!(session
+        .declare_queryable(key_expr)
+        .callback(move |q| c_held.lock().unwrap().push(q)))
+    .unwrap();
+
+    let querier = ztimeout!(session.declare_querier(key_expr)).unwrap();
+
+    // The query's completion callback re-enters the Session via `put`.
+    let c_session = session.clone();
+    ztimeout!(querier.get().with(CallbackDrop {
+        callback: |_reply: Reply| {},
+        drop: move || {
+            c_session.put(key_expr, "done").wait().unwrap();
+        },
+    }))
+    .unwrap();
+
+    // Give the query time to reach the queryable and become pending.
+    tokio::time::sleep(SLEEP).await;
+    
+    // Drop the querier.
+    drop(querier);
+
+    // Release the held queries.
+    held.lock().unwrap().clear();
+}
+
 #[cfg(feature = "internal")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_session_from_cloned_config() {

--- a/zenoh/tests/session.rs
+++ b/zenoh/tests/session.rs
@@ -399,7 +399,7 @@ async fn test_querier_drop_pending_query_completion_callback_reentrancy() {
 
     // Give the query time to reach the queryable and become pending.
     tokio::time::sleep(SLEEP).await;
-    
+
     // Drop the querier.
     drop(querier);
 


### PR DESCRIPTION
See the issue I raised in https://github.com/eclipse-zenoh/zenoh/issues/2634.

## Issue
Dropping a Querier (or calling Querier::undeclare()) while one of its queries is still in flight deadlocks if the query's handler has a completion/drop callback that calls back into the same Session.

The querier destructor removes the pending query while holding the session state write lock. This drops the query's callback inline, which runs the completion callback, and that callback tries to re-acquire the same lock on the same thread → self-deadlock (std::sync::RwLock is non-reentrant).

## Fix

Move the destruction of the queries outside of the lock in `undeclare_querier_inner`.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [x] **Reproduction test added** - Test that fails on main branch without the fix
- [x] **Test passes with fix** - The reproduction test passes with your changes
- [x] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->