### PR TITLE
Refactor `zenoh::Config::insert_json5`

### DIFF
--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -1302,6 +1302,75 @@ impl Config {
         <Self as ValidatedMap>::insert_json5(self, key, value)
     }
 
+    /// Tries to insert or update a JSON5 object in an array using a field filter
+    /// in the last key segment.
+    ///
+    /// A key of the form `<array-key>/<field-name>=<field-value>` addresses an
+    /// object inside the array stored at `<array-key>`. The `<field-name>` part
+    /// is not a config child key; it is a filter applied to objects contained in
+    /// the array. For example, `qos/network/id=rule1` loads the array at
+    /// `qos/network` and matches objects whose `id` field is the string `rule1`.
+    ///
+    /// When a field filter is present, `value` must be a single JSON5 object
+    /// containing the same string field value. The object replaces the first
+    /// matching array element, or is appended if none exists.
+    ///
+    /// Returns `true` if the field-filter operation was applied. If `key` does
+    /// not contain a field filter, this returns `false` and leaves the config
+    /// unchanged.
+    pub fn try_insert_json5_array_item(
+        &mut self,
+        key: &str,
+        value: &str,
+    ) -> Result<bool, validated_struct::InsertionError> {
+        let Some((prefix, field_value)) = key.split_once('=') else {
+            return Ok(false);
+        };
+        let (array_key, field_name) =
+            prefix
+                .rsplit_once('/')
+                .ok_or(validated_struct::InsertionError::Str(
+                    "missing field filter",
+                ))?;
+        let new_item = json5::from_str::<serde_json::Value>(value)?;
+        if new_item
+            .as_object()
+            .and_then(|map| map.get(field_name))
+            .and_then(|v| v.as_str())
+            != Some(field_value)
+        {
+            return Err(validated_struct::InsertionError::String(format!(
+                "field filter mismatch: value must be an object containing {field_name}=\"{field_value}\""
+            )));
+        }
+        let current = serde_json::from_str::<serde_json::Value>(
+            &self
+                .get_json(array_key)
+                .map_err(|err| validated_struct::InsertionError::String(err.to_string()))?,
+        )?;
+        let serde_json::Value::Array(mut list) = current else {
+            return Err(validated_struct::InsertionError::Str("not an array"));
+        };
+        let mut new_item = Some(new_item);
+        for item in list.iter_mut() {
+            let serde_json::Value::Object(map) = item else {
+                return Err(validated_struct::InsertionError::Str(
+                    "array item is not an object",
+                ));
+            };
+
+            if map.get(field_name).and_then(|v| v.as_str()) == Some(field_value) {
+                *item = new_item.take().unwrap();
+                break;
+            }
+        }
+        if let Some(new_item) = new_item {
+            list.push(new_item);
+        }
+        <Self as ValidatedMap>::insert_json5(self, array_key, &serde_json::to_string(&list)?)?;
+        Ok(true)
+    }
+
     pub fn keys(&self) -> impl Iterator<Item = String> {
         <Self as ValidatedMap>::keys(self).into_iter()
     }
@@ -1330,6 +1399,44 @@ impl Config {
             )
         }
         self.plugins.remove(&key["plugins/".len()..])
