### PR TITLE
fix(transport): optionally accept reordered best-effort frames

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -684,6 +684,12 @@
         /// more in-flight data. This is particularly relevant when dealing with large messages.
         /// E.g. for 16MiB rx_buffer_size set the value to: 16777216.
         buffer_size: 65535,
+        /// Number of recent sequence numbers remembered for duplicate detection on
+        /// unordered best-effort links. Reordered, unfragmented Frames inside this
+        /// window are accepted once and delivered immediately. No packets are
+        /// buffered or delayed. Set to 0 to use strict monotonic sequence
+        /// validation.
+        best_effort_reorder_window: 0,
         /// Maximum size of the defragmentation buffer at receiver end.
         /// Fragmented messages that are larger than the configured size will be dropped.
         /// The default value is 1GiB. This would work in most scenarios.

--- a/commons/zenoh-config/src/defaults.rs
+++ b/commons/zenoh-config/src/defaults.rs
@@ -313,6 +313,7 @@ impl Default for LinkRxConf {
     fn default() -> Self {
         Self {
             buffer_size: BatchSize::MAX as usize,
+            best_effort_reorder_window: 0,
             max_message_size: 2_usize.pow(30),
         }
     }

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -793,6 +793,11 @@ validated_struct::validator! {
                     /// more in-flight data. This is particularly relevant when dealing with large messages.
                     /// E.g. for 16MiB rx_buffer_size set the value to: 16777216.
                     buffer_size: usize,
+                    /// Number of recent sequence numbers remembered for duplicate detection on
+                    /// unordered best-effort links. Reordered, unfragmented Frames inside this
+                    /// window are accepted once and delivered immediately. Set to 0 to use strict
+                    /// monotonic sequence validation.
+                    best_effort_reorder_window: usize,
                     /// Maximum size of the defragmentation buffer at receiver end (default: 1GiB).
                     /// Fragmented messages that are larger than the configured size will be dropped.
                     max_message_size: usize,
@@ -2069,6 +2074,31 @@ mod tests {
     use zenoh_protocol::core::{EndPoint, WhatAmI};
 
     use crate::{Config, ModeDependentValue, ZenohId};
+
+    #[test]
+    fn test_best_effort_reorder_window_config() {
+        let mut config = Config::default();
+        assert_eq!(
+            *config
+                .transport
+                .link
+                .rx
+                .best_effort_reorder_window(),
+            0
+        );
+
+        config
+            .insert_json5("transport/link/rx/best_effort_reorder_window", "1024")
+            .unwrap();
+        assert_eq!(
+            *config
+                .transport
+                .link
+                .rx
+                .best_effort_reorder_window(),
+            1024
+        );
+    }
 
     #[test]
     fn test_toml_config_format() {

--- a/io/zenoh-transport/src/common/priority.rs
+++ b/io/zenoh-transport/src/common/priority.rs
@@ -22,7 +22,7 @@ use zenoh_result::ZResult;
 
 use super::{
     defragmentation::DefragBuffer,
-    seq_num::{SeqNum, SeqNumGenerator},
+    seq_num::{SeqNum, SeqNumGenerator, SeqNumWindow},
 };
 
 #[derive(Debug)]
@@ -46,6 +46,7 @@ impl TransportChannelTx {
 #[derive(Debug)]
 pub(crate) struct TransportChannelRx {
     pub(crate) sn: SeqNum,
+    pub(crate) frame_sn: Option<SeqNumWindow>,
     pub(crate) defrag: DefragBuffer,
 }
 
@@ -54,22 +55,34 @@ impl TransportChannelRx {
         reliability: Reliability,
         resolution: Bits,
         defrag_buff_size: usize,
+        best_effort_reorder_window: usize,
     ) -> ZResult<TransportChannelRx> {
         let sn = SeqNum::make(0, resolution)?;
+        let frame_sn = (reliability == Reliability::BestEffort
+            && best_effort_reorder_window != 0)
+            .then(|| SeqNumWindow::make(0, resolution, best_effort_reorder_window))
+            .transpose()?;
         let defrag = DefragBuffer::make(reliability, resolution, defrag_buff_size)?;
-        let tch = TransportChannelRx { sn, defrag };
+        let tch = TransportChannelRx {
+            sn,
+            frame_sn,
+            defrag,
+        };
         Ok(tch)
     }
 
     pub(crate) fn sync(&mut self, sn: TransportSn) -> ZResult<()> {
         // Set the sequence number in the state as it had received a message with sn - 1
         let sn = if sn == 0 {
-            self.sn.resolution() - 1
+            self.sn.resolution()
         } else {
             sn - 1
         };
 
         self.sn.set(sn)?;
+        if let Some(frame_sn) = self.frame_sn.as_mut() {
+            frame_sn.reset(sn)?;
+        }
         self.defrag.sync(sn)
     }
 }
@@ -104,9 +117,23 @@ pub(crate) struct TransportPriorityRx {
 }
 
 impl TransportPriorityRx {
-    pub(crate) fn make(resolution: Bits, defrag_buff_size: usize) -> ZResult<TransportPriorityRx> {
-        let rch = TransportChannelRx::make(Reliability::Reliable, resolution, defrag_buff_size)?;
-        let bch = TransportChannelRx::make(Reliability::BestEffort, resolution, defrag_buff_size)?;
+    pub(crate) fn make(
+        resolution: Bits,
+        defrag_buff_size: usize,
+        best_effort_reorder_window: usize,
+    ) -> ZResult<TransportPriorityRx> {
+        let rch = TransportChannelRx::make(
+            Reliability::Reliable,
+            resolution,
+            defrag_buff_size,
+            best_effort_reorder_window,
+        )?;
+        let bch = TransportChannelRx::make(
+            Reliability::BestEffort,
+            resolution,
+            defrag_buff_size,
+            best_effort_reorder_window,
+        )?;
         let ctr = TransportPriorityRx {
             reliable: Arc::new(Mutex::new(rch)),
             best_effort: Arc::new(Mutex::new(bch)),

--- a/io/zenoh-transport/src/common/seq_num.rs
+++ b/io/zenoh-transport/src/common/seq_num.rs
@@ -43,6 +43,109 @@ pub(crate) struct SeqNum {
     mask: TransportSn,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SeqNumWindowResult {
+    Ahead,
+    Reordered,
+    Duplicate,
+    TooOld,
+}
+
+/// Tracks recently received sequence numbers around a monotonic high-water
+/// mark. This is used by unordered links to accept late packets once while
+/// retaining duplicate suppression.
+#[derive(Debug)]
+pub(crate) struct SeqNumWindow {
+    high_water: SeqNum,
+    seen: Vec<u64>,
+    capacity: usize,
+}
+
+impl SeqNumWindow {
+    pub(crate) fn make(
+        high_water: TransportSn,
+        resolution: Bits,
+        capacity: usize,
+    ) -> ZResult<Self> {
+        if capacity == 0 {
+            bail!("The sequence number window capacity must be non-zero");
+        }
+        let high_water = SeqNum::make(high_water, resolution)?;
+        let max_capacity = ((high_water.resolution() >> 1) + 1)
+            .min(usize::MAX as TransportSn) as usize;
+        let capacity = capacity.min(max_capacity);
+        Ok(Self {
+            high_water,
+            seen: vec![0; capacity.div_ceil(64)],
+            capacity,
+        })
+    }
+
+    pub(crate) fn reset(&mut self, high_water: TransportSn) -> ZResult<()> {
+        self.high_water.set(high_water)?;
+        self.seen.fill(0);
+        Ok(())
+    }
+
+    pub(crate) fn observe(&mut self, value: TransportSn) -> ZResult<SeqNumWindowResult> {
+        if self.high_water.precedes(value)? {
+            let distance =
+                value.wrapping_sub(self.high_water.get()) & self.high_water.resolution();
+            self.advance(distance as usize);
+            self.high_water.set(value)?;
+            self.mark(0);
+            return Ok(SeqNumWindowResult::Ahead);
+        }
+
+        let distance =
+            self.high_water.get().wrapping_sub(value) & self.high_water.resolution();
+        let distance = distance as usize;
+        if distance >= self.capacity {
+            return Ok(SeqNumWindowResult::TooOld);
+        }
+        if self.contains(distance) {
+            return Ok(SeqNumWindowResult::Duplicate);
+        }
+        self.mark(distance);
+        Ok(SeqNumWindowResult::Reordered)
+    }
+
+    fn advance(&mut self, distance: usize) {
+        if distance >= self.capacity {
+            self.seen.fill(0);
+            return;
+        }
+
+        let word_shift = distance / 64;
+        let bit_shift = distance % 64;
+        for dst in (0..self.seen.len()).rev() {
+            let Some(src) = dst.checked_sub(word_shift) else {
+                self.seen[dst] = 0;
+                continue;
+            };
+            let mut value = self.seen[src] << bit_shift;
+            if bit_shift != 0 && src != 0 {
+                value |= self.seen[src - 1] >> (64 - bit_shift);
+            }
+            self.seen[dst] = value;
+        }
+
+        let excess = self.seen.len() * 64 - self.capacity;
+        if excess != 0 {
+            let last = self.seen.len() - 1;
+            self.seen[last] &= u64::MAX >> excess;
+        }
+    }
+
+    fn contains(&self, distance: usize) -> bool {
+        self.seen[distance / 64] & (1 << (distance % 64)) != 0
+    }
+
+    fn mark(&mut self, distance: usize) {
+        self.seen[distance / 64] |= 1 << (distance % 64);
+    }
+}
+
 impl SeqNum {
     /// Create a new sequence number with a given resolution.
     ///
@@ -272,5 +375,68 @@ mod tests {
 
         assert_eq!(sn0.get(), 0);
         assert_eq!(sn1.get(), 6);
+    }
+
+    #[test]
+    fn sn_window_accepts_reordering_once() {
+        let mut window = SeqNumWindow::make(9, Bits::U8, 8).unwrap();
+
+        assert_eq!(window.observe(10).unwrap(), SeqNumWindowResult::Ahead);
+        assert_eq!(window.observe(12).unwrap(), SeqNumWindowResult::Ahead);
+        assert_eq!(
+            window.observe(11).unwrap(),
+            SeqNumWindowResult::Reordered
+        );
+        assert_eq!(
+            window.observe(11).unwrap(),
+            SeqNumWindowResult::Duplicate
+        );
+        assert_eq!(
+            window.observe(12).unwrap(),
+            SeqNumWindowResult::Duplicate
+        );
+    }
+
+    #[test]
+    fn sn_window_rejects_zero_capacity() {
+        assert!(SeqNumWindow::make(0, Bits::U8, 0).is_err());
+    }
+
+    #[test]
+    fn sn_window_rejects_values_outside_window() {
+        let mut window = SeqNumWindow::make(9, Bits::U8, 8).unwrap();
+        assert_eq!(window.observe(20).unwrap(), SeqNumWindowResult::Ahead);
+        assert_eq!(window.observe(12).unwrap(), SeqNumWindowResult::TooOld);
+    }
+
+    #[test]
+    fn sn_window_handles_rollover() {
+        let mask = (u8::MAX >> 1) as TransportSn;
+        let mut window = SeqNumWindow::make(mask - 1, Bits::U8, 8).unwrap();
+
+        assert_eq!(window.observe(mask).unwrap(), SeqNumWindowResult::Ahead);
+        assert_eq!(window.observe(1).unwrap(), SeqNumWindowResult::Ahead);
+        assert_eq!(
+            window.observe(0).unwrap(),
+            SeqNumWindowResult::Reordered
+        );
+        assert_eq!(
+            window.observe(mask).unwrap(),
+            SeqNumWindowResult::Duplicate
+        );
+    }
+
+    #[test]
+    fn sn_window_shifts_across_bitmap_words() {
+        let mut window = SeqNumWindow::make(0, Bits::U16, 130).unwrap();
+
+        assert_eq!(window.observe(1).unwrap(), SeqNumWindowResult::Ahead);
+        assert_eq!(window.observe(66).unwrap(), SeqNumWindowResult::Ahead);
+        assert_eq!(
+            window.observe(1).unwrap(),
+            SeqNumWindowResult::Duplicate
+        );
+        assert_eq!(window.observe(131).unwrap(), SeqNumWindowResult::Ahead);
+        assert_eq!(window.observe(1).unwrap(), SeqNumWindowResult::TooOld);
     }
 }

--- a/io/zenoh-transport/src/manager.rs
+++ b/io/zenoh-transport/src/manager.rs
@@ -135,6 +135,7 @@ pub struct TransportManagerConfig {
     pub queue_alloc: QueueAllocConf,
     pub defrag_buff_size: usize,
     pub link_rx_buffer_size: usize,
+    pub best_effort_reorder_window: usize,
     pub unicast: TransportManagerConfigUnicast,
     pub multicast: TransportManagerConfigMulticast,
     pub link_configs: HashMap<LinkKind, String>, // (protocol, config)
@@ -165,6 +166,10 @@ impl fmt::Debug for TransportManagerConfig {
             .field("queue_alloc", &self.queue_alloc)
             .field("defrag_buff_size", &self.defrag_buff_size)
             .field("link_rx_buffer_size", &self.link_rx_buffer_size)
+            .field(
+                "best_effort_reorder_window",
+                &self.best_effort_reorder_window,
+            )
             .field("unicast", &self.unicast)
             .field("multicast", &self.multicast)
             .field("link_configs", &self.link_configs)
@@ -239,6 +244,7 @@ pub struct TransportManagerBuilder {
     queue_alloc: QueueAllocConf,
     defrag_buff_size: usize,
     link_rx_buffer_size: usize,
+    best_effort_reorder_window: usize,
     unicast: TransportManagerBuilderUnicast,
     multicast: TransportManagerBuilderMulticast,
     link_configs: HashMap<LinkKind, String>, // (protocol, config)
@@ -273,6 +279,10 @@ impl fmt::Debug for TransportManagerBuilder {
             .field("queue_alloc", &self.queue_alloc)
             .field("defrag_buff_size", &self.defrag_buff_size)
             .field("link_rx_buffer_size", &self.link_rx_buffer_size)
+            .field(
+                "best_effort_reorder_window",
+                &self.best_effort_reorder_window,
+            )
             .field("unicast", &self.unicast)
             .field("multicast", &self.multicast)
             .field("link_configs", &self.link_configs)
@@ -372,6 +382,11 @@ impl TransportManagerBuilder {
         self
     }
 
+    pub fn best_effort_reorder_window(mut self, best_effort_reorder_window: usize) -> Self {
+        self.best_effort_reorder_window = best_effort_reorder_window;
+        self
+    }
+
     pub fn link_configs(mut self, link_configs: HashMap<LinkKind, String>) -> Self {
         self.link_configs = link_configs;
         self
@@ -431,6 +446,7 @@ impl TransportManagerBuilder {
         ));
         self = self.defrag_buff_size(*link.rx().max_message_size());
         self = self.link_rx_buffer_size(*link.rx().buffer_size());
+        self = self.best_effort_reorder_window(*link.rx().best_effort_reorder_window());
         self = self.wait_before_drop(duration_from_i64us(*cc_drop.wait_before_drop()));
         self = self.max_wait_before_drop_fragments(duration_from_i64us(
             *cc_drop.max_wait_before_drop_fragments(),
@@ -506,6 +522,7 @@ impl TransportManagerBuilder {
             queue_alloc: self.queue_alloc,
             defrag_buff_size: self.defrag_buff_size,
             link_rx_buffer_size: self.link_rx_buffer_size,
+            best_effort_reorder_window: self.best_effort_reorder_window,
             unicast: unicast.config,
             multicast: multicast.config,
             link_configs: self.link_configs,
@@ -606,6 +623,7 @@ impl Default for TransportManagerBuilder {
             batching_time_limit: Duration::from_millis(backoff),
             defrag_buff_size: *link_rx.max_message_size(),
             link_rx_buffer_size: *link_rx.buffer_size(),
+            best_effort_reorder_window: *link_rx.best_effort_reorder_window(),
             link_configs: HashMap::new(),
             unicast: TransportManagerBuilderUnicast::default(),
             multicast: TransportManagerBuilderMulticast::default(),

--- a/io/zenoh-transport/src/multicast/transport.rs
+++ b/io/zenoh-transport/src/multicast/transport.rs
@@ -365,6 +365,7 @@ impl TransportMulticastInner {
             let tprx = TransportPriorityRx::make(
                 join.resolution.get(Field::FrameSN),
                 self.manager.config.defrag_buff_size,
+                0,
             )?;
             tprx.sync(*sn)?;
             priority_rx.push(tprx);

--- a/io/zenoh-transport/src/unicast/universal/rx.rs
+++ b/io/zenoh-transport/src/unicast/universal/rx.rs
@@ -29,6 +29,7 @@ use crate::{
     common::{
         batch::{Decode, RBatch},
         priority::TransportChannelRx,
+        seq_num::SeqNumWindowResult,
     },
     unicast::transport_unicast_inner::TransportUnicastTrait,
     TransportPeerEventHandler,
@@ -84,6 +85,7 @@ impl TransportUnicastUniversal {
     fn handle_frame<R: BacktrackableReader>(
         &self,
         frame: FrameReader<R>,
+        link: &Link,
         #[cfg(feature = "stats")] stats: &zenoh_stats::LinkStats,
     ) -> ZResult<()> {
         let priority = frame.ext_qos.priority();
@@ -104,7 +106,9 @@ impl TransportUnicastUniversal {
             Reliability::BestEffort => zlock!(c.best_effort),
         };
 
-        if !self.verify_sn("Frame", frame.sn, &mut guard)? {
+        let allow_reordering =
+            frame.reliability == Reliability::BestEffort && !link.is_streamed;
+        if !self.verify_sn("Frame", frame.sn, allow_reordering, &mut guard)? {
             // Drop invalid message and continue
             return Ok(());
         }
@@ -159,7 +163,7 @@ impl TransportUnicastUniversal {
             Reliability::BestEffort => zlock!(c.best_effort),
         };
 
-        if !self.verify_sn("Fragment", sn, &mut guard)? {
+        if !self.verify_sn("Fragment", sn, false, &mut guard)? {
             // Drop invalid message and continue
             return Ok(());
         }
@@ -215,21 +219,56 @@ impl TransportUnicastUniversal {
         &self,
         message_type: &str,
         sn: TransportSn,
+        allow_reordering: bool,
         guard: &mut MutexGuard<'_, TransportChannelRx>,
     ) -> ZResult<bool> {
-        let precedes = guard.sn.roll(sn)?;
-        if !precedes {
-            tracing::trace!(
-                "Transport: {}. {} with invalid SN dropped: {}. Expected: {}.",
-                self.config.zid,
-                message_type,
-                sn,
-                guard.sn.next()
-            );
-            return Ok(false);
+        if allow_reordering {
+            if let Some(frame_sn) = guard.frame_sn.as_mut() {
+                match frame_sn.observe(sn)? {
+                    SeqNumWindowResult::Ahead => {
+                        let advanced = guard.sn.roll(sn)?;
+                        debug_assert!(advanced);
+                        return Ok(true);
+                    }
+                    SeqNumWindowResult::Reordered => return Ok(true),
+                    SeqNumWindowResult::Duplicate => {
+                        tracing::trace!(
+                            "Transport: {}. Duplicate {} dropped: {}.",
+                            self.config.zid,
+                            message_type,
+                            sn,
+                        );
+                        return Ok(false);
+                    }
+                    SeqNumWindowResult::TooOld => {
+                        tracing::trace!(
+                            "Transport: {}. {} outside sequence window dropped: {}. Expected: {}.",
+                            self.config.zid,
+                            message_type,
+                            sn,
+                            guard.sn.next(),
+                        );
+                        return Ok(false);
+                    }
+                }
+            }
         }
 
-        Ok(true)
+        if guard.sn.roll(sn)? {
+            if let Some(frame_sn) = guard.frame_sn.as_mut() {
+                let result = frame_sn.observe(sn)?;
+                debug_assert_eq!(result, SeqNumWindowResult::Ahead);
+            }
+            return Ok(true);
+        }
+        tracing::trace!(
+            "Transport: {}. {} with invalid SN dropped: {}. Expected: {}.",
+            self.config.zid,
+            message_type,
+            sn,
+            guard.sn.next()
+        );
+        Ok(false)
     }
 
     pub(super) fn read_messages<TBuffer: BacktrackableReader + Buffer + Debug>(
@@ -247,6 +286,7 @@ impl TransportUnicastUniversal {
                 }
                 self.handle_frame(
                     frame,
+                    link,
                     #[cfg(feature = "stats")]
                     stats,
                 )?;

--- a/io/zenoh-transport/src/unicast/universal/transport.rs
+++ b/io/zenoh-transport/src/unicast/universal/transport.rs
@@ -120,6 +120,7 @@ impl TransportUnicastUniversal {
             priority_rx.push(TransportPriorityRx::make(
                 config.sn_resolution,
                 manager.config.defrag_buff_size,
+                manager.config.best_effort_reorder_window,
             )?);
         }
 


### PR DESCRIPTION
## Description

### What does this PR do?

Adds an optional receive-side sequence-number window for unfragmented BestEffort Frames arriving over non-streamed links.

When `transport.link.rx.best_effort_reorder_window` is non-zero, Zenoh keeps a bounded bitmap of recently observed sequence numbers. A reordered Frame inside the window is delivered once, while duplicates and Frames older than the window are dropped. Frames are delivered immediately; this does not buffer packets or restore their original delivery order.

The default is `0`, which preserves the existing strict monotonic validation. Reliable Frames, streamed links, multicast, and fragments retain their existing behavior.

Example:

```json5
{
  transport: {
    link: {
      rx: {
        best_effort_reorder_window: 1024,
      },
    },
  },
}
```

### Why is this change needed?

Unordered transports such as QUIC DATAGRAM can deliver valid Frames out of sequence. The current receive path advances its sequence-number high-water mark when a later Frame arrives, then treats subsequently arriving earlier Frames as invalid. Forward batching or other network-induced reordering can therefore be amplified into substantial application-visible loss even when the packets reach the receiver.

In a controlled A/B reproduction using the same sender workload and network profile:

| Mode | Sent | Received | Application loss | Invalid SN | RX qdisc drops |
|---|---:|---:|---:|---:|---:|
| Strict/default | 21,871 | 9,509 | 56.5% | 10,024 | 0 |
| Window = 1024 | 21,871 | 21,871 | 0% | 0 | 0 |

With the window enabled, 9,603 late reordered Frames were accepted. The maximum observed reorder distance was 29 sequence numbers (mean 16.05).

The implementation also handles sequence-number rollover and suppresses duplicate delivery. Reordered fragments are deliberately excluded because the current defragmenter tracks a single sequential message.

### Validation

- `cargo test -p zenoh-config test_best_effort_reorder_window_config --lib`
- `cargo test -p zenoh-transport common::seq_num::tests --lib`
- `cargo test -p zenoh-transport --lib` (30 passed, 1 ignored)
- `cargo clippy -p zenoh-config -p zenoh-transport --lib -- -D warnings`

The full local `zenoh-config` test suite has one unrelated existing failure: the TOML-format test runs although that local feature set reports only JSON, JSON5, and YAML support. The new configuration test passes both independently and within that suite.

### Related Issues

No matching existing issue was found.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `enhancement`

## ✨ Enhancement Requirements

Since this PR enhances existing functionality:

- [ ] **Enhancement scope documented** - Clear description of what is being improved
- [ ] **Minimum necessary code** - Implementation is as simple as possible, doesn't overcomplicate the system
- [ ] **Backwards compatible** - Existing code/APIs still work unchanged
- [ ] **No new APIs added** - Only improving existing functionality
- [ ] **Tests updated** - Existing tests pass, new test cases added if needed
- [ ] **Performance improvement measured** - If applicable, before/after metrics provided
- [ ] **Documentation updated** - Existing docs updated to reflect improvements
- [ ] **User impact documented** - How users benefit from this enhancement

**Remember:** Enhancements should not introduce new APIs or breaking changes.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->