### PR TITLE
Correct typo in examples link

### DIFF
--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -97,7 +97,7 @@
 //! # Usage examples
 //!
 //! Below are basic examples of using Zenoh. More examples are available in the documentation for each module and in
-//! [zenoh-examples](https://github.com/zenoh-io/zenoh/tree/main/examples).
+//! [zenoh-examples](https://github.com/eclipse-zenoh/zenoh/tree/main/examples).
 //!
 //! ## Publishing/Subscribing
 //! The example below shows how to publish and subscribe to data using Zenoh.


### PR DESCRIPTION
## Description

The examples link in the lib.rs is outdated.

### What does this PR do?

The examples link in the lib.rs points to the correct location on github.

### Why is this change needed?

The examples link is broken.

### Related Issues

None that I am aware of.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `documentation`

## 📚 Documentation Update Requirements

Since this PR updates documentation:

- [ ] **Accuracy verified** - Technical details are correct
- [ ] **Examples tested** - Code examples actually work
- [ ] **Links valid** - All links work and point to correct versions
- [ ] **Grammar/spelling** - Text is clear and well-written
- [ ] **Formatting correct** - Markdown/formatting renders properly
- [ ] **Up-to-date** - Reflects current codebase state

**Suggestion:** Have someone unfamiliar with the feature review for clarity.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->