+    }
+
+    /// Tries to remove objects from an array using a field filter in the last
+    /// key segment.
+    ///
+    /// A key of the form `<array-key>/<field-name>=<field-value>` removes every
+    /// object from the array stored at `<array-key>` whose `<field-name>` field
+    /// is the string `<field-value>`. The `<field-name>` part is not a config
+    /// child key; it is a filter applied to objects contained in the array. For
+    /// example, `qos/network/id=rule1` removes objects from `qos/network` where
+    /// `id == "rule1"`.
+    ///
+    /// Returns `true` if the field-filter operation was applied. If `key` does
+    /// not contain a field filter, this returns `false` and leaves the config
+    /// unchanged.
+    pub fn try_remove_json5_array_item<K: AsRef<str>>(&mut self, key: K) -> ZResult<bool> {
+        let key = key.as_ref();
+        let Some((prefix, field_value)) = key.split_once('=') else {
+            return Ok(false);
+        };
+        let (array_key, field_name) = prefix.rsplit_once('/').ok_or("missing field filter")?;
+        let current = serde_json::from_str::<serde_json::Value>(
+            &self.get_json(array_key).map_err(|err| zerror!("{err}"))?,
+        )?;
+        let serde_json::Value::Array(mut list) = current else {
+            bail!("not an array")
+        };
+        let prev_len = list.len();
+        list.retain(|item| match item {
+            serde_json::Value::Object(map) => {
+                map.get(field_name).and_then(|v| v.as_str()) != Some(field_value)
+            }
+            _ => true,
+        });
+        if list.len() != prev_len {
+            self.insert_json5(array_key, &serde_json::to_string(&list)?)?;
+        }
+        Ok(true)
     }
 
     pub fn get_retry_config(
@@ -2007,5 +2114,48 @@ mod tests {
             Config::from_file(&path).unwrap().to_string(),
             expected_config.to_string()
         );
+    }
+
+    #[test]
+    fn insert_remove_json5_array_item_by_id() {
+        let mut config = Config::default();
+
+        assert!(config
+            .try_insert_json5_array_item(
+                "qos/network/id=item1",
+                r#"{
+                        id: "item1",
+                        messages: ["put"],
+                        key_exprs: ["**"],
+                        overwrite: { priority: "data" },
+                        flows: ["egress"]
+                    }"#,
+            )
+            .unwrap());
+        assert!(config
+            .try_insert_json5_array_item(
+                "qos/network/id=item1",
+                r#"{
+                        id: "item1",
+                        messages: ["put"],
+                        key_exprs: ["**"],
+                        overwrite: { priority: "data_high" },
+                        flows: ["egress"]
+                    }"#,
+            )
+            .unwrap());
+
+        let items: serde_json::Value =
+            serde_json::from_str(&config.get_json("qos/network").unwrap()).unwrap();
+        assert_eq!(items.as_array().unwrap().len(), 1);
+        assert_eq!(items[0]["id"], "item1");
+        assert_eq!(items[0]["overwrite"]["priority"], "data_high");
+
+        assert!(config
+            .try_remove_json5_array_item("qos/network/id=item1")
+            .unwrap());
+        let items: serde_json::Value =
+            serde_json::from_str(&config.get_json("qos/network").unwrap()).unwrap();
+        assert_eq!(items.as_array().unwrap().len(), 0);
     }
 }

--- a/zenoh/src/api/config.rs
+++ b/zenoh/src/api/config.rs
@@ -71,65 +71,26 @@ impl Config {
     }
 
     pub fn remove<K: AsRef<str>>(&mut self, key: K) -> ZResult<()> {
-        match key.as_ref().split_once("=") {
-            None => self.0.remove(key.as_ref()),
-            Some((prefix, id_value)) => {
-                let (key, id_key) = prefix.rsplit_once("/").ok_or("missing id")?;
-                let current = serde_json::from_str::<serde_json::Value>(&self.get_json(key)?)?;
-                let serde_json::Value::Array(mut list) = current else {
-                    bail!("not an array")
-                };
-                let prev_len = list.len();
-                list.retain(|item| match item {
-                    serde_json::Value::Object(map) => {
-                        map.get(id_key).and_then(|v| v.as_str()) != Some(id_value)
-                    }
-                    _ => true,
-                });
-                if list.len() != prev_len {
-                    self.0.insert_json5(key, &serde_json::to_string(&list)?)?;
-                }
-                Ok(())
-            }
-        }
+        self.0.remove(key.as_ref())
+    }
+
+    /// See [`zenoh_config::Config::try_remove_json5_array_item`].
+    pub fn try_remove_json5_array_item<K: AsRef<str>>(&mut self, key: K) -> ZResult<bool> {
+        self.0.try_remove_json5_array_item(key)
     }
 
     /// Inserts configuration value `value` at `key`.
     pub fn insert_json5(&mut self, key: &str, value: &str) -> ZResult<()> {
-        match key.split_once("=") {
-            None => self.0.insert_json5(key, value),
-            Some((prefix, id_value)) => {
-                let (key, id_key) = prefix.rsplit_once("/").ok_or("missing id")?;
-                let new_item = json5::from_str::<serde_json::Value>(value)?;
-                if new_item
-                    .as_object()
-                    .and_then(|map| map.get(id_key))
-                    .and_then(|v| v.as_str())
-                    != Some(id_value)
-                {
-                    bail!("id mismatch");
-                }
-                let current = serde_json::from_str::<serde_json::Value>(&self.get_json(key)?)?;
-                let serde_json::Value::Array(mut list) = current else {
-                    bail!("not an array")
-                };
-                let mut new_item = Some(new_item);
-                for item in list.iter_mut() {
-                    let serde_json::Value::Object(map) = item else {
-                        bail!("array item is not an object");
-                    };
-                    if map.get(id_key).and_then(|v| v.as_str()) == Some(id_value) {
-                        *item = new_item.take().unwrap();
-                        break;
-                    }
-                }
-                if let Some(new_item) = new_item {
-                    list.push(new_item);
-                }
-                self.0.insert_json5(key, &serde_json::to_string(&list)?)
-            }
-        }
-        .map_err(|err| zerror!("{err}").into())
+        self.0
+            .insert_json5(key, value)
+            .map_err(|err| zerror!("{err}").into())
+    }
+
+    /// See [`zenoh_config::Config::try_insert_json5_array_item`].
+    pub fn try_insert_json5_array_item(&mut self, key: &str, value: &str) -> ZResult<bool> {
+        self.0
+            .try_insert_json5_array_item(key, value)
+            .map_err(|err| zerror!("{err}").into())
     }
 
     /// Returns a JSON string containing the configuration at `key`.
