### PR TITLE
fix(zenohd): Exit gracefully instead of panicking on config read failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3395,6 +3395,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno 0.2.8",
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3839,6 +3849,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.6.5",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -5568,6 +5579,7 @@ dependencies = [
  "lazy_static",
  "rand 0.8.7",
  "rustc_version",
+ "tokio",
  "tracing",
  "tracing-subscriber",
  "zenoh",

--- a/zenohd/Cargo.toml
+++ b/zenohd/Cargo.toml
@@ -47,6 +47,7 @@ zenoh-util = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true, features = ["default"] }
+tokio = { workspace = true, features = ["macros", "process", "rt", "time"] }
 
 [build-dependencies]
 rustc_version = { workspace = true }

--- a/zenohd/src/main.rs
+++ b/zenohd/src/main.rs
@@ -14,6 +14,7 @@
 use clap::Parser;
 use git_version::git_version;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+use zenoh::internal::bail;
 use zenoh::{config::WhatAmI, Config, Result, Wait};
 use zenoh_config::{EndPoint, EndPoints, ModeDependentValue, PermissionsConf};
 use zenoh_util::LibSearchDirs;
@@ -76,7 +77,7 @@ struct Args {
     adminspace_permissions: Option<String>,
 }
 
-fn main() {
+fn main() -> Result<()> {
     if let Err(e) = init_logging() {
         eprintln!("{e}. Exiting...");
         std::process::exit(-1);
@@ -85,7 +86,7 @@ fn main() {
     tracing::info!("zenohd {}", *LONG_VERSION);
 
     let args = Args::parse();
-    let config = config_from_args(&args);
+    let config = config_from_args(&args)?;
     tracing::info!("Initial conf: {}", &config);
 
     let _session = match zenoh::open(config).wait() {
@@ -97,9 +98,10 @@ fn main() {
     };
 
     std::thread::park();
+    Ok(())
 }
 
-fn config_from_args(args: &Args) -> Config {
+fn config_from_args(args: &Args) -> Result<Config> {
     let mut inline_config = None;
     for json in &args.cfg {
         if let Some(("", cfg)) = json.split_once(':') {
@@ -108,9 +110,9 @@ fn config_from_args(args: &Args) -> Config {
     }
 
     let mut config = if let Some(cfg) = inline_config {
-        Config::from_json5(cfg).expect("Invalid Zenoh config")
+        Config::from_json5(cfg).or_else(|_| bail!("Invalid Zenoh config") as Result<_>)?
     } else if let Some(fname) = args.config.as_ref() {
-        Config::from_file(fname).expect("Failed to load config file")
+        Config::from_file(fname).or_else(|_| bail!("Failed to load config file") as Result<_>)?
     } else {
         Config::default()
     };
@@ -119,18 +121,14 @@ fn config_from_args(args: &Args) -> Config {
         config.set_mode(Some(WhatAmI::Router)).unwrap();
     }
     if let Some(id) = &args.id {
-        config.set_id(Some(id.parse().unwrap())).unwrap();
+        config.set_id(Some(id.parse()?)).unwrap();
     }
     // apply '--rest-http-port' to config only if explicitly set (overwriting config)
     if args.rest_http_port.is_some() {
         let value = args.rest_http_port.as_deref().unwrap_or("8000");
         if !value.eq_ignore_ascii_case("none") {
-            config
-                .insert_json5("plugins/rest/http_port", &format!(r#""{value}""#))
-                .unwrap();
-            config
-                .insert_json5("plugins/rest/__required__", "true")
-                .unwrap();
+            config.insert_json5("plugins/rest/http_port", &format!(r#""{value}""#))?;
+            config.insert_json5("plugins/rest/__required__", "true")?;
         }
     }
     config.adminspace.set_enabled(true).unwrap();
@@ -148,17 +146,11 @@ fn config_from_args(args: &Args) -> Config {
     for plugin in &args.plugin {
         match plugin.split_once(':') {
             Some((name, path)) => {
-                config
-                    .insert_json5(&format!("plugins/{name}/__required__"), "true")
-                    .unwrap();
-                config
-                    .insert_json5(&format!("plugins/{name}/__path__"), &format!("\"{path}\""))
-                    .unwrap();
+                config.insert_json5(&format!("plugins/{name}/__required__"), "true")?;
+                config.insert_json5(&format!("plugins/{name}/__path__"), &format!("\"{path}\""))?;
             }
-            None => config
-                .insert_json5(&format!("plugins/{plugin}/__required__"), "true")
-                .unwrap(),
-        }
+            None => config.insert_json5(&format!("plugins/{plugin}/__required__"), "true")?,
+        };
     }
     if !args.connect.is_empty() {
         config
@@ -167,13 +159,12 @@ fn config_from_args(args: &Args) -> Config {
             .set(
                 args.connect
                     .iter()
-                    .map(|v| match v.parse::<EndPoints>() {
-                        Ok(v) => v,
-                        Err(e) => {
-                            panic!("Couldn't parse option --peer={v} into Locator: {e}");
-                        }
+                    .map(|v| {
+                        v.parse::<EndPoints>().or_else(|e| {
+                            bail!("Couldn't parse option --peer={v} into Locator: {e}")
+                        })
                     })
-                    .collect(),
+                    .collect::<Result<_>>()?,
             )
             .unwrap();
     }
@@ -184,13 +175,12 @@ fn config_from_args(args: &Args) -> Config {
             .set(
                 args.listen
                     .iter()
-                    .map(|v| match v.parse::<EndPoint>() {
-                        Ok(v) => v,
-                        Err(e) => {
-                            panic!("Couldn't parse option --listen={v} into Locator: {e}");
-                        }
+                    .map(|v| {
+                        v.parse::<EndPoint>().or_else(|e| {
+                            bail!("Couldn't parse option --listen={v} into Locator: {e}")
+                        })
                     })
-                    .collect(),
+                    .collect::<Result<_>>()?,
             )
             .unwrap();
     }
@@ -242,7 +232,7 @@ fn config_from_args(args: &Args) -> Config {
                     write: false,
                 })
                 .unwrap(),
-            s => panic!(
+            s => bail!(
                 r#"Invalid option: --adminspace-permissions={s} - Accepted values: "r", "w", "rw" or "none""#
             ),
         };
@@ -259,14 +249,14 @@ fn config_from_args(args: &Args) -> Config {
                         }
                     }
                     Err(e) => tracing::warn!("Couldn't perform configuration {}: {}", json, e),
-                }
+                };
             }
         } else {
-            panic!("--cfg accepts KEY:VALUE pairs. {json} is not a valid KEY:VALUE pair.")
+            bail!("--cfg accepts KEY:VALUE pairs. {json} is not a valid KEY:VALUE pair.")
         }
     }
     tracing::debug!("Config: {:?}", &config);
-    config
+    Ok(config)
 }
 
 fn init_logging() -> Result<()> {
@@ -336,4 +326,52 @@ fn test_no_default_features() {
             // " zenoh/default",
         )
     );
+}
+
+#[test]
+fn test_config_from_args_invalid_inline_c_returns_err() {
+    let args = Args::parse_from(["zenohd", "-c", "/dev/null"]);
+    assert!(config_from_args(&args).is_err());
+}
+
+#[test]
+fn test_config_from_args_invalid_inline_cfg_returns_err() {
+    let args = Args::parse_from(["zenohd", "--cfg", ":not valid json5"]);
+    assert!(config_from_args(&args).is_err());
+}
+
+#[test]
+fn test_config_from_args_missing_config_file_returns_err() {
+    let args = Args::parse_from(["zenohd", "--config", "/nonexistent/path/to/config.json5"]);
+    assert!(config_from_args(&args).is_err());
+}
+
+#[test]
+fn test_config_from_args_invalid_id_returns_err() {
+    let args = Args::parse_from(["zenohd", "--id", "not-a-valid-zid"]);
+    assert!(config_from_args(&args).is_err());
+}
+
+#[test]
+fn test_config_from_args_invalid_connect_endpoint_returns_err() {
+    let args = Args::parse_from(["zenohd", "--connect", "not-an-endpoint"]);
+    assert!(config_from_args(&args).is_err());
+}
+
+#[test]
+fn test_config_from_args_invalid_listen_endpoint_returns_err() {
+    let args = Args::parse_from(["zenohd", "--listen", "not-an-endpoint"]);
+    assert!(config_from_args(&args).is_err());
+}
+
+#[test]
+fn test_config_from_args_invalid_adminspace_permissions_returns_err() {
+    let args = Args::parse_from(["zenohd", "--adminspace-permissions", "bogus"]);
+    assert!(config_from_args(&args).is_err());
+}
+
+#[test]
+fn test_config_from_args_defaults_returns_ok() {
+    let args = Args::parse_from(["zenohd"]);
+    assert!(config_from_args(&args).is_ok());
 }

--- a/zenohd/src/main.rs
+++ b/zenohd/src/main.rs
@@ -14,8 +14,11 @@
 use clap::Parser;
 use git_version::git_version;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
-use zenoh::internal::bail;
-use zenoh::{config::WhatAmI, Config, Result, Wait};
+use zenoh::{
+    config::WhatAmI,
+    internal::{bail, zerror},
+    Config, Result, Wait,
+};
 use zenoh_config::{EndPoint, EndPoints, ModeDependentValue, PermissionsConf};
 use zenoh_util::LibSearchDirs;
 
@@ -77,7 +80,7 @@ struct Args {
     adminspace_permissions: Option<String>,
 }
 
-fn main() -> Result<()> {
+fn main() {
     if let Err(e) = init_logging() {
         eprintln!("{e}. Exiting...");
         std::process::exit(-1);
@@ -86,7 +89,13 @@ fn main() -> Result<()> {
     tracing::info!("zenohd {}", *LONG_VERSION);
 
     let args = Args::parse();
-    let config = config_from_args(&args)?;
+    let config = match config_from_args(&args) {
+        Ok(config) => config,
+        Err(error) => {
+            eprintln!("Error: {error}");
+            std::process::exit(1);
+        }
+    };
     tracing::info!("Initial conf: {}", &config);
 
     let _session = match zenoh::open(config).wait() {
@@ -98,7 +107,6 @@ fn main() -> Result<()> {
     };
 
     std::thread::park();
-    Ok(())
 }
 
 fn config_from_args(args: &Args) -> Result<Config> {
@@ -110,9 +118,10 @@ fn config_from_args(args: &Args) -> Result<Config> {
     }
 
     let mut config = if let Some(cfg) = inline_config {
-        Config::from_json5(cfg).or_else(|_| bail!("Invalid Zenoh config") as Result<_>)?
+        Config::from_json5(cfg).map_err(|error| zerror!("Invalid --cfg configuration: {error}"))?
     } else if let Some(fname) = args.config.as_ref() {
-        Config::from_file(fname).or_else(|_| bail!("Failed to load config file") as Result<_>)?
+        Config::from_file(fname)
+            .map_err(|error| format!("Failed to load config file {fname}: {error}"))?
     } else {
         Config::default()
     };
@@ -127,8 +136,12 @@ fn config_from_args(args: &Args) -> Result<Config> {
     if args.rest_http_port.is_some() {
         let value = args.rest_http_port.as_deref().unwrap_or("8000");
         if !value.eq_ignore_ascii_case("none") {
-            config.insert_json5("plugins/rest/http_port", &format!(r#""{value}""#))?;
-            config.insert_json5("plugins/rest/__required__", "true")?;
+            config
+                .insert_json5("plugins/rest/http_port", &format!(r#""{value}""#))
+                .map_err(|error| format!("Invalid --rest-http-port={value}: {error}"))?;
+            config
+                .insert_json5("plugins/rest/__required__", "true")
+                .map_err(|error| format!("Failed to enable the REST plugin: {error}"))?;
         }
     }
     config.adminspace.set_enabled(true).unwrap();
@@ -146,10 +159,16 @@ fn config_from_args(args: &Args) -> Result<Config> {
     for plugin in &args.plugin {
         match plugin.split_once(':') {
             Some((name, path)) => {
-                config.insert_json5(&format!("plugins/{name}/__required__"), "true")?;
-                config.insert_json5(&format!("plugins/{name}/__path__"), &format!("\"{path}\""))?;
+                config
+                    .insert_json5(&format!("plugins/{name}/__required__"), "true")
+                    .map_err(|error| format!("Invalid --plugin={plugin}: {error}"))?;
+                config
+                    .insert_json5(&format!("plugins/{name}/__path__"), &format!("\"{path}\""))
+                    .map_err(|error| format!("Invalid --plugin={plugin}: {error}"))?;
             }
-            None => config.insert_json5(&format!("plugins/{plugin}/__required__"), "true")?,
+            None => config
+                .insert_json5(&format!("plugins/{plugin}/__required__"), "true")
+                .map_err(|error| format!("Invalid --plugin={plugin}: {error}"))?,
         };
     }
     if !args.connect.is_empty() {
@@ -160,8 +179,8 @@ fn config_from_args(args: &Args) -> Result<Config> {
                 args.connect
                     .iter()
                     .map(|v| {
-                        v.parse::<EndPoints>().or_else(|e| {
-                            bail!("Couldn't parse option --peer={v} into Locator: {e}")
+                        v.parse::<EndPoints>().map_err(|e| {
+                            format!("Couldn't parse option --connect={v} into Locator: {e}").into()
                         })
                     })
                     .collect::<Result<_>>()?,
@@ -176,8 +195,8 @@ fn config_from_args(args: &Args) -> Result<Config> {
                 args.listen
                     .iter()
                     .map(|v| {
-                        v.parse::<EndPoint>().or_else(|e| {
-                            bail!("Couldn't parse option --listen={v} into Locator: {e}")
+                        v.parse::<EndPoint>().map_err(|e| {
+                            format!("Couldn't parse option --listen={v} into Locator: {e}").into()
                         })
                     })
                     .collect::<Result<_>>()?,
@@ -326,12 +345,6 @@ fn test_no_default_features() {
             // " zenoh/default",
         )
     );
-}
-
-#[test]
-fn test_config_from_args_invalid_inline_c_returns_err() {
-    let args = Args::parse_from(["zenohd", "-c", "/dev/null"]);
-    assert!(config_from_args(&args).is_err());
 }
 
 #[test]

--- a/zenohd/tests/cli_errors.rs
+++ b/zenohd/tests/cli_errors.rs
@@ -1,0 +1,188 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+use std::{path::PathBuf, process::Output, time::Duration};
+
+use tokio::process::Command;
+
+const TIMEOUT: Duration = Duration::from_secs(10);
+
+async fn run_zenohd(args: &[&str]) -> Output {
+    tokio::time::timeout(
+        TIMEOUT,
+        Command::new(env!("CARGO_BIN_EXE_zenohd"))
+            .args(args)
+            .env("RUST_LOG", "z=info")
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await
+    .expect("zenohd did not exit within TIMEOUT")
+    .expect("failed to spawn zenohd")
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn mentions(text: &str, token: &str) -> bool {
+    text.to_lowercase().contains(&token.to_lowercase())
+}
+
+fn mentions_source_location(text: &str) -> bool {
+    text.split(".rs:")
+        .skip(1)
+        .any(|rest| rest.starts_with(|character: char| character.is_ascii_digit()))
+}
+
+fn config_file(name: &str, content: &str) -> PathBuf {
+    let path = PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join(name);
+    std::fs::write(&path, content).expect("failed to write config file");
+    path
+}
+
+#[tokio::test]
+async fn missing_config_file() {
+    let output = run_zenohd(&["--config", "/nonexistent/path/config.json5"]).await;
+    let stderr = stderr(&output);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(mentions(&stderr, "config file"));
+    assert!(mentions(&stderr, "/nonexistent/path/config.json5"));
+    assert!(mentions_source_location(&stderr));
+}
+
+#[tokio::test]
+async fn empty_config_file_content() {
+    let path = config_file("empty_config.json5", "");
+    let output = run_zenohd(&["--config", path.to_str().unwrap()]).await;
+    let stderr = stderr(&output);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(mentions(&stderr, "empty"));
+    assert!(mentions(&stderr, path.to_str().unwrap()));
+    assert!(mentions_source_location(&stderr));
+}
+
+#[tokio::test]
+async fn config_file_with_wrong_value_type() {
+    let path = config_file("wrong_value_type.json5", "{ mode: 42 }");
+    let output = run_zenohd(&["--config", path.to_str().unwrap()]).await;
+    let stderr = stderr(&output);
+
+    println!("{stderr}");
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(mentions(&stderr, "invalid type"));
+    assert!(mentions(&stderr, path.to_str().unwrap()));
+    assert!(mentions_source_location(&stderr));
+}
+
+#[tokio::test]
+async fn config_file_failing_validation() {
+    let path = config_file(
+        "failing_validation.json5",
+        r#"{ transport: { auth: { usrpwd: { user: "alice" } } } }"#,
+    );
+    let output = run_zenohd(&["--config", path.to_str().unwrap()]).await;
+    let stderr = stderr(&output);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(mentions(&stderr, "invalid configuration"));
+    assert!(mentions(&stderr, "alice"));
+    assert!(mentions_source_location(&stderr));
+}
+
+#[tokio::test]
+async fn invalid_inline_config_json5() {
+    let output = run_zenohd(&["--cfg", ":not valid json5"]).await;
+    let stderr = stderr(&output);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(mentions(&stderr, "--cfg"));
+    assert!(mentions(&stderr, "not valid json5"));
+    assert!(mentions_source_location(&stderr));
+}
+
+#[tokio::test]
+async fn cfg_without_key_value_separator() {
+    let output = run_zenohd(&["--cfg", "no-colon-pair"]).await;
+    let stderr = stderr(&output);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(mentions(&stderr, "--cfg"));
+    assert!(mentions(&stderr, "no-colon-pair"));
+    assert!(mentions_source_location(&stderr));
+}
+
+#[tokio::test]
+async fn invalid_id() {
+    let output = run_zenohd(&["--id", "not-a-valid-zid"]).await;
+    let stderr = stderr(&output);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(mentions(&stderr, "id"));
+    assert!(mentions(&stderr, "not-a-valid-zid"));
+    assert!(mentions_source_location(&stderr));
+}
+
+#[tokio::test]
+async fn invalid_connect_endpoint() {
+    let output = run_zenohd(&["--connect", "not-an-endpoint"]).await;
+    let stderr = stderr(&output);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(mentions(&stderr, "--connect"));
+    assert!(mentions(&stderr, "not-an-endpoint"));
+    assert!(mentions_source_location(&stderr));
+}
+
+#[tokio::test]
+async fn invalid_listen_endpoint() {
+    let output = run_zenohd(&["--listen", "not-an-endpoint"]).await;
+    let stderr = stderr(&output);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(mentions(&stderr, "--listen"));
+    assert!(mentions(&stderr, "not-an-endpoint"));
+    assert!(mentions_source_location(&stderr));
+}
+
+#[tokio::test]
+async fn invalid_adminspace_permissions() {
+    let output = run_zenohd(&["--adminspace-permissions", "bogus"]).await;
+    let stderr = stderr(&output);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(mentions(&stderr, "--adminspace-permissions"));
+    assert!(mentions(&stderr, "bogus"));
+    assert!(mentions_source_location(&stderr));
+}
+
+#[tokio::test]
+async fn unknown_flag() {
+    let output = run_zenohd(&["--nonexistent-flag"]).await;
+    let stderr = stderr(&output);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(mentions(&stderr, "--nonexistent-flag"));
+}
+
+#[tokio::test]
+async fn flag_without_required_value() {
+    let output = run_zenohd(&["--config"]).await;
+    let stderr = stderr(&output);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(mentions(&stderr, "--config"));
+}


### PR DESCRIPTION
## Description

### What does this PR do?
* Avoid panicking on configuration read failures en error to main.
* ~Change signature zenohd's main to `zenoh::Result<()>`.~
* ~Keep error messages identical to as they were before.~ Improve error messages, ensuring output has diagnostic information and a source file path and line number reference.
* Otherwise keep logic as identical to as it was before.
* Add unit tests.
* Add CLI-invocation tests. 
* Add tokio as dev dependency to zenohd (for CLI tests).

### Why is this change needed?
* On configuration read failures, a core dump to be generated. Causes [problems](https://github.com/eclipse-zenoh/zenoh/issues/2421).
* In the new failure mode, no `SIGABRT` is emitted – no core dump.

### Related Issues
* Fixes #2421

It's my first contribution. Apologies for mistakes!

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `enhancement`

## ✨ Enhancement Requirements

Since this PR enhances existing functionality:

- [x] **Enhancement scope documented** - Clear description of what is being improved
- [x] **Minimum necessary code** - Implementation is as simple as possible, doesn't overcomplicate the system
- [x] **Backwards compatible** - Existing code/APIs still work unchanged
- [x] **No new APIs added** - Only improving existing functionality
- [x] **Tests updated** - Existing tests pass, new test cases added if needed
- [x] **Performance improvement measured** - If applicable, before/after metrics provided
- [x] **Documentation updated** - Existing docs updated to reflect improvements
- [x] **User impact documented** - How users benefit from this enhancement

**Remember:** Enhancements should not introduce new APIs or breaking changes.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->