### PR TITLE
fix(util/net): make zenoh build on FreeBSD and support bind-to-device there

### DIFF
--- a/commons/zenoh-util/src/net/mod.rs
+++ b/commons/zenoh-util/src/net/mod.rs
@@ -12,11 +12,14 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use std::net::{IpAddr, Ipv6Addr};
+#[cfg(target_os = "freebsd")]
+use std::net::{SocketAddr, SocketAddrV6};
 
 #[cfg(unix)]
 use lazy_static::lazy_static;
 #[cfg(unix)]
 use pnet_datalink::NetworkInterface;
+#[cfg(not(target_os = "freebsd"))]
 use tokio::net::{TcpSocket, UdpSocket};
 use zenoh_core::zconfigurable;
 #[cfg(unix)]
@@ -465,4 +468,78 @@ pub fn set_bind_to_device_tcp_socket(socket: &TcpSocket, iface: &str) -> ZResult
 pub fn set_bind_to_device_udp_socket(socket: &UdpSocket, iface: &str) -> ZResult<()> {
     tracing::warn!("Binding the socket {socket:?} to the interface {iface} is not supported on macOS, iOS, and Windows");
     Ok(())
+}
+
+#[cfg(target_os = "freebsd")]
+fn is_link_local(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => ip.is_link_local(),
+        // Ipv6Addr::is_unicast_link_local is still unstable.
+        IpAddr::V6(ip) => (ip.segments()[0] & 0xffc0) == 0xfe80,
+    }
+}
+
+#[cfg(target_os = "freebsd")]
+fn index_of_interface(name: &str) -> ZResult<u32> {
+    match IFACES.iter().find(|iface| iface.name == name) {
+        Some(iface) => Ok(iface.index),
+        None => bail!("Interface {name} not found"),
+    }
+}
+
+/// FreeBSD has no SO_BINDTODEVICE / IP_BOUND_IF equivalent (there is no such sockopt in
+/// netinet/in.h, netinet6/in6.h or sys/socket.h), so the only way to restrict a socket to a
+/// given interface is to bind it to one of that interface's own addresses. Callers on FreeBSD
+/// use this to compute the address to bind *before* their single bind(2) call (a socket can
+/// only be bound once) — there is no `set_bind_to_device_{tcp,udp}_socket` for FreeBSD to call
+/// after an existing bind, unlike Linux/macOS/iOS/Windows.
+///
+/// An `addr` that already carries a concrete IP is validated against `iface` rather than
+/// rewritten: silently binding somewhere the caller did not ask for would hide the
+/// misconfiguration instead of reporting it. An unspecified `addr` selects an address of the
+/// same family from `iface`, preferring a routable one over a link-local.
+///
+/// Note that the interface list is a process-lifetime snapshot, so an address assigned to
+/// `iface` after startup is not visible here.
+#[cfg(target_os = "freebsd")]
+pub fn resolve_bind_addr_for_interface(iface: &str, addr: SocketAddr) -> ZResult<SocketAddr> {
+    let addrs = get_unicast_addresses_of_interface(iface)?;
+
+    if !addr.ip().is_unspecified() {
+        return if addrs.contains(&addr.ip()) {
+            Ok(addr)
+        } else {
+            bail!(
+                "Cannot bind to {} on interface {iface}: the interface has no such address",
+                addr.ip()
+            )
+        };
+    }
+
+    let want_v6 = addr.is_ipv6();
+    let (mut routable, mut link_local) = (None, None);
+    for ip in addrs {
+        if ip.is_ipv6() != want_v6 || ip.is_loopback() {
+            continue;
+        }
+        if is_link_local(&ip) {
+            link_local.get_or_insert(ip);
+        } else if routable.is_none() {
+            routable = Some(ip);
+        }
+    }
+
+    match routable.or(link_local) {
+        // A link-local IPv6 address cannot be bound without its zone index — FreeBSD answers
+        // EADDRNOTAVAIL — and the interface list does not carry one, so take it from the
+        // interface index.
+        Some(IpAddr::V6(ip)) if is_link_local(&IpAddr::V6(ip)) => Ok(SocketAddr::V6(
+            SocketAddrV6::new(ip, addr.port(), 0, index_of_interface(iface)?),
+        )),
+        Some(ip) => Ok(SocketAddr::new(ip, addr.port())),
+        None => bail!(
+            "Interface {iface} has no {} address to bind to",
+            if want_v6 { "IPv6" } else { "IPv4" }
+        ),
+    }
 }

