### PR TITLE
feat(tls): check full-chain CRLs on mTLS handshake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5243,6 +5243,7 @@ version = "1.10.0"
 dependencies = [
  "async-trait",
  "base64",
+ "rcgen",
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -715,6 +715,11 @@
         /// If set to true, links that require certificates (tls/quic) will automatically disconnect when the time of expiration of the remote certificate chain is reached
         /// note that mTLS (client authentication) is required for a listener to disconnect a client on expiration
         close_link_on_expiration: false,
+        /// Paths to PEM or DER CRLs used to check remote certificate revocation.
+        /// Provide a CRL for each CA in the trust path (root and any intermediates).
+        /// When set, rustls checks the full presented chain; a cert without matching CRL coverage is rejected.
+        /// CRLs are loaded at listen/connect time (restart to pick up a new file).
+        crl: null,
         /// Optional configuration for TCP system buffers sizes for TLS links
         ///
         /// Configure TCP read buffer size (bytes)

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -786,6 +786,10 @@ validated_struct::validator! {
                     connect_certificate: Option<String>,
                     verify_name_on_connect: Option<bool>,
                     close_link_on_expiration: Option<bool>,
+                    /// PEM or DER CRL files used to check remote certificate revocation.
+                    /// Provide a CRL for each CA in the presented chain. When set, the
+                    /// full chain is checked; missing CRL coverage fails the handshake.
+                    crl: Option<Vec<String>>,
                     /// Configure TCP write buffer size
                     pub so_sndbuf: Option<u32>,
                     /// Configure TCP read buffer size

--- a/io/zenoh-link-commons/Cargo.toml
+++ b/io/zenoh-link-commons/Cargo.toml
@@ -40,7 +40,7 @@ quic = [
   "dep:zenoh-config",
   "tls",
 ]
-tls = ["dep:rustls", "dep:rustls-webpki"]
+tls = ["dep:rustls", "dep:rustls-webpki", "dep:rustls-pemfile"]
 unsecure_quic = ["quic"]
 uring = []
 

--- a/io/zenoh-link-commons/src/quic/utils.rs
+++ b/io/zenoh-link-commons/src/quic/utils.rs
@@ -24,7 +24,6 @@ use quinn::{crypto::rustls::HandshakeData, TransportConfig};
 use rustls::{
     crypto::CryptoProvider,
     pki_types::{CertificateDer, PrivateKeyDer, TrustAnchor},
-    server::WebPkiClientVerifier,
     version::TLS13,
     ClientConfig, RootCertStore, ServerConfig,
 };
@@ -44,7 +43,10 @@ use crate::{
         plaintext::{SkipServerVerification, SELF_SIGNED_CERT},
         unicast::MultiStreamConfig,
     },
-    tls::{config::*, WebPkiVerifierAnyServerName},
+    tls::{
+        config::*, load_crls, webpki_client_cert_verifier, webpki_server_cert_verifier,
+        WebPkiVerifierAnyServerName,
+    },
     ConfigurationInspector, LinkAuthId,
 };
 
@@ -174,6 +176,15 @@ impl ConfigurationInspector<ZenohConfig> for TlsConfigurator {
             false => ps.push((TLS_CLOSE_LINK_ON_EXPIRATION, "false")),
         }
 
+        let crl_paths = c
+            .crl()
+            .as_ref()
+            .filter(|paths| !paths.is_empty())
+            .map(|paths| paths.join("|"));
+        if let Some(ref crl_paths) = crl_paths {
+            ps.push((TLS_CRL_FILE, crl_paths));
+        }
+
         Ok(parameters::from_iter(ps.drain(..)))
     }
 }
@@ -270,7 +281,8 @@ impl TlsServerConfig {
                 || Err(zerror!("Missing root certificates while mTLS is enabled.")),
                 Ok,
             )?;
-            let client_auth = WebPkiClientVerifier::builder(root_cert_store.into()).build()?;
+            let crls = load_crls(config)?;
+            let client_auth = webpki_client_cert_verifier(root_cert_store, crls)?;
             ServerConfig::builder_with_protocol_versions(&[&TLS13])
                 .with_client_cert_verifier(client_auth)
                 .with_single_cert(certs, keys.remove(0))
