### PR TITLE
Reclaim the receive buffers of stopped io_uring read tasks

### DIFF
--- a/commons/zenoh-uring/src/linux/api/reader/mod.rs
+++ b/commons/zenoh-uring/src/linux/api/reader/mod.rs
@@ -17,6 +17,7 @@ pub mod read_task;
 pub mod rx_buffer;
 
 use std::{
+    collections::HashMap,
     ops::Neg,
     os::fd::{AsRawFd, RawFd},
     sync::{atomic::AtomicBool, Arc},
@@ -44,7 +45,7 @@ use crate::{
         index::IndexGeneration,
         reactor_cmd::ReactorCmd,
         reservable_arena::ReservableArena,
-        rx_context::Rx,
+        rx_context::{Retiring, Rx},
         rx_context_storage::RxContextStorage,
         submission::SubmissionIface,
         window::RxWindow,
@@ -112,6 +113,10 @@ impl Reader {
         let ring_worker = move || -> ZResult<()> {
             // Create Rx context storage
             let mut context_storage = RxContextStorage::new();
+            // Buffer groups of stopped tasks, keyed by the user_data of the
+            // completion they wait for: the task's own terminal receive
+            // completion first, then the RemoveBuffers completion.
+            let mut retiring: HashMap<u64, Retiring> = HashMap::new();
 
             // io_uring read
             let ring: IoUring<squeue::Entry, cqueue::Entry> = IoUring::builder()
@@ -135,6 +140,7 @@ impl Reader {
             fn roll_cmds(
                 receiver: &Receiver<ReactorCmd>,
                 context_storage: &mut RxContextStorage,
+                retiring: &mut HashMap<u64, Retiring>,
                 arena: &GroupedArena,
                 sq: &mut SubmissionQueue<'_>,
                 batch_count: BufferCount,
@@ -152,25 +158,38 @@ impl Reader {
                             let index = context_storage.alloc(rx_context);
                             set_once.set(index)?;
 
+                            // Issued inline (not ASYNC): on a socket without
+                            // data the receive is registered for polling before
+                            // this submission returns, where a cancellation
+                            // finds it. A receive forced onto io-wq can be
+                            // missed by the cancellation while it starts, and
+                            // would then outlive its task.
                             let recv = opcode::RecvMulti::new(types::Fd(fd), group_id)
                                 .build()
-                                .flags(io_uring::squeue::Flags::ASYNC)
                                 .user_data(index.into());
 
                             unsafe { sq.push(&recv)? }
                         }
                         ReactorCmd::StopRx(index_generation) => {
-                            context_storage.free(index_generation);
+                            let Some(rx) = context_storage.take(index_generation) else {
+                                continue;
+                            };
+                            let recv_live = rx.recv_live.get();
+                            let group = rx.into_retiring();
+                            if recv_live {
+                                // wait for the receive to terminate before
+                                // touching its buffers
+                                retiring.insert(index_generation.into(), group);
 
-                            let cancel_builder =
-                                types::CancelBuilder::user_data(index_generation.into()).all();
-
-                            let event = AsyncCancel2::new(cancel_builder)
-                                .build()
-                                .user_data(index_generation.into())
-                                .flags(io_uring::squeue::Flags::ASYNC);
-
-                            unsafe { sq.push(&event)? }
+                                let cancel_builder =
+                                    types::CancelBuilder::user_data(index_generation.into()).all();
+                                let event = AsyncCancel2::new(cancel_builder)
+                                    .build()
+                                    .user_data(IndexGeneration::INVALID_MIN);
+                                unsafe { sq.push(&event)? }
+                            } else {
+                                Reader::retire(index_generation, group, retiring, sq)?;
+                            }
                         }
                     }
                 }
@@ -188,6 +207,7 @@ impl Reader {
                     roll_cmds(
                         &receiver,
                         &mut context_storage,
+                        &mut retiring,
                         &arena,
                         &mut sq,
                         batch_count,
@@ -196,6 +216,11 @@ impl Reader {
                     match e.user_data() {
                         IndexGeneration::INVALID_MIN => {
                             tracing::debug!("Zero-user-data entry: {:?}", e);
+                        }
+                        user_data if IndexGeneration::is_retire_user_data(user_data) => {
+                            if let Some(group) = retiring.remove(&user_data) {
+                                group.buffer_group.buffers_removed(e.result());
+                            }
                         }
                         IndexGeneration::INVALID_MAX => {
                             tracing::debug!("Waker event: {:?}", e);
@@ -209,8 +234,14 @@ impl Reader {
                             }
 
                             let index = unsafe { IndexGeneration::new_unchecked(index) };
-                            let to_submit =
-                                Reader::multi(&context_storage, &e, index, &arena, &mut sq)?;
+                            let to_submit = Reader::multi(
+                                &context_storage,
+                                &mut retiring,
+                                &e,
+                                index,
+                                &arena,
+                                &mut sq,
+                            )?;
                             let len = sq.len() as u32;
                             if to_submit || len >= (batch_count / 2) as u32 {
                                 drop(sq);
@@ -235,6 +266,7 @@ impl Reader {
                 roll_cmds(
                     &receiver,
                     &mut context_storage,
+                    &mut retiring,
                     &arena,
                     &mut sq,
                     batch_count,
@@ -275,22 +307,56 @@ impl Reader {
         }
     }
 
+    /// No receive of the stopped task is in flight anymore: reclaim the
+    /// buffers still queued in its group.
+    fn retire(
+        index: IndexGeneration,
+        group: Retiring,
+        retiring: &mut HashMap<u64, Retiring>,
+        sq: &mut SubmissionQueue<'_>,
+    ) -> ZResult<()> {
+        let user_data = index.retire_user_data();
+        if group.buffer_group.remove_buffers(user_data, sq)? {
+            retiring.insert(user_data, group);
+        }
+        Ok(())
+    }
+
     fn multi(
         context_storage: &RxContextStorage,
+        retiring: &mut HashMap<u64, Retiring>,
         e: &io_uring::cqueue::Entry,
         index: IndexGeneration,
         arena: &GroupedArena,
         sq: &mut SubmissionQueue<'_>,
     ) -> ZResult<bool> {
+        // last completion of a multishot receive
+        let terminal = !cqueue::more(e.flags());
         match context_storage.get(index) {
-            Some(context) => match Reader::read_multi(e, index, context, sq) {
-                Ok(val) => Ok(val),
-                Err(e) => {
-                    context.post_error(e);
-                    Ok(false)
+            Some(context) => {
+                if terminal {
+                    // set again by read_multi if it queues a new receive
+                    context.recv_live.set(false);
                 }
-            },
-            None => Ok(Self::utilize_multi(e, arena)),
+                match Reader::read_multi(e, index, context, sq) {
+                    Ok(val) => Ok(val),
+                    Err(e) => {
+                        context.post_error(e);
+                        Ok(false)
+                    }
+                }
+            }
+            None => {
+                let user_data: u64 = index.into();
+                let consumed = Self::utilize_multi(e, retiring.get(&user_data), arena);
+                if terminal {
+                    if let Some(group) = retiring.remove(&user_data) {
+                        Self::retire(index, group, retiring, sq)?;
+                        return Ok(true);
+                    }
+                }
+                Ok(consumed)
+            }
         }
     }
 
@@ -312,10 +378,10 @@ impl Reader {
                     let recv =
                         opcode::RecvMulti::new(types::Fd(context.fd), context.buffer_group().id())
                             .build()
-                            .flags(io_uring::squeue::Flags::ASYNC)
                             .user_data(index.into());
 
                     unsafe { sq.push(&recv)? };
+                    context.recv_live.set(true);
                     need_submit = true;
                 }
                 libc::ECANCELED => {
@@ -339,10 +405,10 @@ impl Reader {
                     let recv =
                         opcode::RecvMulti::new(types::Fd(context.fd), context.buffer_group().id())
                             .build()
-                            .flags(io_uring::squeue::Flags::ASYNC)
                             .user_data(index.into());
 
                     unsafe { sq.push(&recv)? };
+                    context.recv_live.set(true);
                     need_submit = true;
                 }
 
@@ -354,14 +420,110 @@ impl Reader {
         Ok(need_submit)
     }
 
-    fn utilize_multi(e: &io_uring::cqueue::Entry, arena: &GroupedArena) -> bool {
+    fn utilize_multi(
+        e: &io_uring::cqueue::Entry,
+        group: Option<&Retiring>,
+        arena: &GroupedArena,
+    ) -> bool {
         if e.result() >= 0 {
             if let Some(buf_id) = io_uring::cqueue::buffer_select(e.flags()) {
                 tracing::trace!("(utilize_multi) Read multishot entry: {:?}", e);
-                arena.recycle_batch(buf_id);
+                match group {
+                    Some(group) => group.buffer_group.release_consumed(buf_id),
+                    None => arena.recycle_batch(buf_id),
+                }
                 return true;
             }
         }
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        cell::UnsafeCell,
+        collections::HashMap,
+        io::Write,
+        os::{fd::AsRawFd, unix::net::UnixStream},
+        sync::Arc,
+    };
+
+    use io_uring::{cqueue, opcode, squeue, types, IoUring};
+    use nix::sys::eventfd::{EfdFlags, EventFd};
+
+    use super::Reader;
+    use crate::{
+        api::types::BufferCount,
+        batch_arena::BatchArena,
+        reader::{
+            buffer_group::{BufferGroup, GroupedArena},
+            reservable_arena::ReservableArena,
+            rx_context::{Retiring, Rx, RxCallback},
+            rx_context_storage::RxContextStorage,
+            submission::SubmissionIface,
+        },
+    };
+
+    /// A task whose receive just completed with a buffer and without
+    /// `F_MORE`: `Reader::multi` must queue a replacement receive and mark
+    /// it live even if replenishing the buffer group fails afterwards
+    /// because the submission queue is full.
+    ///
+    /// `free_slots` is the number of SQ entries left for `Reader::multi`.
+    fn terminal_buffer_completion(free_slots: usize) -> bool {
+        let mut ring: IoUring<squeue::Entry, cqueue::Entry> = IoUring::new(4).unwrap();
+        let arena = BatchArena::new(64, 1, BufferCount::MAX).unwrap();
+        let waker = Arc::new(EventFd::from_value_and_flags(0, EfdFlags::EFD_CLOEXEC).unwrap());
+        let (cmd_tx, _cmd_rx) = flume::unbounded();
+        let arena = ReservableArena::new(arena, SubmissionIface::new(waker, cmd_tx));
+        let arena = GroupedArena::new(arena);
+        let (peer, mut writer) = UnixStream::pair().unwrap();
+        let mut storage = RxContextStorage::new();
+        let mut retiring: HashMap<u64, Retiring> = HashMap::new();
+        let (err_tx, mut err_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        // one task with a one-buffer group and a one-shot receive on it
+        let group = BufferGroup::new(&arena, 1, &mut ring.submission()).unwrap();
+        let recv = opcode::Recv::new(types::Fd(peer.as_raw_fd()), std::ptr::null_mut(), 0)
+            .buf_group(group.id())
+            .build()
+            .flags(squeue::Flags::BUFFER_SELECT);
+        let callback = RxCallback::new(UnsafeCell::new(Box::new(|_| Ok(()))));
+        let index = storage.alloc(Rx::new(peer.as_raw_fd(), callback, err_tx, group));
+        unsafe {
+            ring.submission()
+                .push(&recv.user_data(index.into()))
+                .unwrap()
+        };
+        writer.write_all(b"data").unwrap();
+        ring.submit_and_wait(1).unwrap();
+        let cqe = ring.completion().next().unwrap();
+        assert!(cqueue::buffer_select(cqe.flags()).is_some() && !cqueue::more(cqe.flags()));
+
+        // leave exactly `free_slots` entries for the handler
+        let mut sq = ring.submission();
+        while sq.capacity() - sq.len() > free_slots {
+            unsafe { sq.push(&opcode::Nop::new().build()).unwrap() };
+        }
+        let result = Reader::multi(&storage, &mut retiring, &cqe, index, &arena, &mut sq);
+        assert!(result.is_ok(), "handler errors are posted, not returned");
+        assert_eq!(
+            sq.capacity() - sq.len(),
+            0,
+            "the handler used the free slots"
+        );
+        assert!(err_rx.try_recv().is_ok(), "the failed push was reported");
+        storage.get(index).unwrap().recv_live.get()
+    }
+
+    #[test]
+    fn restart_queued_before_replenishment_fails_stays_live() {
+        assert!(terminal_buffer_completion(1));
+    }
+
+    #[test]
+    fn failed_restart_is_not_live() {
+        assert!(!terminal_buffer_completion(0));
     }
 }

--- a/commons/zenoh-uring/src/linux/api/reader/read_task.rs
+++ b/commons/zenoh-uring/src/linux/api/reader/read_task.rs
@@ -49,7 +49,7 @@ impl ReadTask {
         let stop_rx_cmd = ReactorCmd::StopRx(self.index);
         let _ = self.submitter.submit(stop_rx_cmd);
 
-        // waiting for read task context to be destroyed within the reactor
+        // wait for the retirement of the task's buffers, or the reactor exit
         while self.error_receiver.recv().await.is_some() {}
     }
 

--- a/commons/zenoh-uring/src/linux/batch_arena.rs
+++ b/commons/zenoh-uring/src/linux/batch_arena.rs
@@ -12,7 +12,10 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-use std::ops::{Index, IndexMut};
+use std::{
+    ops::{Index, IndexMut},
+    sync::atomic::{AtomicUsize, Ordering},
+};
 
 use zenoh_result::ZResult;
 
@@ -49,6 +52,8 @@ impl Batches {
 pub(crate) struct BatchArena {
     arena: PageArena,
     batch_size: usize,
+    /// Bytes already handed out by `allocate_more_batches`.
+    offered: AtomicUsize,
 }
 
 impl Index<usize> for BatchArena {
@@ -78,15 +83,26 @@ impl BatchArena {
         let size = batch_size * batch_count as usize;
         let capacity = batch_size * max_batch_count as usize;
         let arena = PageArena::new(size, capacity)?;
-        Ok(Self { arena, batch_size })
+        Ok(Self {
+            arena,
+            batch_size,
+            offered: AtomicUsize::new(0),
+        })
     }
 
     pub(crate) fn allocate_more_batches(&self) -> Option<Batches> {
         tracing::debug!("Add batches");
 
-        let (addr, size) = self
-            .arena
-            .add_memory(self.arena.size.load(std::sync::atomic::Ordering::Relaxed))?;
+        // serve the region locked at construction first, then grow
+        let offered = self.offered.load(Ordering::Relaxed);
+        let locked = self.arena.size.load(Ordering::Relaxed);
+        let (addr, size) = if offered < locked {
+            let base = self.arena.memory.load(Ordering::Relaxed);
+            (unsafe { base.add(offered) }, locked - offered)
+        } else {
+            self.arena.add_memory(locked)?
+        };
+        self.offered.store(offered + size, Ordering::Relaxed);
         let additional_batch_count = size / self.batch_size;
         if additional_batch_count == 0 {
             return None;

--- a/commons/zenoh-uring/src/linux/reader/buffer_group.rs
+++ b/commons/zenoh-uring/src/linux/reader/buffer_group.rs
@@ -13,6 +13,7 @@
 //
 
 use std::{
+    cell::RefCell,
     collections::HashSet,
     rc::Rc,
     sync::{atomic::AtomicU16, Arc, Mutex},
@@ -27,7 +28,7 @@ use crate::{
     api::{reader::rx_buffer::RxBuffer, types::BufferCount},
     batch_arena::Batches,
     reader::reservable_arena::{ReservableArena, ReservableArenaInner},
-    types::BufferGroupId,
+    types::{BufferGroupId, BufferId},
 };
 
 // Absolute maximum ratings:
@@ -99,6 +100,8 @@ pub(crate) struct BufferGroup {
     id: BufferGroupId,
     arena: Rc<GroupedArenaInner>,
     buffers_missing: AtomicU16,
+    /// Buffers provided to the kernel and not yet handed back by a completion.
+    provided: RefCell<HashSet<BufferId>>,
 }
 
 impl Drop for BufferGroup {
@@ -122,6 +125,7 @@ impl BufferGroup {
             id,
             arena: arena.inner.clone(),
             buffers_missing: AtomicU16::new(required_buffers_in_ring),
+            provided: RefCell::new(HashSet::new()),
         };
 
         group.ensure_batches_to_ring(sq)?;
@@ -143,10 +147,13 @@ impl BufferGroup {
             .buffers_missing
             .load(std::sync::atomic::Ordering::Relaxed)
             + 1;
-        let leftover = self
-            .arena
-            .arena
-            .provide_batches_to_group(self.id, count, sq)?;
+        let mut provided = self.provided.borrow_mut();
+        provided.remove(&buf_id);
+        let leftover =
+            self.arena
+                .arena
+                .provide_batches_to_group(self.id, count, sq, &mut provided)?;
+        drop(provided);
         self.buffers_missing
             .store(leftover, std::sync::atomic::Ordering::Relaxed);
 
@@ -193,9 +200,58 @@ impl BufferGroup {
         unsafe {
             sq.push(&entry)?;
         }
+        self.provided
+            .borrow_mut()
+            .extend(batches.start_bid..batches.start_bid + batches.nbufs);
 
         self.buffers_missing
             .fetch_sub(batches.nbufs, std::sync::atomic::Ordering::Relaxed);
         Ok(())
+    }
+
+    /// A completion of the stopped task consumed `buf_id`: nobody will read
+    /// it, return it to the arena.
+    pub(crate) fn release_consumed(&self, buf_id: BufferId) {
+        self.provided.borrow_mut().remove(&buf_id);
+        self.arena.arena.recycle_batch(buf_id);
+    }
+
+    /// Once no receive can select from this group anymore, ask the kernel to
+    /// give back the buffers still queued in it. Returns `false` when there
+    /// is nothing to remove.
+    pub(crate) fn remove_buffers(
+        &self,
+        user_data: u64,
+        sq: &mut SubmissionQueue<'_>,
+    ) -> ZResult<bool> {
+        let count = self.provided.borrow().len();
+        if count == 0 {
+            return Ok(false);
+        }
+        let entry = opcode::RemoveBuffers::new(count as u16, self.id)
+            .build()
+            .user_data(user_data);
+        unsafe {
+            sq.push(&entry)?;
+        }
+        Ok(true)
+    }
+
+    /// Completion of `remove_buffers`: the kernel reported how many buffers
+    /// it gave back. Recycle them only if that matches what we tracked; on a
+    /// mismatch the ownership is unknown, so the buffers are left unused.
+    pub(crate) fn buffers_removed(&self, removed: i32) {
+        let provided = std::mem::take(&mut *self.provided.borrow_mut());
+        if removed != provided.len() as i32 {
+            tracing::error!(
+                "Buffer group {}: kernel removed {removed} buffers, {} tracked; leaking them",
+                self.id,
+                provided.len()
+            );
+            return;
+        }
+        for buf_id in provided {
+            self.arena.arena.recycle_batch(buf_id);
+        }
     }
 }

--- a/commons/zenoh-uring/src/linux/reader/index.rs
+++ b/commons/zenoh-uring/src/linux/reader/index.rs
@@ -21,6 +21,21 @@ pub struct IndexGeneration(NonZeroU64);
 impl IndexGeneration {
     pub const INVALID_MIN: u64 = 0;
     pub const INVALID_MAX: u64 = u64::MAX;
+    /// Set in the `user_data` of the `RemoveBuffers` that retires the buffer
+    /// group of a stopped task. Slot indices stay far below this bit: a slot
+    /// is only allocated together with a `u16` buffer group id.
+    const RETIRE_TAG: u64 = 1 << 31;
+
+    /// `user_data` of the buffer-group retirement of this task.
+    #[inline]
+    pub const fn retire_user_data(self) -> u64 {
+        self.0.get() | Self::RETIRE_TAG
+    }
+
+    #[inline]
+    pub const fn is_retire_user_data(val: u64) -> bool {
+        val & Self::RETIRE_TAG != 0 && val != Self::INVALID_MAX
+    }
 
     #[inline]
     pub const fn new(index: u32, generation: NonZeroU32) -> Self {

--- a/commons/zenoh-uring/src/linux/reader/reservable_arena.rs
+++ b/commons/zenoh-uring/src/linux/reader/reservable_arena.rs
@@ -12,7 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use io_uring::{opcode, squeue::Flags, SubmissionQueue};
 use zenoh_result::ZResult;
@@ -62,6 +62,7 @@ impl ReservableArenaInner {
         group_id: BufferGroupId,
         mut count: BufferCount,
         sq: &mut SubmissionQueue<'_>,
+        provided: &mut HashSet<BufferId>,
     ) -> ZResult<BufferCount> {
         // recycle batches from the recycled_batches queue first
         while let Some(buf_id) = self.recycled_batches.pop() {
@@ -80,6 +81,7 @@ impl ReservableArenaInner {
             unsafe {
                 sq.push(&entry)?;
             }
+            provided.insert(buf_id);
 
             count -= 1;
 
@@ -108,6 +110,8 @@ impl ReservableArenaInner {
                 unsafe {
                     sq.push(&entry)?;
                 }
+                provided.extend(primary.start_bid..primary.start_bid + primary.nbufs);
+                count -= primary.nbufs;
 
                 // recycle the leftover batches
                 if let Some(to_recycle) = to_recycle {
@@ -172,5 +176,57 @@ impl ReservableArena {
     pub fn new(arena: BatchArena, submitter: SubmissionIface) -> Self {
         let inner = Arc::new(ReservableArenaInner::new(arena, submitter));
         Self { inner }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashSet, sync::Arc};
+
+    use io_uring::{cqueue, squeue, IoUring};
+    use nix::sys::eventfd::{EfdFlags, EventFd};
+
+    use super::*;
+
+    const BATCH: usize = 6144;
+    const COUNT: BufferCount = 16;
+
+    fn fixture() -> (IoUring<squeue::Entry, cqueue::Entry>, ReservableArena) {
+        let ring = IoUring::builder().build(64).unwrap();
+        let arena = BatchArena::new(BATCH, COUNT, BufferCount::MAX).unwrap();
+        let waker = Arc::new(EventFd::from_value_and_flags(0, EfdFlags::EFD_CLOEXEC).unwrap());
+        let (tx, _rx) = flume::unbounded();
+        (
+            ring,
+            ReservableArena::new(arena, SubmissionIface::new(waker, tx)),
+        )
+    }
+
+    /// The region locked at construction is served first, as one batch.
+    #[test]
+    fn initial_region_served_first() {
+        let (_ring, a) = fixture();
+        let first = a.inner.pop_batches(COUNT);
+        assert_eq!(first.len(), 1);
+        assert_eq!((first[0].start_bid, first[0].nbufs), (0, COUNT));
+        let second = a.inner.pop_batches(COUNT);
+        assert_eq!((second[0].start_bid, second[0].nbufs), (COUNT, COUNT));
+    }
+
+    /// Buffers supplied by an arena expansion count as provided.
+    #[test]
+    fn expansion_satisfies_request() {
+        let (mut ring, a) = fixture();
+        let mut sq = ring.submission();
+        let mut provided = HashSet::new();
+        // use up the initial region so the request has to expand the arena
+        assert_eq!(a.inner.pop_batches(COUNT)[0].nbufs, COUNT);
+        let missing = a
+            .inner
+            .provide_batches_to_group(7, 1, &mut sq, &mut provided)
+            .unwrap();
+        assert_eq!(missing, 0);
+        assert_eq!(provided, HashSet::from([COUNT]));
+        assert_eq!(sq.len(), 1);
     }
 }

--- a/commons/zenoh-uring/src/linux/reader/rx_context.rs
+++ b/commons/zenoh-uring/src/linux/reader/rx_context.rs
@@ -12,7 +12,11 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-use std::{cell::UnsafeCell, os::fd::RawFd, sync::Arc};
+use std::{
+    cell::{Cell, UnsafeCell},
+    os::fd::RawFd,
+    sync::Arc,
+};
 
 use tokio::sync::mpsc::UnboundedSender;
 use zenoh_result::ZResult;
@@ -38,6 +42,17 @@ pub(crate) struct Rx {
     pub fd: RawFd,
     error_sender: UnboundedSender<zenoh_result::Error>,
     buffer_group: BufferGroup,
+    /// Whether a multishot receive of this task is still in flight.
+    pub recv_live: Cell<bool>,
+}
+
+/// Buffer group of a stopped task, kept until the kernel has handed back
+/// every buffer. Dropping it closes the error channel, which is what
+/// `ReadTask::stop` waits for.
+#[derive(Debug)]
+pub(crate) struct Retiring {
+    pub buffer_group: BufferGroup,
+    _error_sender: UnboundedSender<zenoh_result::Error>,
 }
 
 impl Rx {
@@ -52,6 +67,7 @@ impl Rx {
             error_sender,
             fd,
             buffer_group,
+            recv_live: Cell::new(true),
         };
         tracing::debug!("RX context created: {:?}", rx);
         rx
@@ -59,6 +75,16 @@ impl Rx {
 
     pub(crate) fn buffer_group(&self) -> &BufferGroup {
         &self.buffer_group
+    }
+
+    /// Stop the task: the callback is dropped now, the buffer group outlives
+    /// the context until its buffers are reclaimed.
+    pub(crate) fn into_retiring(self) -> Retiring {
+        tracing::debug!("Destroy RX context: {:?}", self);
+        Retiring {
+            buffer_group: self.buffer_group,
+            _error_sender: self.error_sender,
+        }
     }
 
     pub(crate) fn run_callback(&self, buffer: Arc<RxBuffer>) {
@@ -76,11 +102,5 @@ impl Rx {
     pub(crate) fn post_error(&self, error: zenoh_result::Error) {
         tracing::error!("Read task error: {error}");
         let _ = self.error_sender.send(error);
-    }
-}
-
-impl Drop for Rx {
-    fn drop(&mut self) {
-        tracing::debug!("Destroy RX context: {:?}", self);
     }
 }

--- a/commons/zenoh-uring/src/linux/reader/rx_context_storage.rs
+++ b/commons/zenoh-uring/src/linux/reader/rx_context_storage.rs
@@ -37,18 +37,15 @@ impl RxContextCell {
         None
     }
 
-    fn free(&mut self, generation: NonZeroU32) {
+    fn take(&mut self, generation: NonZeroU32) -> Option<Rx> {
         if self.generation == generation {
-            if let Some(context) = self.context.take() {
-                tracing::debug!("Begin RxContext destroy {:?}", context);
-                drop(context);
-                tracing::debug!("End RxContext destroy!");
-            }
+            self.context.take()
         } else {
             tracing::debug!(
                 "Unable to free: generation mismatch! {:?}, generation: {generation}",
                 self
             );
+            None
         }
     }
 
@@ -80,8 +77,8 @@ impl RxContextStorage {
         self.data[id.index() as usize].get(id.generation())
     }
 
-    pub(crate) fn free(&mut self, id: IndexGeneration) {
-        self.data[id.index() as usize].free(id.generation())
+    pub(crate) fn take(&mut self, id: IndexGeneration) -> Option<Rx> {
+        self.data[id.index() as usize].take(id.generation())
     }
 
     pub(crate) fn alloc(&mut self, context: Rx) -> IndexGeneration {

--- a/commons/zenoh-uring/tests/buffer_group_lifecycle.rs
+++ b/commons/zenoh-uring/tests/buffer_group_lifecycle.rs
@@ -1,0 +1,236 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+//! Buffers provided to the kernel for a stopped read task must be reclaimed:
+//! otherwise every link (re)connection grows the mlocked arena.
+
+#[cfg(target_os = "linux")]
+mod linux_tests {
+    use std::{
+        io::Write,
+        net::{TcpListener, TcpStream},
+        os::fd::AsRawFd,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            mpsc, Arc,
+        },
+        time::Duration,
+    };
+
+    use zenoh_uring::api::reader::{rx_buffer::RxBuffer, Reader};
+
+    const TIMEOUT: Duration = Duration::from_secs(10);
+
+    /// Process-wide locked memory; the arena is the only mlock user here.
+    fn vmlck_kib() -> usize {
+        std::fs::read_to_string("/proc/self/status")
+            .unwrap()
+            .lines()
+            .find_map(|l| l.strip_prefix("VmLck:"))
+            .and_then(|v| v.split_whitespace().next())
+            .and_then(|v| v.parse().ok())
+            .unwrap()
+    }
+
+    /// Wait until the reader thread of a dropped `Reader` unmapped its arena.
+    fn wait_unlocked() {
+        let deadline = std::time::Instant::now() + TIMEOUT;
+        while vmlck_kib() != 0 {
+            assert!(std::time::Instant::now() < deadline, "arena not released");
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    struct Link {
+        listener: TcpListener,
+        received: Arc<AtomicUsize>,
+    }
+
+    impl Link {
+        fn new() -> Self {
+            Self {
+                listener: TcpListener::bind("127.0.0.1:0").unwrap(),
+                received: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+
+        /// One link lifetime: connect, receive `msgs` payloads through a read
+        /// task, stop the task, close both sockets.
+        async fn cycle(&self, reader: &Reader, msgs: usize) {
+            let mut client = TcpStream::connect(self.listener.local_addr().unwrap()).unwrap();
+            let (server, _) = self.listener.accept().unwrap();
+            let got = self.received.clone();
+            let expected = got.load(Ordering::SeqCst) + msgs * 64;
+            let mut task = reader
+                .setup_read(server.as_raw_fd(), move |buf| {
+                    got.fetch_add(buf.len(), Ordering::SeqCst);
+                    Ok(())
+                })
+                .await
+                .unwrap();
+            for _ in 0..msgs {
+                client.write_all(&[0xAB; 64]).unwrap();
+            }
+            while self.received.load(Ordering::SeqCst) < expected {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+            // returns once the kernel handed every buffer of the task back
+            task.stop().await;
+        }
+    }
+
+    /// `cycles` sequential link lifetimes on one reader with `msgs` payloads
+    /// each. With concurrency 1 the retired group's buffers are recycled
+    /// before the next group is created, so after the first cycle the locked
+    /// arena must not grow at all.
+    async fn churn(batch_size: usize, batch_count: u16, cycles: usize, msgs: usize) {
+        let reader = Reader::new(batch_size, batch_count).unwrap();
+        let link = Link::new();
+        link.cycle(&reader, msgs).await;
+        let warm = vmlck_kib();
+        for _ in 1..cycles {
+            link.cycle(&reader, msgs).await;
+        }
+        let last = vmlck_kib();
+        println!("[{batch_size}x{batch_count} msgs={msgs}] after first cycle {warm} KiB, after {cycles} cycles {last} KiB");
+        // the arena is 1.5 * batch_size * batch_count, expanded at most once
+        let arena = batch_size * 3 / 2 * batch_count as usize / 1024;
+        assert!(warm >= arena, "arena not locked: {warm} KiB");
+        assert!(warm <= 2 * arena + 64, "arena too big: {warm} KiB");
+        assert_eq!(last, warm, "locked arena grew across {cycles} link cycles");
+        drop(reader);
+        wait_unlocked();
+    }
+
+    /// Stop tasks while the peer keeps writing: buffers may be selected by a
+    /// receive in flight at StopRx time. Retirement must wait for it, so
+    /// stopping must reclaim everything (a leaked group would show up as an
+    /// arena expansion) and the sender must end up rejected.
+    async fn stop_under_traffic(cycles: usize) {
+        let reader = Reader::new(4096, 16).unwrap();
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let mut warm = 0;
+        for cycle in 0..cycles {
+            let mut client = TcpStream::connect(addr).unwrap();
+            let (server, _) = listener.accept().unwrap();
+            let (writer_done, done) = mpsc::channel();
+            let writer = std::thread::spawn(move || {
+                while client.write_all(&[0xCD; 4096]).is_ok() {}
+                writer_done.send(()).unwrap();
+            });
+            let received = Arc::new(AtomicUsize::new(0));
+            let got = received.clone();
+            let mut task = reader
+                .setup_read(server.as_raw_fd(), move |buf| {
+                    assert!(buf.iter().all(|b| *b == 0xCD));
+                    got.fetch_add(buf.len(), Ordering::SeqCst);
+                    Ok(())
+                })
+                .await
+                .unwrap();
+            while received.load(Ordering::SeqCst) < 64 * 1024 {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+            task.stop().await;
+            drop(server);
+            done.recv_timeout(TIMEOUT).expect("writer not rejected");
+            writer.join().unwrap();
+            if cycle == 0 {
+                warm = vmlck_kib();
+            }
+        }
+        let last = vmlck_kib();
+        println!(
+            "[stop under traffic] after first cycle {warm} KiB, after {cycles} cycles {last} KiB"
+        );
+        assert_eq!(
+            last, warm,
+            "locked arena grew across {cycles} stops under traffic"
+        );
+        drop(reader);
+        wait_unlocked();
+    }
+
+    /// Buffers handed to the application outlive their task: they must stay
+    /// intact while later tasks receive, and the arena must neither grow
+    /// while they are held nor stay locked once they are released.
+    async fn buffer_outlives_task() {
+        let reader = Reader::new(4096, 16).unwrap();
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (held_tx, held_rx) = mpsc::channel::<Arc<RxBuffer>>();
+
+        let mut client = TcpStream::connect(addr).unwrap();
+        let (server, _) = listener.accept().unwrap();
+        let mut task = reader
+            .setup_read(server.as_raw_fd(), move |buf| {
+                held_tx.send(buf).unwrap();
+                Ok(())
+            })
+            .await
+            .unwrap();
+        client.write_all(&[0x11; 1000]).unwrap();
+        let mut held: Vec<Arc<RxBuffer>> = Vec::new();
+        while held.iter().map(|b| b.len()).sum::<usize>() < 1000 {
+            held.push(held_rx.recv_timeout(TIMEOUT).unwrap());
+        }
+        task.stop().await;
+        drop(server);
+        drop(client);
+        drop(held_rx);
+        let warm = vmlck_kib();
+
+        // every other buffer cycles through 32 more links carrying data
+        let link = Link::new();
+        for _ in 0..32 {
+            link.cycle(&reader, 8).await;
+        }
+        assert!(
+            held.iter().flat_map(|b| b.iter()).all(|b| *b == 0x11),
+            "held buffers were overwritten"
+        );
+        assert_eq!(
+            vmlck_kib(),
+            warm,
+            "locked arena grew while a buffer was held"
+        );
+        drop(held);
+        link.cycle(&reader, 8).await;
+        assert_eq!(vmlck_kib(), warm);
+        drop(reader);
+        wait_unlocked();
+    }
+
+    #[test]
+    fn stopped_tasks_release_their_buffers() {
+        zenoh_util::try_init_log_from_env();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            tokio::time::timeout(Duration::from_secs(120), async {
+                churn(4096, 16, 24, 0).await;
+                churn(4096, 16, 24, 8).await;
+                // transport geometry: Uring::new(65535, 65535) -> Reader::new(65537, 16)
+                churn(65537, 16, 12, 4).await;
+                stop_under_traffic(24).await;
+                buffer_outlives_task().await;
+            })
+            .await
+            .expect("test timed out");
+        });
+    }
+}


### PR DESCRIPTION
Fixes #2774.

When a read task is stopped, the buffers still queued in the kernel for its group are never returned to the pool, so link churn keeps growing the mlocked arena (numbers in the issue).

The group of a stopped task is now retired in two steps: the receive is cancelled and the group is kept until the receive's terminal completion, then a `RemoveBuffers` takes back what the kernel still holds. The buffers are recycled only if the kernel reports the same count we tracked, and the group id is released only then. `ReadTask::stop` returns once that is done.

The receives and the cancel are no longer forced onto io-wq. On a 6.1 PREEMPT_RT board the cancel missed a starting forced-async receive about half the time, leaving it armed forever; issued inline, the receive is polled before the submission returns and the cancel finds it. Let me know if there was a reason for the ASYNC flag.

Also fixes the missing-count accounting after an arena expansion, and hands out the region locked at construction instead of expanding right away.

Tests: a churn test on one Reader (with and without traffic, stops under traffic, buffers held across stops) asserts that VmLck stays flat after the first cycle; it goes from 96 KiB to 3 MiB on main. Unit tests cover the accounting and the receive-liveness bookkeeping. Crate tests, Clippy and rustfmt pass on x86_64 6.8 and aarch64 6.1 (4 KiB and 64 KiB pages).

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

**No specific label requirements detected.**

Current labels: _No labels_

Add one of these labels to this PR to see relevant checklist items: `api-sync`, `breaking-change`, `bug`, `ci`, `dependencies`, `documentation`, `enhancement`, `new feature`, `internal`

*This section updates automatically when labels change.*

<!-- 🏷️ Label-Based Checklist END -->