--- a/io/zenoh-link-commons/src/quic/socket.rs
+++ b/io/zenoh-link-commons/src/quic/socket.rs
@@ -51,7 +51,14 @@ impl<'a> QuicSocketConfig<'a> {
 
     /// Build a new UDP socket bound to `addr` with the given configuration parameters
     pub async fn new_listener(&self, addr: &SocketAddr) -> ZResult<UdpSocket> {
+        #[cfg(target_os = "freebsd")]
+        let addr = &match self.iface {
+            Some(iface) => zenoh_util::net::resolve_bind_addr_for_interface(iface, *addr)?,
+            None => *addr,
+        };
+
         let socket = tokio::net::UdpSocket::bind(addr).await?;
+        #[cfg(not(target_os = "freebsd"))]
         if let Some(iface) = self.iface {
             zenoh_util::net::set_bind_to_device_udp_socket(&socket, iface)?;
         }
@@ -70,11 +77,19 @@ impl<'a> QuicSocketConfig<'a> {
         } else {
             SocketAddr::new(Ipv6Addr::UNSPECIFIED.into(), 0)
         };
+        // FreeBSD has no SO_BINDTODEVICE equivalent: resolve the interface's own address here,
+        // before the single bind() call below, instead of via set_bind_to_device_udp_socket after.
+        #[cfg(target_os = "freebsd")]
+        let src_addr = match self.iface {
+            Some(iface) => zenoh_util::net::resolve_bind_addr_for_interface(iface, src_addr)?,
+            None => src_addr,
+        };
         let socket = tokio::net::UdpSocket::bind(src_addr).await?;
 
         if let Some(dscp) = self.dscp {
             set_dscp(&socket, src_addr, dscp)?;
         }
+        #[cfg(not(target_os = "freebsd"))]
         if let Some(iface) = self.iface {
             zenoh_util::net::set_bind_to_device_udp_socket(&socket, iface)?;
         };

--- a/io/zenoh-link-commons/src/tcp.rs
+++ b/io/zenoh-link-commons/src/tcp.rs
@@ -50,6 +50,7 @@ impl<'a> TcpSocketConfig<'a> {
         // Build a TcpListener from TcpSocket
         // https://docs.rs/tokio/latest/tokio/net/struct.TcpSocket.html
         socket.set_reuseaddr(true)?;
+        let addr = &self.resolve_listen_addr(addr)?;
         socket.bind(*addr).map_err(|e| zerror!("{}: {}", addr, e))?;
         // backlog (the maximum number of pending connections are queued): 1024
         let listener = socket
@@ -70,7 +71,7 @@ impl<'a> TcpSocketConfig<'a> {
     ) -> ZResult<(TcpStream, SocketAddr, SocketAddr)> {
         let socket = self.socket_with_config(dst_addr)?;
 
-        if let Some(bind_addr) = self.bind_socket {
+        if let Some(bind_addr) = self.resolve_bind_socket(dst_addr)? {
             match (bind_addr, dst_addr) {
                 (SocketAddr::V6(local), SocketAddr::V4(dest)) => {
                     return Err(Box::from(format!(
@@ -107,6 +108,51 @@ impl<'a> TcpSocketConfig<'a> {
         Ok((stream, src_addr, dst_addr))
     }
 
+    /// Resolve the address to listen on, restricting egress/ingress to `self.iface` when set.
+    /// FreeBSD has no SO_BINDTODEVICE equivalent, so the interface is selected by binding to
+    /// its own address instead of a device-level sockopt (see `resolve_bind_addr_for_interface`).
+    /// On other platforms the interface restriction is applied via `set_bind_to_device_tcp_socket`
+    /// in `socket_with_config`, so the listen address is returned unchanged here.
+    #[cfg(target_os = "freebsd")]
+    fn resolve_listen_addr(&self, addr: &SocketAddr) -> ZResult<SocketAddr> {
+        match self.iface {
+            Some(iface) => zenoh_util::net::resolve_bind_addr_for_interface(iface, *addr),
+            None => Ok(*addr),
+        }
+    }
+    #[cfg(not(target_os = "freebsd"))]
+    fn resolve_listen_addr(&self, addr: &SocketAddr) -> ZResult<SocketAddr> {
+        Ok(*addr)
+    }
+
+    /// Resolve the address to bind before connect(), merging `self.iface`'s own address into
+    /// `self.bind_socket` (or synthesizing one) on FreeBSD for the same reason as above.
+    #[cfg(target_os = "freebsd")]
+    fn resolve_bind_socket(&self, dst_addr: &SocketAddr) -> ZResult<Option<SocketAddr>> {
+        match (self.iface, self.bind_socket) {
+            (Some(iface), Some(bind_addr)) => {
+                Ok(Some(zenoh_util::net::resolve_bind_addr_for_interface(
+                    iface, bind_addr,
+                )?))
+            }
+            (Some(iface), None) => {
+                let unspec = if dst_addr.is_ipv6() {
+                    SocketAddr::new(std::net::Ipv6Addr::UNSPECIFIED.into(), 0)
+                } else {
+                    SocketAddr::new(std::net::Ipv4Addr::UNSPECIFIED.into(), 0)
+                };
+                Ok(Some(zenoh_util::net::resolve_bind_addr_for_interface(
+                    iface, unspec,
+                )?))
+            }
+            (None, bind_socket) => Ok(bind_socket),
+        }
+    }
+    #[cfg(not(target_os = "freebsd"))]
+    fn resolve_bind_socket(&self, _dst_addr: &SocketAddr) -> ZResult<Option<SocketAddr>> {
+        Ok(self.bind_socket)
+    }
+
     /// Creates a TcpSocket with the provided config
     fn socket_with_config(&self, addr: &SocketAddr) -> ZResult<TcpSocket> {
         let socket = match addr {
@@ -114,6 +160,7 @@ impl<'a> TcpSocketConfig<'a> {
             SocketAddr::V6(_) => TcpSocket::new_v6(),
         }?;
 
+        #[cfg(not(target_os = "freebsd"))]
         if let Some(iface) = self.iface {
             zenoh_util::net::set_bind_to_device_tcp_socket(&socket, iface)?;
         }

--- a/io/zenoh-links/zenoh-link-udp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/unicast.rs
@@ -336,6 +336,15 @@ impl LinkManagerUnicastUdp {
             SocketAddr::new(Ipv6Addr::UNSPECIFIED.into(), 0)
         };
 
+        // FreeBSD has no SO_BINDTODEVICE equivalent: resolve the interface's own address here,
+        // before the single bind() call below, instead of via set_bind_to_device_udp_socket after
+        // (the socket is already bound by the time that function would be called).
+        #[cfg(target_os = "freebsd")]
+        let src_socket_addr = match iface {
+            Some(iface) => zenoh_util::net::resolve_bind_addr_for_interface(iface, src_socket_addr)?,
+            None => src_socket_addr,
+        };
+
         // Establish a UDP socket
         let socket = UdpSocket::bind(src_socket_addr).await.map_err(|e| {
             let e = zerror!(
@@ -347,6 +356,7 @@ impl LinkManagerUnicastUdp {
             e
         })?;
 
+        #[cfg(not(target_os = "freebsd"))]
         if let Some(iface) = iface {
             zenoh_util::net::set_bind_to_device_udp_socket(&socket, iface)?;
         }
@@ -394,6 +404,12 @@ impl LinkManagerUnicastUdp {
         iface: Option<&str>,
         dscp: Option<u32>,
     ) -> ZResult<(UdpSocket, SocketAddr)> {
+        #[cfg(target_os = "freebsd")]
+        let addr = &match iface {
+            Some(iface) => zenoh_util::net::resolve_bind_addr_for_interface(iface, *addr)?,
+            None => *addr,
+        };
+
         // Bind the UDP socket
         let socket = UdpSocket::bind(addr).await.map_err(|e| {
             let e = zerror!("Can not create a new UDP listener on {}: {}", addr, e);
@@ -401,6 +417,7 @@ impl LinkManagerUnicastUdp {
             e
         })?;
 
+        #[cfg(not(target_os = "freebsd"))]
         if let Some(iface) = iface {
             zenoh_util::net::set_bind_to_device_udp_socket(&socket, iface)?;
         }


### PR DESCRIPTION
## Description

zenoh does not build on FreeBSD at all. `set_bind_to_device_tcp_socket` and `set_bind_to_device_udp_socket` are defined only for `linux | android` and for `macos | ios | windows`, so on FreeBSD `zenoh-link-commons` fails to compile with `cannot find function ... in module 'zenoh_util::net'` — regardless of whether `iface` is ever used.

This PR makes FreeBSD compile, and makes the `iface` option actually work there.

> **Note on the original description of this PR:** it claimed FreeBSD has `IP_BOUND_IF` / `IPV6_BOUND_IF` and that a real implementation was merely out of scope. That was wrong, and the approach has changed accordingly — see below.

### Why FreeBSD can't just be added to the existing `any()` list

There is no `SO_BINDTODEVICE` / `IP_BOUND_IF` / `IPV6_BOUND_IF` on FreeBSD — no such sockopt exists in `netinet/in.h`, `netinet6/in6.h` or `sys/socket.h`. Those are Darwin/Solaris options, not FreeBSD ones.

So `set_bind_to_device_*` cannot be implemented on FreeBSD in any form: by the time either function is called the socket is already bound, and a socket can only be bound once. Adding `freebsd` to the `any()` list would only produce a warning stub, i.e. a function that silently does nothing while the user believes `iface` took effect.

The one mechanism FreeBSD does offer is binding the socket to one of the interface's own addresses. That must happen **before** the single `bind(2)` call each caller already makes — which is why FreeBSD gets an address resolver used at the call sites, rather than another `set_bind_to_device_*` arm.

### What this PR does

- **`zenoh-util`** — adds `resolve_bind_addr_for_interface(iface, addr)`, FreeBSD-only.
- **`zenoh-link-commons`** (`tcp.rs`, `quic/socket.rs`) and **`zenoh-link-udp`** (`unicast.rs`) — on FreeBSD, resolve the bind address before `bind()`. On every other platform the existing `set_bind_to_device_*` call is untouched.

Resolution semantics:

- A **concrete** address is validated against the interface, never rewritten. A mismatched configuration is reported instead of silently binding somewhere the caller never asked for.
- An **unspecified** address (`0.0.0.0` / `::`) selects an address of the same family from the interface, preferring a routable address over a link-local one, skipping loopback.
- A link-local IPv6 address carries the interface index as its scope id. Without it FreeBSD rejects the bind with `EADDRNOTAVAIL`, which makes `iface` + IPv6 unusable.

One caveat worth stating: the interface list is a process-lifetime snapshot, so an address assigned to the interface after startup is not visible. This is inherent to resolving an address instead of naming a device.

### Behaviour on other platforms

Unchanged. Every new code path is behind `#[cfg(target_os = "freebsd")]`.

### Testing

- `cargo check --target x86_64-unknown-freebsd --all-features` for `zenoh-util` and `zenoh-link-commons` — clean. This is the check that fails on `main`.
- `cargo check --all-features` on Linux for those two crates plus `zenoh-link-udp` — clean, no regression.
- Runtime, on FreeBSD 15.1, across two interfaces:
  - a listener with `iface` set binds that interface's address and is reachable on it;
  - an IPv6 listener with `iface` set binds successfully — it fails with `EADDRNOTAVAIL` without the scope-id handling;
  - an explicit address that is not on the interface is rejected with a clear error rather than being silently moved;
  - an explicit address that is on the interface is honoured verbatim;
  - with no `iface`, behaviour is identical to before.

There is no automated coverage for this, because there is no FreeBSD runner in CI — the verification above was done by hand. Happy to follow whatever the project prefers here.

### Known gap, not addressed here

`zenoh-link-udp` still does not compile on FreeBSD, for a reason unrelated to this change: `src/pktinfo/pktinfo_unix.rs` uses the Linux-only `IP_PKTINFO` and `in_pktinfo` (FreeBSD has `IP_RECVDSTADDR` / `IP_RECVIF` instead). This was previously masked, since `zenoh-link-commons` failed to compile first. I've left it alone to keep this PR to one concern — glad to open a separate issue or PR for it.

### Related Issues

None. This is a build fix for FreeBSD support.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `enhancement`

## ✨ Enhancement Requirements

Since this PR enhances existing functionality:

- [x] **Enhancement scope documented** - Clear description of what is being improved
- [x] **Minimum necessary code** - Implementation is as simple as possible, doesn't overcomplicate the system
- [x] **Backwards compatible** - Existing code/APIs still work unchanged
- [ ] **No new APIs added** - Only improving existing functionality
- [x] **Tests updated** - Existing tests pass, new test cases added if needed
- [x] **Performance improvement measured** - If applicable, before/after metrics provided
- [x] **Documentation updated** - Existing docs updated to reflect improvements
- [x] **User impact documented** - How users benefit from this enhancement

**Remember:** Enhancements should not introduce new APIs or breaking changes.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->

---

**On the one unchecked box:** this PR does add one new public item, `zenoh_util::net::resolve_bind_addr_for_interface`, so "No new APIs added" cannot honestly be ticked. It has to be `pub` because `zenoh-link-commons` and `zenoh-link-udp` call it across crate boundaries, and it is `#[cfg(target_os = "freebsd")]`, so it does not widen the API surface on any platform that builds today.

This is really a build fix rather than an enhancement, so the `enhancement` checklist is a slightly awkward fit. I don't have permission to relabel — if a maintainer retags this as `bug`, the checklist should regenerate accordingly.
