### PR TITLE
Add configuration in shared_memory/transport_optimization to select the type of messages to optimize

### DIFF
--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -758,6 +758,14 @@
           pool_size: 16777216,
           /// Allow optimization for messages equal or larger than this threshold in bytes (default `3072`).
           message_size_threshold: 3072,
+          /// Whether SHM optimization is applied to publications (Put) payloads (default `true`).
+          publications: true,
+          /// Whether SHM optimization is applied to query and reply (Request/Response) payloads (default `true`).
+          /// Disabling this keeps queries/replies off the SHM path.
+          /// Set it to `false` for a workaround for the in-transit watchdog invalidation race,
+          /// which could occur under high CPU load.
+          /// See https://github.com/eclipse-zenoh/zenoh/issues/2628).
+          queries_replies: true,
       },
     },
     auth: {

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -758,14 +758,15 @@
           pool_size: 16777216,
           /// Allow optimization for messages equal or larger than this threshold in bytes (default `3072`).
           message_size_threshold: 3072,
-          /// Whether SHM optimization is applied to publications (Put) payloads (default `true`).
-          publications: true,
-          /// Whether SHM optimization is applied to query and reply (Request/Response) payloads (default `true`).
-          /// Disabling this keeps queries/replies off the SHM path.
-          /// Set it to `false` for a workaround for the in-transit watchdog invalidation race,
-          /// which could occur under high CPU load.
-          /// See https://github.com/eclipse-zenoh/zenoh/issues/2628).
-          queries_replies: true,
+          /// The categories of messages the SHM optimization is applied to
+          /// (default: all of "put", "query", "reply").
+          /// Adding "delete" here has no effect since "delete" messages don't have a payload
+          /// and hence are never optimized.
+          /// Removing "query" and "reply" keeps queries/replies off the SHM path. This is
+          /// useful for RPC-style traffic, and a workaround for the in-transit watchdog
+          /// invalidation race that could occur under high CPU load.
+          /// See https://github.com/eclipse-zenoh/zenoh/issues/2628
+          messages: ["put", "query", "reply"],
       },
     },
     auth: {

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -758,13 +758,16 @@
           pool_size: 16777216,
           /// Allow optimization for messages equal or larger than this threshold in bytes (default `3072`).
           message_size_threshold: 3072,
-          /// The categories of messages the SHM optimization is applied to
-          /// (default: all of "put", "query", "reply").
+          /// The categories of messages the *implicit* SHM optimization is applied to,
+          /// i.e. for which a large enough regular payload is automatically copied into
+          /// shared memory (default: "put", "query", "reply").
+          /// This does not affect payloads the application already allocated in shared
+          /// memory: those are always sent over SHM when the peer supports it.
           /// Adding "delete" here has no effect since "delete" messages don't have a payload
           /// and hence are never optimized.
-          /// Removing "query" and "reply" keeps queries/replies off the SHM path. This is
-          /// useful for RPC-style traffic, and a workaround for the in-transit watchdog
-          /// invalidation race that could occur under high CPU load.
+          /// Removing "query" and "reply" keeps auto-promoted queries/replies off the SHM
+          /// path. This is useful for RPC-style traffic, and a workaround for the in-transit
+          /// watchdog invalidation race that could occur under high CPU load.
           /// See https://github.com/eclipse-zenoh/zenoh/issues/2628
           messages: ["put", "query", "reply"],
       },

--- a/commons/zenoh-config/src/defaults.rs
+++ b/commons/zenoh-config/src/defaults.rs
@@ -338,6 +338,8 @@ impl Default for LargeMessageTransportOpt {
             enabled: true,
             pool_size: unsafe { NonZeroUsize::new_unchecked(16 * 1024 * 1024) },
             message_size_threshold: 3072,
+            publications: true,
+            queries_replies: true,
         }
     }
 }

--- a/commons/zenoh-config/src/defaults.rs
+++ b/commons/zenoh-config/src/defaults.rs
@@ -338,8 +338,7 @@ impl Default for LargeMessageTransportOpt {
             enabled: true,
             pool_size: unsafe { NonZeroUsize::new_unchecked(16 * 1024 * 1024) },
             message_size_threshold: 3072,
-            publications: true,
-            queries_replies: true,
+            messages: vec![DataMessage::Put, DataMessage::Query, DataMessage::Reply],
         }
     }
 }

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -110,13 +110,14 @@ pub enum InterceptorFlow {
     Ingress,
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq)]
+/// A category of data message that carries a payload. Used by downsampling, low-pass
+/// filtering, and SHM transport optimization to select which messages a configuration
+/// applies to.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, Hash, PartialEq)]
 #[serde(rename_all = "snake_case")]
-pub enum DownsamplingMessage {
-    Delete,
-    #[deprecated = "Use `Put` or `Delete` instead."]
-    Push,
+pub enum DataMessage {
     Put,
+    Delete,
     Query,
     Reply,
 }
@@ -143,24 +144,11 @@ pub struct DownsamplingItemConf {
     /// Downsampling will be applied for all link types if the parameter is None
     pub link_protocols: Option<NEVec<InterceptorLink>>,
     // list of message types on which the downsampling will be applied
-    pub messages: NEVec<DownsamplingMessage>,
+    pub messages: NEVec<DataMessage>,
     /// A list of downsampling rules: key_expression and the maximum frequency in Hertz
     pub rules: NEVec<DownsamplingRuleConf>,
     /// Downsampling flow directions: egress and/or ingress
     pub flows: Option<NEVec<InterceptorFlow>>,
-}
-
-fn downsampling_validator(d: &Vec<DownsamplingItemConf>) -> bool {
-    for item in d {
-        if item
-            .messages
-            .iter()
-            .any(|m| *m == DownsamplingMessage::Push)
-        {
-            tracing::warn!("In 'downsampling/messages' configuration: 'push' is deprecated and may not be supported in future versions, use 'put' and/or 'delete' instead");
-        }
-    }
-    true
 }
 
 #[derive(Serialize, Debug, Deserialize, Clone)]
@@ -170,18 +158,9 @@ pub struct LowPassFilterConf {
     pub interfaces: Option<NEVec<String>>,
     pub link_protocols: Option<NEVec<InterceptorLink>>,
     pub flows: Option<NEVec<InterceptorFlow>>,
-    pub messages: NEVec<LowPassFilterMessage>,
+    pub messages: NEVec<DataMessage>,
     pub key_exprs: NEVec<OwnedKeyExpr>,
     pub size_limit: usize,
-}
-
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, Hash, PartialEq)]
-#[serde(rename_all = "snake_case")]
-pub enum LowPassFilterMessage {
-    Put,
-    Delete,
-    Query,
-    Reply,
 }
 
 #[derive(Serialize, Debug, Deserialize, Clone)]
@@ -860,12 +839,9 @@ validated_struct::validator! {
                     pool_size: NonZeroUsize,
                     /// Allow optimization for messages equal or larger than this threshold in bytes (default `3072`).
                     message_size_threshold: usize,
-                    /// Whether SHM optimization is applied to publications (Put) payloads (default `true`).
-                    publications: bool,
-                    /// Whether SHM optimization is applied to query and reply (Request/Response) payloads (default `true`).
-                    /// Disabling this keeps queries/replies off the SHM path (workaround for the in-transit
-                    /// watchdog invalidation race, see https://github.com/eclipse-zenoh/zenoh/issues/2628).
-                    queries_replies: bool,
+                    /// The categories of messages the SHM optimization is applied to
+                    /// (default: all of `put`, `delete`, `query`, `reply`).
+                    messages: Vec<DataMessage>,
                 },
             },
             pub auth: #[derive(Default)]
@@ -926,7 +902,7 @@ validated_struct::validator! {
         pub namespace: Option<OwnedNonWildKeyExpr>,
 
         /// Configuration of the downsampling.
-        downsampling: Vec<DownsamplingItemConf> where (downsampling_validator),
+        downsampling: Vec<DownsamplingItemConf>,
 
         /// Configuration of the access control (ACL)
         pub access_control: AclConfig {

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -839,8 +839,11 @@ validated_struct::validator! {
                     pool_size: NonZeroUsize,
                     /// Allow optimization for messages equal or larger than this threshold in bytes (default `3072`).
                     message_size_threshold: usize,
-                    /// The categories of messages the SHM optimization is applied to
-                    /// (default: all of `put`, `delete`, `query`, `reply`).
+                    /// The categories of messages the *implicit* SHM optimization is applied
+                    /// to, i.e. for which a large enough regular payload is automatically
+                    /// copied into shared memory (default: `put`, `query`, `reply`).
+                    /// Payloads the application already allocated in shared memory are always
+                    /// sent over SHM when the peer supports it, regardless of this list.
                     messages: Vec<DataMessage>,
                 },
             },

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -860,6 +860,12 @@ validated_struct::validator! {
                     pool_size: NonZeroUsize,
                     /// Allow optimization for messages equal or larger than this threshold in bytes (default `3072`).
                     message_size_threshold: usize,
+                    /// Whether SHM optimization is applied to publications (Put) payloads (default `true`).
+                    publications: bool,
+                    /// Whether SHM optimization is applied to query and reply (Request/Response) payloads (default `true`).
+                    /// Disabling this keeps queries/replies off the SHM path (workaround for the in-transit
+                    /// watchdog invalidation race, see https://github.com/eclipse-zenoh/zenoh/issues/2628).
+                    queries_replies: bool,
                 },
             },
             pub auth: #[derive(Default)]

