### PR TITLE
fix: skip write subscription for read-only storages in storage_manager

### DIFF
--- a/plugins/zenoh-backend-example/src/lib.rs
+++ b/plugins/zenoh-backend-example/src/lib.rs
@@ -70,6 +70,7 @@ impl Volume for ExampleBackend {
         Capability {
             persistence: Persistence::Volatile,
             history: History::Latest,
+            read_only: false,
         }
     }
     async fn create_storage(&self, _props: StorageConfig) -> ZResult<Box<dyn Storage>> {

--- a/plugins/zenoh-backend-traits/src/lib.rs
+++ b/plugins/zenoh-backend-traits/src/lib.rs
@@ -73,6 +73,7 @@
 //!         Capability{
 //!             persistence: Persistence::Volatile,
 //!             history: History::Latest,
+//!             read_only: false,
 //!         }
 //!     }
 //!
@@ -159,6 +160,8 @@ const FEATURES: &str =
 pub struct Capability {
     pub persistence: Persistence,
     pub history: History,
+    /// Read-only storages serve reads (queries) but ignore incoming writes/samples.
+    pub read_only: bool,
 }
 
 /// Persistence is the guarantee expected from a storage in case of failures
@@ -263,4 +266,20 @@ pub trait Storage: Send + Sync {
     /// The latest Timestamp corresponding to each key is either the timestamp of the delete or put whichever is the latest.
     /// Remember to fetch the entry corresponding to the `None` key
     async fn get_all_entries(&self) -> ZResult<Vec<(Option<OwnedKeyExpr>, Timestamp)>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Capability, History, Persistence};
+
+    #[test]
+    fn read_only_defaults_to_false_for_writable_backends() {
+        let capability = Capability {
+            persistence: Persistence::Volatile,
+            history: History::Latest,
+            read_only: false,
+        };
+
+        assert!(!capability.read_only);
+    }
 }

--- a/plugins/zenoh-backend-traits/src/lib.rs
+++ b/plugins/zenoh-backend-traits/src/lib.rs
@@ -161,6 +161,16 @@ pub struct Capability {
     pub persistence: Persistence,
     pub history: History,
     /// Read-only storages serve reads (queries) but ignore incoming writes/samples.
+    ///
+    /// When `true`, the storage manager does not declare a write subscriber for the
+    /// storage, so samples published on its key expression are never dispatched to the
+    /// backend (which would otherwise trigger a guaranteed-to-fail `put`). The queryable
+    /// is still declared, so reads keep working.
+    ///
+    /// Backends report this through [`Volume::get_capability`]. A backend whose
+    /// read-only mode is configured per-storage should determine the value when the
+    /// storage is created and reflect it here. Defaults to `false`, preserving the
+    /// previous write-subscribing behavior for existing backends.
     pub read_only: bool,
 }
 

