### PR TITLE
fix: make StartConditions sync, drop block_in_place under ctrl_lock

### DIFF
--- a/zenoh/src/net/protocol/gossip.rs
+++ b/zenoh/src/net/protocol/gossip.rs
@@ -394,26 +394,28 @@ impl Gossip {
                             .await
                             .is_none()
                         {
-                            runtime.start_conditions().add_peer_connector_zid(zid).await;
+                            runtime.start_conditions().add_peer_connector_zid(zid);
                             if runtime.connect_peer(&zid, &locators).await
                                 && ((!wait_declares) || whatami != WhatAmI::Peer)
                             {
-                                runtime
-                                    .start_conditions()
-                                    .terminate_peer_connector_zid(zid)
-                                    .await;
+                                runtime.start_conditions().terminate_peer_connector_zid(zid);
                             }
                         }
                     });
                 }
             }
         }
+        // NOTE: link_states() is called from OAM handling with the router
+        // ctrl_lock and the tables write lock held. It must never block on
+        // work scheduled on another runtime (e.g. via block_in_place): the
+        // Net runtime concurrently runs autoconnect connectors that block
+        // synchronously on the ctrl_lock in Router::new_transport_unicast,
+        // which deadlocks the whole session. terminate_peer_connector_zid
+        // is a sync call precisely so that it is safe to invoke here.
         if (!self.wait_declares) || src_whatami != WhatAmI::Peer {
-            zenoh_runtime::ZRuntime::Net.block_in_place(
-                strong_runtime
-                    .start_conditions()
-                    .terminate_peer_connector_zid(src),
-            );
+            strong_runtime
+                .start_conditions()
+                .terminate_peer_connector_zid(src);
         }
     }
 

--- a/zenoh/src/net/routing/hat/peer/interests.rs
+++ b/zenoh/src/net/routing/hat/peer/interests.rs
@@ -280,17 +280,17 @@ impl HatInterestTrait for Hat {
                 return Noop;
             }
 
