### PR TITLE
Pin GitHub Actions to verified commit hashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       runner: ${{ steps.set-runner.outputs.runner }}
     steps:
       - name: Clone this repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Determine which runner to use
         id: set-runner
@@ -86,13 +86,13 @@ jobs:
 
     steps:
       - name: Clone this repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Update Rust 1.75.0 toolchain
         run: rustup update 1.75.0
 
       - name: Setup rust-cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-bin: false
 
@@ -116,7 +116,7 @@ jobs:
 
     steps:
       - name: Clone this repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Update Stable Rust toolchain
         run: rustup update stable
@@ -127,7 +127,7 @@ jobs:
           rustup component add rustfmt --toolchain ${{ env.NIGHTLY_TOOLCHAIN }}
 
       - name: Setup rust-cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-bin: false
 
@@ -213,13 +213,13 @@ jobs:
 
     steps:
       - name: Clone this repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install latest Rust toolchain
         run: rustup show
 
       - name: Setup rust-cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-bin: false
 
@@ -252,7 +252,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -267,13 +267,13 @@ jobs:
 
     steps:
       - name: Clone this repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install latest Rust toolchain
         run: rustup show
 
       - name: Setup rust-cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-bin: false
 
@@ -307,7 +307,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -322,13 +322,13 @@ jobs:
 
     steps:
       - name: Clone this repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install latest Rust toolchain
         run: rustup show
 
       - name: Setup rust-cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-bin: false
 
@@ -359,7 +359,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -370,7 +370,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone this repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install latest Rust toolchain
         run: rustup toolchain install ${{ env.NIGHTLY_TOOLCHAIN }}
@@ -379,7 +379,7 @@ jobs:
         run: cargo +stable install --locked cargo-fuzz
 
       - name: Setup rust-cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-bin: false
           workspaces: |
@@ -433,7 +433,7 @@ jobs:
     needs: check
     steps:
       - name: Clone this repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install latest Rust toolchain
         run: rustup show
@@ -441,7 +441,7 @@ jobs:
       - name: Install valgrind
         uses: taiki-e/install-action@valgrind
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-bin: false
 
@@ -454,7 +454,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone this repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check spelling
         uses: crate-ci/typos@master
@@ -462,8 +462,8 @@ jobs:
   markdown_lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: DavidAnson/markdownlint-cli2-action@v18
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: DavidAnson/markdownlint-cli2-action@6bf21b07787794f89a243495939cd651942aeabe # v24.1.0
         with:
           config: ".markdownlint.yaml"
           globs: "**/README.md"
@@ -475,7 +475,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone this repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Use a similar command than docs.rs build: rustdoc with nightly toolchain
       - name: Install Rust toolchain nightly for docs gen
@@ -517,7 +517,7 @@ jobs:
           sudo apt-get install -y build-essential clang libc6-dev
 
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust toolchain
         env:
@@ -526,7 +526,7 @@ jobs:
           rustup update ${{ env.RUSTUP_TOOLCHAIN }}
           rustup component add llvm-tools-preview
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-bin: false
 
@@ -553,7 +553,7 @@ jobs:
           --skip metadata_link_failure_concurrent
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info

--- a/.github/workflows/fuzz-scheduled.yml
+++ b/.github/workflows/fuzz-scheduled.yml
@@ -77,7 +77,7 @@ jobs:
           - scouting_message
     steps:
       - name: Clone this repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install latest Rust toolchain
         run: |
@@ -88,7 +88,7 @@ jobs:
         run: cargo +stable install --locked cargo-fuzz
 
       - name: Setup rust-cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-bin: false
           workspaces: |
@@ -143,7 +143,7 @@ jobs:
     timeout-minutes: 330
     steps:
       - name: Clone this repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install latest Rust toolchain
         run: |
@@ -154,7 +154,7 @@ jobs:
         run: cargo +stable install --locked cargo-fuzz
 
       - name: Setup rust-cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-bin: false
           workspaces: |

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -45,7 +45,7 @@ jobs:
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Clone this repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install rustup components
         run: rustup component add rustfmt clippy
@@ -84,7 +84,7 @@ jobs:
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Clone this repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install nextest
         run: cargo +stable install --locked cargo-nextest
@@ -109,7 +109,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone this repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       #
       # Temporary workaround to remmove transitive dependency

--- a/commons/zenoh-test/README.md
+++ b/commons/zenoh-test/README.md
@@ -27,7 +27,7 @@ own copy of helpers.  This caused:
 ### Free functions
 
 | Function | Description |
-|---|---|
+| --- | --- |
 | `get_free_tcp_port()` | Binds to a random TCP port and returns the port number.  ⚠️ Susceptible to TOCTOU races; prefer port `0` listeners when possible. |
 | `get_free_udp_port()` | Binds to a random UDP port and returns the port number.  ⚠️ Susceptible to TOCTOU races; prefer port `0` listeners when possible. |
 | `get_tcp_locator(&session)` | Returns the first `tcp/` endpoint from a session's locators. |


### PR DESCRIPTION
## Description
<!-- TODO: Add a clear description of what this PR does and why -->
Update CI, scheduled fuzzing, and pre-release workflows to use immutable, verified commit hashes for versioned GitHub Actions.

### What does this PR do?
<!-- Describe the changes and their purpose -->

- Pins checkout, Rust cache, Codecov, and markdownlint actions to exact commits.
- Adds version comments beside each hash for readability and dependency tracking.
- Updates actions/checkout to v7.0.1, markdownlint-cli2-action to v24.1.0 and codecov-action to v7.0.0.

### Why is this change needed?
<!-- Explain the motivation or problem being solved -->

Version tags are mutable and can resolve to different code over time. Pinning verified commits makes CI execution more secure and reproducible while retaining clear version information.

### Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->
None.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->