--- a/plugins/zenoh-backend-traits/src/lib.rs
+++ b/plugins/zenoh-backend-traits/src/lib.rs
@@ -240,6 +240,17 @@ pub trait Storage: Send + Sync {
     /// on the administration space for this storage.
     fn get_admin_status(&self) -> JsonValue;
 
+    /// Returns capability overrides for this specific storage instance, if any.
+    ///
+    /// Returns `None` by default, meaning the storage inherits its volume's
+    /// [`Capability`] as reported by [`Volume::get_capability`]. Backends whose
+    /// capability depends on per-storage configuration (for example a read-only
+    /// flag set in the storage's volume config) can override this to report the
+    /// effective capability for the created storage.
+    fn capability(&self) -> Option<Capability> {
+        None
+    }
+
     /// Function called for each incoming data ([`Sample`](zenoh::sample::Sample)) to be stored in this storage.
     /// A key can be `None` if it matches the `strip_prefix` exactly.
     /// In order to avoid data loss, the storage must store the `value` and `timestamp` associated with the `None` key

--- a/plugins/zenoh-backend-traits/src/lib.rs
+++ b/plugins/zenoh-backend-traits/src/lib.rs
@@ -156,7 +156,7 @@ const FEATURES: &str =
 
 /// Capability of a storage indicates the guarantees of the storage
 /// It is used by the storage manager to take decisions on the trade-offs to ensure correct performance
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Capability {
     pub persistence: Persistence,
     pub history: History,
@@ -179,8 +179,9 @@ pub struct Capability {
 /// This will include also persisting the metadata that Zenoh stores for the updates.
 /// If a storage is marked Persistent::Volatile, the storage will not have any guarantees on its content after a crash.
 /// This option should be used only if the storage is considered to function as a cache.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum Persistence {
+    #[default]
     Volatile, //default
     Durable,
 }
@@ -188,8 +189,9 @@ pub enum Persistence {
 /// History is the number of values that the backend is expected to save per key
 /// History::Latest saves only the latest value per key
 /// History::All saves all the values including historical values
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum History {
+    #[default]
     Latest, //default
     All,
 }
@@ -301,6 +303,18 @@ mod tests {
             read_only: false,
         };
 
+        assert!(!capability.read_only);
+    }
+
+    #[test]
+    fn capability_default_is_writable() {
+        // Backends can build a Capability from defaults and only override what
+        // they need (e.g. `Capability { read_only: true, ..Default::default() }`),
+        // which keeps adding capability fields source-compatible.
+        let capability = Capability::default();
+
+        assert_eq!(capability.persistence, Persistence::Volatile);
+        assert_eq!(capability.history, History::Latest);
         assert!(!capability.read_only);
     }
 }

--- a/plugins/zenoh-plugin-storage-manager/src/memory_backend/mod.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/memory_backend/mod.rs
@@ -59,6 +59,7 @@ impl Volume for MemoryBackend {
         Capability {
             persistence: Persistence::Volatile,
             history: History::Latest,
+            read_only: false,
         }
     }
 

--- a/plugins/zenoh-plugin-storage-manager/src/storages_mgt/mod.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/storages_mgt/mod.rs
@@ -83,6 +83,12 @@ pub(crate) async fn create_and_start_storage(
     let mut replication_log = None;
     let mut latest_updates = HashMap::default();
     if let Some(replica_config) = &config.replication {
+        if capability.read_only {
+            bail!(
+                "Replication was enabled for storage {name} but it is read-only: replication \
+                 alignment writes to the backend, which a read-only storage cannot accept"
+            );
+        }
         if capability.history != History::Latest {
             bail!(
                 "Replication was enabled for storage {name} but its history capability is not \

--- a/plugins/zenoh-plugin-storage-manager/src/storages_mgt/mod.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/storages_mgt/mod.rs
@@ -57,7 +57,9 @@ pub(crate) async fn create_and_start_storage(
 ) -> ZResult<Sender<StorageMessage>> {
     tracing::trace!("Create storage '{}'", &admin_key);
     let storage = backend.create_storage(config.clone()).await?;
-    let capability = storage.capability().unwrap_or_else(|| backend.get_capability());
+    let capability = storage
+        .capability()
+        .unwrap_or_else(|| backend.get_capability());
 
     // Ex: @/390CEC11A1E34977A1C609A35BC015E6/router/status/plugins/storage_manager/storages/demo1
     // -> 390CEC11A1E34977A1C609A35BC015E6/demo1 (/<type> needed????)

--- a/plugins/zenoh-plugin-storage-manager/src/storages_mgt/mod.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/storages_mgt/mod.rs
@@ -56,8 +56,8 @@ pub(crate) async fn create_and_start_storage(
     zenoh_session: Arc<Session>,
 ) -> ZResult<Sender<StorageMessage>> {
     tracing::trace!("Create storage '{}'", &admin_key);
-    let capability = backend.get_capability();
     let storage = backend.create_storage(config.clone()).await?;
+    let capability = storage.capability().unwrap_or_else(|| backend.get_capability());
 
     // Ex: @/390CEC11A1E34977A1C609A35BC015E6/router/status/plugins/storage_manager/storages/demo1
     // -> 390CEC11A1E34977A1C609A35BC015E6/demo1 (/<type> needed????)

--- a/plugins/zenoh-plugin-storage-manager/src/storages_mgt/service.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/storages_mgt/service.rs
@@ -139,11 +139,20 @@ impl StorageService {
         let storage_key_expr = &self.configuration.key_expr;
 
         // subscribe on key_expr
-        let storage_sub = match self.session.declare_subscriber(storage_key_expr).await {
-            Ok(storage_sub) => storage_sub,
-            Err(e) => {
-                tracing::error!("Error starting storage '{}': {}", self.name, e);
-                return;
+        let storage_sub = if self.capability.read_only {
+            tracing::debug!(
+                "Storage '{}' is read-only; not subscribing to writes on keyexpr '{}'",
+                self.name,
+                storage_key_expr
+            );
+            None
+        } else {
+            match self.session.declare_subscriber(storage_key_expr).await {
+                Ok(storage_sub) => Some(storage_sub),
+                Err(e) => {
+                    tracing::error!("Error starting storage '{}': {}", self.name, e);
+                    return;
+                }
             }
         };
 
@@ -171,7 +180,7 @@ impl StorageService {
             loop {
                 tokio::select!(
                     // on sample for key_expr
-                    sample = storage_sub.recv_async() => {
+                    sample = async { storage_sub.as_ref().unwrap().recv_async().await }, if storage_sub.is_some() => {
                         let sample = match sample {
                             Ok(sample) => sample,
                             Err(e) => {


### PR DESCRIPTION
## Description

### What does this PR do?
Read-only storages no longer subscribe to writes. A `read_only` capability is added to `Capability`, and the storage manager gates the write subscriber on it: a read-only storage keeps its queryable (reads/queries still work) but never declares a write subscriber, so incoming samples are never dispatched to the backend.

Because read-only can be a per-storage setting, the effective capability is resolved from the created `Storage` instance (via a new defaulted `Storage::capability()` accessor) and falls back to the volume's `get_capability()`. Replication, which writes to the backend during alignment, is rejected for read-only storages (mirroring the existing history-capability guard). `Capability` and its enums now derive `Default` so backends can build one from defaults and override only what they need.

### Why is this change needed?
Per #2617, a storage configured read-only still had the storage manager declare a write subscriber on its key expression. Every sample arriving on the key_expr drove `process_sample` -> a backend `get()` followed by a `put()` that the read-only backend immediately errors out. For slow backends (e.g. S3) this is wasted work on the hot path and creates a performance cliff. Skipping the subscriber for read-only storages removes the guaranteed-to-fail get/put cycle while preserving read access.

This is a focused storage-manager mitigation; surfacing read-only as a first-class capability follows the maintainer note on the issue. Backends that do not opt in report `read_only: false` and behave exactly as before.

### Testing
- `cargo build -p zenoh-plugin-storage-manager -p zenoh_backend_traits -p zenoh-backend-example`
- `cargo test -p zenoh_backend_traits` (unit + doctests, including the capability-default backward-compat test)
- `cargo +nightly fmt --check`

### Related Issues
Refs #2617

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [ ] **Root cause documented** - Explain what caused the bug in the PR description
- [ ] **Reproduction test added** - Test that fails on main branch without the fix
- [ ] **Test passes with fix** - The reproduction test passes with your changes
- [ ] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [ ] **Fix is minimal** - Changes are focused only on fixing the bug
- [ ] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->