### PR TITLE
Make zenoh-uring to build only on platforms supported by io-uring

### DIFF
--- a/commons/zenoh-uring/Cargo.toml
+++ b/commons/zenoh-uring/Cargo.toml
@@ -27,7 +27,9 @@ version = { workspace = true }
 [features]
 uring_trace = []
 
-[target.'cfg(target_os = "linux")'.dependencies]
+# Build the code in this crate only on platforms supported by io-uring.
+# Listed from https://github.com/tokio-rs/io-uring/blob/a52c1c07ffa7ab64750fd6a39f2f0a922f205815/src/sys/mod.rs#L18-L28
+[target.'cfg(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64", target_arch = "loongarch64", target_arch = "powerpc64")))'.dependencies]
 atomic-queue = { workspace = true }
 flume = { workspace = true }
 io-uring = { workspace = true }

--- a/commons/zenoh-uring/src/lib.rs
+++ b/commons/zenoh-uring/src/lib.rs
@@ -17,7 +17,7 @@
 //! This module is intended for Zenoh's internal use.
 //!
 //! [Click here for Zenoh's documentation](https://docs.rs/zenoh/latest/zenoh)
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64", target_arch = "loongarch64", target_arch = "powerpc64")))]
 mod linux;
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64", target_arch = "loongarch64", target_arch = "powerpc64")))]
 pub use linux::*;

--- a/commons/zenoh-uring/src/lib.rs
+++ b/commons/zenoh-uring/src/lib.rs
@@ -17,7 +17,25 @@
 //! This module is intended for Zenoh's internal use.
 //!
 //! [Click here for Zenoh's documentation](https://docs.rs/zenoh/latest/zenoh)
-#[cfg(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64", target_arch = "loongarch64", target_arch = "powerpc64")))]
+#[cfg(all(
+    target_os = "linux",
+    any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "riscv64",
+        target_arch = "loongarch64",
+        target_arch = "powerpc64"
+    )
+))]
 mod linux;
-#[cfg(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64", target_arch = "loongarch64", target_arch = "powerpc64")))]
+#[cfg(all(
+    target_os = "linux",
+    any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "riscv64",
+        target_arch = "loongarch64",
+        target_arch = "powerpc64"
+    )
+))]
 pub use linux::*;

--- a/io/zenoh-transport/src/common/batch.rs
+++ b/io/zenoh-transport/src/common/batch.rs
@@ -462,7 +462,17 @@ impl<TBuffer: BacktrackableReader + Buffer> RBatch<TBuffer> {
     }
 }
 
-#[cfg(all(feature = "uring", target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64", target_arch = "loongarch64", target_arch = "powerpc64")))]
+#[cfg(all(
+    feature = "uring",
+    target_os = "linux",
+    any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "riscv64",
+        target_arch = "loongarch64",
+        target_arch = "powerpc64"
+    )
+))]
 impl<TBuffer: BacktrackableReader + Buffer> RBatch<TBuffer>
 where
     RBatch<TBuffer>: DecompressUring,

--- a/io/zenoh-transport/src/common/batch.rs
+++ b/io/zenoh-transport/src/common/batch.rs
@@ -462,7 +462,7 @@ impl<TBuffer: BacktrackableReader + Buffer> RBatch<TBuffer> {
     }
 }
 
-#[cfg(all(feature = "uring", target_os = "linux"))]
+#[cfg(all(feature = "uring", target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64", target_arch = "loongarch64", target_arch = "powerpc64")))]
 impl<TBuffer: BacktrackableReader + Buffer> RBatch<TBuffer>
 where
     RBatch<TBuffer>: DecompressUring,

--- a/io/zenoh-transport/src/lib.rs
+++ b/io/zenoh-transport/src/lib.rs
@@ -26,7 +26,17 @@ pub mod unicast;
 pub mod shm;
 #[cfg(feature = "shared-memory")]
 mod shm_context;
