### PR TITLE
ci: rustdoc renamed --emit=invocation-specific to html-non-static-files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -461,7 +461,7 @@ jobs:
         run: |
           cargo +${{ env.NIGHTLY_TOOLCHAIN }} rustdoc --manifest-path ./zenoh/Cargo.toml --lib --features "shared-memory unstable" -j3 \
             -Z rustdoc-map -Z unstable-options -Z rustdoc-scrape-examples \
-            --config build.rustdocflags='["--cfg", "docsrs", "-Z", "unstable-options", "--emit=invocation-specific", "--cap-lints", "warn", "--extern-html-root-takes-precedence"]'
+            --config build.rustdocflags='["--cfg", "docsrs", "-Z", "unstable-options", "--emit=html-non-static-files", "--cap-lints", "warn", "--extern-html-root-takes-precedence"]'
 
   coverage:
     name: Coverage

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -131,6 +131,6 @@ jobs:
         run: >
           cargo +nightly rustdoc --manifest-path ./zenoh/Cargo.toml --lib --features unstable -j3
           -Z rustdoc-map -Z unstable-options -Z rustdoc-scrape-examples
-          --config build.rustdocflags='["-Z", "unstable-options", "--emit=invocation-specific", "--cap-lints", "warn", "--disable-per-crate-search", "--extern-html-root-takes-precedence"]'
+          --config build.rustdocflags='["-Z", "unstable-options", "--emit=html-non-static-files", "--cap-lints", "warn", "--disable-per-crate-search", "--extern-html-root-takes-precedence"]'
         env:
           RUSTDOCFLAGS: -Dwarnings


### PR DESCRIPTION
Current nightly rustdoc (2026-07-17) rejects the docs jobs' `--emit=invocation-specific` with `error: unrecognized emission type`: the emission types were renamed, and the equivalent of the old flag (emit the invocation-specific HTML while skipping the shared static assets) is now `--emit=html-non-static-files` (accepted set: `html-static-files, html-non-static-files, dep-info`).

Both the `ci.yml` **Generate documentation** job and the `pre-release.yml` docs job install the floating `nightly`, so every new run fails regardless of the change under test (first observed on #2687; PRs whose docs job last ran a few days ago still show green).

Verified by running ci.yml's exact rustdoc command locally on nightly 2026-07-17: fails with the old flag, completes and generates `target/doc/zenoh/index.html` with the new one (shared static assets skipped, as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->