### PR TITLE
fix: don't park the ctrl_lock holder on StartConditions notifications under peer churn

### DIFF
--- a/zenoh/src/net/protocol/gossip.rs
+++ b/zenoh/src/net/protocol/gossip.rs
@@ -409,11 +409,13 @@ impl Gossip {
             }
         }
         if (!self.wait_declares) || src_whatami != WhatAmI::Peer {
-            zenoh_runtime::ZRuntime::Net.block_in_place(
-                strong_runtime
-                    .start_conditions()
-                    .terminate_peer_connector_zid(src),
-            );
+            // Spawned, not `block_in_place`-ed: `link_states` runs under the
+            // routing `ctrl_lock`, and parking the lock holder deadlocks under
+            // peer churn.
+            let start_conditions = strong_runtime.start_conditions().clone();
+            zenoh_runtime::ZRuntime::Net.spawn(async move {
+                start_conditions.terminate_peer_connector_zid(src).await;
+            });
         }
     }
 

--- a/zenoh/src/net/routing/hat/peer/interests.rs
+++ b/zenoh/src/net/routing/hat/peer/interests.rs
@@ -280,17 +280,22 @@ impl HatInterestTrait for Hat {
                 return Noop;
             }
 
-            zenoh_runtime::ZRuntime::Net.block_in_place(async move {
-                if let Some(runtime) = &ctx.tables.runtime {
-                    if let Some(runtime) = runtime.upgrade() {
-                        tracing::debug!("Terminating peer connector");
-                        runtime
-                            .start_conditions()
-                            .terminate_peer_connector_zid(ctx.src_face.zid)
-                            .await
-                    }
-                }
-            });
+            // Spawned, not `block_in_place`-ed: this runs under the routing
+            // `ctrl_lock`, and parking the lock holder deadlocks under peer
+            // churn.
+            let start_conditions = ctx
+                .tables
+                .runtime
+                .as_ref()
+                .and_then(|runtime| runtime.upgrade())
+                .map(|runtime| runtime.start_conditions().clone());
+            let zid = ctx.src_face.zid;
+            if let Some(start_conditions) = start_conditions {
+                zenoh_runtime::ZRuntime::Net.spawn(async move {
+                    tracing::debug!("Terminating peer connector");
+                    start_conditions.terminate_peer_connector_zid(zid).await;
+                });
+            }
 
             Noop
         } else {


### PR DESCRIPTION
Closes [#2581](https://github.com/eclipse-zenoh/zenoh/issues/2581)

## What happens

In peer mode with gossip autoconnect, the routing layer can deadlock permanently
when sessions open and close while other peers are connecting. A long-lived
publisher then stalls forever in `put().wait()` (the symptom reported in #2581),
and every other operation that touches routing (declares, accepts, OAM handling,
session close) wedges behind it. In debug builds the same race can instead
poison the routing `ctrl_lock` and turn every rx callback into a `PoisonError`
panic cascade from `demux.rs`.

## Root cause

Two call sites notify `StartConditions` that a peer connector has terminated by
running `terminate_peer_connector_zid` through `ZRuntime::Net.block_in_place(..)`:

- `hat::peer::interests::route_declare_final` (initial-interest finalization),
  reached under the routing `ctrl_lock` via `Face::send_declare`
- the tail of `gossip::link_states`, reached under the routing `ctrl_lock` via
  OAM handling in `DeMux::handle_message`

`block_in_place` parks the calling thread until the future completes, so in both
cases a thread **holding `ctrl_lock` goes to sleep** waiting on the
`StartConditions::peer_connectors` tokio mutex. That closes a cycle, captured
live with `gdb thread apply all bt` on a hung process:

1. An rx thread handles a `DeclareFinal`, takes `ctrl_lock` in
   `Face::send_declare`, and parks in
   `block_in_place(terminate_peer_connector_zid(..))`, waiting on the
   `StartConditions` mutex.
2. The Net runtime's only worker (`worker_threads = 1` by default) runs a gossip
   autoconnect task (`link_states` -> `connect_peer` ->
   `Gateway::new_transport_unicast`) that blocks synchronously on the same
   `ctrl_lock`.
3. With the Net worker wedged, tasks queued on the `StartConditions` mutex are
   never polled again, so the mutex never frees, the rx thread in (1) never
   wakes, and `ctrl_lock` is never released.

## Fix

Spawn the notification on the Net runtime instead of blocking on it.
`terminate_peer_connector_zid` returns nothing and its only effect is to mark
the connector terminated and possibly `notify_one()` a waiting `open()`, so
deferring it by one task-schedule is semantically equivalent. The call already
raced with `add_peer_connector_zid` across threads (terminate-before-add inserts
an already-terminated entry), so the reordering introduces no new interleavings.
With no thread parked while holding `ctrl_lock`, the cycle cannot form.

## Validation

Reproduced with a stress setup that repeatedly opens ~20 short-lived peer
sessions (declaring queryables and issuing queries) against a router while a
publisher streams at 5 kHz, all sessions gossip-linked. Unpatched, it deadlocked
within ~23 iterations on a 24-core Linux machine; patched, 150 iterations across
2/4/8/24-CPU affinities plus repeated full-suite runs completed with zero hangs
and zero panics. The reproducer from #2581 (`z_p2p_declare_final_stress`)
exercises the same churn pattern.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [ ] **Root cause documented** - Explain what caused the bug in the PR description
- [ ] **Reproduction test added** - Test that fails on main branch without the fix
- [ ] **Test passes with fix** - The reproduction test passes with your changes
- [ ] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [ ] **Fix is minimal** - Changes are focused only on fixing the bug
- [ ] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->