-#[cfg(all(feature = "uring", target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64", target_arch = "loongarch64", target_arch = "powerpc64")))]
+#[cfg(all(
+    feature = "uring",
+    target_os = "linux",
+    any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "riscv64",
+        target_arch = "loongarch64",
+        target_arch = "powerpc64"
+    )
+))]
 mod uring;
 
 use std::{any::Any, sync::Arc};

--- a/io/zenoh-transport/src/lib.rs
+++ b/io/zenoh-transport/src/lib.rs
@@ -26,7 +26,7 @@ pub mod unicast;
 pub mod shm;
 #[cfg(feature = "shared-memory")]
 mod shm_context;
-#[cfg(all(feature = "uring", target_os = "linux"))]
+#[cfg(all(feature = "uring", target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64", target_arch = "loongarch64", target_arch = "powerpc64")))]
 mod uring;
 
 use std::{any::Any, sync::Arc};

--- a/io/zenoh-transport/src/manager.rs
+++ b/io/zenoh-transport/src/manager.rs
@@ -38,7 +38,7 @@ use super::{
 };
 #[cfg(feature = "shared-memory")]
 use crate::shm_context::ShmContext;
-#[cfg(all(feature = "uring", target_os = "linux"))]
+#[cfg(all(feature = "uring", target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64", target_arch = "loongarch64", target_arch = "powerpc64")))]
 use crate::uring::Uring;
 use crate::{
     multicast::manager::{
@@ -175,7 +175,7 @@ pub struct TransportManagerState {
     pub multicast: TransportManagerStateMulticast,
     #[cfg(feature = "shared-memory")]
     pub shm_context: Option<ShmContext>,
-    #[cfg(all(feature = "uring", target_os = "linux"))]
+    #[cfg(all(feature = "uring", target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64", target_arch = "loongarch64", target_arch = "powerpc64")))]
     pub uring: Option<Uring>,
 }
 
@@ -498,12 +498,30 @@ impl TransportManagerBuilder {
             region_name: self.region_name,
         };
 
+        if cfg!(feature = "uring")
+            && !cfg!(all(
+                target_os = "linux",
+                any(
+                    target_arch = "x86_64",
+                    target_arch = "aarch64",
+                    target_arch = "riscv64",
+                    target_arch = "loongarch64",
+                    target_arch = "powerpc64"
+                )
+            ))
+        {
+            tracing::warn!(
+                "The `uring` feature is enabled, but io_uring is only supported with Linux on x86_64, \
+                 aarch64, riscv64, loongarch64 or powerpc64; falling back to tokio RX."
+            );
+        }
+
         let state = TransportManagerState {
             unicast: unicast.state,
             multicast: multicast.state,
             #[cfg(feature = "shared-memory")]
             shm_context,
-            #[cfg(all(feature = "uring", target_os = "linux"))]
+            #[cfg(all(feature = "uring", target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64", target_arch = "loongarch64", target_arch = "powerpc64")))]
             uring: Uring::new(config.batch_size as usize, config.link_rx_buffer_size)
                 .map_err(|e| {
                     tracing::warn!("io_uring reactor init failed, falling back to tokio RX: {e}");

--- a/io/zenoh-transport/src/manager.rs
+++ b/io/zenoh-transport/src/manager.rs
@@ -38,7 +38,17 @@ use super::{
 };
 #[cfg(feature = "shared-memory")]
 use crate::shm_context::ShmContext;
-#[cfg(all(feature = "uring", target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64", target_arch = "loongarch64", target_arch = "powerpc64")))]
+#[cfg(all(
+    feature = "uring",
+    target_os = "linux",
+    any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "riscv64",
+        target_arch = "loongarch64",
+        target_arch = "powerpc64"
+    )
+))]
 use crate::uring::Uring;
 use crate::{
     multicast::manager::{
@@ -175,7 +185,17 @@ pub struct TransportManagerState {
     pub multicast: TransportManagerStateMulticast,
     #[cfg(feature = "shared-memory")]
     pub shm_context: Option<ShmContext>,
-    #[cfg(all(feature = "uring", target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64", target_arch = "loongarch64", target_arch = "powerpc64")))]
+    #[cfg(all(
+        feature = "uring",
+        target_os = "linux",
+        any(
+            target_arch = "x86_64",
+            target_arch = "aarch64",
+            target_arch = "riscv64",
+            target_arch = "loongarch64",
+            target_arch = "powerpc64"
+        )
+    ))]
     pub uring: Option<Uring>,
 }
 
