### PR TITLE
feat(acl): load per-identity access control from a policy store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic-queue"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,7 +554,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
+ "futures-core",
  "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -608,6 +621,21 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -900,6 +928,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dtoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,6 +950,9 @@ name = "either"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "env_home"
@@ -958,6 +995,17 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1126,6 +1174,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,6 +1332,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1294,6 +1355,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1310,6 +1380,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
 
 [[package]]
 name = "hmac"
@@ -1893,7 +1972,10 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
+ "bitflags 2.13.1",
  "libc",
+ "plain",
+ "redox_syscall 0.9.2",
 ]
 
 [[package]]
@@ -1979,6 +2061,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -2339,7 +2431,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -2508,6 +2600,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -2934,10 +3032,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "redis"
+version = "0.32.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "014cc767fefab6a3e798ca45112bccad9c6e0e218fbd49720042716c73cfef44"
+dependencies = [
+ "bytes",
+ "cfg-if",
+ "combine",
+ "futures-util",
+ "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "ryu",
+ "socket2 0.6.5",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1c93da5bb2c5d4e6c0ef7abeead62c89169a0a4882bfb83ac892f2423aea2fe"
 dependencies = [
  "bitflags 2.13.1",
 ]
@@ -3465,6 +3596,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sha2-const-stable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3553,6 +3695,9 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -3597,6 +3742,126 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-postgres",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap 2.14.0",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rustls",
+ "rustls-native-certs",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror 2.0.20",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-postgres",
+ "syn 2.0.119",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags 2.13.1",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.7",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.20",
+ "tracing",
+ "whoami",
 ]
 
 [[package]]
@@ -3671,6 +3936,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -3991,6 +4267,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4012,6 +4299,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -4301,10 +4589,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-xid"
@@ -4481,6 +4790,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4573,6 +4888,16 @@ dependencies = [
  "env_home",
  "rustix",
  "winsafe",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
 ]
 
 [[package]]
@@ -4689,11 +5014,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4707,19 +5041,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
+ "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm",
+ "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -4735,6 +5090,12 @@ checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4744,6 +5105,12 @@ name = "windows_i686_gnu"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4765,6 +5132,12 @@ checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4777,9 +5150,21 @@ checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4792,6 +5177,12 @@ name = "windows_x86_64_msvc"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4919,17 +5310,21 @@ dependencies = [
  "json5",
  "lazy_static",
  "libc",
+ "lru",
  "nonempty-collections",
  "once_cell",
  "petgraph 0.8.3",
  "phf",
  "predicates 3.1.4",
  "rand 0.8.7",
+ "redis",
  "regex",
  "rustc_version",
+ "secrecy",
  "serde",
  "serde_json",
  "socket2 0.5.10",
+ "sqlx",
  "test-case",
  "tokio",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,6 +155,9 @@ quote = "1.0.40"
 rand = { version = "0.8.5", default-features = false } # Default features are disabled due to usage in no_std crates
 rand_chacha = "0.3.1"
 rcgen = "0.14.7"
+redis = { version = "0.32.2", default-features = false, features = [
+  "tokio-rustls-comp",
+] }
 regex = "1.11.2"
 ringbuffer-spsc = "0.1.15"
 rlimit = "0.10.2"
@@ -182,6 +185,11 @@ sha3 = "0.10.8"
 shellexpand = "3.1.1"
 smallvec = "1.15.1"
 socket2 = { version = "0.5.7", features = ["all"] }
+sqlx = { version = "0.8", default-features = false, features = [
+  "postgres",
+  "runtime-tokio",
+  "tls-rustls-ring-native-roots",
+] }
 stabby = "72.1.8"
 static_assertions = "1.1.0"
 static_init = "1.0.3"

--- a/DEFAULT_CONFIG.json5
+++ b/DEFAULT_CONFIG.json5
@@ -499,7 +499,55 @@
   //       "rules": ["rule2"],
   //       "subjects": ["subject3", "subject4"],
   //     },
-  //   ]
+  //   ],
+  //   /// An ACL document for each peer identity can additionally be read from a policy
+  //   /// store, where an external process is responsible for keeping it up to date. The
+  //   /// lists declared above then hold what applies to everyone.
+  //   /// Redis requires zenoh to be built with the `acl_redis` feature, Postgres with
+  //   /// `acl_postgres`.
+  //   "policy_store": {
+  //     /// Authentication attribute used as the peer identity: "cert_common_name",
+  //     /// "username" or "zenoh_id".
+  //     "identity": "cert_common_name",
+  //     /// Delay after which the document for a still connected identity is read again.
+  //     /// Set to null to never read it again on its own, leaving explicit refreshes as
+  //     /// the only way a change reaches a connected identity.
+  //     "entry_ttl_ms": 300000,
+  //     /// Largest number of identity documents kept in memory. Defaults to
+  //     /// transport.unicast.max_sessions so every admitted session can stay cached.
+  //     /// Raise both together. When full, the least recently fetched identity is
+  //     /// dropped; live interceptors are unchanged. If interceptor config reload is used,
+  //     /// keep it at that size: reload rebuilds every interceptor from the cache and
+  //     /// would deny faces evicted while the others were prepared.
+  //     "cache_capacity": 1000,
+  //     /// "redis" or "postgres".
+  //     "type": "redis",
+  //     /// A username may be part of the url, e.g. `redis://user@127.0.0.1:6379` or
+  //     /// `postgres://user@127.0.0.1:5432/zenoh`, but the password must be set separately
+  //     /// so that it is never serialized back out. Use `rediss://` for Redis TLS.
+  //     /// Postgres: add `sslmode=verify-full` to encrypt and verify the server
+  //     /// certificate.
+  //     /// `root_ca_certificate` is a PEM file for a private CA (Redis or Postgres);
+  //     /// omit it to use the native certificate store.
+  //     "url": "redis://127.0.0.1:6379",
+  //     "password": "the-store-password",
+  //     /// Redis: the value stored at "<key_prefix><identity>" is a JSON object holding
+  //     /// the same "rules", "subjects" and "policies" fields as above. Postgres: that
+  //     /// JSON lives in `document_column` of the row whose `identity_column` matches,
+  //     /// in `table` (`name` or `schema.name`).
+  //     /// An identity with no document is enforced with "default_permission"; one
+  //     /// whose document cannot be read is refused at connection. Ids must not collide
+  //     /// with the lists declared here.
+  //     "key_prefix": "zenoh:acl:",
+  //     "table": "zenoh_acl",
+  //     "identity_column": "identity",
+  //     "document_column": "document",
+  //     "root_ca_certificate": "./store-ca.pem",
+  //     /// Timeout of a single store operation.
+  //     "timeout_ms": 3000,
+  //     /// Postgres: largest number of connections to the worker database.
+  //     "pool_size": 8,
+  //   },
   // },
 
   // low_pass_filter: [

--- a/commons/zenoh-config/src/defaults.rs
+++ b/commons/zenoh-config/src/defaults.rs
@@ -351,6 +351,7 @@ impl Default for AclConfig {
             rules: None,
             subjects: None,
             policies: None,
+            policy_store: None,
         }
     }
 }

--- a/commons/zenoh-config/src/lib.rs
+++ b/commons/zenoh-config/src/lib.rs
@@ -340,6 +340,180 @@ pub struct AclConfigPolicyEntry {
     pub subjects: Vec<String>,
 }
 
+/// Redis backend of [`AclPolicyStoreConf`].
+///
+/// An identity's document is stored at `<key_prefix><identity>` as a JSON object with the
+/// same `rules`, `subjects` and `policies` fields as the `access_control` section.
+#[derive(Serialize, Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct AclRedisConf {
+    /// Connection url, e.g. `redis://127.0.0.1:6379` or `rediss://` for TLS.
+    /// A username may be part of it, but the password must be set separately so that it
+    /// is not exposed when the configuration is serialized.
+    pub url: String,
+    // Skip serializing field because it contains a secret
+    #[serde(default, skip_serializing)]
+    pub password: Option<SecretValue>,
+    /// Prefix of the key holding an identity's document.
+    #[serde(default = "default_acl_redis_key_prefix")]
+    pub key_prefix: String,
+    /// PEM file of the CA that signed the server certificate. Used with `rediss://`.
+    #[serde(default)]
+    pub root_ca_certificate: Option<String>,
+    /// Timeout of a single Redis operation.
+    #[serde(default = "default_acl_redis_timeout_ms")]
+    pub timeout_ms: u64,
+}
+
+/// Postgres backend of [`AclPolicyStoreConf`].
+///
+/// An identity's document is the column named by `document_column` of the row whose
+/// `identity_column` matches, as a JSON object with the same `rules`, `subjects` and
+/// `policies` fields as the `access_control` section. The document column may be `text`
+/// or `jsonb`.
+#[derive(Serialize, Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct AclPostgresConf {
+    /// Connection url, e.g. `postgres://user@127.0.0.1:5432/zenoh`.
+    /// A username may be part of it, but the password must be set separately so that it
+    /// is not exposed when the configuration is serialized. Add `sslmode=verify-full` to
+    /// encrypt and verify the server certificate; `root_ca_certificate` is the PEM of a
+    /// private CA, or omit it to use the native store.
+    pub url: String,
+    // Skip serializing field because it contains a secret
+    #[serde(default, skip_serializing)]
+    pub password: Option<SecretValue>,
+    /// Table holding identity documents. `name` or `schema.name`.
+    #[serde(default = "default_acl_postgres_table")]
+    pub table: String,
+    /// Column matched against the peer identity.
+    #[serde(default = "default_acl_postgres_identity_column")]
+    pub identity_column: String,
+    /// Column holding the ACL JSON document.
+    #[serde(default = "default_acl_postgres_document_column")]
+    pub document_column: String,
+    /// PEM file of the CA that signed the server certificate.
+    #[serde(default)]
+    pub root_ca_certificate: Option<String>,
+    /// Timeout of a single Postgres operation.
+    #[serde(default = "default_acl_postgres_timeout_ms")]
+    pub timeout_ms: u64,
+    /// Largest number of connections kept to the database. Must not be zero.
+    #[serde(default = "default_acl_postgres_pool_size")]
+    pub pool_size: usize,
+}
+
+/// How an ACL document is fetched. Flattened into [`AclPolicyStoreConf`] so the
+/// configuration stays a single object with a `type` field.
+#[derive(Serialize, Debug, Deserialize, Clone)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AclPolicyStoreBackend {
+    Redis(AclRedisConf),
+    Postgres(AclPostgresConf),
+}
+
+/// External store of per-identity ACL documents.
+///
+/// Each document is read when a transport carrying that identity connects and merged with
+/// the lists declared in the configuration file, which therefore hold the rules applying to
+/// everyone. Ids must not collide between the two.
+///
+/// An identity whose key is absent is enforced with `default_permission`, the same as a
+/// transport that matches no ACL subject. An identity whose document cannot be read,
+/// because the store is unreachable for instance, is refused at connection.
+///
+/// Redis requires zenoh to be built with the `acl_redis` feature, Postgres with
+/// `acl_postgres`.
+#[derive(Serialize, Debug, Deserialize, Clone)]
+pub struct AclPolicyStoreConf {
+    /// Authentication attribute identifying a peer, used to build the key holding its
+    /// document.
+    pub identity: AclIdentitySource,
+    /// Delay after which the document for a still connected identity is read again.
+    /// Set to `null` to never read it again on its own, leaving explicit refreshes as the
+    /// only way a change reaches a connected identity.
+    #[serde(default = "default_acl_policy_store_entry_ttl_ms")]
+    pub entry_ttl_ms: Option<u64>,
+    /// Largest number of identity documents kept in memory. Defaults to
+    /// `transport.unicast.max_sessions` so every admitted session can stay cached. Raise
+    /// both together. When full, the least recently fetched identity is dropped; live
+    /// interceptors are unchanged. If interceptor config reload is used, keep it at that
+    /// size: reload rebuilds every interceptor from the cache and would deny faces
+    /// evicted while the others were prepared.
+    #[serde(default = "default_acl_policy_store_cache_capacity")]
+    pub cache_capacity: usize,
+    #[serde(flatten)]
+    pub backend: AclPolicyStoreBackend,
+}
+
+impl AclPolicyStoreConf {
+    pub fn redis(&self) -> &AclRedisConf {
+        match &self.backend {
+            AclPolicyStoreBackend::Redis(conf) => conf,
+            AclPolicyStoreBackend::Postgres(_) => {
+                panic!("policy store backend is postgres, not redis")
+            }
+        }
+    }
+
+    pub fn postgres(&self) -> &AclPostgresConf {
+        match &self.backend {
+            AclPolicyStoreBackend::Postgres(conf) => conf,
+            AclPolicyStoreBackend::Redis(_) => {
+                panic!("policy store backend is redis, not postgres")
+            }
+        }
+    }
+}
+
+/// Authentication attribute used as a peer identity in the policy store.
+#[derive(Serialize, Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AclIdentitySource {
+    /// Common name of the peer's TLS or QUIC certificate.
+    CertCommonName,
+    /// Name the peer authenticated with.
+    Username,
+    /// Zenoh id of the peer.
+    ZenohId,
+}
+
+fn default_acl_redis_key_prefix() -> String {
+    "zenoh:acl:".to_string()
+}
+
+fn default_acl_policy_store_entry_ttl_ms() -> Option<u64> {
+    Some(300_000)
+}
+
+fn default_acl_policy_store_cache_capacity() -> usize {
+    1_000
+}
+
+fn default_acl_redis_timeout_ms() -> u64 {
+    3_000
+}
+
+fn default_acl_postgres_table() -> String {
+    "zenoh_acl".to_string()
+}
+
+fn default_acl_postgres_identity_column() -> String {
+    "identity".to_string()
+}
+
+fn default_acl_postgres_document_column() -> String {
+    "document".to_string()
+}
+
+fn default_acl_postgres_timeout_ms() -> u64 {
+    3_000
+}
+
+fn default_acl_postgres_pool_size() -> usize {
+    8
+}
+
 #[derive(Clone, Serialize, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PolicyRule {
