### PR TITLE
fix(rest): parse text/json5 payloads with json5 crate instead of serd…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5456,6 +5456,7 @@ dependencies = [
  "flume",
  "futures",
  "git-version",
+ "json5",
  "jsonschema",
  "lazy_static",
  "mime",

--- a/plugins/zenoh-plugin-rest/Cargo.toml
+++ b/plugins/zenoh-plugin-rest/Cargo.toml
@@ -38,6 +38,7 @@ base64 = { workspace = true }
 flume = { workspace = true }
 futures = { workspace = true }
 git-version = { workspace = true }
+json5 = { workspace = true }
 lazy_static = { workspace = true }
 mime = { workspace = true }
 schemars = { workspace = true }

--- a/plugins/zenoh-plugin-rest/src/lib.rs
+++ b/plugins/zenoh-plugin-rest/src/lib.rs
@@ -151,8 +151,7 @@ impl JSONSample {
         }
         let base64_encode = |data: &[u8]| base64::engine::general_purpose::STANDARD.encode(data);
         match encoding {
-            // If it is a JSON try to deserialize as json, if it fails fallback to base64
-            &Encoding::APPLICATION_JSON | &Encoding::TEXT_JSON | &Encoding::TEXT_JSON5 => {
+            &Encoding::APPLICATION_JSON | &Encoding::TEXT_JSON => {
                 let bytes = payload.to_bytes();
                 serde_json::from_slice(&bytes).unwrap_or_else(|e| {
                     tracing::warn!(
@@ -160,6 +159,23 @@ impl JSONSample {
                     );
                     serde_json::Value::String(base64_encode(&bytes))
                 })
+            }
+            &Encoding::TEXT_JSON5 => {
+                let bytes = payload.to_bytes();
+                match std::str::from_utf8(&bytes) {
+                    Ok(text) => json5::from_str::<serde_json::Value>(text).unwrap_or_else(|e| {
+                        tracing::warn!(
+                            "Encoding is JSON5 but failed to parse, returning as string, Error: {e:?}"
+                        );
+                        serde_json::Value::String(text.to_owned())
+                    }),
+                    Err(e) => {
+                        tracing::warn!(
+                            "Encoding is JSON5 but data is not valid UTF-8, converting to base64, Error: {e:?}"
+                        );
+                        serde_json::Value::String(base64_encode(&bytes))
+                    }
+                }
             }
             &Encoding::TEXT_PLAIN | &Encoding::ZENOH_STRING => serde_json::Value::String(
                 String::from_utf8(payload.to_bytes().into_owned()).unwrap_or_else(|e| {
@@ -169,7 +185,6 @@ impl JSONSample {
                     base64_encode(e.as_bytes())
                 }),
             ),
-            // otherwise convert to JSON string
             _ => serde_json::Value::String(base64_encode(&payload.to_bytes())),
         }
     }
@@ -737,5 +752,32 @@ mod tests {
         }
 
         test_sessions.close().await;
+    }
+
+    #[test]
+    fn payload_to_json_json5_valid() {
+        use crate::JSONSample;
+
+        let payload = ZBytes::from("{a: 1, b: 'hello'}");
+        let value = JSONSample::payload_to_json(&payload, &Encoding::TEXT_JSON5);
+        assert_eq!(value, serde_json::json!({"a": 1, "b": "hello"}));
+    }
+
+    #[test]
+    fn payload_to_json_json5_strict_json() {
+        use crate::JSONSample;
+
+        let payload = ZBytes::from(r#"{"a": 1, "b": "hello"}"#);
+        let value = JSONSample::payload_to_json(&payload, &Encoding::TEXT_JSON5);
+        assert_eq!(value, serde_json::json!({"a": 1, "b": "hello"}));
+    }
+
+    #[test]
+    fn payload_to_json_json5_unparseable() {
+        use crate::JSONSample;
+
+        let payload = ZBytes::from("this is not json5 at all");
+        let value = JSONSample::payload_to_json(&payload, &Encoding::TEXT_JSON5);
+        assert_eq!(value, serde_json::Value::String("this is not json5 at all".to_owned()));
     }
 }

--- a/plugins/zenoh-plugin-rest/src/lib.rs
+++ b/plugins/zenoh-plugin-rest/src/lib.rs
@@ -587,7 +587,11 @@ mod tests {
     use futures::{FutureExt, StreamExt};
     use tokio::time::timeout;
     use tower::ServiceExt;
-    use zenoh::{bytes::Encoding, sample::SampleKind, Session, Wait};
+    use zenoh::{
+        bytes::{Encoding, ZBytes},
+        sample::SampleKind,
+        Session, Wait,
+    };
     use zenoh_test::TestSessions;
 
     use crate::app;


### PR DESCRIPTION
Title: 
 fix(rest): parse TEXT_JSON5 payloads with json5 crate 
 Body: 
 ## What
Use the `json5` crate to parse `TEXT_JSON5` encoded payloads in the REST plugin,                                                                                         
instead of treating them as strict JSON via `serde_json`.                                                                                                                
                                                                                                                                                                         
## Why                                                                                                                                                                   
                                                                                                                                                                         
Fixes #2074                                                                                                                                                              
                                                                                                                                                                         
JSON5 payloads (unquoted keys, single-quoted strings, trailing commas, comments,                                                                                         
NaN/Infinity) are valid TEXT_JSON5 but fail `serde_json` parsing, causing an                                                                                             
unexpected base64 fallback that makes the data unreadable to consumers.                                                                                                  
                                                                                                                                                                         
## Behavior change                                                                                                                                                       
                                                                                                                                                                         
| Scenario | Before | After |                                                                                                                                            
|----------|--------|-------|                                                                                                                                            
| Valid JSON5 (`{a: 1}`) | base64 string | structured JSON (`{"a":1}`) |                                                                                                 
| Strict JSON | structured JSON | structured JSON (unchanged) |                                                                                                          
| Unparseable text | base64 string | raw string |                                                                                                                        
| Non-UTF-8 bytes | base64 string | base64 string (unchanged) |                                                                                                          
                                                                                                                                                                         
> **Note:** This is a breaking change for consumers that relied on the previous                                                                                          
> base64 fallback behavior for JSON5 payloads.                                                                                                                           
                                                                                                                                                                         
## Test plan                                                                                                                                                             
                                                                                                                                                                         
- [x] Unit tests: valid JSON5, strict JSON subset, unparseable fallback                                                                                                  
- [x] `cargo clippy -p zenoh-plugin-rest --all-targets -- --deny warnings`                                                                                               
- [x] `cargo test -p zenoh-plugin-rest`

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [x] **Reproduction test added** - Test that fails on main branch without the fix
- [x] **Test passes with fix** - The reproduction test passes with your changes
- [x] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->