### PR TITLE
fix(zenoh-ext): stop calling user code while holding subscriber state locks

### DIFF
--- a/zenoh-ext/src/advanced_subscriber.rs
+++ b/zenoh-ext/src/advanced_subscriber.rs
@@ -12,7 +12,13 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use std::{
-    cmp::min, collections::BTreeMap, fmt, future::IntoFuture, hash::Hash, str::FromStr, sync::Weak,
+    cmp::min,
+    collections::{BTreeMap, VecDeque},
+    fmt,
+    future::IntoFuture,
+    hash::Hash,
+    str::FromStr,
+    sync::{Condvar, Weak},
     time::Instant,
 };
 
@@ -450,6 +456,18 @@ struct State {
     callback: Option<Callback<Sample>>,
     miss_handlers: HashMap<usize, Callback<Miss>>,
     token: Option<LivelinessToken>,
+    /// Calls into user code staged by the state machine, in the order it
+    /// produced them. Drained by `dispatch_outbox` with this mutex released.
+    outbox: VecDeque<Call>,
+    /// Which thread, if any, is currently draining `outbox`. Exactly one at a
+    /// time, which is what keeps delivery ordered and mutually excluded.
+    ///
+    /// The thread id — rather than a bool — lets `wait_for_delivery` avoid
+    /// waiting on itself, which a callback that undeclares from inside delivery
+    /// would otherwise turn into a self-deadlock.
+    delivering: Option<std::thread::ThreadId>,
+    /// Signalled when `delivering` clears. `wait_callbacks` blocks on it.
+    delivery_done: Arc<Condvar>,
     _gc_task: AbortOnDropHandle<()>,
 }
 
@@ -462,9 +480,14 @@ impl State {
         self.miss_handlers.insert(id, callback);
         id
     }
+    /// Removes a miss callback, returning it to be dropped by the caller.
+    ///
+    /// The caller drops it **after** releasing `statesref`: dropping a user
+    /// callback runs user `Drop` code, which is a call-out like any other.
     #[zenoh_macros::unstable]
-    fn unregister_miss_callback(&mut self, id: &usize) {
-        self.miss_handlers.remove(id);
+    #[must_use = "drop the callback outside the state lock"]
+    fn unregister_miss_callback(&mut self, id: &usize) -> Option<Callback<Miss>> {
+        self.miss_handlers.remove(id)
     }
 }
 
@@ -601,24 +624,204 @@ impl<Receiver> std::ops::DerefMut for AdvancedSubscriber<Receiver> {
     }
 }
 
+/// One deferred call into user code.
+#[zenoh_macros::unstable]
+enum Call {
+    /// A sample for the subscriber's own callback.
+    Sample(Sample),
+    /// A miss report for one specific miss listener.
+    Miss(Callback<Miss>, Miss),
+}
+
+/// Marks the calling thread as the one draining [`State::outbox`].
+///
+/// Held for the duration of a drain so that the flag is cleared even if a user
+/// callback unwinds — otherwise delivery would stop silently for the rest of the
+/// subscriber's life.
+#[zenoh_macros::unstable]
+struct DeliveringRole<'a> {
+    statesref: &'a Arc<Mutex<State>>,
+    released: bool,
+}
+
+#[zenoh_macros::unstable]
+impl DeliveringRole<'_> {
+    /// Gives up the role while `states` is already locked.
+    ///
+    /// The caller passes the live borrow on purpose: the "outbox is empty" test
+    /// and the release have to be one atomic step. Split them, and a sample
+    /// queued in between would find `delivering` still set, decline to deliver,
+    /// and sit in the outbox until some later sample happened to flush it.
+    fn release(&mut self, states: &mut State) {
+        states.delivering = None;
+        states.delivery_done.notify_all();
+        self.released = true;
+    }
+}
+
+#[zenoh_macros::unstable]
+impl Drop for DeliveringRole<'_> {
+    fn drop(&mut self) {
+        if self.released {
+            return;
+        }
+        // Only reached when a user callback unwound. Deliberately not `zlock!`:
+        // this runs on the unwind path, and panicking in a destructor aborts the
+        // process, so a poisoned mutex must not be unwrapped here.
+        if let Ok(mut states) = self.statesref.lock() {
+            states.delivering = None;
+            states.delivery_done.notify_all();
+        }
+    }
+}
+
+/// Delivers everything staged in [`State::outbox`], with the lock released.
+///
+/// This is the *only* place in this file that calls into code Zenoh does not
+/// control. Everything upstream of it records calls into the outbox while
+/// holding `statesref` and then comes here once the guard is gone, which is what
+/// stops a callback re-entering an `AdvancedSubscriber` API — both
+/// `SampleMissListener::drop` and `SampleMissListenerBuilder::wait` take
+/// `statesref` — from deadlocking against the guard its own caller holds.
+///
+/// # Why a shared outbox rather than a per-call-site buffer
+///
+/// Collecting into a local buffer at each call site would fix the deadlock and
+/// **break ordering**, which is the feature `AdvancedSubscriber` exists to
+/// provide. Two threads can be in the sample callback at once (`Callback` is
+/// `Send + Sync`), so with a local buffer one could advance the state to sn=5,
+/// the other to sn=6, and then deliver 6 before 5. Previously the state mutex
+/// made advance-and-deliver atomic, so that could not happen.
+///
+/// A single FIFO plus a single active deliverer restores it: calls leave the
+/// outbox in the order the state machine produced them no matter which thread
+/// drains them. A thread that finds another already draining returns
+/// immediately; the active deliverer picks its work up on the next lap, so
+/// nothing is dropped and callbacks stay mutually excluded exactly as before.
+///
+/// It also makes a re-entrant *publish* safe: a callback that publishes to its
+/// own subscriber queues into the outbox and returns, and the outer lap delivers
+/// it, instead of recursing.
+#[zenoh_macros::unstable]
+fn dispatch_outbox(statesref: &Arc<Mutex<State>>) {
+    // Claim the role and take the first batch in one acquisition.
+    let (callback, mut calls) = {
+        let states = &mut *zlock!(statesref);
+        if states.delivering.is_some() || states.outbox.is_empty() {
+            return;
+        }
+        states.delivering = Some(std::thread::current().id());
+        // Cloned once per drain, not once per sample. Holding our own handle
+        // also means an undeclare part-way through a drain cannot strand the
+        // samples we already took.
+        (states.callback.clone(), std::mem::take(&mut states.outbox))
+    };
+    let mut role = DeliveringRole {
+        statesref,
+        released: false,
+    };
+    loop {
+        for call in calls {
+            match call {
+                Call::Sample(sample) => {
+                    if let Some(callback) = callback.as_ref() {
+                        callback.call(sample);
+                    }
+                }
+                Call::Miss(miss_callback, miss) => miss_callback.call(miss),
+            }
+        }
+        calls = {
+            let states = &mut *zlock!(statesref);
+            if states.outbox.is_empty() {
+                role.release(states);
+                return;
+            }
+            std::mem::take(&mut states.outbox)
+        };
+    }
+}
+
+/// Blocks until no *other* thread is delivering.
+///
+/// This is what `wait_callbacks` needs in order to mean anything. Before
+/// delivery moved out from under `statesref`, a caller that acquired the state
+/// lock was guaranteed no callback was running, because a running callback held
+/// that lock — so `wait_callbacks` could be a no-op. Now that callbacks run
+/// unlocked, the wait has to be explicit.
+///
+/// Never waits on the current thread's own delivery: a callback that undeclares
+/// while it is being delivered would otherwise block forever on itself.
+#[zenoh_macros::unstable]
+fn wait_for_delivery(statesref: &Arc<Mutex<State>>) {
+    let me = std::thread::current().id();
+    let mut guard = zlock!(statesref);
+    let condvar = guard.delivery_done.clone();
+    while guard.delivering.is_some_and(|owner| owner != me) {
+        guard = match condvar.wait(guard) {
+            Ok(guard) => guard,
+            // Poisoned: some other thread panicked holding the state. There is
+            // nothing to wait for and nothing useful to do here.
+            Err(_) => return,
+        };
+    }
+}
+
+/// Stages `sample` for delivery to `callback`.
+#[zenoh_macros::unstable]
+#[inline]
+fn stage_sample(outbox: &mut VecDeque<Call>, sample: Sample) {
+    outbox.push_back(Call::Sample(sample));
+}
+
+/// Stages `miss` for delivery to one miss listener.
+#[zenoh_macros::unstable]
+#[inline]
+fn stage_miss(outbox: &mut VecDeque<Call>, callback: &Callback<Miss>, miss: Miss) {
+    outbox.push_back(Call::Miss(callback.clone(), miss));
+}
+
+/// Feeds a queried-back sample through the state machine, then delivers.
+///
+/// Every reply callback in this file does exactly this, so they all route
+/// through here: the release-before-call obligation is stated once rather than
+/// copied seven times, which is one fewer place for it to be forgotten.
+#[zenoh_macros::unstable]
+fn handle_reply_sample(statesref: &Arc<Mutex<State>>, sample: Sample) {
+    {
+        let states = &mut *zlock!(statesref);
+        tracing::trace!(
+            "AdvancedSubscriber{{key_expr: {}}}: Received reply with Sample{{info:{:?}, ts:{:?}}}",
+            states.key_expr,
+            sample.source_info(),
+            sample.timestamp()
+        );
+        handle_sample(states, sample);
+    }
+    dispatch_outbox(statesref);
+}
+
 #[zenoh_macros::unstable]
 fn handle_sample(states: &mut State, sample: Sample) -> bool {
-    let Some(callback) = states.callback.as_ref() else {
+    // Only whether a callback exists matters here — the callback itself is read
+    // once per drain in `dispatch_outbox`, not held across the state walk.
+    let has_callback = states.callback.is_some();
+    if !has_callback {
         return false;
-    };
+    }
     if let Some(source_info) = sample.source_info().cloned() {
         #[inline]
         fn deliver_and_flush(
             sample: Sample,
             source_sn: impl Into<WrappingSn>,
-            callback: &Callback<Sample>,
             state: &mut SourceState<WrappingSn>,
+            outbox: &mut VecDeque<Call>,
         ) {
             let mut source_sn = source_sn.into();
-            callback.call(sample);
+            stage_sample(outbox, sample);
             state.last_delivered = Some(source_sn);
             while let Some(sample) = state.pending_samples.remove(&(source_sn + 1)) {
-                callback.call(sample);
+                stage_sample(outbox, sample);
                 source_sn += 1;
                 state.last_delivered = Some(source_sn);
             }
@@ -635,14 +838,14 @@ fn handle_sample(states: &mut State, sample: Sample) -> bool {
             // Avoid going through the Map if history_depth == 1
             if states.max_history_depth == 1 {
                 state.last_delivered = Some(source_info.source_sn().into());
-                callback.call(sample);
+                stage_sample(&mut states.outbox, sample);
             } else {
                 state
                     .pending_samples
                     .insert(source_info.source_sn().into(), sample);
                 if state.pending_samples.len() >= states.max_history_depth {
                     if let Some((sn, sample)) = state.pending_samples.pop_first() {
-                        deliver_and_flush(sample, sn, callback, state);
+                        deliver_and_flush(sample, sn, state, &mut states.outbox);
                     }
                 }
             }
@@ -661,17 +864,21 @@ fn handle_sample(states: &mut State, sample: Sample) -> bool {
                         source_info.source_id(),
                     );
                     for miss_callback in states.miss_handlers.values() {
-                        miss_callback.call(Miss {
-                            source: *source_info.source_id(),
-                            nb: source_info.source_sn() - state.last_delivered.unwrap() - 1,
-                        });
+                        stage_miss(
+                            &mut states.outbox,
+                            miss_callback,
+                            Miss {
+                                source: *source_info.source_id(),
+                                nb: source_info.source_sn() - state.last_delivered.unwrap() - 1,
+                            },
+                        );
                     }
-                    callback.call(sample);
+                    stage_sample(&mut states.outbox, sample);
                     state.last_delivered = Some(source_info.source_sn().into());
                 }
             }
         } else {
-            deliver_and_flush(sample, source_info.source_sn(), callback, state);
+            deliver_and_flush(sample, source_info.source_sn(), state, &mut states.outbox);
         }
         state.latest_access = Instant::now();
         new
@@ -684,18 +891,18 @@ fn handle_sample(states: &mut State, sample: Sample) -> bool {
                 || states.max_history_depth == 1
             {
                 state.last_delivered = Some(*timestamp);
-                callback.call(sample);
+                stage_sample(&mut states.outbox, sample);
             } else {
                 state.pending_samples.entry(*timestamp).or_insert(sample);
                 if state.pending_samples.len() >= states.max_history_depth {
-                    flush_timestamped_source(state, Some(callback));
+                    flush_timestamped_source(state, has_callback, &mut states.outbox);
                 }
             }
         }
         state.latest_access = Instant::now();
         false
     } else {
-        callback.call(sample);
+        stage_sample(&mut states.outbox, sample);
         false
     }
 }
