### PR TITLE
Fix `semicolon_in_expressions_from_macros` (nightly) lint failure

### DIFF
--- a/commons/zenoh-shm/build.rs
+++ b/commons/zenoh-shm/build.rs
@@ -41,7 +41,7 @@ fn main() {
         // we use this alias to detect platforms that
         // don't support advisory file locking on tmpfs
         shm_external_lockfile: { any(bsd, target_os = "redox") },
-    }
+    };
 
     println!("cargo:rustc-check-cfg=cfg(apple_targets)");
     println!("cargo:rustc-check-cfg=cfg(bsd)");


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->

New nightly treats `semicolon_in_expressions_from_macros` under deny(future_incompatible), causing rustdoc to fail.


### Why is this change needed?
<!-- Explain the motivation or problem being solved -->

See https://github.com/eclipse-zenoh/zenoh/actions/runs/29501912535/job/87632709997?pr=2671.

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

N/A

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [ ] **No API changes** - Public APIs unchanged
- [ ] **No behavior changes** - External behavior identical
- [ ] **Refactoring/maintenance** - Code improvements only
- [ ] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->