### PR TITLE
fix: create advanced subscriber interval inside runtime task

### DIFF
--- a/zenoh-ext/src/advanced_subscriber.rs
+++ b/zenoh-ext/src/advanced_subscriber.rs
@@ -715,11 +715,12 @@ fn spawn_periodic_queries(
     period: Option<Duration>,
     source_id: EntityGlobalId,
 ) -> Option<AbortOnDropHandle<()>> {
-    let mut interval = tokio::time::interval(period?);
-    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let period = period?;
     let statesref = statesref.clone();
     Some(AbortOnDropHandle::new(ZRuntime::Application.spawn(
         async move {
+            let mut interval = tokio::time::interval(period);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             interval.tick().await; // interval first tick is immediate
             loop {
                 interval.tick().await;


### PR DESCRIPTION
## Description
- tokio::time::interval() was being created before entering the Tokio runtime context.
- In zenoh-c advanced pub/sub usage, that can happen on a non-Tokio thread and panic with `there is no reactor running`.

I tried this patch on zenoh-c repo with a vendored zenoh-ext and the failing test pass.

### What does this PR do?
create advanced subscriber interval inside runtime task

### Why is this change needed?
Aims to fix zenoh-c's [sync lockfile PR CI](https://github.com/eclipse-zenoh/zenoh-c/pull/1283) failure

### Related Issues
See error: https://github.com/eclipse-zenoh/zenoh-c/actions/runs/28438921177/job/84271616380?pr=1283#step:10:152

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`, `internal`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [ ] **Reproduction test added** - Test that fails on main branch without the fix
- [ ] **Test passes with fix** - The reproduction test passes with your changes
- [ ] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [ ] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->