### PR TITLE
feat(zenohd): sd-notify behind opt-in `systemd` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3156,6 +3156,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sd-notify"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e4ef7359e694bfaf1dd27a30f9d760b54c00dfae9f19bd0c05a39bc9128fe76"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "secrecy"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5568,10 +5577,12 @@ dependencies = [
  "lazy_static",
  "rand 0.8.7",
  "rustc_version",
+ "sd-notify",
  "tracing",
  "tracing-subscriber",
  "zenoh",
  "zenoh-config",
+ "zenoh-test",
  "zenoh-util",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,7 @@ rustls-pemfile = "2.2.0"
 rustls-pki-types = "1.12.0"
 rustls-webpki = "0.103.8"
 schemars = { version = "1.1.0", features = ["either1"] }
+sd-notify = "0.5"
 secrecy = { version = "0.8.0", features = ["alloc", "serde"] }
 serde = { version = "1.0.225", default-features = false, features = [
   "derive",

--- a/zenohd/Cargo.toml
+++ b/zenohd/Cargo.toml
@@ -28,6 +28,7 @@ version = { workspace = true }
 [features]
 default = ["zenoh/default"]
 shared-memory = ["zenoh/shared-memory"]
+systemd = ["dep:sd-notify"]
 
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
@@ -45,8 +46,12 @@ zenoh = { workspace = true, default-features = false, features = [
 zenoh-config = { workspace = true }
 zenoh-util = { workspace = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+sd-notify = { workspace = true, optional = true }
+
 [dev-dependencies]
 rand = { workspace = true, features = ["default"] }
+zenoh-test = { workspace = true }
 
 [build-dependencies]
 rustc_version = { workspace = true }

--- a/zenohd/README.md
+++ b/zenohd/README.md
@@ -84,6 +84,23 @@ See also the [roadmap](https://github.com/eclipse-zenoh/roadmap) for more detail
 - **`-V, --version`**  
   Print version.
 
+## Systemd integration
+
+When built with the `systemd` Cargo feature (Linux only, disabled by default), `zenohd` notifies the service manager with `READY=1` once startup completes. This allows a service unit declared with `Type=notify` to delay units ordered `After=zenohd.service` until the router is actually reachable:
+
+```bash
+cargo build --release --features systemd
+```
+
+```ini
+[Service]
+Type=notify
+NotifyAccess=main
+ExecStart=/usr/bin/zenohd -c /etc/zenohd/zenohd.json5
+```
+
+Without the feature (the default), no notification is sent and service units should use `Type=simple`, as the packaged [zenohd.service](.service/zenohd.service) does.
+
 ## Plugins
 
 > [!WARNING]

--- a/zenohd/src/main.rs
+++ b/zenohd/src/main.rs
@@ -96,6 +96,11 @@ fn main() {
         }
     };
 
+    #[cfg(all(feature = "systemd", target_os = "linux"))]
+    if let Err(e) = sd_notify::notify(&[sd_notify::NotifyState::Ready]) {
+        tracing::warn!("failed to notify systemd of readiness: {e}");
+    }
+
     std::thread::park();
 }
 

--- a/zenohd/tests/systemd_notify.rs
+++ b/zenohd/tests/systemd_notify.rs
@@ -1,0 +1,70 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+#![cfg(all(feature = "systemd", target_os = "linux"))]
+
+use std::{
+    net::TcpStream,
+    os::unix::net::UnixDatagram,
+    process::{Child, Command},
+    time::Duration,
+};
+
+use zenoh_test::get_free_tcp_port;
+
+const TIMEOUT: Duration = Duration::from_secs(60);
+
+struct KillOnDrop(Child);
+
+impl Drop for KillOnDrop {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+#[test]
+fn readiness_is_notified_after_listeners_are_bound() {
+    let port = get_free_tcp_port();
+    let socket_path =
+        std::env::temp_dir().join(format!("zenohd-notify-{}.sock", std::process::id()));
+    let _ = std::fs::remove_file(&socket_path);
+    let socket = UnixDatagram::bind(&socket_path).unwrap();
+    socket.set_read_timeout(Some(TIMEOUT)).unwrap();
+
+    let child = Command::new(env!("CARGO_BIN_EXE_zenohd"))
+        .args([
+            "--no-multicast-scouting",
+            "-l",
+            &format!("tcp/127.0.0.1:{port}"),
+        ])
+        .env("NOTIFY_SOCKET", &socket_path)
+        .spawn()
+        .unwrap();
+    let _child = KillOnDrop(child);
+
+    let mut buf = [0u8; 1024];
+    let n = socket
+        .recv(&mut buf)
+        .expect("no readiness notification received");
+    let msg = std::str::from_utf8(&buf[..n]).unwrap();
+    assert!(
+        msg.lines().any(|line| line == "READY=1"),
+        "unexpected notification: {msg}"
+    );
+
+    // READY=1 must not be sent before the router accepts sessions
+    TcpStream::connect(("127.0.0.1", port)).expect("listener not accepting after READY=1");
+
+    let _ = std::fs::remove_file(&socket_path);
+}


### PR DESCRIPTION
## Description

### What does this PR do?
Adds systemd readiness notification support to `zenohd` behind `--features systemd`. When built with this feature, `READY=1` is sent to the service manager immediately after `zenoh::open()` returns (once transport listeners are bound, plugins are started, and the router is accepting sessions).

Default build features are unchanged, and the feature itself is linux-gated. I left the default `.service` untouched; if the maintainers are happy adding this as a default feature (ostensibly safe given the linux-gating, notwithstanding other init systems), I would add `Type=notify` + `NotifyAccess=main` to the service definition.

### Why is this change needed?
With `Type=simple`, systemd considers `zenohd` started the instant it execs, long before listeners are bound. Units ordered `After=zenohd.service` therefore race the router and fail or need retry loops when they connect during startup. 

With notify support (building with the above feature and wrapping in a Type=notify unit), one can ensure dependent services start up after zenohd is ready, without need for a separate polling readiness oracle, or retry logic baked in.

### Related Issues
Resolves #145

Related to #142; the deferred `Type=notify` half.

Loosely related to https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/issues/77; an example of retry logic + polling oracle approaches forced by another unit lacking readiness signaling.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `enhancement`

## ✨ Enhancement Requirements

Since this PR enhances existing functionality:

- [x] **Enhancement scope documented** - Clear description of what is being improved
- [x] **Minimum necessary code** - Implementation is as simple as possible, doesn't overcomplicate the system
- [x] **Backwards compatible** - Existing code/APIs still work unchanged
- [x] **No new APIs added** - Only improving existing functionality
- [x] **Tests updated** - Existing tests pass, new test cases added if needed
- [x] **Performance improvement measured** - If applicable, before/after metrics provided
- [x] **Documentation updated** - Existing docs updated to reflect improvements
- [x] **User impact documented** - How users benefit from this enhancement

**Remember:** Enhancements should not introduce new APIs or breaking changes.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->