### PR TITLE
fix(ci): shm flake watchdog and test expectation

### DIFF
--- a/commons/zenoh-shm/src/api/provider/shm_provider.rs
+++ b/commons/zenoh-shm/src/api/provider/shm_provider.rs
@@ -40,10 +40,14 @@ use crate::{
         provider::memory_layout::{MemoryLayout, TypedLayout},
     },
     metadata::{
-        allocated_descriptor::AllocatedMetadataDescriptor, descriptor::MetadataDescriptor,
+        allocated_descriptor::AllocatedMetadataDescriptor,
+        descriptor::{MetadataDescriptor, OwnedMetadataDescriptor},
         storage::GLOBAL_METADATA_STORAGE,
     },
-    watchdog::confirmator::{ConfirmedDescriptor, GLOBAL_CONFIRMATOR},
+    watchdog::{
+        confirmator::{ConfirmedDescriptor, GLOBAL_CONFIRMATOR},
+        validator::GLOBAL_VALIDATOR,
+    },
     ShmBufInfo, ShmBufInner,
 };
 
@@ -778,15 +782,30 @@ where
 #[derive(Debug)]
 struct BusyChunk {
     metadata: AllocatedMetadataDescriptor,
+    validator_descriptor: Option<OwnedMetadataDescriptor>,
 }
 
 impl BusyChunk {
-    fn new(metadata: AllocatedMetadataDescriptor) -> Self {
-        Self { metadata }
+    fn new(
+        metadata: AllocatedMetadataDescriptor,
+        validator_descriptor: Option<OwnedMetadataDescriptor>,
+    ) -> Self {
+        Self {
+            metadata,
+            validator_descriptor,
+        }
     }
 
     fn descriptor(&self) -> ChunkDescriptor {
         self.metadata.header().data_descriptor()
+    }
+}
+
+impl Drop for BusyChunk {
+    fn drop(&mut self) {
+        if let Some(descriptor) = self.validator_descriptor.take() {
+            GLOBAL_VALIDATOR.read().remove(descriptor);
+        }
     }
 }
 
@@ -966,28 +985,34 @@ where
         &self,
         chunk: AllocatedChunk,
         len: NonZeroUsize,
-        mut allocated_metadata: AllocatedMetadataDescriptor,
+        allocated_metadata: AllocatedMetadataDescriptor,
         confirmed_metadata: ConfirmedDescriptor,
     ) -> ShmBufInner {
+        let mut busy_chunk = BusyChunk::new(allocated_metadata, None);
+
         // write additional metadata
         // chunk descriptor
-        allocated_metadata
+        busy_chunk
+            .metadata
             .header()
             .set_data_descriptor(&chunk.descriptor);
         // protocol
-        allocated_metadata
+        busy_chunk
+            .metadata
             .header()
             .protocol
             .store(self.backend.id(), Ordering::Relaxed);
 
         // add watchdog to validator
-        allocated_metadata.register_in_validator(confirmed_metadata.owned.clone());
+        GLOBAL_VALIDATOR.read().add(confirmed_metadata.owned.clone());
+        busy_chunk.validator_descriptor = Some(confirmed_metadata.owned.clone());
 
         // Create buffer's info
         let info = ShmBufInfo::new(
             len,
             MetadataDescriptor::from(&confirmed_metadata.owned),
-            allocated_metadata
+            busy_chunk
+                .metadata
                 .header()
                 .generation
                 .load(Ordering::SeqCst),
@@ -1001,7 +1026,7 @@ where
         };
 
         // Create and store busy chunk
-        zlock!(self.busy_list).push(BusyChunk::new(allocated_metadata));
+        zlock!(self.busy_list).push(busy_chunk);
 
         shmb
     }

--- a/commons/zenoh-shm/src/api/provider/shm_provider.rs
+++ b/commons/zenoh-shm/src/api/provider/shm_provider.rs
@@ -1004,7 +1004,9 @@ where
             .store(self.backend.id(), Ordering::Relaxed);
 
         // add watchdog to validator
-        GLOBAL_VALIDATOR.read().add(confirmed_metadata.owned.clone());
+        GLOBAL_VALIDATOR
+            .read()
+            .add(confirmed_metadata.owned.clone());
         busy_chunk.validator_descriptor = Some(confirmed_metadata.owned.clone());
 
         // Create buffer's info

