### PR TITLE
ci: pin the nightly toolchain so #2756's coverage job stops being OOM-killed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,9 @@ env:
   # Nightly toolchain identifier used by cargo invocations
   # Normally keep it "nightly" to always use the latest nightly, but in case of a regression in the Rust compiler,
   # it can be useful to fix it to a specific nightly version that is known to work.
-  NIGHTLY_TOOLCHAIN: "nightly"
+  # Pinned: later nightlies OOM the 16 GB coverage runner. See rust-lang/rust#161660.
+  # Return this to "nightly" when that issue is fixed.
+  NIGHTLY_TOOLCHAIN: "nightly-2026-08-19"
 
 jobs:
   changes:


### PR DESCRIPTION
A follow-up for #2756, against its branch rather than `main`, so it lands with it.

**The coverage job's failure on #2756 is not #2756's fault, and this fixes it.**

## Before and after

| | today on `fix-clippy-lints-1.98.0` | with this PR |
|---|---|---|
| `Coverage (ubuntu-latest, nightly)` | OOM-killed, `exit 143`, empty log | **passes** |
| peak memory in that job | 15.9 GB of 15.99 | 3.5 GB |
| every other check | unchanged | unchanged |

## What is wrong

The coverage job dies with `exit 143` and "the runner has received a shutdown signal", printing nothing. It looks like the pull request's problem and is not: it fails the same way on unrelated pull requests, and `--ignore-run-fail` is set on that step, so a failing test cannot cause it. Only the harness dying can.

Sampling memory inside the step shows an OOM:

```
BEFORE: total=15989 used=1097 avail=14892   /dev/root  145G  34G  111G  24% /
SAMPLE 10:40:07 mem_used_mb=9248   mem_avail_mb=6740  disk_avail=105775M
SAMPLE 10:40:22 mem_used_mb=15897  mem_avail_mb=96    disk_avail=105683M
##[error]Process completed with exit code 143.
```

Memory goes from 9.2 GB to 15.9 GB of 15.99 GB in one 15-second window and the runner dies. Disk stays at 105 GB free throughout, so space is not the constraint.

The cause is **[rust-lang/rust#161660](https://github.com/rust-lang/rust/issues/161660)**, which is open. Compile-time memory roughly doubles, and the reporter's own 16 GB runners fail with the same exit code.

Nothing in this repository changed across the break:

| | toolchain | coverage |
|---|---|---|
| `main`, 2026-08-20 | `1.100.0-nightly (f7d782a3b 2026-08-19)` | success |
| pull requests, 2026-08-25 onward | `1.100.0-nightly (e7769602a 2026-08-24)` | failure |

`main` has not moved since `c5d4760e`, and `ci.yml` has not changed since `465ce274`. Only the floating `nightly` moved. The regression also grows nightly by nightly, which is why the job crossed the 16 GB line in that window rather than when the bisected commit first landed.

Only the coverage job is affected, because it is the only one on `nightly` and it builds with coverage instrumentation on top.

## The change

One variable, pinned to the last nightly with a green coverage run. The comment cites the upstream issue so that whoever removes the pin knows what to re-check first.

## What fails without this

`Coverage (ubuntu-latest, nightly)`, on this branch and on every other open pull request.

Verified both directions on the same commit and runner, changing only `NIGHTLY_TOOLCHAIN`:

| toolchain | peak memory | result |
|---|---|---|
| `nightly` (resolves to 2026-08-24 or later) | 15.9 GB, `mem_avail` 96 MB | `exit 143` at about 7 minutes |
| `nightly-2026-08-19` | 3.5 GB | **success** |

## Breaking changes

None. One CI variable.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [ ] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->
