### PR TITLE
Fix missing face transport stats

### DIFF
--- a/zenoh/src/net/routing/dispatcher/face.rs
+++ b/zenoh/src/net/routing/dispatcher/face.rs
@@ -207,6 +207,11 @@ impl FaceStateBuilder {
     }
 
     pub(crate) fn build(self) -> FaceState {
+        #[cfg(feature = "stats")]
+        debug_assert!(
+            self.0.is_local || self.0.stats.is_some(),
+            "non-local faces must be built with transport stats"
+        );
         self.0
     }
 }

--- a/zenoh/src/net/routing/gateway.rs
+++ b/zenoh/src/net/routing/gateway.rs
@@ -279,6 +279,9 @@ impl Gateway {
         let ingress = Arc::new(ArcSwapOption::new(InterceptorsChain::empty().into()));
         let mux = Arc::new(Mux::new(transport.clone(), InterceptorsChain::empty()));
 
+        #[cfg(feature = "stats")]
+        let stats = transport.get_stats().ok();
+
         let newface = tables
             .data
             .faces
@@ -294,6 +297,15 @@ impl Gateway {
                 )
                 .whatami(whatami)
                 .ingress_interceptors(ingress.clone());
+
+                #[cfg(feature = "stats")]
+                let builder = {
+                    if let Some(stats) = stats {
+                        builder.stats(stats)
+                    } else {
+                        builder
+                    }
+                };
 
                 Arc::new(builder.build())
             })


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->

Set face state stats in `new_transport_unicast`.

### Why is this change needed?
<!-- Explain the motivation or problem being solved -->

This is a regression due to #2096 and leads to missing (per-key) metrics in `@/<zid>/<mode>/metrics`.

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

N/A

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [ ] **Reproduction test added** - Test that fails on main branch without the fix
- [ ] **Test passes with fix** - The reproduction test passes with your changes
- [x] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->