### PR TITLE
Reexport EndPoints in zenoh::config

### DIFF
--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -1009,7 +1009,7 @@ pub mod time {
 /// let session = zenoh::open(config).await.unwrap();
 /// # }
 pub mod config {
-    pub use zenoh_config::{EndPoint, Locator, WhatAmI, WhatAmIMatcher, ZenohId};
+    pub use zenoh_config::{EndPoint, EndPoints, Locator, WhatAmI, WhatAmIMatcher, ZenohId};
 
     pub use crate::api::config::Config;
     #[zenoh_macros::unstable]


### PR DESCRIPTION
https://github.com/eclipse-zenoh/zenoh/pull/2320 introduces the public Endpoints type in zenoh_config but this type was not reexported in zenoh::config like other config public types. This PR fixes that.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->