### PR TITLE
fix: clear pending connection for empty scout locators

### DIFF
--- a/zenoh/src/net/runtime/orchestrator.rs
+++ b/zenoh/src/net/runtime/orchestrator.rs
@@ -1086,6 +1086,10 @@ impl Runtime {
     /// Returns `true` if a new Transport instance is established with `zid` or had already been established.
     #[must_use]
     async fn connect(&self, zid: &ZenohIdProto, scouted_locators: &[Locator]) -> bool {
+        if scouted_locators.is_empty() {
+            return false;
+        }
+
         if !self.insert_pending_connection(*zid).await {
             tracing::debug!("Already connecting to {}. Ignore.", zid);
             return false;
@@ -1484,8 +1488,21 @@ mod tests {
         let zid = ZenohIdProto::rand();
 
         assert!(!runtime.connect(&zid, &[]).await);
-        assert!(runtime.insert_pending_connection(zid).await);
-        runtime.remove_pending_connection(&zid).await;
+        assert!(!runtime.remove_pending_connection(&zid).await);
+    }
+
+    #[tokio::test]
+    async fn configured_scouted_locator_does_not_leave_connection_pending() {
+        let mut config = Config::default();
+        config
+            .insert_json5("connect/endpoints", r#"["tcp/localhost:12345"]"#)
+            .unwrap();
+        let runtime = RuntimeBuilder::new(config).build().await.unwrap();
+        let zid = ZenohIdProto::rand();
+        let locator = "tcp/localhost:12345".parse().unwrap();
+
+        assert!(!runtime.connect(&zid, &[locator]).await);
+        assert!(!runtime.remove_pending_connection(&zid).await);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/zenoh/src/net/runtime/orchestrator.rs
+++ b/zenoh/src/net/runtime/orchestrator.rs
@@ -1116,6 +1116,7 @@ impl Runtime {
                 "Already connecting to locators of {} (connect configuration). Ignore.",
                 zid
             );
+            self.remove_pending_connection(zid).await;
             return false;
         }
 
@@ -1472,6 +1473,20 @@ mod tests {
     use tokio::time::{timeout, Duration};
 
     use super::*;
+    use crate::{net::runtime::RuntimeBuilder, Config};
+
+    #[tokio::test]
+    async fn empty_scouted_locators_do_not_leave_connection_pending() {
+        let runtime = RuntimeBuilder::new(Config::default())
+            .build()
+            .await
+            .unwrap();
+        let zid = ZenohIdProto::rand();
+
+        assert!(!runtime.connect(&zid, &[]).await);
+        assert!(runtime.insert_pending_connection(zid).await);
+        runtime.remove_pending_connection(&zid).await;
+    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn scout_sender_can_multicast_on_loopback() {


### PR DESCRIPTION
## Description

### What does this PR do?

Clears a scouted peer from `pending_connections` when all advertised locators are already covered by configured endpoints. A genuinely empty scouted-locator list now returns before inserting pending state. Regression tests cover both cases.

### Why is this change needed?

`Runtime::connect` inserts the peer ZID before filtering locators. The empty-list branch returned without the cleanup performed by the normal path, leaving that ZID permanently pending. Later multicast Hellos with a valid locator were repeatedly rejected as `Already connecting ... Ignore.`

This was reproduced with ten peer-mode nodes under a 256 kbit/s constrained link: D-CRDT state converged but the direct TLS graph remained at 44/45 edges after 75 seconds. With this cleanup, three repeated trials reached 45/45 edges with zero runtime errors.

### Validation

- `cargo fmt --all -- --check`
- `cargo test -p zenoh configured_scouted_locator_does_not_leave_connection_pending --no-default-features`
- `cargo test -p zenoh empty_scouted_locators_do_not_leave_connection_pending --no-default-features`
- `cargo clippy -p zenoh --all-targets --no-default-features -- --deny warnings`
- External 10-node/256 kbit/s formation harness: 3/3 exact 45-edge cliques

### Related Issues

Related to #2753.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `bug`

## 🐛 Bug Fix Requirements

Since this PR is labeled as a **bug fix**, please ensure:

- [x] **Root cause documented** - Explain what caused the bug in the PR description
- [x] **Reproduction test added** - Test that fails on main branch without the fix
- [x] **Test passes with fix** - The reproduction test passes with your changes
- [x] **Regression prevention** - Test will catch if this bug reoccurs in the future
- [x] **Fix is minimal** - Changes are focused only on fixing the bug
- [x] **Related bugs checked** - Verified no similar bugs exist in related code

**Why this matters:** Bugs without tests often reoccur.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->