### PR TITLE
Remove TCP read interest when io_uring handles RX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,7 +251,7 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
           sudo prlimit --memlock=unlimited --pid=$$
-          cargo nextest run -p zenoh -F uring
+          cargo nextest run -p zenoh -p zenoh-link-tcp -F uring
 
       - name: Check for feature leaks
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/io/zenoh-link-commons/src/unicast.rs
+++ b/io/zenoh-link-commons/src/unicast.rs
@@ -95,6 +95,19 @@ pub trait LinkUnicastTrait: Send + Sync {
     async fn close(&self) -> ZResult<()>;
     #[cfg(all(feature = "uring", target_os = "linux"))]
     fn get_fd(&self) -> ZResult<RawFd>;
+    /// Called once io_uring owns the RX side of this link, before the transport
+    /// starts the TX/RX tasks. Links whose fd stays registered with a tokio
+    /// reactor for READABLE interest should re-register it for WRITABLE only:
+    /// otherwise every data arrival also wakes that reactor (the runtime that
+    /// accepted or connected the socket) for nothing. Default: no-op.
+    ///
+    /// # Safety
+    /// The caller must ensure there are no pending I/O futures or concurrent
+    /// accesses to this link, including through clones, during this call.
+    #[cfg(all(feature = "uring", target_os = "linux"))]
+    unsafe fn detach_rx_from_reactor(&self) -> ZResult<()> {
+        Ok(())
+    }
 }
 
 impl Deref for LinkUnicast {

--- a/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
+++ b/io/zenoh-links/zenoh-link-tcp/src/unicast.rs
@@ -16,6 +16,8 @@ use std::os::fd::{AsRawFd, RawFd};
 use std::{cell::UnsafeCell, convert::TryInto, fmt, net::SocketAddr, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
+#[cfg(all(feature = "uring", target_os = "linux"))]
+use tokio::io::{unix::AsyncFd, Interest};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::{TcpListener, TcpStream},
@@ -36,9 +38,55 @@ use crate::{
     TCP_LINGER_TIMEOUT, TCP_LOCATOR_PREFIX,
 };
 
+/// The socket behind a TCP link.
+///
+/// `Tokio` is the regular tokio stream (reads and writes through the tokio
+/// reactor). `WriteOnly` is used once io_uring has taken over the RX side: the
+/// same fd is re-registered with the reactor for WRITABLE interest only, so
+/// incoming data no longer wakes the runtime that accepted/connected the socket.
+enum TcpSocket {
+    Tokio(TcpStream),
+    #[cfg(all(feature = "uring", target_os = "linux"))]
+    WriteOnly(AsyncFd<std::net::TcpStream>),
+    /// Transient state while converting `Tokio` -> `WriteOnly`; also what is
+    /// left behind if that conversion fails midway (the link then errors out).
+    #[cfg(all(feature = "uring", target_os = "linux"))]
+    Detached,
+}
+
+#[cfg(all(feature = "uring", target_os = "linux"))]
+fn detached_error() -> std::io::Error {
+    std::io::Error::other("socket RX is owned by io_uring")
+}
+
+#[cfg(all(feature = "uring", target_os = "linux"))]
+async fn write_nonblocking(
+    fd: &AsyncFd<std::net::TcpStream>,
+    buffer: &[u8],
+) -> std::io::Result<usize> {
+    use std::io::Write;
+    fd.async_io(Interest::WRITABLE, |mut stream| stream.write(buffer))
+        .await
+}
+
+#[cfg(all(feature = "uring", target_os = "linux"))]
+async fn write_all_nonblocking(
+    fd: &AsyncFd<std::net::TcpStream>,
+    mut buffer: &[u8],
+) -> std::io::Result<()> {
+    while !buffer.is_empty() {
+        let n = write_nonblocking(fd, buffer).await?;
+        if n == 0 {
+            return Err(std::io::ErrorKind::WriteZero.into());
+        }
+        buffer = &buffer[n..];
+    }
+    Ok(())
+}
+
 pub struct LinkUnicastTcp {
     // The underlying socket as returned from the tokio library
-    socket: UnsafeCell<TcpStream>,
+    socket: UnsafeCell<TcpSocket>,
     // The source socket address of this link (address used on the local host)
     src_addr: SocketAddr,
     src_locator: Locator,
@@ -101,7 +149,7 @@ impl LinkUnicastTcp {
 
         // Build the Tcp object
         LinkUnicastTcp {
-            socket: UnsafeCell::new(socket),
+            socket: UnsafeCell::new(TcpSocket::Tokio(socket)),
             src_addr,
             src_locator: Locator::new(TCP_LOCATOR_PREFIX, src_addr.to_string(), "").unwrap(),
             dst_addr,
@@ -111,7 +159,7 @@ impl LinkUnicastTcp {
     }
 
     #[allow(clippy::mut_from_ref)]
-    fn get_mut_socket(&self) -> &mut TcpStream {
+    fn get_mut_socket(&self) -> &mut TcpSocket {
         unsafe { &mut *self.socket.get() }
     }
 }
@@ -121,7 +169,14 @@ impl LinkUnicastTrait for LinkUnicastTcp {
     async fn close(&self) -> ZResult<()> {
         tracing::trace!("Closing TCP link: {}", self);
         // Close the underlying TCP socket
-        self.get_mut_socket().shutdown().await.map_err(|e| {
+        let res = match self.get_mut_socket() {
+            TcpSocket::Tokio(socket) => socket.shutdown().await,
+            #[cfg(all(feature = "uring", target_os = "linux"))]
+            TcpSocket::WriteOnly(fd) => fd.get_ref().shutdown(std::net::Shutdown::Write),
+            #[cfg(all(feature = "uring", target_os = "linux"))]
+            TcpSocket::Detached => Ok(()),
+        };
+        res.map_err(|e| {
             let e = zerror!("TCP link shutdown {}: {:?}", self, e);
             tracing::trace!("{}", e);
             e.into()
@@ -129,7 +184,14 @@ impl LinkUnicastTrait for LinkUnicastTcp {
     }
 
     async fn write(&self, buffer: &[u8], _priority: Option<Priority>) -> ZResult<usize> {
-        self.get_mut_socket().write(buffer).await.map_err(|e| {
+        let res = match self.get_mut_socket() {
+            TcpSocket::Tokio(socket) => socket.write(buffer).await,
+            #[cfg(all(feature = "uring", target_os = "linux"))]
+            TcpSocket::WriteOnly(fd) => write_nonblocking(fd, buffer).await,
+            #[cfg(all(feature = "uring", target_os = "linux"))]
+            TcpSocket::Detached => Err(detached_error()),
+        };
+        res.map_err(|e| {
             let e = zerror!("Write error on TCP link {}: {}", self, e);
             tracing::trace!("{}", e);
             e.into()
@@ -137,7 +199,14 @@ impl LinkUnicastTrait for LinkUnicastTcp {
     }
 
     async fn write_all(&self, buffer: &[u8], _priority: Option<Priority>) -> ZResult<()> {
-        self.get_mut_socket().write_all(buffer).await.map_err(|e| {
+        let res = match self.get_mut_socket() {
+            TcpSocket::Tokio(socket) => socket.write_all(buffer).await,
+            #[cfg(all(feature = "uring", target_os = "linux"))]
+            TcpSocket::WriteOnly(fd) => write_all_nonblocking(fd, buffer).await,
+            #[cfg(all(feature = "uring", target_os = "linux"))]
+            TcpSocket::Detached => Err(detached_error()),
+        };
+        res.map_err(|e| {
             let e = zerror!("Write error on TCP link {}: {}", self, e);
             tracing::trace!("{}", e);
             e.into()
@@ -145,7 +214,12 @@ impl LinkUnicastTrait for LinkUnicastTcp {
     }
 
     async fn read(&self, buffer: &mut [u8], _priority: Option<Priority>) -> ZResult<usize> {
-        self.get_mut_socket().read(buffer).await.map_err(|e| {
+        let res = match self.get_mut_socket() {
+            TcpSocket::Tokio(socket) => socket.read(buffer).await,
+            #[cfg(all(feature = "uring", target_os = "linux"))]
+            TcpSocket::WriteOnly(_) | TcpSocket::Detached => Err(detached_error()),
+        };
+        res.map_err(|e| {
             let e = zerror!("Read error on TCP link {}: {}", self, e);
             tracing::trace!("{}", e);
             e.into()
@@ -153,16 +227,16 @@ impl LinkUnicastTrait for LinkUnicastTcp {
     }
 
     async fn read_exact(&self, buffer: &mut [u8], _priority: Option<Priority>) -> ZResult<()> {
-        let _ = self
-            .get_mut_socket()
-            .read_exact(buffer)
-            .await
-            .map_err(|e| {
-                let e = zerror!("Read error on TCP link {}: {}", self, e);
-                tracing::trace!("{}", e);
-                e
-            })?;
-        Ok(())
+        let res = match self.get_mut_socket() {
+            TcpSocket::Tokio(socket) => socket.read_exact(buffer).await.map(|_| ()),
+            #[cfg(all(feature = "uring", target_os = "linux"))]
+            TcpSocket::WriteOnly(_) | TcpSocket::Detached => Err(detached_error()),
+        };
+        res.map_err(|e| {
+            let e = zerror!("Read error on TCP link {}: {}", self, e);
+            tracing::trace!("{}", e);
+            e.into()
+        })
     }
 
     #[inline(always)]
@@ -202,10 +276,34 @@ impl LinkUnicastTrait for LinkUnicastTcp {
 
     #[cfg(all(feature = "uring", target_os = "linux"))]
     fn get_fd(&self) -> ZResult<RawFd> {
-        match unsafe { &*self.socket.get() }.as_raw_fd() {
-            fd if fd < 0 => bail!("FD unavailable"),
-            fd => Ok(fd),
+        let fd = match unsafe { &*self.socket.get() } {
+            TcpSocket::Tokio(socket) => socket.as_raw_fd(),
+            TcpSocket::WriteOnly(fd) => fd.as_raw_fd(),
+            TcpSocket::Detached => -1,
+        };
+        if fd < 0 {
+            bail!("FD unavailable")
         }
+        Ok(fd)
+    }
+
+    #[cfg(all(feature = "uring", target_os = "linux"))]
+    unsafe fn detach_rx_from_reactor(&self) -> ZResult<()> {
+        let slot = self.get_mut_socket();
+        if !matches!(slot, TcpSocket::Tokio(_)) {
+            return Ok(());
+        }
+        let TcpSocket::Tokio(stream) = std::mem::replace(slot, TcpSocket::Detached) else {
+            unreachable!()
+        };
+        // `into_std` deregisters the fd from the tokio reactor that accepted or
+        // connected it; re-register it for WRITABLE interest only, so incoming
+        // data (now read by io_uring) no longer wakes that reactor.
+        let stream = stream.into_std()?;
+        let fd = AsyncFd::with_interest(stream, Interest::WRITABLE)?;
+        *slot = TcpSocket::WriteOnly(fd);
+        tracing::debug!("TCP link {}: RX detached from the tokio reactor", self);
+        Ok(())
     }
 }
 
@@ -456,4 +554,106 @@ async fn accept_task(
     }
 
     Ok(())
+}
+
+#[cfg(all(test, feature = "uring", target_os = "linux"))]
+mod tests {
+    use std::{
+        future::Future,
+        io::{Read, Write},
+        task::Poll,
+    };
+
+    use super::*;
+
+    #[test]
+    fn detached_socket_preserves_writes_and_half_close() {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+                let stream = std::net::TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+                let (mut peer, _) = listener.accept().unwrap();
+                peer.set_read_timeout(Some(Duration::from_secs(10)))
+                    .unwrap();
+                stream.set_nonblocking(true).unwrap();
+                socket2::SockRef::from(&stream)
+                    .set_send_buffer_size(1024)
+                    .unwrap();
+                let stream = TcpStream::from_std(stream).unwrap();
+                let link = LinkUnicastTcp::new(
+                    stream,
+                    peer.peer_addr().unwrap(),
+                    peer.local_addr().unwrap(),
+                );
+                // No I/O futures or other users exist during the conversion.
+                unsafe { link.detach_rx_from_reactor().unwrap() };
+
+                let raw_fd = link.get_fd().unwrap();
+                let mut registrations = 0;
+                for entry in std::fs::read_dir("/proc/self/fdinfo").unwrap() {
+                    let Ok(info) = std::fs::read_to_string(entry.unwrap().path()) else {
+                        continue;
+                    };
+                    for line in info.lines() {
+                        let fields: Vec<_> = line.split_whitespace().collect();
+                        if fields.first() == Some(&"tfd:") && fields[1] == raw_fd.to_string() {
+                            let events = u32::from_str_radix(fields[3], 16).unwrap();
+                            assert_eq!(events & 1, 0, "socket still registered for EPOLLIN");
+                            assert_ne!(events & 4, 0, "socket missing EPOLLOUT");
+                            registrations += 1;
+                        }
+                    }
+                }
+                assert!(registrations > 0);
+
+                // Drive initial readiness so Pending below comes from a blocked write.
+                {
+                    let TcpSocket::WriteOnly(fd) = (unsafe { &*link.socket.get() }) else {
+                        panic!("socket was not converted")
+                    };
+                    let _ = tokio::time::timeout(Duration::from_secs(10), fd.writable())
+                        .await
+                        .unwrap()
+                        .unwrap();
+                }
+                let data = vec![0x5a; 1024 * 1024];
+                let mut write = Box::pin(link.write_all(&data, None));
+                // A small send buffer and a peer that is not reading force backpressure.
+                std::future::poll_fn(|cx| match write.as_mut().poll(cx) {
+                    Poll::Pending => Poll::Ready(()),
+                    Poll::Ready(result) => {
+                        panic!("write did not encounter backpressure: {result:?}")
+                    }
+                })
+                .await;
+                let receiver = std::thread::spawn(move || {
+                    let mut received = Vec::new();
+                    peer.read_to_end(&mut received).unwrap();
+                    assert_eq!(received, vec![0x5a; 1024 * 1024]);
+                    peer.write_all(b"reply").unwrap();
+                });
+                tokio::time::timeout(Duration::from_secs(10), write)
+                    .await
+                    .unwrap()
+                    .unwrap();
+                link.close().await.unwrap();
+
+                let TcpSocket::WriteOnly(fd) = (unsafe { &*link.socket.get() }) else {
+                    panic!("socket was not converted")
+                };
+                let mut read_half = fd.get_ref().try_clone().unwrap();
+                read_half.set_nonblocking(false).unwrap();
+                read_half
+                    .set_read_timeout(Some(Duration::from_secs(10)))
+                    .unwrap();
+                let mut reply = [0; 5];
+                let result = read_half.read_exact(&mut reply);
+                receiver.join().unwrap();
+                result.unwrap();
+                assert_eq!(&reply, b"reply");
+            });
+    }
 }

--- a/io/zenoh-transport/src/unicast/universal/transport.rs
+++ b/io/zenoh-transport/src/unicast/universal/transport.rs
@@ -305,6 +305,28 @@ impl TransportUnicastTrait for TransportUnicastUniversal {
             }
         }
 
+        // io_uring owns the RX side of this link: drop the READABLE registration
+        // the link keeps with its tokio reactor before any task uses the socket.
+        #[cfg(all(
+            feature = "uring",
+            target_os = "linux",
+            any(
+                target_arch = "x86_64",
+                target_arch = "aarch64",
+                target_arch = "riscv64",
+                target_arch = "loongarch64",
+                target_arch = "powerpc64"
+            )
+        ))]
+        if self.manager.state.uring.is_some() && link.link.link.get_fd().is_ok() {
+            // SAFETY: Establishment I/O has completed. The link is not published
+            // to the transport yet, and its TX/RX tasks have not been started.
+            if let Err(e) = unsafe { link.link.link.detach_rx_from_reactor() } {
+                let (l, asl) = link.fail();
+                return Err((e, l, asl, close::reason::GENERIC));
+            }
+        }
+
         // Wrap the link
         let (link, ack, associated_link) = link.unpack();
         let (mut link, consumer) =

--- a/zenoh/tests/uring_tcp.rs
+++ b/zenoh/tests/uring_tcp.rs
@@ -1,0 +1,120 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+#![cfg(all(
+    feature = "uring",
+    feature = "transport_tcp",
+    target_os = "linux",
+    any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "riscv64",
+        target_arch = "loongarch64",
+        target_arch = "powerpc64"
+    )
+))]
+
+use std::{collections::HashSet, fs, time::Duration};
+
+use zenoh::{config::WhatAmI, Config};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn uring_tcp_has_no_read_interest() {
+    tokio::time::timeout(Duration::from_secs(30), async {
+        let port = zenoh_test::get_free_tcp_port();
+        let endpoint = format!("tcp/127.0.0.1:{port}");
+        let mut listen = Config::default();
+        listen.set_mode(Some(WhatAmI::Peer)).unwrap();
+        listen.scouting.multicast.set_enabled(Some(false)).unwrap();
+        listen
+            .listen
+            .endpoints
+            .set(vec![endpoint.parse().unwrap()])
+            .unwrap();
+        let mut connect = Config::default();
+        connect.set_mode(Some(WhatAmI::Peer)).unwrap();
+        connect.scouting.multicast.set_enabled(Some(false)).unwrap();
+        connect
+            .connect
+            .endpoints
+            .set(vec![endpoint.parse().unwrap()])
+            .unwrap();
+        let receiver = zenoh::open(listen).await.unwrap();
+        let subscriber = receiver.declare_subscriber("test/uring/tcp").await.unwrap();
+        let sender = zenoh::open(connect).await.unwrap();
+        let publisher = sender.declare_publisher("test/uring/tcp").await.unwrap();
+        while !publisher.matching_status().await.unwrap().matching() {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        publisher.put("hello").await.unwrap();
+        assert_eq!(
+            subscriber
+                .recv_async()
+                .await
+                .unwrap()
+                .payload()
+                .to_bytes()
+                .as_ref(),
+            b"hello"
+        );
+
+        // Only inspect established connections to this test's listener, not its listening socket.
+        let port = format!("{port:04X}");
+        let inodes: HashSet<_> = fs::read_to_string("/proc/net/tcp")
+            .unwrap()
+            .lines()
+            .skip(1)
+            .filter_map(|line| {
+                let fields: Vec<_> = line.split_whitespace().collect();
+                (fields[3] == "01"
+                    && [fields[1], fields[2]]
+                        .iter()
+                        .any(|address| address.rsplit(':').next() == Some(port.as_str())))
+                .then(|| fields[9].to_owned())
+            })
+            .collect();
+        let fds: HashSet<_> = fs::read_dir("/proc/self/fd")
+            .unwrap()
+            .filter_map(|entry| {
+                let entry = entry.unwrap();
+                let target = fs::read_link(entry.path()).ok()?;
+                let target = target.to_str()?;
+                let inode = target.strip_prefix("socket:[")?.strip_suffix(']')?;
+                inodes
+                    .contains(inode)
+                    .then(|| entry.file_name().to_str().unwrap().to_owned())
+            })
+            .collect();
+        assert_eq!(fds.len(), 2);
+        let mut registered = HashSet::new();
+        for entry in fs::read_dir("/proc/self/fdinfo").unwrap() {
+            let Ok(info) = fs::read_to_string(entry.unwrap().path()) else {
+                continue;
+            };
+            for line in info.lines() {
+                let fields: Vec<_> = line.split_whitespace().collect();
+                if fields.first() == Some(&"tfd:") && fds.contains(fields[1]) {
+                    let events = u32::from_str_radix(fields[3], 16).unwrap();
+                    assert_eq!(events & 1, 0, "TCP fd {} still has EPOLLIN", fields[1]);
+                    assert_ne!(events & 4, 0, "TCP fd {} lost EPOLLOUT", fields[1]);
+                    registered.insert(fields[1].to_owned());
+                }
+            }
+        }
+        assert_eq!(registered, fds);
+        sender.close().await.unwrap();
+        receiver.close().await.unwrap();
+    })
+    .await
+    .unwrap();
+}


### PR DESCRIPTION
Fixes #2770.

TCP sockets keep READABLE interest after io_uring takes over RX, causing redundant Tokio reactor wakeups.

Before publishing a universal TCP link, convert its stream to a WRITABLE-only `AsyncFd`. The unsafe hook states the exclusive-access requirement. Reject the new link if conversion fails, while preserving writable notifications and write-half shutdown.

A session-level regression fails on 1.10.0 and current main, and passes with this patch. Tests also cover backpressure and half-close. Injecting a registration failure rejects the second link while the first continues delivering messages.

In two 500-message runs, acceptor `epoll_wait` calls fell from 6,084 and 4,631 to zero, with complete delivery. Linux tests, Clippy and feature-disabled checks pass. Include the TCP unit test in the existing io_uring CI job.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

**No specific label requirements detected.**

Current labels: _No labels_

Add one of these labels to this PR to see relevant checklist items: `api-sync`, `breaking-change`, `bug`, `ci`, `dependencies`, `documentation`, `enhancement`, `new feature`, `internal`

*This section updates automatically when labels change.*

<!-- 🏷️ Label-Based Checklist END -->