### PR TITLE
chore: remove unused workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,10 +90,6 @@ aes = "0.8.4"
 ahash = { version = "0.8.12", default-features = false }
 anyhow = { version = "1.0.99", default-features = false } # Default features are disabled due to usage in no_std crates
 arc-swap = "1.7.1"
-async-executor = "1.13.3"
-async-global-executor = "3.1.0"
-async-io = "2.6.0"
-async-std = { version = "1.13.2", features = ["tokio1"] }
 async-trait = "0.1.89"
 atomic-queue = "2.2.0"
 axum = "0.8.4"
@@ -102,24 +98,20 @@ bincode = "1.3.3"
 buddy_system_allocator = "0.10.0"
 bytes = "1.11.0"
 clap = { version = "4.5.47", features = ["derive"] }
-console-subscriber = "0.5.0"
 const_format = "0.2.34"
 criterion = "0.7.0"
 crossbeam-channel = "0.5"
 crossbeam-queue = "0.3.12"
 crossbeam-utils = "0.8.21"
-derive-new = "0.7.0"
 derive_more = { version = "2.0.1", features = ["as_ref"] }
 event-listener = "5.4.1"
 flate2 = "1.1.5"
 flume = "0.11.1"
-form_urlencoded = "1.2.2"
 futures = "0.3.31"
 futures-util = { version = "0.3.31", default-features = false } # Default features are disabled due to some crates' requirements
 getrandom = "0.2"
 git-version = "0.3.9"
 hashbrown = "0.16.0"
-hex = { version = "0.4.3", default-features = false } # Default features are disabled due to usage in no_std crates
 hmac = { version = "0.12.1", features = ["std"] }
 home = "0.5.9"
 humantime = "2.3.0"
@@ -141,11 +133,8 @@ nonempty-collections = { version = "0.3.1", features = ["serde"] }
 num-traits = { version = "0.2.19", default-features = false }
 num_cpus = "1.17.0"
 once_cell = "1.21.3"
-ordered-float = "5.1.0"
-panic-message = "0.3.0"
 petgraph = "0.8.3"
 phf = { version = "0.13.1", features = ["macros"] }
-pnet = "0.35.0"
 pnet_datalink = "0.35.0"
 proc-macro2 = "1.0.101"
 prometheus-client = "0.24.0"
@@ -166,7 +155,6 @@ rustls = { version = "0.23.31", default-features = false, features = [
   "ring",
   "tls12",
 ] }
-rustls-native-certs = "0.8.1"
 rustls-pemfile = "2.2.0"
 rustls-pki-types = "1.12.0"
 rustls-webpki = "0.103.8"
@@ -185,7 +173,6 @@ socket2 = { version = "0.5.7", features = ["all"] }
 stabby = "72.1.8"
 static_assertions = "1.1.0"
 static_init = "1.0.3"
-stop-token = "0.7.0"
 syn = "2.0.110"
 talc = { version = "4.4.3", default-features = false }
 test-case = "3.3.1"
@@ -210,9 +197,7 @@ thread-priority = "1.2.0"
 tls-listener = { version = "0.11.0", features = ["rustls-ring"] }
 typenum = "1.18.0"
 uhlc = { version = "0.8.0", default-features = false } # Default features are disabled due to usage in no_std crates
-unzip-n = "0.1.2"
 url = "2.5.7"
-urlencoding = "2.1.3"
 uuid = { version = "1.20.0", default-features = false, features = [
   "v4",
 ] } # Default features are disabled due to usage in no_std crates

--- a/plugins/zenoh-plugin-storage-manager/src/lib.rs
+++ b/plugins/zenoh-plugin-storage-manager/src/lib.rs
@@ -258,7 +258,6 @@ impl StorageRuntimeInner {
                     config.name,
                     config.volume_id
                 );
-                // let _ = async_std::task::block_on(storage.send(StorageMessage::Stop));
                 let _ = storage.send(StorageMessage::Stop); // TODO: was previously spawning a task. do we need that?
             }
         }


### PR DESCRIPTION
## Description
async-std was replaced by tokio, but the workspace dependency entry was left behind. Nothing references it (not present in Cargo.lock), so drop the entry and a stale commented line in the storage-manager plugin.

### What does this PR do?
removes unused dependency

### Why is this change needed?
why keep it?

### Related Issues
none

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `dependencies`

## 📦 Dependency Updates

Since this PR updates dependencies:

- [x] **Changelog reviewed** - Breaking changes in dependency identified and addressed
- [x] **Security advisories checked** - No known vulnerabilities in new version
- [x] **License compatible** - New version license is compatible with project
- [x] **Tests pass** - All tests pass with new dependency versions
- [x] **Transitive deps reviewed** - New transitive dependencies checked
- [x] **Version pinned appropriately** - Semver range is intentional and correct
- [x] **Update scope limited** - Updating one major dependency at a time when possible

**Best practice:** Keep dependency updates focused and test thoroughly.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->