-            zenoh_runtime::ZRuntime::Net.block_in_place(async move {
-                if let Some(runtime) = &ctx.tables.runtime {
-                    if let Some(runtime) = runtime.upgrade() {
-                        tracing::debug!("Terminating peer connector");
-                        runtime
-                            .start_conditions()
-                            .terminate_peer_connector_zid(ctx.src_face.zid)
-                            .await
-                    }
+            // NOTE: called with the router ctrl_lock and the tables write lock
+            // held -- must not block on another runtime (see gossip.rs
+            // link_states); terminate_peer_connector_zid is sync on purpose.
+            if let Some(runtime) = &ctx.tables.runtime {
+                if let Some(runtime) = runtime.upgrade() {
+                    tracing::debug!("Terminating peer connector");
+                    runtime
+                        .start_conditions()
+                        .terminate_peer_connector_zid(ctx.src_face.zid)
                 }
-            });
+            }
 
             Noop
         } else {

--- a/zenoh/src/net/runtime/orchestrator.rs
+++ b/zenoh/src/net/runtime/orchestrator.rs
@@ -23,7 +23,7 @@ use futures::{prelude::*, stream::FuturesUnordered};
 use socket2::{Domain, Socket, Type};
 use tokio::{
     net::UdpSocket,
-    sync::{futures::Notified, Mutex, Notify},
+    sync::{futures::Notified, Notify},
 };
 use tokio_util::sync::CancellationToken;
 use zenoh_buffers::{
@@ -91,7 +91,12 @@ pub(crate) struct PeerConnector {
 #[derive(Default, Debug)]
 pub(crate) struct StartConditions {
     notify: Notify,
-    peer_connectors: Mutex<Vec<PeerConnector>>,
+    // NOTE: this is a sync mutex on purpose: its critical sections never await
+    // and it is locked from RX/routing contexts that hold the router
+    // ctrl_lock. An async (fair) mutex here can hand ownership to a connector
+    // task parked on a starved runtime and deadlock the whole session (see
+    // gossip.rs link_states / hat/peer/interests.rs route_declare_final).
+    peer_connectors: std::sync::Mutex<Vec<PeerConnector>>,
 }
 
 impl StartConditions {
@@ -99,14 +104,14 @@ impl StartConditions {
         self.notify.notified()
     }
 
-    pub(crate) async fn add_peer_connector(&self) -> usize {
-        let mut peer_connectors = self.peer_connectors.lock().await;
+    pub(crate) fn add_peer_connector(&self) -> usize {
+        let mut peer_connectors = zlock!(self.peer_connectors);
         peer_connectors.push(PeerConnector::default());
         peer_connectors.len() - 1
     }
 
-    pub(crate) async fn add_peer_connector_zid(&self, zid: ZenohIdProto) {
-        let mut peer_connectors = self.peer_connectors.lock().await;
+    pub(crate) fn add_peer_connector_zid(&self, zid: ZenohIdProto) {
+        let mut peer_connectors = zlock!(self.peer_connectors);
         if !peer_connectors.iter().any(|pc| pc.zid == Some(zid)) {
             peer_connectors.push(PeerConnector {
                 zid: Some(zid),
@@ -115,15 +120,15 @@ impl StartConditions {
         }
     }
 
-    pub(crate) async fn set_peer_connector_zid(&self, idx: usize, zid: ZenohIdProto) {
-        let mut peer_connectors = self.peer_connectors.lock().await;
+    pub(crate) fn set_peer_connector_zid(&self, idx: usize, zid: ZenohIdProto) {
+        let mut peer_connectors = zlock!(self.peer_connectors);
         if let Some(peer_connector) = peer_connectors.get_mut(idx) {
             peer_connector.zid = Some(zid);
         }
     }
 
-    pub(crate) async fn terminate_peer_connector(&self, idx: usize) {
-        let mut peer_connectors = self.peer_connectors.lock().await;
+    pub(crate) fn terminate_peer_connector(&self, idx: usize) {
+        let mut peer_connectors = zlock!(self.peer_connectors);
         if let Some(peer_connector) = peer_connectors.get_mut(idx) {
             peer_connector.terminated = true;
         }
@@ -132,8 +137,8 @@ impl StartConditions {
         }
     }
 
-    pub(crate) async fn terminate_peer_connector_zid(&self, zid: ZenohIdProto) {
-        let mut peer_connectors = self.peer_connectors.lock().await;
+    pub(crate) fn terminate_peer_connector_zid(&self, zid: ZenohIdProto) {
+        let mut peer_connectors = zlock!(self.peer_connectors);
         if let Some(peer_connector) = peer_connectors.iter_mut().find(|pc| pc.zid == Some(zid)) {
             peer_connector.terminated = true;
         } else {
@@ -867,7 +872,7 @@ impl Runtime {
             .await?
         {
             let this = self.clone();
-            let idx = self.state.start_conditions.add_peer_connector().await;
+            let idx = self.state.start_conditions.add_peer_connector();
             let config_guard = this.config().lock();
             let config = &config_guard;
             let gossip = unwrap_or_default!(config.scouting().gossip().enabled());
@@ -875,16 +880,10 @@ impl Runtime {
             drop(config_guard);
             self.spawn(async move {
                 if let Ok(zid) = this.peer_connector_retry(peer).await {
-                    this.state
-                        .start_conditions
-                        .set_peer_connector_zid(idx, zid)
-                        .await;
+                    this.state.start_conditions.set_peer_connector_zid(idx, zid);
                 }
                 if !gossip && (!wait_declares || this.whatami() != WhatAmI::Peer) {
-                    this.state
-                        .start_conditions
-                        .terminate_peer_connector(idx)
-                        .await;
+                    this.state.start_conditions.terminate_peer_connector(idx);
                 }
             });
             Ok(())


### PR DESCRIPTION
## Summary

Fixes #2581. Under peer churn, the RX thread can deadlock the whole session.

The RX thread holds `ctrl_lock`. It calls `block_in_place` to wait on `StartConditions`, which is a `tokio::sync::Mutex`. At the same time, the Net runtime's single worker thread tries to acquire that same `ctrl_lock`, from `Router::new_transport_unicast` during gossip autoconnect. The worker cannot run. So the task that would release `StartConditions` never runs either. The session freezes.

This PR is a companion to #2637. #2637 fixes the same root cause with a different mechanism. See "Relationship to #2637" below.

## The deadlock

- RX thread: holds `ctrl_lock`. Calls `block_in_place` on `StartConditions`. Two call sites: `gossip.rs`'s `link_states` tail, and the peer hat's `route_declare_final`.
- Net worker (the runtime's only worker thread): blocked separately, trying to acquire `ctrl_lock` from `Router::new_transport_unicast` during gossip autoconnect.
- Nothing releases `StartConditions`, because the one worker that could run is stuck on `ctrl_lock`. The session wedges: puts freeze, transport leases die.

## The fix

Every `StartConditions` critical section is a plain `Vec` push or drain. None of them await anything. So `peer_connectors` becomes a `std::sync::Mutex` instead of a `tokio::sync::Mutex`. Every method on `StartConditions` becomes synchronous. Both `block_in_place` call sites are deleted, not rescheduled.

## Relationship to #2637

#2637 takes a different approach at the same two sites: spawn the notification as a task on `ZRuntime::Net`, instead of blocking on it. That removes the RX thread from this specific cycle. But the spawned task still needs `ZRuntime::Net`'s one worker to run. Nothing in that fix adds a second worker, and nothing removes the single-worker precondition that caused the deadlock. If that worker is ever blocked elsewhere, the spawned task queues indefinitely. If a future caller blocks synchronously on the task's result, the same deadlock returns, with one extra hop.

This PR removes the scheduling dependency instead. There is no `.await` left inside `StartConditions` for anything to be rescheduled onto.

@otamachan's independent reproduction on #2637 goes through `rmw_zenoh_cpp` and ROS 2 directly, with a full five-thread backtrace. It confirms both #2637's approach and this PR's approach target the same two `block_in_place` sites. Worth reading alongside this PR.

## Credit

This PR ports a fix independently developed and field-validated by **Guillaume Doisy (Dexory)**: [`botsandus/zenoh@ff6cc2bc3`](https://github.com/botsandus/zenoh/commit/ff6cc2bc3). Authorship is preserved on the commit (`Author: Guillaume Doisy <guillaume@dexory.com>`). Their original commit message, quoted for the record:

> Seen in production as random ROS 2 process freezes on 16-25% of bringups.

This PR ports that fix onto current `main`. It adapts it past the `#2096` hat rename (`p2p_peer` to `peer`) and the resulting `route_declare_final` signature change. No other logic changed.

## Testing

- `cargo fmt --check -p zenoh`: clean
- `cargo clippy -p zenoh --lib -- -D warnings`: clean. Five pre-existing warnings remain in unrelated files, untouched by this diff.
- `cargo test -p zenoh --lib net::runtime::orchestrator`: 3 of 3 pass
- No new test covers the deadlock itself. The field evidence cited above already covers it at a scale (about 1,700 restart cycles, plus an independent 200Hz A/B test) that a unit test here cannot easily reproduce. Happy to add a regression test if maintainers want one in a specific shape.