@@ -521,7 +541,17 @@ impl TransportManagerBuilder {
             multicast: multicast.state,
             #[cfg(feature = "shared-memory")]
             shm_context,
-            #[cfg(all(feature = "uring", target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64", target_arch = "loongarch64", target_arch = "powerpc64")))]
+            #[cfg(all(
+                feature = "uring",
+                target_os = "linux",
+                any(
+                    target_arch = "x86_64",
+                    target_arch = "aarch64",
+                    target_arch = "riscv64",
+                    target_arch = "loongarch64",
+                    target_arch = "powerpc64"
+                )
+            ))]
             uring: Uring::new(config.batch_size as usize, config.link_rx_buffer_size)
                 .map_err(|e| {
                     tracing::warn!("io_uring reactor init failed, falling back to tokio RX: {e}");

--- a/io/zenoh-transport/src/unicast/universal/link.rs
+++ b/io/zenoh-transport/src/unicast/universal/link.rs
@@ -1,4 +1,4 @@
-#[cfg(all(feature = "uring", target_os = "linux"))]
+#[cfg(all(feature = "uring", target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64", target_arch = "loongarch64", target_arch = "powerpc64")))]
 use std::fmt::Debug;
 //
 // Copyright (c) 2023 ZettaScale Technology
@@ -27,7 +27,7 @@ use futures::{future::select_all, task::AtomicWaker};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use zenoh_buffers::ZSlice;
-#[cfg(all(feature = "uring", target_os = "linux"))]
+#[cfg(all(feature = "uring", target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64", target_arch = "loongarch64", target_arch = "powerpc64")))]
 use zenoh_buffers::{
     buffer::Buffer,
     reader::{BacktrackableReader, HasReader},
@@ -42,7 +42,7 @@ use zenoh_sync::RecyclingObjectPool;
 #[cfg(feature = "unstable")]
 use zenoh_sync::{event, Notifier, Waiter};
 use zenoh_task::TaskController;
-#[cfg(all(feature = "uring", target_os = "linux"))]
+#[cfg(all(feature = "uring", target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64", target_arch = "loongarch64", target_arch = "powerpc64")))]
 use zenoh_uring::api::reader::{
     fragmented_batch::{DefragmentationState, FragmentedBatch},
     rx_buffer::RxBuffer,
@@ -370,7 +370,7 @@ async fn rx_task(
     cancellation_token: CancellationToken,
     #[cfg(feature = "stats")] stats: zenoh_stats::LinkStats,
 ) -> ZResult<()> {
-    #[cfg(all(feature = "uring", target_os = "linux"))]
+    #[cfg(all(feature = "uring", target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64", target_arch = "loongarch64", target_arch = "powerpc64")))]
     if transport.manager.state.uring.is_some() && link.link.get_fd().is_ok() {
         return rx_task_uring(
             link,
@@ -571,7 +571,7 @@ impl Drop for TimeoutTracker {
     }
 }
 
-#[cfg(all(feature = "uring", target_os = "linux"))]
+#[cfg(all(feature = "uring", target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64", target_arch = "loongarch64", target_arch = "powerpc64")))]
 async fn rx_task_uring(
     link: &mut TransportLinkUnicastRx,
     transport: TransportUnicastUniversal,

--- a/io/zenoh-transport/src/unicast/universal/link.rs
+++ b/io/zenoh-transport/src/unicast/universal/link.rs
@@ -1,4 +1,14 @@
-#[cfg(all(feature = "uring", target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64", target_arch = "loongarch64", target_arch = "powerpc64")))]
+#[cfg(all(
+    feature = "uring",
+    target_os = "linux",
+    any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "riscv64",
+        target_arch = "loongarch64",
+        target_arch = "powerpc64"
+    )
+))]
 use std::fmt::Debug;
 //
 // Copyright (c) 2023 ZettaScale Technology
@@ -27,7 +37,17 @@ use futures::{future::select_all, task::AtomicWaker};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use zenoh_buffers::ZSlice;
-#[cfg(all(feature = "uring", target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64", target_arch = "loongarch64", target_arch = "powerpc64")))]
+#[cfg(all(
+    feature = "uring",
+    target_os = "linux",
+    any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "riscv64",
+        target_arch = "loongarch64",
+        target_arch = "powerpc64"
+    )
+))]
 use zenoh_buffers::{
     buffer::Buffer,
     reader::{BacktrackableReader, HasReader},
@@ -42,7 +62,17 @@ use zenoh_sync::RecyclingObjectPool;
 #[cfg(feature = "unstable")]
 use zenoh_sync::{event, Notifier, Waiter};
 use zenoh_task::TaskController;
-#[cfg(all(feature = "uring", target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64", target_arch = "loongarch64", target_arch = "powerpc64")))]
+#[cfg(all(
+    feature = "uring",
+    target_os = "linux",
+    any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "riscv64",
+        target_arch = "loongarch64",
+        target_arch = "powerpc64"
+    )
+))]
 use zenoh_uring::api::reader::{
     fragmented_batch::{DefragmentationState, FragmentedBatch},
     rx_buffer::RxBuffer,
@@ -370,7 +400,17 @@ async fn rx_task(
     cancellation_token: CancellationToken,
     #[cfg(feature = "stats")] stats: zenoh_stats::LinkStats,
 ) -> ZResult<()> {
-    #[cfg(all(feature = "uring", target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64", target_arch = "loongarch64", target_arch = "powerpc64")))]
+    #[cfg(all(
+        feature = "uring",
+        target_os = "linux",
+        any(
+            target_arch = "x86_64",
+            target_arch = "aarch64",
+            target_arch = "riscv64",
+            target_arch = "loongarch64",
+            target_arch = "powerpc64"
+        )
+    ))]
     if transport.manager.state.uring.is_some() && link.link.get_fd().is_ok() {
         return rx_task_uring(
             link,
@@ -571,7 +611,17 @@ impl Drop for TimeoutTracker {
     }
 }
 
-#[cfg(all(feature = "uring", target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64", target_arch = "loongarch64", target_arch = "powerpc64")))]
+#[cfg(all(
+    feature = "uring",
+    target_os = "linux",
+    any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "riscv64",
+        target_arch = "loongarch64",
+        target_arch = "powerpc64"
+    )
+))]
 async fn rx_task_uring(
     link: &mut TransportLinkUnicastRx,
     transport: TransportUnicastUniversal,


### PR DESCRIPTION
Make `zenoh-uring` to build only on platforms supported by `io-uring`.
Currently: x86_64, aarch64, riscv64, loongarch64, powerpc64
Listed from https://github.com/tokio-rs/io-uring/blob/a52c1c07ffa7ab64750fd6a39f2f0a922f205815/src/sys/mod.rs#L18-L28

If the `uring` feature is active on a non-supported platform, `zenoh-uring` builds as an empty crate.
At runtime a warning log is displayed.

Fix #2692

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [x] **Reproduction test added** - Test that fails on main branch without the fix
- [x] **Test passes with fix** - The reproduction test passes with your changes
- [x] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->