### PR TITLE
fix(uring): collapse an else-if that Clippy flags

### DIFF
--- a/commons/zenoh-uring/src/linux/api/reader/mod.rs
+++ b/commons/zenoh-uring/src/linux/api/reader/mod.rs
@@ -328,28 +328,26 @@ impl Reader {
                     bail!("Task-related uring error: {}, task {:?}", unexpected, index);
                 }
             }
-        } else {
-            if let Some(buf_id) = io_uring::cqueue::buffer_select(e.flags()) {
-                #[cfg(feature = "uring_trace")]
-                tracing::trace!("Read multishot entry: {:?}", e);
+        } else if let Some(buf_id) = io_uring::cqueue::buffer_select(e.flags()) {
+            #[cfg(feature = "uring_trace")]
+            tracing::trace!("Read multishot entry: {:?}", e);
 
-                if !io_uring::cqueue::more(e.flags()) {
-                    tracing::debug!("IORING_CQE_F_BUFFER: Restart multishot receive!!!");
+            if !io_uring::cqueue::more(e.flags()) {
+                tracing::debug!("IORING_CQE_F_BUFFER: Restart multishot receive!!!");
 
-                    let recv =
-                        opcode::RecvMulti::new(types::Fd(context.fd), context.buffer_group().id())
-                            .build()
-                            .flags(io_uring::squeue::Flags::ASYNC)
-                            .user_data(index.into());
+                let recv =
+                    opcode::RecvMulti::new(types::Fd(context.fd), context.buffer_group().id())
+                        .build()
+                        .flags(io_uring::squeue::Flags::ASYNC)
+                        .user_data(index.into());
 
-                    unsafe { sq.push(&recv)? };
-                    need_submit = true;
-                }
-
-                let buf_len = e.result() as usize;
-                let buffer = Arc::new(context.buffer_group().read_buffer(buf_id, buf_len, sq)?);
-                context.run_callback(buffer);
+                unsafe { sq.push(&recv)? };
+                need_submit = true;
             }
+
+            let buf_len = e.result() as usize;
+            let buffer = Arc::new(context.buffer_group().read_buffer(buf_id, buf_len, sq)?);
+            context.run_callback(buffer);
         }
         Ok(need_submit)
     }


### PR DESCRIPTION
`clippy::collapsible_else_if` in the io_uring reader's completion handler:

```
commons/zenoh-uring/src/linux/api/reader/mod.rs:331:16:
    warning: this `else { if .. }` block can be collapsed
```

The `else { if let .. }` becomes `else if let ..`. The block moves left by four columns and one brace goes away. Nothing else changes.

## What fails without this

Nothing in CI, and that is worth stating plainly rather than leaving a reader to assume otherwise.

| toolchain | reports it |
|---|---|
| Clippy 0.1.93 | yes |
| Clippy 1.98, which CI pins | no |

`Clippy all features` is green either way. This is a portability fix across toolchains, so it has **no failing baseline** and cannot be given one under the toolchain CI uses.

## How it was found

While sweeping the full CI Clippy matrix without `--deny warnings`, so that every lint reported instead of the run stopping at the first error. It appeared under `--features uring`, `--features test`, `--features unstable,test` and `--all-features`, on a commit that contained no local changes — so it belongs to the tree, not to the branch it was found from.

## Breaking changes

None.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

**No specific label requirements detected.**

Current labels: _No labels_

Add one of these labels to this PR to see relevant checklist items: `api-sync`, `breaking-change`, `bug`, `ci`, `dependencies`, `documentation`, `enhancement`, `new feature`, `internal`

*This section updates automatically when labels change.*

<!-- 🏷️ Label-Based Checklist END -->