### PR TITLE
With Rust 1.75 fix dependency to static_init 1.0.3

### DIFF
--- a/commons/zenoh-pinned-deps-1-75/Cargo.toml
+++ b/commons/zenoh-pinned-deps-1-75/Cargo.toml
@@ -55,7 +55,7 @@ rustc-hash = "=2.1.1"
 serde_spanned = "=1.0.1"
 serde_with = "=3.14.1"
 serde_with_macros = "=3.14.1"
-static_init = "=1.0.3"
+static_init = { version = "=1.0.3", features = ["debug_order"] }
 tempfile = "=3.24.0"
 thread-priority = "=1.2.0"
 time = "=0.3.41"


### PR DESCRIPTION
## Description

On Linux, when building zenoh in debug mode with Rust 1.75 and `zenoh-pinned-deps-1-75` dependency it fails.

To reproduce:
`cargo check --manifest-path ci/zenoh-1-75/Cargo.toml`

Result:
```log
error[E0433]: cannot find module or crate `parking_lot` in this scope
   --> /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/static_init-1.0.3/src/lazy_sequentializer.rs:336:13
    |
336 |         use parking_lot::lock_api::GetThreadId;
    |             ^^^^^^^^^^^ use of unresolved module or unlinked crate `parking_lot`
    |
    = help: if you wanted to use a crate named `parking_lot`, use `cargo add parking_lot` to add it to your `Cargo.toml`

error[E0433]: cannot find module or crate `parking_lot` in this scope
   --> /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/static_init-1.0.3/src/lazy_sequentializer.rs:371:21
    |
371 |                 use parking_lot::lock_api::GetThreadId;
    |                     ^^^^^^^^^^^ use of unresolved module or unlinked crate `parking_lot`
    |
    = help: if you wanted to use a crate named `parking_lot`, use `cargo add parking_lot` to add it to your `Cargo.toml`

error[E0433]: cannot find module or crate `parking_lot` in this scope
   --> /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/static_init-1.0.3/src/lazy_sequentializer.rs:338:13
    |
338 |             parking_lot::RawThreadId.nonzero_thread_id().into(),
    |             ^^^^^^^^^^^ use of unresolved module or unlinked crate `parking_lot`
    |
    = help: if you wanted to use a crate named `parking_lot`, use `cargo add parking_lot` to add it to your `Cargo.toml`

error[E0433]: cannot find module or crate `parking_lot` in this scope
   --> /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/static_init-1.0.3/src/lazy_sequentializer.rs:372:26
    |
372 |                 if id == parking_lot::RawThreadId.nonzero_thread_id().into() {
    |                          ^^^^^^^^^^^ use of unresolved module or unlinked crate `parking_lot`
    |
    = help: if you wanted to use a crate named `parking_lot`, use `cargo add parking_lot` to add it to your `Cargo.toml`
```

The issue is in `static_init` 1.0.3:
on Linux the dependency to `parking_lot` depends on a `debug_mode` config which is not activated when `debug_assertions` is set (i.e. build in debug).

It has been [fixed in 1.0.4](https://gitlab.com/okannen/static_init/-/commit/7b6aeb0f363df4ad39fd7c69d875372285d7f0d8#line_ba2f135ee_A6), but it required Rust >= 1.82.

### What does this PR do?

The fix here is to depend on `static_init` 1.0.3 with the feature `"debug_order"`. This forces the `debug_mode` config and hence the dependency to `parking_lot`.

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `internal`

## 🏠 Internal Change

This PR is marked as **internal** (not user-facing):

- [x] **No API changes** - Public APIs unchanged
- [x] **No behavior changes** - External behavior identical
- [x] **Refactoring/maintenance** - Code improvements only
- [x] **Tests still pass** - All existing tests pass without modification

**Lighter review:** Internal changes may have lighter review requirements.

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->