### PR TITLE
ci: reduce wasteful CI resources usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,14 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches: ["main", "release/*", "!release/dry-run/*"]
   pull_request:
     branches: ["**"]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse


### PR DESCRIPTION
## Description
- Change triggers for ci.yml to run on push only for main and release branches
- Add concurrency group to automatically cancel previous run on the same branch
- Add manual workflow_dispatch trigger

### What does this PR do?
See description

### Why is this change needed?
Reduce the amount of CI resources used by the project by avoiding triggering the ci workflow twice on every push to a branch

### Related Issues
Similar to what was done on https://github.com/eclipse-zenoh/zenoh-pico/pull/1255

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->