### PR TITLE
fix: fail fast when pushing to a transport being closed as unresponsive

### DIFF
--- a/io/zenoh-transport/src/common/pipeline.rs
+++ b/io/zenoh-transport/src/common/pipeline.rs
@@ -872,6 +872,13 @@ impl TransmissionPipelineProducer {
         &self,
         msg: NetworkMessageRef,
     ) -> Result<bool, TransportClosed> {
+        // Fail fast if the pipeline has already been disabled (e.g. because a previous
+        // non droppable message could not be pushed and the transport is being closed).
+        // This prevents threads from blocking up to `wait_before_close` on a transport
+        // that is already known to be unresponsive.
+        if self.status.is_disabled() {
+            return Err(TransportClosed);
+        }
         // If the queue is not QoS, it means that we only have one priority with index 0.
         let (idx, priority) = if self.stage_in.len() > 1 {
             let priority = msg.priority();
@@ -936,6 +943,17 @@ impl TransmissionPipelineProducer {
         // Lock the channel. We are the only one that will be writing on it.
         let mut queue = zlock!(self.stage_in[priority]);
         queue.push_transport_message(msg)
+    }
+
+    /// Marks the pipeline as disabled without acquiring the `stage_in` locks.
+    ///
+    /// Contrary to [`Self::disable`], this method can safely be called while another
+    /// thread is blocked pushing a message on this pipeline (such a thread holds the
+    /// `stage_in` lock until its deadline expires). New pushes fail fast with
+    /// [`TransportClosed`] and the consumer task terminates on its next wakeup
+    /// (e.g. keep-alive), which in turn unblocks any parked pusher.
+    pub(crate) fn mark_disabled(&self) {
+        self.status.set_disabled(true);
     }
 
     pub(crate) fn disable(&self) {

--- a/io/zenoh-transport/src/unicast/universal/tx.rs
+++ b/io/zenoh-transport/src/unicast/universal/tx.rs
@@ -83,6 +83,26 @@ impl TransportUnicastUniversal {
                 "Unable to push non droppable network message to {}. Closing transport!",
                 self.config.zid
             );
+            // Synchronously mark the transmission pipelines of this transport as disabled
+            // so that any subsequent push to this unresponsive transport fails fast with
+            // `TransportClosed` instead of blocking for another `wait_before_close` period.
+            //
+            // This is critical because the thread executing this code may be an RX runtime
+            // worker that is holding routing locks (e.g. the routing tables) while pushing
+            // declarations. If such a thread kept blocking on pushes to this transport,
+            // the close task spawned below on the same starved runtime would never get to
+            // run, leaving the whole session deadlocked
+            // (see https://github.com/eclipse-zenoh/zenoh/issues/1876 and
+            // https://github.com/eclipse-zenoh/zenoh/issues/2581).
+            {
+                let transport_links = self
+                    .links
+                    .read()
+                    .expect("reading `TransportUnicastUniversal::links` should not fail");
+                for tl in transport_links.get_links().iter() {
+                    tl.pipeline.mark_disabled();
+                }
+            }
             zenoh_runtime::ZRuntime::RX.spawn({
                 let transport = self.clone();
                 async move {

--- a/io/zenoh-transport/tests/unicast_unresponsive_peer.rs
+++ b/io/zenoh-transport/tests/unicast_unresponsive_peer.rs
@@ -1,0 +1,230 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+#![cfg(feature = "transport_tcp")]
+
+use std::{
+    convert::TryFrom,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::{Duration, Instant},
+};
+
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+};
+use zenoh_core::ztimeout;
+use zenoh_link::EndPoint;
+use zenoh_protocol::{
+    core::{CongestionControl, Priority, WhatAmI, ZenohIdProto},
+    network::{push::ext::QoSType, NetworkMessage, Push},
+};
+use zenoh_result::ZResult;
+use zenoh_test::get_free_tcp_port;
+use zenoh_transport::{
+    multicast::TransportMulticast, unicast::TransportUnicast, DummyTransportPeerEventHandler,
+    TransportEventHandler, TransportManager, TransportMulticastEventHandler, TransportPeer,
+    TransportPeerEventHandler,
+};
+
+const TIMEOUT: Duration = Duration::from_secs(60);
+
+/// How long a non droppable message is allowed to block before the transport
+/// is considered unresponsive and closed.
+const WAIT_BEFORE_CLOSE: Duration = Duration::from_secs(1);
+
+#[derive(Default)]
+struct SHDummy;
+
+impl TransportEventHandler for SHDummy {
+    fn new_unicast(
+        &self,
+        _peer: TransportPeer,
+        _transport: TransportUnicast,
+    ) -> ZResult<Arc<dyn TransportPeerEventHandler>> {
+        Ok(Arc::new(DummyTransportPeerEventHandler))
+    }
+
+    fn new_multicast(
+        &self,
+        _transport: TransportMulticast,
+    ) -> ZResult<Arc<dyn TransportMulticastEventHandler>> {
+        panic!();
+    }
+}
+
+/// Spawns a TCP proxy from `proxy_addr` to `target_addr` that stops reading from
+/// both sides as soon as `stalled` is set to `true`, simulating a peer whose TCP
+/// connection is alive but which does not consume incoming data anymore
+/// (zero-window situation, e.g. a frozen or abruptly powered off host).
+async fn spawn_stallable_proxy(proxy_addr: String, target_addr: String, stalled: Arc<AtomicBool>) {
+    let listener = TcpListener::bind(proxy_addr).await.unwrap();
+    tokio::spawn(async move {
+        let (downstream, _) = listener.accept().await.unwrap();
+        let upstream = TcpStream::connect(target_addr).await.unwrap();
+        let (down_rx, down_tx) = downstream.into_split();
+        let (up_rx, up_tx) = upstream.into_split();
+
+        async fn pump(
+            mut rx: tokio::net::tcp::OwnedReadHalf,
+            mut tx: tokio::net::tcp::OwnedWriteHalf,
+            stalled: Arc<AtomicBool>,
+        ) {
+            let mut buf = [0u8; 16384];
+            loop {
+                // Once stalled, stop reading. The socket stays open so the sender
+                // side keeps its connection established, its kernel send buffer
+                // fills up, and TCP flow control blocks any further transmission.
+                if stalled.load(Ordering::Relaxed) {
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    continue;
+                }
+                match rx.read(&mut buf).await {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => {
+                        if tx.write_all(&buf[..n]).await.is_err() {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        tokio::join!(
+            pump(down_rx, up_tx, stalled.clone()),
+            pump(up_rx, down_tx, stalled),
+        );
+    });
+}
+
+fn make_message(payload_size: usize) -> NetworkMessage {
+    NetworkMessage::from(Push {
+        wire_expr: "test".into(),
+        ext_qos: QoSType::new(Priority::DEFAULT, CongestionControl::Block, false),
+        ..Push::from(vec![0u8; payload_size])
+    })
+}
+
+/// When a non droppable message cannot be pushed within `wait_before_close`, the
+/// transport is closed. Any subsequent push to this transport must fail fast
+/// instead of blocking for another `wait_before_close` period: the thread pushing
+/// the message may be an RX runtime worker holding routing locks, and blocking it
+/// again would starve the very runtime that has to execute the close task,
+/// deadlocking the whole session (see eclipse-zenoh/zenoh#1876 and
+/// eclipse-zenoh/zenoh#2581).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn transport_unicast_push_fails_fast_on_unresponsive_peer() {
+    zenoh_util::init_log_from_env_or("error");
+
+    // Listener side (the peer that will become unresponsive)
+    let listener_port = get_free_tcp_port();
+    let listener_manager = TransportManager::builder()
+        .whatami(WhatAmI::Peer)
+        .zid(ZenohIdProto::try_from([1]).unwrap())
+        .build_test(Arc::new(SHDummy))
+        .unwrap();
+    let listen_endpoint: EndPoint = format!("tcp/127.0.0.1:{listener_port}")
+        .parse()
+        .unwrap();
+    ztimeout!(listener_manager.add_listener(listen_endpoint)).unwrap();
+
+    // Stallable TCP proxy in front of the listener
+    let proxy_port = get_free_tcp_port();
+    let stalled = Arc::new(AtomicBool::new(false));
+    spawn_stallable_proxy(
+        format!("127.0.0.1:{proxy_port}"),
+        format!("127.0.0.1:{listener_port}"),
+        stalled.clone(),
+    )
+    .await;
+
+    // Connecting side, with a short wait_before_close to keep the test fast
+    let connect_manager = TransportManager::builder()
+        .whatami(WhatAmI::Peer)
+        .zid(ZenohIdProto::try_from([2]).unwrap())
+        .wait_before_close(WAIT_BEFORE_CLOSE)
+        .build_test(Arc::new(SHDummy))
+        .unwrap();
+    let connect_endpoint: EndPoint = format!("tcp/127.0.0.1:{proxy_port}").parse().unwrap();
+    let transport = ztimeout!(connect_manager.open_transport_unicast(connect_endpoint)).unwrap();
+
+    // Check that the transport works
+    assert!(transport.schedule(make_message(64).as_mut()).unwrap());
+
+    // Make the peer unresponsive
+    stalled.store(true, Ordering::Relaxed);
+
+    // Push non droppable messages from a dedicated thread until one of them
+    // cannot be pushed within `wait_before_close`. This message triggers the
+    // "Unable to push non droppable network message. Closing transport!" path.
+    let (tx, rx) = std::sync::mpsc::channel::<(Duration, ZResult<bool>)>();
+    std::thread::spawn(move || {
+        let mut failures = 0;
+        for _ in 0..10_000 {
+            let mut msg = make_message(60_000);
+            let start = Instant::now();
+            let res = transport.schedule(msg.as_mut());
+            let elapsed = start.elapsed();
+            let failed = matches!(res, Ok(false) | Err(_));
+            if tx.send((elapsed, res)).is_err() {
+                break;
+            }
+            if failed {
+                failures += 1;
+                // Stop after the push failure that triggers the transport closure
+                // and one more push demonstrating the post-closure behavior.
+                if failures >= 2 {
+                    break;
+                }
+            }
+        }
+    });
+
+    // Wait for the first push that failed after blocking for wait_before_close
+    let recv_timeout = TIMEOUT;
+    loop {
+        let (elapsed, res) = rx.recv_timeout(recv_timeout).expect(
+            "the pusher thread stopped without any push failing: the peer did not stall?",
+        );
+        match res {
+            Ok(true) => continue,
+            Ok(false) => {
+                // The failing push must have blocked for about wait_before_close
+                assert!(elapsed >= WAIT_BEFORE_CLOSE);
+                break;
+            }
+            Err(e) => panic!("push failed with an error before the transport was closed: {e}"),
+        }
+    }
+
+    // Any subsequent push to this transport must now fail fast with
+    // `TransportClosed` instead of blocking for another `wait_before_close`.
+    // Without the fail fast mechanism, this push blocks for a full
+    // `wait_before_close` period (and so does every following one, potentially
+    // starving the RX runtime and deadlocking the session).
+    let (elapsed, res) = rx
+        .recv_timeout(recv_timeout)
+        .expect("the pusher thread stopped after the first failed push");
+    assert!(
+        res.is_err(),
+        "expected the push following the transport closure to fail, got {res:?}"
+    );
+    assert!(
+        elapsed < WAIT_BEFORE_CLOSE / 2,
+        "the push following the transport closure blocked for {elapsed:?} \
+         instead of failing fast"
+    );
+}


### PR DESCRIPTION
### Problem

When a peer's TCP connection stays established but the peer stops reading (zero-window; e.g. a frozen or abruptly power-cycled host), pushes of non droppable messages to that transport block for `wait_before_close`. When the deadline expires, `TransportUnicastUniversal::handle_push_result` logs `Unable to push non droppable network message ... Closing transport!` and spawns the close task on the RX runtime.

However, the transmission pipelines of the transport remain enabled until the close task actually runs. If the threads pushing to the dead transport are RX runtime workers (forwarding reliable data or declarations, holding routing locks), they immediately block again on the next message for another full `wait_before_close` each, starving the RX runtime. The close task never runs and the whole session is livelocked, logging the message above forever.

Fixes #1876, related to #2581.

### Fix

Synchronously mark the transmission pipelines of the transport as disabled at the moment the closure is decided. This is a new `TransmissionPipelineProducer::mark_disabled` method that only performs an atomic store; contrary to `disable` it does not acquire the `stage_in` locks (which may be held by a currently blocked pusher).

`push_network_message` now fails fast with `TransportClosed` when the pipeline is disabled, before attempting to acquire the `stage_in` lock. Subsequent pushes to the unresponsive transport therefore return immediately, the RX workers are freed, and the spawned close task can run and perform the regular cleanup.

No behavior change for healthy transports: the check is a relaxed atomic load on the already-existing status flag.

### Reproducer

A standalone reproducer with stock `zenohd` + examples (SIGSTOP-ed subscriber, blocking publishers, liveness probe) is attached to #1876. On current `main` the router wedges forever, alternating the error log between the RX workers every `wait_before_close`; with this PR it recovers right after `wait_before_close`.

### Tests

- New integration test `unicast_unresponsive_peer` simulates the zero-window peer with a stallable TCP proxy and asserts that, after the push failure that triggers the closure, the next push fails fast instead of blocking for another `wait_before_close`. It fails on current `main` and passes with this PR.
- `cargo test -p zenoh-transport --features transport_tcp` passes.
- Validated on a production multi-host `rmw_zenoh` deployment: 100 abrupt reboot cycles with zero occurrences of the wedge (previously reproduced within a few dozen cycles).

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [x] **Reproduction test added** - Test that fails on main branch without the fix
- [x] **Test passes with fix** - The reproduction test passes with your changes
- [x] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->