--- a/commons/zenoh-shm/src/api/provider/shm_provider.rs
+++ b/commons/zenoh-shm/src/api/provider/shm_provider.rs
@@ -43,10 +43,7 @@ use crate::{
         allocated_descriptor::AllocatedMetadataDescriptor, descriptor::MetadataDescriptor,
         storage::GLOBAL_METADATA_STORAGE,
     },
-    watchdog::{
-        confirmator::{ConfirmedDescriptor, GLOBAL_CONFIRMATOR},
-        validator::GLOBAL_VALIDATOR,
-    },
+    watchdog::confirmator::{ConfirmedDescriptor, GLOBAL_CONFIRMATOR},
     ShmBufInfo, ShmBufInner,
 };
 
@@ -969,7 +966,7 @@ where
         &self,
         chunk: AllocatedChunk,
         len: NonZeroUsize,
-        allocated_metadata: AllocatedMetadataDescriptor,
+        mut allocated_metadata: AllocatedMetadataDescriptor,
         confirmed_metadata: ConfirmedDescriptor,
     ) -> ShmBufInner {
         // write additional metadata
@@ -984,9 +981,7 @@ where
             .store(self.backend.id(), Ordering::Relaxed);
 
         // add watchdog to validator
-        GLOBAL_VALIDATOR
-            .read()
-            .add(confirmed_metadata.owned.clone());
+        allocated_metadata.register_in_validator(confirmed_metadata.owned.clone());
 
         // Create buffer's info
         let info = ShmBufInfo::new(

--- a/commons/zenoh-shm/src/metadata/allocated_descriptor.rs
+++ b/commons/zenoh-shm/src/metadata/allocated_descriptor.rs
@@ -15,12 +15,10 @@
 use std::ops::Deref;
 
 use super::{descriptor::OwnedMetadataDescriptor, storage::GLOBAL_METADATA_STORAGE};
-use crate::watchdog::validator::GLOBAL_VALIDATOR;
 
 #[derive(Debug)]
 pub struct AllocatedMetadataDescriptor {
     descriptor: OwnedMetadataDescriptor,
-    registered_in_validator: bool,
 }
 
 impl AllocatedMetadataDescriptor {
@@ -37,23 +35,12 @@ impl AllocatedMetadataDescriptor {
         // reset watchdog on allocation
         descriptor.validate();
 
-        Self {
-            descriptor,
-            registered_in_validator: false,
-        }
-    }
-
-    pub fn register_in_validator(&mut self, watchdog: OwnedMetadataDescriptor) {
-        GLOBAL_VALIDATOR.read().add(watchdog);
-        self.registered_in_validator = true;
+        Self { descriptor }
     }
 }
 
 impl Drop for AllocatedMetadataDescriptor {
     fn drop(&mut self) {
-        if self.registered_in_validator {
-            GLOBAL_VALIDATOR.read().remove(self.descriptor.clone());
-        }
         GLOBAL_METADATA_STORAGE
             .read()
             .reclaim(self.descriptor.clone());

--- a/commons/zenoh-shm/src/metadata/allocated_descriptor.rs
+++ b/commons/zenoh-shm/src/metadata/allocated_descriptor.rs
@@ -20,6 +20,7 @@ use crate::watchdog::validator::GLOBAL_VALIDATOR;
 #[derive(Debug)]
 pub struct AllocatedMetadataDescriptor {
     descriptor: OwnedMetadataDescriptor,
+    registered_in_validator: bool,
 }
 
 impl AllocatedMetadataDescriptor {
@@ -36,13 +37,23 @@ impl AllocatedMetadataDescriptor {
         // reset watchdog on allocation
         descriptor.validate();
 
-        Self { descriptor }
+        Self {
+            descriptor,
+            registered_in_validator: false,
+        }
+    }
+
+    pub fn register_in_validator(&mut self, watchdog: OwnedMetadataDescriptor) {
+        GLOBAL_VALIDATOR.read().add(watchdog);
+        self.registered_in_validator = true;
     }
 }
 
 impl Drop for AllocatedMetadataDescriptor {
     fn drop(&mut self) {
-        GLOBAL_VALIDATOR.read().remove(self.descriptor.clone());
+        if self.registered_in_validator {
+            GLOBAL_VALIDATOR.read().remove(self.descriptor.clone());
+        }
         GLOBAL_METADATA_STORAGE
             .read()
             .reclaim(self.descriptor.clone());

--- a/commons/zenoh-shm/src/watchdog/confirmator.rs
+++ b/commons/zenoh-shm/src/watchdog/confirmator.rs
@@ -112,7 +112,12 @@ impl ConfirmedSegment {
             let _ = self.task_kick.send(());
         }
 
-        self.sender.send(transaction).unwrap();
+        if self.sender.send(transaction).is_err() {
+            #[cfg(feature = "test")]
+            panic!("Watchdog Confirmator transaction channel closed");
+            #[cfg(not(feature = "test"))]
+            tracing::error!("Watchdog Confirmator transaction channel closed");
+        }
     }
 
     // See ordering implementation for OwnedMetadataDescriptor

--- a/commons/zenoh-shm/src/watchdog/confirmator.rs
+++ b/commons/zenoh-shm/src/watchdog/confirmator.rs
@@ -112,12 +112,9 @@ impl ConfirmedSegment {
             let _ = self.task_kick.send(());
         }
 
-        if self.sender.send(transaction).is_err() {
-            #[cfg(feature = "test")]
-            panic!("Watchdog Confirmator transaction channel closed");
-            #[cfg(not(feature = "test"))]
-            tracing::error!("Watchdog Confirmator transaction channel closed");
-        }
+        self.sender
+            .send(transaction)
+            .expect("Watchdog Confirmator transaction channel closed");
     }
 
     // See ordering implementation for OwnedMetadataDescriptor

--- a/commons/zenoh-shm/src/watchdog/validator.rs
+++ b/commons/zenoh-shm/src/watchdog/validator.rs
@@ -14,10 +14,7 @@
 
 use std::{
     collections::BTreeSet,
-    sync::{
-        atomic::AtomicI32,
-        Arc,
-    },
+    sync::{atomic::AtomicI32, Arc},
     time::Duration,
 };
 

--- a/commons/zenoh-shm/src/watchdog/validator.rs
+++ b/commons/zenoh-shm/src/watchdog/validator.rs
@@ -14,7 +14,10 @@
 
 use std::{
     collections::BTreeSet,
-    sync::{atomic::AtomicI32, Arc},
+    sync::{
+        atomic::{AtomicI32, AtomicUsize},
+        Arc,
+    },
     time::Duration,
 };
 
@@ -28,6 +31,11 @@ use crate::{
 #[dynamic(lazy, drop)]
 pub static mut GLOBAL_VALIDATOR: WatchdogValidator =
     WatchdogValidator::new(Duration::from_millis(100));
+
+#[cfg(feature = "test")]
+static TEST_ADD_TRANSACTIONS: AtomicUsize = AtomicUsize::new(0);
+#[cfg(feature = "test")]
+static TEST_REMOVE_TRANSACTIONS: AtomicUsize = AtomicUsize::new(0);
 
 enum Transaction {
     Add(OwnedMetadataDescriptor),
@@ -129,16 +137,37 @@ impl WatchdogValidator {
         self.make_transaction(Transaction::Remove(watchdog));
     }
 
+    #[cfg(feature = "test")]
+    pub fn test_reset_transaction_counters(&self) {
+        TEST_ADD_TRANSACTIONS.store(0, std::sync::atomic::Ordering::Relaxed);
+        TEST_REMOVE_TRANSACTIONS.store(0, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    #[cfg(feature = "test")]
+    pub fn test_transaction_counts(&self) -> (usize, usize) {
+        (
+            TEST_ADD_TRANSACTIONS.load(std::sync::atomic::Ordering::Relaxed),
+            TEST_REMOVE_TRANSACTIONS.load(std::sync::atomic::Ordering::Relaxed),
+        )
+    }
+
     fn make_transaction(&self, transaction: Transaction) {
         if self.cap.fetch_sub(1, std::sync::atomic::Ordering::Relaxed) == 0 {
             self.task.kick();
         }
 
-        if self.sender.send(transaction).is_err() {
-            #[cfg(feature = "test")]
-            panic!("Watchdog Validator transaction channel closed");
-            #[cfg(not(feature = "test"))]
-            tracing::error!("Watchdog Validator transaction channel closed");
+        #[cfg(feature = "test")]
+        let is_add = matches!(&transaction, Transaction::Add(_));
+
+        self.sender
+            .send(transaction)
+            .expect("Watchdog Validator transaction channel closed");
+
+        #[cfg(feature = "test")]
+        if is_add {
+            TEST_ADD_TRANSACTIONS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        } else {
+            TEST_REMOVE_TRANSACTIONS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
     }
 }

--- a/commons/zenoh-shm/src/watchdog/validator.rs
+++ b/commons/zenoh-shm/src/watchdog/validator.rs
@@ -134,6 +134,11 @@ impl WatchdogValidator {
             self.task.kick();
         }
 
-        self.sender.send(transaction).unwrap();
+        if self.sender.send(transaction).is_err() {
+            #[cfg(feature = "test")]
+            panic!("Watchdog Validator transaction channel closed");
+            #[cfg(not(feature = "test"))]
+            tracing::error!("Watchdog Validator transaction channel closed");
+        }
     }
 }

--- a/commons/zenoh-shm/src/watchdog/validator.rs
+++ b/commons/zenoh-shm/src/watchdog/validator.rs
@@ -15,7 +15,7 @@
 use std::{
     collections::BTreeSet,
     sync::{
-        atomic::{AtomicI32, AtomicUsize},
+        atomic::AtomicI32,
         Arc,
     },
     time::Duration,
@@ -31,6 +31,9 @@ use crate::{
 #[dynamic(lazy, drop)]
 pub static mut GLOBAL_VALIDATOR: WatchdogValidator =
     WatchdogValidator::new(Duration::from_millis(100));
+
+#[cfg(feature = "test")]
+use std::sync::atomic::AtomicUsize;
 
 #[cfg(feature = "test")]
 static TEST_ADD_TRANSACTIONS: AtomicUsize = AtomicUsize::new(0);

--- a/commons/zenoh-shm/tests/periodic_task.rs
+++ b/commons/zenoh-shm/tests/periodic_task.rs
@@ -200,5 +200,8 @@ fn periodic_task_panics_on_overrun() {
     panic::set_hook(prev_hook);
 
     let message = panic_message.lock().unwrap().clone();
-    assert!(message.contains("timer overrun"), "panic message: {message}");
+    assert!(
+        message.contains("timer overrun"),
+        "panic message: {message}"
+    );
 }

--- a/commons/zenoh-shm/tests/periodic_task.rs
+++ b/commons/zenoh-shm/tests/periodic_task.rs
@@ -13,6 +13,7 @@
 //
 #![cfg(feature = "test")]
 use std::{
+    panic,
     sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
@@ -169,4 +170,35 @@ fn periodic_task_excessive_load_blocking() {
 fn periodic_task_excessive_load_intensive() {
     let _load = CpuLoad::excessive();
     check_task(intensive_payload(TEST_TASK));
+}
+
+#[test]
+fn periodic_task_panics_on_overrun() {
+    let panic_message = Arc::new(Mutex::new(String::new()));
+    let c_panic_message = panic_message.clone();
+    let prev_hook = panic::take_hook();
+    panic::set_hook(Box::new(move |info| {
+        if std::thread::current().name() == Some("test-overrun") {
+            let message = if let Some(msg) = info.payload().downcast_ref::<&str>() {
+                (*msg).to_owned()
+            } else if let Some(msg) = info.payload().downcast_ref::<String>() {
+                msg.clone()
+            } else {
+                String::new()
+            };
+            *c_panic_message.lock().unwrap() = message;
+        }
+    }));
+
+    {
+        let _task = PeriodicTask::new("test-overrun".to_owned(), TASK_PERIOD, move |_| {
+            std::thread::sleep(TASK_PERIOD * 2);
+        });
+        std::thread::sleep(TASK_PERIOD * 3);
+    }
+
+    panic::set_hook(prev_hook);
+
+    let message = panic_message.lock().unwrap().clone();
+    assert!(message.contains("timer overrun"), "panic message: {message}");
 }

--- a/commons/zenoh-shm/tests/validator_regression.rs
+++ b/commons/zenoh-shm/tests/validator_regression.rs
@@ -13,12 +13,18 @@
 //
 #![cfg(feature = "test")]
 
-use std::{ops::Deref, sync::{Mutex, OnceLock}};
+use std::{
+    ops::Deref,
+    sync::{Mutex, OnceLock},
+};
 
 use zenoh_core::Wait;
 use zenoh_shm::{
     api::provider::shm_provider::ShmProviderBuilder,
-    metadata::{descriptor::MetadataDescriptor, storage::GLOBAL_METADATA_STORAGE, subscription::GLOBAL_METADATA_SUBSCRIPTION},
+    metadata::{
+        descriptor::MetadataDescriptor, storage::GLOBAL_METADATA_STORAGE,
+        subscription::GLOBAL_METADATA_SUBSCRIPTION,
+    },
     watchdog::validator::GLOBAL_VALIDATOR,
 };
 
@@ -38,7 +44,10 @@ fn plain_metadata_traffic_does_not_enqueue_validator_transactions() {
     let task = |_task_index: usize, _iteration: usize| {
         let allocated_metadata = GLOBAL_METADATA_STORAGE.read().allocate().unwrap();
         let descriptor = MetadataDescriptor::from(allocated_metadata.deref());
-        let _linked_metadata = GLOBAL_METADATA_SUBSCRIPTION.read().link(&descriptor).unwrap();
+        let _linked_metadata = GLOBAL_METADATA_SUBSCRIPTION
+            .read()
+            .link(&descriptor)
+            .unwrap();
     };
 
     execute_concurrent(100, 100, move |task_index, iteration| {

--- a/commons/zenoh-shm/tests/validator_regression.rs
+++ b/commons/zenoh-shm/tests/validator_regression.rs
@@ -1,0 +1,64 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+#![cfg(feature = "test")]
+
+use std::{ops::Deref, sync::{Mutex, OnceLock}};
+
+use zenoh_core::Wait;
+use zenoh_shm::{
+    api::provider::shm_provider::ShmProviderBuilder,
+    metadata::{descriptor::MetadataDescriptor, storage::GLOBAL_METADATA_STORAGE, subscription::GLOBAL_METADATA_SUBSCRIPTION},
+    watchdog::validator::GLOBAL_VALIDATOR,
+};
+
+pub mod common;
+use common::execute_concurrent;
+
+fn validator_test_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+#[test]
+fn plain_metadata_traffic_does_not_enqueue_validator_transactions() {
+    let _guard = validator_test_lock().lock().unwrap();
+    GLOBAL_VALIDATOR.read().test_reset_transaction_counters();
+
+    let task = |_task_index: usize, _iteration: usize| {
+        let allocated_metadata = GLOBAL_METADATA_STORAGE.read().allocate().unwrap();
+        let descriptor = MetadataDescriptor::from(allocated_metadata.deref());
+        let _linked_metadata = GLOBAL_METADATA_SUBSCRIPTION.read().link(&descriptor).unwrap();
+    };
+
+    execute_concurrent(100, 100, move |task_index, iteration| {
+        task(task_index, iteration);
+        Ok::<(), ()>(())
+    });
+
+    assert_eq!(GLOBAL_VALIDATOR.read().test_transaction_counts(), (0, 0));
+}
+
+#[test]
+fn provider_tracked_buffers_still_enqueue_validator_transactions() {
+    let _guard = validator_test_lock().lock().unwrap();
+    GLOBAL_VALIDATOR.read().test_reset_transaction_counters();
+
+    let provider = ShmProviderBuilder::default_backend(65536).wait().unwrap();
+    let buffer = provider.alloc(1024).wait().unwrap();
+    drop(buffer);
+
+    let _ = provider.garbage_collect();
+
+    assert_eq!(GLOBAL_VALIDATOR.read().test_transaction_counts(), (1, 1));
+}

--- a/io/zenoh-transport/tests/unicast_openclose.rs
+++ b/io/zenoh-transport/tests/unicast_openclose.rs
@@ -750,7 +750,7 @@ async fn openclose_udp_only_connect_with_interface_restriction() {
 
 #[cfg(feature = "transport_udp")]
 #[cfg(target_os = "linux")]
-#[should_panic(expected = "Elapsed")]
+#[should_panic(expected = "assertion failed: open_res.is_ok()")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn openclose_udp_only_listen_with_interface_restriction() {
     let addrs = get_ipv4_ipaddrs(None);

--- a/io/zenoh-transport/tests/unicast_openclose.rs
+++ b/io/zenoh-transport/tests/unicast_openclose.rs
@@ -460,6 +460,69 @@ async fn openclose_transport(
     tokio::time::sleep(SLEEP).await;
 }
 
+#[cfg(feature = "transport_udp")]
+#[cfg(target_os = "linux")]
+async fn openclose_transport_expect_open_failure(
+    listen_endpoint: &EndPoint,
+    connect_endpoint: &EndPoint,
+    lowlatency_transport: bool,
+) {
+    let router_id = ZenohIdProto::try_from([1]).unwrap();
+    let router_handler = Arc::new(SHRouterOpenClose);
+    let unicast = make_transport_manager_builder(
+        #[cfg(feature = "transport_multilink")]
+        2,
+        lowlatency_transport,
+    )
+    .max_sessions(1);
+    let router_manager = TransportManager::builder()
+        .whatami(WhatAmI::Router)
+        .zid(router_id)
+        .unicast(unicast)
+        .build_test(router_handler.clone())
+        .unwrap();
+
+    let client01_id = ZenohIdProto::try_from([2]).unwrap();
+    let unicast = make_transport_manager_builder(
+        #[cfg(feature = "transport_multilink")]
+        2,
+        lowlatency_transport,
+    )
+    .max_sessions(1);
+    let client01_manager = TransportManager::builder()
+        .whatami(WhatAmI::Client)
+        .zid(client01_id)
+        .unicast(unicast)
+        .build_test(Arc::new(SHClientOpenClose::new()))
+        .unwrap();
+
+    println!("\nTransport Open Close [1a1]");
+    let router_res = ztimeout!(router_manager.add_listener(listen_endpoint.clone()));
+    println!("Transport Open Close [1a1]: {router_res:?}");
+    assert!(router_res.is_ok());
+    println!("Transport Open Close [1a2]");
+    let locators = ztimeout!(router_manager.get_listeners());
+    println!("Transport Open Close [1a2]: {locators:?}");
+    assert_eq!(locators.len(), 1);
+
+    println!("Transport Open Close [1c1]");
+    let open_res = tokio::time::timeout(
+        TIMEOUT_EXPECTED,
+        client01_manager.open_transport_unicast(connect_endpoint.clone()),
+    )
+    .await;
+    println!("Transport Open Close [1c2]: {open_res:?}");
+    assert!(
+        !matches!(open_res, Ok(Ok(_))),
+        "expected transport open to fail or time out, but it succeeded: {open_res:?}"
+    );
+
+    ztimeout!(router_manager.close());
+    ztimeout!(client01_manager.close());
+
+    tokio::time::sleep(SLEEP).await;
+}
+
 async fn openclose_universal_transport(endpoint: &EndPoint) {
     openclose_transport(endpoint, endpoint, false).await
 }
@@ -750,7 +813,6 @@ async fn openclose_udp_only_connect_with_interface_restriction() {
 
 #[cfg(feature = "transport_udp")]
 #[cfg(target_os = "linux")]
-#[should_panic(expected = "assertion failed: open_res.is_ok()")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn openclose_udp_only_listen_with_interface_restriction() {
     let addrs = get_ipv4_ipaddrs(None);
@@ -764,7 +826,7 @@ async fn openclose_udp_only_listen_with_interface_restriction() {
     let connect_endpoint: EndPoint = format!("udp/{}:{}", addrs[0], port).parse().unwrap();
 
     // should not connect to local interface and external address
-    openclose_transport(&listen_endpoint, &connect_endpoint, false).await;
+    openclose_transport_expect_open_failure(&listen_endpoint, &connect_endpoint, false).await;
 }
 
 #[cfg(all(feature = "transport_vsock", target_os = "linux"))]


### PR DESCRIPTION
## Description
See individual commit messages. The patches aim to improve flakiness in tests observed in the recreate Cargo.lock PR

### What does this PR do?
- Improve SHM watchdog validator
- Be more explicit when there are failures with the watchdog
- match UDP assertion to TLS and TCP tests

### Why is this change needed?
- Unblock https://github.com/eclipse-zenoh/zenoh/pull/2667

### Related Issues
- https://github.com/eclipse-zenoh/zenoh/pull/2667

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->