### PR TITLE
Skip expensive CI jobs for Markdown-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
     steps:
       - name: Clone this repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check whether code changed
         id: filter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,11 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
     steps:
       - name: Clone this repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check whether code changed
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         with:
           predicate-quantifier: every
           filters: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,28 @@ env:
   NIGHTLY_TOOLCHAIN: "nightly"
 
 jobs:
+  changes:
+    name: Detect changed files
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Clone this repository
+        uses: actions/checkout@v4
+
+      - name: Check whether code changed
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          predicate-quantifier: every
+          filters: |
+            code:
+              - "**"
+              - "!**/*.md"
+
   determine-runner:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     outputs:
       runner: ${{ steps.set-runner.outputs.runner }}
@@ -343,6 +364,8 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   fuzz:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     name: Fuzz target smoke tests
     runs-on: ubuntu-latest
     steps:
@@ -446,6 +469,8 @@ jobs:
           globs: "**/README.md"
 
   doc:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     name: Generate documentation
     runs-on: ubuntu-latest
     steps:
@@ -464,6 +489,8 @@ jobs:
             --config build.rustdocflags='["--cfg", "docsrs", "-Z", "unstable-options", "--emit=html-non-static-files", "--cap-lints", "warn", "--extern-html-root-takes-precedence"]'
 
   coverage:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     name: Coverage
     strategy:
       fail-fast: false
@@ -548,6 +575,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       [
+        changes,
+        determine-runner,
         check_rust,
         check,
         test,
@@ -563,4 +592,10 @@ jobs:
     if: always()
     steps:
       - name: Check whether all jobs pass
-        run: echo '${{ toJson(needs) }}' | jq -e 'all(.result == "success")'
+        env:
+          CODE_CHANGED: ${{ needs.changes.outputs.code }}
+          NEEDS: ${{ toJson(needs) }}
+        run: |
+          jq -e --arg code "$CODE_CHANGED" \
+            'all(.result == "success" or ($code == "false" and .result == "skipped"))' \
+            <<< "$NEEDS"


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->
Skip expensive CI jobs when a pull request changes only Markdown files, while preserving lightweight documentation checks and the required CI status.

### What does this PR do?
<!-- Describe the changes and their purpose -->
- Detects whether a change includes files other than Markdown.
- Skips builds, tests, fuzzing, Valgrind, Rustdoc, and coverage for Markdown-only changes.
- Continues running typo and Markdown lint checks.
- Treats intentionally skipped jobs as valid only for Markdown-only changes.

### Why is this change needed?
<!-- Explain the motivation or problem being solved -->
Markdown-only changes do not require the full Rust CI suite. Skipping unrelated jobs reduces CI time and runner usage without bypassing relevant documentation checks or blocking the required CI status.

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->
None

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->