### PR TITLE
ci: trigger release workflow on changes to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,10 @@ on:
         description: Release branch
         required: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tag:
     name: Branch, bump & tag crates

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,9 @@
 name: Release
 
 on:
-  schedule:
-    - cron: "0 0 * * 1-5"
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       live-run:


### PR DESCRIPTION
## Description
Instead of running the release workflow on a schedule, run it for each push to main. This ties the release workflow to the actual changes landing on main and when development activity is low, we don't waste resources on a daily basis.

I'm not entirely sure on this change though, so I'll leave in draft for now. I'll gather some feedback from the zenoh committers before this can be merged. The reason is that this change has the potential of increase release workflow runs when there's lots of activity consuming even more action minutes, instead of capping them to 20 runs per month. On the other hand, it may give the development team better feedback for each change that lands on main and the concurrency group addition should help on cancelling runs whenever the development activity is intense.

### What does this PR do?
- trigger the release workflow only on a push to the main branch
- remove the scheduled daily run
- add concurrency group to automatically cancel the previous run on the same workflow + branch

### Why is this change needed?
Aim to reduce CI consumption and wasteful daily runs independent of changes. When there's intense development activity only the last one is considered.

### Related Issues
Related to https://github.com/eclipse-zenoh/zenoh/pull/2698

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->