### PR TITLE
chore: pin unescaper for 1.75.0 compatibility

### DIFF
--- a/commons/zenoh-pinned-deps-1-75/Cargo.toml
+++ b/commons/zenoh-pinned-deps-1-75/Cargo.toml
@@ -66,6 +66,7 @@ toml_datetime = "=0.7.1"
 toml_parser = "=1.0.2"
 toml_writer = "=1.0.2"
 twox-hash = "=1.6.3"
+unescaper = "=0.1.8"
 unzip-n = "=0.1.2"
 uuid = "=1.20.0"
 zerofrom = "=0.1.5"
@@ -117,6 +118,7 @@ ignored = [
   "toml_parser",
   "toml_writer",
   "twox-hash",
+  "unescaper",
   "unzip-n",
   "uuid",
   "zerofrom",


### PR DESCRIPTION
## Description
zenoh-c fails the 1.75.0 check because it pulls in a more recent version of the `unescaper` crate.

### What does this PR do?
This PR pins the crate to the latest version compatible with 1.75.0

### Why is this change needed?
To allow zenoh-c to build with 1.75.0 only dependencies

### Related Issues
https://github.com/eclipse-zenoh/zenoh-c/actions/runs/28947385601/job/85884694962?pr=1283
https://github.com/eclipse-zenoh/zenoh-c/pull/1283
https://github.com/eclipse-zenoh/zenoh-c/pull/1286

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `dependencies`, `internal`

## 📦 Dependency Updates

Since this PR updates dependencies:

- [x] **Changelog reviewed** - Breaking changes in dependency identified and addressed
- [x] **Security advisories checked** - No known vulnerabilities in new version
- [x] **License compatible** - New version license is compatible with project
- [x] **Tests pass** - All tests pass with new dependency versions
- [x] **Transitive deps reviewed** - New transitive dependencies checked
- [x] **Version pinned appropriately** - Semver range is intentional and correct
- [x] **Update scope limited** - Updating one major dependency at a time when possible

**Best practice:** Keep dependency updates focused and test thoroughly.

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->