### PR TITLE
Fix multicast scouting on loopback

### DIFF
--- a/commons/zenoh-util/src/net/mod.rs
+++ b/commons/zenoh-util/src/net/mod.rs
@@ -375,7 +375,7 @@ pub fn get_interface_names_by_addr(addr: IpAddr) -> ZResult<Vec<String>> {
     }
 }
 
-pub fn get_ipv4_ipaddrs(interface: Option<&str>) -> Vec<IpAddr> {
+pub fn get_ipv4_ipaddrs(interface: Option<&str>, noloopback: bool) -> Vec<IpAddr> {
     get_local_addresses(interface)
         .unwrap_or_else(|_| vec![])
         .drain(..)
@@ -383,12 +383,17 @@ pub fn get_ipv4_ipaddrs(interface: Option<&str>) -> Vec<IpAddr> {
             IpAddr::V4(a) => Some(a),
             IpAddr::V6(_) => None,
         })
-        .filter(|x| !x.is_loopback() && !x.is_multicast())
+        .filter(|x| {
+            if noloopback && x.is_loopback() {
+                return false;
+            }
+            !x.is_multicast()
+        })
         .map(IpAddr::V4)
         .collect()
 }
 
-pub fn get_ipv6_ipaddrs(interface: Option<&str>) -> Vec<IpAddr> {
+pub fn get_ipv6_ipaddrs(interface: Option<&str>, noloopback: bool) -> Vec<IpAddr> {
     const fn is_unicast_link_local(addr: &Ipv6Addr) -> bool {
         (addr.segments()[0] & 0xffc0) == 0xfe80
     }
@@ -403,7 +408,10 @@ pub fn get_ipv6_ipaddrs(interface: Option<&str>) -> Vec<IpAddr> {
             IpAddr::V6(_) => None,
         })
         .filter(|x| {
-            !x.is_loopback() && !x.is_link_local() && !x.is_multicast() && !x.is_broadcast()
+            if noloopback && x.is_loopback() {
+                return false;
+            }
+            !x.is_link_local() && !x.is_multicast() && !x.is_broadcast()
         });
 
     // Get next all IPv6 addresses
@@ -415,7 +423,12 @@ pub fn get_ipv6_ipaddrs(interface: Option<&str>) -> Vec<IpAddr> {
     // First match non-linklocal IPv6 addresses
     let nll_ipv6_addrs = ipv6_iter
         .clone()
-        .filter(|x| !x.is_loopback() && !x.is_multicast() && !is_unicast_link_local(x))
+        .filter(|x| {
+            if noloopback && x.is_loopback() {
+                return false;
+            }
+            !x.is_multicast() && !is_unicast_link_local(x)
+        })
         .map(|x| IpAddr::V6(*x));
 
     // Second match public IPv4 addresses
@@ -426,7 +439,12 @@ pub fn get_ipv6_ipaddrs(interface: Option<&str>) -> Vec<IpAddr> {
 
     // Third match linklocal IPv6 addresses
     let yll_ipv6_addrs = ipv6_iter
-        .filter(|x| !x.is_loopback() && !x.is_multicast() && is_unicast_link_local(x))
+        .filter(|x| {
+            if noloopback && x.is_loopback() {
+                return false;
+            }
+            !x.is_multicast() && is_unicast_link_local(x)
+        })
         .map(|x| IpAddr::V6(*x));
 
     // Fourth match private IPv4 addresses

--- a/io/zenoh-link-commons/src/listener.rs
+++ b/io/zenoh-link-commons/src/listener.rs
@@ -138,7 +138,7 @@ impl ListenersUnicastIP {
             .collect()
     }
 
-    pub fn get_locators(&self) -> Vec<Locator> {
+    fn get_locators_impl(&self, noloopback: bool) -> Vec<Locator> {
         let mut locators = vec![];
 
         let guard = zread!(self.listeners);
@@ -150,8 +150,8 @@ impl ListenersUnicastIP {
             // Either ipv4/0.0.0.0 or ipv6/[::]
             if kip.is_unspecified() {
                 let mut addrs = match kip {
-                    IpAddr::V4(_) => zenoh_util::net::get_ipv4_ipaddrs(iface),
-                    IpAddr::V6(_) => zenoh_util::net::get_ipv6_ipaddrs(iface),
+                    IpAddr::V4(_) => zenoh_util::net::get_ipv4_ipaddrs(iface, noloopback),
+                    IpAddr::V6(_) => zenoh_util::net::get_ipv6_ipaddrs(iface, noloopback),
                 };
                 let iter = addrs.drain(..).map(|x| {
                     Locator::new(
@@ -162,12 +162,20 @@ impl ListenersUnicastIP {
                     .unwrap()
                 });
                 locators.extend(iter);
-            } else {
+            } else if !noloopback || !kip.is_loopback() {
                 locators.push(value.endpoint.to_locator());
             }
         }
 
         locators
+    }
+
+    pub fn get_locators(&self) -> Vec<Locator> {
+        self.get_locators_impl(false)
+    }
+
+    pub fn get_locators_noloopback(&self) -> Vec<Locator> {
+        self.get_locators_impl(true)
     }
 }
 

--- a/io/zenoh-link-commons/src/unicast.rs
+++ b/io/zenoh-link-commons/src/unicast.rs
@@ -37,6 +37,7 @@ pub trait LinkManagerUnicastTrait: Send + Sync {
     async fn del_listener(&self, endpoint: &EndPoint) -> ZResult<()>;
     async fn get_listeners(&self) -> Vec<EndPoint>;
     async fn get_locators(&self) -> Vec<Locator>;
+    async fn get_locators_noloopback(&self) -> Vec<Locator>;
 }
 pub type NewLinkChannelSender = flume::Sender<LinkUnicast>;
 

--- a/io/zenoh-links/zenoh-link-quic/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-quic/src/unicast.rs
@@ -343,6 +343,10 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastQuic {
     async fn get_locators(&self) -> Vec<Locator> {
         self.listeners.get_locators()
     }
+
+    async fn get_locators_noloopback(&self) -> Vec<Locator> {
+        self.listeners.get_locators_noloopback()
+    }
 }
 
 fn acceptor_callback(link_material: QuicLinkMaterial) -> ZResult<LinkUnicast> {

--- a/io/zenoh-links/zenoh-link-quic_datagram/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-quic_datagram/src/unicast.rs
@@ -327,6 +327,10 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastQuicDatagram {
     async fn get_locators(&self) -> Vec<Locator> {
         self.listeners.get_locators()
     }
+
+    async fn get_locators_noloopback(&self) -> Vec<Locator> {
+        self.listeners.get_locators_noloopback()
+    }
 }
 
 fn acceptor_callback(link_material: QuicLinkMaterial) -> ZResult<LinkUnicast> {

--- a/io/zenoh-links/zenoh-link-serial/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-serial/src/unicast.rs
@@ -420,6 +420,10 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastSerial {
             .map(|x| x.endpoint.to_locator())
             .collect()
     }
+
+    async fn get_locators_noloopback(&self) -> Vec<Locator> {
+        self.get_locators().await
+    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
@@ -390,6 +390,10 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastTcp {
     async fn get_locators(&self) -> Vec<Locator> {
         self.listeners.get_locators()
     }
+
+    async fn get_locators_noloopback(&self) -> Vec<Locator> {
+        self.listeners.get_locators_noloopback()
+    }
 }
 
 async fn accept_task(

--- a/io/zenoh-links/zenoh-link-tls/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/unicast.rs
@@ -485,6 +485,10 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastTls {
     async fn get_locators(&self) -> Vec<Locator> {
         self.listeners.get_locators()
     }
+
+    async fn get_locators_noloopback(&self) -> Vec<Locator> {
+        self.listeners.get_locators_noloopback()
+    }
 }
 
 async fn accept_task(

--- a/io/zenoh-links/zenoh-link-udp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-udp/src/unicast.rs
@@ -609,6 +609,10 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastUdp {
     async fn get_locators(&self) -> Vec<Locator> {
         self.listeners.get_locators()
     }
+
+    async fn get_locators_noloopback(&self) -> Vec<Locator> {
+        self.listeners.get_locators_noloopback()
+    }
 }
 
 async fn accept_read_task(

--- a/io/zenoh-links/zenoh-link-unixpipe/src/unix/unicast.rs
+++ b/io/zenoh-links/zenoh-link-unixpipe/src/unix/unicast.rs
@@ -623,6 +623,10 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastPipe {
             .map(|v| v.uplink_locator.clone())
             .collect()
     }
+
+    async fn get_locators_noloopback(&self) -> Vec<Locator> {
+        self.get_locators().await
+    }
 }
 
 fn endpoint_to_pipe_path(endpoint: &EndPoint) -> (String, u32) {

--- a/io/zenoh-links/zenoh-link-unixsock_stream/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-unixsock_stream/src/unicast.rs
@@ -479,6 +479,10 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastUnixSocketStream {
             .map(|x| x.endpoint.to_locator())
             .collect()
     }
+
+    async fn get_locators_noloopback(&self) -> Vec<Locator> {
+        self.get_locators().await
+    }
 }
 
 async fn accept_task(

--- a/io/zenoh-links/zenoh-link-vsock/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-vsock/src/unicast.rs
@@ -348,6 +348,10 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastVsock {
             .map(|x| x.endpoint.to_locator())
             .collect()
     }
+
+    async fn get_locators_noloopback(&self) -> Vec<Locator> {
+        self.get_locators().await
+    }
 }
 
 async fn accept_task(

--- a/io/zenoh-links/zenoh-link-ws/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-ws/src/unicast.rs
@@ -315,6 +315,63 @@ impl LinkManagerUnicastWs {
             listeners: Arc::new(AsyncRwLock::new(HashMap::new())),
         }
     }
+
+    async fn get_locators_impl(&self, noloopback: bool) -> Vec<Locator> {
+        let mut locators = Vec::new();
+        let default_ipv4 = Ipv4Addr::UNSPECIFIED;
+        let default_ipv6 = Ipv6Addr::UNSPECIFIED;
+
+        let guard = zasyncread!(self.listeners);
+        for (key, value) in guard.iter() {
+            let listener_locator = value.endpoint.to_locator();
+            if key.ip() == default_ipv4 {
+                match zenoh_util::net::get_local_addresses(None) {
+                    Ok(ipaddrs) => {
+                        for ipaddr in ipaddrs {
+                            if (!noloopback || !ipaddr.is_loopback())
+                                && !ipaddr.is_multicast()
+                                && ipaddr.is_ipv4()
+                            {
+                                let l = Locator::new(
+                                    WS_LOCATOR_PREFIX,
+                                    SocketAddr::new(ipaddr, key.port()).to_string(),
+                                    value.endpoint.metadata(),
+                                )
+                                .unwrap();
+                                locators.push(l);
+                            }
+                        }
+                    }
+                    Err(err) => tracing::error!("Unable to get local addresses: {}", err),
+                }
+            } else if key.ip() == default_ipv6 {
+                match zenoh_util::net::get_local_addresses(None) {
+                    Ok(ipaddrs) => {
+                        for ipaddr in ipaddrs {
+                            if (!noloopback || !ipaddr.is_loopback())
+                                && !ipaddr.is_multicast()
+                                && ipaddr.is_ipv6()
+                            {
+                                let l = Locator::new(
+                                    WS_LOCATOR_PREFIX,
+                                    SocketAddr::new(ipaddr, key.port()).to_string(),
+                                    value.endpoint.metadata(),
+                                )
+                                .unwrap();
+                                locators.push(l);
+                            }
+                        }
+                    }
+                    Err(err) => tracing::error!("Unable to get local addresses: {}", err),
+                }
+            } else if !noloopback || !key.ip().is_loopback() {
+                locators.push(listener_locator.clone());
+            }
+        }
+        std::mem::drop(guard);
+
+        locators
+    }
 }
 
 #[async_trait]
@@ -434,54 +491,11 @@ impl LinkManagerUnicastTrait for LinkManagerUnicastWs {
     }
 
     async fn get_locators(&self) -> Vec<Locator> {
-        let mut locators = Vec::new();
-        let default_ipv4 = Ipv4Addr::UNSPECIFIED;
-        let default_ipv6 = Ipv6Addr::UNSPECIFIED;
+        self.get_locators_impl(false).await
+    }
 
-        let guard = zasyncread!(self.listeners);
-        for (key, value) in guard.iter() {
-            let listener_locator = value.endpoint.to_locator();
-            if key.ip() == default_ipv4 {
-                match zenoh_util::net::get_local_addresses(None) {
-                    Ok(ipaddrs) => {
-                        for ipaddr in ipaddrs {
-                            if !ipaddr.is_loopback() && !ipaddr.is_multicast() && ipaddr.is_ipv4() {
-                                let l = Locator::new(
-                                    WS_LOCATOR_PREFIX,
-                                    SocketAddr::new(ipaddr, key.port()).to_string(),
-                                    value.endpoint.metadata(),
-                                )
-                                .unwrap();
-                                locators.push(l);
-                            }
-                        }
-                    }
-                    Err(err) => tracing::error!("Unable to get local addresses: {}", err),
-                }
-            } else if key.ip() == default_ipv6 {
-                match zenoh_util::net::get_local_addresses(None) {
-                    Ok(ipaddrs) => {
-                        for ipaddr in ipaddrs {
-                            if !ipaddr.is_loopback() && !ipaddr.is_multicast() && ipaddr.is_ipv6() {
-                                let l = Locator::new(
-                                    WS_LOCATOR_PREFIX,
-                                    SocketAddr::new(ipaddr, key.port()).to_string(),
-                                    value.endpoint.metadata(),
-                                )
-                                .unwrap();
-                                locators.push(l);
-                            }
-                        }
-                    }
-                    Err(err) => tracing::error!("Unable to get local addresses: {}", err),
-                }
-            } else {
-                locators.push(listener_locator.clone());
-            }
-        }
-        std::mem::drop(guard);
-
-        locators
+    async fn get_locators_noloopback(&self) -> Vec<Locator> {
+        self.get_locators_impl(true).await
     }
 }
 

--- a/io/zenoh-transport/src/manager.rs
+++ b/io/zenoh-transport/src/manager.rs
@@ -765,4 +765,13 @@ impl TransportManager {
         lsu.append(&mut lsm);
         lsu
     }
+
+    // TODO(yuyuan): Can we make this async as above?
+    pub fn get_locators_noloopback(&self) -> Vec<Locator> {
+        let mut lsu =
+            zenoh_runtime::ZRuntime::Net.block_in_place(self.get_locators_unicast_noloopback());
+        let mut lsm = zenoh_runtime::ZRuntime::Net.block_in_place(self.get_locators_multicast());
+        lsu.append(&mut lsm);
+        lsu
+    }
 }

--- a/io/zenoh-transport/src/unicast/manager.rs
+++ b/io/zenoh-transport/src/unicast/manager.rs
@@ -481,6 +481,14 @@ impl TransportManager {
         vec
     }
 
+    pub async fn get_locators_unicast_noloopback(&self) -> Vec<Locator> {
+        let mut vec: Vec<Locator> = vec![];
+        for p in zasynclock!(self.state.unicast.link_managers).values() {
+            vec.extend_from_slice(&p.get_locators_noloopback().await);
+        }
+        vec
+    }
+
     /*************************************/
     /*             TRANSPORT             */
     /*************************************/

--- a/io/zenoh-transport/tests/unicast_bind.rs
+++ b/io/zenoh-transport/tests/unicast_bind.rs
@@ -327,7 +327,7 @@ async fn openclose_transport(
 #[should_panic(expected = "assertion failed: open_res.is_ok()")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn openclose_tcp_only_connect_with_bind_and_interface() {
-    let addrs = get_ipv4_ipaddrs(None);
+    let addrs = get_ipv4_ipaddrs(None, true);
 
     zenoh_util::init_log_from_env_or("error");
 
@@ -353,7 +353,7 @@ async fn openclose_tcp_only_connect_with_bind_and_interface() {
 #[cfg(feature = "transport_tcp")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn openclose_tcp_only_connect_with_bind_restriction() {
-    let addrs = get_ipv4_ipaddrs(None);
+    let addrs = get_ipv4_ipaddrs(None, true);
 
     zenoh_util::init_log_from_env_or("error");
 
@@ -380,8 +380,8 @@ async fn openclose_tcp_only_connect_with_bind_restriction() {
 async fn openclose_tcp_only_connect_with_bind_restriction_mismatch_protocols() {
     use zenoh_util::net::get_ipv6_ipaddrs;
 
-    let addrs = get_ipv4_ipaddrs(None);
-    let addrs_v6 = get_ipv6_ipaddrs(None);
+    let addrs = get_ipv4_ipaddrs(None, true);
+    let addrs_v6 = get_ipv6_ipaddrs(None, true);
 
     if addrs_v6.is_empty() {
         // No IPv6 addresses on this host; test requires IPv6 to produce a protocol mismatch.
@@ -409,8 +409,8 @@ async fn openclose_tcp_only_connect_with_bind_restriction_mismatch_protocols() {
 async fn openclose_udp_only_connect_with_bind_restriction_mismatch_protocols() {
     use zenoh_util::net::get_ipv6_ipaddrs;
 
-    let addrs = get_ipv4_ipaddrs(None);
-    let addrs_v6 = get_ipv6_ipaddrs(None);
+    let addrs = get_ipv4_ipaddrs(None, true);
+    let addrs_v6 = get_ipv6_ipaddrs(None, true);
 
     if addrs_v6.is_empty() {
         // No IPv6 addresses on this host; test requires IPv6 to produce a protocol mismatch.
@@ -437,7 +437,7 @@ async fn openclose_udp_only_connect_with_bind_restriction_mismatch_protocols() {
 #[should_panic(expected = "assertion failed: open_res.is_ok()")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn openclose_udp_only_connect_with_bind_and_interface() {
-    let addrs = get_ipv4_ipaddrs(None);
+    let addrs = get_ipv4_ipaddrs(None, true);
     let listen_port = get_free_udp_port();
     let bind_port = get_free_udp_port();
     let bind_addr_str = format!("{}:{}", addrs[0], bind_port);
@@ -461,7 +461,7 @@ async fn openclose_udp_only_connect_with_bind_and_interface() {
 #[cfg(feature = "transport_udp")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn openclose_udp_only_connect_with_bind_restriction() {
-    let addrs = get_ipv4_ipaddrs(None);
+    let addrs = get_ipv4_ipaddrs(None, true);
     let listen_port = get_free_udp_port();
     let bind_port = get_free_udp_port();
     let bind_addr_str = format!("{}:{}", addrs[0], bind_port);

--- a/io/zenoh-transport/tests/unicast_openclose.rs
+++ b/io/zenoh-transport/tests/unicast_openclose.rs
@@ -756,7 +756,7 @@ async fn openclose_quic_only_with_mtls_and_no_common_name() {
 #[should_panic(expected = "Elapsed")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn openclose_tcp_only_connect_with_interface_restriction() {
-    let addrs = get_ipv4_ipaddrs(None);
+    let addrs = get_ipv4_ipaddrs(None, true);
     let port = get_free_tcp_port();
 
     zenoh_util::init_log_from_env_or("error");
@@ -776,7 +776,7 @@ async fn openclose_tcp_only_connect_with_interface_restriction() {
 #[should_panic(expected = "assertion failed: open_res.is_ok()")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn openclose_tcp_only_listen_with_interface_restriction() {
-    let addrs = get_ipv4_ipaddrs(None);
+    let addrs = get_ipv4_ipaddrs(None, true);
     let port = get_free_tcp_port();
 
     zenoh_util::init_log_from_env_or("error");
@@ -796,7 +796,7 @@ async fn openclose_tcp_only_listen_with_interface_restriction() {
 #[should_panic(expected = "Elapsed")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn openclose_udp_only_connect_with_interface_restriction() {
-    let addrs = get_ipv4_ipaddrs(None);
+    let addrs = get_ipv4_ipaddrs(None, true);
     let port = get_free_udp_port();
 
     zenoh_util::init_log_from_env_or("error");
@@ -815,7 +815,7 @@ async fn openclose_udp_only_connect_with_interface_restriction() {
 #[cfg(target_os = "linux")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn openclose_udp_only_listen_with_interface_restriction() {
-    let addrs = get_ipv4_ipaddrs(None);
+    let addrs = get_ipv4_ipaddrs(None, true);
     let port = get_free_udp_port();
 
     zenoh_util::init_log_from_env_or("error");
@@ -845,7 +845,7 @@ async fn openclose_quic_only_connect_with_interface_restriction() {
     use zenoh_link_commons::tls::config::*;
 
     zenoh_util::init_log_from_env_or("error");
-    let addrs = get_ipv4_ipaddrs(None);
+    let addrs = get_ipv4_ipaddrs(None, true);
     let port = get_free_udp_port();
     let (ca, cert, key) = get_tls_certs();
 
@@ -879,7 +879,7 @@ async fn openclose_quic_only_listen_with_interface_restriction() {
     use zenoh_link_commons::tls::config::*;
 
     zenoh_util::init_log_from_env_or("error");
-    let addrs = get_ipv4_ipaddrs(None);
+    let addrs = get_ipv4_ipaddrs(None, true);
     let port = get_free_udp_port();
     let (ca, cert, key) = get_tls_certs();
 
@@ -913,7 +913,7 @@ async fn openclose_tls_only_connect_with_interface_restriction() {
     use zenoh_link_commons::tls::config::*;
 
     zenoh_util::init_log_from_env_or("error");
-    let addrs = get_ipv4_ipaddrs(None);
+    let addrs = get_ipv4_ipaddrs(None, true);
     let port = get_free_tcp_port();
     let (ca, cert, key) = get_tls_certs();
 
@@ -947,7 +947,7 @@ async fn openclose_tls_only_listen_with_interface_restriction() {
     use zenoh_link_commons::tls::config::*;
 
     zenoh_util::init_log_from_env_or("error");
-    let addrs = get_ipv4_ipaddrs(None);
+    let addrs = get_ipv4_ipaddrs(None, true);
     let port = get_free_tcp_port();
     let (ca, cert, key) = get_tls_certs();
 

--- a/zenoh/src/api/scouting.rs
+++ b/zenoh/src/api/scouting.rs
@@ -13,7 +13,6 @@
 //
 use std::{fmt, net::SocketAddr, ops::Deref, time::Duration};
 
-use tokio::net::UdpSocket;
 use zenoh_config::wrappers::Hello;
 use zenoh_protocol::core::WhatAmIMatcher;
 use zenoh_result::ZResult;
@@ -171,10 +170,10 @@ pub(crate) fn _scout(
     );
     let ifaces = Runtime::get_interfaces(ifaces);
     if !ifaces.is_empty() {
-        let sockets: Vec<UdpSocket> = ifaces
+        let sockets = ifaces
             .into_iter()
             .filter_map(|iface| Runtime::bind_ucast_port(iface, multicast_ttl).ok())
-            .collect();
+            .collect::<Vec<_>>();
         if !sockets.is_empty() {
             let cancellation_token = TerminatableTask::create_cancellation_token();
             let cancellation_token_clone = cancellation_token.clone();

--- a/zenoh/src/net/protocol/gossip.rs
+++ b/zenoh/src/net/protocol/gossip.rs
@@ -197,7 +197,7 @@ impl Gossip {
             whatami: self.graph[idx].whatami,
             locators: if details.locators {
                 if idx == self.idx {
-                    Some(self.runtime.upgrade().unwrap().get_locators())
+                    Some(self.runtime.upgrade().unwrap().get_locators_noloopback())
                 } else {
                     self.graph[idx].locators.clone()
                 }

--- a/zenoh/src/net/protocol/network.rs
+++ b/zenoh/src/net/protocol/network.rs
@@ -339,7 +339,7 @@ impl Network {
             whatami: self.graph[idx].whatami,
             locators: if details.locators {
                 if idx == self.idx {
-                    Some(self.runtime.upgrade().unwrap().get_locators())
+                    Some(self.runtime.upgrade().unwrap().get_locators_noloopback())
                 } else {
                     self.graph[idx].locators.clone()
                 }

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -637,7 +637,7 @@ fn local_data(prefix: &keyexpr, context: &AdminContext, query: Query) {
 
     // locators info
     let locators: Vec<serde_json::Value> = transport_mgr
-        .get_locators()
+        .get_locators_noloopback()
         .iter()
         .map(|locator| json!(locator.as_str()))
         .collect();

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -174,6 +174,7 @@ pub(crate) struct RuntimeState {
     manager: TransportManager,
     transport_handlers: std::sync::RwLock<Vec<Arc<dyn TransportEventHandler>>>,
     locators: std::sync::RwLock<Vec<Locator>>,
+    locators_noloopback: std::sync::RwLock<Vec<Locator>>,
     hlc: Option<Arc<HLC>>,
     // TODO: lazy_hlc is added for timestamp instrumentation feature, in order to avoid breaking
     // existing logic that relies on state of hlc Option to check if timestamping is enabled or
@@ -206,6 +207,7 @@ pub trait IRuntime: Send + Sync {
     #[cfg(feature = "unstable")]
     fn get_ts_stack_timestamp(&self, context: TimestampContext) -> (Vec<u8>, bool);
     fn get_locators(&self) -> Vec<Locator>;
+    fn get_locators_noloopback(&self) -> Vec<Locator>;
     fn get_zids(&self, whatami: WhatAmI) -> Box<dyn Iterator<Item = ZenohId> + Send + Sync>;
     fn new_handler(&self, handler: Arc<dyn TransportEventHandler>);
 
@@ -297,6 +299,10 @@ impl IRuntime for RuntimeState {
 
     fn get_locators(&self) -> Vec<Locator> {
         self.locators.read().unwrap().clone()
+    }
+
+    fn get_locators_noloopback(&self) -> Vec<Locator> {
+        self.locators_noloopback.read().unwrap().clone()
     }
 
     fn hlc(&self) -> Option<&HLC> {
@@ -816,6 +822,7 @@ impl RuntimeBuilder {
                 manager: transport_manager,
                 transport_handlers: std::sync::RwLock::new(vec![]),
                 locators: std::sync::RwLock::new(vec![]),
+                locators_noloopback: std::sync::RwLock::new(vec![]),
                 hlc,
                 #[cfg(feature = "unstable")]
                 lazy_hlc: OnceLock::new(),
@@ -949,6 +956,10 @@ impl Runtime {
 
     pub fn get_locators(&self) -> Vec<Locator> {
         self.state.get_locators()
+    }
+
+    pub fn get_locators_noloopback(&self) -> Vec<Locator> {
+        self.state.get_locators_noloopback()
     }
 
     /// Spawns a task within runtime.

--- a/zenoh/src/net/runtime/orchestrator.rs
+++ b/zenoh/src/net/runtime/orchestrator.rs
@@ -13,7 +13,7 @@
 //
 use std::{
     collections::{HashMap, HashSet},
-    net::{IpAddr, Ipv6Addr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     ops::DerefMut,
     str::FromStr,
     time::Duration,
@@ -52,6 +52,29 @@ const RCV_BUF_SIZE: usize = u16::MAX as usize;
 const SCOUT_INITIAL_PERIOD: Duration = Duration::from_millis(1_000);
 const SCOUT_MAX_PERIOD: Duration = Duration::from_millis(8_000);
 const SCOUT_PERIOD_INCREASE_FACTOR: u32 = 2;
+
+// TODO(fuzzypixelz): collapse per-interface scout sockets into one wildcard socket
+// per address family. Select egress with `set_multicast_if_*` before send;
+// serialize set+send because the socket option is mutable.
+/// UDP scout socket for one multicast egress interface.
+///
+/// The socket is wildcard-bound; `iface` pins multicast egress via socket
+/// options.[^mcast-if]
+///
+/// [^mcast-if]: [`Socket::set_multicast_if_v4`], [`Socket::set_multicast_if_v6`].
+pub(crate) struct ScoutSocket {
+    /// Wildcard-bound UDP socket used for Scout/Hello traffic.
+    socket: UdpSocket,
+    /// Interface address used for multicast egress and responder matching.
+    iface: IpAddr,
+}
+
+impl ScoutSocket {
+    /// Sends a multicast datagram through this socket's egress interface.
+    async fn send_multicast(&self, buffer: &[u8], dst: SocketAddr) -> std::io::Result<usize> {
+        self.socket.send_to(buffer, dst).await
+    }
+}
 
 #[derive(Debug)]
 pub enum Loop {
@@ -184,7 +207,7 @@ impl Runtime {
                 if ifaces.is_empty() {
                     bail!("Unable to find multicast interface!")
                 } else {
-                    let sockets: Vec<UdpSocket> = ifaces
+                    let sockets: Vec<ScoutSocket> = ifaces
                         .into_iter()
                         .filter_map(|iface| Runtime::bind_ucast_port(iface, multicast_ttl).ok())
                         .collect();
@@ -309,7 +332,7 @@ impl Runtime {
         let ifaces = Runtime::get_interfaces(&ifaces);
         let mcast_socket = Runtime::bind_mcast_port(&addr, &ifaces, multicast_ttl).await?;
         if !ifaces.is_empty() {
-            let sockets: Vec<UdpSocket> = ifaces
+            let sockets: Vec<ScoutSocket> = ifaces
                 .into_iter()
                 .filter_map(|iface| Runtime::bind_ucast_port(iface, multicast_ttl).ok())
                 .collect();
@@ -585,9 +608,11 @@ impl Runtime {
     }
 
     fn print_locators(&self) {
-        let mut locators = self.state.locators.write().unwrap();
-        *locators = self.manager().get_locators();
-        for locator in &*locators {
+        let locators = self.manager().get_locators();
+        let locators_noloopback = self.manager().get_locators_noloopback();
+        *self.state.locators.write().unwrap() = locators;
+        *self.state.locators_noloopback.write().unwrap() = locators_noloopback.clone();
+        for locator in &locators_noloopback {
             tracing::info!("Zenoh can be reached at: {}", locator);
         }
     }
@@ -720,40 +745,120 @@ impl Runtime {
         Ok(udp_socket)
     }
 
-    pub fn bind_ucast_port(addr: IpAddr, multicast_ttl: u32) -> ZResult<UdpSocket> {
-        let sockaddr = || SocketAddr::new(addr, 0);
-        let socket = match Socket::new(Domain::for_address(sockaddr()), Type::DGRAM, None) {
+    /// Binds a scout socket for `iface`.
+    ///
+    /// The socket is bound to the address-family wildcard; `iface` is selected
+    /// with multicast egress socket options.[^mcast-if]
+    ///
+    /// [^mcast-if]: [`Socket::set_multicast_if_v4`], [`Socket::set_multicast_if_v6`].
+    pub(crate) fn bind_ucast_port(iface: IpAddr, multicast_ttl: u32) -> ZResult<ScoutSocket> {
+        let bind_addr = match iface {
+            IpAddr::V4(_) => SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
+            IpAddr::V6(_) => SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
+        };
+        let socket = match Socket::new(Domain::for_address(bind_addr), Type::DGRAM, None) {
             Ok(socket) => socket,
             Err(err) => {
-                tracing::warn!("Unable to create datagram socket: {}", err);
-                bail!(err=> "Unable to create datagram socket");
+                tracing::warn!(
+                    "Unable to create UDP scout socket for multicast interface {}: {}",
+                    iface,
+                    err
+                );
+                bail!(err => "Unable to create UDP scout socket for multicast interface {}", iface);
             }
         };
-        match socket.bind(&sockaddr().into()) {
+
+        match iface {
+            IpAddr::V4(addr) => {
+                if !addr.is_unspecified() {
+                    socket.set_multicast_if_v4(&addr).map_err(|err| {
+                        zerror!(
+                            "Unable to select multicast interface {} on UDP scout socket: {}",
+                            iface,
+                            err
+                        )
+                    })?;
+                }
+                socket.set_multicast_ttl_v4(multicast_ttl).map_err(|err| {
+                    zerror!(
+                        "Unable to set multicast TTL {} on UDP scout socket for multicast interface {}: {}",
+                        multicast_ttl,
+                        iface,
+                        err
+                    )
+                })?;
+            }
+            IpAddr::V6(addr) => {
+                if !addr.is_unspecified() {
+                    let idx = zenoh_util::net::get_index_of_interface(IpAddr::V6(addr))?;
+                    socket.set_multicast_if_v6(idx).map_err(|err| {
+                        zerror!(
+                            "Unable to select multicast interface {} on UDP scout socket: {}",
+                            iface,
+                            err
+                        )
+                    })?;
+                }
+                socket.set_multicast_hops_v6(multicast_ttl).map_err(|err| {
+                    zerror!(
+                        "Unable to set multicast hop limit {} on UDP scout socket for multicast interface {}: {}",
+                        multicast_ttl,
+                        iface,
+                        err
+                    )
+                })?;
+            }
+        }
+
+        match socket.bind(&bind_addr.into()) {
             Ok(()) => {
                 #[allow(clippy::or_fun_call)]
                 let local_addr = socket
                     .local_addr()
-                    .unwrap_or(sockaddr().into())
+                    .unwrap_or(bind_addr.into())
                     .as_socket()
-                    .unwrap_or(sockaddr());
-                tracing::debug!("UDP port bound to {}", local_addr);
+                    .unwrap_or(bind_addr);
+                tracing::debug!(
+                    "UDP scout socket bound to {} for multicast interface {}",
+                    local_addr,
+                    iface
+                );
             }
             Err(err) => {
-                tracing::warn!("Unable to bind udp port {}:0: {}", addr, err);
-                bail!(err => "Unable to bind udp port {}:0", addr);
+                tracing::warn!(
+                    "Unable to bind UDP scout socket to {} for multicast interface {}: {}",
+                    bind_addr,
+                    iface,
+                    err
+                );
+                bail!(err => "Unable to bind UDP scout socket to {} for multicast interface {}", bind_addr, iface);
             }
         }
 
         // Must set to nonblocking according to the doc of tokio
         // https://docs.rs/tokio/latest/tokio/net/struct.UdpSocket.html#notes
-        socket.set_nonblocking(true)?;
-        socket.set_multicast_ttl_v4(multicast_ttl)?;
+        socket.set_nonblocking(true).map_err(|err| {
+            zerror!(
+                "Unable to make UDP scout socket non-blocking for multicast interface {}: {}",
+                iface,
+                err
+            )
+        })?;
 
         // UdpSocket::from_std requires a runtime even though it's a sync function
         let udp_socket = zenoh_runtime::ZRuntime::Net
-            .block_in_place(async { UdpSocket::from_std(socket.into()) })?;
-        Ok(udp_socket)
+            .block_in_place(async { UdpSocket::from_std(socket.into()) })
+            .map_err(|err| {
+                zerror!(
+                    "Unable to create async UDP scout socket for multicast interface {}: {}",
+                    iface,
+                    err
+                )
+            })?;
+        Ok(ScoutSocket {
+            socket: udp_socket,
+            iface,
+        })
     }
 
     async fn spawn_peer_connector(&self, peer: EndPoint) -> ZResult<()> {
@@ -889,8 +994,8 @@ impl Runtime {
             .map(|peers| peers[0])
     }
 
-    pub async fn scout<Fut, F>(
-        sockets: &[UdpSocket],
+    pub(crate) async fn scout<Fut, F>(
+        sockets: &[ScoutSocket],
         matcher: WhatAmIMatcher,
         mcast_addr: &SocketAddr,
         f: F,
@@ -919,21 +1024,14 @@ impl Runtime {
                         "Send {:?} to {} on interface {}",
                         scout.body,
                         mcast_addr,
-                        socket
-                            .local_addr()
-                            .map_or("unknown".to_string(), |addr| addr.ip().to_string())
+                        socket.iface
                     );
-                    if let Err(err) = socket
-                        .send_to(wbuf.as_slice(), mcast_addr.to_string())
-                        .await
-                    {
+                    if let Err(err) = socket.send_multicast(wbuf.as_slice(), *mcast_addr).await {
                         tracing::debug!(
                             "Unable to send {:?} to {} on interface {}: {}",
                             scout.body,
                             mcast_addr,
-                            socket
-                                .local_addr()
-                                .map_or("unknown".to_string(), |addr| addr.ip().to_string()),
+                            socket.iface,
                             err
                         );
                     }
@@ -949,7 +1047,7 @@ impl Runtime {
             async move {
                 let mut buf = vec![0; RCV_BUF_SIZE];
                 loop {
-                    match socket.recv_from(&mut buf).await {
+                    match socket.socket.recv_from(&mut buf).await {
                         Ok((n, peer)) => {
                             let mut reader = buf.as_slice()[..n].reader();
                             let codec = Zenoh080::new();
@@ -1126,7 +1224,7 @@ impl Runtime {
 
     async fn connect_first(
         &self,
-        sockets: &[UdpSocket],
+        sockets: &[ScoutSocket],
         what: WhatAmIMatcher,
         addr: &SocketAddr,
         timeout: std::time::Duration,
@@ -1158,7 +1256,7 @@ impl Runtime {
 
     async fn autoconnect_all(
         &self,
-        ucast_sockets: &[UdpSocket],
+        ucast_sockets: &[ScoutSocket],
         autoconnect: AutoConnect,
         addr: &SocketAddr,
     ) {
@@ -1178,34 +1276,52 @@ impl Runtime {
         .await
     }
 
-    async fn responder(&self, mcast_socket: &UdpSocket, ucast_sockets: &[UdpSocket]) {
-        fn get_best_match<'a>(addr: &IpAddr, sockets: &'a [UdpSocket]) -> Option<&'a UdpSocket> {
+    /// Locators advertised in a scouting [`HelloProto`] to `peer`.
+    ///
+    /// Loopback peers get loopback locators; public locators intentionally
+    /// exclude loopback.
+    fn get_hello_locators(&self, peer: &SocketAddr) -> Vec<Locator> {
+        if peer.ip().is_loopback() {
+            self.get_locators()
+        } else {
+            self.get_locators_noloopback()
+        }
+    }
+
+    async fn responder(&self, mcast_socket: &UdpSocket, ucast_sockets: &[ScoutSocket]) {
+        fn get_best_match<'a>(
+            addr: &IpAddr,
+            sockets: &'a [ScoutSocket],
+        ) -> Option<&'a ScoutSocket> {
             fn octets(addr: &IpAddr) -> Vec<u8> {
                 match addr {
                     IpAddr::V4(addr) => addr.octets().to_vec(),
                     IpAddr::V6(addr) => addr.octets().to_vec(),
                 }
             }
-            fn matching_octets(addr: &IpAddr, sock: &UdpSocket) -> usize {
+            fn matching_octets(addr: &IpAddr, sock: &ScoutSocket) -> usize {
                 octets(addr)
                     .iter()
-                    .zip(octets(&sock.local_addr().unwrap().ip()))
+                    .zip(octets(&sock.iface))
                     .map(|(x, y)| x.cmp(&y))
                     .position(|ord| ord != std::cmp::Ordering::Equal)
                     .unwrap_or_else(|| octets(addr).len())
             }
-            sockets
-                .iter()
-                .filter(|sock| sock.local_addr().is_ok())
-                .max_by(|sock1, sock2| {
-                    matching_octets(addr, sock1).cmp(&matching_octets(addr, sock2))
-                })
+            sockets.iter().max_by(|sock1, sock2| {
+                matching_octets(addr, sock1).cmp(&matching_octets(addr, sock2))
+            })
         }
 
         let mut buf = vec![0; RCV_BUF_SIZE];
         let local_addrs: Vec<SocketAddr> = ucast_sockets
             .iter()
-            .filter_map(|sock| sock.local_addr().ok())
+            .filter_map(|sock| {
+                sock.socket
+                    .local_addr()
+                    .ok()
+                    .map(|addr| (sock.iface, addr.port()))
+            })
+            .map(|(iface, port)| SocketAddr::new(iface, port))
             .collect();
         tracing::debug!("Waiting for UDP datagram...");
         loop {
@@ -1231,7 +1347,7 @@ impl Runtime {
                             version: zenoh_protocol::VERSION,
                             whatami: self.whatami(),
                             zid,
-                            locators: self.get_locators(),
+                            locators: self.get_hello_locators(&peer),
                         }
                         .into();
                         let socket = get_best_match(&peer.ip(), ucast_sockets).unwrap();
@@ -1239,13 +1355,11 @@ impl Runtime {
                             "Send {:?} to {} on interface {}",
                             hello.body,
                             peer,
-                            socket
-                                .local_addr()
-                                .map_or("unknown".to_string(), |addr| addr.ip().to_string())
+                            socket.iface
                         );
                         codec.write(&mut writer, &hello).unwrap();
 
-                        if let Err(err) = socket.send_to(wbuf.as_slice(), peer).await {
+                        if let Err(err) = socket.socket.send_to(wbuf.as_slice(), peer).await {
                             tracing::error!("Unable to send {:?} to {}: {}", hello.body, peer, err);
                         }
                     }
@@ -1350,5 +1464,34 @@ impl Runtime {
             .values()
             .flat_map(|hat| hat.links_info().into_iter())
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::time::{timeout, Duration};
+
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn scout_sender_can_multicast_on_loopback() {
+        let iface = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        let group = IpAddr::V4(Ipv4Addr::new(224, 0, 0, 224));
+        let rx = Runtime::bind_mcast_port(&SocketAddr::new(group, 0), &[iface], 1)
+            .await
+            .unwrap();
+        let dst = SocketAddr::new(group, rx.local_addr().unwrap().port());
+        let tx = Runtime::bind_ucast_port(iface, 1).unwrap();
+        let payload = b"zenoh loopback multicast regression";
+
+        let sent = tx.send_multicast(payload, dst).await.unwrap();
+        assert_eq!(sent, payload.len());
+
+        let mut buf = [0; 256];
+        let (n, _) = timeout(Duration::from_secs(2), rx.recv_from(&mut buf))
+            .await
+            .expect("timed out waiting for loopback multicast packet")
+            .unwrap();
+        assert_eq!(&buf[..n], payload);
     }
 }

--- a/zenoh/tests/scouting.rs
+++ b/zenoh/tests/scouting.rs
@@ -1,0 +1,152 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    time::Duration,
+};
+
+use tokio::time::timeout;
+use zenoh::config::WhatAmI;
+#[cfg(all(feature = "unstable", feature = "transport_tcp"))]
+use zenoh::sample::SampleKind;
+use zenoh_config::{Config, ModeDependentValue, WhatAmIMatcher};
+use zenoh_link::EndPoint;
+use zenoh_test::get_free_udp_port;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn multicast_scouting_works_on_loopback() {
+    zenoh::init_log_from_env_or("error");
+
+    let mcast_addr = SocketAddr::new(
+        IpAddr::V4(Ipv4Addr::new(224, 0, 0, 224)),
+        get_free_udp_port(),
+    );
+
+    let mut responder_config = Config::default();
+    responder_config.set_mode(Some(WhatAmI::Router)).unwrap();
+    responder_config
+        .listen
+        .endpoints
+        .set(Vec::<EndPoint>::new())
+        .unwrap();
+    responder_config
+        .scouting
+        .gossip
+        .set_enabled(Some(false))
+        .unwrap();
+    responder_config
+        .scouting
+        .multicast
+        .set_enabled(Some(true))
+        .unwrap();
+    responder_config
+        .scouting
+        .multicast
+        .set_address(Some(mcast_addr))
+        .unwrap();
+    responder_config
+        .scouting
+        .multicast
+        .set_interface(Some("127.0.0.1".to_string()))
+        .unwrap();
+    responder_config
+        .scouting
+        .multicast
+        .set_autoconnect(Some(ModeDependentValue::Unique(WhatAmIMatcher::empty())))
+        .unwrap();
+
+    let responder = zenoh::open(responder_config).await.unwrap();
+    let responder_zid = responder.zid();
+
+    let mut scout_config = Config::default();
+    scout_config
+        .scouting
+        .gossip
+        .set_enabled(Some(false))
+        .unwrap();
+    scout_config
+        .scouting
+        .multicast
+        .set_address(Some(mcast_addr))
+        .unwrap();
+    scout_config
+        .scouting
+        .multicast
+        .set_interface(Some("127.0.0.1".to_string()))
+        .unwrap();
+
+    let scout = zenoh::scout(WhatAmI::Router, scout_config).await.unwrap();
+    let hello = timeout(Duration::from_secs(5), scout.recv_async())
+        .await
+        .expect("timed out waiting for multicast scout Hello")
+        .unwrap();
+
+    assert_eq!(hello.whatami(), WhatAmI::Router);
+    assert_eq!(hello.zid(), responder_zid);
+
+    scout.stop();
+    responder.close().await.unwrap();
+}
+
+#[cfg(all(feature = "unstable", feature = "transport_tcp"))]
+#[tokio::test(flavor = "multi_thread")]
+async fn multicast_autoconnect_works_on_loopback() {
+    zenoh::init_log_from_env_or("error");
+
+    let mcast_addr = SocketAddr::new(
+        IpAddr::V4(Ipv4Addr::new(224, 0, 0, 224)),
+        get_free_udp_port(),
+    );
+    let peer_config = || {
+        let mut config = Config::default();
+        config.set_mode(Some(WhatAmI::Peer)).unwrap();
+        config.scouting.gossip.set_enabled(Some(false)).unwrap();
+        config.scouting.multicast.set_enabled(Some(true)).unwrap();
+        config
+            .scouting
+            .multicast
+            .set_address(Some(mcast_addr))
+            .unwrap();
+        config
+            .scouting
+            .multicast
+            .set_interface(Some("127.0.0.1".to_string()))
+            .unwrap();
+        config
+    };
+
+    let peer1 = zenoh::open(peer_config()).await.unwrap();
+    let peer1_events = peer1
+        .info()
+        .transport_events_listener()
+        .with(flume::bounded(32))
+        .await
+        .unwrap();
+    let peer2 = zenoh::open(peer_config()).await.unwrap();
+    let peer2_zid = peer2.zid();
+
+    timeout(Duration::from_secs(5), async {
+        loop {
+            let event = peer1_events.recv_async().await.unwrap();
+            if event.kind() == SampleKind::Put && event.transport().zid() == &peer2_zid {
+                break;
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for loopback scout connection");
+
+    peer2.close().await.unwrap();
+    peer1.close().await.unwrap();
+}


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->

Fixes #2408.

### What does this PR do?
<!-- Describe the changes and their purpose -->

This addresses two loopback-specific failures:
- macOS rejects multicast `Scout` sends from a loopback-bound socket; TX sockets now bind unspecified and select a multicast egress interface with `IP_MULTICAST_IF`/`IPV6_MULTICAST_IF`.
- Discovery could receive `Hello` over loopback but fail autoconnect because unspecified listeners did not advertise loopback locators; `Hello` locators now include loopback reachability for loopback peers.

### Why is this change needed?
<!-- Explain the motivation or problem being solved -->

See #2408.

Furthermore, the fact that loopback locators were not included in `Hello` means that multicast scouting on loopback-only hosts was also broken on Linux and Windows prior to this patch:

```text
TRACE zenoh::net::runtime::orchestrator: Received Hello(HelloProto { version: 9, whatami: Peer, zid: 3d308f15edb0d1dac3e6f14deac8e0db, locators: [] }) from 127.0.0.1:51945
DEBUG zenoh::net::runtime::orchestrator: Received Hello with no locators: HelloProto { version: 9, whatami: Peer, zid: 3d308f15edb0d1dac3e6f14deac8e0db, locators: [] }
```

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

Well, #2408.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [x] **Reproduction test added** - Test that fails on main branch without the fix
- [x] **Test passes with fix** - The reproduction test passes with your changes
- [x] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->