### PR TITLE
Propagate io_uring reactor startup errors

### DIFF
--- a/commons/zenoh-uring/src/linux/api/reader/mod.rs
+++ b/commons/zenoh-uring/src/linux/api/reader/mod.rs
@@ -109,11 +109,14 @@ impl Reader {
         let (join_sender, mut join_receiver) = tokio::sync::watch::channel("".into());
         join_receiver.mark_unchanged();
 
+        let (init_sender, init_receiver) = std::sync::mpsc::channel::<ZResult<()>>();
+        let ready_sender = init_sender.clone();
+
         let ring_worker = move || -> ZResult<()> {
             // Create Rx context storage
             let mut context_storage = RxContextStorage::new();
 
-            // io_uring read
+            // io_uring read (created on the reactor thread: SINGLE_ISSUER)
             let ring: IoUring<squeue::Entry, cqueue::Entry> = IoUring::builder()
                 .setup_submit_all()
                 .setup_defer_taskrun()
@@ -131,6 +134,10 @@ impl Reader {
                     .flags(io_uring::squeue::Flags::ASYNC);
 
             unsafe { ring.submission_shared().push(&waker_read)? };
+
+            // Confirm actual startup, including the first submission, before selecting io_uring.
+            ring.submit()?;
+            ready_sender.send(Ok(()))?;
 
             fn roll_cmds(
                 receiver: &Receiver<ReactorCmd>,
@@ -255,10 +262,12 @@ impl Reader {
             if let Err(e) = ring_worker() {
                 tracing::error!("Uring reactor error: {e}");
                 let _ = join_sender.send(e.to_string());
+                let _ = init_sender.send(Err(e));
             }
             tracing::debug!("Uring reactor thread finished!");
         });
 
+        init_receiver.recv()??;
         let inner = Arc::new(ReaderInner::new(submitter, exit_flag));
 
         Ok(Self {

--- a/commons/zenoh-uring/tests/initialization.rs
+++ b/commons/zenoh-uring/tests/initialization.rs
@@ -1,0 +1,153 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+#![cfg(all(
+    target_os = "linux",
+    any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "riscv64",
+        target_arch = "loongarch64",
+        target_arch = "powerpc64"
+    )
+))]
+
+use std::{
+    process::Command,
+    time::{Duration, Instant},
+};
+
+use zenoh_uring::api::reader::Reader;
+
+#[test]
+fn initialization() {
+    const CHILD: &str = "ZENOH_URING_INIT_TEST";
+    let Ok(case) = std::env::var(CHILD) else {
+        // Resource limits and seccomp must not affect other tests or their runtimes.
+        for case in ["available", "setup", "enter", "memlock"] {
+            let mut child = Command::new(std::env::current_exe().unwrap())
+                .args(["--exact", "initialization", "--nocapture"])
+                .env(CHILD, case)
+                .spawn()
+                .unwrap();
+            let deadline = Instant::now() + Duration::from_secs(20);
+            loop {
+                if let Some(status) = child.try_wait().unwrap() {
+                    assert!(status.success(), "initialization case {case}: {status}");
+                    break;
+                }
+                if Instant::now() >= deadline {
+                    child.kill().unwrap();
+                    child.wait().unwrap();
+                    panic!("initialization case {case} timed out");
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        }
+        return;
+    };
+
+    match case.as_str() {
+        "setup" | "enter" => {
+            let syscall = if case == "setup" {
+                libc::SYS_io_uring_setup
+            } else {
+                libc::SYS_io_uring_enter
+            };
+            let mut filter = [
+                libc::sock_filter {
+                    code: (libc::BPF_LD | libc::BPF_W | libc::BPF_ABS) as u16,
+                    jt: 0,
+                    jf: 0,
+                    k: 0,
+                },
+                libc::sock_filter {
+                    code: (libc::BPF_JMP | libc::BPF_JEQ | libc::BPF_K) as u16,
+                    jt: 0,
+                    jf: 1,
+                    k: syscall as u32,
+                },
+                libc::sock_filter {
+                    code: (libc::BPF_RET | libc::BPF_K) as u16,
+                    jt: 0,
+                    jf: 0,
+                    k: libc::SECCOMP_RET_ERRNO | libc::EPERM as u32,
+                },
+                libc::sock_filter {
+                    code: (libc::BPF_RET | libc::BPF_K) as u16,
+                    jt: 0,
+                    jf: 0,
+                    k: libc::SECCOMP_RET_ALLOW,
+                },
+            ];
+            let program = libc::sock_fprog {
+                len: filter.len() as u16,
+                filter: filter.as_mut_ptr(),
+            };
+            unsafe {
+                assert_eq!(libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0), 0);
+                assert_eq!(
+                    libc::prctl(
+                        libc::PR_SET_SECCOMP,
+                        libc::SECCOMP_MODE_FILTER,
+                        &program,
+                        0,
+                        0
+                    ),
+                    0
+                );
+            }
+        }
+        "memlock" => {
+            let status = std::fs::read_to_string("/proc/self/status").unwrap();
+            let capabilities = status
+                .lines()
+                .find_map(|line| line.strip_prefix("CapEff:"))
+                .unwrap();
+            // CAP_IPC_LOCK bypasses RLIMIT_MEMLOCK, regardless of the process UID.
+            if u64::from_str_radix(capabilities.trim(), 16).unwrap() & (1 << 14) != 0 {
+                eprintln!("Skipping memlock case: CAP_IPC_LOCK bypasses RLIMIT_MEMLOCK");
+                return;
+            }
+            let limit = libc::rlimit {
+                rlim_cur: 65536,
+                rlim_max: 65536,
+            };
+            assert_eq!(unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &limit) }, 0);
+        }
+        "available" => {}
+        _ => unreachable!(),
+    }
+
+    let result = Reader::new(65537, 16);
+    if case == "available" {
+        result.unwrap();
+    } else {
+        let error = result.expect_err("Reader must return the actual reactor startup error");
+        if case == "memlock" {
+            assert!(
+                error.to_string().contains("Unable to reserve initial"),
+                "{error}"
+            );
+        } else {
+            assert_eq!(
+                error
+                    .downcast_ref::<std::io::Error>()
+                    .unwrap()
+                    .raw_os_error(),
+                Some(libc::EPERM)
+            );
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2768.

`Reader::new` returns before the RX worker starts. If ring creation or the initial `mlock` fails, the manager still selects io_uring and TCP messages stop arriving.

Wait for the worker to finish ring creation, arena allocation and the first submission before returning success. Startup errors then reach the existing Tokio fallback. Ring creation and submission stay on the same thread for `SINGLE_ISSUER`.

Regression tests cover denied setup, denied enter, low memlock and successful startup. The failure cases fail on 1.10.0 and pass with this patch. Linux crate tests and Clippy pass; the low-memlock pub/sub reproduction also receives messages with the fix.

One open point: the constructor waits without a timeout if the RX blocking pool is full. This PR keeps the existing worker pool.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

**No specific label requirements detected.**

Current labels: _No labels_

Add one of these labels to this PR to see relevant checklist items: `api-sync`, `breaking-change`, `bug`, `ci`, `dependencies`, `documentation`, `enhancement`, `new feature`, `internal`

*This section updates automatically when labels change.*

<!-- 🏷️ Label-Based Checklist END -->