@@ -769,14 +976,7 @@ fn periodic_query(statesref: &Arc<Mutex<State>>, source_id: EntityGlobalId) {
             move |r: Reply| {
                 if let Ok(s) = r.into_result() {
                     if key_expr.intersects(s.key_expr()) {
-                        let states = &mut *zlock!(handler.statesref);
-                        tracing::trace!(
-                            "AdvancedSubscriber{{key_expr: {}}}: Received reply with Sample{{info:{:?}, ts:{:?}}}",
-                            states.key_expr,
-                            s.source_info(),
-                            s.timestamp()
-                        );
-                        handle_sample(states, s);
+                        handle_reply_sample(&handler.statesref, s);
                     }
                 }
             }
@@ -883,6 +1083,9 @@ impl<Handler> AdvancedSubscriber<Handler> {
                 callback: Some(callback),
                 miss_handlers: HashMap::new(),
                 token: None,
+                outbox: VecDeque::new(),
+                delivering: None,
+                delivery_done: Arc::new(Condvar::new()),
                 _gc_task: AbortOnDropHandle::new(
                     ZRuntime::Application.spawn(gc_task(weak.clone(), retention_period)),
                 ),
@@ -895,62 +1098,71 @@ impl<Handler> AdvancedSubscriber<Handler> {
             let key_expr = key_expr.clone().into_owned();
 
             move |s: Sample| {
-                let mut lock = zlock!(statesref);
-                let states = &mut *lock;
-                let source_id = s.source_info().map(|si| *si.source_id());
-                let new = handle_sample(states, s);
+                // Stage under the lock; deliver after releasing it. Calling
+                // user code while holding `statesref` is what used to deadlock
+                // any callback that re-entered an `AdvancedSubscriber` API.
+                // Decided under the lock, issued once it is released.
+                let mut retransmission_query = None;
+                {
+                    let states = &mut *zlock!(statesref);
+                    let source_id = s.source_info().map(|si| *si.source_id());
+                    let new = handle_sample(states, s);
 
-                if let Some(source_id) = source_id {
-                    if let Some(state) = states.sequenced_states.get_mut(&source_id) {
-                        if new {
-                            state.periodic_task =
-                                spawn_periodic_queries(&statesref, states.period, source_id);
-                        }
-                        if retransmission.is_some()
-                            && state.pending_queries == 0
-                            && !state.pending_samples.is_empty()
-                        {
-                            state.pending_queries += 1;
-                            let query_expr = &key_expr
-                                / KE_ADV_PREFIX
-                                / KE_STAR
-                                / &source_id.zid().into_keyexpr()
-                                / &KeyExpr::try_from(source_id.eid().to_string()).unwrap()
-                                / KE_STARSTAR;
-                            let seq_num_range =
-                                seq_num_range(state.last_delivered.map(|s| s + 1), None);
-                            tracing::trace!(
-                                "AdvancedSubscriber{{key_expr: {}}}: Querying missing samples {}?{}",
-                                states.key_expr,
-                                query_expr,
-                                seq_num_range
-                            );
-                            drop(lock);
-                            let handler = SequencedRepliesHandler {
-                                source_id,
-                                statesref: statesref.clone(),
-                            };
-                            let _ = session
-                                .get(Selector::from((query_expr, seq_num_range)))
-                                .callback({
-                                    let key_expr = key_expr.clone().into_owned();
-                                    move |r: Reply| {
-                                        if let Ok(s) = r.into_result() {
-                                            if key_expr.intersects(s.key_expr()) {
-                                                let states = &mut *zlock!(handler.statesref);
-                                                tracing::trace!("AdvancedSubscriber{{key_expr: {}}}: Received reply with Sample{{info:{:?}, ts:{:?}}}", states.key_expr, s.source_info(), s.timestamp());
-                                                handle_sample(states, s);
-                                            }
-                                        }
-                                    }
-                                })
-                                .consolidation(ConsolidationMode::None)
-                                .accept_replies(ReplyKeyExpr::Any)
-                                .target(query_target)
-                                .timeout(query_timeout)
-                                .wait();
+                    if let Some(source_id) = source_id {
+                        if let Some(state) = states.sequenced_states.get_mut(&source_id) {
+                            if new {
+                                state.periodic_task =
+                                    spawn_periodic_queries(&statesref, states.period, source_id);
+                            }
+                            if retransmission.is_some()
+                                && state.pending_queries == 0
+                                && !state.pending_samples.is_empty()
+                            {
+                                state.pending_queries += 1;
+                                let query_expr = &key_expr
+                                    / KE_ADV_PREFIX
+                                    / KE_STAR
+                                    / &source_id.zid().into_keyexpr()
+                                    / &KeyExpr::try_from(source_id.eid().to_string()).unwrap()
+                                    / KE_STARSTAR;
+                                let seq_num_range =
+                                    seq_num_range(state.last_delivered.map(|s| s + 1), None);
+                                tracing::trace!(
+                                    "AdvancedSubscriber{{key_expr: {}}}: Querying missing samples {}?{}",
+                                    states.key_expr,
+                                    query_expr,
+                                    seq_num_range
+                                );
+                                retransmission_query = Some((source_id, query_expr, seq_num_range));
+                            }
                         }
                     }
+                }
+                // Same order as before the refactor: deliver, then query.
+                dispatch_outbox(&statesref);
+
+                if let Some((source_id, query_expr, seq_num_range)) = retransmission_query {
+                    let handler = SequencedRepliesHandler {
+                        source_id,
+                        statesref: statesref.clone(),
+                    };
+                    let _ = session
+                        .get(Selector::from((query_expr, seq_num_range)))
+                        .callback({
+                            let key_expr = key_expr.clone().into_owned();
+                            move |r: Reply| {
+                                if let Ok(s) = r.into_result() {
+                                    if key_expr.intersects(s.key_expr()) {
+                                        handle_reply_sample(&handler.statesref, s);
+                                    }
+                                }
+                            }
+                        })
+                        .consolidation(ConsolidationMode::None)
+                        .accept_replies(ReplyKeyExpr::Any)
+                        .target(query_target)
+                        .timeout(query_timeout)
+                        .wait();
                 }
             }
         };
@@ -960,9 +1172,30 @@ impl<Handler> AdvancedSubscriber<Handler> {
         let drop_callback = {
             let statesref = statesref.clone();
             move || {
-                let mut states = statesref.lock().unwrap();
-                states.callback.take();
-                states.miss_handlers.clear();
+                // Deliberately does NOT drain the outbox first. Every stage site
+                // dispatches immediately afterwards, so a non-empty outbox here
+                // means another thread is mid-drain — and that thread holds its
+                // own handle to the callback and will finish the job. Draining
+                // here would therefore be a no-op that could, on the one path
+                // where it is not, invoke a user callback from inside a `Drop`.
+                // A panic there is a panic in a destructor, which aborts.
+                //
+                // Take them out under the lock, drop them outside it: dropping a
+                // user callback runs user `Drop` code, and that must not happen
+                // while `statesref` is held.
+                let (callback, miss_handlers) = {
+                    let states = &mut *zlock!(statesref);
+                    (
+                        states.callback.take(),
+                        std::mem::take(&mut states.miss_handlers),
+                    )
+                };
+                // A delivery in flight holds its own clones and is still running
+                // user code; let it finish before releasing ours, so that
+                // undeclaring the subscriber still means "callbacks are done".
+                wait_for_delivery(&statesref);
+                drop(callback);
+                drop(miss_handlers);
             }
         };
 
@@ -1009,14 +1242,7 @@ impl<Handler> AdvancedSubscriber<Handler> {
                     move |r: Reply| {
                         if let Ok(s) = r.into_result() {
                             if key_expr.intersects(s.key_expr()) {
-                                let states = &mut *zlock!(handler.statesref);
-                                tracing::trace!(
-                                    "AdvancedSubscriber{{key_expr: {}}}: Received reply with Sample{{info:{:?}, ts:{:?}}}",
-                                    states.key_expr,
-                                    s.source_info(),
-                                    s.timestamp()
-                                );
-                                handle_sample(states, s);
+                                handle_reply_sample(&handler.statesref, s);
                             }
                         }
                     }
@@ -1105,10 +1331,7 @@ impl<Handler> AdvancedSubscriber<Handler> {
                                         move |r: Reply| {
                                             if let Ok(s) = r.into_result() {
                                                 if key_expr.intersects(s.key_expr()) {
-                                                    let states =
-                                                        &mut *zlock!(handler.statesref);
-                                                    tracing::trace!("AdvancedSubscriber{{key_expr: {}}}: Received reply with Sample{{info:{:?}, ts:{:?}}}", states.key_expr, s.source_info(), s.timestamp());
-                                                    handle_sample(states, s);
+                                                    handle_reply_sample(&handler.statesref, s);
                                                 }
                                             }
                                         }
@@ -1188,9 +1411,7 @@ impl<Handler> AdvancedSubscriber<Handler> {
                                         move |r: Reply| {
                                             if let Ok(s) = r.into_result() {
                                                 if key_expr.intersects(s.key_expr()) {
-                                                    let states = &mut *zlock!(handler.statesref);
-                                                    tracing::trace!("AdvancedSubscriber{{key_expr: {}}}: Received reply with Sample{{info:{:?}, ts:{:?}}}", states.key_expr, s.source_info(), s.timestamp());
-                                                    handle_sample(states, s);
+                                                    handle_reply_sample(&handler.statesref, s);
                                                 }
                                             }
                                         }
@@ -1241,9 +1462,7 @@ impl<Handler> AdvancedSubscriber<Handler> {
                                     move |r: Reply| {
                                         if let Ok(s) = r.into_result() {
                                             if key_expr.intersects(s.key_expr()) {
-                                                let states = &mut *zlock!(handler.statesref);
-                                                tracing::trace!("AdvancedSubscriber{{key_expr: {}}}: Received reply with Sample{{info:{:?}, ts:{:?}}}", states.key_expr, s.source_info(), s.timestamp());
-                                                handle_sample(states, s);
+                                                handle_reply_sample(&handler.statesref, s);
                                             }
                                         }
                                     }
@@ -1362,9 +1581,7 @@ impl<Handler> AdvancedSubscriber<Handler> {
                                 move |r: Reply| {
                                     if let Ok(s) = r.into_result() {
                                         if key_expr.intersects(s.key_expr()) {
-                                            let states = &mut *zlock!(handler.statesref);
-                                            tracing::trace!("AdvancedSubscriber{{key_expr: {}}}: Received reply with Sample{{info:{:?}, ts:{:?}}}", states.key_expr, s.source_info(), s.timestamp());
-                                            handle_sample(states, s);
+                                            handle_reply_sample(&handler.statesref, s);
                                         }
                                     }
                                 }
@@ -1502,13 +1719,14 @@ impl<Handler> AdvancedSubscriber<Handler> {
 #[inline]
 fn flush_sequenced_source(
     state: &mut SourceState<WrappingSn>,
-    callback: Option<&Callback<Sample>>,
+    has_callback: bool,
     source_id: &EntityGlobalId,
     miss_handlers: &HashMap<usize, Callback<Miss>>,
+    outbox: &mut VecDeque<Call>,
 ) {
-    let Some(callback) = callback else {
+    if !has_callback {
         return;
-    };
+    }
     if state.pending_queries == 0 && !state.pending_samples.is_empty() {
         let mut pending_samples = BTreeMap::new();
         std::mem::swap(&mut state.pending_samples, &mut pending_samples);
@@ -1516,11 +1734,11 @@ fn flush_sequenced_source(
             match state.last_delivered {
                 None => {
                     state.last_delivered = Some(seq_num);
-                    callback.call(sample);
+                    stage_sample(outbox, sample);
                 }
                 Some(last) if seq_num == last + 1 => {
                     state.last_delivered = Some(seq_num);
-                    callback.call(sample);
+                    stage_sample(outbox, sample);
                 }
                 Some(last) if seq_num > last + 1 => {
                     tracing::warn!(
@@ -1529,13 +1747,17 @@ fn flush_sequenced_source(
                         source_id,
                     );
                     for miss_callback in miss_handlers.values() {
-                        miss_callback.call(Miss {
-                            source: *source_id,
-                            nb: seq_num - last - 1,
-                        })
+                        stage_miss(
+                            outbox,
+                            miss_callback,
+                            Miss {
+                                source: *source_id,
+                                nb: seq_num - last - 1,
+                            },
+                        )
                     }
                     state.last_delivered = Some(seq_num);
-                    callback.call(sample);
+                    stage_sample(outbox, sample);
                 }
                 _ => {
                     // duplicate
@@ -1549,11 +1771,12 @@ fn flush_sequenced_source(
 #[inline]
 fn flush_timestamped_source(
     state: &mut SourceState<Timestamp>,
-    callback: Option<&Callback<Sample>>,
+    has_callback: bool,
+    outbox: &mut VecDeque<Call>,
 ) {
-    let Some(callback) = callback else {
+    if !has_callback {
         return;
-    };
+    }
     if state.pending_queries == 0 && !state.pending_samples.is_empty() {
         for (timestamp, sample) in std::mem::take(&mut state.pending_samples) {
             if state
@@ -1562,7 +1785,7 @@ fn flush_timestamped_source(
                 .unwrap_or(true)
             {
                 state.last_delivered = Some(timestamp);
-                callback.call(sample);
+                stage_sample(outbox, sample);
             }
         }
     }
@@ -1577,28 +1800,33 @@ struct InitialRepliesHandler {
 #[zenoh_macros::unstable]
 impl Drop for InitialRepliesHandler {
     fn drop(&mut self) {
-        let states = &mut *zlock!(self.statesref);
-        states.global_pending_queries = states.global_pending_queries.saturating_sub(1);
-        tracing::trace!(
-            "AdvancedSubscriber{{key_expr: {}}}: Flush initial replies",
-            states.key_expr
-        );
+        {
+            let states = &mut *zlock!(self.statesref);
+            states.global_pending_queries = states.global_pending_queries.saturating_sub(1);
+            tracing::trace!(
+                "AdvancedSubscriber{{key_expr: {}}}: Flush initial replies",
+                states.key_expr
+            );
 
-        if states.global_pending_queries == 0 {
-            for (source_id, state) in states.sequenced_states.iter_mut() {
-                flush_sequenced_source(
-                    state,
-                    states.callback.as_ref(),
-                    source_id,
-                    &states.miss_handlers,
-                );
-                state.periodic_task =
-                    spawn_periodic_queries(&self.statesref, states.period, *source_id);
-            }
-            for (_, state) in states.timestamped_states.iter_mut() {
-                flush_timestamped_source(state, states.callback.as_ref());
+            if states.global_pending_queries == 0 {
+                let has_callback = states.callback.is_some();
+                for (source_id, state) in states.sequenced_states.iter_mut() {
+                    flush_sequenced_source(
+                        state,
+                        has_callback,
+                        source_id,
+                        &states.miss_handlers,
+                        &mut states.outbox,
+                    );
+                    state.periodic_task =
+                        spawn_periodic_queries(&self.statesref, states.period, *source_id);
+                }
+                for (_, state) in states.timestamped_states.iter_mut() {
+                    flush_timestamped_source(state, has_callback, &mut states.outbox);
+                }
             }
         }
+        dispatch_outbox(&self.statesref);
     }
 }
 
@@ -1612,23 +1840,28 @@ struct SequencedRepliesHandler {
 #[zenoh_macros::unstable]
 impl Drop for SequencedRepliesHandler {
     fn drop(&mut self) {
-        let states = &mut *zlock!(self.statesref);
-        // use peek_mut so query without samples do not prevent the state to be garbage collected
-        if let Some(state) = states.sequenced_states.peek_mut(&self.source_id) {
-            state.pending_queries = state.pending_queries.saturating_sub(1);
-            if states.global_pending_queries == 0 {
-                tracing::trace!(
-                    "AdvancedSubscriber{{key_expr: {}}}: Flush sequenced samples",
-                    states.key_expr
-                );
-                flush_sequenced_source(
-                    state,
-                    states.callback.as_ref(),
-                    &self.source_id,
-                    &states.miss_handlers,
-                )
+        {
+            let states = &mut *zlock!(self.statesref);
+            let has_callback = states.callback.is_some();
+            // use peek_mut so query without samples do not prevent the state to be garbage collected
+            if let Some(state) = states.sequenced_states.peek_mut(&self.source_id) {
+                state.pending_queries = state.pending_queries.saturating_sub(1);
+                if states.global_pending_queries == 0 {
+                    tracing::trace!(
+                        "AdvancedSubscriber{{key_expr: {}}}: Flush sequenced samples",
+                        states.key_expr
+                    );
+                    flush_sequenced_source(
+                        state,
+                        has_callback,
+                        &self.source_id,
+                        &states.miss_handlers,
+                        &mut states.outbox,
+                    )
+                }
             }
         }
+        dispatch_outbox(&self.statesref);
     }
 }
 
@@ -1642,18 +1875,22 @@ struct TimestampedRepliesHandler {
 #[zenoh_macros::unstable]
 impl Drop for TimestampedRepliesHandler {
     fn drop(&mut self) {
-        let states = &mut *zlock!(self.statesref);
-        // use peek_mut so query without samples do not prevent the state to be garbage collected
-        if let Some(state) = states.timestamped_states.peek_mut(&self.id) {
-            state.pending_queries = state.pending_queries.saturating_sub(1);
-            if states.global_pending_queries == 0 {
-                tracing::trace!(
-                    "AdvancedSubscriber{{key_expr: {}}}: Flush timestamped samples",
-                    states.key_expr
-                );
-                flush_timestamped_source(state, states.callback.as_ref());
+        {
+            let states = &mut *zlock!(self.statesref);
+            let has_callback = states.callback.is_some();
+            // use peek_mut so query without samples do not prevent the state to be garbage collected
+            if let Some(state) = states.timestamped_states.peek_mut(&self.id) {
+                state.pending_queries = state.pending_queries.saturating_sub(1);
+                if states.global_pending_queries == 0 {
+                    tracing::trace!(
+                        "AdvancedSubscriber{{key_expr: {}}}: Flush timestamped samples",
+                        states.key_expr
+                    );
+                    flush_timestamped_source(state, has_callback, &mut states.outbox);
+                }
             }
         }
+        dispatch_outbox(&self.statesref);
     }
 }
 
@@ -1716,13 +1953,19 @@ impl<Handler> SampleMissListener<Handler> {
     where
         Handler: Send,
     {
-        SampleMissHandlerUndeclaration { listener: self }
+        SampleMissHandlerUndeclaration {
+            listener: self,
+            wait_callbacks: false,
+        }
     }
 
     fn undeclare_impl(&mut self) -> ZResult<()> {
         // set the flag first to avoid double panic if this function panic
         self.undeclare_on_drop = false;
-        zlock!(self.statesref).unregister_miss_callback(&self.id);
+        // The guard is a temporary and is released at the end of this statement,
+        // so `callback` — whose `Drop` is user code — is dropped unlocked below.
+        let callback = zlock!(self.statesref).unregister_miss_callback(&self.id);
+        drop(callback);
         Ok(())
     }
 
@@ -1771,6 +2014,7 @@ impl<Handler> std::ops::DerefMut for SampleMissListener<Handler> {
 #[zenoh_macros::unstable]
 pub struct SampleMissHandlerUndeclaration<Handler> {
     listener: SampleMissListener<Handler>,
+    wait_callbacks: bool,
 }
 
 #[zenoh_macros::unstable]
@@ -1784,9 +2028,13 @@ impl<Handler> fmt::Debug for SampleMissHandlerUndeclaration<Handler> {
 
 impl<Handler> SampleMissHandlerUndeclaration<Handler> {
     /// Block in undeclare operation until all currently running instances of sample miss listener callback (if any) return.
-    pub fn wait_callbacks(self) -> Self {
-        // Note: no particular synchronization is required as of now since miss listener callbacks are always executed
-        // under state lock
+    pub fn wait_callbacks(mut self) -> Self {
+        // This used to be a no-op, on the stated grounds that "miss listener
+        // callbacks are always executed under state lock" — so acquiring that
+        // lock during undeclare was itself the wait. Callbacks are no longer
+        // invoked under the lock (that is what made them able to deadlock), so
+        // the wait is now explicit. See `wait_for_delivery`.
+        self.wait_callbacks = true;
         self
     }
 }
@@ -1799,7 +2047,14 @@ impl<Handler> Resolvable for SampleMissHandlerUndeclaration<Handler> {
 #[zenoh_macros::unstable]
 impl<Handler> Wait for SampleMissHandlerUndeclaration<Handler> {
     fn wait(mut self) -> <Self as Resolvable>::To {
-        self.listener.undeclare_impl()
+        let statesref = self.listener.statesref.clone();
+        self.listener.undeclare_impl()?;
+        if self.wait_callbacks {
+            // Unregistering drops our handle, but a delivery already in flight
+            // holds its own clone and is still running the callback. Wait for it.
+            wait_for_delivery(&statesref);
+        }
+        Ok(())
     }
 }
 

--- a/zenoh-ext/src/advanced_subscriber.rs
+++ b/zenoh-ext/src/advanced_subscriber.rs
@@ -677,12 +677,18 @@ impl Drop for DeliveringRole<'_> {
 
 /// Delivers everything staged in [`State::outbox`], with the lock released.
 ///
-/// This is the *only* place in this file that calls into code Zenoh does not
-/// control. Everything upstream of it records calls into the outbox while
-/// holding `statesref` and then comes here once the guard is gone, which is what
-/// stops a callback re-entering an `AdvancedSubscriber` API — both
-/// `SampleMissListener::drop` and `SampleMissListenerBuilder::wait` take
-/// `statesref` — from deadlocking against the guard its own caller holds.
+/// This is the *only* place in this file that invokes a callback. Everything
+/// upstream of it records calls into the outbox while holding `statesref` and
+/// then comes here once the guard is gone, which is what stops a callback
+/// re-entering an `AdvancedSubscriber` API — both `SampleMissListener::drop`
+/// and `SampleMissListenerBuilder::wait` take `statesref` — from deadlocking
+/// against the guard its own caller holds.
+///
+/// Invoking a callback is not the only way this file reaches user code:
+/// *dropping* a `Callback` runs the user's `Drop`. Those sites are handled
+/// separately, by taking the value out of the state and releasing the guard
+/// before it falls out of scope — see `unregister_miss_callback` and the
+/// subscriber's drop callback.
 ///
 /// # Why a shared outbox rather than a per-call-site buffer
 ///

--- a/zenoh-ext/src/advanced_subscriber.rs
+++ b/zenoh-ext/src/advanced_subscriber.rs
@@ -459,12 +459,9 @@ struct State {
     /// Calls into user code staged by the state machine, in the order it
     /// produced them. Drained by `dispatch_outbox` with this mutex released.
     outbox: VecDeque<Call>,
-    /// Which thread, if any, is currently draining `outbox`. Exactly one at a
-    /// time, which is what keeps delivery ordered and mutually excluded.
-    ///
-    /// The thread id — rather than a bool — lets `wait_for_delivery` avoid
-    /// waiting on itself, which a callback that undeclares from inside delivery
-    /// would otherwise turn into a self-deadlock.
+    /// Which thread, if any, is draining `outbox`. One at a time, which keeps
+    /// delivery ordered and mutually excluded. An id rather than a bool so
+    /// `wait_for_delivery` can tell its own delivery apart and not wait on it.
     delivering: Option<std::thread::ThreadId>,
     /// Signalled when `delivering` clears. `wait_callbacks` blocks on it.
     delivery_done: Arc<Condvar>,
@@ -626,18 +623,13 @@ impl<Receiver> std::ops::DerefMut for AdvancedSubscriber<Receiver> {
 
 /// One deferred call into user code.
 ///
-/// Each variant carries its own target. Staging is a commitment to deliver, and
-/// resolving the target later would break that: an undeclare landing between
-/// the stage and the drain would take `State::callback` away and the staged
-/// sample would be discarded without ever reaching the callback that was
-/// registered when it arrived. Before delivery was deferred that could not
-/// happen, because a sample that entered `handle_sample` was delivered under the
-/// same guard. The cost is one handle clone per staged call.
+/// Each variant carries its own target, at the cost of a handle clone per call:
+/// staging is a commitment to deliver, and an undeclare landing before the drain
+/// would otherwise take `State::callback` away and discard the sample.
 ///
-/// `Sample` is ~272 bytes against `Miss`'s ~56, so every queue slot is sized for
-/// the larger. Boxing it, as `clippy::large_enum_variant` suggests, would trade
-/// that for a heap allocation on every delivered sample — the hot path — to save
-/// memory in a queue that is empty whenever delivery keeps up.
+/// `clippy::large_enum_variant` wants `Sample` (~272 bytes, against `Miss`'s
+/// ~56) boxed. That trades a queue slot for a heap allocation on every delivered
+/// sample, to save memory in a queue that is empty whenever delivery keeps up.
 #[zenoh_macros::unstable]
 #[allow(clippy::large_enum_variant)]
 enum Call {
@@ -649,9 +641,8 @@ enum Call {
 
 /// Marks the calling thread as the one draining [`State::outbox`].
 ///
-/// Held for the duration of a drain so that the flag is cleared even if a user
-/// callback unwinds — otherwise delivery would stop silently for the rest of the
-/// subscriber's life.
+/// RAII, so the marker clears even if a user callback unwinds; otherwise the
+/// subscriber would stop delivering for the rest of its life.
 #[zenoh_macros::unstable]
 struct DeliveringRole<'a> {
     statesref: &'a Arc<Mutex<State>>,
@@ -660,12 +651,11 @@ struct DeliveringRole<'a> {
 
 #[zenoh_macros::unstable]
 impl DeliveringRole<'_> {
-    /// Gives up the role while `states` is already locked.
+    /// Gives up the role.
     ///
-    /// The caller passes the live borrow on purpose: the "outbox is empty" test
-    /// and the release have to be one atomic step. Split them, and a sample
-    /// queued in between would find `delivering` still set, decline to deliver,
-    /// and sit in the outbox until some later sample happened to flush it.
+    /// Takes the live borrow so the empty-outbox test and the release are one
+    /// atomic step: split them, and a call staged in between sits in the outbox
+    /// until some later call flushes it.
     fn release(&mut self, states: &mut State) {
         states.delivering = None;
         states.delivery_done.notify_all();
@@ -679,26 +669,15 @@ impl Drop for DeliveringRole<'_> {
         if self.released {
             return;
         }
-        // Only reached when a user callback unwound. Deliberately not `zlock!`:
-        // this runs on the unwind path, and panicking in a destructor aborts the
-        // process, so a poisoned mutex must not be unwrapped here.
+        // Only reached when a user callback unwound. Not `zlock!`: unwrapping a
+        // poisoned mutex here would panic in a destructor, which aborts.
         //
-        // Poisoning is recovered from rather than skipped. This guard exists to
-        // clear the marker unconditionally, so a case where it silently does not
-        // would defeat it — the role would stay claimed for the rest of the
-        // subscriber's life. `into_inner` hands back the state either way.
-        //
-        // The outbox is emptied here, not left for a later staging thread.
-        // `wait_for_delivery` treats a non-empty outbox as work that some thread
-        // is on its way to drain, which holds at every staging site but not
-        // here: this thread was that drainer and it is unwinding. Anything a
-        // concurrent thread staged while the callback ran would otherwise sit
-        // with `delivering` cleared and nobody coming, and the next
-        // `wait_callbacks` — or the subscriber's own drop — would block on it
-        // forever. Discarding is the honest option: the calls cannot be
-        // delivered from an unwinding destructor, and before delivery moved out
-        // from under this mutex a panicking callback poisoned it and lost them
-        // anyway.
+        // The outbox is emptied, not left. `wait_for_delivery` waits on a
+        // non-empty outbox because a staging thread is always on its way to
+        // drain it — untrue here, where this thread was the drainer, so anything
+        // staged during the callback would wedge the next `wait_callbacks`.
+        // Undeliverable from an unwinding destructor, and a panicking callback
+        // used to poison this mutex and lose them anyway.
         let calls = {
             let states = &mut *match self.statesref.lock() {
                 Ok(states) => states,
@@ -708,61 +687,35 @@ impl Drop for DeliveringRole<'_> {
             states.delivery_done.notify_all();
             std::mem::take(&mut states.outbox)
         };
-        // Dropped with the guard released, and behind `catch_unwind`. Each
-        // `Call` owns a `Callback` clone, so dropping the last one runs the
-        // user's `Drop`: that must not re-enter the state lock, and must not
-        // panic while this thread is already unwinding, which would abort the
-        // process.
+        // Guard released, and `catch_unwind`: the last `Callback` clone drops
+        // user code, which must not re-enter the lock nor panic mid-unwind.
         let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || drop(calls)));
     }
 }
 
 /// Delivers everything staged in [`State::outbox`], with the lock released.
 ///
-/// This is the *only* place in this file that invokes a callback. Everything
-/// upstream of it records calls into the outbox while holding `statesref` and
-/// then comes here once the guard is gone, which is what stops a callback
-/// re-entering an `AdvancedSubscriber` API — both `SampleMissListener::drop`
-/// and `SampleMissListenerBuilder::wait` take `statesref` — from deadlocking
-/// against the guard its own caller holds.
+/// The only place in this file that invokes a callback. Callers stage while
+/// holding `statesref` and come here once the guard is gone, so a callback that
+/// re-enters an `AdvancedSubscriber` API — `SampleMissListener::drop` and
+/// `SampleMissListenerBuilder::wait` both take `statesref` — cannot deadlock
+/// against its own caller's guard.
 ///
-/// Invoking a callback is not the only way this file reaches user code:
-/// *dropping* a `Callback` runs the user's `Drop`. Those sites are handled
-/// separately, by taking the value out of the state and releasing the guard
-/// before it falls out of scope — see `unregister_miss_callback` and the
-/// subscriber's drop callback.
+/// Dropping a `Callback` also runs user code; those sites release the guard
+/// first instead — see `unregister_miss_callback` and the drop callback.
 ///
-/// # Why a shared outbox rather than a per-call-site buffer
+/// One shared FIFO, one active deliverer. Per-call-site buffers would fix the
+/// deadlock and break ordering: `Callback` is `Send + Sync`, so two threads can
+/// advance the state to sn=5 and sn=6 and deliver them out of order. A thread
+/// that finds another draining stages and returns; the deliverer takes the work
+/// on its next lap, so callbacks stay mutually excluded as before.
 ///
-/// Collecting into a local buffer at each call site would fix the deadlock and
-/// **break ordering**, which is the feature `AdvancedSubscriber` exists to
-/// provide. Two threads can be in the sample callback at once (`Callback` is
-/// `Send + Sync`), so with a local buffer one could advance the state to sn=5,
-/// the other to sn=6, and then deliver 6 before 5. Previously the state mutex
-/// made advance-and-deliver atomic, so that could not happen.
-///
-/// A single FIFO plus a single active deliverer restores it: calls leave the
-/// outbox in the order the state machine produced them no matter which thread
-/// drains them. A thread that finds another already draining returns
-/// immediately; the active deliverer picks its work up on the next lap, so
-/// nothing is dropped and callbacks stay mutually excluded exactly as before.
-///
-/// It also makes a re-entrant *publish* safe: a callback that publishes to its
-/// own subscriber queues into the outbox and returns, and the outer lap delivers
-/// it, instead of recursing. That holds for a callback that publishes
-/// *conditionally*. One that republishes on every sample now spins in the refill
-/// loop below rather than deadlocking — the failure is livelock instead of
-/// deadlock, and it is still the callback's own recursion.
-///
-/// # The outbox is not backpressure
-///
-/// The state mutex used to throttle producers: a thread that arrived while a
-/// callback was running blocked on the guard until it finished. Staging returns
-/// immediately, so a producer faster than the callback grows the outbox instead
-/// of being slowed by it. Nothing here bounds that. Bounding it would mean
-/// either dropping samples or reintroducing a block, both of which are larger
-/// semantic changes than removing the deadlock, so this is left as a documented
-/// property rather than decided here.
+/// Two consequences worth knowing. A re-entrant publish is safe only if it is
+/// *conditional* — republishing on every sample refills the outbox as fast as
+/// the loop drains it, livelock where it used to deadlock. And the outbox is not
+/// backpressure: the mutex used to throttle producers, staging does not, and
+/// nothing bounds the queue. Bounding it means dropping samples or restoring a
+/// block, both larger changes than removing the deadlock.
 #[zenoh_macros::unstable]
 fn dispatch_outbox(statesref: &Arc<Mutex<State>>) {
     // Claim the role and take the first batch in one acquisition.
@@ -798,43 +751,25 @@ fn dispatch_outbox(statesref: &Arc<Mutex<State>>) {
 
 /// Blocks until every call another thread has committed to has been delivered.
 ///
-/// This is what `wait_callbacks` needs in order to mean anything. Before
-/// delivery moved out from under `statesref`, a caller that acquired the state
-/// lock was guaranteed no callback was running, because a running callback held
-/// that lock — so `wait_callbacks` could be a no-op. Now that callbacks run
-/// unlocked, the wait has to be explicit.
+/// `wait_callbacks` was a no-op while a running callback held the state lock:
+/// acquiring it was proof none was running. Callbacks now run unlocked, so the
+/// wait has to be explicit.
 ///
-/// # Waiting on `delivering` alone is not enough
+/// Waiting on `delivering` alone is not enough. A staging thread releases the
+/// guard before claiming the role, so `delivering` is `None` while the outbox
+/// still holds committed calls, and each carries its own callback handle —
+/// unregistering first does not stop it. So a non-empty outbox counts as
+/// outstanding, which is safe because every staging site calls `dispatch_outbox`
+/// on the way out. The exception is a callback unwinding, which is why
+/// `DeliveringRole::drop` empties the outbox.
 ///
-/// A staging thread releases the guard before it claims the delivering role in
-/// `dispatch_outbox`. In that window `delivering` is `None` while the outbox is
-/// not empty, so a wait that only watched `delivering` would return while a call
-/// was still owed — and every staged `Call` carries its own callback handle, so
-/// unregistering first does not stop it. A caller of `wait_callbacks` would
-/// then see its listener fire after `wait_callbacks` had returned, which is
-/// precisely the guarantee it exists to give.
+/// Never waits on this thread's own delivery: a callback that undeclares while
+/// being delivered would otherwise block on itself — the original defect in
+/// another hat.
 ///
-/// So a non-empty outbox counts as outstanding work. That is safe to wait for
-/// because every site that stages calls `dispatch_outbox` on the way out, with
-/// nothing between the two that can fail: a non-empty outbox always has a thread
-/// on its way to drain it.
-///
-/// The one path that could break that invariant is a user callback unwinding
-/// out of `dispatch_outbox`, which leaves the drainer gone and anything staged
-/// meanwhile unclaimed. `DeliveringRole::drop` empties the outbox for exactly
-/// this reason — see the comment there.
-///
-/// # Never waits on this thread's own delivery
-///
-/// A callback that undeclares while it is being delivered would otherwise block
-/// forever on itself — the original defect wearing a different hat. When this
-/// thread holds the delivering role, everything outstanding is its own work and
-/// there is nothing to wait for.
-///
-/// The wait is per-subscriber, not per-listener: `wait_callbacks` on a sample
-/// miss listener therefore also waits out any sample callback in flight. That is
-/// broader than the name suggests, and deliberate — the outbox interleaves both,
-/// so a listener's staged misses cannot be waited for in isolation.
+/// The wait is per-subscriber, not per-listener. `wait_callbacks` on a miss
+/// listener also waits out any sample callback in flight; the outbox interleaves
+/// both, so a listener's misses cannot be waited for in isolation.
 #[zenoh_macros::unstable]
 fn wait_for_delivery(statesref: &Arc<Mutex<State>>) {
     let me = std::thread::current().id();

--- a/zenoh-ext/src/advanced_subscriber.rs
+++ b/zenoh-ext/src/advanced_subscriber.rs
@@ -718,34 +718,40 @@ impl Drop for DeliveringRole<'_> {
 /// block, both larger changes than removing the deadlock.
 #[zenoh_macros::unstable]
 fn dispatch_outbox(statesref: &Arc<Mutex<State>>) {
+    // Drained into across laps rather than taking the outbox itself, so both
+    // buffers keep their capacity instead of being freed and reallocated once
+    // per batch — which, when delivery keeps up and a batch is one call, is once
+    // per sample.
+    let mut calls: Vec<Call> = Vec::new();
     // Claim the role and take the first batch in one acquisition.
-    let mut calls = {
+    {
         let states = &mut *zlock!(statesref);
         if states.delivering.is_some() || states.outbox.is_empty() {
             return;
         }
         states.delivering = Some(std::thread::current().id());
-        std::mem::take(&mut states.outbox)
-    };
+        calls.extend(states.outbox.drain(..));
+    }
     let mut role = DeliveringRole {
         statesref,
         released: false,
     };
     loop {
-        for call in calls {
+        for call in calls.drain(..) {
             match call {
                 Call::Sample(callback, sample) => callback.call(sample),
                 Call::Miss(miss_callback, miss) => miss_callback.call(miss),
             }
         }
-        calls = {
+        // Braced so the guard's scope is explicit: no user code may run inside.
+        {
             let states = &mut *zlock!(statesref);
             if states.outbox.is_empty() {
                 role.release(states);
                 return;
             }
-            std::mem::take(&mut states.outbox)
-        };
+            calls.extend(states.outbox.drain(..));
+        }
     }
 }
 

--- a/zenoh-ext/src/advanced_subscriber.rs
+++ b/zenoh-ext/src/advanced_subscriber.rs
@@ -682,10 +682,17 @@ impl Drop for DeliveringRole<'_> {
         // Only reached when a user callback unwound. Deliberately not `zlock!`:
         // this runs on the unwind path, and panicking in a destructor aborts the
         // process, so a poisoned mutex must not be unwrapped here.
-        if let Ok(mut states) = self.statesref.lock() {
-            states.delivering = None;
-            states.delivery_done.notify_all();
-        }
+        //
+        // Poisoning is recovered from rather than skipped. This guard exists to
+        // clear the marker unconditionally, so a case where it silently does not
+        // would defeat it — the role would stay claimed for the rest of the
+        // subscriber's life. `into_inner` hands back the state either way.
+        let states = &mut *match self.statesref.lock() {
+            Ok(states) => states,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        states.delivering = None;
+        states.delivery_done.notify_all();
     }
 }
 
@@ -805,7 +812,13 @@ fn dispatch_outbox(statesref: &Arc<Mutex<State>>) {
 #[zenoh_macros::unstable]
 fn wait_for_delivery(statesref: &Arc<Mutex<State>>) {
     let me = std::thread::current().id();
-    let mut guard = zlock!(statesref);
+    // Deliberately not `zlock!`. The subscriber's drop callback calls this, and
+    // that runs inside `CallbackDrop`'s destructor — unwrapping a poisoned mutex
+    // there is a panic in a `Drop`, which aborts the process. The wait loop below
+    // already treats poisoning as "nothing to wait for"; so does this.
+    let Ok(mut guard) = statesref.lock() else {
+        return;
+    };
     let condvar = guard.delivery_done.clone();
     loop {
         match guard.delivering {
@@ -1255,8 +1268,16 @@ impl<Handler> AdvancedSubscriber<Handler> {
                 // Take the handles out under the lock and drop them outside it:
                 // dropping a user callback runs user `Drop` code, and that must
                 // not happen while `statesref` is held.
+                //
+                // Deliberately not `zlock!`: this closure runs inside
+                // `CallbackDrop`'s destructor, so unwrapping a poisoned mutex here
+                // is a panic in a `Drop`, which aborts. Recover the state instead —
+                // the handles still have to be released.
                 let (callback, miss_handlers) = {
-                    let states = &mut *zlock!(statesref);
+                    let states = &mut *match statesref.lock() {
+                        Ok(states) => states,
+                        Err(poisoned) => poisoned.into_inner(),
+                    };
                     (
                         states.callback.take(),
                         std::mem::take(&mut states.miss_handlers),

--- a/zenoh-ext/src/advanced_subscriber.rs
+++ b/zenoh-ext/src/advanced_subscriber.rs
@@ -625,10 +625,24 @@ impl<Receiver> std::ops::DerefMut for AdvancedSubscriber<Receiver> {
 }
 
 /// One deferred call into user code.
+///
+/// Each variant carries its own target. Staging is a commitment to deliver, and
+/// resolving the target later would break that: an undeclare landing between
+/// the stage and the drain would take `State::callback` away and the staged
+/// sample would be discarded without ever reaching the callback that was
+/// registered when it arrived. Before delivery was deferred that could not
+/// happen, because a sample that entered `handle_sample` was delivered under the
+/// same guard. The cost is one handle clone per staged call.
+///
+/// `Sample` is ~272 bytes against `Miss`'s ~56, so every queue slot is sized for
+/// the larger. Boxing it, as `clippy::large_enum_variant` suggests, would trade
+/// that for a heap allocation on every delivered sample — the hot path — to save
+/// memory in a queue that is empty whenever delivery keeps up.
 #[zenoh_macros::unstable]
+#[allow(clippy::large_enum_variant)]
 enum Call {
     /// A sample for the subscriber's own callback.
-    Sample(Sample),
+    Sample(Callback<Sample>, Sample),
     /// A miss report for one specific miss listener.
     Miss(Callback<Miss>, Miss),
 }
@@ -707,20 +721,30 @@ impl Drop for DeliveringRole<'_> {
 ///
 /// It also makes a re-entrant *publish* safe: a callback that publishes to its
 /// own subscriber queues into the outbox and returns, and the outer lap delivers
-/// it, instead of recursing.
+/// it, instead of recursing. That holds for a callback that publishes
+/// *conditionally*. One that republishes on every sample now spins in the refill
+/// loop below rather than deadlocking — the failure is livelock instead of
+/// deadlock, and it is still the callback's own recursion.
+///
+/// # The outbox is not backpressure
+///
+/// The state mutex used to throttle producers: a thread that arrived while a
+/// callback was running blocked on the guard until it finished. Staging returns
+/// immediately, so a producer faster than the callback grows the outbox instead
+/// of being slowed by it. Nothing here bounds that. Bounding it would mean
+/// either dropping samples or reintroducing a block, both of which are larger
+/// semantic changes than removing the deadlock, so this is left as a documented
+/// property rather than decided here.
 #[zenoh_macros::unstable]
 fn dispatch_outbox(statesref: &Arc<Mutex<State>>) {
     // Claim the role and take the first batch in one acquisition.
-    let (callback, mut calls) = {
+    let mut calls = {
         let states = &mut *zlock!(statesref);
         if states.delivering.is_some() || states.outbox.is_empty() {
             return;
         }
         states.delivering = Some(std::thread::current().id());
-        // Cloned once per drain, not once per sample. Holding our own handle
-        // also means an undeclare part-way through a drain cannot strand the
-        // samples we already took.
-        (states.callback.clone(), std::mem::take(&mut states.outbox))
+        std::mem::take(&mut states.outbox)
     };
     let mut role = DeliveringRole {
         statesref,
@@ -729,11 +753,7 @@ fn dispatch_outbox(statesref: &Arc<Mutex<State>>) {
     loop {
         for call in calls {
             match call {
-                Call::Sample(sample) => {
-                    if let Some(callback) = callback.as_ref() {
-                        callback.call(sample);
-                    }
-                }
+                Call::Sample(callback, sample) => callback.call(sample),
                 Call::Miss(miss_callback, miss) => miss_callback.call(miss),
             }
         }
@@ -748,7 +768,7 @@ fn dispatch_outbox(statesref: &Arc<Mutex<State>>) {
     }
 }
 
-/// Blocks until no *other* thread is delivering.
+/// Blocks until every call another thread has committed to has been delivered.
 ///
 /// This is what `wait_callbacks` needs in order to mean anything. Before
 /// delivery moved out from under `statesref`, a caller that acquired the state
@@ -756,14 +776,48 @@ fn dispatch_outbox(statesref: &Arc<Mutex<State>>) {
 /// that lock — so `wait_callbacks` could be a no-op. Now that callbacks run
 /// unlocked, the wait has to be explicit.
 ///
-/// Never waits on the current thread's own delivery: a callback that undeclares
-/// while it is being delivered would otherwise block forever on itself.
+/// # Waiting on `delivering` alone is not enough
+///
+/// A staging thread releases the guard before it claims the delivering role in
+/// `dispatch_outbox`. In that window `delivering` is `None` while the outbox is
+/// not empty, so a wait that only watched `delivering` would return while a call
+/// was still owed — and every staged `Call` carries its own callback handle, so
+/// unregistering first does not stop it. A caller of `wait_callbacks` would
+/// then see its listener fire after `wait_callbacks` had returned, which is
+/// precisely the guarantee it exists to give.
+///
+/// So a non-empty outbox counts as outstanding work. That is safe to wait for
+/// because every site that stages calls `dispatch_outbox` on the way out, with
+/// nothing between the two that can fail: a non-empty outbox always has a thread
+/// on its way to drain it.
+///
+/// # Never waits on this thread's own delivery
+///
+/// A callback that undeclares while it is being delivered would otherwise block
+/// forever on itself — the original defect wearing a different hat. When this
+/// thread holds the delivering role, everything outstanding is its own work and
+/// there is nothing to wait for.
+///
+/// The wait is per-subscriber, not per-listener: `wait_callbacks` on a sample
+/// miss listener therefore also waits out any sample callback in flight. That is
+/// broader than the name suggests, and deliberate — the outbox interleaves both,
+/// so a listener's staged misses cannot be waited for in isolation.
 #[zenoh_macros::unstable]
 fn wait_for_delivery(statesref: &Arc<Mutex<State>>) {
     let me = std::thread::current().id();
     let mut guard = zlock!(statesref);
     let condvar = guard.delivery_done.clone();
-    while guard.delivering.is_some_and(|owner| owner != me) {
+    loop {
+        match guard.delivering {
+            // Ours. Waiting would be waiting on ourselves.
+            Some(owner) if owner == me => return,
+            // Someone else is mid-drain.
+            Some(_) => {}
+            // Nobody has claimed the role, and nothing is staged: quiescent.
+            None if guard.outbox.is_empty() => return,
+            // Staged but unclaimed — the staging thread is on its way in.
+            None => {}
+        }
         guard = match condvar.wait(guard) {
             Ok(guard) => guard,
             // Poisoned: some other thread panicked holding the state. There is
@@ -776,8 +830,8 @@ fn wait_for_delivery(statesref: &Arc<Mutex<State>>) {
 /// Stages `sample` for delivery to `callback`.
 #[zenoh_macros::unstable]
 #[inline]
-fn stage_sample(outbox: &mut VecDeque<Call>, sample: Sample) {
-    outbox.push_back(Call::Sample(sample));
+fn stage_sample(outbox: &mut VecDeque<Call>, callback: &Callback<Sample>, sample: Sample) {
+    outbox.push_back(Call::Sample(callback.clone(), sample));
 }
 
 /// Stages `miss` for delivery to one miss listener.
@@ -809,25 +863,27 @@ fn handle_reply_sample(statesref: &Arc<Mutex<State>>, sample: Sample) {
 
 #[zenoh_macros::unstable]
 fn handle_sample(states: &mut State, sample: Sample) -> bool {
-    // Only whether a callback exists matters here — the callback itself is read
-    // once per drain in `dispatch_outbox`, not held across the state walk.
-    let has_callback = states.callback.is_some();
-    if !has_callback {
+    // Cloned once per call, not once per staged sample, and owned so that it does
+    // not borrow `states` across the state walk. Staging it with each sample is
+    // what makes a sample that got this far certain to be delivered, even if the
+    // subscriber is undeclared before the outbox is drained.
+    let Some(callback) = states.callback.clone() else {
         return false;
-    }
+    };
     if let Some(source_info) = sample.source_info().cloned() {
         #[inline]
         fn deliver_and_flush(
             sample: Sample,
             source_sn: impl Into<WrappingSn>,
             state: &mut SourceState<WrappingSn>,
+            callback: &Callback<Sample>,
             outbox: &mut VecDeque<Call>,
         ) {
             let mut source_sn = source_sn.into();
-            stage_sample(outbox, sample);
+            stage_sample(outbox, callback, sample);
             state.last_delivered = Some(source_sn);
             while let Some(sample) = state.pending_samples.remove(&(source_sn + 1)) {
-                stage_sample(outbox, sample);
+                stage_sample(outbox, callback, sample);
                 source_sn += 1;
                 state.last_delivered = Some(source_sn);
             }
@@ -844,14 +900,14 @@ fn handle_sample(states: &mut State, sample: Sample) -> bool {
             // Avoid going through the Map if history_depth == 1
             if states.max_history_depth == 1 {
                 state.last_delivered = Some(source_info.source_sn().into());
-                stage_sample(&mut states.outbox, sample);
+                stage_sample(&mut states.outbox, &callback, sample);
             } else {
                 state
                     .pending_samples
                     .insert(source_info.source_sn().into(), sample);
                 if state.pending_samples.len() >= states.max_history_depth {
                     if let Some((sn, sample)) = state.pending_samples.pop_first() {
-                        deliver_and_flush(sample, sn, state, &mut states.outbox);
+                        deliver_and_flush(sample, sn, state, &callback, &mut states.outbox);
                     }
                 }
             }
@@ -879,12 +935,18 @@ fn handle_sample(states: &mut State, sample: Sample) -> bool {
                             },
                         );
                     }
-                    stage_sample(&mut states.outbox, sample);
+                    stage_sample(&mut states.outbox, &callback, sample);
                     state.last_delivered = Some(source_info.source_sn().into());
                 }
             }
         } else {
-            deliver_and_flush(sample, source_info.source_sn(), state, &mut states.outbox);
+            deliver_and_flush(
+                sample,
+                source_info.source_sn(),
+                state,
+                &callback,
+                &mut states.outbox,
+            );
         }
         state.latest_access = Instant::now();
         new
@@ -897,18 +959,18 @@ fn handle_sample(states: &mut State, sample: Sample) -> bool {
                 || states.max_history_depth == 1
             {
                 state.last_delivered = Some(*timestamp);
-                stage_sample(&mut states.outbox, sample);
+                stage_sample(&mut states.outbox, &callback, sample);
             } else {
                 state.pending_samples.entry(*timestamp).or_insert(sample);
                 if state.pending_samples.len() >= states.max_history_depth {
-                    flush_timestamped_source(state, has_callback, &mut states.outbox);
+                    flush_timestamped_source(state, &callback, &mut states.outbox);
                 }
             }
         }
         state.latest_access = Instant::now();
         false
     } else {
-        stage_sample(&mut states.outbox, sample);
+        stage_sample(&mut states.outbox, &callback, sample);
         false
     }
 }
@@ -1178,17 +1240,21 @@ impl<Handler> AdvancedSubscriber<Handler> {
         let drop_callback = {
             let statesref = statesref.clone();
             move || {
-                // Deliberately does NOT drain the outbox first. Every stage site
-                // dispatches immediately afterwards, so a non-empty outbox here
-                // means another thread is mid-drain — and that thread holds its
-                // own handle to the callback and will finish the job. Draining
-                // here would therefore be a no-op that could, on the one path
-                // where it is not, invoke a user callback from inside a `Drop`.
-                // A panic there is a panic in a destructor, which aborts.
+                // Deliberately does NOT drain the outbox itself. Every stage site
+                // dispatches on the way out, and each staged `Call` carries its
+                // own callback handle, so anything already queued has a thread on
+                // its way to deliver it. `wait_for_delivery` below waits for
+                // exactly that. Draining here would be redundant, and would put a
+                // user callback inside a `Drop` for no gain.
                 //
-                // Take them out under the lock, drop them outside it: dropping a
-                // user callback runs user `Drop` code, and that must not happen
-                // while `statesref` is held.
+                // Note this is not a rule the rest of the file follows: the four
+                // `*RepliesHandler::drop` impls do call `dispatch_outbox`, as they
+                // called user callbacks from their `Drop` before this change too.
+                // They have queued work of their own to flush; this one does not.
+                //
+                // Take the handles out under the lock and drop them outside it:
+                // dropping a user callback runs user `Drop` code, and that must
+                // not happen while `statesref` is held.
                 let (callback, miss_handlers) = {
                     let states = &mut *zlock!(statesref);
                     (
@@ -1725,14 +1791,14 @@ impl<Handler> AdvancedSubscriber<Handler> {
 #[inline]
 fn flush_sequenced_source(
     state: &mut SourceState<WrappingSn>,
-    has_callback: bool,
+    callback: &Callback<Sample>,
     source_id: &EntityGlobalId,
     miss_handlers: &HashMap<usize, Callback<Miss>>,
     outbox: &mut VecDeque<Call>,
 ) {
-    if !has_callback {
-        return;
-    }
+    // The caller has already established there is a callback. It is staged with
+    // each sample so that a sample which reached this point is delivered even if
+    // the subscriber is undeclared before the outbox is drained.
     if state.pending_queries == 0 && !state.pending_samples.is_empty() {
         let mut pending_samples = BTreeMap::new();
         std::mem::swap(&mut state.pending_samples, &mut pending_samples);
@@ -1740,11 +1806,11 @@ fn flush_sequenced_source(
             match state.last_delivered {
                 None => {
                     state.last_delivered = Some(seq_num);
-                    stage_sample(outbox, sample);
+                    stage_sample(outbox, callback, sample);
                 }
                 Some(last) if seq_num == last + 1 => {
                     state.last_delivered = Some(seq_num);
-                    stage_sample(outbox, sample);
+                    stage_sample(outbox, callback, sample);
                 }
                 Some(last) if seq_num > last + 1 => {
                     tracing::warn!(
@@ -1763,7 +1829,7 @@ fn flush_sequenced_source(
                         )
                     }
                     state.last_delivered = Some(seq_num);
-                    stage_sample(outbox, sample);
+                    stage_sample(outbox, callback, sample);
                 }
                 _ => {
                     // duplicate
@@ -1777,12 +1843,12 @@ fn flush_sequenced_source(
 #[inline]
 fn flush_timestamped_source(
     state: &mut SourceState<Timestamp>,
-    has_callback: bool,
+    callback: &Callback<Sample>,
     outbox: &mut VecDeque<Call>,
 ) {
-    if !has_callback {
-        return;
-    }
+    // The caller has already established there is a callback. It is staged with
+    // each sample so that a sample which reached this point is delivered even if
+    // the subscriber is undeclared before the outbox is drained.
     if state.pending_queries == 0 && !state.pending_samples.is_empty() {
         for (timestamp, sample) in std::mem::take(&mut state.pending_samples) {
             if state
@@ -1791,7 +1857,7 @@ fn flush_timestamped_source(
                 .unwrap_or(true)
             {
                 state.last_delivered = Some(timestamp);
-                stage_sample(outbox, sample);
+                stage_sample(outbox, callback, sample);
             }
         }
     }
@@ -1815,20 +1881,27 @@ impl Drop for InitialRepliesHandler {
             );
 
             if states.global_pending_queries == 0 {
-                let has_callback = states.callback.is_some();
+                // Owned, so it does not borrow `states` across the flushes. The
+                // periodic queries are respawned whether or not a callback is
+                // registered, as before — only the flushing is conditional.
+                let callback = states.callback.clone();
                 for (source_id, state) in states.sequenced_states.iter_mut() {
-                    flush_sequenced_source(
-                        state,
-                        has_callback,
-                        source_id,
-                        &states.miss_handlers,
-                        &mut states.outbox,
-                    );
+                    if let Some(callback) = callback.as_ref() {
+                        flush_sequenced_source(
+                            state,
+                            callback,
+                            source_id,
+                            &states.miss_handlers,
+                            &mut states.outbox,
+                        );
+                    }
                     state.periodic_task =
                         spawn_periodic_queries(&self.statesref, states.period, *source_id);
                 }
-                for (_, state) in states.timestamped_states.iter_mut() {
-                    flush_timestamped_source(state, has_callback, &mut states.outbox);
+                if let Some(callback) = callback.as_ref() {
+                    for (_, state) in states.timestamped_states.iter_mut() {
+                        flush_timestamped_source(state, callback, &mut states.outbox);
+                    }
                 }
             }
         }
@@ -1848,7 +1921,7 @@ impl Drop for SequencedRepliesHandler {
     fn drop(&mut self) {
         {
             let states = &mut *zlock!(self.statesref);
-            let has_callback = states.callback.is_some();
+            let callback = states.callback.clone();
             // use peek_mut so query without samples do not prevent the state to be garbage collected
             if let Some(state) = states.sequenced_states.peek_mut(&self.source_id) {
                 state.pending_queries = state.pending_queries.saturating_sub(1);
@@ -1857,13 +1930,15 @@ impl Drop for SequencedRepliesHandler {
                         "AdvancedSubscriber{{key_expr: {}}}: Flush sequenced samples",
                         states.key_expr
                     );
-                    flush_sequenced_source(
-                        state,
-                        has_callback,
-                        &self.source_id,
-                        &states.miss_handlers,
-                        &mut states.outbox,
-                    )
+                    if let Some(callback) = callback.as_ref() {
+                        flush_sequenced_source(
+                            state,
+                            callback,
+                            &self.source_id,
+                            &states.miss_handlers,
+                            &mut states.outbox,
+                        )
+                    }
                 }
             }
         }
@@ -1883,7 +1958,7 @@ impl Drop for TimestampedRepliesHandler {
     fn drop(&mut self) {
         {
             let states = &mut *zlock!(self.statesref);
-            let has_callback = states.callback.is_some();
+            let callback = states.callback.clone();
             // use peek_mut so query without samples do not prevent the state to be garbage collected
             if let Some(state) = states.timestamped_states.peek_mut(&self.id) {
                 state.pending_queries = state.pending_queries.saturating_sub(1);
@@ -1892,7 +1967,9 @@ impl Drop for TimestampedRepliesHandler {
                         "AdvancedSubscriber{{key_expr: {}}}: Flush timestamped samples",
                         states.key_expr
                     );
-                    flush_timestamped_source(state, has_callback, &mut states.outbox);
+                    if let Some(callback) = callback.as_ref() {
+                        flush_timestamped_source(state, callback, &mut states.outbox);
+                    }
                 }
             }
         }
@@ -2034,6 +2111,17 @@ impl<Handler> fmt::Debug for SampleMissHandlerUndeclaration<Handler> {
 
 impl<Handler> SampleMissHandlerUndeclaration<Handler> {
     /// Block in undeclare operation until all currently running instances of sample miss listener callback (if any) return.
+    ///
+    /// The wait covers a miss report that has already been staged for delivery,
+    /// not only one whose callback is running at this instant. Both are calls the
+    /// subscriber has committed to and neither is cancelled by undeclaring.
+    ///
+    /// It is subscriber-wide: a sample callback in flight is waited out too. The
+    /// staged calls share one queue, so a listener's own cannot be waited for in
+    /// isolation.
+    ///
+    /// Calling this from inside a callback that is itself being delivered does
+    /// not deadlock — see `wait_for_delivery`.
     pub fn wait_callbacks(mut self) -> Self {
         // This used to be a no-op, on the stated grounds that "miss listener
         // callbacks are always executed under state lock" — so acquiring that

--- a/zenoh-ext/src/advanced_subscriber.rs
+++ b/zenoh-ext/src/advanced_subscriber.rs
@@ -687,12 +687,33 @@ impl Drop for DeliveringRole<'_> {
         // clear the marker unconditionally, so a case where it silently does not
         // would defeat it — the role would stay claimed for the rest of the
         // subscriber's life. `into_inner` hands back the state either way.
-        let states = &mut *match self.statesref.lock() {
-            Ok(states) => states,
-            Err(poisoned) => poisoned.into_inner(),
+        //
+        // The outbox is emptied here, not left for a later staging thread.
+        // `wait_for_delivery` treats a non-empty outbox as work that some thread
+        // is on its way to drain, which holds at every staging site but not
+        // here: this thread was that drainer and it is unwinding. Anything a
+        // concurrent thread staged while the callback ran would otherwise sit
+        // with `delivering` cleared and nobody coming, and the next
+        // `wait_callbacks` — or the subscriber's own drop — would block on it
+        // forever. Discarding is the honest option: the calls cannot be
+        // delivered from an unwinding destructor, and before delivery moved out
+        // from under this mutex a panicking callback poisoned it and lost them
+        // anyway.
+        let calls = {
+            let states = &mut *match self.statesref.lock() {
+                Ok(states) => states,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            states.delivering = None;
+            states.delivery_done.notify_all();
+            std::mem::take(&mut states.outbox)
         };
-        states.delivering = None;
-        states.delivery_done.notify_all();
+        // Dropped with the guard released, and behind `catch_unwind`. Each
+        // `Call` owns a `Callback` clone, so dropping the last one runs the
+        // user's `Drop`: that must not re-enter the state lock, and must not
+        // panic while this thread is already unwinding, which would abort the
+        // process.
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || drop(calls)));
     }
 }
 
@@ -797,6 +818,11 @@ fn dispatch_outbox(statesref: &Arc<Mutex<State>>) {
 /// because every site that stages calls `dispatch_outbox` on the way out, with
 /// nothing between the two that can fail: a non-empty outbox always has a thread
 /// on its way to drain it.
+///
+/// The one path that could break that invariant is a user callback unwinding
+/// out of `dispatch_outbox`, which leaves the drainer gone and anything staged
+/// meanwhile unclaimed. `DeliveringRole::drop` empties the outbox for exactly
+/// this reason — see the comment there.
 ///
 /// # Never waits on this thread's own delivery
 ///

--- a/zenoh-ext/src/querying_subscriber.rs
+++ b/zenoh-ext/src/querying_subscriber.rs
@@ -481,6 +481,102 @@ impl Iterator for MergeQueueValues {
 struct InnerState {
     pending_fetches: u64,
     merge_queue: MergeQueue,
+    /// Samples staged under this mutex, in the order the state machine produced
+    /// them. Drained by [`dispatch_outbox`] with the mutex released.
+    outbox: VecDeque<Sample>,
+    /// Which thread, if any, is draining `outbox`. At most one at a time, so
+    /// the callback stays mutually excluded and delivery stays ordered.
+    delivering: Option<std::thread::ThreadId>,
+}
+
+/// Marks the calling thread as the one draining [`InnerState::outbox`].
+///
+/// Held for the duration of a drain so the flag clears even if a user callback
+/// unwinds. Otherwise delivery would stop silently for the rest of the
+/// subscriber's life.
+struct DeliveringRole<'a> {
+    state: &'a Arc<Mutex<InnerState>>,
+    released: bool,
+}
+
+impl DeliveringRole<'_> {
+    /// Gives up the role while `state` is already locked.
+    ///
+    /// The caller passes the live borrow on purpose: the "outbox is empty" test
+    /// and the release have to be one atomic step. Split them, and a sample
+    /// staged in between would find `delivering` still set, decline to deliver,
+    /// and sit in the outbox until some later sample happened to flush it.
+    fn release(&mut self, state: &mut InnerState) {
+        state.delivering = None;
+        self.released = true;
+    }
+}
+
+impl Drop for DeliveringRole<'_> {
+    fn drop(&mut self) {
+        if self.released {
+            return;
+        }
+        // Only reached when a user callback unwound. Deliberately not `zlock!`:
+        // this runs on the unwind path, and a panic in a destructor aborts the
+        // process, so a poisoned mutex must not be unwrapped here.
+        if let Ok(mut state) = self.state.lock() {
+            state.delivering = None;
+        }
+    }
+}
+
+/// Delivers everything staged in [`InnerState::outbox`], with the lock released.
+///
+/// This is the only place in this file that calls into code Zenoh does not
+/// control. Both call sites record samples into the outbox while they hold the
+/// state mutex, then come here once the guard is gone. That is what stops a
+/// callback which re-enters a `FetchingSubscriber` API from deadlocking against
+/// the guard its own caller holds: `FetchingSubscriber::fetch` resolves to
+/// `register_handler`, which takes the same mutex.
+///
+/// # Why a shared outbox rather than a per-call-site buffer
+///
+/// Collecting into a local buffer at each call site would fix the deadlock and
+/// **break ordering**, which is the feature this subscriber exists to provide.
+/// It merges fetched replies with live samples, and the state mutex is what
+/// serialises that merge. `Callback` is `Send + Sync`, so two threads can be in
+/// the sample callback at once; with local buffers one could stage a live sample
+/// and another drain the merge queue, and the live sample could overtake the
+/// replies it was meant to follow.
+///
+/// A single FIFO plus a single active deliverer restores it: samples leave the
+/// outbox in the order the state machine produced them, whichever thread drains
+/// them. A thread that finds another already draining returns immediately; the
+/// active deliverer picks that work up on its next lap, so nothing is dropped
+/// and callbacks stay mutually excluded exactly as before.
+fn dispatch_outbox(state: &Arc<Mutex<InnerState>>, callback: &Callback<Sample>) {
+    // Claim the role and take the first batch in one acquisition.
+    let mut samples = {
+        let guard = &mut *zlock!(state);
+        if guard.delivering.is_some() || guard.outbox.is_empty() {
+            return;
+        }
+        guard.delivering = Some(std::thread::current().id());
+        std::mem::take(&mut guard.outbox)
+    };
+    let mut role = DeliveringRole {
+        state,
+        released: false,
+    };
+    loop {
+        for sample in samples {
+            callback.call(sample);
+        }
+        samples = {
+            let guard = &mut *zlock!(state);
+            if guard.outbox.is_empty() {
+                role.release(guard);
+                return;
+            }
+            std::mem::take(&mut guard.outbox)
+        };
+    }
 }
 
 /// The builder of [`FetchingSubscriber`], allowing to configure it.
@@ -909,6 +1005,8 @@ impl<Handler> FetchingSubscriber<Handler> {
         let state = Arc::new(Mutex::new(InnerState {
             pending_fetches: 0,
             merge_queue: MergeQueue::new(),
+            outbox: VecDeque::new(),
+            delivering: None,
         }));
         let (callback, receiver) = conf.handler.into_handler();
 
@@ -916,25 +1014,29 @@ impl<Handler> FetchingSubscriber<Handler> {
             let state = state.clone();
             let callback = callback.clone();
             move |s| {
-                let state = &mut zlock!(state);
-                if state.pending_fetches == 0 {
-                    callback.call(s);
-                } else {
-                    tracing::trace!(
-                        "Sample received while fetch in progress: push it to merge_queue"
-                    );
+                {
+                    let guard = &mut *zlock!(state);
+                    if guard.pending_fetches == 0 {
+                        guard.outbox.push_back(s);
+                    } else {
+                        tracing::trace!(
+                            "Sample received while fetch in progress: push it to merge_queue"
+                        );
 
-                    // ensure the sample has a timestamp, thus it will always be sorted into the MergeQueue
-                    // after any timestamped Sample possibly coming from a fetch reply.
-                    let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().into(); // UNIX_EPOCH is Returns a Timespec::zero(), Unwrap Should be permissible here
-                    let timestamp = s
-                        .timestamp()
-                        .cloned()
-                        .unwrap_or(Timestamp::new(now, session_id.into()));
-                    state
-                        .merge_queue
-                        .push(SampleBuilder::from(s).timestamp(timestamp).into());
+                        // ensure the sample has a timestamp, thus it will always be sorted into the MergeQueue
+                        // after any timestamped Sample possibly coming from a fetch reply.
+                        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().into(); // UNIX_EPOCH is Returns a Timespec::zero(), Unwrap Should be permissible here
+                        let timestamp = s
+                            .timestamp()
+                            .cloned()
+                            .unwrap_or(Timestamp::new(now, session_id.into()));
+                        guard
+                            .merge_queue
+                            .push(SampleBuilder::from(s).timestamp(timestamp).into());
+                    }
                 }
+                // The guard is gone before any user code runs.
+                dispatch_outbox(&state, &callback);
             }
         };
 
@@ -1059,21 +1161,28 @@ struct RepliesHandler {
 
 impl Drop for RepliesHandler {
     fn drop(&mut self) {
-        let mut state = zlock!(self.state);
-        state.pending_fetches -= 1;
-        tracing::trace!(
-            "Fetch done - {} fetches still in progress",
-            state.pending_fetches
-        );
-        if state.pending_fetches == 0 {
-            tracing::debug!(
-                "All fetches done. Replies and live publications merged - {} samples to propagate",
-                state.merge_queue.len()
+        {
+            let state = &mut *zlock!(self.state);
+            state.pending_fetches -= 1;
+            tracing::trace!(
+                "Fetch done - {} fetches still in progress",
+                state.pending_fetches
             );
-            for s in state.merge_queue.drain() {
-                self.callback.call(s);
+            if state.pending_fetches == 0 {
+                tracing::debug!(
+                    "All fetches done. Replies and live publications merged - {} samples to propagate",
+                    state.merge_queue.len()
+                );
+                // Staged, not delivered. `drain` hands back an owning iterator,
+                // so the merge order is fixed here and preserved by the FIFO.
+                let merged = state.merge_queue.drain();
+                state.outbox.extend(merged);
             }
         }
+        // The guard is gone before any user code runs. Dropping a value inside a
+        // callback is not something a user reads as re-entering the middleware,
+        // so this path is the one most likely to reach someone unannounced.
+        dispatch_outbox(&self.state, &self.callback);
     }
 }
 

--- a/zenoh-ext/src/querying_subscriber.rs
+++ b/zenoh-ext/src/querying_subscriber.rs
@@ -528,12 +528,16 @@ impl Drop for DeliveringRole<'_> {
 
 /// Delivers everything staged in [`InnerState::outbox`], with the lock released.
 ///
-/// This is the only place in this file that calls into code Zenoh does not
-/// control. Both call sites record samples into the outbox while they hold the
-/// state mutex, then come here once the guard is gone. That is what stops a
-/// callback which re-enters a `FetchingSubscriber` API from deadlocking against
-/// the guard its own caller holds: `FetchingSubscriber::fetch` resolves to
-/// `register_handler`, which takes the same mutex.
+/// This is the only place in this file that invokes a callback. Both call sites
+/// record samples into the outbox while they hold the state mutex, then come
+/// here once the guard is gone. That is what stops a callback which re-enters a
+/// `FetchingSubscriber` API from deadlocking against the guard its own caller
+/// holds: `FetchingSubscriber::fetch` resolves to `register_handler`, which
+/// takes the same mutex.
+///
+/// Invoking a callback is not the only way this file reaches user code:
+/// *dropping* a `Callback` runs the user's `Drop`. `RepliesHandler` owns one,
+/// and it falls out of scope after `drop` has released the guard.
 ///
 /// # Why a shared outbox rather than a per-call-site buffer
 ///

--- a/zenoh-ext/src/querying_subscriber.rs
+++ b/zenoh-ext/src/querying_subscriber.rs
@@ -494,6 +494,12 @@ struct InnerState {
 /// Held for the duration of a drain so the flag clears even if a user callback
 /// unwinds. Otherwise delivery would stop silently for the rest of the
 /// subscriber's life.
+///
+/// `advanced_subscriber.rs` carries a type of the same name and shape. They are
+/// kept separate on purpose: this one has no condition variable, because
+/// `FetchingSubscriber` has no `wait_callbacks`-style API to make one mean
+/// anything, and this type is deprecated. Sharing them would tie a deprecated
+/// type's lifetime to the current one's.
 struct DeliveringRole<'a> {
     state: &'a Arc<Mutex<InnerState>>,
     released: bool,
@@ -554,6 +560,20 @@ impl Drop for DeliveringRole<'_> {
 /// them. A thread that finds another already draining returns immediately; the
 /// active deliverer picks that work up on its next lap, so nothing is dropped
 /// and callbacks stay mutually excluded exactly as before.
+///
+/// A callback that publishes to its own subscriber is therefore safe as long as
+/// it publishes *conditionally*. One that republishes on every sample now spins
+/// in the refill loop below rather than deadlocking — livelock instead of
+/// deadlock, and still the callback's own recursion.
+///
+/// # The outbox is not backpressure
+///
+/// The state mutex used to throttle producers: a thread arriving while a
+/// callback ran blocked on the guard until it finished. Staging returns
+/// immediately, so a producer faster than the callback grows the outbox instead
+/// of being slowed by it. Nothing here bounds that. Bounding it would mean
+/// dropping samples or reintroducing a block, both larger semantic changes than
+/// removing the deadlock, so it is documented rather than decided here.
 fn dispatch_outbox(state: &Arc<Mutex<InnerState>>, callback: &Callback<Sample>) {
     // Claim the role and take the first batch in one acquisition.
     let mut samples = {

--- a/zenoh-ext/src/querying_subscriber.rs
+++ b/zenoh-ext/src/querying_subscriber.rs
@@ -551,31 +551,36 @@ impl Drop for DeliveringRole<'_> {
 /// instead of deadlocking. And the outbox is not backpressure: the mutex used to
 /// throttle producers, staging does not, and nothing bounds the queue.
 fn dispatch_outbox(state: &Arc<Mutex<InnerState>>, callback: &Callback<Sample>) {
+    // Drained into across laps rather than taking the outbox itself, so both
+    // buffers keep their capacity instead of being freed and reallocated once
+    // per batch.
+    let mut samples: Vec<Sample> = Vec::new();
     // Claim the role and take the first batch in one acquisition.
-    let mut samples = {
+    {
         let guard = &mut *zlock!(state);
         if guard.delivering || guard.outbox.is_empty() {
             return;
         }
         guard.delivering = true;
-        std::mem::take(&mut guard.outbox)
-    };
+        samples.extend(guard.outbox.drain(..));
+    }
     let mut role = DeliveringRole {
         state,
         released: false,
     };
     loop {
-        for sample in samples {
+        for sample in samples.drain(..) {
             callback.call(sample);
         }
-        samples = {
+        // Braced so the guard's scope is explicit: no user code may run inside.
+        {
             let guard = &mut *zlock!(state);
             if guard.outbox.is_empty() {
                 role.release(guard);
                 return;
             }
-            std::mem::take(&mut guard.outbox)
-        };
+            samples.extend(guard.outbox.drain(..));
+        }
     }
 }
 

--- a/zenoh-ext/src/querying_subscriber.rs
+++ b/zenoh-ext/src/querying_subscriber.rs
@@ -484,36 +484,32 @@ struct InnerState {
     /// Samples staged under this mutex, in the order the state machine produced
     /// them. Drained by [`dispatch_outbox`] with the mutex released.
     outbox: VecDeque<Sample>,
-    /// Which thread, if any, is draining `outbox`. At most one at a time, so
-    /// the callback stays mutually excluded and delivery stays ordered.
-    delivering: Option<std::thread::ThreadId>,
+    /// Set while a thread is draining `outbox`. One at a time, so the callback
+    /// stays mutually excluded and delivery stays ordered.
+    delivering: bool,
 }
 
 /// Marks the calling thread as the one draining [`InnerState::outbox`].
 ///
-/// Held for the duration of a drain so the flag clears even if a user callback
-/// unwinds. Otherwise delivery would stop silently for the rest of the
-/// subscriber's life.
+/// RAII, so the marker clears even if a user callback unwinds.
 ///
-/// `advanced_subscriber.rs` carries a type of the same name and shape. They are
-/// kept separate on purpose: this one has no condition variable, because
+/// `advanced_subscriber.rs` has a type of the same name and shape. They are kept
+/// separate on purpose: this one needs no condition variable, because
 /// `FetchingSubscriber` has no `wait_callbacks`-style API to make one mean
-/// anything, and this type is deprecated. Sharing them would tie a deprecated
-/// type's lifetime to the current one's.
+/// anything, and this type is deprecated.
 struct DeliveringRole<'a> {
     state: &'a Arc<Mutex<InnerState>>,
     released: bool,
 }
 
 impl DeliveringRole<'_> {
-    /// Gives up the role while `state` is already locked.
+    /// Gives up the role.
     ///
-    /// The caller passes the live borrow on purpose: the "outbox is empty" test
-    /// and the release have to be one atomic step. Split them, and a sample
-    /// staged in between would find `delivering` still set, decline to deliver,
-    /// and sit in the outbox until some later sample happened to flush it.
+    /// Takes the live borrow so the empty-outbox test and the release are one
+    /// atomic step: split them, and a sample staged in between sits in the
+    /// outbox until some later sample flushes it.
     fn release(&mut self, state: &mut InnerState) {
-        state.delivering = None;
+        state.delivering = false;
         self.released = true;
     }
 }
@@ -523,72 +519,45 @@ impl Drop for DeliveringRole<'_> {
         if self.released {
             return;
         }
-        // Only reached when a user callback unwound. Deliberately not `zlock!`:
-        // this runs on the unwind path, and a panic in a destructor aborts the
-        // process, so a poisoned mutex must not be unwrapped here.
-        //
-        // Poisoning is recovered from rather than skipped. This guard exists to
-        // clear the marker unconditionally, so a case where it silently does not
-        // would defeat it — the role would stay claimed for the rest of the
-        // subscriber's life. `into_inner` hands back the state either way.
+        // Only reached when a user callback unwound. Not `zlock!`: unwrapping a
+        // poisoned mutex here would panic in a destructor, which aborts.
         let state = &mut *match self.state.lock() {
             Ok(state) => state,
             Err(poisoned) => poisoned.into_inner(),
         };
-        state.delivering = None;
+        state.delivering = false;
     }
 }
 
 /// Delivers everything staged in [`InnerState::outbox`], with the lock released.
 ///
-/// This is the only place in this file that invokes a callback. Both call sites
-/// record samples into the outbox while they hold the state mutex, then come
-/// here once the guard is gone. That is what stops a callback which re-enters a
-/// `FetchingSubscriber` API from deadlocking against the guard its own caller
-/// holds: `FetchingSubscriber::fetch` resolves to `register_handler`, which
-/// takes the same mutex.
+/// The only place in this file that invokes a callback. Both call sites stage
+/// while holding the state mutex and come here once the guard is gone, so a
+/// callback that re-enters a `FetchingSubscriber` API cannot deadlock against
+/// its own caller's guard — `fetch` resolves to `register_handler`, which takes
+/// the same mutex.
 ///
-/// Invoking a callback is not the only way this file reaches user code:
-/// *dropping* a `Callback` runs the user's `Drop`. `RepliesHandler` owns one,
-/// and it falls out of scope after `drop` has released the guard.
+/// Dropping a `Callback` also runs user code; `RepliesHandler` owns one and it
+/// falls out of scope after `drop` has released the guard.
 ///
-/// # Why a shared outbox rather than a per-call-site buffer
+/// One shared FIFO, one active deliverer. Per-call-site buffers would fix the
+/// deadlock and break the merge ordering this subscriber exists to provide:
+/// `Callback` is `Send + Sync`, so a live sample could overtake the replies it
+/// was meant to follow. A thread that finds another draining stages and returns;
+/// the deliverer takes the work on its next lap.
 ///
-/// Collecting into a local buffer at each call site would fix the deadlock and
-/// **break ordering**, which is the feature this subscriber exists to provide.
-/// It merges fetched replies with live samples, and the state mutex is what
-/// serialises that merge. `Callback` is `Send + Sync`, so two threads can be in
-/// the sample callback at once; with local buffers one could stage a live sample
-/// and another drain the merge queue, and the live sample could overtake the
-/// replies it was meant to follow.
-///
-/// A single FIFO plus a single active deliverer restores it: samples leave the
-/// outbox in the order the state machine produced them, whichever thread drains
-/// them. A thread that finds another already draining returns immediately; the
-/// active deliverer picks that work up on its next lap, so nothing is dropped
-/// and callbacks stay mutually excluded exactly as before.
-///
-/// A callback that publishes to its own subscriber is therefore safe as long as
-/// it publishes *conditionally*. One that republishes on every sample now spins
-/// in the refill loop below rather than deadlocking — livelock instead of
-/// deadlock, and still the callback's own recursion.
-///
-/// # The outbox is not backpressure
-///
-/// The state mutex used to throttle producers: a thread arriving while a
-/// callback ran blocked on the guard until it finished. Staging returns
-/// immediately, so a producer faster than the callback grows the outbox instead
-/// of being slowed by it. Nothing here bounds that. Bounding it would mean
-/// dropping samples or reintroducing a block, both larger semantic changes than
-/// removing the deadlock, so it is documented rather than decided here.
+/// Two consequences worth knowing. A re-entrant publish is safe only if it is
+/// *conditional* — republishing on every sample livelocks in the refill loop
+/// instead of deadlocking. And the outbox is not backpressure: the mutex used to
+/// throttle producers, staging does not, and nothing bounds the queue.
 fn dispatch_outbox(state: &Arc<Mutex<InnerState>>, callback: &Callback<Sample>) {
     // Claim the role and take the first batch in one acquisition.
     let mut samples = {
         let guard = &mut *zlock!(state);
-        if guard.delivering.is_some() || guard.outbox.is_empty() {
+        if guard.delivering || guard.outbox.is_empty() {
             return;
         }
-        guard.delivering = Some(std::thread::current().id());
+        guard.delivering = true;
         std::mem::take(&mut guard.outbox)
     };
     let mut role = DeliveringRole {
@@ -1037,7 +1006,7 @@ impl<Handler> FetchingSubscriber<Handler> {
             pending_fetches: 0,
             merge_queue: MergeQueue::new(),
             outbox: VecDeque::new(),
-            delivering: None,
+            delivering: false,
         }));
         let (callback, receiver) = conf.handler.into_handler();
 

--- a/zenoh-ext/src/querying_subscriber.rs
+++ b/zenoh-ext/src/querying_subscriber.rs
@@ -526,9 +526,16 @@ impl Drop for DeliveringRole<'_> {
         // Only reached when a user callback unwound. Deliberately not `zlock!`:
         // this runs on the unwind path, and a panic in a destructor aborts the
         // process, so a poisoned mutex must not be unwrapped here.
-        if let Ok(mut state) = self.state.lock() {
-            state.delivering = None;
-        }
+        //
+        // Poisoning is recovered from rather than skipped. This guard exists to
+        // clear the marker unconditionally, so a case where it silently does not
+        // would defeat it — the role would stay claimed for the rest of the
+        // subscriber's life. `into_inner` hands back the state either way.
+        let state = &mut *match self.state.lock() {
+            Ok(state) => state,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        state.delivering = None;
     }
 }
 

--- a/zenoh-ext/tests/reentrancy.rs
+++ b/zenoh-ext/tests/reentrancy.rs
@@ -12,7 +12,11 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-//! Re-entrancy of `AdvancedSubscriber`'s sample callback.
+//! Re-entrancy of the zenoh-ext subscribers' sample callbacks.
+//!
+//! Two files carried the same defect, and this file covers both.
+//! `AdvancedSubscriber` comes first; the `QueryingSubscriber` scenarios are at
+//! the end, behind their own banner.
 //!
 //! `advanced_subscriber.rs` used to take `zlock!(statesref)` and call the user's
 //! sample callback while that guard was live. Any callback re-entering an
@@ -57,6 +61,8 @@ use std::{
 
 use zenoh::{sample::Sample, Wait};
 use zenoh_ext::{AdvancedSubscriber, AdvancedSubscriberBuilderExt, Miss};
+#[allow(deprecated)]
+use zenoh_ext::{FetchingSubscriber, SubscriberBuilderExt};
 
 /// Generous by design. The deadlock is deterministic and immediate, so any wait
 /// that survives scheduler noise proves the point; the work being done is
@@ -278,4 +284,151 @@ fn the_callback_guard_fires_when_the_callback_never_runs() {
             "expected the in-callback guard to fire when nothing is delivered, got {other:?}"
         ),
     }
+}
+
+// ---------------------------------------------------------------------------
+// `QueryingSubscriber` / `FetchingSubscriber`
+//
+// Same defect class, different file. `querying_subscriber.rs` took
+// `zlock!(state)` and called the user's callback under it at two sites: the
+// sample callback, and `RepliesHandler::drop` draining the merge queue.
+//
+// The reachable re-entrant surface here is `FetchingSubscriber::fetch`, which
+// resolves to `register_handler` and takes the same mutex. A callback that
+// publishes re-enters through zenoh's synchronous local delivery instead.
+// ---------------------------------------------------------------------------
+
+/// The querying subscriber under test, parked so its own callback can re-enter
+/// it. `.callback(..)` consumes the sample stream, so the handler is `()`.
+#[allow(deprecated)]
+type QSubSlot = Arc<Mutex<Option<FetchingSubscriber<()>>>>;
+
+/// Calling `fetch` from inside the sample callback.
+///
+/// `FetchBuilder::wait` → `register_handler` → `zlock!(state)`, which the caller
+/// of this very callback is holding.
+#[allow(deprecated)]
+fn fetch_in_querying_callback() -> Outcome {
+    run_scenario(|| {
+        let session = zenoh::open(isolated_config()).wait().unwrap();
+
+        let sub_slot: QSubSlot = Arc::new(Mutex::new(None));
+        let in_callback = Arc::new(AtomicBool::new(false));
+        let fetched_once = Arc::new(AtomicBool::new(false));
+
+        // Set only on the branch that actually re-enters. Without it, an empty
+        // slot would skip the fetch and the scenario would pass vacuously —
+        // against the unfixed code too.
+        let did_fetch = Arc::new(AtomicBool::new(false));
+
+        let sub_slot_cb = sub_slot.clone();
+        let flag = in_callback.clone();
+        let once = fetched_once.clone();
+        let fetch_session = session.clone();
+        let did_fetch_cb = did_fetch.clone();
+
+        let sub = session
+            .declare_subscriber("test/reentrancy/querying-fetch")
+            .callback(move |_s: Sample| {
+                flag.store(true, Ordering::SeqCst);
+                // Once only: a fetch reply is itself delivered through this
+                // subscriber, so an unconditional fetch would recurse.
+                if once.swap(true, Ordering::SeqCst) {
+                    return;
+                }
+                if let Some(sub) = sub_slot_cb.lock().unwrap().as_ref() {
+                    let _ = sub
+                        .fetch(|cb| {
+                            fetch_session
+                                .get("test/reentrancy/querying-fetch")
+                                .callback(cb)
+                                .wait()
+                        })
+                        .wait();
+                    did_fetch_cb.store(true, Ordering::SeqCst);
+                }
+            })
+            .querying()
+            .wait()
+            .unwrap();
+
+        *sub_slot.lock().unwrap() = Some(sub);
+
+        session
+            .put("test/reentrancy/querying-fetch", "trigger")
+            .wait()
+            .unwrap();
+
+        assert_callback_ran(&in_callback);
+        assert!(
+            did_fetch.load(Ordering::SeqCst),
+            "the callback ran but never reached `fetch`, so nothing re-entered \
+             the subscriber and this scenario proves nothing"
+        );
+    })
+}
+
+/// Publishing from inside the sample callback.
+///
+/// Zenoh delivers a sample published on the same session synchronously, on the
+/// publishing thread, so the subscriber re-enters `zlock!(state)` on the thread
+/// that already holds it.
+#[allow(deprecated)]
+fn publish_in_querying_callback() -> Outcome {
+    run_scenario(|| {
+        let session = zenoh::open(isolated_config()).wait().unwrap();
+
+        let in_callback = Arc::new(AtomicBool::new(false));
+        let published_once = Arc::new(AtomicBool::new(false));
+
+        let flag = in_callback.clone();
+        let once = published_once.clone();
+        let echo_session = session.clone();
+
+        let _sub = session
+            .declare_subscriber("test/reentrancy/querying-publish")
+            .callback(move |_s: Sample| {
+                flag.store(true, Ordering::SeqCst);
+                // Once only: the echo matches the same key expression.
+                if once.swap(true, Ordering::SeqCst) {
+                    return;
+                }
+                let _ = echo_session
+                    .put("test/reentrancy/querying-publish", "echo")
+                    .wait();
+            })
+            .querying()
+            .wait()
+            .unwrap();
+
+        session
+            .put("test/reentrancy/querying-publish", "trigger")
+            .wait()
+            .unwrap();
+
+        assert_callback_ran(&in_callback);
+    })
+}
+
+#[test]
+fn fetching_from_inside_a_querying_subscriber_callback_is_safe() {
+    let outcome = fetch_in_querying_callback();
+    assert!(
+        matches!(outcome, Outcome::Completed),
+        "`FetchBuilder::wait` reaches `register_handler`, which takes the same \
+         `state` mutex the sample callback used to be invoked under. A \
+         `Deadlocked` here means the staged-then-drained delivery in \
+         `querying_subscriber.rs` has been undone. Got {outcome:?}."
+    );
+}
+
+#[test]
+fn publishing_from_inside_a_querying_subscriber_callback_is_safe() {
+    let outcome = publish_in_querying_callback();
+    assert!(
+        matches!(outcome, Outcome::Completed),
+        "Zenoh delivers a locally published sample synchronously, so this \
+         re-enters the subscriber on the publishing thread. A `Deadlocked` here \
+         means the callback is being invoked under `state` again. Got {outcome:?}."
+    );
 }

--- a/zenoh-ext/tests/reentrancy.rs
+++ b/zenoh-ext/tests/reentrancy.rs
@@ -1,0 +1,281 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+//! Re-entrancy of `AdvancedSubscriber`'s sample callback.
+//!
+//! `advanced_subscriber.rs` used to take `zlock!(statesref)` and call the user's
+//! sample callback while that guard was live. Any callback re-entering an
+//! `AdvancedSubscriber` API taking the same mutex then self-deadlocked on a
+//! non-reentrant `std::sync::Mutex` — one thread, no race, every time.
+//!
+//! The reachable re-entrant surface is the sample-miss listener:
+//!
+//! * `SampleMissListenerBuilder::wait()` → `zlock!(statesref).register_miss_callback(..)`
+//! * `SampleMissListener::drop`          → `zlock!(statesref).unregister_miss_callback(..)`
+//!
+//! The second is the nastier one: *dropping* a value inside a callback is not
+//! something a user would think of as re-entering the middleware.
+//!
+//! Both now complete. Deliveries are staged into `State::outbox` under the guard
+//! and drained once it is released, so these tests pin the fix rather than the
+//! defect: reintroduce a `callback.call(..)` under `statesref` and they hang
+//! again.
+//!
+//! # Reading these tests
+//!
+//! A timeout on its own proves nothing — "the callback never ran" and "the
+//! callback ran and wedged" look identical from outside. Each scenario therefore
+//! asserts it actually entered the callback, and [`Outcome`] keeps *deadlocked*,
+//! *panicked* and *completed* apart instead of collapsing them into a bool.
+//! That distinction matters more now, not less: a scenario whose callback
+//! silently stopped running would otherwise *pass* against the fixed code.
+//! `the_callback_guard_fires_when_the_callback_never_runs` is the control that
+//! proves that guard is live rather than decorative.
+
+#![cfg(feature = "unstable")]
+
+use std::{
+    any::Any,
+    panic::AssertUnwindSafe,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
+    time::Duration,
+};
+
+use zenoh::{sample::Sample, Wait};
+use zenoh_ext::{AdvancedSubscriber, AdvancedSubscriberBuilderExt, Miss};
+
+/// Generous by design. The deadlock is deterministic and immediate, so any wait
+/// that survives scheduler noise proves the point; the work being done is
+/// microseconds.
+const WAIT: Duration = Duration::from_secs(10);
+
+/// How long to give local delivery before concluding the callback never ran.
+const DELIVERY_GRACE: Duration = Duration::from_millis(500);
+
+/// An isolated session: no multicast, no gossip, no listeners.
+///
+/// These scenarios are single-process and need no network at all. Left on
+/// defaults they peer with anything else scouting on the machine — including
+/// the sibling tests in this file when cargo runs them in parallel, which is
+/// enough to break the control's "nothing is delivered here" premise.
+fn isolated_config() -> zenoh::Config {
+    let mut config = zenoh::Config::default();
+    config
+        .insert_json5("scouting/multicast/enabled", "false")
+        .unwrap();
+    config
+        .insert_json5("scouting/gossip/enabled", "false")
+        .unwrap();
+    config.insert_json5("listen/endpoints", "[]").unwrap();
+    config
+}
+
+/// Slot holding a value the callback can drop without having created it.
+/// `Box<dyn Any + Send>` avoids naming the listener's handler type.
+type Slot = Arc<Mutex<Option<Box<dyn Any + Send>>>>;
+
+/// The subscriber under test, stored so its own callback can re-enter it.
+///
+/// The handler parameter is `()`: `.callback(..)` consumes the sample stream
+/// itself, leaving no receiver behind.
+type SubSlot = Arc<Mutex<Option<AdvancedSubscriber<()>>>>;
+
+/// What happened to the scenario thread.
+#[derive(Debug)]
+enum Outcome {
+    /// Ran to completion — no deadlock.
+    Completed,
+    /// Still blocked after [`WAIT`]. This is the deadlock.
+    Deadlocked,
+    /// Unwound. Carries the panic message so a test can assert *which* failure.
+    Panicked(String),
+}
+
+/// Runs `body` on its own thread and classifies the result.
+///
+/// Distinguishing `Panicked` from `Deadlocked` matters: a bare `recv_timeout`
+/// error would report an assertion failure inside the scenario as a deadlock,
+/// which is precisely the lie these tests are built to avoid.
+fn run_scenario(body: impl FnOnce() + Send + 'static) -> Outcome {
+    let (tx, rx) = std::sync::mpsc::channel();
+    // Leaked deliberately on the deadlock path: the thread is wedged holding a
+    // lock it will never release, which is the thing being demonstrated.
+    std::thread::spawn(move || {
+        let result = std::panic::catch_unwind(AssertUnwindSafe(body));
+        let _ = tx.send(result.map_err(|payload| {
+            payload
+                .downcast_ref::<&str>()
+                .map(|s| (*s).to_owned())
+                .or_else(|| payload.downcast_ref::<String>().cloned())
+                .unwrap_or_else(|| "<non-string panic payload>".to_owned())
+        }));
+    });
+    match rx.recv_timeout(WAIT) {
+        Ok(Ok(())) => Outcome::Completed,
+        Ok(Err(msg)) => Outcome::Panicked(msg),
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => Outcome::Deadlocked,
+        // `tx` is owned by the closure and only dropped when it finishes, and
+        // the closure always sends first. Reaching this means the process
+        // aborted the thread outright.
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            Outcome::Panicked("<thread aborted without sending>".to_owned())
+        }
+    }
+}
+
+/// The guard every scenario runs last: without it, a timeout would be
+/// indistinguishable from "delivery never happened".
+fn assert_callback_ran(flag: &AtomicBool) {
+    std::thread::sleep(DELIVERY_GRACE);
+    assert!(
+        flag.load(Ordering::SeqCst),
+        "the callback never ran, so this test proves nothing about re-entrancy"
+    );
+}
+
+/// Dropping a `SampleMissListener` from inside the sample callback.
+///
+/// `publish_to` is separate from the subscribed key expression only so the
+/// control test can aim the sample somewhere the subscriber does not match.
+fn drop_miss_listener_in_callback(subscribe_to: &'static str, publish_to: &'static str) -> Outcome {
+    run_scenario(move || {
+        let session = zenoh::open(isolated_config()).wait().unwrap();
+
+        let slot: Slot = Arc::new(Mutex::new(None));
+        let in_callback = Arc::new(AtomicBool::new(false));
+
+        let slot_cb = slot.clone();
+        let flag = in_callback.clone();
+        let sub = session
+            .declare_subscriber(subscribe_to)
+            .callback(move |_s: Sample| {
+                flag.store(true, Ordering::SeqCst);
+                // Re-entry: this `Drop` takes `statesref`, which the caller of
+                // this very callback is holding.
+                let taken = slot_cb.lock().unwrap().take();
+                drop(taken);
+            })
+            .advanced()
+            .wait()
+            .unwrap();
+
+        let listener = sub
+            .sample_miss_listener()
+            .callback(|_m: Miss| {})
+            .wait()
+            .unwrap();
+        *slot.lock().unwrap() = Some(Box::new(listener));
+
+        session.put(publish_to, "trigger").wait().unwrap();
+
+        assert_callback_ran(&in_callback);
+    })
+}
+
+/// Registering a `SampleMissListener` from inside the sample callback.
+///
+/// The subscriber is parked in a slot its own callback closes over, which is
+/// what makes the re-entrant call reachable at all.
+fn register_miss_listener_in_callback() -> Outcome {
+    run_scenario(|| {
+        let session = zenoh::open(isolated_config()).wait().unwrap();
+
+        let sub_slot: SubSlot = Arc::new(Mutex::new(None));
+        let holder: Slot = Arc::new(Mutex::new(None));
+        let in_callback = Arc::new(AtomicBool::new(false));
+
+        let sub_slot_cb = sub_slot.clone();
+        let holder_cb = holder.clone();
+        let flag = in_callback.clone();
+
+        let sub = session
+            .declare_subscriber("test/reentrancy/register")
+            .callback(move |_s: Sample| {
+                flag.store(true, Ordering::SeqCst);
+                // Re-entry through the registration path rather than `Drop`:
+                // `SampleMissListenerBuilder::wait` takes `statesref`.
+                if let Some(sub) = sub_slot_cb.lock().unwrap().as_ref() {
+                    let listener = sub
+                        .sample_miss_listener()
+                        .callback(|_m: Miss| {})
+                        .wait()
+                        .unwrap();
+                    *holder_cb.lock().unwrap() = Some(Box::new(listener));
+                }
+            })
+            .advanced()
+            .wait()
+            .unwrap();
+
+        *sub_slot.lock().unwrap() = Some(sub);
+
+        session
+            .put("test/reentrancy/register", "trigger")
+            .wait()
+            .unwrap();
+
+        assert_callback_ran(&in_callback);
+    })
+}
+
+#[test]
+fn dropping_a_miss_listener_inside_the_callback_is_safe() {
+    let outcome = drop_miss_listener_in_callback("test/reentrancy/drop", "test/reentrancy/drop");
+    assert!(
+        matches!(outcome, Outcome::Completed),
+        "`SampleMissListener::drop` takes `statesref`. This deadlocked until the \
+         sample callback stopped being invoked under that guard; a `Deadlocked` \
+         here means collect · release · call has been undone somewhere. Got \
+         {outcome:?}."
+    );
+}
+
+#[test]
+fn registering_a_miss_listener_inside_the_callback_is_safe() {
+    let outcome = register_miss_listener_in_callback();
+    assert!(
+        matches!(outcome, Outcome::Completed),
+        "`SampleMissListenerBuilder::wait` takes `statesref`. This deadlocked \
+         until the sample callback stopped being invoked under that guard. Got \
+         {outcome:?}."
+    );
+}
+
+/// Control. Publishes where the subscriber does not match, so the callback
+/// cannot run and no lock is ever re-entered.
+///
+/// This is what makes the two tests above trustworthy. It proves the
+/// `assert_callback_ran` guard is live — a scenario that never enters the
+/// callback is reported as a *panic*, not silently as a deadlock — and with it
+/// that [`run_scenario`] really does tell the two apart. Without this control,
+/// the assertion above would be an assertion nobody has ever seen execute.
+#[test]
+fn the_callback_guard_fires_when_the_callback_never_runs() {
+    // Its own key namespace, so a sibling test running concurrently cannot
+    // deliver into it and falsify the premise.
+    let outcome =
+        drop_miss_listener_in_callback("test/reentrancy/control", "test/reentrancy/control-other");
+    match outcome {
+        Outcome::Panicked(msg) => assert!(
+            msg.contains("the callback never ran"),
+            "expected the in-callback guard to fire, got a different panic: {msg}"
+        ),
+        other => panic!(
+            "expected the in-callback guard to fire when nothing is delivered, got {other:?}"
+        ),
+    }
+}

--- a/zenoh-ext/tests/reentrancy.rs
+++ b/zenoh-ext/tests/reentrancy.rs
@@ -47,6 +47,9 @@
 //! `the_callback_guard_fires_when_the_callback_never_runs` is the control that
 //! proves that guard is live rather than decorative.
 
+// Every type under test is `#[zenoh_macros::unstable]`. Without this gate the
+// file does not compile when that feature is off, and CI builds exactly that
+// configuration.
 #![cfg(feature = "unstable")]
 
 use std::{
@@ -61,6 +64,12 @@ use std::{
 
 use zenoh::{sample::Sample, Wait};
 use zenoh_ext::{AdvancedSubscriber, AdvancedSubscriberBuilderExt, Miss};
+// Both of these are deprecated in favour of the advanced API, and CI denies
+// warnings, so importing them without the allow is a hard error.
+//
+// They keep their own `use` on purpose. The attribute covers a whole statement,
+// so merging them with the line above would silence a future deprecation of the
+// advanced types too, which should still fail the build.
 #[allow(deprecated)]
 use zenoh_ext::{FetchingSubscriber, SubscriberBuilderExt};
 
@@ -296,6 +305,10 @@ fn the_callback_guard_fires_when_the_callback_never_runs() {
 // The reachable re-entrant surface here is `FetchingSubscriber::fetch`, which
 // resolves to `register_handler` and takes the same mutex. A callback that
 // publishes re-enters through zenoh's synchronous local delivery instead.
+//
+// The type is deprecated, not removed. It still ships and still compiles, so a
+// user who has not migrated gets a hang rather than a warning. That is why
+// these scenarios exist despite the `#[allow(deprecated)]` they cost.
 // ---------------------------------------------------------------------------
 
 /// The querying subscriber under test, parked so its own callback can re-enter


### PR DESCRIPTION
## Summary

Two `zenoh-ext` subscribers call user code while they hold a non-reentrant `std::sync::Mutex`. A callback that re-enters the subscriber takes a mutex its own thread already holds. The thread then waits on itself.

This PR records each call under the guard. It replays the call after it releases the guard. `AdvancedSubscriber` and `QueryingSubscriber` both get the fix.

## What changes for a user

| a callback that … | before | after |
|---|---|---|
| undeclares or registers a sample-miss listener | **deadlocks** | works |
| calls `fetch` on a `FetchingSubscriber` | **deadlocks** | works |
| publishes to its own subscriber, conditionally | **deadlocks** | works |
| publishes to its own subscriber on *every* sample | deadlocks | livelocks — still its own recursion (**B5**) |
| panics while another thread stages a call | poisons the mutex, and the subscriber stops working | the subscriber stays usable (**B6**) |

The API does not change. Callbacks still never run concurrently. Samples still arrive in the order the state machine produced them.

## Why it deadlocks

```mermaid
sequenceDiagram
    autonumber
    participant App as Publishing thread
    participant Sub as zenoh-ext subscriber
    participant Core as Session

    App->>Sub: sample arrives
    activate Sub
    Sub->>Sub: zlock!(state)
    Sub->>App: user callback runs, guard held
    App->>Core: publish, fetch, or drop a handle
    Core->>Sub: re-enters on the same thread
    Sub--xSub: zlock!(state) — this thread holds it
    Note over Sub: the thread waits on itself
    deactivate Sub
```

Step 6 takes several shapes. `SampleMissListener::drop` and `SampleMissListenerBuilder::wait` take `statesref`. `FetchingSubscriber::fetch` resolves to `register_handler`, which takes `state`. A callback that publishes re-enters through the session's synchronous local delivery.

The `Drop` shapes reach a user unannounced. A user does not read "drop a value" as "re-enter the middleware".

## The fix

The state walk and the callout interleave, so the callout cannot simply move out of the locked region. Each state gains a FIFO outbox and a `delivering` marker. A thread stages its call under the guard. One thread claims the delivering role and drains the outbox with the guard released.

| | before | after |
|---|---|---|
| state walk | under the guard | under the guard, unchanged |
| the callout | **under the guard** | staged, then called with the guard released |
| delivery order | the guard serialised it | the FIFO preserves it |
| two threads delivering | the guard excluded them | the marker excludes them |
| a callback that re-enters | deadlocks | stages its work and returns |

Each staged call carries the callback handle it is for. An undeclare between the stage and the drain therefore cannot discard the sample.

The two files keep separate copies of this mechanism. `QueryingSubscriber` needs no condition variable. It is also deprecated, so sharing the code would tie a deprecated type's lifetime to the current one's.

## What fails without this

| control | tests | result |
|---|---|---|
| `main`, plus the test file | `AdvancedSubscriber` scenarios | fail: `Got Deadlocked.` |
| commit 1, plus the test file, `querying_subscriber.rs` untouched | 5 reentrancy tests | `3 passed, 2 failed` — the two new ones, both `Deadlocked` |

The second control keeps the first fix and removes only the second. The two new tests therefore pin the second commit.

> [!NOTE]
> Commits 3 to 5 have no failing baseline, and a test cannot honestly give them one. Each closes a race that needs an undeclare, a panic, or a stage to land inside a window bounded by one guard release and the next acquisition. A test that hit such a window would be timing-dependent. A test that missed it would read as proof of absence. The argument for each is the control flow, stated at the code.

## Behaviour changes

| | change | who is affected | action |
|---|---|---|---|
| **B1** | `wait_callbacks()` now blocks. It was a no-op | callers who relied on an immediate return | none, unless you depended on the no-op |
| **B2** | callbacks run with the state guard released | callbacks that observed the implicit exclusion | none: exclusion and ordering are preserved |
| **B3** | another thread may deliver your sample | callbacks that read thread-local state | audit callbacks for thread affinity |
| **B4** | the outbox is not backpressure | a producer faster than the callback | none today: the queue grows where the producer used to block |
| **B5** | an unconditional republish livelocks instead of deadlocking | callbacks that publish on every sample | make the republish conditional |
| **B6** | a panicking callback no longer poisons the state mutex | callbacks that panic | none: calls staged during the panic are discarded |

**B3 and B4 are the two to read.** The subscriber never promised a delivering thread, but one thread delivering another thread's sample is new. And the state mutex used to throttle a fast producer as a side effect; nothing bounds the queue now. A bound means dropping samples or restoring a block. Both are larger decisions than removing the deadlock, so this PR does not take them.

## Performance

| added, per delivered sample | note |
|---|---|
| two more uncontended acquisitions of the state mutex | stage, claim the role, then the empty-check that releases it |
| one `Arc` clone and drop | the callback handle each staged call carries |
| a `VecDeque` push, and a drain into the deliverer's buffer | no allocation in steady state: both buffers keep their capacity |
| one `notify_all` with no waiters | a futex check, not a syscall |

That is tens of nanoseconds on a path that has already crossed the network. Contention improves in the case that used to be worst: a slow callback no longer blocks the threads that arrive during it.

Heap residency is one slot per queued call. A slot holds ~280 bytes, because `Call::Sample` is larger than `Call::Miss`. The queue holds about one call while delivery keeps up. Queue depth under a faster producer is **B4**.

> [!NOTE]
> Both readings come from the code. No benchmark was run.

## Testing

`zenoh-ext/tests/reentrancy.rs` adds 5 scenarios. A timeout alone proves nothing, because "the callback ran and wedged" and "the callback never ran" look the same from outside. So:

- Each scenario asserts that it entered the callback.
- `run_scenario` returns `Completed`, `Deadlocked` or `Panicked`. It therefore never reports an assertion failure as a hang.
- `the_callback_guard_fires_when_the_callback_never_runs` is the positive control. It proves the guard executes.
- The scenarios disable scouting, gossip and listeners. They are single-process and need no network.

Full `zenoh-ext` suite: 30 passed, 0 failed. The checks on this page are the current CI state.

This PR adds one `#[allow]`, on the `Call` enum. `clippy::large_enum_variant` wants `Sample` boxed. Boxing it would put a heap allocation on the hot path to shrink a queue that is empty whenever delivery keeps up.

## Breaking changes

None. No public signature, type or name changes.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [x] **Reproduction test added** - Test that fails on main branch without the fix
- [x] **Test passes with fix** - The reproduction test passes with your changes
- [x] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->

