### PR TITLE
fix: parse array-item config key filter from the last `=`

### DIFF
--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -1323,7 +1323,7 @@ impl Config {
         key: &str,
         value: &str,
     ) -> Result<bool, validated_struct::InsertionError> {
-        let Some((prefix, field_value)) = key.split_once('=') else {
+        let Some((prefix, field_value)) = key.rsplit_once('=') else {
             return Ok(false);
         };
         let (array_key, field_name) =
@@ -1416,7 +1416,7 @@ impl Config {
     /// unchanged.
     pub fn try_remove_json5_array_item<K: AsRef<str>>(&mut self, key: K) -> ZResult<bool> {
         let key = key.as_ref();
-        let Some((prefix, field_value)) = key.split_once('=') else {
+        let Some((prefix, field_value)) = key.rsplit_once('=') else {
             return Ok(false);
         };
         let (array_key, field_name) = prefix.rsplit_once('/').ok_or("missing field filter")?;
@@ -2156,6 +2156,40 @@ mod tests {
             .unwrap());
         let items: serde_json::Value =
             serde_json::from_str(&config.get_json("qos/network").unwrap()).unwrap();
+        assert_eq!(items.as_array().unwrap().len(), 0);
+    }
+
+    // Regression test for https://github.com/eclipse-zenoh/zenoh/issues/2655:
+    // the field filter is only the last `<field-name>=<field-value>` segment, so
+    // a `=` appearing earlier in the array key (e.g. in a plugin subkey) must not
+    // be mistaken for the filter separator.
+    #[test]
+    fn insert_remove_json5_array_item_with_equals_in_array_key() {
+        let mut config = Config::default();
+
+        // Seed an empty array under a key whose path contains an earlier `=`.
+        config
+            .insert_json5("plugins/example/a=b/items", "[]")
+            .unwrap();
+
+        assert!(config
+            .try_insert_json5_array_item(
+                "plugins/example/a=b/items/id=item1",
+                r#"{ id: "item1", value: 1 }"#,
+            )
+            .unwrap());
+
+        let items: serde_json::Value =
+            serde_json::from_str(&config.get_json("plugins/example/a=b/items").unwrap()).unwrap();
+        assert_eq!(items.as_array().unwrap().len(), 1);
+        assert_eq!(items[0]["id"], "item1");
+        assert_eq!(items[0]["value"], 1);
+
+        assert!(config
+            .try_remove_json5_array_item("plugins/example/a=b/items/id=item1")
+            .unwrap());
+        let items: serde_json::Value =
+            serde_json::from_str(&config.get_json("plugins/example/a=b/items").unwrap()).unwrap();
         assert_eq!(items.as_array().unwrap().len(), 0);
     }
 }


### PR DESCRIPTION
## Description

### What does this PR do?
`Config::try_insert_json5_array_item` and `Config::try_remove_json5_array_item` accept a key of the form `<array-key>/<field-name>=<field-value>`, where the `<field-name>=<field-value>` field filter is the **last** key segment. They previously used `split_once('=')`, which splits on the **first** `=`.

When the array key itself contains a `=` — for example a plugin subkey addressed via the admin space such as `@/<zid>/<mode>/config/plugins/example/a=b/items/id=item1` — the first `=` is not the filter separator. The key was mis-parsed: `plugins/example/a` was taken as the prefix and `b/items/id=item1` as the field value, so the operation targeted the wrong field (`a`) and failed with a "field filter mismatch" error.

This PR switches both methods to `rsplit_once('=')`, so the filter is always taken from the last `=`.

### Why is this change needed?
Array-item config updates/removals over the admin space are broken for any array whose key path contains an earlier `=` (e.g. plugin configuration subkeys). See #2655.

A regression test (`insert_remove_json5_array_item_with_equals_in_array_key`) is added; it reproduces the reported mis-parse (fails before the fix, passes after).

### Verification
- `cargo test -p zenoh-config --all-features` — all tests pass
- `cargo clippy -p zenoh-config --all-features` — clean
- `cargo fmt -p zenoh-config -- --check` — clean

### Related Issues
Fixes #2655

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [x] **Reproduction test added** - Test that fails on main branch without the fix
- [x] **Test passes with fix** - The reproduction test passes with your changes
- [x] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->