@@ -215,6 +176,17 @@ impl<T> Clone for Notifier<T> {
     }
 }
 
+fn ensure_config_key_is_dynamically_writable(key: &str) -> ZResult<()> {
+    if !key.starts_with("plugins/") {
+        bail!(
+            "Error inserting conf value {} : updating config is only \
+                supported for keys starting with `plugins/`",
+            key
+        );
+    }
+    Ok(())
+}
+
 impl Notifier<ExpandedConfig> {
     pub fn new(inner: ExpandedConfig) -> Self {
         Notifier {
@@ -273,17 +245,30 @@ impl Notifier<ExpandedConfig> {
         Ok(())
     }
 
-    pub fn insert_json5(&self, key: &str, value: &str) -> ZResult<()> {
-        if !key.starts_with("plugins/") {
-            bail!(
-                "Error inserting conf value {} : updating config is only \
-                    supported for keys starting with `plugins/`",
-                key
-            );
+    pub fn try_remove_json5_array_item<K: AsRef<str>>(&self, key: K) -> ZResult<bool> {
+        let applied = self
+            .lock_config()
+            .try_remove_json5_array_item(key.as_ref())?;
+        if applied {
+            self.notify(key);
         }
+        Ok(applied)
+    }
+
+    pub fn insert_json5(&self, key: &str, value: &str) -> ZResult<()> {
+        ensure_config_key_is_dynamically_writable(key)?;
         self.lock_config().insert_json5(key, value)?;
         self.notify(key);
         Ok(())
+    }
+
+    pub fn try_insert_json5_array_item(&self, key: &str, value: &str) -> ZResult<bool> {
+        ensure_config_key_is_dynamically_writable(key)?;
+        let applied = self.lock_config().try_insert_json5_array_item(key, value)?;
+        if applied {
+            self.notify(key);
+        }
+        Ok(applied)
     }
 }
 
@@ -294,7 +279,31 @@ mod tests {
     use crate::Config;
 
     #[test]
-    fn insert_remove_list_item() {
+    fn runtime_try_insert_json5_array_item_rejects_non_plugin_keys() {
+        let config = super::Notifier::new(zenoh_config::Config::default().expanded());
+        let before = config.lock().get_json("qos/network").unwrap();
+
+        let err = config
+            .try_insert_json5_array_item(
+                "qos/network/id=item1",
+                r#"{
+                    id: "item1",
+                    messages: ["put"],
+                    key_exprs: ["**"],
+                    overwrite: { priority: "real_time" },
+                    flows: ["egress"]
+                }"#,
+            )
+            .unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("supported for keys starting with `plugins/`"));
+        assert_eq!(config.lock().get_json("qos/network").unwrap(), before);
+    }
+
+    #[test]
+    fn insert_remove_json5_array_item() {
         let mut config = Config::default();
 
         let item1 = r#"{
@@ -306,7 +315,9 @@ mod tests {
             },
             flows: ["egress"]
         }"#;
-        config.insert_json5("qos/network/id=item1", item1).unwrap();
+        assert!(config
+            .try_insert_json5_array_item("qos/network/id=item1", item1)
+            .unwrap());
         let items = serde_json::from_str::<Vec<QosOverwriteItemConf>>(
             &config.get_json("qos/network").unwrap(),
         )
@@ -327,7 +338,9 @@ mod tests {
             },
             flows: ["ingress"]
         }"#;
-        config.insert_json5("qos/network/id=item1", item1).unwrap();
+        assert!(config
+            .try_insert_json5_array_item("qos/network/id=item1", item1)
+            .unwrap());
         let items = serde_json::from_str::<Vec<QosOverwriteItemConf>>(
             &config.get_json("qos/network").unwrap(),
         )
@@ -348,7 +361,9 @@ mod tests {
             },
             flows: ["egress"]
         }"#;
-        config.insert_json5("qos/network/id=item2", item2).unwrap();
+        assert!(config
+            .try_insert_json5_array_item("qos/network/id=item2", item2)
+            .unwrap());
         let items = serde_json::from_str::<Vec<QosOverwriteItemConf>>(
             &config.get_json("qos/network").unwrap(),
         )
@@ -365,7 +380,9 @@ mod tests {
             InterceptorFlow::Egress
         );
 
-        config.remove("qos/network/id=item2").unwrap();
+        assert!(config
+            .try_remove_json5_array_item("qos/network/id=item2")
+            .unwrap());
         let items = serde_json::from_str::<Vec<QosOverwriteItemConf>>(
             &config.get_json("qos/network").unwrap(),
         )
@@ -377,7 +394,9 @@ mod tests {
             InterceptorFlow::Ingress
         );
 
-        config.remove("qos/network/id=item1").unwrap();
+        assert!(config
+            .try_remove_json5_array_item("qos/network/id=item1")
+            .unwrap());
         let items = serde_json::from_str::<Vec<QosOverwriteItemConf>>(
             &config.get_json("qos/network").unwrap(),
         )

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -408,7 +408,18 @@ impl Primitives for AdminSpace {
                             key,
                             json
                         );
-                        if let Err(e) = self.context.runtime.state.config.insert_json5(key, json) {
+                        let config = &self.context.runtime.state.config;
+                        if let Err(e) =
+                            config
+                                .try_insert_json5_array_item(key, json)
+                                .and_then(|applied| {
+                                    if applied {
+                                        Ok(())
+                                    } else {
+                                        config.insert_json5(key, json)
+                                    }
+                                })
+                        {
                             error!(
                                 "Error inserting conf value @/{}/{}/config/{} : {} - {}",
                                 self.context.runtime.state.zid,
@@ -431,7 +442,14 @@ impl Primitives for AdminSpace {
                         self.context.runtime.state.whatami,
                         key
                     );
-                    if let Err(e) = self.context.runtime.state.config.remove(key) {
+                    let config = &self.context.runtime.state.config;
+                    if let Err(e) = config.try_remove_json5_array_item(key).and_then(|applied| {
+                        if applied {
+                            Ok(())
+                        } else {
+                            config.remove(key)
+                        }
+                    }) {
                         tracing::error!("Error deleting conf value {} : {}", msg.wire_expr, e)
                     }
                 }


### PR DESCRIPTION
### What does this PR do?

In f8f4edd the behavior of `zenoh::Config::insert_json5` was changed in a way incompatible with `zenoh_config::Config::insert_json5` yet the method name stayed the same, leading to avoidable confusion.

#2096 subsequently introduced `ExpandedConfig` which derefs into `zenoh_config::Config` instead of `zenoh::Config` leads to change in behavior for the callers of `zenoh::Config::insert_json5`. Methods with identical names on objects with identical names are supposed to have the same behavior.

### Why is this change needed?

Adminspace config updates that use the `=` syntax are broken.

### Related Issues

N/A

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [x] **Reproduction test added** - Test that fails on main branch without the fix
- [x] **Test passes with fix** - The reproduction test passes with your changes
- [x] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->