@@ -914,6 +1088,7 @@ validated_struct::validator! {
             pub rules: Option<Vec<AclConfigRule>>,
             pub subjects: Option<Vec<AclConfigSubjects>>,
             pub policies: Option<Vec<AclConfigPolicyEntry>>,
+            pub policy_store: Option<AclPolicyStoreConf>,
         },
 
         /// Configuration of the low-pass filter
@@ -969,6 +1144,231 @@ fn set_true() -> bool {
 }
 fn set_false() -> bool {
     false
+}
+
+#[test]
+fn access_control_policy_store_deser() {
+    let config = Config::from_deserializer(
+        &mut json5::Deserializer::from_str(
+            r#"{
+        access_control: {
+          enabled: true,
+          policy_store: {
+            type: "redis",
+            url: "redis://127.0.0.1:6379",
+            identity: "cert_common_name",
+          }
+        }
+      }"#,
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    let store = config.access_control().policy_store.as_ref().unwrap();
+    assert_eq!(store.identity, AclIdentitySource::CertCommonName);
+    // Omitted fields fall back to their defaults.
+    assert_eq!(store.entry_ttl_ms, Some(300_000));
+    assert_eq!(store.cache_capacity, 1_000);
+    let redis = store.redis();
+    assert_eq!(redis.url, "redis://127.0.0.1:6379");
+    assert!(redis.password.is_none());
+    assert_eq!(redis.key_prefix, "zenoh:acl:");
+    assert!(redis.root_ca_certificate.is_none());
+    assert_eq!(redis.timeout_ms, 3_000);
+
+    // An explicit null disables the periodic read, for deployments that refresh an identity
+    // themselves rather than waiting for its entry to expire.
+    let config = Config::from_deserializer(
+        &mut json5::Deserializer::from_str(
+            r#"{
+        access_control: {
+          policy_store: {
+            type: "redis",
+            url: "redis://127.0.0.1:6379",
+            identity: "zenoh_id",
+            entry_ttl_ms: null,
+          }
+        }
+      }"#,
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        config
+            .access_control()
+            .policy_store
+            .as_ref()
+            .unwrap()
+            .entry_ttl_ms,
+        None
+    );
+
+    // No policy store unless one is configured.
+    assert!(Config::default().access_control().policy_store.is_none());
+
+    // The password is read from the configuration but never serialized back out,
+    // so it cannot leak through the admin space.
+    let config = Config::from_deserializer(
+        &mut json5::Deserializer::from_str(
+            r#"{
+        access_control: {
+          policy_store: {
+            type: "redis",
+            url: "redis://127.0.0.1:6379",
+            identity: "username",
+            password: "hunter2",
+          }
+        }
+      }"#,
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    let password = config
+        .access_control()
+        .policy_store
+        .as_ref()
+        .unwrap()
+        .redis()
+        .password
+        .as_ref()
+        .unwrap();
+    assert_eq!(
+        secrecy::ExposeSecret::expose_secret(password).as_str(),
+        "hunter2"
+    );
+    let serialized = serde_json::to_string(&config).unwrap();
+    assert!(serialized.contains("redis://127.0.0.1:6379"));
+    assert!(!serialized.contains("hunter2"));
+
+    let config = Config::from_deserializer(
+        &mut json5::Deserializer::from_str(
+            r#"{
+        access_control: {
+          policy_store: {
+            type: "redis",
+            url: "rediss://127.0.0.1:6379",
+            identity: "username",
+            root_ca_certificate: "./redis-ca.pem",
+          }
+        }
+      }"#,
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        config
+            .access_control()
+            .policy_store
+            .as_ref()
+            .unwrap()
+            .redis()
+            .root_ca_certificate
+            .as_deref(),
+        Some("./redis-ca.pem")
+    );
+
+    // A misspelled field is reported rather than silently ignored.
+    assert!(Config::from_deserializer(
+        &mut json5::Deserializer::from_str(
+            r#"{access_control: {policy_store: {type: "redis", url: "redis://x", key: "k", pol_interval_ms: 1}}}"#,
+        )
+        .unwrap(),
+    )
+    .is_err());
+
+    // An unknown store type is reported rather than silently ignored.
+    assert!(Config::from_deserializer(
+        &mut json5::Deserializer::from_str(
+            r#"{access_control: {policy_store: {type: "mysql", url: "mysql://x"}}}"#,
+        )
+        .unwrap(),
+    )
+    .is_err());
+
+    let config = Config::from_deserializer(
+        &mut json5::Deserializer::from_str(
+            r#"{
+        access_control: {
+          enabled: true,
+          policy_store: {
+            type: "postgres",
+            url: "postgres://zenoh@127.0.0.1:5432/zenoh?sslmode=verify-full",
+            identity: "cert_common_name",
+            root_ca_certificate: "./postgres-ca.pem",
+          }
+        }
+      }"#,
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    let store = config.access_control().policy_store.as_ref().unwrap();
+    assert_eq!(store.identity, AclIdentitySource::CertCommonName);
+    let postgres = store.postgres();
+    assert_eq!(
+        postgres.url,
+        "postgres://zenoh@127.0.0.1:5432/zenoh?sslmode=verify-full"
+    );
+    assert!(postgres.password.is_none());
+    assert_eq!(postgres.table, "zenoh_acl");
+    assert_eq!(postgres.identity_column, "identity");
+    assert_eq!(postgres.document_column, "document");
+    assert_eq!(
+        postgres.root_ca_certificate.as_deref(),
+        Some("./postgres-ca.pem")
+    );
+    assert_eq!(postgres.timeout_ms, 3_000);
+    assert_eq!(postgres.pool_size, 8);
+
+    let config = Config::from_deserializer(
+        &mut json5::Deserializer::from_str(
+            r#"{
+        access_control: {
+          policy_store: {
+            type: "postgres",
+            url: "postgres://zenoh@127.0.0.1:5432/zenoh",
+            identity: "username",
+            password: "hunter2",
+            table: "acl.policies",
+            identity_column: "robot_id",
+            document_column: "acl",
+          }
+        }
+      }"#,
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    let postgres = config
+        .access_control()
+        .policy_store
+        .as_ref()
+        .unwrap()
+        .postgres();
+    assert_eq!(postgres.table, "acl.policies");
+    assert_eq!(postgres.identity_column, "robot_id");
+    assert_eq!(postgres.document_column, "acl");
+    assert!(postgres.root_ca_certificate.is_none());
+    let password = postgres.password.as_ref().unwrap();
+    assert_eq!(
+        secrecy::ExposeSecret::expose_secret(password).as_str(),
+        "hunter2"
+    );
+    let serialized = serde_json::to_string(&config).unwrap();
+    assert!(serialized.contains("postgres://zenoh@127.0.0.1:5432/zenoh"));
+    assert!(!serialized.contains("hunter2"));
+
+    // Redis-only fields are rejected on a postgres store rather than silently ignored.
+    assert!(Config::from_deserializer(
+        &mut json5::Deserializer::from_str(
+            r#"{access_control: {policy_store: {type: "postgres", url: "postgres://x", identity: "username", key_prefix: "k"}}}"#,
+        )
+        .unwrap(),
+    )
+    .is_err());
 }
 
 #[test]

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -29,6 +29,9 @@ version = { workspace = true }
 maintenance = { status = "actively-developed" }
 
 [features]
+acl_policy_store = ["dep:lru", "dep:secrecy"]
+acl_postgres = ["acl_policy_store", "dep:sqlx"]
+acl_redis = ["acl_policy_store", "dep:redis"]
 auth_pubkey = ["zenoh-transport/auth_pubkey"]
 auth_usrpwd = ["zenoh-transport/auth_usrpwd"]
 default = [
@@ -97,14 +100,18 @@ git-version = { workspace = true }
 itertools = { workspace = true }
 json5 = { workspace = true }
 lazy_static = { workspace = true }
+lru = { workspace = true, optional = true }
 nonempty-collections = { workspace = true }
 once_cell = { workspace = true }
 petgraph = { workspace = true }
 phf = { workspace = true }
 rand = { workspace = true, features = ["default"] }
+redis = { workspace = true, optional = true }
+secrecy = { workspace = true, optional = true }
 serde = { workspace = true, features = ["default"] }
 serde_json = { workspace = true }
 socket2 = { workspace = true }
+sqlx = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["macros", "rt", "time"] }
 tokio-util = { workspace = true }
 tracing = { workspace = true }

--- a/zenoh/src/net/routing/dispatcher/face.rs
+++ b/zenoh/src/net/routing/dispatcher/face.rs
@@ -34,7 +34,7 @@ use zenoh_protocol::{
 };
 use zenoh_sync::get_mut_unchecked;
 use zenoh_task::TaskController;
-use zenoh_transport::multicast::TransportMulticast;
+use zenoh_transport::{multicast::TransportMulticast, unicast::TransportUnicast};
 
 use super::{
     super::gateway::*, interests::PendingCurrentInterest, resource::*, tables::TablesLock,
@@ -247,6 +247,14 @@ impl FaceState {
             id += 1;
         }
         id
+    }
+
+    /// Unicast transport of this face, if it has one.
+    pub(crate) fn unicast_transport(&self) -> Option<&TransportUnicast> {
+        self.primitives
+            .as_any()
+            .downcast_ref::<Mux>()
+            .map(|mux| &mux.handler)
     }
 
     pub(crate) fn update_interceptors_caches(&self, res: &mut Arc<Resource>) {

--- a/zenoh/src/net/routing/dispatcher/tables.rs
+++ b/zenoh/src/net/routing/dispatcher/tables.rs
@@ -38,7 +38,7 @@ use crate::net::{
     routing::{
         dispatcher::{face::FaceId, region::RegionMap},
         hat::{HatTrait, Sources},
-        interceptor::{interceptor_factories, InterceptorFactory},
+        interceptor::{interceptors, InterceptorFactory, InterceptorState},
     },
     runtime::WeakRuntime,
 };
@@ -134,7 +134,10 @@ pub(crate) struct TablesData {
     pub(crate) face_counter: FaceId,
 
     pub(crate) next_interceptor_version: AtomicUsize,
-    pub(crate) interceptors: Vec<InterceptorFactory>,
+    pub(crate) interceptors: Arc<Vec<InterceptorFactory>>,
+    /// Shared so that a caller can read or refresh them once the routing tables are
+    /// unlocked again, since both are allowed to block.
+    pub(crate) interceptor_states: Arc<HashMap<&'static str, Arc<dyn InterceptorState>>>,
 
     pub(crate) faces: HashMap<FaceId, Arc<FaceState>>,
 
@@ -191,6 +194,7 @@ impl TablesData {
             &mut stats_keys,
             config.stats.filters().iter().map(|f| &*f.key),
         );
+        let built_interceptors = interceptors(config)?;
 
         Ok(TablesData {
             zid,
@@ -200,7 +204,8 @@ impl TablesData {
             queries_default_timeout,
             interests_timeout,
             root_res: Resource::root(),
-            interceptors: interceptor_factories(config)?,
+            interceptors: Arc::new(built_interceptors.factories),
+            interceptor_states: Arc::new(built_interceptors.states),
             next_interceptor_version: AtomicUsize::new(0),
             hats: hat,
             face_counter: 0,
@@ -533,8 +538,37 @@ impl TablesLock {
                 config.stats.filters().iter().map(|k| &*k.key),
             );
         }
-        tables.data.interceptors = interceptor_factories(config)?;
+        let built_interceptors = interceptors(config)?;
+        tables.data.interceptors = Arc::new(built_interceptors.factories);
+        tables.data.interceptor_states = Arc::new(built_interceptors.states);
         drop(tables);
+
+        // The new interceptors hold nothing yet about the transports already admitted, so
+        // they are given a chance to read it before those transports are handed over. Left
+        // out, an interceptor enforcing per-transport state would apply its empty self.
+        let (states, transports) = {
+            let tables = zread!(self.tables);
+            (
+                tables.data.interceptor_states.clone(),
+                tables
+                    .data
+                    .faces
+                    .values()
+                    .filter_map(|face| face.unicast_transport().cloned())
+                    .collect::<Vec<_>>(),
+            )
+        };
+        for state in states.values() {
+            for transport in &transports {
+                if let Err(e) = state.prepare(transport) {
+                    tracing::error!(
+                        "Cannot prepare interceptor state for an already admitted transport: {}",
+                        e
+                    );
+                }
+            }
+        }
+
         let tables = zread!(self.tables);
         let version = tables
             .data

--- a/zenoh/src/net/routing/gateway.rs
+++ b/zenoh/src/net/routing/gateway.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 use std::{
+    collections::HashSet,
     str::FromStr,
     sync::{atomic::Ordering, Arc, Mutex, RwLock},
 };
@@ -24,6 +25,7 @@ use zenoh_config::{
 };
 use zenoh_protocol::core::{Bound, Region, WhatAmI, ZenohIdProto};
 use zenoh_result::ZResult;
+use zenoh_runtime::ZRuntime;
 use zenoh_transport::{multicast::TransportMulticast, unicast::TransportUnicast, TransportPeer};
 
 pub use super::dispatcher::{pubsub::*, resource::*};
@@ -33,7 +35,7 @@ use super::{
         tables::{TablesData, TablesLock},
     },
     hat,
-    interceptor::InterceptorsChain,
+    interceptor::{InterceptorState, InterceptorsChain, RefreshOutcome},
     runtime::Runtime,
 };
 use crate::net::{
@@ -261,6 +263,19 @@ impl Gateway {
         Arc::new(face)
     }
 
+    /// Lets the interceptors read what they keep about a transport before
+    /// [`Self::new_transport_unicast`] locks the routing tables to admit it.
+    ///
+    /// Their state is taken out from under the lock first, because reading it is allowed
+    /// to block. An error refuses the transport.
+    pub(crate) fn prepare_transport_unicast(&self, transport: &TransportUnicast) -> ZResult<()> {
+        let states = zread!(self.tables.tables).data.interceptor_states.clone();
+        for state in states.values() {
+            state.prepare(transport)?;
+        }
+        Ok(())
+    }
+
     pub fn new_transport_unicast(
         &self,
         transport: TransportUnicast,
@@ -464,5 +479,136 @@ impl Gateway {
             interceptor,
             this_zid,
         )))
+    }
+
+    /// Whether any interceptor keeps state that can go stale.
+    pub(crate) fn keeps_interceptor_state(&self) -> bool {
+        !zread!(self.tables.tables)
+            .data
+            .interceptor_states
+            .is_empty()
+    }
+
+    /// Reads again what interceptor `name` keeps for `identity` and hands it to the
+    /// transports it applies to.
+    pub(crate) fn refresh_interceptor_state(&self, name: &str, identity: &str) {
+        let Some(state) = zread!(self.tables.tables)
+            .data
+            .interceptor_states
+            .get(name)
+            .cloned()
+        else {
+            return;
+        };
+        self.refresh_interceptor_state_identities(state, HashSet::from([identity.to_string()]));
+    }
+
+    /// Reads again whatever each interceptor keeps that has grown too old.
+    ///
+    /// Only the interceptor that reported an identity stale is refreshed for it.
+    /// Nothing else refreshes a transport that stays connected, since its interceptors are
+    /// built once when it is admitted.
+    pub(crate) fn refresh_stale_interceptor_state(&self) {
+        let (states, transports) = {
+            let tables = zread!(self.tables.tables);
+            (
+                tables.data.interceptor_states.clone(),
+                tables
+                    .data
+                    .faces
+                    .values()
+                    .filter_map(|face| face.unicast_transport().cloned())
+                    .collect::<Vec<_>>(),
+            )
+        };
+
+        for state in states.values() {
+            // Only what a connected transport is still using. What a transport left behind
+            // when it went away is dropped when next asked for, rather than read again for
+            // as long as it is held.
+            let connected = transports
+                .iter()
+                .filter_map(|transport| state.identity_of(transport))
+                .collect::<HashSet<_>>();
+            let stale = state
+                .stale_identities()
+                .into_iter()
+                .filter(|identity| connected.contains(identity))
+                .collect::<HashSet<_>>();
+            if !stale.is_empty() {
+                self.refresh_interceptor_state_identities(state.clone(), stale);
+            }
+        }
+    }
+
+    /// Only the transports the given identities apply to on `state` are rebuilt.
+    /// Rebuilding the others would hand them a policy compiled from state that may
+    /// meanwhile have expired, and so cut off transports that nothing was said about.
+    ///
+    /// Transports whose refresh failed are closed outside the tables lock: fail-closed,
+    /// same as refusing them on connect.
+    fn refresh_interceptor_state_identities(
+        &self,
+        state: Arc<dyn InterceptorState>,
+        identities: HashSet<String>,
+    ) {
+        let mut updated = HashSet::new();
+        let mut failed = HashSet::new();
+        for identity in identities {
+            match state.refresh(&identity) {
+                RefreshOutcome::Updated => {
+                    updated.insert(identity);
+                }
+                RefreshOutcome::Failed => {
+                    failed.insert(identity);
+                }
+            }
+        }
+        if updated.is_empty() && failed.is_empty() {
+            return;
+        }
+
+        let mut to_close = Vec::new();
+        {
+            let tables = zread!(self.tables.tables);
+            let version = (!updated.is_empty()).then(|| {
+                tables
+                    .data
+                    .next_interceptor_version
+                    .fetch_add(1, Ordering::SeqCst)
+                    + 1
+            });
+            for face in tables.data.faces.values() {
+                let Some(transport) = face.unicast_transport() else {
+                    continue;
+                };
+                let Some(identity) = state.identity_of(transport) else {
+                    continue;
+                };
+                if failed.contains(&identity) {
+                    to_close.push((identity, transport.clone()));
+                    continue;
+                }
+                let Some(version) = version else {
+                    continue;
+                };
+                if updated.contains(&identity) {
+                    face.set_interceptors_from_factories(&tables.data.interceptors, version);
+                }
+            }
+        }
+
+        for (identity, transport) in to_close {
+            tracing::warn!(
+                "Closing transport for identity '{}': interceptor state could not be refreshed",
+                identity
+            );
+            if let Err(e) = ZRuntime::Application.block_in_place(transport.close()) {
+                tracing::error!(
+                    "Failed to close transport after interceptor refresh failure: {}",
+                    e
+                );
+            }
+        }
     }
 }

--- a/zenoh/src/net/routing/interceptor/access_control.rs
+++ b/zenoh/src/net/routing/interceptor/access_control.rs
@@ -40,15 +40,19 @@ use zenoh_transport::{multicast::TransportMulticast, unicast::TransportUnicast};
 
 use super::{
     authorization::PolicyEnforcer, EgressInterceptor, IngressInterceptor, InterceptorFactory,
-    InterceptorFactoryTrait, InterceptorLinkWrapper, InterceptorTrait,
+    InterceptorFactoryTrait, InterceptorLinkWrapper, InterceptorState, InterceptorTrait,
 };
 use crate::{
     key_expr::KeyExpr,
     net::routing::interceptor::{authorization::SubjectQuery, InterceptorContext},
 };
 pub struct AclEnforcer {
-    enforcer: Arc<PolicyEnforcer>,
+    /// Rules applying to everyone, and to identities for which the policy store holds none.
+    default_policy_enforcer: Arc<PolicyEnforcer>,
+    #[cfg(feature = "acl_policy_store")]
+    policy_cache: Option<Arc<super::acl_policy_store::PolicyCache>>,
 }
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AuthSubject {
     id: usize,
@@ -694,27 +698,59 @@ impl IngressAclEnforcer {
     }
 }
 
-pub(crate) fn acl_interceptor_factories(
-    acl_config: &AclConfig,
-) -> ZResult<Vec<InterceptorFactory>> {
-    let mut res: Vec<InterceptorFactory> = vec![];
+type AclInterceptor = (InterceptorFactory, Option<Arc<dyn InterceptorState>>);
 
-    if acl_config.enabled {
-        let mut policy_enforcer = PolicyEnforcer::new();
-        match policy_enforcer.init(acl_config) {
-            Ok(_) => {
-                tracing::debug!("Access control is enabled");
-                res.push(Box::new(AclEnforcer {
-                    enforcer: Arc::new(policy_enforcer),
-                }))
-            }
-            Err(e) => bail!("Access control not enabled due to: {}", e),
+pub(crate) fn acl_interceptor_factories(acl_config: &AclConfig) -> ZResult<Option<AclInterceptor>> {
+    if !acl_config.enabled {
+        if acl_config.policy_store.is_some() {
+            tracing::warn!("Access control is disabled, the configured policy store is ignored");
         }
-    } else {
         tracing::debug!("Access control is disabled");
+        return Ok(None);
     }
 
-    Ok(res)
+    #[cfg(not(feature = "acl_policy_store"))]
+    if acl_config.policy_store.is_some() {
+        bail!("Access control is configured with a policy store, but zenoh was built without a policy store feature (`acl_redis` or `acl_postgres`)");
+    }
+
+    // The policy store holds the rules for each identity, leaving the configuration
+    // file free to declare only what applies to everyone, or nothing at all.
+    #[cfg(feature = "acl_policy_store")]
+    let from_config;
+    #[cfg(feature = "acl_policy_store")]
+    let (acl_config, policy_cache, state) = match &acl_config.policy_store {
+        Some(_) => {
+            from_config = super::acl_policy_store::with_empty_lists(acl_config);
+            let cache = Arc::new(super::acl_policy_store::PolicyCache::new(
+                from_config.clone(),
+            )?);
+            (
+                &from_config,
+                Some(cache.clone()),
+                Some(cache as Arc<dyn InterceptorState>),
+            )
+        }
+        None => (acl_config, None, None),
+    };
+    #[cfg(not(feature = "acl_policy_store"))]
+    let state = None;
+
+    let mut policy_enforcer = PolicyEnforcer::new();
+    match policy_enforcer.init(acl_config) {
+        Ok(_) => {
+            tracing::debug!("Access control is enabled");
+            Ok(Some((
+                Box::new(AclEnforcer {
+                    default_policy_enforcer: Arc::new(policy_enforcer),
+                    #[cfg(feature = "acl_policy_store")]
+                    policy_cache,
+                }),
+                state,
+            )))
+        }
+        Err(e) => bail!("Access control not enabled due to: {}", e),
+    }
 }
 
 impl InterceptorFactoryTrait for AclEnforcer {
@@ -722,6 +758,18 @@ impl InterceptorFactoryTrait for AclEnforcer {
         &self,
         transport: &TransportUnicast,
     ) -> (Option<IngressInterceptor>, Option<EgressInterceptor>) {
+        // This runs while the routing tables are locked for writing. The store was already
+        // read in `prepare`; this only looks up what that left in the cache.
+        #[cfg(feature = "acl_policy_store")]
+        let enforcer = match &self.policy_cache {
+            Some(cache) => cache
+                .held_for(transport)
+                .unwrap_or_else(|| self.default_policy_enforcer.clone()),
+            None => self.default_policy_enforcer.clone(),
+        };
+        #[cfg(not(feature = "acl_policy_store"))]
+        let enforcer = self.default_policy_enforcer.clone();
+
         let auth_ids = match transport.get_auth_ids() {
             Ok(auth_ids) => auth_ids,
             Err(err) => {
@@ -789,7 +837,7 @@ impl InterceptorFactoryTrait for AclEnforcer {
                 zid,
             };
 
-            for entry in self.enforcer.subject_store.query(&query) {
+            for entry in enforcer.subject_store.query(&query) {
                 auth_subjects.insert(AuthSubject {
                     id: entry.id,
                     name: format!("{query}"),
@@ -809,7 +857,7 @@ impl InterceptorFactoryTrait for AclEnforcer {
         if auth_subjects.is_empty() {
             tracing::info!(
                 "{zid} did not match any configured ACL subject. Default permission `{:?}` will be applied on all messages",
-                self.enforcer.default_permission
+                enforcer.default_permission
             );
         }
         #[cfg(feature = "stats")]
@@ -821,25 +869,25 @@ impl InterceptorFactoryTrait for AclEnforcer {
             return (None, None);
         };
         let ingress_interceptor = Box::new(IngressAclEnforcer {
-            policy_enforcer: self.enforcer.clone(),
+            policy_enforcer: enforcer.clone(),
             zid,
             subject: auth_subjects.clone(),
             #[cfg(feature = "stats")]
             stats: stats.clone(),
         });
         let egress_interceptor = Box::new(EgressAclEnforcer {
-            policy_enforcer: self.enforcer.clone(),
+            policy_enforcer: enforcer.clone(),
             zid,
             subject: auth_subjects,
             #[cfg(feature = "stats")]
             stats: stats.clone(),
         });
         (
-            self.enforcer
+            enforcer
                 .interface_enabled
                 .ingress
                 .then_some(ingress_interceptor),
-            self.enforcer
+            enforcer
                 .interface_enabled
                 .egress
                 .then_some(egress_interceptor),

--- a/zenoh/src/net/routing/interceptor/acl_policy_store/acl_postgres.rs
+++ b/zenoh/src/net/routing/interceptor/acl_policy_store/acl_postgres.rs
@@ -1,0 +1,322 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+use std::{num::NonZeroUsize, time::Duration};
+
+use secrecy::ExposeSecret;
+use sqlx::{
+    postgres::{PgConnectOptions, PgPoolOptions, PgSslMode},
+    PgPool,
+};
+use zenoh_config::AclPostgresConf;
+use zenoh_result::{bail, zerror, ZResult};
+use zenoh_runtime::ZRuntime;
+
+use super::{parse, AclPolicyDocument, PolicyStore};
+
+pub(super) struct PostgresStore {
+    sql: String,
+    timeout_ms: u64,
+    pool: PgPool,
+}
+
+impl PostgresStore {
+    pub(super) fn new(conf: AclPostgresConf) -> ZResult<Self> {
+        let sql = format!(
+            "SELECT {}::text FROM {} WHERE {} = $1",
+            ident("column", &conf.document_column)?,
+            table_name(&conf.table)?,
+            ident("column", &conf.identity_column)?,
+        );
+        let pool_size = NonZeroUsize::new(conf.pool_size)
+            .ok_or_else(|| zerror!("Access control postgres pool_size must not be zero"))?;
+        let timeout = Duration::from_millis(conf.timeout_ms);
+        let options = open_options(&conf)?;
+        let max_connections = pool_size.get() as u32;
+        // sqlx spawns idle/lifetime maintenance, which needs a Tokio handle.
+        let pool = match tokio::runtime::Handle::try_current() {
+            Ok(_) => PgPoolOptions::new()
+                .max_connections(max_connections)
+                .acquire_timeout(timeout)
+                .connect_lazy_with(options),
+            Err(_) => ZRuntime::Application.block_on(async {
+                PgPoolOptions::new()
+                    .max_connections(max_connections)
+                    .acquire_timeout(timeout)
+                    .connect_lazy_with(options)
+            }),
+        };
+        Ok(Self {
+            sql,
+            timeout_ms: conf.timeout_ms,
+            pool,
+        })
+    }
+
+    async fn fetch_async(&self, identity: &str) -> ZResult<AclPolicyDocument> {
+        let timeout = Duration::from_millis(self.timeout_ms);
+        let row: Option<Option<String>> = match tokio::time::timeout(
+            timeout,
+            sqlx::query_scalar(&self.sql)
+                .bind(identity)
+                .fetch_optional(&self.pool),
+        )
+        .await
+        {
+            Ok(Ok(row)) => row,
+            Ok(Err(e)) => {
+                return Err(zerror!(
+                    "Cannot read identity '{}' from Postgres table: {}",
+                    identity,
+                    e
+                )
+                .into());
+            }
+            Err(_) => {
+                return Err(
+                    zerror!("Timeout reading identity '{}' from Postgres", identity).into(),
+                );
+            }
+        };
+
+        match row {
+            Some(Some(value)) => parse(&value),
+            Some(None) | None => {
+                tracing::debug!(
+                    "No access control document for identity '{}' in Postgres",
+                    identity
+                );
+                Ok(AclPolicyDocument::default())
+            }
+        }
+    }
+}
+
+impl PolicyStore for PostgresStore {
+    /// Reads the document held in Postgres for one identity.
+    ///
+    /// A missing row yields an empty document, leaving the identity to be enforced with the
+    /// rules that apply to everyone. Being unable to read it at all is an error, so that the
+    /// caller can refuse the transport.
+    fn fetch(&self, identity: &str) -> ZResult<AclPolicyDocument> {
+        ZRuntime::Application.block_in_place(self.fetch_async(identity))
+    }
+}
+
+fn open_options(conf: &AclPostgresConf) -> ZResult<PgConnectOptions> {
+    let mut opts: PgConnectOptions = conf
+        .url
+        .parse()
+        .map_err(|e| zerror!("Invalid Postgres url '{}': {}", conf.url, e))?;
+    if let Some(password) = &conf.password {
+        opts = opts.password(password.expose_secret().as_str());
+    }
+    if let Some(path) = &conf.root_ca_certificate {
+        if matches!(opts.get_ssl_mode(), PgSslMode::Disable) {
+            bail!("Postgres root_ca_certificate is set but the url has sslmode=disable");
+        }
+        let pem = std::fs::read(path)
+            .map_err(|e| zerror!("Cannot read Postgres CA '{}': {}", path, e))?;
+        if pem.is_empty() {
+            bail!("Postgres CA '{}' contains no certificates", path);
+        }
+        opts = opts.ssl_root_cert(path);
+    }
+    Ok(opts)
+}
+
+fn ident<'a>(kind: &str, ident: &'a str) -> ZResult<&'a str> {
+    if ident.is_empty()
+        || !ident.starts_with(|c: char| c.is_ascii_alphabetic() || c == '_')
+        || !ident.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+    {
+        bail!("Postgres {} '{}' must be a plain identifier", kind, ident);
+    }
+    Ok(ident)
+}
+
+fn table_name(table: &str) -> ZResult<String> {
+    let mut parts = table.split('.');
+    let first = parts.next().unwrap_or("");
+    let second = parts.next();
+    if parts.next().is_some() {
+        bail!(
+            "Postgres table '{}' must be a plain identifier (`name` or `schema.name`)",
+            table
+        );
+    }
+    match second {
+        None => Ok(ident("table", first)?.to_string()),
+        Some(name) => Ok(format!(
+            "{}.{}",
+            ident("table", first)?,
+            ident("table", name)?
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use zenoh_config::{
+        AclConfig, AclIdentitySource, AclPolicyStoreBackend, AclPolicyStoreConf, AclPostgresConf,
+    };
+
+    use super::super::super::access_control::acl_interceptor_factories;
+    use super::*;
+
+    const POSTGRES_DOCUMENT: &str = r#"{
+        "rules": [
+            {"id": "pg-rule", "key_exprs": ["a/**"], "messages": ["put"], "permission": "allow"}
+        ],
+        "subjects": [{"id": "pg-subject", "usernames": ["alice"]}],
+        "policies": [{"rules": ["pg-rule"], "subjects": ["pg-subject"]}]
+    }"#;
+
+    fn conf(table: &str) -> AclPostgresConf {
+        AclPostgresConf {
+            url: "postgres://127.0.0.1:5432/zenoh".to_string(),
+            password: None,
+            table: table.to_string(),
+            identity_column: "identity".to_string(),
+            document_column: "document".to_string(),
+            root_ca_certificate: None,
+            timeout_ms: 3_000,
+            pool_size: 8,
+        }
+    }
+
+    #[test]
+    fn table_name_must_be_a_plain_identifier() {
+        assert!(PostgresStore::new(conf("zenoh_acl")).is_ok());
+        assert!(PostgresStore::new(conf("public.zenoh_acl")).is_ok());
+        assert!(PostgresStore::new(conf("zenoh-acl")).is_err());
+        assert!(PostgresStore::new(conf("zenoh_acl;drop")).is_err());
+        assert!(PostgresStore::new(conf("")).is_err());
+        assert!(PostgresStore::new(conf("a.b.c")).is_err());
+    }
+
+    #[test]
+    fn column_names_must_be_plain_identifiers() {
+        let mut conf = conf("zenoh_acl");
+        conf.identity_column = "identity;drop".to_string();
+        assert!(PostgresStore::new(conf.clone()).is_err());
+        conf.identity_column = "identity".to_string();
+        conf.document_column = "acl-json".to_string();
+        assert!(PostgresStore::new(conf).is_err());
+    }
+
+    #[test]
+    fn pool_size_must_not_be_zero() {
+        let mut conf = conf("zenoh_acl");
+        conf.pool_size = 0;
+        assert!(PostgresStore::new(conf).is_err());
+    }
+
+    #[test]
+    fn a_missing_ca_file_is_rejected() {
+        let mut conf = conf("zenoh_acl");
+        conf.root_ca_certificate = Some("/no/such/postgres-ca.pem".to_string());
+        assert!(PostgresStore::new(conf).is_err());
+    }
+
+    #[test]
+    fn a_ca_file_cannot_be_paired_with_sslmode_disable() {
+        let mut conf = conf("zenoh_acl");
+        conf.url = "postgres://127.0.0.1:5432/zenoh?sslmode=disable".to_string();
+        conf.root_ca_certificate = Some("/no/such/postgres-ca.pem".to_string());
+        assert!(PostgresStore::new(conf).is_err());
+    }
+
+    /// Exercises the round trip against a real server, which the other tests deliberately
+    /// do not need. Run it with:
+    ///
+    /// ```sh
+    /// docker run --rm -d -p 5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust postgres:16-alpine
+    /// cargo test -p zenoh --features acl_postgres --lib identity_document_is_read -- --ignored
+    /// ```
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[ignore = "requires a running Postgres server"]
+    async fn identity_document_is_read_from_a_running_server() {
+        let url = std::env::var("ZENOH_TEST_POSTGRES_URL")
+            .unwrap_or_else(|_| "postgres://postgres@127.0.0.1:5432/postgres".to_string());
+        let pool = PgPool::connect(&url).await.unwrap();
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS zenoh_acl (
+                identity TEXT PRIMARY KEY,
+                document TEXT NOT NULL
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO zenoh_acl (identity, document) VALUES ($1, $2)
+             ON CONFLICT (identity) DO UPDATE SET document = EXCLUDED.document",
+        )
+        .bind("alice")
+        .bind(POSTGRES_DOCUMENT)
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query("DELETE FROM zenoh_acl WHERE identity = $1")
+            .bind("absent")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let mut store_conf = conf("zenoh_acl");
+        store_conf.url = url;
+        let store = PostgresStore::new(store_conf).unwrap();
+
+        let document = store.fetch("alice").unwrap();
+        assert_eq!(document.rules[0].id, "pg-rule");
+        assert_eq!(document.subjects[0].id, "pg-subject");
+
+        // An identity the store knows nothing about is left to the rules applying to everyone,
+        // rather than being an error.
+        let absent = store.fetch("absent").unwrap();
+        assert!(absent.rules.is_empty());
+
+        // A server that cannot be reached is an error, so the caller can refuse the
+        // identity instead of enforcing rules it failed to read.
+        let mut unreachable_conf = conf("zenoh_acl");
+        unreachable_conf.url = "postgres://127.0.0.1:1/zenoh".to_string();
+        let unreachable = PostgresStore::new(unreachable_conf).unwrap();
+        assert!(unreachable.fetch("alice").is_err());
+    }
+
+    #[test]
+    fn a_policy_store_needs_no_rules_in_the_configuration_file() {
+        // A deployment holding every rule in the store declares none here, which
+        // `PolicyEnforcer::init` refuses outright unless the lists are filled in.
+        let config = AclConfig {
+            enabled: true,
+            policy_store: Some(AclPolicyStoreConf {
+                identity: AclIdentitySource::Username,
+                entry_ttl_ms: None,
+                cache_capacity: 8,
+                backend: AclPolicyStoreBackend::Postgres(conf("zenoh_acl")),
+            }),
+            ..AclConfig::default()
+        };
+        assert!(config.rules.is_none());
+
+        let Some((_, state)) = acl_interceptor_factories(&config).unwrap() else {
+            panic!("expected an access control factory");
+        };
+        // The policies are reachable from the routing tables, so that a refresh can read
+        // them again without going through a factory.
+        assert!(state.is_some());
+    }
+}

--- a/zenoh/src/net/routing/interceptor/acl_policy_store/acl_redis.rs
+++ b/zenoh/src/net/routing/interceptor/acl_policy_store/acl_redis.rs
@@ -1,0 +1,246 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+use std::{sync::Mutex, time::Duration};
+
+use redis::{aio::MultiplexedConnection, ConnectionAddr, IntoConnectionInfo, TlsCertificates};
+use secrecy::ExposeSecret;
+use zenoh_config::AclRedisConf;
+use zenoh_result::{bail, zerror, ZResult};
+use zenoh_runtime::ZRuntime;
+
+use super::{parse, AclPolicyDocument, PolicyStore};
+
+pub(super) struct RedisStore {
+    url: String,
+    key_prefix: String,
+    timeout_ms: u64,
+    client: redis::Client,
+    /// Shared multiplexed connection. Dropped when a command fails so the next read
+    /// opens a new one.
+    connection: Mutex<Option<MultiplexedConnection>>,
+}
+
+impl RedisStore {
+    pub(super) fn new(conf: AclRedisConf) -> ZResult<Self> {
+        let client = open_client(&conf)?;
+        Ok(Self {
+            url: conf.url,
+            key_prefix: conf.key_prefix,
+            timeout_ms: conf.timeout_ms,
+            client,
+            connection: Mutex::new(None),
+        })
+    }
+
+    async fn multiplexed_connection(&self) -> ZResult<MultiplexedConnection> {
+        if let Some(connection) = self.connection.lock().unwrap().clone() {
+            return Ok(connection);
+        }
+        let timeout = Duration::from_millis(self.timeout_ms);
+        let connection =
+            tokio::time::timeout(timeout, self.client.get_multiplexed_async_connection())
+                .await
+                .map_err(|_| zerror!("Timeout connecting to Redis at '{}'", self.url))?
+                .map_err(|e| zerror!("Cannot connect to Redis at '{}': {}", self.url, e))?;
+        *self.connection.lock().unwrap() = Some(connection.clone());
+        Ok(connection)
+    }
+
+    async fn fetch_async(&self, identity: &str) -> ZResult<AclPolicyDocument> {
+        let timeout = Duration::from_millis(self.timeout_ms);
+        let key = format!("{}{}", self.key_prefix, identity);
+        let mut connection = self.multiplexed_connection().await?;
+
+        let value: Option<String> = match tokio::time::timeout(
+            timeout,
+            redis::cmd("GET")
+                .arg(&key)
+                .query_async::<Option<String>>(&mut connection),
+        )
+        .await
+        {
+            Ok(Ok(value)) => value,
+            Ok(Err(e)) => {
+                self.connection.lock().unwrap().take();
+                return Err(zerror!("Cannot read key '{}' from Redis: {}", key, e).into());
+            }
+            Err(_) => {
+                self.connection.lock().unwrap().take();
+                return Err(zerror!("Timeout reading key '{}' from Redis", key).into());
+            }
+        };
+
+        match value {
+            Some(value) => parse(&value),
+            None => {
+                tracing::debug!("No access control document at key '{}'", key);
+                Ok(AclPolicyDocument::default())
+            }
+        }
+    }
+}
+
+impl PolicyStore for RedisStore {
+    /// Reads the document held in Redis for one identity.
+    ///
+    /// An absent key yields an empty document, leaving the identity to be enforced with the
+    /// rules that apply to everyone. Being unable to read it at all is an error, so that the
+    /// caller can refuse the transport.
+    fn fetch(&self, identity: &str) -> ZResult<AclPolicyDocument> {
+        ZRuntime::Application.block_in_place(self.fetch_async(identity))
+    }
+}
+
+fn open_client(conf: &AclRedisConf) -> ZResult<redis::Client> {
+    let mut connection_info = conf
+        .url
+        .as_str()
+        .into_connection_info()
+        .map_err(|e| zerror!("Invalid Redis url '{}': {}", conf.url, e))?;
+    if let Some(password) = &conf.password {
+        connection_info.redis.password = Some(password.expose_secret().to_string());
+    }
+    let client = match &conf.root_ca_certificate {
+        None => redis::Client::open(connection_info),
+        Some(path) => {
+            if !matches!(connection_info.addr, ConnectionAddr::TcpTls { .. }) {
+                bail!("Redis root_ca_certificate is set but the url is not rediss://");
+            }
+            let pem = std::fs::read(path)
+                .map_err(|e| zerror!("Cannot read Redis CA '{}': {}", path, e))?;
+            if pem.is_empty() {
+                bail!("Redis CA '{}' contains no certificates", path);
+            }
+            redis::Client::build_with_tls(
+                connection_info,
+                TlsCertificates {
+                    client_tls: None,
+                    root_cert: Some(pem),
+                },
+            )
+        }
+    };
+    client.map_err(|e| zerror!("Invalid Redis url '{}': {}", conf.url, e).into())
+}
+
+#[cfg(test)]
+mod tests {
+    use zenoh_config::{
+        AclConfig, AclIdentitySource, AclPolicyStoreBackend, AclPolicyStoreConf, AclRedisConf,
+    };
+
+    use super::super::super::access_control::acl_interceptor_factories;
+    use super::*;
+
+    const REDIS_DOCUMENT: &str = r#"{
+        "rules": [
+            {"id": "redis-rule", "key_exprs": ["a/**"], "messages": ["put"], "permission": "allow"}
+        ],
+        "subjects": [{"id": "redis-subject", "usernames": ["alice"]}],
+        "policies": [{"rules": ["redis-rule"], "subjects": ["redis-subject"]}]
+    }"#;
+
+    /// Exercises the round trip against a real server, which the other tests deliberately
+    /// do not need. Run it with:
+    ///
+    /// ```sh
+    /// docker run --rm -d -p 6379:6379 redis:7-alpine
+    /// cargo test -p zenoh --features acl_redis --lib identity_document_is_read -- --ignored
+    /// ```
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[ignore = "requires a running Redis server"]
+    async fn identity_document_is_read_from_a_running_server() {
+        let url = std::env::var("ZENOH_TEST_REDIS_URL")
+            .unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
+        let client = redis::Client::open(url.as_str()).unwrap();
+        let mut connection = client.get_multiplexed_async_connection().await.unwrap();
+        let _: () = redis::cmd("SET")
+            .arg("zenoh:acl:alice")
+            .arg(REDIS_DOCUMENT)
+            .query_async(&mut connection)
+            .await
+            .unwrap();
+        let _: () = redis::cmd("DEL")
+            .arg("zenoh:acl:absent")
+            .query_async(&mut connection)
+            .await
+            .unwrap();
+
+        let conf = redis_conf(&url);
+        let store = RedisStore::new(conf).unwrap();
+
+        let document = store.fetch("alice").unwrap();
+        assert_eq!(document.rules[0].id, "redis-rule");
+        assert_eq!(document.subjects[0].id, "redis-subject");
+
+        // An identity the store knows nothing about is left to the rules applying to everyone,
+        // rather than being an error.
+        let absent = store.fetch("absent").unwrap();
+        assert!(absent.rules.is_empty());
+
+        // A server that cannot be reached is an error, so the caller can refuse the
+        // identity instead of enforcing rules it failed to read.
+        let unreachable = RedisStore::new(redis_conf("redis://127.0.0.1:1")).unwrap();
+        assert!(unreachable.fetch("alice").is_err());
+    }
+
+    fn redis_conf(url: &str) -> AclRedisConf {
+        AclRedisConf {
+            url: url.to_string(),
+            password: None,
+            key_prefix: "zenoh:acl:".to_string(),
+            root_ca_certificate: None,
+            timeout_ms: 3_000,
+        }
+    }
+
+    #[test]
+    fn a_missing_ca_file_is_rejected() {
+        let mut conf = redis_conf("rediss://127.0.0.1:6379");
+        conf.root_ca_certificate = Some("/no/such/redis-ca.pem".to_string());
+        assert!(RedisStore::new(conf).is_err());
+    }
+
+    #[test]
+    fn a_ca_file_cannot_be_paired_with_a_plaintext_url() {
+        let mut conf = redis_conf("redis://127.0.0.1:6379");
+        conf.root_ca_certificate = Some("/no/such/redis-ca.pem".to_string());
+        assert!(RedisStore::new(conf).is_err());
+    }
+
+    #[test]
+    fn a_policy_store_needs_no_rules_in_the_configuration_file() {
+        // A deployment holding every rule in the store declares none here, which
+        // `PolicyEnforcer::init` refuses outright unless the lists are filled in.
+        let config = AclConfig {
+            enabled: true,
+            policy_store: Some(AclPolicyStoreConf {
+                identity: AclIdentitySource::Username,
+                entry_ttl_ms: None,
+                cache_capacity: 8,
+                backend: AclPolicyStoreBackend::Redis(redis_conf("redis://127.0.0.1:6379")),
+            }),
+            ..AclConfig::default()
+        };
+        assert!(config.rules.is_none());
+
+        let Some((_, state)) = acl_interceptor_factories(&config).unwrap() else {
+            panic!("expected an access control factory");
+        };
+        // The policies are reachable from the routing tables, so that a refresh can read
+        // them again without going through a factory.
+        assert!(state.is_some());
+    }
+}

--- a/zenoh/src/net/routing/interceptor/acl_policy_store/mod.rs
+++ b/zenoh/src/net/routing/interceptor/acl_policy_store/mod.rs
@@ -1,0 +1,564 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+//! ⚠️ WARNING ⚠️
+//!
+//! This module is intended for Zenoh's internal use.
+//!
+//! [Click here for Zenoh's documentation](https://docs.rs/zenoh/latest/zenoh)
+
+#[cfg(feature = "acl_postgres")]
+mod acl_postgres;
+#[cfg(feature = "acl_redis")]
+mod acl_redis;
+
+use std::{
+    num::NonZeroUsize,
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
+
+use lru::LruCache;
+use serde::Deserialize;
+use zenoh_config::{
+    AclConfig, AclConfigPolicyEntry, AclConfigRule, AclConfigSubjects, AclIdentitySource,
+    AclPolicyStoreBackend,
+};
+use zenoh_link::LinkAuthId;
+use zenoh_result::{bail, zerror, ZResult};
+use zenoh_transport::unicast::TransportUnicast;
+
+use super::{authorization::PolicyEnforcer, InterceptorState, RefreshOutcome};
+
+/// Access control lists as held in the policy store, with the same fields as the
+/// `access_control` section of the configuration.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct AclPolicyDocument {
+    #[serde(default)]
+    rules: Vec<AclConfigRule>,
+    #[serde(default)]
+    subjects: Vec<AclConfigSubjects>,
+    #[serde(default)]
+    policies: Vec<AclConfigPolicyEntry>,
+}
+
+/// Backend that can return the ACL document held for one identity.
+pub(super) trait PolicyStore: Send + Sync {
+    fn fetch(&self, identity: &str) -> ZResult<AclPolicyDocument>;
+}
+
+/// Identity of the peer behind a transport, read from the configured attribute.
+///
+/// `None` means the transport carries no such attribute, leaving it to be enforced with
+/// the rules that apply to everyone. An error means the identity could not be
+/// established, and the caller is expected to deny the transport.
+fn identity_of(transport: &TransportUnicast, source: AclIdentitySource) -> ZResult<Option<String>> {
+    let auth_ids = transport
+        .get_auth_ids()
+        .map_err(|e| zerror!("Cannot read the transport authentication ids: {}", e))?;
+    Ok(match source {
+        AclIdentitySource::Username => auth_ids.username().cloned(),
+        AclIdentitySource::ZenohId => Some(auth_ids.zid().to_string()),
+        AclIdentitySource::CertCommonName => {
+            let mut names = auth_ids
+                .link_auth_ids()
+                .iter()
+                .filter_map(|auth_id| match auth_id {
+                    LinkAuthId::Tls(name) | LinkAuthId::Quic(name) => name.as_ref(),
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            names.sort_unstable();
+            names.dedup();
+            match names.as_slice() {
+                [] => None,
+                [name] => Some((*name).clone()),
+                _ => bail!(
+                    "Transport presents {} different certificate common names, \
+                     its identity is ambiguous",
+                    names.len()
+                ),
+            }
+        }
+    })
+}
+
+/// Compiled policies of the identities this router has seen.
+///
+/// Holds one policy per identity rather than one for the whole fleet, so that a change
+/// costs a single read and a single small compilation.
+pub(crate) struct PolicyCache {
+    /// The rules, subjects and policies applying to everyone, as declared in the
+    /// configuration file.
+    base: AclConfig,
+    identity: AclIdentitySource,
+    entry_ttl_ms: Option<u64>,
+    cache_capacity: usize,
+    store: Arc<dyn PolicyStore>,
+    /// By identity, as read from each transport with [`identity_of`].
+    entries: Mutex<LruCache<String, CacheEntry>>,
+}
+
+struct CacheEntry {
+    policy: Arc<PolicyEnforcer>,
+    fetched_at: Instant,
+}
+
+impl PolicyCache {
+    /// Fails when `base` declares no policy store, or one that cannot hold anything.
+    pub(crate) fn new(base: AclConfig) -> ZResult<Self> {
+        let Some(conf) = base.policy_store.clone() else {
+            bail!("Access control is not configured with a policy store");
+        };
+        let store: Arc<dyn PolicyStore> = match conf.backend {
+            #[cfg(feature = "acl_redis")]
+            AclPolicyStoreBackend::Redis(redis) => Arc::new(acl_redis::RedisStore::new(redis)?),
+            #[cfg(not(feature = "acl_redis"))]
+            AclPolicyStoreBackend::Redis(_) => {
+                bail!("Access control is configured with a Redis policy store, but zenoh was built without the `acl_redis` feature")
+            }
+            #[cfg(feature = "acl_postgres")]
+            AclPolicyStoreBackend::Postgres(postgres) => {
+                Arc::new(acl_postgres::PostgresStore::new(postgres)?)
+            }
+            #[cfg(not(feature = "acl_postgres"))]
+            AclPolicyStoreBackend::Postgres(_) => {
+                bail!("Access control is configured with a Postgres policy store, but zenoh was built without the `acl_postgres` feature")
+            }
+        };
+        Self::with_store(
+            base,
+            store,
+            conf.identity,
+            conf.entry_ttl_ms,
+            conf.cache_capacity,
+        )
+    }
+
+    fn with_store(
+        base: AclConfig,
+        store: Arc<dyn PolicyStore>,
+        identity: AclIdentitySource,
+        entry_ttl_ms: Option<u64>,
+        cache_capacity: usize,
+    ) -> ZResult<Self> {
+        let capacity = NonZeroUsize::new(cache_capacity)
+            .ok_or_else(|| zerror!("Access control cache_capacity must not be zero"))?;
+        Ok(Self {
+            base,
+            identity,
+            entry_ttl_ms,
+            cache_capacity,
+            store,
+            entries: Mutex::new(LruCache::new(capacity)),
+        })
+    }
+
+    /// Policy held for a transport, or `None` when it carries no identity and is
+    /// therefore left to the rules applying to everyone.
+    ///
+    /// Uses [`Self::held`], so a stale entry is still the policy this transport was
+    /// admitted with. Never reads the store, so that it can be called while the routing tables
+    /// are locked. [`InterceptorState::prepare`] has already refused a transport whose
+    /// policy could not be established, so a miss here is left to the configuration-file
+    /// enforcer.
+    pub(crate) fn held_for(&self, transport: &TransportUnicast) -> Option<Arc<PolicyEnforcer>> {
+        let identity = identity_of(transport, self.identity).ok().flatten()?;
+        self.held(&identity)
+    }
+
+    /// Returns a still-fresh policy, reading the store when none is held or the ttl has elapsed.
+    fn fresh_or_fetch(&self, identity: &str) -> ZResult<Arc<PolicyEnforcer>> {
+        if let Some(policy) = self.fresh(identity) {
+            return Ok(policy);
+        }
+        // nothing prevents two connections of the same identity from reading
+        // the store at the same time. Both get the same answer, so the cost is one wasted
+        // read; a map of in-flight reads is the upgrade if it ever shows up.
+        self.fetch_and_store(identity)
+    }
+
+    fn fetch_and_store(&self, identity: &str) -> ZResult<Arc<PolicyEnforcer>> {
+        let document = self.store.fetch(identity)?;
+        let policy = Arc::new(self.compile(document)?);
+        self.insert(identity, policy.clone());
+        Ok(policy)
+    }
+
+    fn insert(&self, identity: &str, policy: Arc<PolicyEnforcer>) {
+        let mut entries = self.entries.lock().unwrap();
+        if let Some((evicted, _)) = entries.push(
+            identity.to_string(),
+            CacheEntry {
+                policy,
+                fetched_at: Instant::now(),
+            },
+        ) {
+            if evicted != identity {
+                tracing::warn!(
+                    "Access control cache is full (capacity {}), dropping identity '{}'",
+                    self.cache_capacity,
+                    evicted
+                );
+            }
+        }
+    }
+
+    /// Policy held for `identity` if it is still within `entry_ttl_ms`.
+    ///
+    /// Past the ttl the entry is dropped so the next [`Self::fresh_or_fetch`] reads the store
+    /// again. Does not apply the ttl when it is `None`.
+    fn fresh(&self, identity: &str) -> Option<Arc<PolicyEnforcer>> {
+        let mut entries = self.entries.lock().unwrap();
+        let entry = entries.get(identity)?;
+        match self.entry_ttl_ms {
+            Some(ttl) if entry.fetched_at.elapsed() >= Duration::from_millis(ttl) => {
+                entries.pop(identity);
+                None
+            }
+            _ => Some(entry.policy.clone()),
+        }
+    }
+
+    /// Last policy stored for an identity, even if it is past its ttl.
+    ///
+    /// Used while interceptors are built under the routing tables lock: a stale entry is
+    /// still the policy this transport was admitted with, until [`InterceptorState::refresh`]
+    /// replaces it.
+    fn held(&self, identity: &str) -> Option<Arc<PolicyEnforcer>> {
+        self.entries
+            .lock()
+            .unwrap()
+            .get(identity)
+            .map(|entry| entry.policy.clone())
+    }
+
+    /// Drops the policy held for an identity, so that it is read again when next needed.
+    #[cfg(test)]
+    fn invalidate(&self, identity: &str) {
+        self.entries.lock().unwrap().pop(identity);
+    }
+
+    /// Compiles the rules applying to everyone together with those held for one identity.
+    fn compile(&self, document: AclPolicyDocument) -> ZResult<PolicyEnforcer> {
+        let mut enforcer = PolicyEnforcer::new();
+        enforcer.init(&with_empty_lists(&merge(&self.base, document)))?;
+        Ok(enforcer)
+    }
+}
+
+impl InterceptorState for PolicyCache {
+    /// Reads the policy for the identity behind a transport and holds it.
+    ///
+    /// Failure refuses the transport: there is then no session to enforce a fallback on.
+    fn prepare(&self, transport: &TransportUnicast) -> ZResult<()> {
+        match identity_of(transport, self.identity) {
+            Ok(None) => Ok(()),
+            Ok(Some(identity)) => self.fresh_or_fetch(&identity).map(|_| ()),
+            Err(e) => Err(e),
+        }
+    }
+
+    fn refresh(&self, identity: &str) -> RefreshOutcome {
+        match self.fetch_and_store(identity) {
+            Ok(_) => RefreshOutcome::Updated,
+            Err(e) => {
+                tracing::error!(
+                    "Cannot read the access control policy for identity '{}': {}",
+                    identity,
+                    e
+                );
+                // Drop the held policy so a reconnect cannot reuse it while the store is still
+                // unreachable. The gateway closes matching transports.
+                self.entries.lock().unwrap().pop(identity);
+                RefreshOutcome::Failed
+            }
+        }
+    }
+
+    fn identity_of(&self, transport: &TransportUnicast) -> Option<String> {
+        identity_of(transport, self.identity).ok().flatten()
+    }
+
+    fn stale_identities(&self) -> Vec<String> {
+        let Some(ttl) = self.entry_ttl_ms.map(Duration::from_millis) else {
+            return Vec::new();
+        };
+        self.entries
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(_, entry)| entry.fetched_at.elapsed() >= ttl)
+            .map(|(identity, _)| identity.clone())
+            .collect()
+    }
+}
+
+/// The same configuration with its three lists always present.
+///
+/// The policy store holds the rules for each identity, so the configuration file may
+/// declare none at all, and an identity the store holds nothing for must be enforced with
+/// `default_permission`.
+/// Both are cases `PolicyEnforcer::init` would otherwise refuse outright.
+pub(crate) fn with_empty_lists(config: &AclConfig) -> AclConfig {
+    let mut config = config.clone();
+    config.rules.get_or_insert_with(Vec::new);
+    config.subjects.get_or_insert_with(Vec::new);
+    config.policies.get_or_insert_with(Vec::new);
+    config
+}
+
+pub(super) fn parse(document: &str) -> ZResult<AclPolicyDocument> {
+    json5::from_str(document).map_err(|e| {
+        zerror!(
+            "Invalid access control document read from the policy store: {}",
+            e
+        )
+        .into()
+    })
+}
+
+/// Appends the lists read from the policy store to the ones declared in the configuration file.
+///
+/// Ids are deliberately not deduplicated: a collision between the two sources makes the
+/// resulting policy ambiguous, and is reported when it is compiled.
+fn merge(config: &AclConfig, document: AclPolicyDocument) -> AclConfig {
+    fn append<T>(base: &mut Option<Vec<T>>, mut extra: Vec<T>) {
+        if extra.is_empty() {
+            return;
+        }
+        base.get_or_insert_with(Vec::new).append(&mut extra);
+    }
+
+    let mut merged = config.clone();
+    append(&mut merged.rules, document.rules);
+    append(&mut merged.subjects, document.subjects);
+    append(&mut merged.policies, document.policies);
+    merged
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const STORE_DOCUMENT: &str = r#"{
+        "rules": [
+            {"id": "store-rule", "key_exprs": ["a/**"], "messages": ["put"], "permission": "allow"}
+        ],
+        "subjects": [{"id": "store-subject", "usernames": ["alice"]}],
+        "policies": [{"rules": ["store-rule"], "subjects": ["store-subject"]}]
+    }"#;
+
+    const OTHER_DOCUMENT: &str = r#"{
+        "rules": [
+            {"id": "other-rule", "key_exprs": ["b/**"], "messages": ["put"], "permission": "deny"}
+        ],
+        "subjects": [{"id": "other-subject", "usernames": ["bob"]}],
+        "policies": [{"rules": ["other-rule"], "subjects": ["other-subject"]}]
+    }"#;
+
+    struct NullStore;
+
+    impl PolicyStore for NullStore {
+        fn fetch(&self, _: &str) -> ZResult<AclPolicyDocument> {
+            Ok(AclPolicyDocument::default())
+        }
+    }
+
+    struct ScriptedStore {
+        answers: Mutex<std::collections::VecDeque<ZResult<AclPolicyDocument>>>,
+    }
+
+    impl PolicyStore for ScriptedStore {
+        fn fetch(&self, _: &str) -> ZResult<AclPolicyDocument> {
+            self.answers
+                .lock()
+                .unwrap()
+                .pop_front()
+                .expect("unexpected fetch")
+        }
+    }
+
+    fn cache_with(entry_ttl_ms: Option<u64>, cache_capacity: usize) -> PolicyCache {
+        PolicyCache::with_store(
+            AclConfig {
+                enabled: true,
+                ..AclConfig::default()
+            },
+            Arc::new(NullStore),
+            AclIdentitySource::Username,
+            entry_ttl_ms,
+            cache_capacity,
+        )
+        .unwrap()
+    }
+
+    fn cache_policy(cache: &PolicyCache, identity: &str, document: &str) {
+        let policy = Arc::new(cache.compile(parse(document).unwrap()).unwrap());
+        cache.insert(identity, policy);
+    }
+
+    #[test]
+    fn store_document_is_appended_to_the_configured_lists() {
+        // The store alone can provide the whole policy.
+        let from_store = merge(&AclConfig::default(), parse(STORE_DOCUMENT).unwrap());
+        assert_eq!(from_store.rules.as_ref().unwrap().len(), 1);
+        assert_eq!(from_store.subjects.as_ref().unwrap().len(), 1);
+        assert_eq!(from_store.policies.as_ref().unwrap().len(), 1);
+
+        // What it provides is added to what the configuration file already declares,
+        // rather than replacing it.
+        let merged = merge(&from_store, parse(OTHER_DOCUMENT).unwrap());
+        let rules = merged.rules.as_ref().unwrap();
+        assert_eq!(rules.len(), 2);
+        assert_eq!(rules[0].id, "store-rule");
+        assert_eq!(rules[1].id, "other-rule");
+        assert_eq!(merged.subjects.as_ref().unwrap().len(), 2);
+        assert_eq!(merged.policies.as_ref().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn a_colliding_id_between_file_and_store_is_rejected() {
+        // Merge does not deduplicate; a shared id would otherwise make the compiled
+        // policy ambiguous.
+        let cache = PolicyCache::with_store(
+            merge(
+                &AclConfig {
+                    enabled: true,
+                    ..AclConfig::default()
+                },
+                parse(STORE_DOCUMENT).unwrap(),
+            ),
+            Arc::new(NullStore),
+            AclIdentitySource::Username,
+            None,
+            8,
+        )
+        .unwrap();
+        assert!(cache.compile(parse(STORE_DOCUMENT).unwrap()).is_err());
+    }
+
+    #[test]
+    fn empty_document_leaves_the_configuration_untouched() {
+        let merged = merge(&AclConfig::default(), parse("{}").unwrap());
+        assert!(merged.rules.is_none());
+        assert!(merged.subjects.is_none());
+        assert!(merged.policies.is_none());
+    }
+
+    #[test]
+    fn an_identity_the_store_holds_nothing_for_still_compiles() {
+        // Without this, such an identity would be denied by a compilation error rather than
+        // enforced with `default_permission`.
+        let cache = cache_with(Some(300_000), 8);
+        let policy = cache.compile(parse("{}").unwrap()).unwrap();
+        assert!(policy.acl_enabled);
+        assert!(policy.policy_map.is_empty());
+    }
+
+    #[test]
+    fn fresh_drops_a_policy_past_its_ttl() {
+        let cache = cache_with(Some(20), 8);
+        cache_policy(&cache, "alice", STORE_DOCUMENT);
+        assert!(cache.fresh("alice").is_some());
+        assert!(cache.held("alice").is_some());
+
+        std::thread::sleep(Duration::from_millis(30));
+        // `held` ignores the ttl; `fresh` applies it (and drops the entry).
+        assert!(cache.held("alice").is_some());
+        assert!(cache.fresh("alice").is_none());
+        assert!(cache.held("alice").is_none());
+
+        // A cache without a ttl trusts what it holds until something invalidates it.
+        let cache = cache_with(None, 8);
+        cache_policy(&cache, "alice", STORE_DOCUMENT);
+        std::thread::sleep(Duration::from_millis(30));
+        assert!(cache.fresh("alice").is_some());
+        assert!(cache.held("alice").is_some());
+
+        cache.invalidate("alice");
+        assert!(cache.fresh("alice").is_none());
+        assert!(cache.held("alice").is_none());
+    }
+
+    #[test]
+    fn policies_past_their_ttl_are_reported_as_stale() {
+        let cache = cache_with(Some(20), 8);
+        cache_policy(&cache, "alice", STORE_DOCUMENT);
+        assert!(cache.stale_identities().is_empty());
+
+        std::thread::sleep(Duration::from_millis(30));
+        assert_eq!(cache.stale_identities(), vec!["alice".to_string()]);
+
+        // Without a ttl nothing goes stale on its own, leaving an explicit refresh as the
+        // only way a change reaches a connected identity.
+        let cache = cache_with(None, 8);
+        cache_policy(&cache, "alice", STORE_DOCUMENT);
+        std::thread::sleep(Duration::from_millis(30));
+        assert!(cache.stale_identities().is_empty());
+    }
+
+    #[test]
+    fn holding_more_identities_than_capacity_drops_the_least_recently_used() {
+        let cache = cache_with(None, 2);
+        cache_policy(&cache, "alice", STORE_DOCUMENT);
+        cache_policy(&cache, "bob", STORE_DOCUMENT);
+        // Reading alice makes bob the next to go.
+        assert!(cache.held("alice").is_some());
+        cache_policy(&cache, "carol", STORE_DOCUMENT);
+
+        assert!(cache.held("bob").is_none());
+        assert!(cache.held("alice").is_some());
+        assert!(cache.held("carol").is_some());
+    }
+
+    #[test]
+    fn a_fetched_document_is_compiled_and_a_failed_refresh_drops_it() {
+        let cache = PolicyCache::with_store(
+            AclConfig {
+                enabled: true,
+                ..AclConfig::default()
+            },
+            Arc::new(ScriptedStore {
+                answers: Mutex::new(std::collections::VecDeque::from([
+                    Ok(parse(STORE_DOCUMENT).unwrap()),
+                    Err(zerror!("store unreachable").into()),
+                ])),
+            }),
+            AclIdentitySource::Username,
+            None,
+            8,
+        )
+        .unwrap();
+
+        let policy = cache.fresh_or_fetch("alice").unwrap();
+        assert!(!policy.policy_map.is_empty());
+        assert!(cache.held("alice").is_some());
+
+        // A later read that cannot reach the store must not leave the last policy in
+        // place for a reconnect.
+        assert!(matches!(cache.refresh("alice"), RefreshOutcome::Failed));
+        assert!(cache.held("alice").is_none());
+    }
+
+    #[test]
+    fn malformed_document_is_rejected() {
+        // A misspelled field would otherwise silently drop rules the operator believes
+        // are enforced.
+        assert!(parse(r#"{"rulez": []}"#).is_err());
+        assert!(parse("not json").is_err());
+        assert!(parse(r#"{"rules": [{"id": "no-key-exprs"}]}"#).is_err());
+    }
+}

--- a/zenoh/src/net/routing/interceptor/mod.rs
+++ b/zenoh/src/net/routing/interceptor/mod.rs
@@ -19,6 +19,8 @@
 //! [Click here for Zenoh's documentation](https://docs.rs/zenoh/latest/zenoh)
 //!
 mod access_control;
+#[cfg(feature = "acl_policy_store")]
+mod acl_policy_store;
 use access_control::acl_interceptor_factories;
 use nonempty_collections::NEVec;
 use zenoh_link::LinkAuthId;
@@ -26,6 +28,7 @@ use zenoh_link::LinkAuthId;
 mod authorization;
 use std::{
     any::Any,
+    collections::HashMap,
     sync::{
         atomic::{AtomicPtr, Ordering},
         Arc,
@@ -127,8 +130,61 @@ pub(crate) trait InterceptorFactoryTrait {
 
 pub(crate) type InterceptorFactory = Box<dyn InterceptorFactoryTrait + Send + Sync>;
 
-pub(crate) fn interceptor_factories(config: &Config) -> ZResult<Vec<InterceptorFactory>> {
+/// Result of [`InterceptorState::refresh`].
+///
+/// The gateway rebuilds interceptors for [`Self::Updated`] identities and closes matching
+/// unicast transports for [`Self::Failed`] ones. Whether a given interceptor reports
+/// [`Self::Failed`] (drop the session) or keeps the last policy and reports [`Self::Updated`]
+/// can later be made configurable on that interceptor. An interceptor that cannot
+/// re-read the store reports [`Self::Failed`].
+#[cfg_attr(not(feature = "acl_policy_store"), allow(dead_code))]
+pub(crate) enum RefreshOutcome {
+    Updated,
+    Failed,
+}
+
+/// State an interceptor keeps for transport identities, read from somewhere the router
+/// does not control.
+///
+/// Held by the routing tables rather than by the factory, because it is reached both when
+/// a transport is admitted and when the router is told that what it holds went stale.
+pub(crate) trait InterceptorState: Send + Sync {
+    /// Gets whatever is needed for a transport that is about to be admitted.
+    ///
+    /// [`InterceptorFactoryTrait::new_transport_unicast`] runs while the routing tables
+    /// are held for writing, so anything that can block belongs here instead. Called once
+    /// per transport, before those tables are locked. Returning an error refuses the
+    /// transport.
+    fn prepare(&self, transport: &TransportUnicast) -> ZResult<()>;
+
+    /// Reads again what is held for `identity`.
+    ///
+    /// Allowed to block, and never called while the routing tables are locked.
+    /// [`RefreshOutcome::Updated`] rebuilds interceptors for matching transports;
+    /// [`RefreshOutcome::Failed`] closes them.
+    fn refresh(&self, identity: &str) -> RefreshOutcome;
+
+    /// Identity this state uses for a transport, so that the router can tell which
+    /// transports a refresh applies to.
+    fn identity_of(&self, transport: &TransportUnicast) -> Option<String>;
+
+    /// Identities whose state has grown too old to be trusted and should be read again.
+    fn stale_identities(&self) -> Vec<String>;
+}
+
+/// Admin-space path segment and key in [`Interceptors::states`] for access control.
+pub(crate) const ACCESS_CONTROL: &str = "access_control";
+
+/// The interceptors a configuration asks for, and the state they keep.
+pub(crate) struct Interceptors {
+    pub(crate) factories: Vec<InterceptorFactory>,
+    /// By interceptor name, so that a caller can address one of them.
+    pub(crate) states: HashMap<&'static str, Arc<dyn InterceptorState>>,
+}
+
+pub(crate) fn interceptors(config: &Config) -> ZResult<Interceptors> {
     let mut res: Vec<InterceptorFactory> = vec![];
+    let mut states = HashMap::new();
     // Uncomment to log the interceptors initialisation
     // res.push(Box::new(LoggerInterceptor {}));
     #[cfg(test)]
@@ -139,10 +195,18 @@ pub(crate) fn interceptor_factories(config: &Config) -> ZResult<Vec<InterceptorF
         }
     }
     res.extend(downsampling_interceptor_factories(config.downsampling())?);
-    res.extend(acl_interceptor_factories(config.access_control())?);
+    if let Some((factory, state)) = acl_interceptor_factories(config.access_control())? {
+        res.push(factory);
+        if let Some(state) = state {
+            states.insert(ACCESS_CONTROL, state);
+        }
+    }
     res.extend(qos_overwrite_interceptor_factories(config.qos().network())?);
     res.extend(low_pass_interceptor_factories(config.low_pass_filter())?);
-    Ok(res)
+    Ok(Interceptors {
+        factories: res,
+        states,
+    })
 }
 
 pub(crate) struct InterceptorsChain {

--- a/zenoh/src/net/runtime/adminspace.rs
+++ b/zenoh/src/net/runtime/adminspace.rs
@@ -61,7 +61,10 @@ use crate::{
     bytes::Encoding,
     net::{
         primitives::Primitives,
-        routing::{dispatcher::tables::Tables, gateway::Resource, hat::Sources},
+        routing::{
+            dispatcher::tables::Tables, gateway::Resource, hat::Sources,
+            interceptor::ACCESS_CONTROL,
+        },
         runtime::{region, DynamicRuntime},
     },
     LONG_VERSION,
@@ -348,6 +351,17 @@ impl AdminSpace {
                 wire_expr: [&root_key, "/config/**"].concat().into(),
             }),
         });
+
+        primitives.send_declare(&mut Declare {
+            interest_id: None,
+            ext_qos: ext::QoSType::DECLARE,
+            ext_tstamp: None,
+            ext_nodeid: ext::NodeIdType::DEFAULT,
+            body: DeclareBody::DeclareSubscriber(DeclareSubscriber {
+                id: runtime.next_id(),
+                wire_expr: [&root_key, "/", ACCESS_CONTROL, "/refresh"].concat().into(),
+            }),
+        });
     }
 
     pub fn key_expr_to_string<'a>(&self, key_expr: &'a WireExpr) -> ZResult<KeyExpr<'a>> {
@@ -413,6 +427,39 @@ impl Primitives for AdminSpace {
                 return;
             }
         };
+
+        // Writing an identity here tells the router that what access control holds for it
+        // went stale, and is answered by reading it again. Handled off this thread because
+        // reading it can block, and this one is routing messages.
+        let local_access_control_refresh_key: OwnedKeyExpr = format!(
+            "@/{}/{}/{}/refresh",
+            self.zid, self.context.runtime.state.whatami, ACCESS_CONTROL,
+        )
+        .try_into()
+        .unwrap();
+        if local_access_control_refresh_key.intersects(&key_expr) {
+            if let PushBody::Put(put) = &msg.payload {
+                match std::str::from_utf8(&put.payload.contiguous()) {
+                    Ok(identity) if !identity.trim().is_empty() => {
+                        let identity = identity.trim().to_string();
+                        let router = self.context.runtime.state.router.clone();
+                        zenoh_runtime::ZRuntime::Net.spawn(async move {
+                            router.refresh_interceptor_state(ACCESS_CONTROL, &identity);
+                        });
+                    }
+                    Ok(_) => tracing::error!(
+                        "Received a PUT on '{}' without an identity to refresh",
+                        key_expr
+                    ),
+                    Err(e) => tracing::error!(
+                        "Received a PUT on '{}' whose identity is not valid utf8: {}",
+                        key_expr,
+                        e
+                    ),
+                }
+            }
+            return;
+        }
 
         static CONFIG_FORMAT: OnceLock<KeFormat<'static, [Segment<'static>; 3]>> = OnceLock::new();
         let config_format = CONFIG_FORMAT.get_or_init(|| {

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -37,6 +37,7 @@ use std::{
         atomic::{AtomicU32, Ordering},
         Arc, Weak,
     },
+    time::Duration,
 };
 
 pub use adminspace::AdminSpace;
@@ -847,6 +848,26 @@ impl RuntimeBuilder {
             AdminSpace::start(&runtime).await;
         }
 
+        // How often the state the interceptors keep is looked over for entries too old to
+        // be trusted. Kept well under the shortest expiry an interceptor is likely to be
+        // given, so that staleness is bounded by that expiry plus one tick.
+        const INTERCEPTOR_STATE_SWEEP_INTERVAL: Duration = Duration::from_secs(10);
+
+        // only started when an interceptor already keeps state, so one added by
+        // a later configuration reload is not swept until the next restart. Asking the
+        // gateway on every tick instead would trade that for a timer in every session.
+        if runtime.router().keeps_interceptor_state() {
+            let router = runtime.router();
+            runtime.spawn_abortable(async move {
+                let mut interval = tokio::time::interval(INTERCEPTOR_STATE_SWEEP_INTERVAL);
+                interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+                loop {
+                    interval.tick().await;
+                    router.refresh_stale_interceptor_state();
+                }
+            });
+        }
+
         // Start plugins
         #[cfg(feature = "plugins")]
         start_plugins(&runtime);
@@ -1139,6 +1160,11 @@ impl TransportEventHandler for RuntimeTransportEventHandler {
                 {
                     bail!("Client runtimes only accept one north-bound transport");
                 }
+
+                // Anything the interceptors have to get for this transport is fetched
+                // here, because `new_transport_unicast` below holds the routing tables
+                // for writing and would stall the router for as long as it takes.
+                runtime.state.router.prepare_transport_unicast(&transport)?;
 
                 Ok(Arc::new(RuntimeSession {
                     runtime: runtime.clone(),

--- a/zenohd/Cargo.toml
+++ b/zenohd/Cargo.toml
@@ -27,6 +27,8 @@ version = { workspace = true }
 
 [features]
 default = ["zenoh/default"]
+acl_postgres = ["zenoh/acl_postgres"]
+acl_redis = ["zenoh/acl_redis"]
 shared-memory = ["zenoh/shared-memory"]
 
 [dependencies]


### PR DESCRIPTION
A connected peer's rules can change without restarting the router. The document is fetched at connect, cached, and re-read on PUT @/{zid}/{whatami}/access_control/refresh or when its optional TTL elapses. Fail-closed: refuse the transport when the store cannot be read, and close matching sessions if a refresh fails.

Configured under access_control.policy_store (type redis or postgres); requires --features acl_redis or --features acl_postgres.

## Description

Add an option to load the ACL for a connecting identity from an external store, and to refresh it while the session stays up.

### What does this PR do?

When a transport is admitted and `access_control.policy_store` is set:
- resolve the peer identity from the configured attribute (`username`, `zenoh_id`, or `cert_common_name`)
- fetch the ACL document for that identity from Redis or Postgres
- compile it together with the static `access_control` lists (those lists are then the rules that apply to everyone)
- cache the compiled policy for later interceptors and refreshes

A missing document is not an error: the identity is enforced with the static lists and `default_permission`.
A store that cannot be read is: the transport is refused.
A transport with no such identity attribute is left on the everyone-rules, without a fetch.

Refresh, without a router restart:

- `PUT @/{zid}/{whatami}/access_control/refresh` with the identity as payload (admin space)
- if `entry_ttl_ms` is set (default 300000), a 10s sweep re-reads documents that have gone stale for still-connected identities; `null` disables that and leaves only the explicit PUT

A failed refresh drops the cached policy and closes matching sessions (same fail-closed rule as connect). Ids must not collide between the file and a store document; a collision makes the compiled policy invalid.

Compile-time: `--features acl_redis` and/or `--features acl_postgres`. A config that sets `policy_store` without the matching feature fails at startup. With neither the option nor the feature, behavior is unchanged.

### Why is this change needed?

Static ACL in `config.json5` does not scale to a large, changing fleet: the file grows with every client, and a policy change currently needs a router reload. Fleet management of devices connected to a cloud router is the motivating case: keep only the everyone-rules in the file, and fetch per-identity documents for sessions that are actually connected.

### Related Issues

Related to #1432 and #2659: same motivation (static ACL does not scale for a dynamic fleet). This PR does not implement trust-based / token authorization (#1432) nor key-expression templating (#2659); it adds a router-side per-identity policy store with refresh.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

**No specific label requirements detected.**

Current labels: _No labels_

Add one of these labels to this PR to see relevant checklist items: `api-sync`, `breaking-change`, `bug`, `ci`, `dependencies`, `documentation`, `enhancement`, `new feature`, `internal`

*This section updates automatically when labels change.*

<!-- 🏷️ Label-Based Checklist END -->