--- a/io/zenoh-transport/src/multicast/establishment.rs
+++ b/io/zenoh-transport/src/multicast/establishment.rs
@@ -84,6 +84,7 @@ pub(crate) async fn open_link(
         crate::shm_context::MulticastTransportShmContext::new(
             context.shm_reader.clone(),
             context.shm_provider.clone(),
+            context.policy,
         )
     });
 

--- a/io/zenoh-transport/src/multicast/tx.rs
+++ b/io/zenoh-transport/src/multicast/tx.rs
@@ -48,7 +48,12 @@ impl TransportMulticastInner {
     pub(super) fn schedule(&self, mut msg: NetworkMessageMut) -> ZResult<bool> {
         #[cfg(feature = "shared-memory")]
         if let Some(shm_context) = &self.shm_context {
-            map_zmsg_to_partner(&mut msg, &shm_context.shm_config, &shm_context.shm_provider);
+            map_zmsg_to_partner(
+                &mut msg,
+                &shm_context.shm_config,
+                &shm_context.shm_provider,
+                shm_context.policy,
+            );
         }
 
         let res = self.schedule_on_link(msg.as_ref())?;

--- a/io/zenoh-transport/src/shm.rs
+++ b/io/zenoh-transport/src/shm.rs
@@ -207,19 +207,20 @@ impl PartnerShmConfig for MulticastTransportShmConfig {
     }
 }
 
-/// Controls which categories of messages are eligible for SHM optimization on TX,
-/// derived from the `transport_optimization.messages` configuration.
+/// Controls which categories of messages are eligible for the *implicit* SHM
+/// optimization on TX, derived from the `transport_optimization.messages` configuration.
 ///
-/// Gating a category disables *both* the implicit optimization (wrapping a large raw
-/// payload into SHM) and the forwarding of an already-allocated SHM buffer as a
-/// descriptor, so the payload is sent over the regular network path instead.
+/// Each flag gates only the implicit optimization for its category — automatically
+/// copying a large raw payload into SHM. A payload the application already allocated in
+/// SHM is always forwarded as a descriptor (when the partner supports its protocol),
+/// regardless of these flags.
 #[derive(Clone, Copy, Debug)]
 pub struct ShmOptimizationPolicy {
-    /// Whether publication (`Put`) payloads may use SHM.
+    /// Whether publication (`Put`) payloads may be implicitly copied into SHM.
     pub put: bool,
-    /// Whether query (`Request`) payloads may use SHM.
+    /// Whether query (`Request`) payloads may be implicitly copied into SHM.
     pub query: bool,
-    /// Whether reply (`Response`: `Reply`/`Err`) payloads may use SHM.
+    /// Whether reply (`Response`: `Reply`/`Err`) payloads may be implicitly copied into SHM.
     pub reply: bool,
 }
 
@@ -229,30 +230,36 @@ pub fn map_zmsg_to_partner<ShmCfg: PartnerShmConfig>(
     shm_provider: &Option<Arc<LazyShmProvider>>,
     policy: ShmOptimizationPolicy,
 ) {
+    // The policy gates only the *implicit* optimization (auto-copying a large raw
+    // payload into SHM): a category is granted the provider only when it is enabled.
+    // An already-allocated SHM buffer is *always* forwarded as a descriptor (subject to
+    // the partner supporting its protocol) since the explicit branch of `map_to_partner`
+    // does not use the provider.
+    let no_provider: Option<Arc<LazyShmProvider>> = None;
     match &mut msg.body {
-        NetworkBodyMut::Push(Push { payload, .. }) => {
-            if policy.put {
-                match payload {
-                    PushBody::Put(b) => b.map_to_partner(partner_shm_cfg, shm_provider),
-                    PushBody::Del(_) => {}
-                }
+        NetworkBodyMut::Push(Push { payload, .. }) => match payload {
+            PushBody::Put(b) => {
+                let p = if policy.put { shm_provider } else { &no_provider };
+                b.map_to_partner(partner_shm_cfg, p);
             }
-        }
-        NetworkBodyMut::Request(Request { payload, .. }) => {
-            if policy.query {
-                match payload {
-                    RequestBody::Query(b) => b.map_to_partner(partner_shm_cfg, shm_provider),
-                }
+            PushBody::Del(_) => {}
+        },
+        NetworkBodyMut::Request(Request { payload, .. }) => match payload {
+            RequestBody::Query(b) => {
+                let p = if policy.query { shm_provider } else { &no_provider };
+                b.map_to_partner(partner_shm_cfg, p);
             }
-        }
-        NetworkBodyMut::Response(Response { payload, .. }) => {
-            if policy.reply {
-                match payload {
-                    ResponseBody::Reply(b) => b.map_to_partner(partner_shm_cfg, shm_provider),
-                    ResponseBody::Err(b) => b.map_to_partner(partner_shm_cfg, shm_provider),
-                }
+        },
+        NetworkBodyMut::Response(Response { payload, .. }) => match payload {
+            ResponseBody::Reply(b) => {
+                let p = if policy.reply { shm_provider } else { &no_provider };
+                b.map_to_partner(partner_shm_cfg, p);
             }
-        }
+            ResponseBody::Err(b) => {
+                let p = if policy.reply { shm_provider } else { &no_provider };
+                b.map_to_partner(partner_shm_cfg, p);
+            }
+        },
         NetworkBodyMut::ResponseFinal(_)
         | NetworkBodyMut::Interest(_)
         | NetworkBodyMut::Declare(_)

--- a/io/zenoh-transport/src/shm.rs
+++ b/io/zenoh-transport/src/shm.rs
@@ -207,23 +207,54 @@ impl PartnerShmConfig for MulticastTransportShmConfig {
     }
 }
 
+/// Controls which categories of messages are eligible for SHM optimization on TX.
+///
+/// Gating a category disables *both* the implicit optimization (wrapping a large raw
+/// payload into SHM) and the forwarding of an explicitly-allocated SHM buffer as a
+/// descriptor, so the payload is sent over the regular network path instead.
+///
+/// Disabling `queries_replies` is a workaround for the in-transit watchdog invalidation
+/// race (see https://github.com/eclipse-zenoh/zenoh/issues/2628): reliable query traffic
+/// (e.g. ROS 2 services over rmw_zenoh) can be silently dropped when a SHM buffer is
+/// invalidated before the receiver mounts it.
+#[derive(Clone, Copy, Debug)]
+pub struct ShmOptimizationPolicy {
+    /// Whether publications (Put) payloads may use SHM.
+    pub publications: bool,
+    /// Whether query and reply (Request/Response) payloads may use SHM.
+    pub queries_replies: bool,
+}
+
 pub fn map_zmsg_to_partner<ShmCfg: PartnerShmConfig>(
     msg: &mut NetworkMessageMut,
     partner_shm_cfg: &ShmCfg,
     shm_provider: &Option<Arc<LazyShmProvider>>,
+    policy: ShmOptimizationPolicy,
 ) {
     match &mut msg.body {
-        NetworkBodyMut::Push(Push { payload, .. }) => match payload {
-            PushBody::Put(b) => b.map_to_partner(partner_shm_cfg, shm_provider),
-            PushBody::Del(_) => {}
-        },
-        NetworkBodyMut::Request(Request { payload, .. }) => match payload {
-            RequestBody::Query(b) => b.map_to_partner(partner_shm_cfg, shm_provider),
-        },
-        NetworkBodyMut::Response(Response { payload, .. }) => match payload {
-            ResponseBody::Reply(b) => b.map_to_partner(partner_shm_cfg, shm_provider),
-            ResponseBody::Err(b) => b.map_to_partner(partner_shm_cfg, shm_provider),
-        },
+        NetworkBodyMut::Push(Push { payload, .. }) => {
+            if policy.publications {
+                match payload {
+                    PushBody::Put(b) => b.map_to_partner(partner_shm_cfg, shm_provider),
+                    PushBody::Del(_) => {}
+                }
+            }
+        }
+        NetworkBodyMut::Request(Request { payload, .. }) => {
+            if policy.queries_replies {
+                match payload {
+                    RequestBody::Query(b) => b.map_to_partner(partner_shm_cfg, shm_provider),
+                }
+            }
+        }
+        NetworkBodyMut::Response(Response { payload, .. }) => {
+            if policy.queries_replies {
+                match payload {
+                    ResponseBody::Reply(b) => b.map_to_partner(partner_shm_cfg, shm_provider),
+                    ResponseBody::Err(b) => b.map_to_partner(partner_shm_cfg, shm_provider),
+                }
+            }
+        }
         NetworkBodyMut::ResponseFinal(_)
         | NetworkBodyMut::Interest(_)
         | NetworkBodyMut::Declare(_)

--- a/io/zenoh-transport/src/shm.rs
+++ b/io/zenoh-transport/src/shm.rs
@@ -239,24 +239,40 @@ pub fn map_zmsg_to_partner<ShmCfg: PartnerShmConfig>(
     match &mut msg.body {
         NetworkBodyMut::Push(Push { payload, .. }) => match payload {
             PushBody::Put(b) => {
-                let p = if policy.put { shm_provider } else { &no_provider };
+                let p = if policy.put {
+                    shm_provider
+                } else {
+                    &no_provider
+                };
                 b.map_to_partner(partner_shm_cfg, p);
             }
             PushBody::Del(_) => {}
         },
         NetworkBodyMut::Request(Request { payload, .. }) => match payload {
             RequestBody::Query(b) => {
-                let p = if policy.query { shm_provider } else { &no_provider };
+                let p = if policy.query {
+                    shm_provider
+                } else {
+                    &no_provider
+                };
                 b.map_to_partner(partner_shm_cfg, p);
             }
         },
         NetworkBodyMut::Response(Response { payload, .. }) => match payload {
             ResponseBody::Reply(b) => {
-                let p = if policy.reply { shm_provider } else { &no_provider };
+                let p = if policy.reply {
+                    shm_provider
+                } else {
+                    &no_provider
+                };
                 b.map_to_partner(partner_shm_cfg, p);
             }
             ResponseBody::Err(b) => {
-                let p = if policy.reply { shm_provider } else { &no_provider };
+                let p = if policy.reply {
+                    shm_provider
+                } else {
+                    &no_provider
+                };
                 b.map_to_partner(partner_shm_cfg, p);
             }
         },

--- a/io/zenoh-transport/src/shm.rs
+++ b/io/zenoh-transport/src/shm.rs
@@ -207,22 +207,20 @@ impl PartnerShmConfig for MulticastTransportShmConfig {
     }
 }
 
-/// Controls which categories of messages are eligible for SHM optimization on TX.
+/// Controls which categories of messages are eligible for SHM optimization on TX,
+/// derived from the `transport_optimization.messages` configuration.
 ///
 /// Gating a category disables *both* the implicit optimization (wrapping a large raw
-/// payload into SHM) and the forwarding of an explicitly-allocated SHM buffer as a
+/// payload into SHM) and the forwarding of an already-allocated SHM buffer as a
 /// descriptor, so the payload is sent over the regular network path instead.
-///
-/// Disabling `queries_replies` is a workaround for the in-transit watchdog invalidation
-/// race (see https://github.com/eclipse-zenoh/zenoh/issues/2628): reliable query traffic
-/// (e.g. ROS 2 services over rmw_zenoh) can be silently dropped when a SHM buffer is
-/// invalidated before the receiver mounts it.
 #[derive(Clone, Copy, Debug)]
 pub struct ShmOptimizationPolicy {
-    /// Whether publications (Put) payloads may use SHM.
-    pub publications: bool,
-    /// Whether query and reply (Request/Response) payloads may use SHM.
-    pub queries_replies: bool,
+    /// Whether publication (`Put`) payloads may use SHM.
+    pub put: bool,
+    /// Whether query (`Request`) payloads may use SHM.
+    pub query: bool,
+    /// Whether reply (`Response`: `Reply`/`Err`) payloads may use SHM.
+    pub reply: bool,
 }
 
 pub fn map_zmsg_to_partner<ShmCfg: PartnerShmConfig>(
@@ -233,7 +231,7 @@ pub fn map_zmsg_to_partner<ShmCfg: PartnerShmConfig>(
 ) {
     match &mut msg.body {
         NetworkBodyMut::Push(Push { payload, .. }) => {
-            if policy.publications {
+            if policy.put {
                 match payload {
                     PushBody::Put(b) => b.map_to_partner(partner_shm_cfg, shm_provider),
                     PushBody::Del(_) => {}
@@ -241,14 +239,14 @@ pub fn map_zmsg_to_partner<ShmCfg: PartnerShmConfig>(
             }
         }
         NetworkBodyMut::Request(Request { payload, .. }) => {
-            if policy.queries_replies {
+            if policy.query {
                 match payload {
                     RequestBody::Query(b) => b.map_to_partner(partner_shm_cfg, shm_provider),
                 }
             }
         }
         NetworkBodyMut::Response(Response { payload, .. }) => {
-            if policy.queries_replies {
+            if policy.reply {
                 match payload {
                     ResponseBody::Reply(b) => b.map_to_partner(partner_shm_cfg, shm_provider),
                     ResponseBody::Err(b) => b.map_to_partner(partner_shm_cfg, shm_provider),

--- a/io/zenoh-transport/src/shm_context.rs
+++ b/io/zenoh-transport/src/shm_context.rs
@@ -18,7 +18,9 @@ use zenoh_result::ZResult;
 use zenoh_shm::{api::client_storage::GLOBAL_CLIENT_STORAGE, reader::ShmReader};
 
 use crate::{
-    shm::{LazyShmProvider, MulticastTransportShmConfig, TransportShmConfig},
+    shm::{
+        LazyShmProvider, MulticastTransportShmConfig, ShmOptimizationPolicy, TransportShmConfig,
+    },
     unicast::establishment::ext::shm::AuthUnicast,
 };
 
@@ -27,14 +29,20 @@ pub(super) struct MulticastTransportShmContext {
     pub(crate) shm_reader: ShmReader,
     pub(super) shm_provider: Option<Arc<LazyShmProvider>>,
     pub(super) shm_config: MulticastTransportShmConfig,
+    pub(crate) policy: ShmOptimizationPolicy,
 }
 
 impl MulticastTransportShmContext {
-    pub(super) fn new(shm_reader: ShmReader, shm_provider: Option<Arc<LazyShmProvider>>) -> Self {
+    pub(super) fn new(
+        shm_reader: ShmReader,
+        shm_provider: Option<Arc<LazyShmProvider>>,
+        policy: ShmOptimizationPolicy,
+    ) -> Self {
         Self {
             shm_reader,
             shm_provider,
             shm_config: MulticastTransportShmConfig,
+            policy,
         }
     }
 }
@@ -44,6 +52,7 @@ pub(super) struct UnicastTransportShmContext {
     pub(crate) shm_reader: ShmReader,
     pub(super) shm_provider: Option<Arc<LazyShmProvider>>,
     pub(super) shm_config: TransportShmConfig,
+    pub(crate) policy: ShmOptimizationPolicy,
 }
 
 impl UnicastTransportShmContext {
@@ -51,11 +60,13 @@ impl UnicastTransportShmContext {
         shm_reader: ShmReader,
         shm_provider: Option<Arc<LazyShmProvider>>,
         shm_config: TransportShmConfig,
+        policy: ShmOptimizationPolicy,
     ) -> Self {
         Self {
             shm_reader,
             shm_provider,
             shm_config,
+            policy,
         }
     }
 }
@@ -63,6 +74,7 @@ impl UnicastTransportShmContext {
 pub struct ShmContext {
     pub(crate) shm_reader: ShmReader,
     pub(super) shm_provider: Option<Arc<LazyShmProvider>>,
+    pub(crate) policy: ShmOptimizationPolicy,
     pub(super) auth: AuthUnicast,
 }
 
@@ -94,6 +106,11 @@ impl ShmContext {
             None
         };
 
+        let policy = ShmOptimizationPolicy {
+            publications: *cfg.transport_optimization.publications(),
+            queries_replies: *cfg.transport_optimization.queries_replies(),
+        };
+
         let shm_reader = external_reader
             .unwrap_or_else(|| ShmReader::new((*GLOBAL_CLIENT_STORAGE.read()).clone()));
 
@@ -101,6 +118,7 @@ impl ShmContext {
 
         Ok(Some(Self {
             shm_provider,
+            policy,
             shm_reader,
             auth,
         }))

--- a/io/zenoh-transport/src/shm_context.rs
+++ b/io/zenoh-transport/src/shm_context.rs
@@ -106,9 +106,11 @@ impl ShmContext {
             None
         };
 
+        let messages = cfg.transport_optimization.messages();
         let policy = ShmOptimizationPolicy {
-            publications: *cfg.transport_optimization.publications(),
-            queries_replies: *cfg.transport_optimization.queries_replies(),
+            put: messages.contains(&zenoh_config::DataMessage::Put),
+            query: messages.contains(&zenoh_config::DataMessage::Query),
+            reply: messages.contains(&zenoh_config::DataMessage::Reply),
         };
 
         let shm_reader = external_reader

--- a/io/zenoh-transport/src/unicast/lowlatency/tx.rs
+++ b/io/zenoh-transport/src/unicast/lowlatency/tx.rs
@@ -28,7 +28,12 @@ impl TransportUnicastLowlatency {
     pub(crate) fn internal_schedule(&self, mut msg: NetworkMessageMut) -> ZResult<()> {
         #[cfg(feature = "shared-memory")]
         if let Some(shm_context) = &self.shm_context {
-            map_zmsg_to_partner(&mut msg, &shm_context.shm_config, &shm_context.shm_provider);
+            map_zmsg_to_partner(
+                &mut msg,
+                &shm_context.shm_config,
+                &shm_context.shm_provider,
+                shm_context.policy,
+            );
         }
 
         let msg = msg.as_ref();

--- a/io/zenoh-transport/src/unicast/manager.rs
+++ b/io/zenoh-transport/src/unicast/manager.rs
@@ -664,6 +664,7 @@ impl TransportManager {
                     context.shm_reader.clone(),
                     shm_provider,
                     shm_config.clone(),
+                    context.policy,
                 )
             }),
             None => None,

--- a/io/zenoh-transport/src/unicast/universal/tx.rs
+++ b/io/zenoh-transport/src/unicast/universal/tx.rs
@@ -110,7 +110,12 @@ impl TransportUnicastUniversal {
     pub(crate) fn internal_schedule(&self, mut msg: NetworkMessageMut) -> ZResult<bool> {
         #[cfg(feature = "shared-memory")]
         if let Some(shm_context) = &self.shm_context {
-            map_zmsg_to_partner(&mut msg, &shm_context.shm_config, &shm_context.shm_provider);
+            map_zmsg_to_partner(
+                &mut msg,
+                &shm_context.shm_config,
+                &shm_context.shm_provider,
+                shm_context.policy,
+            );
         }
         let msg = msg.as_ref();
         let transport_links = self

--- a/io/zenoh-transport/tests/unicast_shm.rs
+++ b/io/zenoh-transport/tests/unicast_shm.rs
@@ -389,18 +389,22 @@ mod tests {
     }
 }
 
-// Unit tests for the per-category SHM optimization gating (config fields
-// `transport_optimization.publications` and `.queries_replies`).
+// Unit tests for the per-category SHM optimization gating (`transport_optimization.messages`).
 //
-// They exercise the actual implicit transport optimization: a normal (non-SHM) ZBuf
-// payload above the size threshold is handed to `map_zmsg_to_partner` together with a
-// ready provider, and we check whether it gets copied into an SHM buffer
-// (downcasts to ShmBufInner, ZSliceKind::ShmPtr, `ext_shm` set) depending on the policy.
+// Two behaviors are covered:
+// - Implicit optimization: a normal (non-SHM) ZBuf payload above the size threshold is
+//   copied into SHM only when its category is enabled in the policy.
+// - Explicit forwarding: a payload already allocated in SHM is always forwarded as a
+//   descriptor, regardless of the policy.
+//
+// In both cases "promoted" is observed as ZSliceKind::ShmPtr together with the `ext_shm`
+// extension being set on the message.
 #[cfg(feature = "shared-memory")]
 mod optimization_policy {
     use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 
     use zenoh_buffers::{ZBuf, ZSliceKind};
+    use zenoh_core::Wait;
     use zenoh_protocol::{
         core::{CongestionControl, Encoding, Priority},
         network::{push::ext::QoSType, NetworkBody, NetworkMessage, Push, Request, Response},
@@ -410,7 +414,14 @@ mod optimization_policy {
             PushBody, Put, RequestBody, ResponseBody,
         },
     };
-    use zenoh_shm::{api::common::types::ProtocolID, ShmBufInner};
+    use zenoh_shm::{
+        api::{
+            common::types::ProtocolID,
+            protocol_implementations::posix::posix_shm_provider_backend_binary_heap::PosixShmProviderBackendBinaryHeap,
+            provider::shm_provider::{BlockOn, GarbageCollect, ShmProviderBuilder},
+        },
+        ShmBufInner,
+    };
     use zenoh_transport::shm::{
         map_zmsg_to_partner, LazyShmProvider, PartnerShmConfig, ProviderInitState,
         ShmOptimizationPolicy,
@@ -491,9 +502,9 @@ mod optimization_policy {
         NetworkMessage::from(NetworkBody::Response(response))
     }
 
-    // Run map_zmsg_to_partner and report whether the payload was promoted to SHM.
-    // Asserts that the three promotion signals (backed by ShmBufInner, ZSliceKind::ShmPtr,
-    // and the `ext_shm` extension) are consistent with each other.
+    // Run map_zmsg_to_partner and report whether the payload was promoted to SHM
+    // (i.e. it will be sent as a descriptor). Asserts the two promotion signals
+    // (ZSliceKind::ShmPtr and the `ext_shm` extension) are consistent with each other.
     fn map_and_check_promoted(
         mut msg: NetworkMessage,
         provider: &Option<Arc<LazyShmProvider>>,
@@ -534,20 +545,16 @@ mod optimization_policy {
             other => panic!("unexpected message body: {other:?}"),
         };
 
-        let zs = payload.zslices().next().unwrap();
-        // For the implicit path, "promoted" means the raw payload was actually copied
-        // into an SHM buffer. All three signals must agree.
-        let is_shm_buf = zs.downcast_ref::<ShmBufInner>().is_some();
-        let kind_is_shmptr = zs.kind == ZSliceKind::ShmPtr;
+        // "Promoted" = the payload will be sent over SHM as a descriptor, signaled by
+        // ZSliceKind::ShmPtr and by the `ext_shm` extension; both must agree. We key on
+        // these rather than on `downcast_ref::<ShmBufInner>()`, because an explicitly
+        // allocated SHM buffer downcasts to ShmBufInner whether or not it is forwarded.
+        let kind_is_shmptr = payload.zslices().next().unwrap().kind == ZSliceKind::ShmPtr;
         assert_eq!(
-            is_shm_buf, kind_is_shmptr,
-            "inconsistent SHM promotion signals (ShmBufInner vs ZSliceKind::ShmPtr)"
+            kind_is_shmptr, ext_shm_set,
+            "inconsistent SHM promotion signals (ZSliceKind::ShmPtr vs ext_shm)"
         );
-        assert_eq!(
-            is_shm_buf, ext_shm_set,
-            "inconsistent SHM promotion signals (ShmBufInner vs ext_shm)"
-        );
-        is_shm_buf
+        kind_is_shmptr
     }
 
     const ALL_ON: ShmOptimizationPolicy = ShmOptimizationPolicy {
@@ -555,21 +562,25 @@ mod optimization_policy {
         query: true,
         reply: true,
     };
-    const NO_QUERIES: ShmOptimizationPolicy = ShmOptimizationPolicy {
-        put: true,
-        query: false,
-        reply: false,
-    };
     const NO_PUBS: ShmOptimizationPolicy = ShmOptimizationPolicy {
         put: false,
         query: true,
         reply: true,
     };
+    const NO_QUERIES: ShmOptimizationPolicy = ShmOptimizationPolicy {
+        put: true,
+        query: false,
+        reply: true,
+    };
+    const NO_REPLIES: ShmOptimizationPolicy = ShmOptimizationPolicy {
+        put: true,
+        query: true,
+        reply: false,
+    };
 
     #[tokio::test]
     async fn publications_flag_gates_put() {
         let provider = ready_provider().await;
-        // Put follows `publications`, independently of `queries_replies`.
         assert!(map_and_check_promoted(
             put_message(raw_payload()),
             &provider,
@@ -579,6 +590,11 @@ mod optimization_policy {
             put_message(raw_payload()),
             &provider,
             NO_QUERIES
+        ));
+        assert!(map_and_check_promoted(
+            put_message(raw_payload()),
+            &provider,
+            NO_REPLIES
         ));
         assert!(!map_and_check_promoted(
             put_message(raw_payload()),
@@ -588,9 +604,9 @@ mod optimization_policy {
     }
 
     #[tokio::test]
-    async fn queries_replies_flag_gates_query() {
+    async fn query_flag_gates_query() {
         let provider = ready_provider().await;
-        // Query follows `queries_replies`, independently of `publications`.
+        // Query follows the `query` flag, independently of `put` and `reply`.
         assert!(map_and_check_promoted(
             query_message(raw_payload()),
             &provider,
@@ -600,6 +616,11 @@ mod optimization_policy {
             query_message(raw_payload()),
             &provider,
             NO_PUBS
+        ));
+        assert!(map_and_check_promoted(
+            query_message(raw_payload()),
+            &provider,
+            NO_REPLIES
         ));
         assert!(!map_and_check_promoted(
             query_message(raw_payload()),
@@ -609,9 +630,9 @@ mod optimization_policy {
     }
 
     #[tokio::test]
-    async fn queries_replies_flag_gates_reply() {
+    async fn reply_flag_gates_reply() {
         let provider = ready_provider().await;
-        // Reply (query response) also follows `queries_replies`.
+        // Reply follows the `reply` flag, independently of `put` and `query`.
         assert!(map_and_check_promoted(
             reply_message(raw_payload()),
             &provider,
@@ -622,10 +643,15 @@ mod optimization_policy {
             &provider,
             NO_PUBS
         ));
-        assert!(!map_and_check_promoted(
+        assert!(map_and_check_promoted(
             reply_message(raw_payload()),
             &provider,
             NO_QUERIES
+        ));
+        assert!(!map_and_check_promoted(
+            reply_message(raw_payload()),
+            &provider,
+            NO_REPLIES
         ));
     }
 
@@ -643,6 +669,68 @@ mod optimization_policy {
         assert!(!map_and_check_promoted(
             query_message(small()),
             &provider,
+            ALL_ON
+        ));
+        assert!(!map_and_check_promoted(
+            reply_message(small()),
+            &provider,
+            ALL_ON
+        ));
+    }
+
+    // Allocate a real SHM buffer and return it as a ZBuf payload. Its ZSlice downcasts to
+    // ShmBufInner, exercising the explicit-forwarding branch of map_to_partner.
+    async fn shm_payload() -> ZBuf {
+        const SHM_ARENA: usize = 4 * LARGE_PAYLOAD_SIZE;
+        let backend = PosixShmProviderBackendBinaryHeap::builder(SHM_ARENA)
+            .wait()
+            .unwrap();
+        let provider = ShmProviderBuilder::backend(backend).wait();
+        let layout = provider.alloc_layout(LARGE_PAYLOAD_SIZE).unwrap();
+        let sbuf = layout
+            .alloc()
+            .with_policy::<BlockOn<GarbageCollect>>()
+            .await
+            .unwrap();
+        let zbuf: ZBuf = sbuf.into();
+        assert!(zbuf
+            .zslices()
+            .next()
+            .unwrap()
+            .downcast_ref::<ShmBufInner>()
+            .is_some());
+        zbuf
+    }
+
+    // Explicitly-allocated SHM buffers are always forwarded as descriptors, even when the
+    // implicit optimization is disabled for that message category (and even with no
+    // implicit provider at all).
+    #[tokio::test]
+    async fn explicit_shm_buffer_always_forwarded() {
+        // No implicit provider: only the explicit branch can promote here.
+        let no_provider: Option<Arc<LazyShmProvider>> = None;
+
+        // Category disabled -> still forwarded.
+        assert!(map_and_check_promoted(
+            put_message(shm_payload().await),
+            &no_provider,
+            NO_PUBS
+        ));
+        assert!(map_and_check_promoted(
+            query_message(shm_payload().await),
+            &no_provider,
+            NO_QUERIES
+        ));
+        assert!(map_and_check_promoted(
+            reply_message(shm_payload().await),
+            &no_provider,
+            NO_REPLIES
+        ));
+
+        // Category enabled -> forwarded as well.
+        assert!(map_and_check_promoted(
+            query_message(shm_payload().await),
+            &no_provider,
             ALL_ON
         ));
     }

--- a/io/zenoh-transport/tests/unicast_shm.rs
+++ b/io/zenoh-transport/tests/unicast_shm.rs
@@ -551,16 +551,19 @@ mod optimization_policy {
     }
 
     const ALL_ON: ShmOptimizationPolicy = ShmOptimizationPolicy {
-        publications: true,
-        queries_replies: true,
+        put: true,
+        query: true,
+        reply: true,
     };
     const NO_QUERIES: ShmOptimizationPolicy = ShmOptimizationPolicy {
-        publications: true,
-        queries_replies: false,
+        put: true,
+        query: false,
+        reply: false,
     };
     const NO_PUBS: ShmOptimizationPolicy = ShmOptimizationPolicy {
-        publications: false,
-        queries_replies: true,
+        put: false,
+        query: true,
+        reply: true,
     };
 
     #[tokio::test]

--- a/io/zenoh-transport/tests/unicast_shm.rs
+++ b/io/zenoh-transport/tests/unicast_shm.rs
@@ -388,3 +388,211 @@ mod tests {
         run(&endpoint, true).await;
     }
 }
+
+// Unit tests for the per-category SHM optimization gating (config fields
+// `transport_optimization.publications` and `.queries_replies`).
+//
+// They exercise the actual implicit transport optimization: a normal (non-SHM) ZBuf
+// payload above the size threshold is handed to `map_zmsg_to_partner` together with a
+// ready provider, and we check whether it gets copied into an SHM buffer
+// (downcasts to ShmBufInner, ZSliceKind::ShmPtr, `ext_shm` set) depending on the policy.
+#[cfg(feature = "shared-memory")]
+mod optimization_policy {
+    use std::{num::NonZeroUsize, sync::Arc, time::Duration};
+
+    use zenoh_buffers::{ZBuf, ZSliceKind};
+    use zenoh_protocol::{
+        core::{CongestionControl, Encoding, Priority},
+        network::{push::ext::QoSType, NetworkBody, NetworkMessage, Push, Request, Response},
+        zenoh::{
+            query::{ext::QueryBodyType, Query},
+            reply::Reply,
+            PushBody, Put, RequestBody, ResponseBody,
+        },
+    };
+    use zenoh_shm::{api::common::types::ProtocolID, ShmBufInner};
+    use zenoh_transport::shm::{
+        map_zmsg_to_partner, LazyShmProvider, PartnerShmConfig, ProviderInitState,
+        ShmOptimizationPolicy,
+    };
+
+    // Implicit transport optimization only kicks in for payloads at or above this size.
+    const MESSAGE_SIZE_THRESHOLD: usize = 3072;
+    // A raw (non-SHM) payload larger than the threshold, hence eligible for the
+    // implicit optimization (automatic copy into SHM).
+    const LARGE_PAYLOAD_SIZE: usize = 4096;
+    // SHM arena size: must comfortably exceed a handful of LARGE_PAYLOAD_SIZE allocations.
+    const POOL_SIZE: usize = 1024 * 1024;
+
+    // Partner that supports every SHM protocol. Only relevant to the explicit-buffer
+    // branch; the implicit optimization does not consult it, but the argument is required.
+    struct AllProtocols;
+    impl PartnerShmConfig for AllProtocols {
+        fn supports_protocol(&self, _protocol: ProtocolID) -> bool {
+            true
+        }
+    }
+
+    // Build a LazyShmProvider for the implicit optimization and drive its lazy
+    // initialization to completion, so map_zmsg_to_partner can actually wrap payloads.
+    async fn ready_provider() -> Option<Arc<LazyShmProvider>> {
+        let provider = Arc::new(LazyShmProvider::new(
+            NonZeroUsize::new(POOL_SIZE).unwrap(),
+            MESSAGE_SIZE_THRESHOLD,
+        ));
+        loop {
+            match provider.try_get_provider() {
+                ProviderInitState::Ready(_) => break,
+                ProviderInitState::Initializing(_) => {
+                    tokio::time::sleep(Duration::from_millis(10)).await
+                }
+                ProviderInitState::Error => panic!("failed to initialize SHM provider"),
+            }
+        }
+        Some(provider)
+    }
+
+    // A normal, non-SHM payload large enough to be eligible for implicit optimization.
+    fn raw_payload() -> ZBuf {
+        ZBuf::from(vec![0u8; LARGE_PAYLOAD_SIZE])
+    }
+
+    fn put_message(payload: ZBuf) -> NetworkMessage {
+        NetworkMessage::from(Push {
+            wire_expr: "test".into(),
+            ext_qos: QoSType::new(Priority::DEFAULT, CongestionControl::Block, false),
+            ..Push::from(Put {
+                payload,
+                ..Put::default()
+            })
+        })
+    }
+
+    fn query_message(payload: ZBuf) -> NetworkMessage {
+        let mut query = Query::rand();
+        query.ext_body = Some(QueryBodyType {
+            ext_shm: None,
+            encoding: Encoding::default(),
+            payload,
+        });
+        let mut request = Request::rand();
+        request.payload = RequestBody::Query(query);
+        NetworkMessage::from(NetworkBody::Request(request))
+    }
+
+    fn reply_message(payload: ZBuf) -> NetworkMessage {
+        let mut reply = Reply::rand();
+        reply.payload = PushBody::Put(Put {
+            payload,
+            ..Put::default()
+        });
+        let mut response = Response::rand();
+        response.payload = ResponseBody::Reply(reply);
+        NetworkMessage::from(NetworkBody::Response(response))
+    }
+
+    // Run map_zmsg_to_partner and report whether the payload was promoted to SHM.
+    // Asserts that the three promotion signals (backed by ShmBufInner, ZSliceKind::ShmPtr,
+    // and the `ext_shm` extension) are consistent with each other.
+    fn map_and_check_promoted(
+        mut msg: NetworkMessage,
+        provider: &Option<Arc<LazyShmProvider>>,
+        policy: ShmOptimizationPolicy,
+    ) -> bool {
+        {
+            let mut m = msg.as_mut();
+            map_zmsg_to_partner(&mut m, &AllProtocols, provider, policy);
+        }
+
+        let (payload, ext_shm_set) = match &msg.body {
+            NetworkBody::Push(Push {
+                payload: PushBody::Put(Put {
+                    payload, ext_shm, ..
+                }),
+                ..
+            }) => (payload, ext_shm.is_some()),
+            NetworkBody::Request(Request {
+                payload: RequestBody::Query(Query {
+                    ext_body: Some(body),
+                    ..
+                }),
+                ..
+            }) => (&body.payload, body.ext_shm.is_some()),
+            NetworkBody::Response(Response {
+                payload: ResponseBody::Reply(Reply {
+                    payload: PushBody::Put(Put {
+                        payload, ext_shm, ..
+                    }),
+                    ..
+                }),
+                ..
+            }) => (payload, ext_shm.is_some()),
+            other => panic!("unexpected message body: {other:?}"),
+        };
+
+        let zs = payload.zslices().next().unwrap();
+        // For the implicit path, "promoted" means the raw payload was actually copied
+        // into an SHM buffer. All three signals must agree.
+        let is_shm_buf = zs.downcast_ref::<ShmBufInner>().is_some();
+        let kind_is_shmptr = zs.kind == ZSliceKind::ShmPtr;
+        assert_eq!(
+            is_shm_buf, kind_is_shmptr,
+            "inconsistent SHM promotion signals (ShmBufInner vs ZSliceKind::ShmPtr)"
+        );
+        assert_eq!(
+            is_shm_buf, ext_shm_set,
+            "inconsistent SHM promotion signals (ShmBufInner vs ext_shm)"
+        );
+        is_shm_buf
+    }
+
+    const ALL_ON: ShmOptimizationPolicy = ShmOptimizationPolicy {
+        publications: true,
+        queries_replies: true,
+    };
+    const NO_QUERIES: ShmOptimizationPolicy = ShmOptimizationPolicy {
+        publications: true,
+        queries_replies: false,
+    };
+    const NO_PUBS: ShmOptimizationPolicy = ShmOptimizationPolicy {
+        publications: false,
+        queries_replies: true,
+    };
+
+    #[tokio::test]
+    async fn publications_flag_gates_put() {
+        let provider = ready_provider().await;
+        // Put follows `publications`, independently of `queries_replies`.
+        assert!(map_and_check_promoted(put_message(raw_payload()), &provider, ALL_ON));
+        assert!(map_and_check_promoted(put_message(raw_payload()), &provider, NO_QUERIES));
+        assert!(!map_and_check_promoted(put_message(raw_payload()), &provider, NO_PUBS));
+    }
+
+    #[tokio::test]
+    async fn queries_replies_flag_gates_query() {
+        let provider = ready_provider().await;
+        // Query follows `queries_replies`, independently of `publications`.
+        assert!(map_and_check_promoted(query_message(raw_payload()), &provider, ALL_ON));
+        assert!(map_and_check_promoted(query_message(raw_payload()), &provider, NO_PUBS));
+        assert!(!map_and_check_promoted(query_message(raw_payload()), &provider, NO_QUERIES));
+    }
+
+    #[tokio::test]
+    async fn queries_replies_flag_gates_reply() {
+        let provider = ready_provider().await;
+        // Reply (query response) also follows `queries_replies`.
+        assert!(map_and_check_promoted(reply_message(raw_payload()), &provider, ALL_ON));
+        assert!(map_and_check_promoted(reply_message(raw_payload()), &provider, NO_PUBS));
+        assert!(!map_and_check_promoted(reply_message(raw_payload()), &provider, NO_QUERIES));
+    }
+
+    // A payload below the threshold is never promoted, even when the category is
+    // enabled: this is the size gate of the transport optimization itself.
+    #[tokio::test]
+    async fn below_threshold_is_never_promoted() {
+        let provider = ready_provider().await;
+        let small = || ZBuf::from(vec![0u8; MESSAGE_SIZE_THRESHOLD - 1]);
+        assert!(!map_and_check_promoted(put_message(small()), &provider, ALL_ON));
+        assert!(!map_and_check_promoted(query_message(small()), &provider, ALL_ON));
+    }
+}

--- a/io/zenoh-transport/tests/unicast_shm.rs
+++ b/io/zenoh-transport/tests/unicast_shm.rs
@@ -506,25 +506,29 @@ mod optimization_policy {
 
         let (payload, ext_shm_set) = match &msg.body {
             NetworkBody::Push(Push {
-                payload: PushBody::Put(Put {
-                    payload, ext_shm, ..
-                }),
+                payload:
+                    PushBody::Put(Put {
+                        payload, ext_shm, ..
+                    }),
                 ..
             }) => (payload, ext_shm.is_some()),
             NetworkBody::Request(Request {
-                payload: RequestBody::Query(Query {
-                    ext_body: Some(body),
-                    ..
-                }),
+                payload:
+                    RequestBody::Query(Query {
+                        ext_body: Some(body),
+                        ..
+                    }),
                 ..
             }) => (&body.payload, body.ext_shm.is_some()),
             NetworkBody::Response(Response {
-                payload: ResponseBody::Reply(Reply {
-                    payload: PushBody::Put(Put {
-                        payload, ext_shm, ..
+                payload:
+                    ResponseBody::Reply(Reply {
+                        payload:
+                            PushBody::Put(Put {
+                                payload, ext_shm, ..
+                            }),
+                        ..
                     }),
-                    ..
-                }),
                 ..
             }) => (payload, ext_shm.is_some()),
             other => panic!("unexpected message body: {other:?}"),
@@ -563,27 +567,63 @@ mod optimization_policy {
     async fn publications_flag_gates_put() {
         let provider = ready_provider().await;
         // Put follows `publications`, independently of `queries_replies`.
-        assert!(map_and_check_promoted(put_message(raw_payload()), &provider, ALL_ON));
-        assert!(map_and_check_promoted(put_message(raw_payload()), &provider, NO_QUERIES));
-        assert!(!map_and_check_promoted(put_message(raw_payload()), &provider, NO_PUBS));
+        assert!(map_and_check_promoted(
+            put_message(raw_payload()),
+            &provider,
+            ALL_ON
+        ));
+        assert!(map_and_check_promoted(
+            put_message(raw_payload()),
+            &provider,
+            NO_QUERIES
+        ));
+        assert!(!map_and_check_promoted(
+            put_message(raw_payload()),
+            &provider,
+            NO_PUBS
+        ));
     }
 
     #[tokio::test]
     async fn queries_replies_flag_gates_query() {
         let provider = ready_provider().await;
         // Query follows `queries_replies`, independently of `publications`.
-        assert!(map_and_check_promoted(query_message(raw_payload()), &provider, ALL_ON));
-        assert!(map_and_check_promoted(query_message(raw_payload()), &provider, NO_PUBS));
-        assert!(!map_and_check_promoted(query_message(raw_payload()), &provider, NO_QUERIES));
+        assert!(map_and_check_promoted(
+            query_message(raw_payload()),
+            &provider,
+            ALL_ON
+        ));
+        assert!(map_and_check_promoted(
+            query_message(raw_payload()),
+            &provider,
+            NO_PUBS
+        ));
+        assert!(!map_and_check_promoted(
+            query_message(raw_payload()),
+            &provider,
+            NO_QUERIES
+        ));
     }
 
     #[tokio::test]
     async fn queries_replies_flag_gates_reply() {
         let provider = ready_provider().await;
         // Reply (query response) also follows `queries_replies`.
-        assert!(map_and_check_promoted(reply_message(raw_payload()), &provider, ALL_ON));
-        assert!(map_and_check_promoted(reply_message(raw_payload()), &provider, NO_PUBS));
-        assert!(!map_and_check_promoted(reply_message(raw_payload()), &provider, NO_QUERIES));
+        assert!(map_and_check_promoted(
+            reply_message(raw_payload()),
+            &provider,
+            ALL_ON
+        ));
+        assert!(map_and_check_promoted(
+            reply_message(raw_payload()),
+            &provider,
+            NO_PUBS
+        ));
+        assert!(!map_and_check_promoted(
+            reply_message(raw_payload()),
+            &provider,
+            NO_QUERIES
+        ));
     }
 
     // A payload below the threshold is never promoted, even when the category is
@@ -592,7 +632,15 @@ mod optimization_policy {
     async fn below_threshold_is_never_promoted() {
         let provider = ready_provider().await;
         let small = || ZBuf::from(vec![0u8; MESSAGE_SIZE_THRESHOLD - 1]);
-        assert!(!map_and_check_promoted(put_message(small()), &provider, ALL_ON));
-        assert!(!map_and_check_promoted(query_message(small()), &provider, ALL_ON));
+        assert!(!map_and_check_promoted(
+            put_message(small()),
+            &provider,
+            ALL_ON
+        ));
+        assert!(!map_and_check_promoted(
+            query_message(small()),
+            &provider,
+            ALL_ON
+        ));
     }
 }

--- a/zenoh/src/api/builders/scouting.rs
+++ b/zenoh/src/api/builders/scouting.rs
@@ -21,7 +21,7 @@ use zenoh_result::ZResult;
 
 use crate::api::{
     handlers::{locked, Callback, DefaultHandler, IntoHandler},
-    scouting::{Scout, _scout},
+    scouting::{_scout, Scout},
 };
 
 /// A builder for initializing a [`Scout`], returned by the

--- a/zenoh/src/api/builders/scouting.rs
+++ b/zenoh/src/api/builders/scouting.rs
@@ -21,7 +21,7 @@ use zenoh_result::ZResult;
 
 use crate::api::{
     handlers::{locked, Callback, DefaultHandler, IntoHandler},
-    scouting::{_scout, Scout},
+    scouting::{Scout, _scout},
 };
 
 /// A builder for initializing a [`Scout`], returned by the

--- a/zenoh/src/net/routing/interceptor/downsampling.rs
+++ b/zenoh/src/net/routing/interceptor/downsampling.rs
@@ -27,7 +27,7 @@ use std::{
 };
 
 use nonempty_collections::NEVec;
-use zenoh_config::{DownsamplingItemConf, DownsamplingMessage, DownsamplingRuleConf};
+use zenoh_config::{DataMessage, DownsamplingItemConf, DownsamplingRuleConf};
 use zenoh_core::zlock;
 use zenoh_keyexpr::keyexpr_tree::{
     impls::KeyedSetProvider, support::UnknownWildness, IKeyExprTree, IKeyExprTreeMut, KeBoxTree,
@@ -169,19 +169,14 @@ pub(crate) struct DownsamplingFilters {
 }
 
 impl DownsamplingFilters {
-    fn new<T: IntoIterator<Item = DownsamplingMessage>>(iter: T) -> Self {
+    fn new<T: IntoIterator<Item = DataMessage>>(iter: T) -> Self {
         let mut filters = Self::default();
         for m in iter {
             match m {
-                DownsamplingMessage::Delete => filters.delete = true,
-                #[allow(deprecated)]
-                DownsamplingMessage::Push => {
-                    filters.put = true;
-                    filters.delete = true;
-                }
-                DownsamplingMessage::Put => filters.put = true,
-                DownsamplingMessage::Query => filters.query = true,
-                DownsamplingMessage::Reply => filters.reply = true,
+                DataMessage::Delete => filters.delete = true,
+                DataMessage::Put => filters.put = true,
+                DataMessage::Query => filters.query = true,
+                DataMessage::Reply => filters.reply = true,
             }
         }
         filters

--- a/zenoh/src/net/routing/interceptor/low_pass.rs
+++ b/zenoh/src/net/routing/interceptor/low_pass.rs
@@ -24,7 +24,7 @@ use ahash::HashMap;
 use itertools::Itertools;
 use nonempty_collections::nev;
 use zenoh_buffers::buffer::Buffer;
-use zenoh_config::{InterceptorFlow, InterceptorLink, LowPassFilterConf, LowPassFilterMessage};
+use zenoh_config::{DataMessage, InterceptorFlow, InterceptorLink, LowPassFilterConf};
 use zenoh_keyexpr::{
     keyexpr,
     keyexpr_tree::{IKeyExprTree, IKeyExprTreeMut, IKeyExprTreeNode, KeBoxTree},
@@ -259,7 +259,7 @@ impl LowPassInterceptor {
     ) -> bool {
         let payload_size: usize;
         let attachment_size: usize;
-        let message_type: LowPassFilterMessage;
+        let message_type: DataMessage;
         let max_allowed_size: Option<usize>;
 
         match &msg.body {
@@ -267,7 +267,7 @@ impl LowPassInterceptor {
                 payload: RequestBody::Query(query),
                 ..
             }) => {
-                message_type = LowPassFilterMessage::Query;
+                message_type = DataMessage::Query;
                 payload_size = query
                     .ext_body
                     .as_ref()
@@ -288,7 +288,7 @@ impl LowPassInterceptor {
                     }),
                 ..
             }) => {
-                message_type = LowPassFilterMessage::Reply;
+                message_type = DataMessage::Reply;
                 payload_size = put.payload.len();
                 attachment_size = put
                     .ext_attachment
@@ -305,7 +305,7 @@ impl LowPassInterceptor {
                     }),
                 ..
             }) => {
-                message_type = LowPassFilterMessage::Reply;
+                message_type = DataMessage::Reply;
                 payload_size = 0;
                 attachment_size = delete
                     .ext_attachment
@@ -318,7 +318,7 @@ impl LowPassInterceptor {
                 payload: PushBody::Put(put),
                 ..
             }) => {
-                message_type = LowPassFilterMessage::Put;
+                message_type = DataMessage::Put;
                 payload_size = put.payload.len();
                 attachment_size = put
                     .ext_attachment
@@ -331,7 +331,7 @@ impl LowPassInterceptor {
                 payload: PushBody::Del(delete),
                 ..
             }) => {
-                message_type = LowPassFilterMessage::Delete;
+                message_type = DataMessage::Delete;
                 payload_size = 0;
                 attachment_size = delete
                     .ext_attachment
@@ -344,7 +344,7 @@ impl LowPassInterceptor {
                 payload: ResponseBody::Err(zenoh_protocol::zenoh::Err { payload, .. }),
                 ..
             }) => {
-                message_type = LowPassFilterMessage::Reply;
+                message_type = DataMessage::Reply;
                 payload_size = payload.len();
                 attachment_size = 0;
                 max_allowed_size = cache.map(|c| c.reply);
@@ -366,11 +366,7 @@ impl LowPassInterceptor {
             .is_some_and(|s| s <= max_allowed_size)
     }
 
-    fn get_max_allowed_message_size(
-        &self,
-        message: LowPassFilterMessage,
-        key_expr: &keyexpr,
-    ) -> usize {
+    fn get_max_allowed_message_size(&self, message: DataMessage, key_expr: &keyexpr) -> usize {
         match self
             .subjects
             .iter()
@@ -406,10 +402,10 @@ struct Cache {
 impl InterceptorTrait for LowPassInterceptor {
     fn compute_keyexpr_cache(&self, key_expr: &keyexpr) -> Option<Box<dyn Any + Send + Sync>> {
         Some(Box::new(Cache {
-            put: self.get_max_allowed_message_size(LowPassFilterMessage::Put, key_expr),
-            delete: self.get_max_allowed_message_size(LowPassFilterMessage::Delete, key_expr),
-            query: self.get_max_allowed_message_size(LowPassFilterMessage::Query, key_expr),
-            reply: self.get_max_allowed_message_size(LowPassFilterMessage::Reply, key_expr),
+            put: self.get_max_allowed_message_size(DataMessage::Put, key_expr),
+            delete: self.get_max_allowed_message_size(DataMessage::Delete, key_expr),
+            query: self.get_max_allowed_message_size(DataMessage::Query, key_expr),
+            reply: self.get_max_allowed_message_size(DataMessage::Reply, key_expr),
         }))
     }
 
@@ -491,21 +487,21 @@ struct LowPassFilterMessages {
 }
 
 impl LowPassFilterMessages {
-    fn message(&self, message: &LowPassFilterMessage) -> &LowPassFilterTree {
+    fn message(&self, message: &DataMessage) -> &LowPassFilterTree {
         match message {
-            LowPassFilterMessage::Put => &self.put,
-            LowPassFilterMessage::Delete => &self.delete,
-            LowPassFilterMessage::Query => &self.query,
-            LowPassFilterMessage::Reply => &self.reply,
+            DataMessage::Put => &self.put,
+            DataMessage::Delete => &self.delete,
+            DataMessage::Query => &self.query,
+            DataMessage::Reply => &self.reply,
         }
     }
 
-    fn message_mut(&mut self, message: &LowPassFilterMessage) -> &mut LowPassFilterTree {
+    fn message_mut(&mut self, message: &DataMessage) -> &mut LowPassFilterTree {
         match message {
-            LowPassFilterMessage::Put => &mut self.put,
-            LowPassFilterMessage::Delete => &mut self.delete,
-            LowPassFilterMessage::Query => &mut self.query,
-            LowPassFilterMessage::Reply => &mut self.reply,
+            DataMessage::Put => &mut self.put,
+            DataMessage::Delete => &mut self.delete,
+            DataMessage::Query => &mut self.query,
+            DataMessage::Reply => &mut self.reply,
         }
     }
 }

--- a/zenoh/tests/interceptors.rs
+++ b/zenoh/tests/interceptors.rs
@@ -26,7 +26,7 @@ use std::{
 use nonempty_collections::nev;
 use zenoh::{key_expr::KeyExpr, query::ConsolidationMode, Wait};
 use zenoh_config::{
-    Config, DownsamplingItemConf, DownsamplingMessage, DownsamplingRuleConf, InterceptorFlow,
+    Config, DataMessage, DownsamplingItemConf, DownsamplingRuleConf, InterceptorFlow,
 };
 use zenoh_test::TestSessions;
 
@@ -163,7 +163,7 @@ fn downsampling_by_keyexpr_impl(flow: InterceptorFlow) {
         flows: Some(nev![flow]),
         interfaces: None,
         link_protocols: None,
-        messages: nev![DownsamplingMessage::Put],
+        messages: nev![DataMessage::Put],
         rules: nev![
             DownsamplingRuleConf {
                 key_expr: ke_10hz.clone().into(),
@@ -218,7 +218,7 @@ fn downsampling_by_interface_impl(flow: InterceptorFlow) {
             flows: Some(nev![flow]),
             interfaces: Some(nev!["lo".to_string(), "lo0".to_string()]),
             link_protocols: None,
-            messages: nev![DownsamplingMessage::Put],
+            messages: nev![DataMessage::Put],
             rules: nev![DownsamplingRuleConf {
                 key_expr: ke_10hz.clone().into(),
                 freq: 10.0,
@@ -229,7 +229,7 @@ fn downsampling_by_interface_impl(flow: InterceptorFlow) {
             flows: Some(nev![flow]),
             interfaces: Some(nev!["some_unknown_interface".to_string()]),
             link_protocols: None,
-            messages: nev![DownsamplingMessage::Put],
+            messages: nev![DataMessage::Put],
             rules: nev![DownsamplingRuleConf {
                 key_expr: ke_no_effect.clone().into(),
                 freq: 10.0,
@@ -276,7 +276,7 @@ fn downsampling_by_protocol_impl(flow: InterceptorFlow) {
             flows: Some(nev![flow]),
             interfaces: None,
             link_protocols: Some(nev![InterceptorLink::Tcp]),
-            messages: nev![DownsamplingMessage::Put],
+            messages: nev![DataMessage::Put],
             rules: nev![DownsamplingRuleConf {
                 key_expr: ke_10hz.clone().into(),
                 freq: 10.0,
@@ -287,7 +287,7 @@ fn downsampling_by_protocol_impl(flow: InterceptorFlow) {
             flows: Some(nev![flow]),
             interfaces: None,
             link_protocols: Some(nev![InterceptorLink::Serial]),
-            messages: nev![DownsamplingMessage::Put],
+            messages: nev![DataMessage::Put],
             rules: nev![DownsamplingRuleConf {
                 key_expr: ke_no_effect.clone().into(),
                 freq: 10.0,
@@ -446,7 +446,7 @@ fn downsampling_query_rate_test(flow: InterceptorFlow) {
         flows: Some(nev![flow]),
         interfaces: None,
         link_protocols: None,
-        messages: nev![DownsamplingMessage::Query],
+        messages: nev![DataMessage::Query],
         rules: nev![DownsamplingRuleConf {
             key_expr: queryable_ke.try_into().unwrap(),
             freq: 0.01,
@@ -473,7 +473,7 @@ fn downsampling_reply_rate_test(flow: InterceptorFlow) {
         flows: Some(nev![flow]),
         interfaces: None,
         link_protocols: None,
-        messages: nev![DownsamplingMessage::Reply],
+        messages: nev![DataMessage::Reply],
         rules: nev![DownsamplingRuleConf {
             key_expr: queryable_ke.try_into().unwrap(),
             freq: 0.01,

--- a/zenoh/tests/low_pass.rs
+++ b/zenoh/tests/low_pass.rs
@@ -24,9 +24,7 @@ use nonempty_collections::{nev, NEVec};
 #[cfg(feature = "unstable")]
 use zenoh::query::{ConsolidationMode, Reply};
 use zenoh::{bytes::ZBytes, Wait};
-use zenoh_config::{
-    Config, InterceptorFlow, InterceptorLink, LowPassFilterConf, LowPassFilterMessage,
-};
+use zenoh_config::{Config, DataMessage, InterceptorFlow, InterceptorLink, LowPassFilterConf};
 use zenoh_test::{get_locators_from_session_sync, TestSessions};
 
 static SMALL_MSG_STR: &str = "S";
@@ -321,7 +319,7 @@ fn lowpass_query_filter_test(
         flows: Some(nev![flow]),
         interfaces,
         link_protocols,
-        messages: nev![LowPassFilterMessage::Query],
+        messages: nev![DataMessage::Query],
         key_exprs: nev![format!("{prefix}/**").try_into().unwrap()],
         size_limit: LOWPASS_RULE_BYTES,
     };
@@ -345,7 +343,7 @@ fn lowpass_reply_filter_test(
         flows: Some(nev![flow]),
         interfaces,
         link_protocols,
-        messages: nev![LowPassFilterMessage::Reply],
+        messages: nev![DataMessage::Reply],
         key_exprs: nev![format!("{prefix}/**").try_into().unwrap()],
         size_limit: LOWPASS_RULE_BYTES,
     };
@@ -369,7 +367,7 @@ fn lowpass_put_filter_test(
         flows: Some(nev![flow]),
         interfaces,
         link_protocols,
-        messages: nev![LowPassFilterMessage::Put],
+        messages: nev![DataMessage::Put],
         key_exprs: nev![format!("{prefix}/**").try_into().unwrap()],
         size_limit: LOWPASS_RULE_BYTES,
     };
@@ -393,7 +391,7 @@ fn lowpass_del_filter_test(
         flows: Some(nev![flow]),
         interfaces,
         link_protocols,
-        messages: nev![LowPassFilterMessage::Delete],
+        messages: nev![DataMessage::Delete],
         key_exprs: nev![format!("{prefix}/**").try_into().unwrap()],
         size_limit: LOWPASS_RULE_BYTES,
     };


### PR DESCRIPTION
## Description

This PR replaces the SHM `transport_optimization` on/off granularity with a single
`messages` list under `transport/shared_memory/transport_optimization`, letting users
select exactly which categories of messages are eligible for the SHM transport
optimization. Internally, it also unifies the message-category type shared by downsampling, low-pass
filtering and this new setting.

### What does this PR do?

- **Adds a `messages` field** to the `transport_optimization` section (defaults to `["put", "query", "reply"]`, so behavior is unchanged):
  - A message category present in the list is eligible for SHM optimization; a category
    left out is always sent over the regular network path.
  - e.g. `messages: ["put"]` keeps queries/replies off SHM while preserving it
    for publications.
  - `"delete"` category is accepted but ignored since "delete" messages have no payload and hence are never optimized.

- **Unifies the configuration message-category enum:**
  - Introduces a single `DataMessage` type (`put`, `delete`, `query`, `reply`), replacing
    the previously duplicated `DownsamplingMessage` and `LowPassFilterMessage`, and reuses
    it for `downsampling/messages`, `low_pass_filter/messages` and
    `transport_optimization/messages`.
  - Removes the deprecated `push` message category.

- **Plumbs the selection** from the config down to the transport TX mapping:
  - New `ShmOptimizationPolicy` (per-category flags) carried through `ShmContext` and the
    per-transport SHM contexts (unicast universal, unicast lowlatency, multicast).
  - `map_zmsg_to_partner` takes the policy and skips the whole SHM mapping for a message
    category that is not selected.

- When a category is not in `messages`, only the **implicit** optimization is disabled for it: a large regular payload is no longer auto-copied into SHM and is sent over the regular network path instead. Payloads the application already allocated in shared memory are **always** forwarded as descriptors when the peer supports the protocol, regardless of this setting. The RX path is untouched, so a node keeps decoding SHM messages from peers regardless of its own setting (backward compatible, no wire-protocol change).

- **Adds unit tests** validating that each category independently gates its message type
  through the real implicit-optimization path, plus a check that sub-threshold payloads are
  never promoted.

### Why is this change needed?

Today the transport optimization is all-or-nothing: `transport_optimization.enabled` turns
implicit SHM promotion on or off for every message category at once. Selecting categories
individually is useful in its own right, for several reasons:

- **Match the optimization to the traffic profile.** SHM promotion pays off for large,
  bulk, streaming data: the typical pub/sub data plane. Query/reply traffic is usually
  small, one-shot RPC-style exchanges (services, actions, control plane) where the cost of
  promotion (SHM allocation, copy, watchdog bookkeeping, first-use provider init latency)
  often outweighs the benefit. Users can now enable SHM only where it actually helps.

- **Isolate and protect the SHM pool.** The optimization draws from a fixed-size SHM arena
  (`pool_size`). Bursts of small query/reply buffers (e.g. a startup storm of service
  calls) compete with the high-value bulk pub/sub traffic for that arena and can create
  pool pressure. Restricting optimization to publications keeps the pool dedicated to the
  data that benefits most.

- **Mitigation for a known SHM issue.** As one concrete case, the SHM optimization can
  silently drop reliable query traffic under CPU contention when an in-transit SHM buffer
  is invalidated by the watchdog before the receiver mounts it (see #2628). Since queries
  are treated as reliable and not retried (e.g. ROS 2 services over rmw_zenoh), a single
  drop hangs the caller until the query timeout. Dropping `query` and `reply` from
  `messages` keeps queries/replies off the SHM path while preserving SHM benefits for
  publications.

### Breaking changes

- The deprecated `push` value is removed from the message-category lists
  (`downsampling/messages`, `low_pass_filter/messages`); use `put` and/or `delete` instead.

### Related Issues

- Related to #2628
- Related to [ros2/rmw_zenoh#978](https://github.com/ros2/rmw_zenoh/issues/978)

### Did you use Generative AI?

Yes: Claude Opus 5

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `enhancement`

## ✨ Enhancement Requirements

Since this PR enhances existing functionality:

- [x] **Enhancement scope documented** - Clear description of what is being improved
- [x] **Minimum necessary code** - Implementation is as simple as possible, doesn't overcomplicate the system
- [x] **Backwards compatible** - Existing code/APIs still work unchanged
- [x] **No new APIs added** - Only improving existing functionality
- [x] **Tests updated** - Existing tests pass, new test cases added if needed
- [x] **Performance improvement measured** - If applicable, before/after metrics provided
- [x] **Documentation updated** - Existing docs updated to reflect improvements
- [x] **User impact documented** - How users benefit from this enhancement

**Remember:** Enhancements should not introduce new APIs or breaking changes.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->