### PR TITLE
Update stabby and don't pin it.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,9 +3400,9 @@ dependencies = [
 
 [[package]]
 name = "stabby"
-version = "72.1.2"
+version = "72.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9e9da673d4db1d470fa36cf4483ad5b1fdea349a392d400fea5d3673a9c5ca"
+checksum = "a7b834ec7ced12095fea1e4b07dcb7e8cf2b59b18afa3eac52494d835965a5ec"
 dependencies = [
  "rustversion",
  "stabby-abi",
@@ -3410,9 +3410,9 @@ dependencies = [
 
 [[package]]
 name = "stabby-abi"
-version = "72.1.2"
+version = "72.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a281b17b3cf11531b7dc4e5f1c6be27db86a06e19c477e7a88fa4ee1b6daf3"
+checksum = "ff1a4f477858a5bdf927c9fab7f579899de9b13e39f8b3b3b300c89fbab632f4"
 dependencies = [
  "rustc_version",
  "rustversion",
@@ -3422,15 +3422,14 @@ dependencies = [
 
 [[package]]
 name = "stabby-macros"
-version = "72.1.2"
+version = "72.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "605b39114a0c132d77ffdd7d179491323dbaa8369e7dcbcdf3da09d0b43c13cf"
+checksum = "b31c4b2434980b67ad83f300a58088ba14d59454dcd79ba3d87419bbd924d31e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "rand 0.8.5",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,7 +176,7 @@ sha3 = "0.10.8"
 shellexpand = "3.1.1"
 smallvec = "1.15.1"
 socket2 = { version = "0.5.7", features = ["all"] }
-stabby = "72.1.2"
+stabby = "72.1.8"
 static_assertions = "1.1.0"
 static_init = "1.0.3"
 stop-token = "0.7.0"

--- a/commons/zenoh-pinned-deps-1-75/Cargo.toml
+++ b/commons/zenoh-pinned-deps-1-75/Cargo.toml
@@ -53,7 +53,6 @@ rustc-hash = "=2.1.1"
 serde_spanned = "=1.0.1"
 serde_with = "=3.14.1"
 serde_with_macros = "=3.14.1"
-stabby-macros = "=72.1.2"
 static_init = "=1.0.3"
 tempfile = "=3.24.0"
 thread-priority = "=1.2.0"
@@ -103,7 +102,6 @@ ignored = [
   "serde_spanned",
   "serde_with",
   "serde_with_macros",
-  "stabby-macros",
   "static_init",
   "tempfile",
   "thread-priority",


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->
We pinned the stabby in the PR.
https://github.com/eclipse-zenoh/zenoh/pull/2639
But now stabby is [compatible with 1.75](https://github.com/ZettaScaleLabs/stabby/pull/133#issuecomment-4680393434), so we can unpin and update the version

### What does this PR do?
<!-- Describe the changes and their purpose -->
Update stabby

### Why is this change needed?
<!-- Explain the motivation or problem being solved -->
Avoid build failure when running cargo update

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->
None

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->