### PR TITLE
fix: make the gossip autoconnect task abortable

### DIFF
--- a/zenoh/src/net/protocol/gossip.rs
+++ b/zenoh/src/net/protocol/gossip.rs
@@ -387,7 +387,7 @@ impl Gossip {
                 if let Some(locators) = locators {
                     let runtime = strong_runtime.clone();
                     let wait_declares = self.wait_declares;
-                    strong_runtime.spawn(async move {
+                    strong_runtime.spawn_abortable(async move {
                         if runtime
                             .manager()
                             .get_transport_unicast(&zid)

--- a/zenoh/tests/close_under_peer_churn.rs
+++ b/zenoh/tests/close_under_peer_churn.rs
@@ -1,0 +1,139 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use tokio::time::timeout;
+use zenoh_config::Config;
+use zenoh_test::get_free_udp_port;
+
+/// Closing a session must not wait forever on a peer connection.
+///
+/// Two peers that have discovered each other over multicast and then open and
+/// close repeatedly used to deadlock in `Session::close`: gossip's autoconnect
+/// task was spawned with `TaskController::spawn`, so the cancellation token
+/// never reached it, and `terminate_all_async()` -- which has no timeout --
+/// waited for a peer connection that would never complete.
+///
+/// A regression here HANGS rather than fails, so every close is bounded by an
+/// explicit timeout and the whole test is bounded by the number of rounds.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn close_does_not_hang_under_peer_churn() {
+    zenoh::init_log_from_env_or("error");
+
+    // A multicast group of this test's own, so it neither discovers nor is
+    // discovered by anything else on the machine -- including other tests
+    // running in parallel.
+    let mcast_addr = SocketAddr::new(
+        IpAddr::V4(Ipv4Addr::new(224, 0, 0, 224)),
+        get_free_udp_port(),
+    );
+
+    // Everything except the multicast group is left at its default, and that
+    // matters twice over: the peers must LISTEN for each other to connect at
+    // all, and autoconnect must stay enabled because the gossip autoconnect
+    // task is the thing under test. Clearing either makes this test pass
+    // against the bug.
+    let config = move || {
+        let mut config = Config::default();
+        config
+            .scouting
+            .multicast
+            .set_enabled(Some(true))
+            .unwrap();
+        config
+            .scouting
+            .multicast
+            .set_address(Some(mcast_addr))
+            .unwrap();
+        config
+            .scouting
+            .multicast
+            .set_interface(Some("127.0.0.1".to_string()))
+            .unwrap();
+        config
+    };
+
+    // The other peers, churning alongside us. Several of them, and all of them
+    // opening AND closing: a long-lived peer plus one side closing does not
+    // reproduce this, and neither does a single neighbour -- there has to be a
+    // connection in flight when a session goes away.
+    let stop = Arc::new(AtomicBool::new(false));
+    let neighbours: Vec<_> = (0..4).map(|_| tokio::spawn({
+        let stop = stop.clone();
+        let config = config.clone();
+        async move {
+            while !stop.load(Ordering::Relaxed) {
+                let session = zenoh::open(config()).await.unwrap();
+                // Long enough to be discovered. A session that lives a
+                // millisecond is never found, and then this test proves
+                // nothing -- see the assertion on the other side.
+                tokio::time::sleep(Duration::from_millis(30)).await;
+                let _ = session.close().await;
+            }
+        }
+    })).collect();
+
+    const ROUNDS: usize = 30;
+    const CLOSE_TIMEOUT: Duration = Duration::from_secs(30);
+
+    let mut rounds_with_a_peer = 0usize;
+    for round in 0..ROUNDS {
+        let session = zenoh::open(config()).await.unwrap();
+
+        // WAIT FOR THE PEER. The deadlock needs a peer connection to be in
+        // flight when the session closes, so a round where nobody was found
+        // exercises nothing.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        let mut found = false;
+        while tokio::time::Instant::now() < deadline {
+            if session.info().peers_zid().await.next().is_some() {
+                found = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        if found {
+            rounds_with_a_peer += 1;
+        }
+
+        // Two ways this can report the regression: `close()` returns its own
+        // "close operation timed out" error, or it never returns at all. The
+        // outer timeout catches the second, so a failure is a failure rather
+        // than a hung CI job.
+        timeout(CLOSE_TIMEOUT, session.close())
+            .await
+            .unwrap_or_else(|_| panic!("session close never returned on round {round}"))
+            .unwrap_or_else(|e| panic!("session close failed on round {round}: {e}"));
+    }
+
+    // Guards the test against quietly becoming a no-op: if the peers never
+    // find each other, nothing above can deadlock and a pass means nothing.
+    assert!(
+        rounds_with_a_peer > 0,
+        "no round ever saw a peer, so this test exercised nothing"
+    );
+    eprintln!("{rounds_with_a_peer} of {ROUNDS} rounds had a peer connected");
+
+    stop.store(true, Ordering::Relaxed);
+    for n in neighbours {
+        let _ = timeout(CLOSE_TIMEOUT, n).await;
+    }
+}


### PR DESCRIPTION
## Description
Session close could hang forever under peer churn. `Runtime::close_inner` waits on `terminate_all_async()`, which waits for every tracked task with no timeout, and gossip's autoconnect was spawned with `spawn` -- so the cancellation token never reached it, and it sat in `connect_peer()` against a peer that was itself shutting down.

That does not meet `spawn`'s documented contract, which requires the task to be cancellable or to finish in finite time; connecting to a remote peer is neither. `spawn_abortable` is what the multicast scouting side already uses for the same work (`autoconnect_all`, orchestrator.rs:343 and :360). The task stays tracked, so shutdown still waits for it, but it now observes the token and finishes.

`token.cancel()` is only reached from `terminate_all` and `terminate_all_async`, so nothing changes during normal operation.

Adds a regression test, which fails without this change with "close operation timed out" and passes with it.

### What does this PR do?
Spawns gossip's autoconnect task with `spawn_abortable` instead of `spawn`, so
that session close can no longer wait on it for ever.

```diff
-                    strong_runtime.spawn(async move {
+                    strong_runtime.spawn_abortable(async move {
```

It also adds a regression test, `zenoh/tests/close_under_peer_churn.rs`.

### Why is this change needed?

Two peer sessions that discover each other over multicast and then open and close repeatedly deadlock forever inside session close. One process alone always finishes. Two, started together, hang within a handful of cycles and never
recover.

The wait is in `Runtime::close_inner`, on its **first** await - found by instrumenting the two lines, not by reading them. The marker before `terminate_all_async` prints; the one after it never does, so `manager.close()` is never reached and the transports are never closed:

```rust
// zenoh/src/net/runtime/mod.rs
async fn close_inner(&self, _: ()) {
    self.task_controller.terminate_all_async().await;   // <-- never returns
    self.manager.close().await;                         // <-- never reached
    ...
}
```

`terminate_all_async()` is unbounded - it waits for every tracked task, with no timeout:

```rust
// commons/zenoh-task/src/lib.rs
pub async fn terminate_all_async(&self) {
    self.tracker.close();
    self.token.cancel();
    self.tracker.wait().await
}
```

and the task it waits for is gossip's autoconnect, spawned with `spawn`:

```rust
// zenoh/src/net/protocol/gossip.rs:390
strong_runtime.spawn(async move {
    if runtime.manager().get_transport_unicast(&zid).await.is_none() {
        runtime.start_conditions().add_peer_connector_zid(zid).await;
        if runtime.connect_peer(&zid, &locators).await && ... {
            runtime.start_conditions().terminate_peer_connector_zid(zid).await;
        }
    }
});
```

`token.cancel()` therefore does nothing to it, and it is sitting in `connect_peer()` against a peer that is itself shutting down.

`spawn`'s own documentation says it is for a task that

> can be cancelled [by] a token obtained by `TaskController::get_cancellation_token()`, was created via `TaskController::into_abortable()`, **or can run to completion in finite amount of time**

and `terminate_all` puts that obligation explicitly on the caller:

> The caller **must ensure that all tasks spawned with `TaskController::spawn()`… can yield in finite amount of time**

Connecting to a remote peer is not finite, and this task holds no cancellation token, so neither branch of the contract holds. The equivalent task on the multicast scouting path - the same job, connecting to a peer that discovery just turned up - already uses `spawn_abortable`: `autoconnect_all` (`orchestrator.rs:343`, `:360`) and the scouting `responder` (`orchestrator.rs:223`, `:343`, `:355`). Gossip looks like the odd one out.

`spawn_abortable` still tracks the task, so `terminate_all_async` still waits for it; the task simply now observes the token and finishes instead of never. `token.cancel()` is only ever reached from `terminate_all` and `terminate_all_async`, so this changes nothing during normal operation - aborts happen only at shutdown.

## How to reproduce

A ~20-line program, default config, nothing else:

```cpp
#include <zenoh.hxx>
#include <cstdio>
#include <unistd.h>

int main()
{
    for (int cycle = 0; cycle < 50; ++cycle)
    {
        std::fprintf(stderr, "[%d] cycle %d\n", getpid(), cycle);
        zenoh::Session::open(zenoh::Config::create_default());
    }
    std::fprintf(stderr, "[%d] done -- did not deadlock\n", getpid());
    return 0;
}
```

```
./repro & ./repro & wait
```

One process alone always completes all 50 cycles. Two hang, typically by cycle 3-12; the last line each prints is the cycle it died on, and it never recovers (observed >10 minutes). While hung, every zenoh runtime worker is idle in `kevent` with nothing runnable, so this is a wakeup that never arrives rather than contention with a running thread.

### Related Issues
Related to #2409 and tokio-rs/tokio#7892 (the `block_in_place` family).

Not fixed by #2637, which was the obvious candidate - same file, same family (`block_in_place` parking the `ctrl_lock` holder on a tokio mutex under peer churn, which is exactly this workload). It was applied in full and measured first: **still hung 6 runs out of 8**. Its two hunks are in `terminate_peer_connector_zid`'s callers; this is a different task in the same function that is never cancelled. Both look worth having; only this one closes this hang.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [x] **Reproduction test added** - Test that fails on main branch without the fix
- [x] **Test passes with fix** - The reproduction test passes with your changes
- [x] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->