### PR TITLE
Add `test_complete_queryable_failover`

### DIFF
--- a/zenoh/src/net/tests/regions/adminspace.rs
+++ b/zenoh/src/net/tests/regions/adminspace.rs
@@ -19,7 +19,10 @@ use std::collections::HashSet;
 use zenoh_buffers::buffer::SplitBuffer;
 use zenoh_protocol::{
     core::{Region, WhatAmI},
-    network::interest::{InterestMode, InterestOptions},
+    network::{
+        declare::queryable::ext::QueryableInfoType,
+        interest::{InterestMode, InterestOptions},
+    },
     zenoh::{PushBody, ResponseBody},
 };
 
@@ -60,7 +63,12 @@ fn test_sourced_entities_and_interests(mode: WhatAmI) {
 
     for (prefix, face) in [("g", &g), ("s", &s), ("c", &c), ("p", &p)] {
         face.declare_subscriber(None, 1, format!("{prefix}/subscriber"));
-        face.declare_queryable(None, 1, format!("{prefix}/queryable"));
+        face.declare_queryable(
+            None,
+            1,
+            format!("{prefix}/queryable"),
+            QueryableInfoType::DEFAULT,
+        );
         face.declare_token(None, 1, format!("{prefix}/token"));
         face.interest(
             1,

--- a/zenoh/src/net/tests/regions/declare.rs
+++ b/zenoh/src/net/tests/regions/declare.rs
@@ -16,7 +16,7 @@
 
 use zenoh_protocol::{
     core::{Bound, Region, WhatAmI, WireExpr},
-    network::Mapping,
+    network::{declare::queryable::ext::QueryableInfoType, Mapping},
 };
 
 use super::{
@@ -315,9 +315,10 @@ fn test_duplicate_queryable_undeclaration() {
             suffix: "".into(),
             mapping: Mapping::Sender,
         },
+        QueryableInfoType::DEFAULT,
     );
 
-    c0.declare_queryable(None, 2, "k");
+    c0.declare_queryable(None, 2, "k", QueryableInfoType::DEFAULT);
 
     c0.undeclare_queryable(1);
 

--- a/zenoh/src/net/tests/regions/forwarding.rs
+++ b/zenoh/src/net/tests/regions/forwarding.rs
@@ -18,6 +18,7 @@
 use zenoh_protocol::{
     core::{Bound, Region, Reliability, WhatAmI, WireExpr},
     network::{
+        declare::queryable::ext::QueryableInfoType,
         interest::{InterestMode, InterestOptions},
         Mapping, Push,
     },
@@ -111,8 +112,8 @@ fn test_p2p_inter_subregion_query_routing() {
 
     let ke = "k";
 
-    p0.declare_queryable(None, 1, ke);
-    p1.declare_queryable(None, 1, ke);
+    p0.declare_queryable(None, 1, ke, QueryableInfoType::DEFAULT);
+    p1.declare_queryable(None, 1, ke, QueryableInfoType::DEFAULT);
 
     p0.query(1, ke);
     p1.query(1, ke);
@@ -249,8 +250,8 @@ fn test_r2r_inter_subregion_query_routing() {
 
     let ke = "k";
 
-    r0s.declare_queryable(None, 1, ke);
-    r1s.declare_queryable(None, 1, ke);
+    r0s.declare_queryable(None, 1, ke, QueryableInfoType::DEFAULT);
+    r1s.declare_queryable(None, 1, ke, QueryableInfoType::DEFAULT);
     bi_fwd_all();
 
     r0s.query(1, ke);
@@ -323,8 +324,8 @@ fn test_c2c_inter_subregion_query_routing() {
 
     let ke = "k";
 
-    c0.declare_queryable(None, 1, ke);
-    c1.declare_queryable(None, 1, ke);
+    c0.declare_queryable(None, 1, ke, QueryableInfoType::DEFAULT);
+    c1.declare_queryable(None, 1, ke, QueryableInfoType::DEFAULT);
 
     c0.query(1, ke);
     c1.query(1, ke);
@@ -491,7 +492,7 @@ fn test_multiple_gateways_query_routing_r2p_downstream() {
 
     let ke = "k";
 
-    ps.declare_queryable(None, 1, ke);
+    ps.declare_queryable(None, 1, ke, QueryableInfoType::DEFAULT);
     bi_fwd_all();
 
     rs.query(1, ke);
@@ -667,7 +668,7 @@ fn test_multiple_gateways_query_routing_r2r_downstream() {
 
     let ke = "k";
 
-    ss.declare_queryable(None, 1, ke);
+    ss.declare_queryable(None, 1, ke, QueryableInfoType::DEFAULT);
     bi_fwd_all();
 
     ns.query(1, ke);
@@ -934,7 +935,7 @@ fn test_multiple_gateways_query_routing_p2r_upstream() {
 
     let ke = "k";
 
-    rs.declare_queryable(None, 1, ke);
+    rs.declare_queryable(None, 1, ke, QueryableInfoType::DEFAULT);
     bi_fwd_all();
 
     // The peer routes the query upstream unconditionally without having sent an interest.
@@ -1021,7 +1022,7 @@ fn test_multiple_gateways_query_routing_p2r_upstream_with_interest() {
 
     let ke = "k";
 
-    rs.declare_queryable(None, 1, ke);
+    rs.declare_queryable(None, 1, ke, QueryableInfoType::DEFAULT);
     bi_fwd_all();
 
     ps.interest(
@@ -1201,7 +1202,7 @@ fn test_multiple_gateways_query_routing_r2r_upstream() {
 
     let ke = "k";
 
-    ns.declare_queryable(None, 1, ke);
+    ns.declare_queryable(None, 1, ke, QueryableInfoType::DEFAULT);
     bi_fwd_all();
 
     ss.query(1, ke);
@@ -1394,7 +1395,7 @@ fn test_multiple_gateways_query_routing_p2p_downstream() {
 
     let ke = "k";
 
-    ss.declare_queryable(None, 1, ke);
+    ss.declare_queryable(None, 1, ke, QueryableInfoType::DEFAULT);
     bi_fwd_all();
 
     ns.query(1, ke);
@@ -1693,7 +1694,7 @@ fn test_multiple_gateways_query_routing_p2p_upstream() {
 
     let ke = "k";
 
-    ns.declare_queryable(None, 1, ke);
+    ns.declare_queryable(None, 1, ke, QueryableInfoType::DEFAULT);
     bi_fwd_all();
 
     ss.query(1, ke);
@@ -1790,7 +1791,7 @@ fn test_multiple_gateways_query_routing_p2p_upstream_with_interest() {
 
     let ke = "k";
 
-    ns.declare_queryable(None, 1, ke);
+    ns.declare_queryable(None, 1, ke, QueryableInfoType::DEFAULT);
     bi_fwd_all();
 
     ss.interest(
@@ -1985,7 +1986,7 @@ fn test_multiple_gateways_query_routing_r2r_upstream_gateway_source() {
 
     let ke = "k";
 
-    ns.declare_queryable(None, 1, ke);
+    ns.declare_queryable(None, 1, ke, QueryableInfoType::DEFAULT);
     bi_fwd_all();
 
     g1s.query(1, ke);
@@ -2045,4 +2046,105 @@ fn test_push_message_consumption() {
         push, push_clone,
         "the push message should not be modified as `consume` is false"
     );
+}
+
+/// Test that query routes in router networks are disabled even if queryable info doesn't change upon some queryable undeclaration.
+#[test]
+fn test_complete_queryable_failover() {
+    let r0 = HarnessBuilder::new()
+        .mode(WhatAmI::Router)
+        .subregions([Region::Local])
+        .start_runtime(true)
+        .build();
+
+    let r1 = HarnessBuilder::new()
+        .mode(WhatAmI::Router)
+        .subregions([Region::Local])
+        .start_runtime(true)
+        .build();
+
+    let r2 = HarnessBuilder::new()
+        .mode(WhatAmI::Router)
+        .subregions([Region::Local])
+        .start_runtime(true)
+        .build();
+
+    let mut r0_r1 = Connection {
+        a: &r0,
+        a2b: FaceDef::default().mode(WhatAmI::Router),
+        b: &r1,
+        b2a: FaceDef::default().mode(WhatAmI::Router),
+    }
+    .establish();
+
+    let mut r0_r2 = Connection {
+        a: &r0,
+        a2b: FaceDef::default().mode(WhatAmI::Router),
+        b: &r2,
+        b2a: FaceDef::default().mode(WhatAmI::Router),
+    }
+    .establish();
+
+    let mut bi_fwd_all = || {
+        EstablishedConnection::bi_fwd_many_unbounded([&mut r0_r1, &mut r0_r2]);
+        assert!(r0_r1.is_bi_complete());
+        assert!(r0_r2.is_bi_complete());
+    };
+
+    bi_fwd_all();
+
+    let s0 = r0.new_session();
+    let s1 = r1.new_session();
+    let s2 = r2.new_session();
+
+    let ke = "k";
+
+    s1.declare_queryable(
+        None,
+        1,
+        ke,
+        QueryableInfoType {
+            complete: true,
+            distance: 0,
+        },
+    );
+
+    s2.declare_queryable(
+        None,
+        1,
+        ke,
+        QueryableInfoType {
+            complete: true,
+            distance: 0,
+        },
+    );
+
+    bi_fwd_all();
+
+    s0.query(1, ke);
+
+    bi_fwd_all();
+
+    let is_reqs1_empty = s1.recorder().requests().is_empty();
+    let is_reqs2_empty = s2.recorder().requests().is_empty();
+
+    assert!(
+        is_reqs1_empty || is_reqs2_empty,
+        "exactly one queryable should receive the query"
+    );
+
+    if !is_reqs1_empty {
+        s1.undeclare_queryable(1);
+    } else {
+        s2.undeclare_queryable(1);
+    }
+
+    bi_fwd_all();
+
+    s0.query(2, ke);
+
+    bi_fwd_all();
+
+    assert_eq!(r0_r1.a2b.recorder().requests().len(), 1);
+    assert_eq!(r0_r2.a2b.recorder().requests().len(), 1);
 }

--- a/zenoh/src/net/tests/regions/interest.rs
+++ b/zenoh/src/net/tests/regions/interest.rs
@@ -17,7 +17,7 @@
 use zenoh_protocol::{
     core::{Bound, Region, WhatAmI},
     network::{
-        declare::{DeclareToken, TokenId},
+        declare::{queryable::ext::QueryableInfoType, DeclareToken, TokenId},
         interest::{InterestMode, InterestOptions},
     },
 };
@@ -233,7 +233,7 @@ fn test_current_future_interest_propagation_on_open(north: WhatAmI, south: WhatA
     assert_eq!(n.recorder().interests().len(), 1);
     assert_eq!(s.recorder().queryables().len(), 0);
 
-    n.declare_queryable(Some(42), 1999, "k");
+    n.declare_queryable(Some(42), 1999, "k", QueryableInfoType::DEFAULT);
 
     assert_eq!(s.recorder().queryables().len(), 1);
 }

--- a/zenoh/src/net/tests/regions/mod.rs
+++ b/zenoh/src/net/tests/regions/mod.rs
@@ -43,7 +43,7 @@ use zenoh_protocol::{
     network::{
         declare::{
             common::ext::WireExprType,
-            queryable::{QueryableId, UndeclareQueryable},
+            queryable::{ext::QueryableInfoType, QueryableId, UndeclareQueryable},
             subscriber::{SubscriberId, UndeclareSubscriber},
             token::{TokenId, UndeclareToken},
             DeclareQueryable, DeclareSubscriber, DeclareToken,
@@ -601,8 +601,8 @@ impl MockFace {
         interest_id: Option<InterestId>,
         id: QueryableId,
         wire_expr: impl Into<WireExpr<'static>>,
+        info: QueryableInfoType,
     ) {
-        use zenoh_protocol::network::declare::queryable::ext::QueryableInfoType;
         self.face.send_declare(&mut Declare {
             interest_id,
             ext_qos: ext::QoSType::DECLARE,
@@ -611,7 +611,7 @@ impl MockFace {
             body: DeclareBody::DeclareQueryable(DeclareQueryable {
                 id,
                 wire_expr: wire_expr.into(),
-                ext_info: QueryableInfoType::DEFAULT,
+                ext_info: info,
             }),
         });
     }


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->

This is a regression test for a routing bug: query routes are not disabled up queryable declarations that leave info unchanged. For example, one out of two complete queryables may be undeclared yet the gateway keeps routes that point to the old queryable only because all queryables for resource in question reduce to the same complete queryable.

### Why is this change needed?
<!-- Explain the motivation or problem being solved -->

The bugfix is relatively obvious: add `UnregisterEntityResult::DisableRoutes` and handle it accordingly in the dispatcher.

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

TBD

cc @OlivierHecart.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

**No specific label requirements detected.**

Current labels: _No labels_

Add one of these labels to this PR to see relevant checklist items: `api-sync`, `breaking-change`, `bug`, `ci`, `dependencies`, `documentation`, `enhancement`, `new feature`, `internal`

*This section updates automatically when labels change.*

<!-- 🏷️ Label-Based Checklist END -->