@@ -401,6 +413,11 @@ impl TlsClientConfig {
             root_cert_store.extend(custom_root_cert.roots);
         }
 
+        let crls = load_crls(config)?;
+        if !crls.is_empty() && !tls_server_name_verification {
+            tracing::warn!("TLS CRLs are ignored when verify_name_on_connect is false");
+        }
+
         let cc = if tls_client_server_auth {
             tracing::debug!("Loading client authentication key and certificate...");
             let tls_client_private_key = TlsClientConfig::load_tls_private_key(config).await?;
@@ -439,9 +456,15 @@ impl TlsClientConfig {
             let builder = ClientConfig::builder_with_protocol_versions(&[&TLS13]);
 
             if tls_server_name_verification {
-                builder
-                    .with_root_certificates(root_cert_store)
-                    .with_client_auth_cert(certs, keys.remove(0))
+                if crls.is_empty() {
+                    builder
+                        .with_root_certificates(root_cert_store)
+                        .with_client_auth_cert(certs, keys.remove(0))
+                } else {
+                    builder
+                        .with_webpki_verifier(webpki_server_cert_verifier(root_cert_store, crls)?)
+                        .with_client_auth_cert(certs, keys.remove(0))
+                }
             } else {
                 builder
                     .dangerous()
@@ -454,9 +477,15 @@ impl TlsClientConfig {
         } else {
             let builder = ClientConfig::builder();
             if tls_server_name_verification {
-                builder
-                    .with_root_certificates(root_cert_store)
-                    .with_no_client_auth()
+                if crls.is_empty() {
+                    builder
+                        .with_root_certificates(root_cert_store)
+                        .with_no_client_auth()
+                } else {
+                    builder
+                        .with_webpki_verifier(webpki_server_cert_verifier(root_cert_store, crls)?)
+                        .with_no_client_auth()
+                }
             } else {
                 builder
                     .dangerous()

--- a/io/zenoh-link-commons/src/tls.rs
+++ b/io/zenoh-link-commons/src/tls.rs
@@ -1,16 +1,19 @@
 use alloc::vec::Vec;
+use std::{fs, io::Cursor, sync::Arc};
 
 use rustls::{
     client::{
         danger::{ServerCertVerified, ServerCertVerifier},
-        verify_server_cert_signed_by_trust_anchor,
+        verify_server_cert_signed_by_trust_anchor, WebPkiServerVerifier,
     },
     crypto::{verify_tls12_signature, verify_tls13_signature},
-    pki_types::{CertificateDer, ServerName, UnixTime},
-    server::ParsedCertificate,
+    pki_types::{CertificateDer, CertificateRevocationListDer, ServerName, UnixTime},
+    server::{danger::ClientCertVerifier, ParsedCertificate, WebPkiClientVerifier},
     RootCertStore,
 };
 use webpki::ALL_VERIFICATION_ALGS;
+use zenoh_protocol::core::endpoint::Config;
+use zenoh_result::{bail, zerror, ZResult};
 
 pub mod config {
     pub const TLS_ROOT_CA_CERTIFICATE_FILE: &str = "root_ca_certificate_file";
@@ -42,9 +45,89 @@ pub mod config {
     pub const TLS_CLOSE_LINK_ON_EXPIRATION: &str = "close_link_on_expiration";
     pub const TLS_CLOSE_LINK_ON_EXPIRATION_DEFAULT: bool = false;
 
+    /// `|`-separated list of CRL file paths (PEM or DER).
+    pub const TLS_CRL_FILE: &str = "crl";
+
     /// The time duration in milliseconds to wait for the TLS handshake to complete.
     pub const TLS_HANDSHAKE_TIMEOUT_MS: &str = "tls_handshake_timeout_ms";
     pub const TLS_HANDSHAKE_TIMEOUT_MS_DEFAULT: u64 = 10_000;
+}
+
+fn looks_like_pem(bytes: &[u8]) -> bool {
+    let start = bytes
+        .iter()
+        .position(|b| !b.is_ascii_whitespace())
+        .unwrap_or(bytes.len());
+    bytes[start..].starts_with(b"-----BEGIN")
+}
+
+/// Parse one or more CRLs from PEM (possibly concatenated) or a single DER blob.
+pub fn parse_crls(bytes: &[u8]) -> ZResult<Vec<CertificateRevocationListDer<'static>>> {
+    let pem_crls = rustls_pemfile::crls(&mut Cursor::new(bytes))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|err| zerror!("Error processing PEM CRL: {err}."))?;
+    if !pem_crls.is_empty() {
+        return Ok(pem_crls);
+    }
+    if looks_like_pem(bytes) {
+        bail!("PEM file contains no CRLs");
+    }
+    if bytes.iter().all(u8::is_ascii_whitespace) {
+        bail!("Empty CRL");
+    }
+    Ok(vec![CertificateRevocationListDer::from(bytes.to_vec())])
+}
+
+/// Load CRLs from `crl` file paths (`|`-separated in endpoint config).
+pub fn load_crls(config: &Config<'_>) -> ZResult<Vec<CertificateRevocationListDer<'static>>> {
+    let mut crls = Vec::new();
+    for path in config.values(config::TLS_CRL_FILE) {
+        if path.is_empty() {
+            continue;
+        }
+        let bytes =
+            fs::read(path).map_err(|err| zerror!("Invalid TLS CRL file '{path}': {err}"))?;
+        let parsed = parse_crls(&bytes)
+            .map_err(|err| zerror!("Error processing TLS CRL file '{path}': {err}"))?;
+        if parsed.is_empty() {
+            bail!("No CRL found in '{path}'");
+        }
+        crls.extend(parsed);
+    }
+    Ok(crls)
+}
+
+/// Client-cert verifier. When `crls` is non-empty, rustls checks the full chain
+/// (not only the leaf) and rejects unknown revocation status.
+pub fn webpki_client_cert_verifier(
+    roots: RootCertStore,
+    crls: Vec<CertificateRevocationListDer<'static>>,
+) -> ZResult<Arc<dyn ClientCertVerifier>> {
+    let builder = WebPkiClientVerifier::builder(roots.into());
+    let builder = if crls.is_empty() {
+        builder
+    } else {
+        builder.with_crls(crls)
+    };
+    builder
+        .build()
+        .map_err(|err| zerror!("TLS client certificate verifier: {err}").into())
+}
+
+/// Server-cert verifier with optional CRLs (full chain, unknown status is an error).
+pub fn webpki_server_cert_verifier(
+    roots: RootCertStore,
+    crls: Vec<CertificateRevocationListDer<'static>>,
+) -> ZResult<Arc<WebPkiServerVerifier>> {
+    let builder = WebPkiServerVerifier::builder(roots.into());
+    let builder = if crls.is_empty() {
+        builder
+    } else {
+        builder.with_crls(crls)
+    };
+    builder
+        .build()
+        .map_err(|err| zerror!("TLS server certificate verifier: {err}").into())
 }
 
 impl ServerCertVerifier for WebPkiVerifierAnyServerName {

--- a/io/zenoh-links/zenoh-link-tls/Cargo.toml
+++ b/io/zenoh-links/zenoh-link-tls/Cargo.toml
@@ -51,5 +51,8 @@ zenoh-protocol = { workspace = true }
 zenoh-result = { workspace = true }
 zenoh-runtime = { workspace = true }
 
+[dev-dependencies]
+rcgen = { workspace = true }
+
 [package.metadata.cargo-machete]
 ignored = ["rustls-webpki"]

--- a/io/zenoh-links/zenoh-link-tls/src/utils.rs
+++ b/io/zenoh-links/zenoh-link-tls/src/utils.rs
@@ -23,7 +23,6 @@ use std::{
 
 use rustls::{
     pki_types::{CertificateDer, PrivateKeyDer, TrustAnchor},
-    server::WebPkiClientVerifier,
     version::TLS13,
     ClientConfig, RootCertStore, ServerConfig,
 };
@@ -36,6 +35,7 @@ use zenoh_link_commons::{
     tcp::TcpSocketConfig,
     tls::{
         config::{self, *},
+        load_crls, webpki_client_cert_verifier, webpki_server_cert_verifier,
         WebPkiVerifierAnyServerName,
     },
     ConfigurationInspector, BIND_INTERFACE, BIND_SOCKET, TCP_SO_RCV_BUF, TCP_SO_SND_BUF,
@@ -156,6 +156,15 @@ impl ConfigurationInspector<ZenohConfig> for TlsConfigurator {
             false => ps.push((TLS_CLOSE_LINK_ON_EXPIRATION, "false")),
         }
 
+        let crl_paths = c
+            .crl()
+            .as_ref()
+            .filter(|paths| !paths.is_empty())
+            .map(|paths| paths.join("|"));
+        if let Some(ref crl_paths) = crl_paths {
+            ps.push((TLS_CRL_FILE, crl_paths));
+        }
+
         let rx_buffer_size;
         if let Some(size) = c.so_rcvbuf() {
             rx_buffer_size = size.to_string();
@@ -240,7 +249,8 @@ impl<'a> TlsServerConfig<'a> {
                 || Err(zerror!("Missing root certificates while mTLS is enabled.")),
                 Ok,
             )?;
-            let client_auth = WebPkiClientVerifier::builder(root_cert_store.into()).build()?;
+            let crls = load_crls(config)?;
+            let client_auth = webpki_client_cert_verifier(root_cert_store, crls)?;
             ServerConfig::builder_with_protocol_versions(&[&TLS13])
                 .with_client_cert_verifier(client_auth)
                 .with_single_cert(certs, keys.remove(0))
@@ -357,6 +367,11 @@ impl<'a> TlsClientConfig<'a> {
             root_cert_store.extend(custom_root_cert.roots);
         }
 
+        let crls = load_crls(config)?;
+        if !crls.is_empty() && !tls_server_name_verification {
+            tracing::warn!("TLS CRLs are ignored when verify_name_on_connect is false");
+        }
+
         // Install ring based rustls CryptoProvider.
         rustls::crypto::ring::default_provider()
             // This can be called successfully at most once in any process execution.
@@ -405,9 +420,15 @@ impl<'a> TlsClientConfig<'a> {
             let builder = ClientConfig::builder_with_protocol_versions(&[&TLS13]);
 
             if tls_server_name_verification {
-                builder
-                    .with_root_certificates(root_cert_store)
-                    .with_client_auth_cert(certs, keys.remove(0))
+                if crls.is_empty() {
+                    builder
+                        .with_root_certificates(root_cert_store)
+                        .with_client_auth_cert(certs, keys.remove(0))
+                } else {
+                    builder
+                        .with_webpki_verifier(webpki_server_cert_verifier(root_cert_store, crls)?)
+                        .with_client_auth_cert(certs, keys.remove(0))
+                }
             } else {
                 builder
                     .dangerous()
@@ -420,9 +441,15 @@ impl<'a> TlsClientConfig<'a> {
         } else {
             let builder = ClientConfig::builder();
             if tls_server_name_verification {
-                builder
-                    .with_root_certificates(root_cert_store)
-                    .with_no_client_auth()
+                if crls.is_empty() {
+                    builder
+                        .with_root_certificates(root_cert_store)
+                        .with_no_client_auth()
+                } else {
+                    builder
+                        .with_webpki_verifier(webpki_server_cert_verifier(root_cert_store, crls)?)
+                        .with_no_client_auth()
+                }
             } else {
                 builder
                     .dangerous()
@@ -604,4 +631,177 @@ pub fn get_tls_host<'a>(address: &'a Address<'a>) -> ZResult<&'a str> {
 
 pub fn get_tls_server_name<'a>(address: &'a Address<'a>) -> ZResult<ServerName<'a>> {
     Ok(ServerName::try_from(get_tls_host(address)?).map_err(|e| zerror!(e))?)
+}
+
+#[cfg(test)]
+mod tests {
+    use rcgen::{
+        BasicConstraints, CertificateParams, CertificateRevocationListParams, CertifiedIssuer,
+        DistinguishedName, DnType, ExtendedKeyUsagePurpose, IsCa, Issuer, KeyIdMethod, KeyPair,
+        KeyUsagePurpose, RevocationReason, RevokedCertParams, SerialNumber,
+    };
+    use rustls::{
+        pki_types::{CertificateDer, CertificateRevocationListDer, UnixTime},
+        RootCertStore,
+    };
+    use time::{Duration, OffsetDateTime};
+    use zenoh_link_commons::tls::parse_crls;
+
+    use super::*;
+
+    const LEAF_SERIAL: u64 = 42;
+    const ISSUER_SERIAL: u64 = 7;
+
+    fn install_crypto() {
+        rustls::crypto::ring::default_provider()
+            .install_default()
+            .ok();
+    }
+
+    fn ca_params(cn: &str, serial: u64) -> CertificateParams {
+        let mut params = CertificateParams::new(Vec::<String>::new()).unwrap();
+        let mut dn = DistinguishedName::new();
+        dn.push(DnType::CommonName, cn);
+        params.distinguished_name = dn;
+        params.serial_number = Some(SerialNumber::from(serial));
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+        params
+    }
+
+    fn crl(issuer: &Issuer<'_, KeyPair>, revoked: &[u64]) -> CertificateRevocationListDer<'static> {
+        let now = OffsetDateTime::now_utc();
+        CertificateRevocationListParams {
+            this_update: now - Duration::hours(1),
+            next_update: now + Duration::hours(1),
+            crl_number: SerialNumber::from(1),
+            issuing_distribution_point: None,
+            revoked_certs: revoked
+                .iter()
+                .map(|serial| RevokedCertParams {
+                    serial_number: SerialNumber::from(*serial),
+                    revocation_time: now - Duration::minutes(1),
+                    reason_code: Some(RevocationReason::KeyCompromise),
+                    invalidity_date: None,
+                })
+                .collect(),
+            key_identifier_method: KeyIdMethod::Sha256,
+        }
+        .signed_by(issuer)
+        .unwrap()
+        .into()
+    }
+
+    struct Chain {
+        roots: RootCertStore,
+        leaf: CertificateDer<'static>,
+        issuer: CertificateDer<'static>,
+        root_issuer: CertifiedIssuer<'static, KeyPair>,
+        issuer_ca: CertifiedIssuer<'static, KeyPair>,
+    }
+
+    fn chain() -> Chain {
+        let root =
+            CertifiedIssuer::self_signed(ca_params("test-root", 1), KeyPair::generate().unwrap())
+                .unwrap();
+        let issuer_ca = CertifiedIssuer::signed_by(
+            ca_params("test-issuer", ISSUER_SERIAL),
+            KeyPair::generate().unwrap(),
+            &root,
+        )
+        .unwrap();
+
+        let mut leaf_params = CertificateParams::new(Vec::<String>::new()).unwrap();
+        let mut dn = DistinguishedName::new();
+        dn.push(DnType::CommonName, "device");
+        leaf_params.distinguished_name = dn;
+        leaf_params.serial_number = Some(SerialNumber::from(LEAF_SERIAL));
+        leaf_params.is_ca = IsCa::NoCa;
+        leaf_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ClientAuth];
+        let leaf_key = KeyPair::generate().unwrap();
+        let leaf = leaf_params.signed_by(&leaf_key, &issuer_ca).unwrap();
+
+        let mut roots = RootCertStore::empty();
+        roots.add(root.der().clone()).unwrap();
+        Chain {
+            roots,
+            leaf: leaf.der().clone(),
+            issuer: issuer_ca.der().clone(),
+            root_issuer: root,
+            issuer_ca,
+        }
+    }
+
+    fn verify(
+        roots: RootCertStore,
+        crls: Vec<CertificateRevocationListDer<'static>>,
+        leaf: &CertificateDer<'_>,
+        issuer: &CertificateDer<'_>,
+    ) -> Result<(), rustls::Error> {
+        install_crypto();
+        let verifier = webpki_client_cert_verifier(roots, crls).unwrap();
+        rustls::server::danger::ClientCertVerifier::verify_client_cert(
+            verifier.as_ref(),
+            leaf,
+            std::slice::from_ref(issuer),
+            UnixTime::now(),
+        )
+        .map(|_| ())
+    }
+
+    #[test]
+    fn parse_der_and_pem_crls() {
+        let chain = chain();
+        let der = crl(&chain.issuer_ca, &[]);
+        assert_eq!(parse_crls(&der).unwrap().len(), 1);
+
+        let pem = rcgen::CertificateRevocationListParams {
+            this_update: OffsetDateTime::now_utc() - Duration::hours(1),
+            next_update: OffsetDateTime::now_utc() + Duration::hours(1),
+            crl_number: SerialNumber::from(1),
+            issuing_distribution_point: None,
+            revoked_certs: vec![],
+            key_identifier_method: KeyIdMethod::Sha256,
+        }
+        .signed_by(&chain.issuer_ca)
+        .unwrap()
+        .pem()
+        .unwrap();
+        assert_eq!(parse_crls(pem.as_bytes()).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn full_chain_accepts_empty_crls() {
+        let chain = chain();
+        let crls = vec![crl(&chain.root_issuer, &[]), crl(&chain.issuer_ca, &[])];
+        verify(chain.roots, crls, &chain.leaf, &chain.issuer).unwrap();
+    }
+
+    #[test]
+    fn full_chain_rejects_revoked_leaf() {
+        let chain = chain();
+        let crls = vec![
+            crl(&chain.root_issuer, &[]),
+            crl(&chain.issuer_ca, &[LEAF_SERIAL]),
+        ];
+        assert!(verify(chain.roots, crls, &chain.leaf, &chain.issuer).is_err());
+    }
+
+    #[test]
+    fn full_chain_rejects_revoked_issuer() {
+        let chain = chain();
+        let crls = vec![
+            crl(&chain.root_issuer, &[ISSUER_SERIAL]),
+            crl(&chain.issuer_ca, &[]),
+        ];
+        assert!(verify(chain.roots, crls, &chain.leaf, &chain.issuer).is_err());
+    }
+
+    #[test]
+    fn full_chain_requires_both_crls() {
+        let chain = chain();
+        // Issuer CRL only: rustls treats the intermediate as unknown revocation status.
+        let crls = vec![crl(&chain.issuer_ca, &[])];
+        assert!(verify(chain.roots, crls, &chain.leaf, &chain.issuer).is_err());
+    }
 }


### PR DESCRIPTION
Load PEM/DER CRL files from transport.link.tls.crl and pass them to rustls so leaf and issuer revocation are both enforced.

## Description

Using mtls authentication currently only verifies that the presented certificate is signed by a trusted authority. Some use cases require being able to revoke the ability of a client to connect by presenting a certificate if this certificate has been revoked. A commonly used solution is to distribute CRLs and enforce them at client / server tls connection.

### What does this PR do?

This PR implements certificate revocation check with Certificate Revocation Lists .

It defines a new transport.link.tls.crl option int he config file that can reference one or multiple local files with their filesystem path. 

If one or multiple CRLs are given it expects all certificates in the trust chain (except the trust root) to be validates against a CRL, so e.g. if you use one intermediate certificate authority, you must provide the CRL of the root CA and the CRL of the intermediate CA.

### Why is this change needed?

zenoh does not currently provide any way to take into account certificates revocation.

### Related Issues

None but I can write one if needed, feel free to ask.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

**No specific label requirements detected.**

Current labels: _No labels_

Add one of these labels to this PR to see relevant checklist items: `api-sync`, `breaking-change`, `bug`, `ci`, `dependencies`, `documentation`, `enhancement`, `new feature`, `internal`

*This section updates automatically when labels change.*

<!-- 🏷️ Label-Based Checklist END -->