### PR TITLE
Remove dependency on rustls-pemfile crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3118,15 +3118,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5136,7 +5127,6 @@ dependencies = [
  "quinn-proto",
  "rcgen",
  "rustls",
- "rustls-pemfile",
  "rustls-pki-types",
  "rustls-webpki",
  "secrecy",
@@ -5228,7 +5218,6 @@ dependencies = [
  "async-trait",
  "base64",
  "rustls",
- "rustls-pemfile",
  "rustls-pki-types",
  "rustls-webpki",
  "secrecy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,7 +166,6 @@ rustls = { version = "0.23.31", default-features = false, features = [
   "tls12",
 ] }
 rustls-native-certs = "0.8.1"
-rustls-pemfile = "2.2.0"
 rustls-pki-types = "1.12.0"
 rustls-webpki = "0.103.8"
 schemars = { version = "1.1.0", features = ["either1"] }

--- a/io/zenoh-link-commons/Cargo.toml
+++ b/io/zenoh-link-commons/Cargo.toml
@@ -32,7 +32,6 @@ quic = [
   "dep:quinn",
   "dep:quinn-proto",
   "dep:rcgen",
-  "dep:rustls-pemfile",
   "dep:rustls-pki-types",
   "dep:secrecy",
   "dep:webpki-roots",
@@ -54,7 +53,6 @@ quinn = { workspace = true, optional = true }
 quinn-proto = { workspace = true, optional = true }
 rcgen = { workspace = true, optional = true }
 rustls = { workspace = true, optional = true }
-rustls-pemfile = { workspace = true, optional = true }
 rustls-pki-types = { workspace = true, optional = true }
 rustls-webpki = { workspace = true, optional = true }
 secrecy = { workspace = true, optional = true }

--- a/io/zenoh-link-commons/src/quic/utils.rs
+++ b/io/zenoh-link-commons/src/quic/utils.rs
@@ -14,7 +14,7 @@
 use std::{
     fmt::{self, Debug},
     fs::File,
-    io::{self, BufReader, Cursor},
+    io::{self, BufReader},
     net::SocketAddr,
     sync::Arc,
     time::Duration,
@@ -23,7 +23,7 @@ use std::{
 use quinn::{crypto::rustls::HandshakeData, TransportConfig};
 use rustls::{
     crypto::CryptoProvider,
-    pki_types::{CertificateDer, PrivateKeyDer, TrustAnchor},
+    pki_types::{pem::PemObject, CertificateDer, PrivateKeyDer, TrustAnchor},
     server::WebPkiClientVerifier,
     version::TLS13,
     ClientConfig, RootCertStore, ServerConfig,
@@ -236,30 +236,13 @@ impl TlsServerConfig {
         let tls_server_private_key = TlsServerConfig::load_tls_private_key(config).await?;
         let tls_server_certificate = TlsServerConfig::load_tls_certificate(config).await?;
 
-        let certs: Vec<CertificateDer> =
-            rustls_pemfile::certs(&mut Cursor::new(&tls_server_certificate))
-                .collect::<Result<_, _>>()
-                .map_err(|err| zerror!("Error processing server certificate: {err}."))?;
+        let certs: Vec<CertificateDer> = PemObject::pem_slice_iter(&tls_server_certificate)
+            .collect::<Result<_, _>>()
+            .map_err(|err| zerror!("Error processing server certificate: {err}."))?;
 
-        let mut keys: Vec<PrivateKeyDer> =
-            rustls_pemfile::rsa_private_keys(&mut Cursor::new(&tls_server_private_key))
-                .map(|x| x.map(PrivateKeyDer::from))
-                .collect::<Result<_, _>>()
-                .map_err(|err| zerror!("Error processing server key: {err}."))?;
-
-        if keys.is_empty() {
-            keys = rustls_pemfile::pkcs8_private_keys(&mut Cursor::new(&tls_server_private_key))
-                .map(|x| x.map(PrivateKeyDer::from))
-                .collect::<Result<_, _>>()
-                .map_err(|err| zerror!("Error processing server key: {err}."))?;
-        }
-
-        if keys.is_empty() {
-            keys = rustls_pemfile::ec_private_keys(&mut Cursor::new(&tls_server_private_key))
-                .map(|x| x.map(PrivateKeyDer::from))
-                .collect::<Result<_, _>>()
-                .map_err(|err| zerror!("Error processing server key: {err}."))?;
-        }
+        let mut keys: Vec<PrivateKeyDer> = PrivateKeyDer::from_pem_slice(&tls_server_private_key)
+            .map(|x| vec![x])
+            .map_err(|err| zerror!("Error processing server key: {err}."))?;
 
         if keys.is_empty() {
             bail!("No private key found for TLS server.");
@@ -406,31 +389,14 @@ impl TlsClientConfig {
             let tls_client_private_key = TlsClientConfig::load_tls_private_key(config).await?;
             let tls_client_certificate = TlsClientConfig::load_tls_certificate(config).await?;
 
-            let certs: Vec<CertificateDer> =
-                rustls_pemfile::certs(&mut Cursor::new(&tls_client_certificate))
-                    .collect::<Result<_, _>>()
-                    .map_err(|err| zerror!("Error processing client certificate: {err}."))?;
+            let certs: Vec<CertificateDer> = PemObject::pem_slice_iter(&tls_client_certificate)
+                .collect::<Result<_, _>>()
+                .map_err(|err| zerror!("Error processing client certificate: {err}."))?;
 
             let mut keys: Vec<PrivateKeyDer> =
-                rustls_pemfile::rsa_private_keys(&mut Cursor::new(&tls_client_private_key))
-                    .map(|x| x.map(PrivateKeyDer::from))
-                    .collect::<Result<_, _>>()
+                PrivateKeyDer::from_pem_slice(&tls_client_private_key)
+                    .map(|x| vec![x])
                     .map_err(|err| zerror!("Error processing client key: {err}."))?;
-
-            if keys.is_empty() {
-                keys =
-                    rustls_pemfile::pkcs8_private_keys(&mut Cursor::new(&tls_client_private_key))
-                        .map(|x| x.map(PrivateKeyDer::from))
-                        .collect::<Result<_, _>>()
-                        .map_err(|err| zerror!("Error processing client key: {err}."))?;
-            }
-
-            if keys.is_empty() {
-                keys = rustls_pemfile::ec_private_keys(&mut Cursor::new(&tls_client_private_key))
-                    .map(|x| x.map(PrivateKeyDer::from))
-                    .collect::<Result<_, _>>()
-                    .map_err(|err| zerror!("Error processing client key: {err}."))?;
-            }
 
             if keys.is_empty() {
                 bail!("No private key found for TLS client.");
@@ -501,7 +467,7 @@ impl TlsClientConfig {
 }
 
 fn process_pem(pem: &mut dyn io::BufRead) -> ZResult<Vec<TrustAnchor<'static>>> {
-    let certs: Vec<CertificateDer> = rustls_pemfile::certs(pem)
+    let certs: Vec<CertificateDer> = PemObject::pem_reader_iter(pem)
         .map(|result| result.map_err(|err| zerror!("Error processing PEM certificates: {err}.")))
         .collect::<Result<Vec<CertificateDer>, ZError>>()?;
 

--- a/io/zenoh-links/zenoh-link-tls/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-tls/Cargo.toml
@@ -31,7 +31,6 @@ uring = []
 async-trait = { workspace = true }
 base64 = { workspace = true }
 rustls = { workspace = true }
-rustls-pemfile = { workspace = true }
 rustls-pki-types = { workspace = true }
 rustls-webpki = { workspace = true }
 secrecy = { workspace = true }

--- a/io/zenoh-links/zenoh-link-tls/src/utils.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/utils.rs
@@ -14,7 +14,7 @@
 use std::{
     convert::TryFrom,
     fs::File,
-    io::{self, BufReader, Cursor},
+    io::{self, BufReader},
     net::SocketAddr,
     str::FromStr,
     sync::Arc,
@@ -22,12 +22,11 @@ use std::{
 };
 
 use rustls::{
-    pki_types::{CertificateDer, PrivateKeyDer, TrustAnchor},
+    pki_types::{pem::PemObject, CertificateDer, PrivateKeyDer, ServerName, TrustAnchor},
     server::WebPkiClientVerifier,
     version::TLS13,
     ClientConfig, RootCertStore, ServerConfig,
 };
-use rustls_pki_types::ServerName;
 use secrecy::ExposeSecret;
 use webpki::anchor_from_trusted_cert;
 use zenoh_config::Config as ZenohConfig;
@@ -196,30 +195,13 @@ impl<'a> TlsServerConfig<'a> {
         let tls_server_private_key = TlsServerConfig::load_tls_private_key(config).await?;
         let tls_server_certificate = TlsServerConfig::load_tls_certificate(config).await?;
 
-        let certs: Vec<CertificateDer> =
-            rustls_pemfile::certs(&mut Cursor::new(&tls_server_certificate))
-                .collect::<Result<_, _>>()
-                .map_err(|err| zerror!("Error processing server certificate: {err}."))?;
+        let certs: Vec<CertificateDer> = PemObject::pem_slice_iter(&tls_server_certificate)
+            .collect::<Result<_, _>>()
+            .map_err(|err| zerror!("Error processing server certificate: {err}."))?;
 
-        let mut keys: Vec<PrivateKeyDer> =
-            rustls_pemfile::rsa_private_keys(&mut Cursor::new(&tls_server_private_key))
-                .map(|x| x.map(PrivateKeyDer::from))
-                .collect::<Result<_, _>>()
-                .map_err(|err| zerror!("Error processing server key: {err}."))?;
-
-        if keys.is_empty() {
-            keys = rustls_pemfile::pkcs8_private_keys(&mut Cursor::new(&tls_server_private_key))
-                .map(|x| x.map(PrivateKeyDer::from))
-                .collect::<Result<_, _>>()
-                .map_err(|err| zerror!("Error processing server key: {err}."))?;
-        }
-
-        if keys.is_empty() {
-            keys = rustls_pemfile::ec_private_keys(&mut Cursor::new(&tls_server_private_key))
-                .map(|x| x.map(PrivateKeyDer::from))
-                .collect::<Result<_, _>>()
-                .map_err(|err| zerror!("Error processing server key: {err}."))?;
-        }
+        let mut keys: Vec<PrivateKeyDer> = PrivateKeyDer::from_pem_slice(&tls_server_private_key)
+            .map(|x| vec![x])
+            .map_err(|err| zerror!("Error processing server key: {err}."))?;
 
         if keys.is_empty() {
             bail!("No private key found for TLS server.");
@@ -372,31 +354,14 @@ impl<'a> TlsClientConfig<'a> {
             let tls_client_private_key = TlsClientConfig::load_tls_private_key(config).await?;
             let tls_client_certificate = TlsClientConfig::load_tls_certificate(config).await?;
 
-            let certs: Vec<CertificateDer> =
-                rustls_pemfile::certs(&mut Cursor::new(&tls_client_certificate))
-                    .collect::<Result<_, _>>()
-                    .map_err(|err| zerror!("Error processing client certificate: {err}."))?;
+            let certs: Vec<CertificateDer> = PemObject::pem_slice_iter(&tls_client_certificate)
+                .collect::<Result<_, _>>()
+                .map_err(|err| zerror!("Error processing client certificate: {err}."))?;
 
             let mut keys: Vec<PrivateKeyDer> =
-                rustls_pemfile::rsa_private_keys(&mut Cursor::new(&tls_client_private_key))
-                    .map(|x| x.map(PrivateKeyDer::from))
-                    .collect::<Result<_, _>>()
+                PrivateKeyDer::from_pem_slice(&tls_client_private_key)
+                    .map(|x| vec![x])
                     .map_err(|err| zerror!("Error processing client key: {err}."))?;
-
-            if keys.is_empty() {
-                keys =
-                    rustls_pemfile::pkcs8_private_keys(&mut Cursor::new(&tls_client_private_key))
-                        .map(|x| x.map(PrivateKeyDer::from))
-                        .collect::<Result<_, _>>()
-                        .map_err(|err| zerror!("Error processing client key: {err}."))?;
-            }
-
-            if keys.is_empty() {
-                keys = rustls_pemfile::ec_private_keys(&mut Cursor::new(&tls_client_private_key))
-                    .map(|x| x.map(PrivateKeyDer::from))
-                    .collect::<Result<_, _>>()
-                    .map_err(|err| zerror!("Error processing client key: {err}."))?;
-            }
 
             if keys.is_empty() {
                 bail!("No private key found for TLS client.");
@@ -487,7 +452,7 @@ impl<'a> TlsClientConfig<'a> {
 }
 
 fn process_pem(pem: &mut dyn io::BufRead) -> ZResult<Vec<TrustAnchor<'static>>> {
-    let certs: Vec<CertificateDer> = rustls_pemfile::certs(pem)
+    let certs: Vec<CertificateDer> = PemObject::pem_reader_iter(pem)
         .map(|result| result.map_err(|err| zerror!("Error processing PEM certificates: {err}.")))
         .collect::<Result<Vec<CertificateDer>, ZError>>()?;
 


### PR DESCRIPTION
## Description

### What does this PR do?

This PR replaces all usage of the rustls-pemfile crate with corresponding calls into the rustls_pki_types crate.

### Why is this change needed?

The rustls-pemfile crate is no longer maintained (see https://rustsec.org/advisories/RUSTSEC-2025-0134). However, it is also not needed because it basically is a wrapper around the rustl_pki_types crate.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `enhancement`

## ✨ Enhancement Requirements

Since this PR enhances existing functionality:

- [ ] **Enhancement scope documented** - Clear description of what is being improved
- [ ] **Minimum necessary code** - Implementation is as simple as possible, doesn't overcomplicate the system
- [ ] **Backwards compatible** - Existing code/APIs still work unchanged
- [ ] **No new APIs added** - Only improving existing functionality
- [ ] **Tests updated** - Existing tests pass, new test cases added if needed
- [ ] **Performance improvement measured** - If applicable, before/after metrics provided
- [ ] **Documentation updated** - Existing docs updated to reflect improvements
- [ ] **User impact documented** - How users benefit from this enhancement

**Remember:** Enhancements should not introduce new APIs or breaking changes.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->