### PR TITLE
fix(runtime): make the connector and listener retry tasks abortable

### DIFF
--- a/zenoh/src/net/protocol/gossip.rs
+++ b/zenoh/src/net/protocol/gossip.rs
@@ -387,7 +387,7 @@ impl Gossip {
                 if let Some(locators) = locators {
                     let runtime = strong_runtime.clone();
                     let wait_declares = self.wait_declares;
-                    strong_runtime.spawn(async move {
+                    strong_runtime.spawn_abortable(async move {
                         if runtime
                             .manager()
                             .get_transport_unicast(&zid)

--- a/zenoh/src/net/protocol/network.rs
+++ b/zenoh/src/net/protocol/network.rs
@@ -632,7 +632,7 @@ impl Network {
 
     fn connect_discovered_peer(&self, zid: ZenohIdProto, locators: Vec<Locator>) {
         let runtime = self.runtime.upgrade().unwrap();
-        self.runtime.upgrade().unwrap().spawn(async move {
+        self.runtime.upgrade().unwrap().spawn_abortable(async move {
             if runtime
                 .manager()
                 .get_transport_unicast(&zid)

--- a/zenoh/src/net/runtime/orchestrator.rs
+++ b/zenoh/src/net/runtime/orchestrator.rs
@@ -575,7 +575,7 @@ impl Runtime {
         retry_config: zenoh_config::ConnectionRetryConf,
     ) {
         let this = self.clone();
-        self.spawn(async move {
+        self.spawn_abortable(async move {
             this.add_listener_retry(listener, retry_config).await;
             this.print_locators();
         });
@@ -873,7 +873,7 @@ impl Runtime {
             let gossip = unwrap_or_default!(config.scouting().gossip().enabled());
             let wait_declares = unwrap_or_default!(config.open().return_conditions().declares());
             drop(config_guard);
-            self.spawn(async move {
+            self.spawn_abortable(async move {
                 if let Ok(zid) = this.peer_connector_retry(peer).await {
                     this.state
                         .start_conditions
@@ -1404,7 +1404,7 @@ impl Runtime {
 
         if !peers.is_empty() {
             let runtime = session.runtime.clone();
-            session.runtime.spawn(async move {
+            session.runtime.spawn_abortable(async move {
                 runtime
                     .peers_connector_retry(peers, runtime.whatami() == WhatAmI::Client)
                     .await
@@ -1438,7 +1438,7 @@ impl Runtime {
 
         if peers.contains(&endpoint) && zwrite!(session.endpoints).remove(&endpoint) {
             let runtime = session.runtime.clone();
-            session.runtime.spawn(async move {
+            session.runtime.spawn_abortable(async move {
                 let _ = runtime.peer_connector_retry(endpoint).await;
             });
         }

--- a/zenoh/tests/close_with_failing_listener.rs
+++ b/zenoh/tests/close_with_failing_listener.rs
@@ -1,0 +1,80 @@
+//
+// Copyright (c) 2026 Oliver Harley
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   Oliver Harley
+//
+
+//! A session whose listener can never bind must still close.
+//!
+//! `TaskController::spawn` carries a documented obligation, restated on
+//! `Runtime::spawn` itself:
+//!
+//! > Spawns a task within runtime. **Upon close runtime will block until this
+//! > task completes**
+//!
+//! `spawn_add_listener` used it for `add_listener_retry`, which is
+//! `loop { if add_listener().await.is_ok() { break } sleep(period).await }` —
+//! unbounded, and holding no cancellation token. So a listener that can never
+//! bind means close blocks forever.
+//!
+//! The configured listen timeout does not save it. `bind_listeners` wraps
+//! `bind_listeners_impl` in `tokio::time::timeout`, but on this branch
+//! (`exit_on_failure == false`) that function *spawns* and returns immediately —
+//! so the timeout bounds the spawning, not the spawned work.
+//!
+//! Reaching the spawned path needs both conditions together, which is why the
+//! existing `connection_retry.rs` tests miss it: they leave `exit_on_failure` at
+//! its default and so take the inline branch, where the retry really is awaited
+//! and really is bounded.
+
+use std::time::{Duration, Instant};
+
+use zenoh::Config;
+use zenoh_core::Wait;
+
+/// A listener that can never bind must not stop the session from closing.
+///
+/// `tcp/8.8.8.8:8` is chosen so the failure is local and immediate: binding an
+/// address that belongs to no local interface fails in the kernel with
+/// `EADDRNOTAVAIL` without a single packet leaving the machine. No connection is
+/// attempted, so this neither touches the network nor prompts a firewall dialog.
+#[test]
+fn close_completes_when_listener_never_binds() {
+    let mut config = Config::default();
+    config
+        .insert_json5("listen/endpoints", r#"["tcp/8.8.8.8:8"]"#)
+        .unwrap();
+    // Non-zero timeout AND exit_on_failure=false is the exact pair that reaches
+    // `spawn_add_listener`. Either one alone takes a bounded path.
+    config.insert_json5("listen/timeout_ms", "1000").unwrap();
+    config
+        .insert_json5("listen/exit_on_failure", "false")
+        .unwrap();
+
+    // Opening is expected to succeed: the listener failure is backgrounded, which
+    // is the documented point of `exit_on_failure=false`.
+    let session = zenoh::open(config).wait().unwrap();
+
+    let start = Instant::now();
+    session.close().wait().unwrap();
+    let elapsed = start.elapsed();
+
+    // Generous on purpose. The unfixed behaviour is not "a bit slow" but "never
+    // returns", so any bound at all discriminates, and a loose one keeps the test
+    // from going flaky on a loaded CI machine. If this ever fails it will fail by
+    // a mile, not by a margin.
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "close() took {elapsed:?} with a permanently-failing listener; the \
+         background add_listener_retry loop is not observing the runtime's \
+         cancellation token"
+    );
+}

--- a/zenoh/tests/gossip_timing_probe.rs
+++ b/zenoh/tests/gossip_timing_probe.rs
@@ -1,0 +1,366 @@
+//
+// Copyright (c) 2026 Oliver Harley
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   Oliver Harley
+//
+
+//! Reproducer for an **upstream** session-close hang. Asserts nothing; prints
+//! timings. `#[ignore]`d — run it deliberately:
+//!
+//! ```text
+//! cargo test -p zenoh --features unstable --test gossip_timing_probe -- --nocapture --ignored
+//! PROBE_OPEN_TIMEOUT=1 cargo test ... --ignored     # the kill-test
+//! ```
+//!
+//! ## What it shows
+//!
+//! With gossip off, every open and close is sub-20ms. With gossip on, **opens
+//! are unchanged** and closes pin at exactly 10.00s and fail. So nothing is
+//! *spending* 20 seconds — a task is not cancelling, and `close()` is giving up
+//! at its own bound.
+//!
+//! ## The chain, verified
+//!
+//! 1. Gossip discovers a peer; peer-mode autoconnect fires
+//!    (`orchestrator.rs:866`, `spawn_peer_connector`). A client never gossips
+//!    and a router autoconnects to nothing, which is why only peer-mode
+//!    topologies with something to discover are affected.
+//! 2. It uses `TaskController::spawn` (`orchestrator.rs:878`), which does **not**
+//!    wrap the future in a select on the cancellation token — cancellation is
+//!    opt-in per task (`zenoh-task/src/lib.rs:95-104`).
+//! 3. Inside, the retry *sleep* is cancellable (`orchestrator.rs:907-916`) but
+//!    the connect attempt — `open_transport_unicast` at `orchestrator.rs:942` —
+//!    is not. It runs to `transport.unicast.open_timeout`, default **10000ms**.
+//! 4. `terminate_all_async` (`zenoh-task/src/lib.rs:142-146`) awaits
+//!    `tracker.wait()` with no bound of its own, so close blocks on that task.
+//! 5. `CloseBuilder`'s own 10s (`close.rs:58`, applied at `:132-137`) expires
+//!    first → `"close operation timed out"`.
+//!
+//! Step 3 is the defect; the rest is why it surfaces where it does.
+//!
+//! ## Why the failures are *faster* than the passes
+//!
+//! ~12s failing versus ~20.4s passing looks backwards until you see it is a
+//! timeout: a run that gives up at 10s is quicker than one that waits for the
+//! task to finish on its own. That inversion is the signature.
+//!
+//! ## The kill-test
+//!
+//! `PROBE_OPEN_TIMEOUT=1` sets `open_timeout` to 2000ms with gossip still on.
+//! Every close then succeeds and the hang tracks the new value —
+//! measured 1.86s / 2.74s / 2.02s against >10s. Direct causal confirmation
+//! rather than arithmetic that happens to fit.
+//!
+//! Loopback only, multicast off, so no firewall prompt.
+
+#![cfg(feature = "unstable")]
+
+use std::time::{Duration, Instant};
+
+use zenoh::Config;
+
+fn cfg(listen: Option<&str>, connect: Option<&str>, gossip: bool) -> Config {
+    let mut c = Config::default();
+    // Exactly what TestSessions does...
+    c.scouting.multicast.set_enabled(Some(false)).unwrap();
+    // ...plus the one variable under test.
+    c.scouting.gossip.set_enabled(Some(gossip)).unwrap();
+    // Kill-test: if the stuck task is blocked in `open_transport_unicast`
+    // (orchestrator.rs:942, which is NOT wrapped in a select on the
+    // cancellation token), then shortening this must shorten the hang.
+    if std::env::var("PROBE_OPEN_TIMEOUT").is_ok() {
+        c.transport.unicast.set_open_timeout(2000).unwrap();
+    }
+    if let Some(l) = listen {
+        c.listen.endpoints.set(vec![l.parse().unwrap()]).unwrap();
+    }
+    if let Some(x) = connect {
+        c.connect.endpoints.set(vec![x.parse().unwrap()]).unwrap();
+    }
+    c
+}
+
+/// open + close a two-peer topology, timing each phase separately.
+async fn probe(gossip: bool) {
+    let t = Instant::now();
+    let listener = zenoh::open(cfg(Some("tcp/127.0.0.1:0"), None, gossip))
+        .await
+        .unwrap();
+    let open_listener = t.elapsed();
+
+    let ep = zenoh_test::get_tcp_locator(&listener).await;
+
+    let t = Instant::now();
+    let connector = zenoh::open(cfg(None, Some(&ep.to_string()), gossip))
+        .await
+        .unwrap();
+    let open_connector = t.elapsed();
+
+    // A second connector into the now-standing topology. If the cost is paid at
+    // topology *formation*, this is cheap; if it is per-participant, it is not.
+    let t = Instant::now();
+    let connector2 = zenoh::open(cfg(None, Some(&ep.to_string()), gossip))
+        .await
+        .unwrap();
+    let open_connector2 = t.elapsed();
+
+    // Deliberately not unwrapped: a close that times out is the thing being
+    // measured, so it must be reported rather than panicked on.
+    let t = Instant::now();
+    let r1 = connector.close().await;
+    let close_connector = t.elapsed();
+
+    let t = Instant::now();
+    let r2 = connector2.close().await;
+    let close_connector2 = t.elapsed();
+
+    let t = Instant::now();
+    let r3 = listener.close().await;
+    let close_listener = t.elapsed();
+
+    let ok = |r: &zenoh::Result<()>| if r.is_ok() { "ok" } else { "TIMEOUT" };
+    println!(
+        "                close outcomes: conn1 {}  conn2 {}  listener {}",
+        ok(&r1),
+        ok(&r2),
+        ok(&r3)
+    );
+
+    println!(
+        "gossip={gossip:<5}  open[listener {:>7.2?}  conn1 {:>7.2?}  conn2 {:>7.2?}]  \
+         close[conn1 {:>7.2?}  conn2 {:>7.2?}  listener {:>7.2?}]",
+        open_listener,
+        open_connector,
+        open_connector2,
+        close_connector,
+        close_connector2,
+        close_listener,
+    );
+}
+
+/// The same hang with **gossip off entirely** — the minimal form.
+///
+/// `peers_connector_retry` is not gossip-specific. It is reached from the
+/// configured `connect.endpoints` path (`orchestrator.rs:426`) as well as from
+/// gossip (`:994`). So gossip is a *trigger*, not the condition: any session
+/// closing while a configured connect is in flight to an unresponsive endpoint
+/// inherits the same 10s stall.
+///
+/// The black hole is a plain `TcpListener` that accepts and then says nothing.
+/// That matters — a *refused* connection returns immediately and the retry
+/// sleep that follows is cancellable. It is the accepted-but-silent case that
+/// parks inside `open_transport_unicast` until `open_timeout`.
+/// Does `spawn_add_listener` actually hang close, or does it only look like it?
+///
+/// `spawn_add_listener` (`orchestrator.rs`) spawns `add_listener_retry`, a bare
+/// `loop { if add_listener().await.is_ok() { break } sleep(period).await }` with
+/// **no cancellation token at all** — so unlike `peers_connector_retry` it has
+/// not even a partial guard. If that is a real instance of the bug, a listener
+/// that can never bind should block close.
+///
+/// `tcp/8.8.8.8:8` is unbindable locally: the kernel rejects it with
+/// `EADDRNOTAVAIL` without a packet leaving the machine. Deterministic, offline,
+/// and no firewall prompt. `exit_on_failure: false` is what selects the
+/// spawn-and-retry branch rather than failing the open.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "diagnostic reproducer for an upstream close hang; asserts nothing, run deliberately"]
+async fn does_the_listener_retry_site_hang_close() {
+    zenoh_util::init_log_from_env_or("error");
+
+    let mut c = Config::default();
+    c.scouting.multicast.set_enabled(Some(false)).unwrap();
+    c.scouting.gossip.set_enabled(Some(false)).unwrap();
+    c.listen
+        .endpoints
+        .set(vec!["tcp/8.8.8.8:8".parse().unwrap()])
+        .unwrap();
+    c.listen
+        .set_exit_on_failure(Some(zenoh_config::ModeDependentValue::Unique(false)))
+        .unwrap();
+    // Load-bearing, and the reason a naive attempt at this shows nothing:
+    // `listen.timeout_ms` defaults to **0**, so `add_listener_retry` gives up
+    // immediately and there is no loop left to hang on. -1 is infinite retry,
+    // which is what an operator sets for a listener expected to come back.
+    c.listen
+        .set_timeout_ms(Some(zenoh_config::ModeDependentValue::Unique(-1)))
+        .unwrap();
+
+    let t = Instant::now();
+    let session = match zenoh::open(c).await {
+        Ok(s) => s,
+        Err(e) => {
+            println!("\nopen refused ({e}) - exit_on_failure did not take; test inconclusive\n");
+            return;
+        }
+    };
+    let opened = t.elapsed();
+
+    let t = Instant::now();
+    let r = session.close().await;
+    println!(
+        "\nunbindable listener, exit_on_failure=false:  open {:>9.2?}  close {:>9.2?}  {}\n\
+         (a close in the seconds means `spawn_add_listener` is a real instance;\n \
+          a close in milliseconds means it is not, and the site is pattern-match only)\n",
+        opened,
+        t.elapsed(),
+        if r.is_ok() { "ok" } else { "TIMEOUT" }
+    );
+}
+
+/// Measures the **bind-before-accept window** at listener startup.
+///
+/// `zenoh-link-tcp/src/unicast.rs`: `new_listener` binds *and listens* (`:314`),
+/// but the `accept_task` is only constructed (`:326-332`) and registered
+/// (`:334-337`) afterwards. Between those, the kernel completes TCP handshakes
+/// into the backlog and nothing answers them — structurally the same condition
+/// as the black hole, arising from ordinary startup rather than fault injection.
+///
+/// The question is its **width**. If sub-millisecond it is irrelevant beside a
+/// 10 s `open_timeout`; if wide, the close hang is reachable during any rolling
+/// restart.
+///
+/// Method: race a real client against listener startup and time the client's
+/// `open()`. A client that lands in the window would park in
+/// `open_transport_unicast` and show ~`open_timeout`; one that misses it shows
+/// milliseconds. Repeated, because it is a race.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "diagnostic reproducer for an upstream close hang; asserts nothing, run deliberately"]
+async fn bind_before_accept_window() {
+    zenoh_util::init_log_from_env_or("error");
+
+    println!("\n--- client racing listener startup (10 rounds) ---");
+    let mut worst = Duration::ZERO;
+
+    for round in 0..10 {
+        // A port nothing holds. The TOCTOU window here is the point: we want the
+        // client attempting while the listener is still coming up.
+        let port = {
+            let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            l.local_addr().unwrap().port()
+        };
+        let addr = format!("tcp/127.0.0.1:{port}");
+
+        let mut lc = Config::default();
+        lc.scouting.multicast.set_enabled(Some(false)).unwrap();
+        lc.scouting.gossip.set_enabled(Some(false)).unwrap();
+        lc.listen
+            .endpoints
+            .set(vec![addr.parse().unwrap()])
+            .unwrap();
+
+        let mut cc = Config::default();
+        cc.scouting.multicast.set_enabled(Some(false)).unwrap();
+        cc.scouting.gossip.set_enabled(Some(false)).unwrap();
+        cc.connect
+            .endpoints
+            .set(vec![addr.parse().unwrap()])
+            .unwrap();
+
+        // Client first, so it is already retrying when the listener binds.
+        let client_task = tokio::spawn(async move {
+            let t = Instant::now();
+            let s = zenoh::open(cc).await;
+            (t.elapsed(), s.is_ok())
+        });
+
+        let listener = zenoh::open(lc).await.unwrap();
+        let (client_elapsed, ok) = client_task.await.unwrap();
+        worst = worst.max(client_elapsed);
+        println!(
+            "round {round}: client open {:>9.2?}  {}",
+            client_elapsed,
+            if ok { "ok" } else { "FAILED" }
+        );
+
+        let _ = listener.close().await;
+    }
+
+    println!("worst client open: {worst:.2?}");
+    println!(
+        "(>= ~10s would mean the window is wide enough to park a peer for open_timeout;\n \
+         milliseconds means the window is real but too narrow to matter)\n"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "diagnostic reproducer for an upstream close hang; asserts nothing, run deliberately"]
+async fn the_hang_without_gossip() {
+    zenoh_util::init_log_from_env_or("error");
+
+    let sink = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = sink.local_addr().unwrap();
+    std::thread::spawn(move || {
+        // Hold every accepted connection open and never speak zenoh.
+        let mut held = Vec::new();
+        for s in sink.incoming() {
+            match s {
+                Ok(s) => held.push(s),
+                Err(_) => break,
+            }
+        }
+    });
+
+    println!("\n--- gossip OFF, configured unresponsive endpoint(s) ---");
+    // `n` copies of the same black hole: does the stall stack across endpoints,
+    // or do the connector tasks overlap? Severity depends on the answer — a
+    // real node often has several configured peers.
+    for (open_timeout, n) in [(10_000u64, 1usize), (2_000, 1), (2_000, 3)] {
+        let mut c = Config::default();
+        c.scouting.multicast.set_enabled(Some(false)).unwrap();
+        c.scouting.gossip.set_enabled(Some(false)).unwrap();
+        c.connect
+            .endpoints
+            .set(
+                (0..n)
+                    .map(|_| format!("tcp/{addr}").parse().unwrap())
+                    .collect::<Vec<_>>(),
+            )
+            .unwrap();
+        c.transport.unicast.set_open_timeout(open_timeout).unwrap();
+
+        let t = Instant::now();
+        let opened = tokio::time::timeout(Duration::from_secs(30), zenoh::open(c)).await;
+        let open_elapsed = t.elapsed();
+        let Ok(Ok(session)) = opened else {
+            println!("open_timeout={open_timeout:>6}ms n={n}  open did not return in 30s ({open_elapsed:.2?}) - different shape, see header");
+            continue;
+        };
+
+        let t = Instant::now();
+        let r = session.close().await;
+        println!(
+            "open_timeout={open_timeout:>6}ms  endpoints={n}  open {:>9.2?}  close {:>9.2?}  {}",
+            open_elapsed,
+            t.elapsed(),
+            if r.is_ok() { "ok" } else { "TIMEOUT" }
+        );
+    }
+    println!();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "diagnostic reproducer for an upstream close hang; asserts nothing, run deliberately"]
+async fn where_does_the_time_go() {
+    zenoh_util::init_log_from_env_or("error");
+
+    println!("\n--- gossip OFF (control) ---");
+    for _ in 0..3 {
+        probe(false).await;
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    println!("\n--- gossip ON ---");
+    for _ in 0..3 {
+        probe(true).await;
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    println!();
+}


### PR DESCRIPTION
## Description

`TaskController::spawn` documents an obligation on the caller: the spawned task must either run to completion in finite time, or observe the cancellation token from `get_cancellation_token()`. Three spawned tasks do neither, because the work they await is a network connect and they hold no token at all. Three more *do* observe the token, but only around the retry sleep — so they satisfy the contract's letter while still stalling close for `open_timeout`. Both are fixed here; the distinction is drawn below because it decides which sites are urgent.

`Runtime::close_inner` awaits `TaskController::terminate_all_async()` first, and that is:

```rust
self.tracker.close();
self.token.cancel();
self.tracker.wait().await   // unbounded
```

`tracker.wait()` has no timeout of its own — `CloseBuilder`'s 10 s default is the only bound. So a task that never observes the token turns session close into a 10 s stall ending in `"close operation timed out!"`, with nothing naming the cause.

The peer-connector path *does* thread a `CancellationToken` into the task, and `wait_next_peer_retry` correctly `select!`s on it — but only around the retry **sleep**. The blocking connect, `open_transport_unicast(...).await`, is not covered, and runs to `transport.unicast.open_timeout` (10000 ms default). The token is present and used in the one place that is cheap to interrupt, rather than the one that blocks.

### The fix

`spawn` → `spawn_abortable` at six sites. `spawn_abortable` wraps the future in `run_until_cancelled_owned`, so the whole task is dropped at its next await point. The task stays tracked, so shutdown still waits for it; it now yields.

This is the same call already used for the multicast scouting equivalents (`orchestrator.rs:223`, `:343-360`), so it restores consistency rather than introducing a pattern.

| File | Site | Observes the token today? |
| --- | --- | --- |
| `orchestrator.rs` | `spawn_add_listener` → `add_listener_retry` | **no** — bare `loop`, no token |
| `orchestrator.rs` | `spawn_peer_connector` → `peer_connector_retry` (configured `connect.endpoints`) | yes, but only around the sleep |
| `orchestrator.rs` | `closed_session` → `peers_connector_retry` (reconnect) | yes, but only around the sleep |
| `orchestrator.rs` | `closed_link` → `peer_connector_retry` (reconnect) | yes, but only around the sleep |
| `gossip.rs` | autoconnect → `connect_peer` | **no** — no token check |
| `network.rs` | `connect_discovered_peer` → `connect_peer` | **no** — no token check |

### Two of these are a regression, not a latent bug

- **#2012** ("Fix `Session::close` timeout while client attempts to reconnect", `252f6a883`, 2025-07-24) changed the reconnect path in `closed_session` from `spawn` to `spawn_abortable`, for exactly this reason.
- **#2173** ("Fix multlink reconnect", `225085647`, 2025-10-09) rewrote that function for an unrelated purpose. The `WhatAmI::Client` arm carrying `spawn_abortable` was dropped, and the replacement uses two plain `spawn` calls.

So the close-timeout fix was silently lost in a refactor, and the site count doubled.

### The trigger is narrower than "unreachable peer"

A **refused** connection returns immediately, and the retry sleep that follows is already cancellable — no hang. The hang needs an endpoint that **completes the TCP handshake but not the zenoh handshake**: a paused or frozen container (`podman pause` reproduces it in one command), a firewall that DROPs, or a wedged process.

Close time then tracks `open_timeout` directly, with gossip and multicast both disabled and a single configured endpoint pointed at a `TcpListener` that accepts and sends nothing:

| `open_timeout` | open | close |
| --- | --- | --- |
| 10000 ms | 509.95 ms | **9.50 s** |
| 2000 ms | 504.61 ms | **1.50 s** |

It does **not** stack across endpoints — three configured endpoints still cost one `open_timeout`, because the connector tasks overlap.

### Relationship to #2733

#2733 diagnoses the same defect independently and fixes the `gossip.rs` site. That analysis is correct and this PR agrees with it in full — including that `spawn_abortable` is the right remedy rather than a hand-written `select!`.

This PR is offered as the more complete version: the same defect is reachable through four further call sites, including the configured `connect.endpoints` path, which means a deployment that lists peers explicitly and does not use gossip is still affected after #2733. Happy for this to be closed in favour of #2733 plus a follow-up, or for the two to be combined — whichever the maintainers prefer.

Likely also the root cause of **#2675** (`session.close()` blocks ~10 s under bursty packet loss), which has had no comments since July: loss on an *established* link puts you in exactly the completes-TCP-but-not-zenoh case.

### Tests

`zenoh/tests/close_with_failing_listener.rs` is a regression test. It fails without this change (close times out after 10 s) and passes with it — verified both ways.

`zenoh/tests/gossip_timing_probe.rs` is **four `#[ignore]`d diagnostics that assert nothing.** They record how the timings above were measured and are included for the reader rather than for CI. **Suggest dropping this file before merge** — it is deliberately separable, and nothing else depends on it. It is here because reviewers asked for reproducers on similar issues, not because it belongs in the test suite.

### What this PR does not address

`open_transport_unicast` itself remains a bare await. The fix is entirely at the spawn sites, which is minimal and sufficient — but any future `spawn` of that function reintroduces the bug. Worth noting for anyone adding a call site.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

**No specific label requirements detected.**

Current labels: _No labels_

Add one of these labels to this PR to see relevant checklist items: `api-sync`, `breaking-change`, `bug`, `ci`, `dependencies`, `documentation`, `enhancement`, `new feature`, `internal`

*This section updates automatically when labels change.*

<!-- 🏷️ Label-Based Checklist END -->
